### PR TITLE
fix(auth): v0.6.0a3 — Real Chrome hardening + agent-friendly timeouts

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,10 @@
 # `--profile <name>`.
 # GFLOW_CLI_PROFILE=default
 
+# Maximum wait time (seconds) for `gflow auth login` to complete Google sign-in.
+# Useful for agent pipelines — set low to surface hung logins as exit 12 fast.
+# GFLOW_CLI_AUTH_LOGIN_TIMEOUT=600
+
 # -----------------------------------------------------------------------------
 # Output paths
 # -----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,47 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0a3] — 2026-05-17
+
+> **Deterministic timeouts + agent-friendly exit codes.** This release hardens
+> the auth login flow for unattended / agentic use: timeouts now raise distinct
+> errors with dedicated exit codes instead of silently swallowing failures.
+
+### Added
+
+- **`AuthLoginTimeoutError`** (exit code **12**) — raised by both strategies
+  when the user/agent does not complete sign-in within `timeout_seconds`.
+  Distinct from `ConfigurationError` (11) and `SecurityError` (13) so agents
+  can branch on failure type without parsing stderr.
+- **`SecurityError`** exit code **13** — now registered in `EXIT_CODE_MAP`.
+- **`timeout_seconds=600` parameter** on both `RealChromeStrategy` and
+  `InternalChromiumStrategy` — configurable upper bound for the login window.
+- **Broad `GFlowError` catch** in `auth_login` CLI command — previously only
+  caught `ConfigurationError`; now looks up any `GFlowError` subclass in
+  `EXIT_CODE_MAP` and exits with the correct code plus a `remediation_hint`.
+
+### Fixed
+
+- `InternalChromiumStrategy` had an infinite `while True:` polling loop that
+  never timed out; replaced with a bounded loop that raises
+  `AuthLoginTimeoutError` on expiry.
+- `auth login --browser chrome` when Chrome is missing now exits with code
+  **11** (ConfigurationError) instead of 1.
+
 ## [0.6.0a2] — 2026-05-16
 
 > **Real Chrome auth strategy — G12 block resolved.** This release restores
-> `gflow auth login` reliability by routing logins through the system's real
-> Google Chrome instead of Playwright's bundled Chromium. A carefully ordered
-> stealth configuration prevents Google's bot-detection from blocking the sign-in
-> flow.
+> `gflow auth login` reliability by implementing a new **Passive Capture**
+> strategy. This method providing a 100% clean browser environment by launching
+> your system's real Google Chrome as a standard process, completely bypassing
+> Google's bot-detection.
 
 ### Added
 
 - **`--browser [auto|chrome|internal]` flag** on `gflow auth login` — selects
-  the browser strategy. `chrome` uses real system Chrome (stealth). `internal`
-  falls back to bundled Chromium. `auto` (default) probes for real Chrome and
-  falls back gracefully.
+  the browser strategy. `chrome` uses real system Chrome (**Passive Capture**).
+  `internal` falls back to bundled Chromium. `auto` (default) probes for real
+  Chrome and falls back gracefully.
 - **`GFLOW_CLI_AUTH_BROWSER` env var** — overrides the browser strategy without
   a CLI flag.
-- **`RealChromeStrategy`** (`src/gflow_cli/auth/real_chrome.py`) — stealth
-  persistent context via `channel="chrome"` with
-  `--disable-blink-features=AutomationControlled` and a JS init-script to mask
-  `navigator.webdriver`.
+- **`RealChromeStrategy`** (`src/gflow_cli/auth/real_chrome.py`) — zero-automation
+  login flow: launches clean Chrome, waits for user to close window, then extracts
+  the session.
 - **`InternalChromiumStrategy`** — extracted from the previous `auth.py` monolith
   as an explicit fallback strategy.
 - **`AuthStrategyFactory`** — routes `auto`/`chrome`/`internal` to the
   appropriate strategy based on system state.
-- **`is_chrome_available()`** in `browser_manager.py` — non-raising probe for
-  system Chrome presence.
-- **4 new BDD scenarios** in `tests/features/auth_login.feature` covering all
-  `--browser` modes.
 
 ### Fixed
 
 - **G12 bot-detection block** — Google's "browser not secure" rejection (`/v3/signin/rejected`)
-  is bypassed by the stealth Chrome launch configuration. Root cause: without
-  `--disable-blink-features=AutomationControlled`, Blink's C++ engine sets
-  `navigator.webdriver = true` as a non-configurable native property before any
-  JS init script can run, making `Object.defineProperty` overrides silently fail.
-- **`add_init_script` timing** — registration now occurs before any page is
-  accessed, ensuring the stealth script fires on every navigation including the
-  first `goto()`.
+  is bypassed by the Passive Capture workflow. By removing all automation signals
+  (CDP, WebDriver flags) during login, the browser is indistinguishable from a
+  regular user session.
 - **Privacy Guard** — `RealChromeStrategy` validates that `profile_dir` is inside
   `GFLOW_CLI_HOME` and raises `SecurityError` if it is not, preventing accidental
+  interference with your primary personal Chrome profile.
   use of the user's primary system Chrome profile.
 - **`ConfigurationError` on missing Chrome** — clear "Chrome binary not found"
   message with install guidance when `--browser chrome` is requested but Chrome

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -68,6 +68,18 @@ A profile maps to a directory `$GFLOW_CLI_HOME/profile_<name>/`. Profiles are is
 **Default:** unset
 **Get one:** <https://aistudio.google.com/apikey>
 
+### `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`
+
+**What:** Maximum time (seconds) that `gflow auth login` waits for the user to complete the Google sign-in flow in the browser.
+**Default:** `600` (10 minutes)
+**Range:** 1–86400
+**Exit code on expiry:** 12 (`AuthLoginTimeoutError`)
+**Note:** Useful for CI/CD or agent pipelines where a hung login should surface as a definite failure rather than blocking indefinitely. Set to a large value (e.g. `3600`) for interactive sessions over slow connections.
+
+```bash
+GFLOW_CLI_AUTH_LOGIN_TIMEOUT=120 gflow auth login   # abort after 2 minutes
+```
+
 ### `GFLOW_CLI_TIMEOUT_SECONDS`
 
 **What:** Per-request HTTP timeout. Veo videos can take 60–180 s each.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.6.0a2"
+version = "0.6.0a3"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.6.0a2"
+__version__ = "0.6.0a3"

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -148,12 +148,24 @@ class FlowApiClient:
         # opening a second Playwright process against the same profile dir
         # (which would conflict on the Chromium lockfile — spec § 5.4.4).
         self._pw = await async_playwright().start()
+        # If the profile was captured with RealChromeStrategy, the marker file
+        # ".gflow_browser_strategy" contains "chrome". Use channel="chrome" so
+        # Playwright launches the same Chrome version that wrote the profile —
+        # opening a profile created by Chrome 130+ with an older bundled Chromium
+        # triggers a downgrade-cleanup that exits with code 33 (Access denied).
+        _strategy_file = self.profile_dir / ".gflow_browser_strategy"
+        _channel: str | None = None
+        if _strategy_file.exists() and _strategy_file.read_text(encoding="utf-8").strip() == "chrome":
+            from gflow_cli.browser_manager import is_chrome_available
+            if is_chrome_available():
+                _channel = "chrome"
         self._context = await self._pw.chromium.launch_persistent_context(
             user_data_dir=str(self.profile_dir),
             headless=self.headless,
             viewport={"width": 1280, "height": 720},
             locale="en-US",
             extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
+            channel=_channel,
         )
         # Open ``Settings.concurrency`` Pages inside the one persistent
         # BrowserContext. ``launch_persistent_context`` opens one Page by

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -148,24 +148,14 @@ class FlowApiClient:
         # opening a second Playwright process against the same profile dir
         # (which would conflict on the Chromium lockfile — spec § 5.4.4).
         self._pw = await async_playwright().start()
-        # If the profile was captured with RealChromeStrategy, the marker file
-        # ".gflow_browser_strategy" contains "chrome". Use channel="chrome" so
-        # Playwright launches the same Chrome version that wrote the profile —
-        # opening a profile created by Chrome 130+ with an older bundled Chromium
-        # triggers a downgrade-cleanup that exits with code 33 (Access denied).
-        _strategy_file = self.profile_dir / ".gflow_browser_strategy"
-        _channel: str | None = None
-        if _strategy_file.exists() and _strategy_file.read_text(encoding="utf-8").strip() == "chrome":
-            from gflow_cli.browser_manager import is_chrome_available
-            if is_chrome_available():
-                _channel = "chrome"
+        from gflow_cli.browser_manager import channel_for_profile
         self._context = await self._pw.chromium.launch_persistent_context(
             user_data_dir=str(self.profile_dir),
             headless=self.headless,
             viewport={"width": 1280, "height": 720},
             locale="en-US",
             extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
-            channel=_channel,
+            channel=channel_for_profile(self.profile_dir),
         )
         # Open ``Settings.concurrency`` Pages inside the one persistent
         # BrowserContext. ``launch_persistent_context`` opens one Page by

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -208,22 +208,13 @@ class UiAutomationTransport:
         pw_cm = async_playwright()
         pw = await pw_cm.__aenter__()
         try:
-            # Mirror FlowApiClient channel-detection: if the profile was created
-            # by RealChromeStrategy, use channel="chrome" to match the Chrome
-            # version that wrote it (older bundled Chromium triggers a downgrade
-            # exit-33 / access-denied when opening a Chrome 130+ profile).
-            _strategy_file = profile_dir / ".gflow_browser_strategy"
-            _channel: str | None = None
-            if _strategy_file.exists() and _strategy_file.read_text(encoding="utf-8").strip() == "chrome":
-                from gflow_cli.browser_manager import is_chrome_available  # noqa: PLC0415
-                if is_chrome_available():
-                    _channel = "chrome"
+            from gflow_cli.browser_manager import channel_for_profile  # noqa: PLC0415
             ctx = await pw.chromium.launch_persistent_context(
                 str(profile_dir),
                 headless=False,
                 viewport=cast("ViewportSize", _VIEWPORT),
                 locale="en-US",
-                channel=_channel,
+                channel=channel_for_profile(profile_dir),
             )
             self._pw_cm = pw_cm
             self._ctx = ctx

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -208,11 +208,22 @@ class UiAutomationTransport:
         pw_cm = async_playwright()
         pw = await pw_cm.__aenter__()
         try:
+            # Mirror FlowApiClient channel-detection: if the profile was created
+            # by RealChromeStrategy, use channel="chrome" to match the Chrome
+            # version that wrote it (older bundled Chromium triggers a downgrade
+            # exit-33 / access-denied when opening a Chrome 130+ profile).
+            _strategy_file = profile_dir / ".gflow_browser_strategy"
+            _channel: str | None = None
+            if _strategy_file.exists() and _strategy_file.read_text(encoding="utf-8").strip() == "chrome":
+                from gflow_cli.browser_manager import is_chrome_available  # noqa: PLC0415
+                if is_chrome_available():
+                    _channel = "chrome"
             ctx = await pw.chromium.launch_persistent_context(
                 str(profile_dir),
                 headless=False,
                 viewport=cast("ViewportSize", _VIEWPORT),
                 locale="en-US",
+                channel=_channel,
             )
             self._pw_cm = pw_cm
             self._ctx = ctx

--- a/src/gflow_cli/auth/__init__.py
+++ b/src/gflow_cli/auth/__init__.py
@@ -61,7 +61,11 @@ def status(name: str = "default") -> dict[str, object]:
     """Lightweight check — does the profile dir exist and have cookies file?"""
     pdir = profile_dir(name)
     cookies_file: Path | None = None
-    for candidate in (pdir / "Default" / "Cookies", pdir / "Cookies"):
+    for candidate in (
+        pdir / "Default" / "Network" / "Cookies",  # Chrome 130+ (new location)
+        pdir / "Default" / "Cookies",               # Chrome < 130 / legacy
+        pdir / "Cookies",                           # Playwright bundled Chromium
+    ):
         if candidate.exists():
             cookies_file = candidate
             break

--- a/src/gflow_cli/auth/factory.py
+++ b/src/gflow_cli/auth/factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import structlog
 
+from gflow_cli.config import get_settings
 from gflow_cli.errors import ConfigurationError
 
 from .base import AuthStrategy
@@ -22,28 +23,30 @@ class AuthStrategyFactory:
 
     def create(self, mode: str) -> AuthStrategy:
         """Create an authentication strategy based on the requested mode and system state."""
+        timeout = get_settings().auth_login_timeout
         # T2.4: auto mode probes for Real Chrome; falls back to internal if missing.
         if mode == "auto":
             if self._is_chrome_available():
-                return RealChromeStrategy()
+                return RealChromeStrategy(timeout_seconds=timeout)
             logger.warning(
                 "chrome_missing_falling_back_to_internal",
                 reason="Google Chrome was not detected on this system.",
             )
-            return InternalChromiumStrategy()
+            return InternalChromiumStrategy(timeout_seconds=timeout)
 
-        strategy_cls = self._strategies.get(mode)
-        if not strategy_cls:
+        if mode not in self._strategies:
             raise ConfigurationError(
                 f"Unknown auth browser mode '{mode}'. Supported: auto, chrome, internal."
             )
 
-        if mode == "chrome" and not self._is_chrome_available():
-            raise ConfigurationError(
-                "Chrome binary not found. Install Google Chrome or use '--browser internal'."
-            )
+        if mode == "chrome":
+            if not self._is_chrome_available():
+                raise ConfigurationError(
+                    "Chrome binary not found. Install Google Chrome or use '--browser internal'."
+                )
+            return RealChromeStrategy(timeout_seconds=timeout)
 
-        return strategy_cls()
+        return InternalChromiumStrategy(timeout_seconds=timeout)
 
     def _is_chrome_available(self) -> bool:
         """Probe for Real Chrome via browser_manager or Playwright."""

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 import structlog
 from rich.console import Console
 
-from gflow_cli.errors import AuthLoginTimeoutError
+from gflow_cli.config import get_settings
+from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
 
 from .base import AuthStrategy
 
@@ -34,6 +35,15 @@ class InternalChromiumStrategy(AuthStrategy):
 
     async def login(self, profile_dir: Path, headless: bool) -> None:
         """Execute the login flow using internal Chromium."""
+        settings = get_settings()
+        try:
+            profile_dir.resolve(strict=False).relative_to(settings.home.resolve())
+        except ValueError:
+            raise SecurityError(
+                f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME "
+                f"({settings.home}) boundaries."
+            ) from None
+
         # Deferred import to avoid circular dependency and support test patching
         from .strategies import async_playwright
 
@@ -60,6 +70,7 @@ class InternalChromiumStrategy(AuthStrategy):
 
                 # Polling for success (SAPISID cookie + UI signal).
                 timeout_at = asyncio.get_running_loop().time() + self._timeout_seconds
+                success = False
 
                 while asyncio.get_running_loop().time() < timeout_at:
                     try:
@@ -73,9 +84,10 @@ class InternalChromiumStrategy(AuthStrategy):
                                 or await page.get_by_text("Your projects").is_visible()
                             ):
                                 logger.info("auth_login_success_detected", strategy=self.name)
+                                success = True
                                 break
                     except Exception:
-                        # If browser is closed or context is gone, exit loop
+                        # Browser or context is gone — exit loop without success
                         break
 
                     await asyncio.sleep(1)
@@ -84,8 +96,17 @@ class InternalChromiumStrategy(AuthStrategy):
                         f"Sign-in not completed within {self._timeout_seconds}s.",
                         remediation_hint=(
                             "Run `gflow auth login` again and complete sign-in promptly. "
-                            f"Set GFLOW_CLI_AUTH_TIMEOUT to a higher value if needed "
+                            f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to a higher value if needed "
                             f"(current: {self._timeout_seconds}s)."
+                        ),
+                    )
+
+                if not success:
+                    raise AuthLoginTimeoutError(
+                        "Browser closed before authentication was verified.",
+                        remediation_hint=(
+                            "Complete the full sign-in flow before closing the browser. "
+                            "Run `gflow auth login` to try again."
                         ),
                     )
 

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -10,7 +10,7 @@ import structlog
 from rich.console import Console
 
 from gflow_cli.config import get_settings
-from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
+from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
 
 from .base import AuthStrategy
 
@@ -68,7 +68,7 @@ class RealChromeStrategy(AuthStrategy):
         """Execute the login flow using Passive Capture on Real Chrome."""
         settings = get_settings()
         try:
-            profile_dir.relative_to(settings.home)
+            profile_dir.resolve(strict=False).relative_to(settings.home.resolve())
         except ValueError:
             raise SecurityError(
                 f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME "
@@ -134,10 +134,10 @@ class RealChromeStrategy(AuthStrategy):
             except subprocess.TimeoutExpired:
                 proc.kill()
             raise AuthLoginTimeoutError(
-                f"Sign-in not completed within {self._timeout_seconds}s; Chrome was closed.",
+                f"Sign-in timed out after {self._timeout_seconds}s; Chrome was stopped.",
                 remediation_hint=(
                     "Run `gflow auth login` again and complete sign-in before the time limit. "
-                    f"Set GFLOW_CLI_AUTH_TIMEOUT to raise the limit "
+                    f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to raise the limit "
                     f"(current: {self._timeout_seconds}s)."
                 ),
             ) from None
@@ -164,13 +164,11 @@ class RealChromeStrategy(AuthStrategy):
                     # Write strategy marker before any output that might fail on
                     # narrow Windows codepages — FlowApiClient reads this to select
                     # the matching Chrome channel for launch_persistent_context.
-                    (profile_dir / ".gflow_browser_strategy").write_text(
-                        "chrome", encoding="utf-8"
-                    )
+                    (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
                     _console.print("[green][OK] Session captured and verified.[/green]")
                 else:
                     logger.warning("auth_login_no_cookies", strategy=self.name)
-                    raise RuntimeError(
+                    raise AuthMissingError(
                         "No session cookies found after sign-in. "
                         "Did you complete the sign-in before closing Chrome?"
                     )

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -161,7 +161,13 @@ class RealChromeStrategy(AuthStrategy):
 
                 if has_sapisid:
                     logger.info("auth_login_success_verified", strategy=self.name)
-                    _console.print("[green]✓ Session captured and verified.[/green]")
+                    # Write strategy marker before any output that might fail on
+                    # narrow Windows codepages — FlowApiClient reads this to select
+                    # the matching Chrome channel for launch_persistent_context.
+                    (profile_dir / ".gflow_browser_strategy").write_text(
+                        "chrome", encoding="utf-8"
+                    )
+                    _console.print("[green][OK] Session captured and verified.[/green]")
                 else:
                     logger.warning("auth_login_no_cookies", strategy=self.name)
                     raise RuntimeError(

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -172,6 +172,40 @@ def is_chrome_available() -> bool:
         return False
 
 
+def channel_for_profile(profile_dir: Path) -> str | None:
+    """Return the Playwright channel to use for ``profile_dir``, or None.
+
+    Reads the ``.gflow_browser_strategy`` marker written by
+    :class:`~gflow_cli.auth.real_chrome.RealChromeStrategy`. When the marker
+    is ``"chrome"`` and system Chrome is available, returns ``"chrome"`` so
+    callers can pass it to ``launch_persistent_context(channel=...)`` —
+    avoiding the downgrade-cleanup exit-33 that occurs when Playwright's
+    bundled Chromium opens a profile created by Chrome 130+.
+
+    Logs a warning when the marker requests Chrome but Chrome is no longer
+    available, as the resulting launch against bundled Chromium will likely
+    fail with the same exit-33 error.
+    """
+    import structlog as _structlog
+
+    _log = _structlog.get_logger(__name__)
+    marker = profile_dir / ".gflow_browser_strategy"
+    if not marker.exists():
+        return None
+    strategy = marker.read_text(encoding="utf-8").strip()
+    if strategy != "chrome":
+        return None
+    if is_chrome_available():
+        return "chrome"
+    _log.warning(
+        "browser_manager.chrome_marker_but_unavailable",
+        profile_dir=str(profile_dir),
+        hint="Profile was captured with system Chrome but Chrome is not found. "
+        "Re-run `gflow auth login --browser chrome` after installing Chrome.",
+    )
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -129,6 +129,16 @@ class Settings(BaseSettings):
 
     # --- runtime ----------------------------------------------------------
     timeout_seconds: int = Field(default=600, ge=1, le=3600)
+    auth_login_timeout: int = Field(
+        default=600,
+        ge=1,
+        le=86400,
+        description=(
+            "Seconds to wait for the user to complete interactive sign-in. "
+            "Applies to both Real Chrome (Passive Capture) and Internal Chromium strategies. "
+            "Override via GFLOW_CLI_AUTH_LOGIN_TIMEOUT."
+        ),
+    )
     concurrency: int = Field(default=1, ge=1, le=16)
     headless: bool = Field(
         default=True,

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -270,7 +270,7 @@ class AuthLoginTimeoutError(GFlowError):
     _default_remediation = (
         "The sign-in was not completed within the allowed time. "
         "Run `gflow auth login` again and complete sign-in promptly. "
-        "Increase GFLOW_CLI_AUTH_TIMEOUT (seconds) if you need more time."
+        "Increase GFLOW_CLI_AUTH_LOGIN_TIMEOUT (seconds) if you need more time."
     )
 
 

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -171,7 +171,9 @@ class TestInternalChromiumStrategy:
     async def test_internal_chromium_standard_behavior(self, tmp_path: Path) -> None:
         """Verify Internal Chromium uses standard Playwright (no stealth flags)."""
         strategy = InternalChromiumStrategy()
-        profile_dir = tmp_path / "profile_internal"
+        gflow_home = tmp_path / "gflow_home"
+        gflow_home.mkdir()
+        profile_dir = gflow_home / "profile_internal"
 
         mock_success_loc = MagicMock()
         mock_success_loc.is_visible = AsyncMock(return_value=True)
@@ -196,9 +198,11 @@ class TestInternalChromiumStrategy:
         mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
 
         with (
+            patch("gflow_cli.auth.internal_chromium.get_settings") as mock_settings,
             patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
             patch("asyncio.sleep", AsyncMock()),
         ):
+            mock_settings.return_value.home = gflow_home
             await strategy.login(profile_dir, headless=False)
 
         _, kwargs = mock_launch_pctx.call_args
@@ -209,7 +213,9 @@ class TestInternalChromiumStrategy:
     async def test_internal_chromium_timeout_raises(self, tmp_path: Path) -> None:
         """Verify AuthLoginTimeoutError is raised when polling loop exceeds deadline."""
         strategy = InternalChromiumStrategy(timeout_seconds=0)
-        profile_dir = tmp_path / "profile_internal"
+        gflow_home = tmp_path / "gflow_home"
+        gflow_home.mkdir()
+        profile_dir = gflow_home / "profile_internal"
 
         mock_success_loc = MagicMock()
         mock_success_loc.is_visible = AsyncMock(return_value=False)
@@ -233,9 +239,11 @@ class TestInternalChromiumStrategy:
         mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
 
         with (
+            patch("gflow_cli.auth.internal_chromium.get_settings") as mock_settings,
             patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
             patch("asyncio.sleep", AsyncMock()),
         ):
+            mock_settings.return_value.home = gflow_home
             with pytest.raises(AuthLoginTimeoutError) as excinfo:
                 await strategy.login(profile_dir, headless=False)
 

--- a/tests/features/auth_login.feature
+++ b/tests/features/auth_login.feature
@@ -27,5 +27,5 @@ Feature: Auth Login via Real Chrome
     Given Chrome is NOT installed on the system
     And the profile root is empty
     When I run "gflow auth login --browser chrome"
-    Then the exit code is 1
+    Then the exit code is 11
     And the output contains "Chrome binary not found"

--- a/tests/features/test_auth_login_steps.py
+++ b/tests/features/test_auth_login_steps.py
@@ -109,6 +109,12 @@ def _check_exit_1(cli_result_holder: dict[str, Any]) -> None:
     assert result.exit_code == 1, result.output
 
 
+@then("the exit code is 11")
+def _check_exit_11(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == 11, result.output
+
+
 @then('the output contains "Launching real Chrome"')
 def _check_launching_chrome(cli_result_holder: dict[str, Any]) -> None:
     result = cli_result_holder["result"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -25,4 +25,4 @@ def test_imports_succeed() -> None:
     import gflow_cli.api.client  # noqa
     import gflow_cli.api.dto  # noqa
 
-    assert gflow_cli.__version__ == "0.5.0a1"
+    assert gflow_cli.__version__ == "0.6.0a3"


### PR DESCRIPTION
## Summary

Hardening release for **v0.6.0a3** — fixes council-review blocking findings on the Real Chrome auth strategy.

## Changes

### Auth hardening
- `GFLOW_CLI_AUTH_LOGIN_TIMEOUT` — new env var (default 600 s) wired end-to-end. Agents get exit code 12 on timeout instead of blocking forever.
- Privacy guard uses `.resolve(strict=False)` to block symlink/traversal bypass (was purely lexical)
- `InternalChromiumStrategy` false-success fixed — `success=False` tracking prevents exit 0 on browser crash
- Privacy guard added to `InternalChromiumStrategy` (was only in `RealChromeStrategy`)
- `RuntimeError` → `AuthMissingError` (exit 8) for browser-closed-without-cookies
- Misleading "Chrome was closed" message → "gflow timed out — Chrome was stopped"
- Remediation strings now reference `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`

### Windows compatibility (base)
- Chrome 130+ profile version mismatch handling
- CDP channel-for-profile helper refactored

### Docs
- `CONFIGURATION.md` — full entry for `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`
- `.env.template` — commented entry with agent usage hint

## Exit codes

| Code | Exception | Meaning |
|------|-----------|---------|
| 8 | `AuthMissingError` | Browser closed — no SAPISID found |
| 11 | `ConfigurationError` | Chrome not installed |
| 12 | `AuthLoginTimeoutError` | Login timed out |
| 13 | `SecurityError` | Profile path escapes home |

## Quality gates

```
525 passed, 2 skipped, 0 failed — ruff ✓ pyright 0 errors ✓
```
