### PR TITLE
fix(auth): guide rejected browser login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gflow auth login` now verifies a real Flow app session before reporting
   success — fixes issue #15, where a Google-only sign-in was wrongly accepted
   and later failed with HTTP 401.
+- **`gflow auth login --browser internal` now fails fast when Google rejects
+  Playwright's bundled Chromium**, returning `AuthBrowserRejectedError` exit
+  code 14 with guidance to rerun using real Chrome
+  (`gflow auth login --browser chrome`) or set
+  `GFLOW_CLI_AUTH_BROWSER=chrome`.
 
 ## [0.6.0a6] — 2026-05-17
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -421,6 +421,13 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `5`  | `ContentPolicyError`  | Flow rejected the prompt (200 + empty `media[]`) | Soften prompt wording                                      |
 | `6`  | `NetworkError`        | Network failure persisted across 3 attempts      | Check connectivity                                         |
 | `7`  | `WireFormatError`     | Unexpected response shape — Flow API changed     | File a bug (do NOT include captured tokens or signed URLs) |
+| `8`  | `AuthMissingError`    | Required auth credential is absent from profile   | `gflow auth login --profile <name>`                        |
+| `9`  | `TransportTimeoutError` | Browser/API operation exceeded its timeout      | Retry; raise the relevant timeout if needed                |
+| `10` | `WafRejectionError`   | Flow security layer rejected the request          | Change prompt/request and retry                            |
+| `11` | `ConfigurationError`  | Local configuration or browser mode is invalid    | Fix the option/env var shown in the error                  |
+| `12` | `AuthLoginTimeoutError` | Browser sign-in was not completed in time       | Re-run login or raise `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`       |
+| `13` | `SecurityError`       | Unsafe local profile or secret handling blocked   | Follow the error's safety guidance                         |
+| `14` | `AuthBrowserRejectedError` | Google rejected the login browser             | `gflow auth login --browser chrome`                        |
 | `130`| SIGINT                | User-interrupted (Ctrl-C)                        | —                                                          |
 
 All errors emit a structured `error_raised` event (or `error_unhandled` for
@@ -445,6 +452,12 @@ if [ "$rc" -ne 0 ]; then
     4|6) echo "Transient infra issue (rate limit / network) — try again later"; exit 1 ;;
     5)   echo "Content policy rejected the prompt — rewrite and retry"; exit 1 ;;
     7)   echo "Flow API shape changed — upgrade gflow-cli or file a bug"; exit 1 ;;
+    8)   echo "Auth profile is missing a required credential — run: gflow auth login"; exit 1 ;;
+    9|12) echo "Operation timed out — retry with a larger timeout if needed"; exit 1 ;;
+    10)  echo "Flow rejected the request — adjust the prompt/request and retry"; exit 1 ;;
+    11)  echo "Configuration error — fix the option or env var shown above"; exit 1 ;;
+    13)  echo "Security guard blocked unsafe local state — follow the error guidance"; exit 1 ;;
+    14)  echo "Google rejected the login browser — run: gflow auth login --browser chrome"; exit 1 ;;
     130) echo "Cancelled with Ctrl-C"; exit 130 ;;
     *)   echo "Unknown failure (exit $rc)"; exit 1 ;;
   esac

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -8,7 +8,7 @@ from playwright.async_api import Error as PlaywrightError
 from rich.console import Console
 
 from gflow_cli.config import get_settings
-from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
+from gflow_cli.errors import AuthBrowserRejectedError, AuthLoginTimeoutError, SecurityError
 
 from .base import AuthStrategy
 from .verification import SESSION_API_URL, FlowSessionOutcome, evaluate_session_response
@@ -17,6 +17,13 @@ logger = structlog.get_logger(__name__)
 _console = Console()
 
 GEMINI_URL = "https://labs.google/fx/tools/flow?hl=en"
+GOOGLE_REJECTED_BROWSER_ROUTE = "accounts.google.com/v3/signin/rejected"
+
+
+def _is_google_rejected_browser_page(page: object) -> bool:
+    """Return True when Google has already routed login to its rejection page."""
+    url = getattr(page, "url", "")
+    return isinstance(url, str) and GOOGLE_REJECTED_BROWSER_ROUTE in url
 
 
 class InternalChromiumStrategy(AuthStrategy):
@@ -75,6 +82,9 @@ class InternalChromiumStrategy(AuthStrategy):
 
                 while asyncio.get_running_loop().time() < timeout_at:
                     try:
+                        if _is_google_rejected_browser_page(page):
+                            raise AuthBrowserRejectedError()
+
                         cookies = await ctx.cookies()
                         google_session = any(c.get("name") == "SAPISID" for c in cookies)
                         resp = await page.request.get(SESSION_API_URL, timeout=15_000)
@@ -94,6 +104,8 @@ class InternalChromiumStrategy(AuthStrategy):
                             success = True
                             break
                     except asyncio.CancelledError:
+                        raise
+                    except AuthBrowserRejectedError:
                         raise
                     except PlaywrightError:
                         # Browser / page / context closed — stop polling.

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -296,10 +296,23 @@ class AuthLoginTimeoutError(GFlowError):
     )
 
 
+class AuthBrowserRejectedError(GFlowError):
+    """Raised when Google rejects the login browser before sign-in can complete."""
+
+    problem_type = "https://gflow-cli.dev/errors/auth-browser-rejected"
+    title = "Login browser rejected"
+    _default_remediation = (
+        "Google rejected Playwright's bundled Chromium as an insecure browser. "
+        "Install Google Chrome and rerun `gflow auth login --browser chrome`, "
+        "or set GFLOW_CLI_AUTH_BROWSER=chrome so future logins use real Chrome."
+    )
+
+
 # EXIT_CODE_MAP — most-specific class FIRST per isinstance walk semantics.
 # Subclasses inherit their parent's exit code if they don't have their own
 # entry. New entries MUST go BEFORE their parent class in this dict.
 EXIT_CODE_MAP: dict[type[GFlowError], int] = {
+    AuthBrowserRejectedError: 14,
     AuthLoginTimeoutError: 12,
     SecurityError: 13,
     AuthMissingError: 8,

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -8,7 +8,12 @@ import pytest
 from gflow_cli.auth.real_chrome import _UNVERIFIED_HINT, _UNVERIFIED_MESSAGE, GEMINI_URL
 from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
 from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
-from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
+from gflow_cli.errors import (
+    AuthBrowserRejectedError,
+    AuthLoginTimeoutError,
+    AuthMissingError,
+    SecurityError,
+)
 
 
 def _status(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessionStatus:
@@ -291,4 +296,50 @@ class TestInternalChromiumStrategy:
                 await strategy.login(profile_dir, headless=False)
 
         assert "0s" in str(excinfo.value)
+        mock_ctx.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_internal_chromium_rejected_browser_raises_guidance(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Google's rejected-browser page should fail fast with Chrome guidance."""
+        strategy = InternalChromiumStrategy(timeout_seconds=600)
+        gflow_home = tmp_path / "gflow_home"
+        gflow_home.mkdir()
+        profile_dir = gflow_home / "profile_internal"
+
+        mock_success_loc = MagicMock()
+        mock_success_loc.is_visible = AsyncMock(return_value=False)
+
+        mock_page = MagicMock(name="page")
+        mock_page.url = "https://accounts.google.com/v3/signin/rejected?continue=flow"
+        mock_page.goto = AsyncMock()
+        mock_page.get_by_text.return_value = mock_success_loc
+
+        mock_ctx = MagicMock(name="ctx")
+        mock_ctx.pages = [mock_page]
+        mock_ctx.cookies = AsyncMock(return_value=[])
+        mock_ctx.close = AsyncMock()
+        mock_ctx.new_page = AsyncMock(return_value=mock_page)
+
+        mock_pw_obj = MagicMock(name="pw")
+        mock_pw_obj.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
+
+        mock_cm = MagicMock(name="cm")
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
+
+        with (
+            patch("gflow_cli.auth.internal_chromium.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(AuthBrowserRejectedError) as excinfo:
+                await strategy.login(profile_dir, headless=False)
+
+        assert "--browser chrome" in excinfo.value.remediation_hint
+        assert "GFLOW_CLI_AUTH_BROWSER=chrome" in excinfo.value.remediation_hint
         mock_ctx.close.assert_called_once()

--- a/tests/cli/test_error_handling.py
+++ b/tests/cli/test_error_handling.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from gflow_cli.cli import main
 from gflow_cli.errors import (
+    AuthBrowserRejectedError,
     AuthExpiredError,
     AuthLoginTimeoutError,
     ContentPolicyError,
@@ -341,8 +342,14 @@ class TestAuthLoginErrors:
         """Invoke `gflow auth login` with asyncio.run mocked to raise *error*."""
         from unittest.mock import patch
 
+        def _raise_and_close(awaitable: object) -> None:
+            close = getattr(awaitable, "close", None)
+            if callable(close):
+                close()
+            raise error
+
         runner = CliRunner()
-        with patch("gflow_cli.cli.asyncio.run", side_effect=error):
+        with patch("gflow_cli.cli.asyncio.run", side_effect=_raise_and_close):
             return runner.invoke(
                 main, ["auth", "login", "--browser", "internal", "--profile", "test"]
             )
@@ -379,4 +386,13 @@ class TestAuthLoginErrors:
 
         result = self._invoke_auth_login(ConfigurationError("unknown browser mode"))
         assert result.exit_code == 11, result.output
+        assert "Session saved" not in result.output
+
+    def test_browser_rejected_exits_14_with_chrome_guidance(self) -> None:
+        """AuthBrowserRejectedError points users at real Chrome instead of another retry."""
+        result = self._invoke_auth_login(AuthBrowserRejectedError())
+        assert result.exit_code == 14, result.output
+        assert "Login browser rejected" in result.output
+        assert "--browser chrome" in result.output
+        assert "GFLOW_CLI_AUTH_BROWSER=chrome" in result.output
         assert "Session saved" not in result.output

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ import pytest
 
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
+    AuthBrowserRejectedError,
     AuthExpiredError,
     AuthMissingError,
     ConfigurationError,
@@ -106,6 +107,10 @@ def test_to_problem_details_table(exc_cls, kwargs, expect_keys, expect_absent, e
 
 def test_problem_type_uris_stable():
     """Lock the URIs — they're greppable identifiers in production logs."""
+    assert (
+        AuthBrowserRejectedError.problem_type
+        == "https://gflow-cli.dev/errors/auth-browser-rejected"
+    )
     assert AuthExpiredError.problem_type == "https://gflow-cli.dev/errors/auth-expired"
     assert RateLimitError.problem_type == "https://gflow-cli.dev/errors/rate-limit"
     assert ContentPolicyError.problem_type == "https://gflow-cli.dev/errors/content-policy"
@@ -138,6 +143,7 @@ def test_exit_code_map_synthetic_subclass_inherits_parent_code():
     "exc_cls, expected_code",
     [
         (AuthExpiredError, 3),
+        (AuthBrowserRejectedError, 14),
         (RateLimitError, 4),
         (ContentPolicyError, 5),
         (NetworkError, 6),


### PR DESCRIPTION
## Summary

- detect Google's `accounts.google.com/v3/signin/rejected` route during the internal Chromium login polling loop
- raise `AuthBrowserRejectedError` with exit code 14 and guidance to rerun with real Chrome
- document the new exit code and cover the strategy, CLI output, and error metadata with tests

Fixes #5.

## Validation

- `uv run pytest tests/auth/strategies/test_strategies.py::TestInternalChromiumStrategy::test_internal_chromium_rejected_browser_raises_guidance tests/test_errors.py::test_problem_type_uris_stable tests/test_errors.py::test_exit_code_map_per_class tests/cli/test_error_handling.py::TestAuthLoginErrors::test_browser_rejected_exits_14_with_chrome_guidance -q` - 9 passed
- `uv run python scripts/ci/check_repo_hygiene.py` - passed
- `uv run ruff check src tests` - passed
- `uv run ruff format --check src tests` - passed
- `uv run pyright src` - 0 errors
- `uv run pytest -q --cov=gflow_cli` - 587 passed, 13 skipped, 1 xfailed; 88% coverage
- `git diff --check` - passed
- `git diff | gitleaks stdin --no-banner --redact` - no leaks found
- `git diff --cached --check` - passed
- `git diff --cached | gitleaks stdin --no-banner --redact` - no leaks found

## Notes

- I did not run a live Google/Flow login; the regression is covered with mocked Playwright tests.
- `markdownlint-cli2 CHANGELOG.md docs/USAGE.md` was not run because `markdownlint-cli2` is not installed on PATH here.
- AI assistance was used; I reviewed the diff and ran the validation above.
