### PR TITLE
feat(api): downstream integration ergonomics (issue #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `gflow_cli.exceptions` module as a standard alias for `gflow_cli.errors` — both module names resolve identically.
+- `FlowApiClient.health_check()` async method — returns `True` if browser context is alive and on a Google domain; safe to call from long-lived workers without try/except.
+
+### Changed
+
+- `FlowApiClient.generate_image()` and `generate_images_batch()`: `project_id` is now optional (`str | None = None`). When omitted, a new Flow project is created automatically. Existing callers passing an explicit `project_id` are unaffected.
+
 ## [0.6.0a6] — 2026-05-17
 
 > **Stability & code-quality release.** Fixes a concurrency bug in image

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,6 +185,7 @@ src/gflow_cli/
 
 - **Target DDD names** (not yet implemented): `RateLimitExceededError`, `QuotaExhaustedError`, `InvalidPromptError`, `ProjectNotFoundError`, `JobNotFoundError`, `ProviderUnavailableError`.
 - **Current Phase 4 classes** (shipped in v0.4.0a2, see `gflow_cli.errors`): `AuthExpiredError`, `RateLimitError`, `ContentPolicyError`, `NetworkError`, `WireFormatError`. All inherit from `FlowApiError → GFlowError`; `EXIT_CODE_MAP` walks them in subclass-first order so `except FlowApiError` still catches every typed leaf. Per-class exit codes: 3 (auth), 4 (rate-limit), 5 (content-policy), 6 (network), 7 (wire-format).
+- **Module alias:** `gflow_cli.exceptions` is a complete re-export of `gflow_cli.errors`. Both module paths resolve to identical class objects. The alias exists so downstream integrators can use the conventional `exceptions` name without a special import path.
 
 ## CQRS
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,6 +39,8 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 **"How does the layered structure work?"** → [ARCHITECTURE § Layers](ARCHITECTURE.md#layers)
 **"What env var should I set for X?"** → [CONFIGURATION § Reference](CONFIGURATION.md#reference)
 **"How do I report a security issue?"** → [SECURITY § Reporting](SECURITY.md#reporting)
+**"How do I embed FlowApiClient in a long-lived worker / service?"** → [USER_GUIDE § Journey 14](USER_GUIDE.md#journey-14--embedding-flowapiclient-in-a-long-lived-worker)
+**"What's the standard way to import gflow errors in my code?"** → [USAGE § Programmatic use](USAGE.md#programmatic-use)
 
 ## Documentation governance
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -455,32 +455,73 @@ fi
 
 ## Programmatic use
 
-The CLI is a thin shell over `gflow_cli.api.client.FlowApiClient`. All public methods used by the commands above are also available directly:
+The CLI is a thin shell over `gflow_cli.api.client.FlowApiClient`. All public methods used by the commands above are also available directly.
+
+### Importing errors
+
+Two module paths resolve to the same error classes. Use whichever feels natural for your codebase:
+
+```python
+from gflow_cli.errors import GFlowError, AuthExpiredError   # canonical
+from gflow_cli.exceptions import GFlowError, AuthExpiredError  # standard alias
+```
+
+Both are identical objects — `gflow_cli.exceptions` is a re-export of `gflow_cli.errors`. The alias exists because many developers and tools expect the conventional `exceptions` name.
+
+### Single-shot generation
 
 ```python
 import asyncio
 from pathlib import Path
 from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.image import GenerateImageRequest, Model, Aspect
 from gflow_cli.config import get_settings
 
 async def main() -> None:
     settings = get_settings()
     profile_dir = settings.profile_subdir("default")
     async with FlowApiClient(profile_dir=profile_dir, headless=settings.headless) as client:
-        project = await client.create_project(title="archive demo")
-        asset = await client.upload_image(project.project_id, Path("hero.png"))
-        # ... do work with project.project_id and asset.name ...
-        # Each uploaded asset and each generated media item has its own
-        # workflow_id — pass that to archive_workflow when you're done:
-        await client.archive_workflow(
-            workflow_id=asset.workflow_id,
-            project_id=project.project_id,
-        )
+        req = GenerateImageRequest(prompt="a peaceful lake at dawn", model=Model.IMAGE4)
+        # project_id is optional — omit it and a new project is created automatically.
+        image = await client.generate_image(req=req)
+        await client.download_image(image, Path("lake.png"))
 
 asyncio.run(main())
 ```
 
+`project_id` defaults to `None`. When omitted, `generate_image()` (and `generate_images_batch()`) call `create_project()` internally. Pass an explicit `project_id` when you want multiple generations to land in the same Flow project.
+
+### Archive / cleanup
+
+```python
+async with FlowApiClient(profile_dir=profile_dir) as client:
+    project = await client.create_project(title="archive demo")
+    asset = await client.upload_image(project.project_id, Path("hero.png"))
+    # Each uploaded asset and each generated media item has its own workflow_id.
+    await client.archive_workflow(
+        workflow_id=asset.workflow_id,
+        project_id=project.project_id,
+    )
+```
+
 `FlowApiClient.archive_workflow(workflow_id, project_id)` issues `PATCH /v1/flowWorkflows/{id}` to soft-delete a workflow. Useful in batch scripts that spin up a project per call and want to clean up afterwards. `workflow_id` comes from any `AssetInfo` (`upload_image` return) or `VideoOperation` / `VideoStatus` / `ImageResult` (generation returns) — `ProjectInfo` itself only carries `project_id` and `title`.
+
+### Health check (long-lived workers)
+
+For worker processes that hold a `FlowApiClient` open across many requests, call `health_check()` before dispatching to detect a dead browser context without catching exceptions yourself:
+
+```python
+async with FlowApiClient(profile_dir=profile_dir) as client:
+    while True:
+        job = await queue.get()
+        if not await client.health_check():
+            # browser context is dead — re-enter or restart the worker
+            break
+        image = await client.generate_image(req=job.req)
+        await handle_result(image)
+```
+
+`health_check()` returns `True` if the underlying Playwright page is alive and the current URL is on a Google domain. It returns `False` (never raises) on `TargetClosedError` or any other exception.
 
 ## See also
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -774,6 +774,93 @@ Full exit-code table with shell-script branching examples: [USAGE § Exit codes]
 
 ---
 
+## Journey 14 — Embedding `FlowApiClient` in a long-lived worker
+
+**Goal:** run `FlowApiClient` inside a service or background worker that handles many jobs over its lifetime without restarting the browser between calls.
+
+### 14.1 The minimal worker loop
+
+```python
+import asyncio
+from pathlib import Path
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.image import GenerateImageRequest, Model
+from gflow_cli.exceptions import GFlowError   # standard alias for gflow_cli.errors
+from gflow_cli.config import get_settings
+
+async def worker(job_queue: asyncio.Queue) -> None:
+    settings = get_settings()
+    profile_dir = settings.profile_subdir("default")
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=True) as client:
+        while True:
+            job = await job_queue.get()
+            if job is None:
+                break  # poison pill — graceful shutdown
+
+            if not await client.health_check():
+                # Browser context died (OS killed the process, GPU crash, etc.)
+                # Re-raise so the supervisor can restart this worker.
+                raise RuntimeError("FlowApiClient health check failed — browser context dead")
+
+            try:
+                image = await client.generate_image(req=job.req)
+                # project_id omitted → a new Flow project is created automatically
+                await client.download_image(image, job.out_path)
+                job.result_queue.put_nowait(image)
+            except GFlowError as exc:
+                job.result_queue.put_nowait(exc)
+```
+
+Key points:
+- `health_check()` is a cheap liveness probe. Call it before every dispatch — it returns `False` (never raises) so you can branch without try/except.
+- `project_id` is omitted from `generate_image()`. Each job gets its own auto-created Flow project, which matches Flow's one-project-per-generation model.
+- Import from `gflow_cli.exceptions` or `gflow_cli.errors` — both resolve to identical classes.
+
+### 14.2 Catching typed errors in a worker
+
+All gflow errors inherit from `GFlowError`. Use `EXIT_CODE_MAP` to get the canonical exit code for any error class — useful for reporting or retry decisions:
+
+```python
+from gflow_cli.exceptions import GFlowError, AuthExpiredError, RateLimitError
+from gflow_cli.errors import EXIT_CODE_MAP
+
+try:
+    image = await client.generate_image(req=req)
+except AuthExpiredError:
+    # Exit code 3 — session expired; re-authenticate and retry
+    await re_login(profile_dir)
+except RateLimitError as exc:
+    # Exit code 4 — back off by exc.retry_after seconds (or a safe default)
+    await asyncio.sleep(exc.retry_after or 60)
+except GFlowError as exc:
+    code = EXIT_CODE_MAP.get(type(exc), 1)
+    logger.error("generation_failed", error_class=type(exc).__name__, exit_code=code)
+```
+
+### 14.3 Checking health after a long idle period
+
+A browser context that was idle for several minutes may have its page navigated away by a background Flow JS update. `health_check()` confirms the page is still on a Google domain before trusting the session:
+
+```python
+IDLE_THRESHOLD = 300  # seconds
+
+last_used = time.monotonic()
+
+async def dispatch(client: FlowApiClient, req: GenerateImageRequest) -> ...:
+    if time.monotonic() - last_used > IDLE_THRESHOLD:
+        if not await client.health_check():
+            raise RuntimeError("session lost after idle — restart worker")
+    ...
+```
+
+### 14.4 What `health_check()` does NOT cover
+
+- It does **not** verify that the Google session (cookies) is still valid. A page can be alive and on `labs.google` with an expired session cookie — the next API call will raise `AuthExpiredError` (exit 3).
+- It does **not** refresh the session. On `False`, restart the worker and re-enter `async with FlowApiClient(...)`.
+
+---
+
 ## See also
 
 - [USAGE.md](USAGE.md) — every flag, every output path, every command in alphabetical order.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -823,6 +823,7 @@ class FlowApiClient:
             finally:
                 self._checkin_page(page)
         except Exception:
+            logger.debug("health_check_failed", exc_info=True)
             return False
 
 

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -694,7 +694,7 @@ class FlowApiClient:
     async def generate_image(
         self,
         *,
-        project_id: str,
+        project_id: str | None = None,
         req: GenerateImageRequest,
         seed: int | None = None,
         recaptcha_action: str = "imageGeneration",
@@ -708,12 +708,22 @@ class FlowApiClient:
         (see ``generate_images_batch``); this method always returns the FIRST
         media item.
 
+        When ``project_id`` is ``None``, a new Flow project is created
+        automatically via :meth:`create_project`.  Existing callers that supply
+        an explicit ``project_id`` are unaffected.
+
         Idempotency: calling twice with the same ``seed`` and ``batch_id``
         yields identical bodies modulo the per-call reCAPTCHA token AND the
         per-attempt session-id timestamp.
         """
+        resolved_project_id: str
+        if project_id is None:
+            project = await self.create_project()
+            resolved_project_id = project.project_id
+        else:
+            resolved_project_id = project_id
         return await self._drive_image_generation(
-            project_id=project_id,
+            project_id=resolved_project_id,
             req=req,
             seed=seed if seed is not None else secrets.randbelow(2**31),
             batch_id=batch_id or _new_batch_id(),
@@ -723,7 +733,7 @@ class FlowApiClient:
     async def generate_images_batch(
         self,
         *,
-        project_id: str,
+        project_id: str | None = None,
         req: GenerateImageRequest,
         count: int = 1,
         seeds: Sequence[int] | None = None,
@@ -739,7 +749,8 @@ class FlowApiClient:
         concurrently — one per Page.
 
         Args:
-            project_id: Flow project ID.
+            project_id: Flow project ID.  When ``None``, a new project is
+                created automatically via :meth:`create_project`.
             req: Shared request (prompt, aspect, reference image, ...).
             count: How many images to generate. Must be 1..4 (Flow UI cap).
             seeds: Optional explicit seeds. Defaults to ``count`` random
@@ -768,6 +779,14 @@ class FlowApiClient:
         else:
             seeds_list = list(seeds)
 
+        # Resolve project_id once — do NOT create N projects for N parallel shots.
+        resolved_project_id: str
+        if project_id is None:
+            project = await self.create_project()
+            resolved_project_id = project.project_id
+        else:
+            resolved_project_id = project_id
+
         shared_batch_id = _new_batch_id()
 
         # asyncio.gather preserves input order in its result list, so the
@@ -776,7 +795,7 @@ class FlowApiClient:
         return await asyncio.gather(
             *(
                 self._drive_image_generation(
-                    project_id=project_id,
+                    project_id=resolved_project_id,
                     req=req,
                     seed=s,
                     batch_id=shared_batch_id,
@@ -786,6 +805,25 @@ class FlowApiClient:
             ),
             return_exceptions=False,
         )
+
+    async def health_check(self) -> bool:
+        """Return True if the browser context is alive and on a Google domain.
+
+        Safe to call from long-lived workers. Returns False (never raises) on
+        TargetClosedError or any other exception so callers can branch without
+        try/except.
+        """
+        if self._page_queue is None:
+            return False
+        try:
+            page = await self._checkout_page()
+            try:
+                hostname: str = await page.evaluate("() => document.location.hostname")
+                return hostname.endswith(".google") or hostname == "google.com"
+            finally:
+                self._checkin_page(page)
+        except Exception:
+            return False
 
 
 def _default_project_title() -> str:

--- a/src/gflow_cli/api/transports/base.py
+++ b/src/gflow_cli/api/transports/base.py
@@ -48,7 +48,7 @@ class FlowTransportStrategy(Protocol):
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Send batchGenerateImages. recaptcha_token lives on `request` —

--- a/src/gflow_cli/api/transports/experimental/bearer.py
+++ b/src/gflow_cli/api/transports/experimental/bearer.py
@@ -258,7 +258,7 @@ class BearerTransport:
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Generate images via pure httpx, replaying the captured fingerprint.
@@ -266,6 +266,8 @@ class BearerTransport:
         Proactive refresh if token is near expiry; single-retry on 401.
         Raises ``TransportTimeoutError`` if the call hangs > PER_CALL_TIMEOUT_S.
         """
+        if project_id is None:
+            raise ValueError("BearerTransport requires an explicit project_id")
         if self._cached is None:
             raise AuthMissingError("bearer: setup() was not called before generate_images()")
 

--- a/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
+++ b/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
@@ -182,14 +182,20 @@ class EvaluateFetchTransport:
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Generate images via page.evaluate fetch.
 
         Enforces a 30 s wall-clock budget. On HTTP 401, calls refresh_auth()
         and retries exactly once; a second 401 raises AuthExpiredError.
+
+        ``project_id`` is required by this transport (used in the REST URL).
+        Pass ``None`` only via :class:`UiAutomationTransport`, which creates
+        its own project internally.
         """
+        if project_id is None:
+            raise ValueError("EvaluateFetchTransport requires an explicit project_id")
         return await self._generate_images_inner(
             project_id=project_id, request=request, is_retry=False
         )

--- a/src/gflow_cli/api/transports/experimental/sapisidhash.py
+++ b/src/gflow_cli/api/transports/experimental/sapisidhash.py
@@ -214,7 +214,7 @@ class SapisidhashTransport:
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Generate images via pure httpx, replaying SAPISID + fingerprint.
@@ -222,6 +222,8 @@ class SapisidhashTransport:
         Single-retry on 401 (SAPISID rotation); raises TransportTimeoutError
         if the call hangs beyond PER_CALL_TIMEOUT_S.
         """
+        if project_id is None:
+            raise ValueError("SapisidhashTransport requires an explicit project_id")
         if self._sapisid is None or self._profile_dir is None:
             raise AuthMissingError("sapisidhash: setup() was not called before generate_images()")
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -756,7 +756,7 @@ class UiAutomationTransport:
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Submit ``request.prompt`` through Flow's editor and return the

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -2,6 +2,24 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
+__all__ = [
+    "ProblemDetails",
+    "GFlowError",
+    "FlowApiError",
+    "AuthExpiredError",
+    "RateLimitError",
+    "ContentPolicyError",
+    "NetworkError",
+    "WireFormatError",
+    "TransportTimeoutError",
+    "WafRejectionError",
+    "ConfigurationError",
+    "SecurityError",
+    "AuthMissingError",
+    "AuthLoginTimeoutError",
+    "EXIT_CODE_MAP",
+]
+
 
 class ProblemDetails(TypedDict, total=False):
     """RFC 9457 Problem Details JSON shape (https://datatracker.ietf.org/doc/html/rfc9457).

--- a/src/gflow_cli/exceptions.py
+++ b/src/gflow_cli/exceptions.py
@@ -7,5 +7,18 @@ remains the canonical location.
 
 from __future__ import annotations
 
-from gflow_cli.errors import *  # noqa: F401, F403
-from gflow_cli.errors import __all__ as __all__  # re-export __all__
+from gflow_cli.errors import EXIT_CODE_MAP as EXIT_CODE_MAP
+from gflow_cli.errors import AuthExpiredError as AuthExpiredError
+from gflow_cli.errors import AuthLoginTimeoutError as AuthLoginTimeoutError
+from gflow_cli.errors import AuthMissingError as AuthMissingError
+from gflow_cli.errors import ConfigurationError as ConfigurationError
+from gflow_cli.errors import ContentPolicyError as ContentPolicyError
+from gflow_cli.errors import FlowApiError as FlowApiError
+from gflow_cli.errors import GFlowError as GFlowError
+from gflow_cli.errors import NetworkError as NetworkError
+from gflow_cli.errors import ProblemDetails as ProblemDetails
+from gflow_cli.errors import RateLimitError as RateLimitError
+from gflow_cli.errors import SecurityError as SecurityError
+from gflow_cli.errors import TransportTimeoutError as TransportTimeoutError
+from gflow_cli.errors import WafRejectionError as WafRejectionError
+from gflow_cli.errors import WireFormatError as WireFormatError

--- a/src/gflow_cli/exceptions.py
+++ b/src/gflow_cli/exceptions.py
@@ -1,0 +1,11 @@
+"""gflow_cli.exceptions — standard alias for gflow_cli.errors.
+
+Both module names resolve to the same set of public names.  Library
+consumers may use whichever feels more idiomatic; ``gflow_cli.errors``
+remains the canonical location.
+"""
+
+from __future__ import annotations
+
+from gflow_cli.errors import *  # noqa: F401, F403
+from gflow_cli.errors import __all__ as __all__  # re-export __all__

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -200,7 +200,7 @@ class _FakeTransport:
     async def refresh_auth(self) -> None:
         pass
 
-    async def generate_images(self, *, project_id: str, request: object) -> list[object]:
+    async def generate_images(self, *, project_id: str | None, request: object) -> list[object]:
         return []
 
     async def teardown(self) -> None:
@@ -291,7 +291,7 @@ async def test_client_delegates_image_gen_to_transport(
         dimensions=(512, 512),
     )
 
-    async def fake_gen(*, project_id: str, request: object) -> list[GeneratedImage]:
+    async def fake_gen(*, project_id: str | None, request: object) -> list[GeneratedImage]:
         assert project_id == "test-proj-xyz"
         assert isinstance(request, GenerateImageRequest)
         assert request.prompt == "delegated"

--- a/tests/api/test_client_image.py
+++ b/tests/api/test_client_image.py
@@ -90,7 +90,7 @@ class _FakeTransport:
     async def generate_images(
         self,
         *,
-        project_id: str,
+        project_id: str | None,
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         self.calls.append({"project_id": project_id, "request": request})
@@ -171,7 +171,7 @@ class TestGenerateImage:
 
         class _EmptyTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 return []
 
@@ -223,7 +223,7 @@ class TestGenerateImage:
 
         class _ErrorTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 raise FlowApiError(
                     400,
@@ -288,7 +288,7 @@ class TestGenerateImagesBatch:
 
         class _CountingTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 nonlocal call_count
                 call_count += 1
@@ -305,7 +305,7 @@ class TestGenerateImagesBatch:
 
         class _CountingTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 nonlocal call_count
                 call_count += 1
@@ -327,7 +327,7 @@ class TestGenerateImagesBatch:
 
         class _CountingTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 nonlocal call_count
                 call_count += 1
@@ -354,7 +354,7 @@ class TestGenerateImagesBatch:
 
         class _DelayedTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 nonlocal call_index
                 idx = call_index
@@ -392,7 +392,7 @@ class TestGenerateImagesBatch:
 
         class _FailingTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 nonlocal call_count
                 call_count += 1
@@ -736,7 +736,7 @@ class TestWireFormatDiscoveryAndRedaction:
 
         class _WireErrorTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 raise WireFormatError(
                     detail="non-JSON response",
@@ -778,7 +778,7 @@ class TestWireFormatDiscoveryAndRedaction:
 
         class _RedactedWireErrorTransport(_FakeTransport):
             async def generate_images(  # type: ignore[override]
-                self, *, project_id: str, request: GenerateImageRequest
+                self, *, project_id: str | None, request: GenerateImageRequest
             ) -> list[GeneratedImage]:
                 raise WireFormatError(
                     detail="non-JSON response",
@@ -807,3 +807,109 @@ class TestWireFormatDiscoveryAndRedaction:
         assert "SECRET-TOKEN-XYZ" not in body_prefix
         # And the redacted marker should be present.
         assert "<redacted>" in body_prefix
+
+
+class TestGenerateImageAutoCreateProject:
+    """When project_id is None, generate_image / generate_images_batch must
+    call create_project() once and use its project_id."""
+
+    async def test_generate_image_without_project_id_auto_creates_project(
+        self, tmp_path: Path
+    ) -> None:
+        """generate_image(req=...) with no project_id calls create_project once
+        and delegates to the transport with the resolved id."""
+        from gflow_cli.api.dto import ProjectInfo
+
+        fake_project = ProjectInfo(project_id="auto-proj-42", title="auto")
+        transport = _FakeTransport(images=[_FAKE_IMAGE])
+        client = _client_with_transport(tmp_path, transport)
+        client.create_project = AsyncMock(return_value=fake_project)  # type: ignore[method-assign]
+
+        result = await client.generate_image(req=_make_req())
+
+        client.create_project.assert_awaited_once()  # type: ignore[attr-defined]
+        assert result.fife_url == _FAKE_FIFE_URL
+        assert transport.calls[0]["project_id"] == "auto-proj-42"
+
+    async def test_generate_images_batch_without_project_id_auto_creates_project(
+        self, tmp_path: Path
+    ) -> None:
+        """generate_images_batch(req=..., count=2) with no project_id calls
+        create_project exactly once (not once per parallel shot)."""
+        from gflow_cli.api.dto import ProjectInfo
+
+        fake_project = ProjectInfo(project_id="auto-batch-proj", title="auto")
+        call_count = 0
+
+        class _CountingTransport(_FakeTransport):
+            async def generate_images(  # type: ignore[override]
+                self, *, project_id: str | None, request: GenerateImageRequest
+            ) -> list[GeneratedImage]:
+                nonlocal call_count
+                call_count += 1
+                return [_make_image_for_seed(call_count)]
+
+        transport = _CountingTransport()
+        client = _client_with_transport(tmp_path, transport)
+        client.create_project = AsyncMock(return_value=fake_project)  # type: ignore[method-assign]
+
+        results = await client.generate_images_batch(req=_make_req(), count=2)
+
+        # create_project called ONCE — not once per parallel shot.
+        client.create_project.assert_awaited_once()  # type: ignore[attr-defined]
+        assert len(results) == 2
+        for call in transport.calls:
+            assert call["project_id"] == "auto-batch-proj"
+
+
+class TestHealthCheck:
+    """FlowApiClient.health_check() contract tests."""
+
+    async def test_health_check_returns_false_when_not_entered(self, tmp_path: Path) -> None:
+        """Before entering the async context, _page_queue is None → False."""
+        client = FlowApiClient(profile_dir=tmp_path / "prof")
+        result = await client.health_check()
+        assert result is False
+
+    async def test_health_check_returns_true_on_google_domain(self, tmp_path: Path) -> None:
+        """A page whose document.location.hostname is a Google domain → True."""
+        transport = _FakeTransport()
+        client = _client_with_transport(tmp_path, transport)
+
+        # Simulate an open page queue with a fake page returning a Google hostname.
+        fake_page = MagicMock()
+        fake_page.evaluate = AsyncMock(return_value="labs.google")
+        client._page_queue = asyncio.Queue(maxsize=1)
+        client._page_queue.put_nowait(fake_page)
+
+        result = await client.health_check()
+
+        assert result is True
+
+    async def test_health_check_returns_false_on_non_google_domain(self, tmp_path: Path) -> None:
+        """A page whose hostname is not on google → False."""
+        transport = _FakeTransport()
+        client = _client_with_transport(tmp_path, transport)
+
+        fake_page = MagicMock()
+        fake_page.evaluate = AsyncMock(return_value="example.com")
+        client._page_queue = asyncio.Queue(maxsize=1)
+        client._page_queue.put_nowait(fake_page)
+
+        result = await client.health_check()
+
+        assert result is False
+
+    async def test_health_check_returns_false_on_evaluate_exception(self, tmp_path: Path) -> None:
+        """If page.evaluate raises (e.g. TargetClosedError) → False, never raises."""
+        transport = _FakeTransport()
+        client = _client_with_transport(tmp_path, transport)
+
+        fake_page = MagicMock()
+        fake_page.evaluate = AsyncMock(side_effect=RuntimeError("target closed"))
+        client._page_queue = asyncio.Queue(maxsize=1)
+        client._page_queue.put_nowait(fake_page)
+
+        result = await client.health_check()
+
+        assert result is False

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -311,3 +311,45 @@ async def test_e2e_30s_timeout_budget(
         )
     elapsed = time.monotonic() - start
     assert elapsed < 35.0, f"TransportTimeoutError must fire within 35 s; took {elapsed:.1f} s"
+
+
+# ---------------------------------------------------------------------------
+# Auto-create project_id (Issue #16 — optional project_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_generate_image_without_project_id(strategy: str) -> None:
+    """generate_image(req=req) without project_id auto-creates a project.
+
+    Confirms the auto-create path works end-to-end against the real Flow API.
+    """
+    profile = _profile_dir()
+    req = GenerateImageRequest(prompt=_PROMPT, model=Model.NARWHAL)
+
+    async with _make_client(strategy, profile) as client:
+        # Intentionally omit project_id — the client must create one internally.
+        image = await client.generate_image(req=req)
+
+    assert image.media_name, "media_name must be non-empty"
+    assert image.fife_url.startswith("https://"), (
+        f"fife_url must be an https:// URL, got: {image.fife_url!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# health_check() (Issue #16 — new method)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_health_check_returns_true_when_active(strategy: str) -> None:
+    """health_check() returns True for a live browser context on a Google domain."""
+    profile = _profile_dir()
+
+    async with _make_client(strategy, profile) as client:
+        result = await client.health_check()
+
+    assert result is True, "health_check() must return True for an active Google-domain page"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -302,3 +302,25 @@ def test_configuration_error_exit_code():
 def test_auth_missing_error_exit_code():
     err = AuthMissingError("SAPISID cookie missing in profile")
     assert _exit_code_for(err) == 8
+
+
+# ---------- gflow_cli.exceptions alias ----------
+
+
+def test_exceptions_module_is_alias_for_errors() -> None:
+    """gflow_cli.exceptions must re-export the same objects as gflow_cli.errors.
+
+    Both module names must resolve to identical class objects — ``is`` check
+    ensures no accidental duplicate-class creation (which would break
+    ``except GFlowError`` clauses imported from one module while the raise
+    site uses the other).
+    """
+    import gflow_cli.errors as _errors
+    import gflow_cli.exceptions as _exceptions
+
+    assert _exceptions.GFlowError is _errors.GFlowError
+    assert _exceptions.FlowApiError is _errors.FlowApiError
+    assert _exceptions.AuthExpiredError is _errors.AuthExpiredError
+    assert _exceptions.ContentPolicyError is _errors.ContentPolicyError
+    assert _exceptions.EXIT_CODE_MAP is _errors.EXIT_CODE_MAP
+    assert _exceptions.ProblemDetails is _errors.ProblemDetails


### PR DESCRIPTION
Resolves #16 — three downstream integration friction points identified during integration of `gflow-cli` into an external worker.

## Summary

- **`gflow_cli.exceptions` alias** — explicit per-name re-exports from `errors` using the `X as X` re-export pattern. Downstream code that expects `from gflow_cli.exceptions import GFlowError` now works without changes to the canonical `errors.py`.

- **`project_id` optional in `generate_image` / `generate_images_batch`** — both methods now accept `project_id: str | None = None`. When omitted, the client auto-calls `create_project()` internally. `UiAutomationTransport` callers no longer need to pass a dummy `""`.

- **`FlowApiClient.health_check()`** — new async method returning `True` when the browser context is alive and on a Google domain, `False` on any failure (including `TargetClosedError`). Safe to call from long-lived worker processes without try/except.

## Changes

| File | Change |
|---|---|
| `src/gflow_cli/exceptions.py` | New — explicit re-exports from `errors` |
| `src/gflow_cli/errors.py` | Added `__all__` |
| `src/gflow_cli/api/client.py` | `project_id` optional + `health_check()` |
| `src/gflow_cli/api/transports/base.py` | Protocol: `project_id: str \| None` |
| `src/gflow_cli/api/transports/ui_automation.py` | Signature updated to match Protocol |
| `src/gflow_cli/api/transports/experimental/{bearer,sapisidhash,evaluate_fetch}.py` | Signature updated |
| `tests/api/test_client_image.py` | 5 new unit tests (auto-create + health_check) |
| `tests/test_errors.py` | `exceptions` alias import test |
| `tests/e2e/test_transports_e2e.py` | 2 new e2e criteria (no project_id + health_check) |
| `docs/USAGE.md` | Programmatic use section rewritten |
| `docs/USER_GUIDE.md` | Journey 14 — long-lived worker embedding |
| `docs/ARCHITECTURE.md` | exceptions alias noted in domain errors section |
| `docs/INDEX.md` | Shortcut lines for Journey 14 |
| `CHANGELOG.md` | `[Unreleased]` entries |

## Test plan

- [x] `uv run pytest -q --cov=gflow_cli -m "not e2e"` — 588 passed, 87% coverage
- [x] `uv run pyright src` — 0 errors
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run python scripts/ci/check_repo_hygiene.py` — clean
- [ ] E2E: `test_e2e_generate_image_without_project_id` and `test_e2e_health_check_returns_true_when_active` require `GFLOW_CLI_E2E_PROFILE` — run on `develop` before merge to `main`

## Sonar

Two issues pre-empted before analysis ran:
- `python:S2208` wildcard import in `exceptions.py` → replaced with explicit `X as X` re-exports
- `python:S110` bare except without logging in `health_check()` → added `logger.debug("health_check_failed", exc_info=True)`

---
_Generated by [Claude Code](https://claude.ai/code/session_014ai2p6CF6q7AiVg6rFxaWB)_