### PR TITLE
docs: add DEVELOPMENT.md and fix stale test markers in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,18 @@ def test_parse_uuid_from_url(): ...
 @pytest.mark.integration       # Mocked HTTP, real Provider plumbing.
 async def test_upload_returns_asset(): ...
 
-@pytest.mark.live              # Hits the real Flow API. Requires GFLOW_LIVE=1 env var.
-# Note: the live-test gate is GFLOW_LIVE (deliberately short — not GFLOW_CLI_LIVE) so
-# you can opt in with a single export. Runtime config still uses the GFLOW_CLI_* prefix.
-@pytest.mark.skipif(not os.getenv("GFLOW_LIVE"), reason="live tests opt-in")
+@pytest.mark.e2e               # Hits the real Flow API. Requires GFLOW_CLI_E2E_PROFILE env var.
 async def test_full_i2v_roundtrip(): ...
 ```
 
-CI runs `unit` + `integration` on every push. `live` tests run only on the maintainer's machine, against the maintainer's own account, before tagging a release.
+CI runs `unit` + `integration` on every push. `e2e` tests require a live authenticated profile and are opt-in:
+
+```bash
+export GFLOW_CLI_E2E_PROFILE=<profile-name>   # name of a logged-in profile
+uv run pytest -m e2e -v
+```
+
+E2e tests spend real Veo/Imagen credits — run them on `develop` before opening a release PR to `main`. See [docs/DEVELOPMENT.md § E2e gate](docs/DEVELOPMENT.md#e2e-gate-before-merging-develop--main).
 
 ### Coverage targets
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,122 @@
+# Development Workflow
+
+> For _contributing_ (TDD, quality gates, commit style, how to add a route) see [CONTRIBUTING.md](../CONTRIBUTING.md).
+> This document covers the **internal development process**: branching model, PR protocol, e2e gate, and release pipeline.
+
+---
+
+## Branching model
+
+```
+feature/* ──┐
+fix/*       ├──► develop ──► main
+docs/*      ┘
+chore/*
+```
+
+| Branch | Purpose | Merges into |
+|---|---|---|
+| `main` | Stable releases only. Tagged. Published to PyPI. | — |
+| `develop` | Integration branch. E2e tests run here. | `main` (via release PR) |
+| `feature/*` | New capabilities. | `develop` |
+| `fix/*` | Bug fixes. | `develop` |
+| `docs/*` | Documentation only. | `develop` |
+| `chore/*` | Deps, CI, tooling, refactor. | `develop` |
+
+**Nothing merges directly to `main`.** All work flows through `develop` first.
+
+---
+
+## Branch naming
+
+```
+<type>/<short-kebab-description>
+<type>/issue-<N>-<short-kebab-description>   # when tracking a GitHub issue
+```
+
+Examples:
+
+```
+feature/issue-16-integration-ergonomics
+fix/issue-15-sapisidhash-uploadimage-401
+docs/dev-workflow-and-branching-protocol
+chore/bump-playwright-1-49
+```
+
+Types mirror Conventional Commits: `feature`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`.
+
+---
+
+## PR protocol
+
+### Opening a PR
+
+1. Branch off `develop` (not `main`).
+2. Use Conventional Commits for all commit messages.
+3. Open the PR as a **draft** until all quality gates pass locally.
+4. Target `develop` as the base branch.
+5. PR title follows Conventional Commits: `feat(api): ...`, `fix(cli): ...`, `docs: ...`.
+
+### Quality gates (all must pass before merge)
+
+```bash
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run pytest -q --cov=gflow_cli -m "not e2e"
+```
+
+CI runs the same five on every push. Do not bypass with `--no-verify`.
+
+### Merging feature PRs into develop
+
+- Squash merge preferred — keeps `develop` history linear.
+- The squash commit message becomes the canonical record; make it clean.
+- Delete the feature branch after merge.
+
+### E2e gate before merging develop → main
+
+E2e tests require a live authenticated profile and are **not run in CI** (they spend real Veo/Imagen credits). Before opening a `develop → main` release PR:
+
+```bash
+export GFLOW_CLI_E2E_PROFILE=<your-profile-name>
+uv run pytest -m e2e -v
+```
+
+All `@pytest.mark.e2e` scenarios must pass. See [CONTRIBUTING § E2e tests](../CONTRIBUTING.md#test-categories) for the full marker reference.
+
+---
+
+## Version bump protocol
+
+Version bumps belong in the **`develop → main` release PR**, not in feature PRs. The sequence:
+
+1. All feature PRs for a release batch are merged to `develop`.
+2. E2e gate passes on `develop`.
+3. Open a release PR: `develop → main`.
+4. In that PR, bump `version` in `pyproject.toml` and finalize `CHANGELOG.md [Unreleased]` → `[vX.Y.Z]`.
+5. Use the `/release` skill to automate steps 4 + tagging.
+6. Merge the release PR to `main` — CI publishes to PyPI automatically.
+
+**Alpha releases** use the form `vX.Y.ZaN` (e.g. `v0.6.0a7`). Ship alphas from `develop → main` to validate with real users before cutting a stable `vX.Y.Z`.
+
+---
+
+## AI-assisted development (Claude Code)
+
+This repo is actively developed with Claude Code (see [CLAUDE.md](../CLAUDE.md)). A few conventions that keep the workflow clean:
+
+- Claude branches are renamed to the appropriate `feature/`, `fix/`, `docs/` prefix before the PR is opened. The `claude/` prefix is internal scaffolding.
+- Claude never bumps the version or cuts a release without explicit instruction — use `/release`.
+- Claude opens PRs as **drafts** targeting `develop`. The maintainer reviews, runs e2e if needed, and merges.
+- Commit messages never carry `Co-Authored-By: Claude` or any AI attribution — author credit is the human maintainer's only.
+
+---
+
+## See also
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — TDD, quality gates, how to add a route, commit style
+- [RELEASE.md](../RELEASE.md) — release checklist, PyPI/GitHub publishing, tag protocol
+- [CHANGELOG.md](../CHANGELOG.md) — version history
+- [CLAUDE.md](../CLAUDE.md) — project memory hub for AI agents

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [DISCLAIMER](../DISCLAIMER.md) | Legal scope, takedown policy, prohibited uses | Before deploying anywhere non-trivial |
 | [LICENSE](../LICENSE) | MIT license text | Always |
 | [CONTRIBUTING](../CONTRIBUTING.md) | TDD workflow, test categories, coverage targets | Before opening a PR |
+| **[docs/DEVELOPMENT.md](DEVELOPMENT.md)** | Branching model, PR protocol, e2e gate, version bump protocol, AI-assisted workflow | Understanding the end-to-end dev process |
 | [.env.template](../.env.template) | All environment variables with defaults | Setting up a new shell or container |
 | **[docs/AUTHENTICATION.md](AUTHENTICATION.md)** | Full auth flow, session storage, multi-account, refresh | First `gflow auth login`, or auth errors |
 | **[docs/CONFIGURATION.md](CONFIGURATION.md)** | All env vars, precedence chain, default paths per OS | Tuning behaviour, picking output paths |
@@ -39,6 +40,9 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 **"How does the layered structure work?"** → [ARCHITECTURE § Layers](ARCHITECTURE.md#layers)
 **"What env var should I set for X?"** → [CONFIGURATION § Reference](CONFIGURATION.md#reference)
 **"How do I report a security issue?"** → [SECURITY § Reporting](SECURITY.md#reporting)
+**"What branch do I work on? How do I name it?"** → [DEVELOPMENT § Branching model](DEVELOPMENT.md#branching-model)
+**"How do I run e2e tests before a release?"** → [DEVELOPMENT § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop--main)
+**"When does the version get bumped?"** → [DEVELOPMENT § Version bump protocol](DEVELOPMENT.md#version-bump-protocol)
 **"How do I embed FlowApiClient in a long-lived worker / service?"** → [USER_GUIDE § Journey 14](USER_GUIDE.md#journey-14--embedding-flowapiclient-in-a-long-lived-worker)
 **"What's the standard way to import gflow errors in my code?"** → [USAGE § Programmatic use](USAGE.md#programmatic-use)
 


### PR DESCRIPTION
Documents the development workflow that emerged from issue #16 work.

## Changes

- **`docs/DEVELOPMENT.md`** (new) — branching model, branch naming convention, PR protocol, e2e gate before `develop → main`, version bump protocol, AI-assisted workflow rules
- **`CONTRIBUTING.md`** — fix stale test category docs: `@pytest.mark.live` / `GFLOW_LIVE` → `@pytest.mark.e2e` / `GFLOW_CLI_E2E_PROFILE` to match the actual test suite; cross-link to `DEVELOPMENT.md`
- **`docs/INDEX.md`** — add `DEVELOPMENT.md` row to routing table and three shortcut lines (branching, e2e gate, version bump)

## Test plan

- [x] Hygiene gate: clean
- [x] Ruff lint + format: clean
- [x] Pyright: 0 errors
- [x] Docs-only change — no test changes required

---
_Generated by [Claude Code](https://claude.ai/code/session_014ai2p6CF6q7AiVg6rFxaWB)_