### PR TITLE
fix(auth): verify a real Flow app session on login (issue #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FlowApiClient.generate_image()` and `generate_images_batch()`: `project_id` is now optional (`str | None = None`). When omitted, a new Flow project is created automatically. Existing callers passing an explicit `project_id` are unaffected.
 
+### Fixed
+
+- `gflow auth login` now verifies a real Flow app session before reporting
+  success — fixes issue #15, where a Google-only sign-in was wrongly accepted
+  and later failed with HTTP 401.
+
 ## [0.6.0a6] — 2026-05-17
 
 > **Stability & code-quality release.** Fixes a concurrency bug in image

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,6 +14,87 @@ Living list of behaviour that's broken, surprising, or limited by design — alo
 
 ## Open
 
+### Image generation returns HTTP 401 — `aisandbox-pa` generation endpoint
+
+- **Status:** Open · **Severity:** High (blocks image generation in the e2e path; production-CLI impact unconfirmed) · **Affects:** v0.6.0a6 · **Tracked:** N/A — needs a dedicated issue
+
+Image **generation** calls fail with HTTP 401 even on a profile that holds a
+fully verified Flow session. Discovered 2026-05-17 while building the e2e test
+suite, probing `profile_denon82` immediately after a successful
+`gflow auth login` (`auth_flow_session_verified`, `[OK] Flow session verified`).
+
+**What works vs. what fails — on the same freshly verified profile:**
+
+| Operation | Endpoint | Result |
+|---|---|---|
+| `verify_flow_session` | `labs.google/fx/api/auth/session` | ✅ `AUTHENTICATED` |
+| `FlowApiClient.health_check()` | Flow page context | ✅ `True` |
+| `create_project` | `labs.google/fx/api/trpc/project.createProject` | ✅ 200 |
+| **image generation** | `aisandbox-pa.googleapis.com` (private API) | ❌ **HTTP 401** |
+
+The `evaluate_fetch` transport receives a 401 on the generation request, runs
+its refresh path (`refresh_auth()` re-navigates to the Flow URL), retries once,
+gets 401 again, and raises:
+
+```
+AuthExpiredError: evaluate_fetch: HTTP 401 persisted after refresh — session expired
+```
+
+from `src/gflow_cli/api/transports/experimental/evaluate_fetch.py`
+(`_handle_response`). Call chain: `FlowApiClient.generate_image` /
+`generate_images_batch` → `_drive_image_generation` → `transport.generate_images`
+→ `_generate_images_inner` → `_handle_response`.
+
+**Distinct from issue #15.** Issue #15 was a 401 on `create_project` caused by
+the *profile* being signed in to Google but not the Flow app — fixed on the
+`fix/issue-15-i2v-bearer-auth` branch by verifying the real Flow session at
+login. That fix is confirmed working: `create_project` now succeeds. **This is
+a different 401** — it occurs on a profile that *is* verified and *can* create
+projects, specifically on the `aisandbox-pa.googleapis.com` generation
+endpoint, a different surface from the `labs.google` tRPC API.
+
+**Scope.** The 401 affects every image-generation path uniformly on the
+`evaluate_fetch` transport (the live one): `test_e2e_single_image_gen` (C2,
+pre-existing), `test_e2e_generate_image_without_project_id` (PR #20,
+pre-existing), and the dropped `test_e2e_generate_images_batch_without_project_id`.
+It is **not** caused by recent test changes — `test_transports_e2e.py` is
+self-described scaffold ("Task D.1 scaffold; Task D.2 drives the real
+execution") that was never run green, and PR #20's e2e tests were merged
+without live execution. Whether the production CLI (`gflow image t2i` /
+`gflow video i2v`) is equally affected is **unconfirmed** — it uses the same
+`FlowApiClient` + transport, so it very likely is, but that has not been
+observed directly and should be checked first thing.
+
+**Experimental transports also broken.** The `bearer` and `sapisidhash`
+transports (`api/transports/experimental/`) fail before generation is even
+reached: `bearer` cannot intercept an OAuth token (`AuthExpiredError: bearer:
+failed to intercept Bearer token from Flow page`); `sapisidhash` cascades off
+the resulting profile-lock contention. These are obsolete — only
+`evaluate_fetch` is viable. Issue-#15 investigation notes had already
+disproven the "bearer header" hypothesis for `create_project`.
+
+**Where to investigate.**
+
+- The login OAuth flow *does* request the
+  `https://www.googleapis.com/auth/aisandbox` scope (visible in the sign-in
+  URL), so the account is authorized — the 401 points at how the credential is
+  *presented* to `aisandbox-pa`, not at missing authorization.
+- Capture a real generation request from `evaluate_fetch` — the exact URL,
+  headers, and credential it sends — and compare with what the Flow web UI
+  sends for the same action (browser DevTools network capture).
+- The `aisandbox-pa.googleapis.com` host may require a Bearer token: the
+  issue-#15 "bearer header" hypothesis was disproven for the `labs.google`
+  tRPC `create_project` route, but may hold for this *different* Google API
+  host.
+- Files: `src/gflow_cli/api/transports/experimental/evaluate_fetch.py`
+  (`generate_images`, `_generate_images_inner`, `_handle_response`,
+  `refresh_auth`) and `src/gflow_cli/api/client.py` (`_drive_image_generation`).
+
+**Workaround:** none known. Image generation against the live API does not
+currently succeed via the e2e transport path.
+
+---
+
 ### Browser session expires periodically — manual re-login required
 
 - **Status:** Open · **Severity:** Medium · **Affects:** all versions · **Tracked:** N/A (architectural)

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -196,3 +196,18 @@ If you hit something not listed here:
    - Exact command that failed + full error output
    - What you expected vs. what happened
 3. For **security issues**, see [docs/SECURITY.md § Reporting](docs/SECURITY.md#reporting) — email instead of public issue.
+
+---
+
+### Auth verification depends on Google's NextAuth session endpoint
+
+`gflow auth login` verifies a real Flow sign-in by calling
+`https://labs.google/fx/api/auth/session` (see `src/gflow_cli/auth/verification.py`)
+and by checking for the Google `SAPISID` cookie. These are **external Google
+surfaces** — if Google changes the endpoint path, the response shape, or the
+cookie names, verification degrades **fail-closed**: it reports
+`VERIFICATION_ERROR` (an honest "could not verify") rather than a false
+success. The expected authenticated response shape is pinned by the
+`AUTHENTICATED_BODY` fixture in `tests/auth/test_verification.py` — a Google
+change surfaces there as a failing test. Start any investigation of a sudden
+`gflow auth login` verification failure at that fixture and `verification.py`.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -20,7 +20,7 @@ Living list of behaviour that's broken, surprising, or limited by design — alo
 
 Image **generation** calls fail with HTTP 401 even on a profile that holds a
 fully verified Flow session. Discovered 2026-05-17 while building the e2e test
-suite, probing `profile_denon82` immediately after a successful
+suite, against a profile probed immediately after a successful
 `gflow auth login` (`auth_flow_session_verified`, `[OK] Flow session verified`).
 
 **What works vs. what fails — on the same freshly verified profile:**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -141,7 +141,20 @@ find "$HOME/Downloads/gflow-cli" -type f -mtime +30 -delete
 
 ## Mitigated
 
-_(none yet)_
+### Auth verification depends on Google's NextAuth session endpoint
+
+- **Status:** Mitigated · **Severity:** Low (degrades fail-closed) · **Affects:** issue #15 fix onward · **Tracked:** issue #15
+
+`gflow auth login` verifies a real Flow sign-in by calling
+`https://labs.google/fx/api/auth/session` (see `src/gflow_cli/auth/verification.py`)
+and by checking for the Google `SAPISID` cookie. These are **external Google
+surfaces** — if Google changes the endpoint path, the response shape, or the
+cookie names, verification degrades **fail-closed**: it reports
+`VERIFICATION_ERROR` (an honest "could not verify") rather than a false
+success. The expected authenticated response shape is pinned by the
+`AUTHENTICATED_BODY` fixture in `tests/auth/test_verification.py` — a Google
+change surfaces there as a failing test. Start any investigation of a sudden
+`gflow auth login` verification failure at that fixture and `verification.py`.
 
 ---
 
@@ -196,18 +209,3 @@ If you hit something not listed here:
    - Exact command that failed + full error output
    - What you expected vs. what happened
 3. For **security issues**, see [docs/SECURITY.md § Reporting](docs/SECURITY.md#reporting) — email instead of public issue.
-
----
-
-### Auth verification depends on Google's NextAuth session endpoint
-
-`gflow auth login` verifies a real Flow sign-in by calling
-`https://labs.google/fx/api/auth/session` (see `src/gflow_cli/auth/verification.py`)
-and by checking for the Google `SAPISID` cookie. These are **external Google
-surfaces** — if Google changes the endpoint path, the response shape, or the
-cookie names, verification degrades **fail-closed**: it reports
-`VERIFICATION_ERROR` (an honest "could not verify") rather than a false
-success. The expected authenticated response shape is pinned by the
-`AUTHENTICATED_BODY` fixture in `tests/auth/test_verification.py` — a Google
-change surfaces there as a failing test. Start any investigation of a sudden
-`gflow auth login` verification failure at that fixture and `verification.py`.

--- a/docs/superpowers/2026-05-17-issue-15-handover.md
+++ b/docs/superpowers/2026-05-17-issue-15-handover.md
@@ -1,0 +1,59 @@
+# Handover — Issue #15 (`gflow video i2v` 401) — 2026-05-17
+
+## Status: investigation complete, fix NOT started
+
+Root cause found — and it is **not** what issue #15 or the v2 spec assumed.
+Full evidence: [`specs/2026-05-17-issue-15-root-cause-findings.md`](specs/2026-05-17-issue-15-root-cause-findings.md).
+
+## Root cause (one line)
+
+`gflow auth login` does not persist the `labs.google` NextAuth session cookie
+(`__Secure-next-auth.session-token`) into the profile. The CLI ends up signed
+out of the Flow *app* (it has Google SSO cookies but not the app session), so
+`create_project` — the first `i2v` step — returns `401 UNAUTHORIZED` and i2v
+never reaches `uploadImage`. The "missing Bearer header" hypothesis is disproven.
+
+## Superseded — do NOT implement as written
+
+- `specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md` (v2 spec)
+- `plans/2026-05-17-issue-15-i2v-bearer-auth.md` (7-task plan)
+
+Both targeted the wrong layer (an aisandbox-pa `Bearer` header). Kept for
+history; the findings doc explains why they are wrong.
+
+## Branch `fix/issue-15-i2v-bearer-auth` (off `develop`, pushed)
+
+Committed:
+- v2 spec + 7-task plan (superseded — kept for history).
+- Root-cause findings doc.
+- `feat(api): env-flagged outgoing request-header logging` — `client.py` gained
+  `_redact_headers_for_log` + `GFLOW_CLI_LOG_REQUEST_HEADERS=1` request-header
+  logging. **Keep it** — genuinely useful diagnostic tooling.
+- A merge of `develop` into the branch.
+
+Exploratory probes (local only, `tmp/issue-15-phase1/`, untracked — `tmp/` is
+gitignored): `probe_createproject.py`, `har_trace.py`, `probe_cookiedb.py`,
+`trace.har` (25 MB HAR), and `*.log` run logs.
+
+## Next step — fresh brainstorm → spec → plan for the AUTH-LAYER fix
+
+The fix belongs in the auth layer: capture and persist the full Flow **app
+session** (Playwright `storage_state`, or the live cookie jar *including*
+session cookies) at the moment sign-in completes — *before* the Passive-Capture
+browser closes — and restore it into `FlowApiClient`'s context. Also strengthen
+`auth_login` verification to assert a real `labs.google` app session, not just
+`SAPISID` presence.
+
+One open sub-question (findings §5): exactly why the session-token is not
+flushed (in-memory session cookie vs. NextAuth callback not completing). One
+small probe answers it; do that first.
+
+Skills to use: `superpowers:brainstorming` → `superpowers:writing-plans`; raise
+the `architect` and a security review for the session-credential handling.
+
+## Workflow
+
+`develop` is the integration branch; branch from `develop`, PR to `develop`,
+`develop` → `main` only for releases. `main` is GitHub-branch-protected
+(PR + 5 CI checks, no direct pushes). PRs to `develop` only after the code is
+fully functional and E2E tested.

--- a/docs/superpowers/plans/2026-05-17-e2e-test-coverage.md
+++ b/docs/superpowers/plans/2026-05-17-e2e-test-coverage.md
@@ -1,0 +1,463 @@
+# E2E Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the existing e2e suite against a real profile to get a baseline, then add e2e coverage for the issue-#15 auth-verification feature and for PR #20's integration-ergonomics feature.
+
+**Architecture:** Test-only work. The issue-#15 e2e tests call `verify_flow_session` directly against real profiles (the full `gflow auth login` CLI cannot be e2e-automated — interactive browser sign-in). The PR #20 e2e tests exercise `FlowApiClient.health_check()` and `generate_images_batch` auto-project-creation. A new `tests/e2e/conftest.py` holds shared fixtures. **No production code changes.**
+
+**Tech Stack:** Python 3.11+, `pytest` + `pytest-asyncio` (`asyncio_mode = "auto"`), Playwright, `uv`.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md` (Rev 2).
+
+---
+
+## Important context for every task
+
+- **Branch:** `fix/issue-15-i2v-bearer-auth` — commit there. NEVER add a `Co-Authored-By` trailer.
+- **These are acceptance tests of already-shipped features.** Unlike TDD, the expectation is the test **PASSES on first run**. A FAIL is a real signal — investigate (feature regression / stale profile / network), do not "make the test pass" by weakening it.
+- **Environment:** `uv run pytest` fails here with "Failed to canonicalize script path" — always use `uv run python -m pytest`. `uv run ruff` / `uv run pyright` work normally.
+- **Running e2e:** e2e tests are gated by `-m e2e` AND the `GFLOW_CLI_E2E_PROFILE` env var. The profile is **`denon82`**. On Windows PowerShell:
+  ```
+  $env:GFLOW_CLI_E2E_PROFILE = "denon82"
+  $env:PYTHONUTF8 = "1"
+  uv run python -m pytest tests/e2e -m e2e -v -p no:cov
+  ```
+  (bash equivalent: `GFLOW_CLI_E2E_PROFILE=denon82 uv run python -m pytest ...`)
+- **Never** run e2e with `pytest-xdist` (`-n`) — parallel real-Chrome instances risk OOM on this machine.
+- **Credits:** image-generating tests spend real Flow credits (approved). The auth-verification and `health_check` tests spend **zero**.
+- If a run shows failures clustered on auth-shaped errors (HTTP 401, `AuthExpiredError`/`AuthMissingError`), the `denon82` session has likely expired — run `gflow auth login --profile denon82` and re-run before treating it as a regression.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `tests/e2e/conftest.py` | Shared e2e fixtures: `e2e_profile_dir` (resolve `GFLOW_CLI_E2E_PROFILE`), `e2e_nosession_profile` (a fresh empty profile dir inside the gflow home). | Create |
+| `tests/e2e/test_auth_verification_e2e.py` | Part B — issue-#15 e2e: `verify_flow_session` AUTHENTICATED (+ usable-by-client chain) and NO_SESSION. | Create |
+| `tests/e2e/test_transports_e2e.py` | Part C — append `health_check()` false-path and `generate_images_batch` auto-create tests. | Modify |
+| `tmp/e2e-baseline.md` | Recorded baseline run results (gitignored scratch — not committed). | Create |
+
+---
+
+## Task 1: Part A — baseline run of the existing e2e suite
+
+Establish a truthful baseline of what the existing suite does *before* adding anything, so pre-existing failures are never mistaken for regressions. No code changes.
+
+**Files:** none (writes a scratch record to `tmp/e2e-baseline.md`).
+
+- [ ] **Step 1: Run the full existing e2e suite**
+
+PowerShell:
+```
+$env:GFLOW_CLI_E2E_PROFILE = "denon82"
+$env:PYTHONUTF8 = "1"
+uv run python -m pytest tests/e2e -m e2e -v -p no:cov
+```
+This is a real, credit-spending run (≈69 image generations). Expect it to take several minutes. Capture the full per-test pass/fail/skip output.
+
+- [ ] **Step 2: Record the baseline**
+
+Write `tmp/e2e-baseline.md` containing, per test (and per `strategy` parameter): the test id and its outcome (passed / failed / skipped), plus the final pytest summary line. For any failure, note whether it looks pre-existing (e.g. an obsolete `bearer`/`sapisidhash` transport strategy, or an auth-shaped error) versus unexplained. This file is scratch — do **not** `git add` it.
+
+- [ ] **Step 3: Report**
+
+Report the baseline table to the orchestrator. Do not commit. If the run could not start at all (e.g. `denon82` profile missing or its session dead), report BLOCKED — the rest of the plan needs a working profile.
+
+---
+
+## Task 2: Shared e2e fixtures — `tests/e2e/conftest.py`
+
+A `conftest.py` so the new auth-verification module gets the profile-resolution gate and a safe temp-profile fixture without duplicating logic.
+
+**Files:**
+- Create: `tests/e2e/conftest.py`
+
+- [ ] **Step 1: Create `tests/e2e/conftest.py`**
+
+```python
+"""Shared fixtures for the e2e test suite.
+
+e2e tests hit the real Flow API / real Google auth endpoints and are opt-in:
+run with `-m e2e` and `GFLOW_CLI_E2E_PROFILE=<profile_name>` set. See
+docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.config import get_settings
+
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+
+
+@pytest.fixture
+def e2e_profile_dir() -> Path:
+    """Resolve the authenticated Chromium profile from GFLOW_CLI_E2E_PROFILE.
+
+    Skips the test when the env var is unset or the profile dir is absent.
+    """
+    name = os.environ.get(_E2E_PROFILE_ENV, "")
+    if not name:
+        pytest.skip(
+            f"E2E tests require {_E2E_PROFILE_ENV} - set it to a logged-in "
+            "profile name and re-run with -m e2e"
+        )
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+
+    candidate = _resolve_profile_dir(name)
+    if not candidate.exists():
+        pytest.skip(
+            f"Profile directory not found: {candidate}. "
+            f"Run `gflow auth login --profile {name}` to create it."
+        )
+    return candidate
+
+
+@pytest.fixture
+def e2e_nosession_profile() -> Iterator[Path]:
+    """Yield a fresh, empty profile dir INSIDE the gflow home.
+
+    `verify_flow_session` enforces a boundary check that the profile dir
+    resolves inside GFLOW_CLI_HOME, so a pytest `tmp_path` dir (system temp)
+    cannot be used. The dir is UUID-named so it can never collide with a real
+    `profile_<name>` dir, and is removed in teardown — `ignore_errors=True`
+    plus a short delay tolerate the Windows Chrome profile lock that may
+    briefly outlive `ctx.close()`.
+    """
+    home = get_settings().home
+    home.mkdir(parents=True, exist_ok=True)
+    path = home / f"profile_e2e_nosession_{uuid.uuid4().hex}"
+    assert not path.exists(), f"temp profile dir unexpectedly already exists: {path}"
+    path.mkdir()
+    try:
+        yield path
+    finally:
+        time.sleep(0.5)  # let Chrome release the Windows profile lock
+        shutil.rmtree(path, ignore_errors=True)
+```
+
+- [ ] **Step 2: Lint and type-check**
+
+Run:
+```
+uv run ruff check tests/e2e/conftest.py
+uv run ruff format --check tests/e2e/conftest.py
+uv run pyright tests/e2e/conftest.py
+```
+Expected: ruff clean (run `uv run ruff format tests/e2e/conftest.py` if formatting is off), pyright 0 errors.
+
+- [ ] **Step 3: Verify the conftest collects cleanly**
+
+Run: `uv run python -m pytest tests/e2e --collect-only -q`
+Expected: collection succeeds with no import error (tests are listed; they will not run without `-m e2e`).
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/e2e/conftest.py
+git commit -m "test(e2e): add shared profile fixtures for e2e suite"
+```
+
+---
+
+## Task 3: Part B — issue-#15 auth-verification e2e
+
+New module probing the real Google `/api/auth/session` endpoint via
+`verify_flow_session`. Zero credits.
+
+**Files:**
+- Create: `tests/e2e/test_auth_verification_e2e.py`
+
+- [ ] **Step 1: Create `tests/e2e/test_auth_verification_e2e.py`**
+
+```python
+"""E2E tests for the issue-#15 Flow-session verification feature.
+
+These probe the REAL Google `/api/auth/session` endpoint via
+`verify_flow_session`, and (positive case) confirm a verified profile is
+actually usable by `FlowApiClient`. Opt-in: `-m e2e` + `GFLOW_CLI_E2E_PROFILE`.
+Zero Flow credits are spent - no image generation.
+
+Async tests need no `@pytest.mark.asyncio` decorator: `asyncio_mode = "auto"`
+is set in pyproject.toml.
+
+See docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.auth.verification import FlowSessionOutcome, verify_flow_session
+
+pytestmark = pytest.mark.e2e
+
+
+async def test_e2e_verify_flow_session_authenticated(e2e_profile_dir: Path) -> None:
+    """A logged-in profile verifies as AUTHENTICATED and is usable by the client.
+
+    Two linked assertions - the real issue-#15 invariant:
+      1. verify_flow_session pronounces the profile AUTHENTICATED.
+      2. the SAME profile actually works: FlowApiClient.health_check() is True.
+    """
+    status = await verify_flow_session(
+        e2e_profile_dir, channel="chrome", source="chrome"
+    )
+    assert status.outcome is FlowSessionOutcome.AUTHENTICATED, (
+        f"expected AUTHENTICATED, got {status.outcome} - is the profile's "
+        "Flow session still valid? Re-run `gflow auth login` if not."
+    )
+    assert isinstance(status.user_email, str) and status.user_email, (
+        "an AUTHENTICATED status must carry a non-empty user_email"
+    )
+    assert status.authenticated is True
+
+    # Verified => usable: a profile pronounced AUTHENTICATED must actually work.
+    async with FlowApiClient(
+        profile_dir=e2e_profile_dir, transport="evaluate_fetch"
+    ) as client:
+        assert await client.health_check() is True, (
+            "a verified profile must pass FlowApiClient.health_check()"
+        )
+
+
+async def test_e2e_verify_flow_session_no_session(
+    e2e_nosession_profile: Path,
+) -> None:
+    """A fresh, empty profile verifies as NO_SESSION.
+
+    Empty profile dir -> real headless Chrome launches -> no SAPISID cookie ->
+    `/api/auth/session` returns `200 {}` -> NO_SESSION. Zero credits.
+
+    Environmental caveat: the probe needs outbound network to labs.google.
+    A VERIFICATION_ERROR result indicates no connectivity, not a bug.
+    """
+    status = await verify_flow_session(
+        e2e_nosession_profile, channel="chrome", source="chrome"
+    )
+    assert status.outcome is FlowSessionOutcome.NO_SESSION, (
+        f"expected NO_SESSION for an empty profile, got {status.outcome}. "
+        "If VERIFICATION_ERROR: check network connectivity to labs.google."
+    )
+```
+
+- [ ] **Step 2: Lint and type-check**
+
+Run:
+```
+uv run ruff check tests/e2e/test_auth_verification_e2e.py
+uv run ruff format --check tests/e2e/test_auth_verification_e2e.py
+uv run pyright tests/e2e/test_auth_verification_e2e.py
+```
+Expected: ruff clean (`uv run ruff format ...` if needed), pyright 0 errors.
+
+- [ ] **Step 3: Run the two tests (expect PASS)**
+
+PowerShell:
+```
+$env:GFLOW_CLI_E2E_PROFILE = "denon82"
+$env:PYTHONUTF8 = "1"
+uv run python -m pytest tests/e2e/test_auth_verification_e2e.py -m e2e -v -p no:cov
+```
+Expected: **2 passed.** `test_e2e_verify_flow_session_authenticated` proves the
+issue-#15 fix works against the real endpoint and the profile is usable;
+`test_e2e_verify_flow_session_no_session` proves the empty-profile path.
+If `authenticated` fails with a non-AUTHENTICATED outcome, the `denon82`
+session may be stale — re-run `gflow auth login --profile denon82`. If
+`no_session` returns `VERIFICATION_ERROR`, that is a network issue, not a bug.
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/e2e/test_auth_verification_e2e.py
+git commit -m "test(e2e): verify Flow-session auth against real endpoint (issue #15)"
+```
+
+---
+
+## Task 4: Part C — additional PR #20 integration-ergonomics e2e
+
+Append two tests to the existing transport e2e module. They cover the genuine
+gaps PR #20's two existing e2e tests leave: `health_check()`'s false path, and
+`generate_images_batch` auto-project-creation (PR #20's existing test only
+covers the single-image `generate_image` auto-create).
+
+**Files:**
+- Modify: `tests/e2e/test_transports_e2e.py` (append at end of file)
+
+- [ ] **Step 1: Append the two tests to `tests/e2e/test_transports_e2e.py`**
+
+Add these at the very end of the file (after `test_e2e_health_check_returns_true_when_active`).
+They reuse the file's existing helpers `_profile_dir()`, `_make_client()`, the
+`STRATEGIES` list, `_PROMPT`, `GenerateImageRequest`, and `Model` — all already
+imported/defined in that file.
+
+```python
+
+
+# ---------------------------------------------------------------------------
+# health_check() false path (Issue #16 — new method)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_health_check_false_after_close(strategy: str) -> None:
+    """health_check() returns False (never raises) once the client is closed.
+
+    A long-lived worker holding a client whose context has been torn down must
+    get a clean False, not an exception. Zero credits — no image generation.
+    """
+    profile = _profile_dir()
+    client = _make_client(strategy, profile)
+
+    async with client:
+        assert await client.health_check() is True, (
+            "health_check() must be True while the context is live"
+        )
+
+    # Context is now closed.
+    assert await client.health_check() is False, (
+        "health_check() must return False (not raise) on a closed client"
+    )
+
+
+# ---------------------------------------------------------------------------
+# generate_images_batch auto-create project_id (Issue #16 — optional project_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_generate_images_batch_without_project_id(strategy: str) -> None:
+    """generate_images_batch(req=req, count=4) without project_id auto-creates
+    a project and returns 4 images.
+
+    PR #20's existing auto-create e2e test only covers single-image
+    generate_image(); generate_images_batch() has its own distinct
+    "resolve project_id once" path (one project for N parallel shots).
+    """
+    profile = _profile_dir()
+    req = GenerateImageRequest(prompt=_PROMPT, model=Model.NARWHAL)
+
+    async with _make_client(strategy, profile) as client:
+        # Intentionally omit project_id — the client must create one internally.
+        images = await client.generate_images_batch(req=req, count=4)
+
+    assert len(images) == 4, f"expected 4 images, got {len(images)}"
+    for img in images:
+        assert img.fife_url.startswith("https://"), (
+            f"fife_url must be an https:// URL, got: {img.fife_url!r}"
+        )
+```
+
+- [ ] **Step 2: Lint and type-check**
+
+Run:
+```
+uv run ruff check tests/e2e/test_transports_e2e.py
+uv run ruff format --check tests/e2e/test_transports_e2e.py
+uv run pyright tests/e2e/test_transports_e2e.py
+```
+Expected: ruff clean (`uv run ruff format ...` if needed), pyright 0 errors.
+
+- [ ] **Step 3: Run the two new tests (expect PASS)**
+
+PowerShell:
+```
+$env:GFLOW_CLI_E2E_PROFILE = "denon82"
+$env:PYTHONUTF8 = "1"
+uv run python -m pytest tests/e2e/test_transports_e2e.py -m e2e -v -p no:cov -k "health_check_false_after_close or batch_without_project_id"
+```
+Expected: **6 passed** (each test ×3 strategies). `health_check_false_after_close`
+spends 0 credits; `batch_without_project_id` generates 4 images per strategy
+(12 total). If a strategy's run fails with an obsolete-transport error that
+also appeared in the Task 1 baseline, that is pre-existing — note it, it is not
+a regression introduced here.
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/e2e/test_transports_e2e.py
+git commit -m "test(e2e): cover health_check false-path and batch auto-create (issue #16)"
+```
+
+---
+
+## Task 5: Full verification
+
+Confirm the new tests are clean and the whole e2e suite still behaves as the
+baseline (modulo the new tests). No new code.
+
+**Files:** none.
+
+- [ ] **Step 1: Lint and type-check all new/changed e2e files**
+
+```
+uv run ruff check tests/e2e
+uv run ruff format --check tests/e2e
+uv run pyright tests/e2e/conftest.py tests/e2e/test_auth_verification_e2e.py tests/e2e/test_transports_e2e.py
+```
+Expected: ruff clean, ruff format clean, pyright 0 errors. Fix any issue, then
+`git add` the affected file and commit with `chore(e2e): ...`.
+
+- [ ] **Step 2: Confirm the non-e2e suite is unaffected**
+
+The new files are e2e-gated, but confirm a normal collection is not broken:
+```
+uv run python -m pytest tests/e2e --collect-only -q
+```
+Expected: all e2e tests collected, no import/collection error.
+
+- [ ] **Step 3: Full e2e run**
+
+PowerShell:
+```
+$env:GFLOW_CLI_E2E_PROFILE = "denon82"
+$env:PYTHONUTF8 = "1"
+uv run python -m pytest tests/e2e -m e2e -v -p no:cov
+```
+This is the full credit-spending run. Expected: the existing suite behaves as
+the Task 1 baseline (any failure that was already failing in `tmp/e2e-baseline.md`
+is pre-existing, not a regression); the 4 new tests (Part B ×2 + Part C ×2,
+parametrized) all pass.
+
+- [ ] **Step 4: Report**
+
+Report a final table: baseline outcome vs final outcome per test. Explicitly
+state (a) the 4 new tests' results, and (b) that no previously-passing test
+regressed. If a previously-passing test now fails, that IS a regression —
+report it and stop for review. Do not commit anything in this step unless
+Step 1 required a lint/type fix.
+
+---
+
+## Notes on spec reconciliation
+
+One concrete decision made while planning, flagged for plan review:
+
+1. **Part C is two tests, not three; no production code changes.** The spec
+   (§5) listed a contingent third test — "a second generation reuses an
+   auto-created project" — possibly needing a `FlowApiClient` instrumentation
+   hook. Inspecting the code: `generate_image`/`generate_images_batch` resolve
+   `project_id` with a plain `if project_id is None: create_project()`. The
+   "explicit `project_id` is honoured" case is **already** covered by the
+   existing C2 test (`test_e2e_single_image_gen` passes an explicit
+   `project_id`). The "create one project for N shots" guarantee is mock-test
+   territory, not e2e, and adding a counter hook to production code for a
+   single e2e assertion is unjustified. The contingent test is therefore
+   **dropped**, and the spec's §8 "one possible exception" (a production hook)
+   does **not** materialise — this plan is strictly test-only.

--- a/docs/superpowers/plans/2026-05-17-issue-15-auth-verification-fix.md
+++ b/docs/superpowers/plans/2026-05-17-issue-15-auth-verification-fix.md
@@ -1,0 +1,1439 @@
+# Issue #15 — Auth-Layer Verification Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gflow auth login` report success only when the profile holds a real, usable Flow app session — fixing issue #15, where a `SAPISID`-only check green-lights profiles that 401 on the first API call.
+
+**Architecture:** A new `auth/verification.py` module owns one question — "is this profile signed in to the Flow app?" — answered by probing the NextAuth session endpoint (`/api/auth/session`), the same surface `FlowApiClient` authenticates on. A pure `evaluate_session_response` function holds the decision logic; an async `verify_flow_session` wrapper does the headless browser I/O. Both auth strategies adopt it for one consistent, fail-closed definition of "signed in".
+
+**Tech Stack:** Python 3.11+, Playwright (async), `structlog`, `pytest` + `pytest-asyncio`, `uv`. Strict typing (`pyright`), `ruff` lint/format.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md` (Rev 2).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/gflow_cli/auth/verification.py` | The Flow-session verification module — enum, status dataclass, pure evaluator, async probe. | Create |
+| `src/gflow_cli/auth/real_chrome.py` | `RealChromeStrategy` — opens Chrome at the Flow URL; verifies via `verify_flow_session` after close. | Modify |
+| `src/gflow_cli/auth/internal_chromium.py` | `InternalChromiumStrategy` — live-polls `/api/auth/session` instead of UI-text scraping. | Modify |
+| `src/gflow_cli/errors.py` | Refresh the now-misleading `AuthMissingError` docstring. | Modify |
+| `tests/auth/test_verification.py` | Unit tests for `verification.py` (pure core + async probe). | Create |
+| `tests/auth/strategies/test_strategies.py` | Strategy tests — updated for the new verification path. | Modify |
+| `KNOWN_ISSUES.md` | Record the `/api/auth/session` endpoint as an external coupling. | Modify |
+
+**Why this split:** `verification.py` is the single source of truth for "signed in". The pure `evaluate_session_response` is the testable decision core (zero mocks); `verify_flow_session` is the thin I/O shell. Both strategies depend on it — no duplicated, drifting definitions of success.
+
+**Import-cycle rule:** `strategies.py` imports both strategy modules at load; `real_chrome.py` / `internal_chromium.py` import `verification.py` at the top. Therefore `verification.py` MUST NOT import `.strategies` at the top level — it imports the `async_playwright` shim lazily, inside `verify_flow_session`.
+
+---
+
+## Task 1: `verification.py` — the evaluation core
+
+The pure decision logic: the outcome enum, the status dataclass, and `evaluate_session_response`. No I/O — testable with zero mocks.
+
+**Files:**
+- Create: `src/gflow_cli/auth/verification.py`
+- Test: `tests/auth/test_verification.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/auth/test_verification.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gflow_cli.auth.verification import (
+    FlowSessionOutcome,
+    FlowSessionStatus,
+    evaluate_session_response,
+)
+
+# Representative authenticated /api/auth/session body. Sanitised — no real
+# PII. Pins the endpoint contract: if Google changes the response shape, the
+# AUTHENTICATED assertions below fail loudly instead of the change going silent.
+AUTHENTICATED_BODY = json.dumps(
+    {
+        "user": {
+            "name": "Test User",
+            "email": "test.user@example.com",
+            "image": "https://lh3.googleusercontent.com/a/fake",
+        },
+        "expires": "2026-06-16T08:39:21.000Z",
+    }
+)
+
+
+class TestEvaluateSessionResponse:
+    def test_authenticated_user_with_email(self) -> None:
+        status = evaluate_session_response(
+            200, AUTHENTICATED_BODY, google_session=True, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.AUTHENTICATED
+        assert status.authenticated is True
+        assert status.user_email == "test.user@example.com"
+        assert status.detail == "Flow app session verified."
+
+    def test_empty_session_with_google_cookie(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=True, source="chrome")
+        assert status.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY
+        assert status.authenticated is False
+        assert status.user_email is None
+
+    def test_empty_session_no_google_cookie(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=False, source="chrome")
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    def test_null_user_does_not_crash(self) -> None:
+        status = evaluate_session_response(
+            200, '{"user": null}', google_session=False, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"user": {"name": "x"}}',        # user present, no email key
+            '{"user": {"email": ""}}',        # empty-string email
+            '{"user": ["not", "a", "dict"]}', # user is not a dict
+            "[]",                              # JSON array, not an object
+            '{"user":',                        # truncated JSON
+            "",                                # empty body
+            "   ",                             # whitespace only
+            "not json at all",                 # garbage
+        ],
+    )
+    def test_unexpected_or_malformed_body_is_verification_error(self, body: str) -> None:
+        status = evaluate_session_response(200, body, google_session=True, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert status.detail == "Could not verify the Flow session."
+
+    @pytest.mark.parametrize("status_code", [302, 401, 403, 404, 500, 503])
+    def test_non_200_is_verification_error(self, status_code: int) -> None:
+        # google_session is irrelevant on the error path.
+        status = evaluate_session_response(
+            status_code, AUTHENTICATED_BODY, google_session=True, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+
+    def test_source_is_passed_through(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=False, source="internal")
+        assert status.source == "internal"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/auth/test_verification.py -v`
+Expected: FAIL at collection — `ModuleNotFoundError: No module named 'gflow_cli.auth.verification'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/gflow_cli/auth/verification.py`:
+
+```python
+"""Flow app-session verification — the single source of truth for
+"is this profile signed in to the Flow app?".
+
+A profile can hold Google SSO cookies (e.g. SAPISID) without holding the Flow
+app's NextAuth session (`__Secure-next-auth.session-token`). Only the latter
+authenticates Flow's tRPC API. This module probes the same surface
+`FlowApiClient` authenticates on — the NextAuth session endpoint — so a login
+is never reported successful unless a real, usable Flow session exists.
+
+See docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+# The NextAuth session endpoint. Expected authenticated 200 body shape:
+#   {"user": {"name": ..., "email": ..., "image": ...}, "expires": "..."}
+# An unauthenticated request returns `200 {}`. This contract is pinned by the
+# AUTHENTICATED_BODY fixture in tests/auth/test_verification.py — if Google
+# changes the shape, that test fails rather than the change going silent.
+SESSION_API_URL = "https://labs.google/fx/api/auth/session"
+
+
+class FlowSessionOutcome(str, Enum):
+    """Mutually-exclusive results of probing a profile for a Flow session."""
+
+    AUTHENTICATED = "authenticated"
+    GOOGLE_SESSION_ONLY = "google_session_only"
+    NO_SESSION = "no_session"
+    VERIFICATION_ERROR = "verification_error"
+
+
+_DETAIL_BY_OUTCOME: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.AUTHENTICATED: "Flow app session verified.",
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: "Signed in to Google, but not to the Flow app.",
+    FlowSessionOutcome.NO_SESSION: "No sign-in detected.",
+    FlowSessionOutcome.VERIFICATION_ERROR: "Could not verify the Flow session.",
+}
+
+
+@dataclass(frozen=True)
+class FlowSessionStatus:
+    """The verdict of a Flow-session probe.
+
+    `detail` is a derived property — always one of the four fixed strings in
+    `_DETAIL_BY_OUTCOME`, never built from response, cookie, or exception
+    content. Deriving it (rather than storing a free string) makes it
+    structurally impossible to leak a secret through this field.
+    """
+
+    outcome: FlowSessionOutcome
+    user_email: str | None
+    source: str
+
+    @property
+    def detail(self) -> str:
+        return _DETAIL_BY_OUTCOME[self.outcome]
+
+    @property
+    def authenticated(self) -> bool:
+        return self.outcome is FlowSessionOutcome.AUTHENTICATED
+
+
+def evaluate_session_response(
+    status_code: int,
+    body: str,
+    *,
+    google_session: bool,
+    source: str,
+) -> FlowSessionStatus:
+    """Map a raw /api/auth/session response to a FlowSessionStatus.
+
+    Pure and total: no I/O, no exceptions raised or used for control flow.
+    Every (status_code, body) maps to exactly one outcome. Fail-closed — only
+    a 200 carrying a usable `user.email` yields AUTHENTICATED. Only `email` is
+    read; `name`, `image`, and `expires` are ignored, and the parsed dict is
+    never retained beyond this function.
+    """
+
+    def _result(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessionStatus:
+        return FlowSessionStatus(outcome=outcome, user_email=email, source=source)
+
+    if status_code != 200:
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    if not isinstance(parsed, dict):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    user = parsed.get("user")
+    if user is None or user == {}:
+        # Authenticated-shaped endpoint reachable, but no Flow session.
+        if google_session:
+            return _result(FlowSessionOutcome.GOOGLE_SESSION_ONLY)
+        return _result(FlowSessionOutcome.NO_SESSION)
+
+    if not isinstance(user, dict):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    email = user.get("email")
+    if isinstance(email, str) and email:
+        return _result(FlowSessionOutcome.AUTHENTICATED, email)
+
+    # `user` present but no usable email — unexpected shape (see spec §10).
+    return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/auth/test_verification.py -v`
+Expected: PASS — all `TestEvaluateSessionResponse` cases green.
+
+- [ ] **Step 5: Lint, type-check, and commit**
+
+```bash
+uv run ruff check src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+uv run ruff format src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+uv run pyright src/gflow_cli/auth/verification.py
+git add src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+git commit -m "feat(auth): add Flow-session evaluation core (issue #15)"
+```
+
+---
+
+## Task 2: `verification.py` — the `verify_flow_session` probe
+
+The async I/O wrapper: launches a headless context on the profile, fetches `/api/auth/session` with bounded retries, and delegates the verdict to `evaluate_session_response`. Fail-closed.
+
+**Files:**
+- Modify: `src/gflow_cli/auth/verification.py`
+- Test: `tests/auth/test_verification.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/auth/test_verification.py` — and extend the top imports:
+
+Change the import block at the top of the file from:
+
+```python
+from gflow_cli.auth.verification import (
+    FlowSessionOutcome,
+    FlowSessionStatus,
+    evaluate_session_response,
+)
+```
+
+to:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gflow_cli.auth.verification import (
+    FlowSessionOutcome,
+    FlowSessionStatus,
+    evaluate_session_response,
+    verify_flow_session,
+)
+from gflow_cli.errors import SecurityError
+```
+
+Append at the end of the file:
+
+```python
+# ---------------------------------------------------------------------------
+# verify_flow_session — async headless probe
+# ---------------------------------------------------------------------------
+
+
+def _build_verify_mock(
+    *,
+    cookies: list[dict] | None = None,
+    response_status: int = 200,
+    response_body: str = "{}",
+    get_side_effect: object = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Return (mock_async_playwright, mock_ctx) for verify_flow_session.
+
+    Mocks the headless persistent context: ctx.cookies(), ctx.request.get()
+    (an APIResponse-like object with `.status` and async `.text()`), and
+    ctx.close(). Patch target for the shim is gflow_cli.auth.strategies.
+    """
+    if cookies is None:
+        cookies = [{"name": "SAPISID", "value": "x"}]
+
+    mock_resp = MagicMock(name="resp")
+    mock_resp.status = response_status
+    mock_resp.text = AsyncMock(return_value=response_body)
+
+    mock_request = MagicMock(name="request")
+    if get_side_effect is not None:
+        mock_request.get = AsyncMock(side_effect=get_side_effect)
+    else:
+        mock_request.get = AsyncMock(return_value=mock_resp)
+
+    mock_ctx = MagicMock(name="ctx")
+    mock_ctx.cookies = AsyncMock(return_value=cookies)
+    mock_ctx.request = mock_request
+    mock_ctx.close = AsyncMock()
+
+    mock_pw_obj = MagicMock(name="pw")
+    mock_pw_obj.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
+
+    mock_cm = MagicMock(name="cm")
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
+    return mock_ap, mock_ctx
+
+
+class TestVerifyFlowSession:
+    @pytest.fixture
+    def gflow_home(self, tmp_path: Path) -> Path:
+        home = tmp_path / "gflow_home"
+        home.mkdir()
+        return home
+
+    @pytest.mark.asyncio
+    async def test_authenticated_profile(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, mock_ctx = _build_verify_mock(response_body=AUTHENTICATED_BODY)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, channel="chrome", source="chrome")
+        assert status.outcome is FlowSessionOutcome.AUTHENTICATED
+        assert status.user_email == "test.user@example.com"
+        mock_ctx.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_google_session_only(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock(
+            cookies=[{"name": "SAPISID", "value": "x"}], response_body="{}"
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY
+
+    @pytest.mark.asyncio
+    async def test_no_session(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock(cookies=[], response_body="{}")
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    @pytest.mark.asyncio
+    async def test_launch_failure_is_verification_error(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock()
+        mock_ap.return_value.__aenter__.return_value.chromium.launch_persistent_context = (
+            AsyncMock(side_effect=RuntimeError("launch failed"))
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+
+    @pytest.mark.asyncio
+    async def test_transient_errors_exhaust_to_verification_error(
+        self, gflow_home: Path
+    ) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # Every fetch attempt raises a network error -> retries exhausted.
+        mock_ap, mock_ctx = _build_verify_mock(
+            get_side_effect=[RuntimeError("net::ERR")] * 3
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retryable_status_retried_then_returned(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # HTTP 503 every time -> retried 3x, then evaluated as VERIFICATION_ERROR.
+        mock_ap, mock_ctx = _build_verify_mock(response_status=503)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_status_not_retried(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # HTTP 401 -> not retried; one attempt, then VERIFICATION_ERROR.
+        mock_ap, mock_ctx = _build_verify_mock(response_status=401)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ctx_closed_on_error_path(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, mock_ctx = _build_verify_mock(
+            get_side_effect=[RuntimeError("net::ERR")] * 3
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await verify_flow_session(profile, source="chrome")
+        mock_ctx.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_profile_outside_home_raises_security_error(self, gflow_home: Path) -> None:
+        outside = gflow_home.parent / "outside_profile"
+        outside.mkdir()
+        with patch("gflow_cli.auth.verification.get_settings") as mock_settings:
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(SecurityError):
+                await verify_flow_session(outside, source="chrome")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/auth/test_verification.py::TestVerifyFlowSession -v`
+Expected: FAIL at collection — `ImportError: cannot import name 'verify_flow_session'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/gflow_cli/auth/verification.py`, replace the import block:
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+```
+
+with:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+from gflow_cli.config import get_settings
+from gflow_cli.errors import SecurityError
+
+if TYPE_CHECKING:
+    from playwright.async_api import BrowserContext
+
+logger = structlog.get_logger(__name__)
+```
+
+Then add, just below `SESSION_API_URL`:
+
+```python
+# Per-request timeout for the session probe (milliseconds).
+_REQUEST_TIMEOUT_MS = 15_000
+# Total fetch attempts (initial + retries) before giving up.
+_MAX_ATTEMPTS = 3
+# HTTP statuses worth retrying — transient server-side conditions only.
+_RETRYABLE_STATUSES = frozenset({429, 503, 504})
+```
+
+And append at the end of the file:
+
+```python
+async def _fetch_session(ctx: BrowserContext) -> tuple[int, str]:
+    """Fetch /api/auth/session, retrying transient failures.
+
+    Returns the final (status_code, body). Makes up to `_MAX_ATTEMPTS`
+    attempts; an attempt is retried only on a network/timeout error or an
+    HTTP status in `_RETRYABLE_STATUSES`, with exponential backoff (1s, 2s;
+    capped at 8s). Re-raises the last error if no attempt produced a response.
+
+    An explicit loop (rather than a `tenacity` decorator) is used so the final
+    `(status_code, body)` survives — the caller logs the real status code as a
+    durability signal (spec §10). The spec (§4.1) sanctions either form.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            resp = await ctx.request.get(SESSION_API_URL, timeout=_REQUEST_TIMEOUT_MS)
+            body = await resp.text()
+        except Exception as exc:  # noqa: BLE001 - retried below, or re-raised
+            last_exc = exc
+            if attempt == _MAX_ATTEMPTS:
+                raise
+        else:
+            if resp.status not in _RETRYABLE_STATUSES or attempt == _MAX_ATTEMPTS:
+                return resp.status, body
+        await asyncio.sleep(float(min(2 ** (attempt - 1), 8)))
+    # Unreachable — the loop always returns or raises by the final attempt.
+    raise last_exc or RuntimeError("session probe produced no response")
+
+
+async def verify_flow_session(
+    profile_dir: Path,
+    *,
+    channel: str = "chrome",
+    source: str = "chrome",
+) -> FlowSessionStatus:
+    """Headlessly probe `profile_dir` for a usable Flow app session.
+
+    Launches a headless persistent context on the profile, reads cookies, and
+    calls the NextAuth session endpoint. Fail-closed: any failure — boundary
+    violation aside — yields VERIFICATION_ERROR, never AUTHENTICATED.
+
+    Precondition: `profile_dir` must resolve inside GFLOW_CLI_HOME. The check
+    uses `strict=True` (the directory exists by the time verification runs);
+    `RealChromeStrategy.login`'s own pre-`mkdir` check deliberately stays
+    `strict=False` — see the design spec §4.2.
+    """
+    home = get_settings().home.resolve()
+    try:
+        profile_dir.resolve(strict=True).relative_to(home)
+    except (ValueError, OSError):
+        raise SecurityError(
+            f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME ({home})."
+        ) from None
+
+    # Lazy import — a top-level `from .strategies import ...` would create the
+    # cycle strategies -> real_chrome -> verification -> strategies.
+    from .strategies import async_playwright
+
+    status_code: int
+    body: str
+    try:
+        async with async_playwright() as pw:
+            ctx = await pw.chromium.launch_persistent_context(
+                user_data_dir=str(profile_dir),
+                channel=channel,
+                headless=True,
+            )
+            try:
+                cookies = await ctx.cookies()
+                google_session = any(c.get("name") == "SAPISID" for c in cookies)
+                status_code, body = await _fetch_session(ctx)
+            finally:
+                await ctx.close()
+    except Exception as exc:  # noqa: BLE001 - fail-closed: any failure -> VERIFICATION_ERROR
+        logger.warning(
+            "auth_flow_session_probe_error", source=source, error=type(exc).__name__
+        )
+        return FlowSessionStatus(
+            outcome=FlowSessionOutcome.VERIFICATION_ERROR, user_email=None, source=source
+        )
+
+    result = evaluate_session_response(
+        status_code, body, google_session=google_session, source=source
+    )
+    if result.outcome is FlowSessionOutcome.VERIFICATION_ERROR:
+        # Observable durability signal — distinguishes a moved/changed endpoint
+        # from a flaky link. The status code is safe to log; the body is not.
+        logger.warning(
+            "auth_flow_session_unexpected_response", source=source, status_code=status_code
+        )
+    return result
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/auth/test_verification.py -v`
+Expected: PASS — `TestEvaluateSessionResponse` and `TestVerifyFlowSession` all green.
+
+- [ ] **Step 5: Lint, type-check, and commit**
+
+```bash
+uv run ruff check src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+uv run ruff format src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+uv run pyright src/gflow_cli/auth/verification.py
+git add src/gflow_cli/auth/verification.py tests/auth/test_verification.py
+git commit -m "feat(auth): add verify_flow_session headless probe (issue #15)"
+```
+
+---
+
+## Task 3: Refresh the `AuthMissingError` docstring
+
+`AuthMissingError`'s docstring describes a `SapisidhashTransport` scenario that no longer reflects how the error is used. Docstring-only — no behaviour change.
+
+**Files:**
+- Modify: `src/gflow_cli/errors.py:266-274`
+
+- [ ] **Step 1: Edit the docstring and remediation text**
+
+In `src/gflow_cli/errors.py`, replace:
+
+```python
+class AuthMissingError(GFlowError):
+    """Raised when a strategy lacks a required prerequisite credential
+    (e.g. SAPISID cookie missing from profile dir for SapisidhashTransport)."""
+
+    problem_type = "https://gflow-cli.dev/errors/auth-missing"
+    title = "Authentication credential missing"
+    _default_remediation = (
+        "A required credential (e.g. SAPISID cookie) is absent from the profile. "
+        "Run `gflow auth login --profile <name>` to capture a fresh session."
+    )
+```
+
+with:
+
+```python
+class AuthMissingError(GFlowError):
+    """Raised when a profile lacks a usable session for the requested action.
+
+    Covers both a wholly absent session and the issue-#15 case: a profile
+    signed in to Google but not to the Flow app (no NextAuth session). The
+    raising site supplies a message and `remediation_hint` describing which.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/auth-missing"
+    title = "Authentication credential missing"
+    _default_remediation = (
+        "No usable Flow session was found in the profile. "
+        "Run `gflow auth login --profile <name>` and complete the Flow sign-in."
+    )
+```
+
+- [ ] **Step 2: Verify nothing broke**
+
+Run: `uv run pyright src/gflow_cli/errors.py && uv run pytest tests/ -q -k errors`
+Expected: pyright clean; any error-taxonomy tests still PASS (no behaviour changed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/gflow_cli/errors.py
+git commit -m "docs(errors): refresh AuthMissingError docstring for issue #15"
+```
+
+---
+
+## Task 4: `RealChromeStrategy` — verify the Flow app session
+
+Open Chrome at the Flow URL, clarify the guidance, and replace the post-close `SAPISID` check with `verify_flow_session`.
+
+**Files:**
+- Modify: `src/gflow_cli/auth/real_chrome.py`
+- Test: `tests/auth/strategies/test_strategies.py`
+
+- [ ] **Step 1: Update the strategy tests (failing)**
+
+In `tests/auth/strategies/test_strategies.py`:
+
+(a) Replace the import block at the top:
+
+```python
+from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
+from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
+```
+
+with:
+
+```python
+from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
+from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
+from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
+```
+
+(b) Delete the `_build_verify_pw_mock` helper entirely (lines ~16-43). `RealChromeStrategy`'s verification is now `verify_flow_session`, which the strategy tests mock directly — the Playwright-level mock plumbing for verification lives in `tests/auth/test_verification.py`.
+
+(c) Add this helper next to `_build_mock_proc`:
+
+```python
+def _status(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessionStatus:
+    """Build a FlowSessionStatus for mocking verify_flow_session."""
+    return FlowSessionStatus(outcome=outcome, user_email=email, source="chrome")
+```
+
+(d) Replace `test_real_chrome_launch_flags` — same assertions, but mock
+`verify_flow_session` instead of Playwright:
+
+```python
+    @pytest.mark.asyncio
+    async def test_real_chrome_launch_flags(self, tmp_path: Path) -> None:
+        """Verify Chrome launches WITHOUT --remote-debugging-port or --enable-automation."""
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        gflow_home.mkdir()
+
+        mock_proc = _build_mock_proc()
+        mock_create = AsyncMock(return_value=mock_proc)
+        fake_chrome = r"C:\fake\chrome.exe"
+        verified = _status(FlowSessionOutcome.AUTHENTICATED, "test@example.com")
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch("gflow_cli.auth.real_chrome.find_chrome_executable", return_value=fake_chrome),
+            patch("gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec", mock_create),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=verified),
+            ),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await strategy.login(profile_dir, headless=False)
+
+        args_list = mock_create.call_args.args
+        assert args_list[0] == fake_chrome
+        assert f"--user-data-dir={profile_dir}" in args_list
+        assert "--enable-automation" not in args_list
+        assert not any("--remote-debugging-port" in a for a in args_list)
+```
+
+(e) Replace `test_real_chrome_success_verified_via_sapisid` with:
+
+```python
+    @pytest.mark.asyncio
+    async def test_real_chrome_success_writes_marker(self, tmp_path: Path) -> None:
+        """On an authenticated Flow session, login writes the .gflow_browser_strategy marker."""
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        gflow_home.mkdir()
+
+        mock_proc = _build_mock_proc()
+        verified = _status(FlowSessionOutcome.AUTHENTICATED, "test@example.com")
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch(
+                "gflow_cli.auth.real_chrome.find_chrome_executable",
+                return_value=r"C:\fake\chrome.exe",
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=verified),
+            ),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await strategy.login(profile_dir, headless=False)
+
+        marker = profile_dir / ".gflow_browser_strategy"
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8") == "chrome"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome",
+        [
+            FlowSessionOutcome.GOOGLE_SESSION_ONLY,
+            FlowSessionOutcome.NO_SESSION,
+            FlowSessionOutcome.VERIFICATION_ERROR,
+        ],
+    )
+    async def test_real_chrome_unverified_raises_auth_missing(
+        self, tmp_path: Path, outcome: FlowSessionOutcome
+    ) -> None:
+        """A non-authenticated outcome fails the login with AuthMissingError."""
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        gflow_home.mkdir()
+
+        mock_proc = _build_mock_proc()
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch(
+                "gflow_cli.auth.real_chrome.find_chrome_executable",
+                return_value=r"C:\fake\chrome.exe",
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=_status(outcome)),
+            ),
+        ):
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(AuthMissingError):
+                await strategy.login(profile_dir, headless=False)
+
+        assert not (profile_dir / ".gflow_browser_strategy").exists()
+```
+
+`test_real_chrome_privacy_guard` and `test_real_chrome_timeout_raises` are
+**unchanged** — both raise before verification is reached, so they neither
+need nor reference `verify_flow_session`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/auth/strategies/test_strategies.py::TestRealChromeStrategy -v`
+Expected: FAIL — `verify_flow_session` is not yet importable in `real_chrome`, and the marker/`AuthMissingError` behaviour does not exist yet.
+
+- [ ] **Step 3: Edit `real_chrome.py`**
+
+(a) Replace the import line:
+
+```python
+from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
+
+from .base import AuthStrategy
+```
+
+with:
+
+```python
+from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
+
+from .base import AuthStrategy
+from .verification import FlowSessionOutcome, verify_flow_session
+```
+
+(b) Add these module-level dicts just below the `GEMINI_URL = ...` line:
+
+```python
+# User-facing guidance per non-authenticated verification outcome (issue #15).
+_UNVERIFIED_MESSAGE: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: (
+        "Signed in to your Google account, but the Flow app sign-in wasn't completed."
+    ),
+    FlowSessionOutcome.NO_SESSION: "No sign-in detected.",
+    FlowSessionOutcome.VERIFICATION_ERROR: (
+        "Could not verify the Flow session — this is often a network problem."
+    ),
+}
+_UNVERIFIED_HINT: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: (
+        "Re-run `gflow auth login` and continue until the Flow editor "
+        "(the prompt box / your projects) loads before closing Chrome."
+    ),
+    FlowSessionOutcome.NO_SESSION: (
+        "Re-run `gflow auth login`, sign in to Google, and continue until "
+        "the Flow editor loads."
+    ),
+    FlowSessionOutcome.VERIFICATION_ERROR: (
+        "Check your connection and re-run `gflow auth login`."
+    ),
+}
+```
+
+(c) Replace the `chrome_args` list (currently lines ~86-93):
+
+```python
+        chrome_args = [
+            chrome_exe,
+            f"--user-data-dir={profile_dir}",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--window-size=1280,800",
+            # No --remote-debugging-port: zero automation surface.
+        ]
+```
+
+with:
+
+```python
+        chrome_args = [
+            chrome_exe,
+            f"--user-data-dir={profile_dir}",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--window-size=1280,800",
+            # No --remote-debugging-port: zero automation surface.
+            GEMINI_URL,  # open straight on the Flow sign-in page
+        ]
+```
+
+(d) Replace the guidance block (currently lines ~108-114, the four `_console.print`
+steps inside `if not headless:`):
+
+```python
+            _console.print("1. A Google Chrome window will open.")
+            _console.print(f"2. Sign in at: [bold]{GEMINI_URL}[/bold]")
+            _console.print("3. Complete sign-in until you reach the Flow editor.")
+            _console.print(
+                "4. [bold yellow]CLOSE THE BROWSER[/bold yellow] when done — "
+                "gflow will verify your session automatically."
+            )
+```
+
+with:
+
+```python
+            _console.print("1. A Google Chrome window opens at the Flow sign-in page.")
+            _console.print("2. Sign in with your Google account.")
+            _console.print(
+                "3. [bold yellow]Keep going until the Flow editor itself loads[/bold yellow] "
+                "— the prompt box and your projects."
+            )
+            _console.print(
+                "   Signing in to Google is NOT enough; gflow needs a completed "
+                "Flow app sign-in."
+            )
+            _console.print(
+                "4. Then [bold yellow]CLOSE THE BROWSER[/bold yellow] — gflow verifies "
+                "the Flow session automatically."
+            )
+```
+
+(e) Replace the entire post-close verification block (currently lines ~146-177,
+from `_console.print("\n[bold green]Browser closed...` through the end of the
+method):
+
+```python
+        _console.print("\n[bold green]Browser closed.[/bold green] Verifying session...")
+
+        # Headless probe: read persisted cookies from the isolated profile dir.
+        # channel="chrome" uses the system Chrome binary so verification avoids
+        # Playwright's own automation flags (belt-and-suspenders stealth).
+        from playwright.async_api import async_playwright
+
+        async with async_playwright() as pw:
+            ctx = await pw.chromium.launch_persistent_context(
+                user_data_dir=str(profile_dir),
+                channel="chrome",
+                headless=True,
+            )
+            try:
+                cookies = await ctx.cookies()
+                has_sapisid = any(c.get("name") == "SAPISID" for c in cookies)
+
+                if has_sapisid:
+                    logger.info("auth_login_success_verified", strategy=self.name)
+                    # Write strategy marker before any output that might fail on
+                    # narrow Windows codepages — FlowApiClient reads this to select
+                    # the matching Chrome channel for launch_persistent_context.
+                    (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
+                    _console.print("[green][OK] Session captured and verified.[/green]")
+                else:
+                    logger.warning("auth_login_no_cookies", strategy=self.name)
+                    raise AuthMissingError(
+                        "No session cookies found after sign-in. "
+                        "Did you complete the sign-in before closing Chrome?"
+                    )
+            finally:
+                await ctx.close()
+```
+
+with:
+
+```python
+        _console.print("\n[bold green]Browser closed.[/bold green] Verifying Flow session...")
+
+        # Verify the real Flow app session — not just the Google SSO cookie.
+        status = await verify_flow_session(profile_dir, channel="chrome", source=self.name)
+
+        if status.authenticated:
+            logger.info(
+                "auth_flow_session_verified",
+                strategy=self.name,
+                source=status.source,
+                user_email=status.user_email,
+            )
+            # Marker read by browser_manager.channel_for_profile so FlowApiClient
+            # selects the system Chrome channel. Load-bearing — must persist here.
+            (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
+            _console.print(
+                f"[green][OK] Flow session verified ({status.user_email}).[/green]"
+            )
+        else:
+            logger.warning(
+                "auth_flow_session_unverified",
+                strategy=self.name,
+                outcome=status.outcome.value,
+            )
+            raise AuthMissingError(
+                _UNVERIFIED_MESSAGE[status.outcome],
+                remediation_hint=_UNVERIFIED_HINT[status.outcome],
+            )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/auth/strategies/test_strategies.py::TestRealChromeStrategy -v`
+Expected: PASS — all `TestRealChromeStrategy` tests green.
+
+- [ ] **Step 5: Lint, type-check, and commit**
+
+```bash
+uv run ruff check src/gflow_cli/auth/real_chrome.py tests/auth/strategies/test_strategies.py
+uv run ruff format src/gflow_cli/auth/real_chrome.py tests/auth/strategies/test_strategies.py
+uv run pyright src/gflow_cli/auth/real_chrome.py
+git add src/gflow_cli/auth/real_chrome.py tests/auth/strategies/test_strategies.py
+git commit -m "fix(auth): real-chrome verifies the Flow app session (issue #15)"
+```
+
+---
+
+## Task 5: `InternalChromiumStrategy` — live-poll `/api/auth/session`
+
+Swap the fragile `SAPISID` + UI-text check for the authoritative live check; harden the loop's exception handling.
+
+**Files:**
+- Modify: `src/gflow_cli/auth/internal_chromium.py`
+- Test: `tests/auth/strategies/test_strategies.py`
+
+- [ ] **Step 1: Update the internal-chromium tests (failing)**
+
+In `tests/auth/strategies/test_strategies.py`, replace `test_internal_chromium_standard_behavior` and `test_internal_chromium_timeout_raises` with versions that mock `page.request.get` instead of `page.get_by_text`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_internal_chromium_standard_behavior(self, tmp_path: Path) -> None:
+        """Internal Chromium detects success via the /api/auth/session probe."""
+        strategy = InternalChromiumStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        gflow_home.mkdir()
+        profile_dir = gflow_home / "profile_internal"
+
+        mock_resp = MagicMock(name="resp")
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(
+            return_value='{"user": {"email": "test@example.com"}}'
+        )
+
+        mock_page = MagicMock(name="page")
+        mock_page.goto = AsyncMock()
+        mock_page.request.get = AsyncMock(return_value=mock_resp)
+
+        mock_ctx = MagicMock(name="ctx")
+        mock_ctx.pages = [mock_page]
+        mock_ctx.cookies = AsyncMock(return_value=[{"name": "SAPISID", "value": "x"}])
+        mock_ctx.close = AsyncMock()
+        mock_ctx.new_page = AsyncMock(return_value=mock_page)
+
+        mock_pw_obj = MagicMock(name="pw")
+        mock_launch_pctx = AsyncMock(return_value=mock_ctx)
+        mock_pw_obj.chromium.launch_persistent_context = mock_launch_pctx
+
+        mock_cm = MagicMock(name="cm")
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
+
+        with (
+            patch("gflow_cli.auth.internal_chromium.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await strategy.login(profile_dir, headless=False)
+
+        _, kwargs = mock_launch_pctx.call_args
+        assert "channel" not in kwargs or kwargs["channel"] != "chrome"
+        mock_page.request.get.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_internal_chromium_timeout_raises(self, tmp_path: Path) -> None:
+        """AuthLoginTimeoutError is raised when the session never authenticates."""
+        strategy = InternalChromiumStrategy(timeout_seconds=0)
+        gflow_home = tmp_path / "gflow_home"
+        gflow_home.mkdir()
+        profile_dir = gflow_home / "profile_internal"
+
+        mock_resp = MagicMock(name="resp")
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value="{}")
+
+        mock_page = MagicMock(name="page")
+        mock_page.goto = AsyncMock()
+        mock_page.request.get = AsyncMock(return_value=mock_resp)
+
+        mock_ctx = MagicMock(name="ctx")
+        mock_ctx.pages = [mock_page]
+        mock_ctx.cookies = AsyncMock(return_value=[])
+        mock_ctx.close = AsyncMock()
+        mock_ctx.new_page = AsyncMock(return_value=mock_page)
+
+        mock_pw_obj = MagicMock(name="pw")
+        mock_pw_obj.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
+
+        mock_cm = MagicMock(name="cm")
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
+
+        with (
+            patch("gflow_cli.auth.internal_chromium.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(AuthLoginTimeoutError) as excinfo:
+                await strategy.login(profile_dir, headless=False)
+
+        assert "0s" in str(excinfo.value)
+        mock_ctx.close.assert_called_once()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/auth/strategies/test_strategies.py::TestInternalChromiumStrategy -v`
+Expected: FAIL — `internal_chromium.py` still calls `get_by_text`, never `page.request.get`, so `mock_page.request.get.assert_awaited()` fails.
+
+- [ ] **Step 3: Edit `internal_chromium.py`**
+
+(a) Replace the import block:
+
+```python
+from gflow_cli.config import get_settings
+from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
+
+from .base import AuthStrategy
+```
+
+with:
+
+```python
+from playwright.async_api import Error as PlaywrightError
+
+from gflow_cli.config import get_settings
+from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
+
+from .base import AuthStrategy
+from .verification import SESSION_API_URL, FlowSessionOutcome, evaluate_session_response
+```
+
+(b) Replace the polling block — currently the `while` loop with the
+`has_sapisid` + `get_by_text` check (lines ~67-107, from the `timeout_at = ...`
+line through the `if not success:` raise):
+
+```python
+                # Polling for success (SAPISID cookie + UI signal).
+                timeout_at = asyncio.get_running_loop().time() + self._timeout_seconds
+                success = False
+
+                while asyncio.get_running_loop().time() < timeout_at:
+                    try:
+                        cookies = await ctx.cookies()
+                        has_sapisid = any(c.get("name") == "SAPISID" for c in cookies)
+
+                        if has_sapisid:
+                            # Final confirmation via UI signal
+                            if (
+                                await page.get_by_text("New project").is_visible()
+                                or await page.get_by_text("Your projects").is_visible()
+                            ):
+                                logger.info("auth_login_success_detected", strategy=self.name)
+                                success = True
+                                break
+                    except Exception:
+                        # Browser or context is gone — exit loop without success
+                        break
+
+                    await asyncio.sleep(1)
+                else:
+                    raise AuthLoginTimeoutError(
+                        f"Sign-in not completed within {self._timeout_seconds}s.",
+                        remediation_hint=(
+                            "Run `gflow auth login` again and complete sign-in promptly. "
+                            f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to a higher value if needed "
+                            f"(current: {self._timeout_seconds}s)."
+                        ),
+                    )
+
+                if not success:
+                    raise AuthLoginTimeoutError(
+                        "Browser closed before authentication was verified.",
+                        remediation_hint=(
+                            "Complete the full sign-in flow before closing the browser. "
+                            "Run `gflow auth login` to try again."
+                        ),
+                    )
+```
+
+with:
+
+```python
+                # Poll the NextAuth session endpoint live until the Flow app
+                # sign-in completes. Non-AUTHENTICATED outcomes (including a
+                # transient VERIFICATION_ERROR) just mean "keep waiting" — the
+                # user may still be signing in.
+                timeout_at = asyncio.get_running_loop().time() + self._timeout_seconds
+                success = False
+
+                while asyncio.get_running_loop().time() < timeout_at:
+                    try:
+                        cookies = await ctx.cookies()
+                        google_session = any(c.get("name") == "SAPISID" for c in cookies)
+                        resp = await page.request.get(SESSION_API_URL, timeout=15_000)
+                        status = evaluate_session_response(
+                            resp.status,
+                            await resp.text(),
+                            google_session=google_session,
+                            source=self.name,
+                        )
+                        if status.outcome is FlowSessionOutcome.AUTHENTICATED:
+                            logger.info(
+                                "auth_flow_session_verified",
+                                strategy=self.name,
+                                source=status.source,
+                                user_email=status.user_email,
+                            )
+                            success = True
+                            break
+                    except asyncio.CancelledError:
+                        raise
+                    except PlaywrightError:
+                        # Browser / page / context closed — stop polling.
+                        break
+                    except Exception as exc:  # noqa: BLE001 - unexpected; log and stop
+                        logger.warning(
+                            "auth_flow_session_poll_error",
+                            strategy=self.name,
+                            error=type(exc).__name__,
+                        )
+                        break
+
+                    await asyncio.sleep(3)
+                else:
+                    raise AuthLoginTimeoutError(
+                        f"Flow sign-in not completed within {self._timeout_seconds}s.",
+                        remediation_hint=(
+                            "Run `gflow auth login` again and continue until the Flow "
+                            "editor loads. Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT higher if "
+                            f"needed (current: {self._timeout_seconds}s)."
+                        ),
+                    )
+
+                if not success:
+                    raise AuthLoginTimeoutError(
+                        "Browser closed before the Flow editor sign-in was verified.",
+                        remediation_hint=(
+                            "Complete the Flow sign-in — until the editor loads — "
+                            "before closing the browser. Run `gflow auth login` to retry."
+                        ),
+                    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/auth/strategies/test_strategies.py -v`
+Expected: PASS — all `TestRealChromeStrategy` and `TestInternalChromiumStrategy` tests green.
+
+- [ ] **Step 5: Lint, type-check, and commit**
+
+```bash
+uv run ruff check src/gflow_cli/auth/internal_chromium.py tests/auth/strategies/test_strategies.py
+uv run ruff format src/gflow_cli/auth/internal_chromium.py tests/auth/strategies/test_strategies.py
+uv run pyright src/gflow_cli/auth/internal_chromium.py
+git add src/gflow_cli/auth/internal_chromium.py tests/auth/strategies/test_strategies.py
+git commit -m "fix(auth): internal-chromium verifies via /api/auth/session (issue #15)"
+```
+
+---
+
+## Task 6: Record the external endpoint coupling in `KNOWN_ISSUES.md`
+
+The fix depends on Google's `/api/auth/session` endpoint. Record it so a future maintainer knows where to look if Google changes Flow's auth.
+
+**Files:**
+- Modify: `KNOWN_ISSUES.md`
+
+- [ ] **Step 1: Append the coupling note**
+
+Open `KNOWN_ISSUES.md` and append the following entry, matching the file's
+existing heading/format style (use the same heading level as other entries):
+
+```markdown
+### Auth verification depends on Google's NextAuth session endpoint
+
+`gflow auth login` verifies a real Flow sign-in by calling
+`https://labs.google/fx/api/auth/session` (see `src/gflow_cli/auth/verification.py`)
+and by checking for the Google `SAPISID` cookie. These are **external Google
+surfaces** — if Google changes the endpoint path, the response shape, or the
+cookie names, verification degrades **fail-closed**: it reports
+`VERIFICATION_ERROR` (an honest "could not verify") rather than a false
+success. The expected authenticated response shape is pinned by the
+`AUTHENTICATED_BODY` fixture in `tests/auth/test_verification.py` — a Google
+change surfaces there as a failing test. Start any investigation of a sudden
+`gflow auth login` verification failure at that fixture and `verification.py`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add KNOWN_ISSUES.md
+git commit -m "docs: record the Flow session-endpoint coupling in KNOWN_ISSUES"
+```
+
+---
+
+## Task 7: Full verification gate
+
+Run the project's full quality gate and confirm no regressions — including the BDD scenarios.
+
+**Files:** none modified (verification only).
+
+- [ ] **Step 1: Confirm no test or step definition references the removed log events**
+
+Run: `git grep -n "auth_login_success_verified\|auth_login_no_cookies\|auth_login_success_detected" tests/ ; echo "exit:$?"`
+Expected: `exit:1` (no matches). If any match is found in a `.feature` step
+definition or `conftest.py`, update that assertion to the new event names
+(`auth_flow_session_verified` / `auth_flow_session_unverified`) and re-run.
+
+- [ ] **Step 2: Run the full quality gate**
+
+```bash
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run pytest -q --cov=gflow_cli
+```
+
+Expected: hygiene gate passes; ruff lint + format clean; pyright reports no
+errors; the full test suite passes with overall coverage ≥ 80%.
+
+- [ ] **Step 3: Confirm the auth BDD scenarios pass**
+
+Run: `uv run pytest tests/ -q -k "auth"`
+Expected: PASS — all auth unit and BDD scenarios green.
+
+- [ ] **Step 4: Update the changelog**
+
+Add a line under `CHANGELOG.md` `[Unreleased]` (the change is user-visible):
+
+```markdown
+### Fixed
+- `gflow auth login` now verifies a real Flow app session before reporting
+  success — fixes issue #15, where a Google-only sign-in was wrongly accepted
+  and later failed with HTTP 401.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for issue #15 auth-verification fix"
+```
+
+---
+
+## Notes on spec reconciliation
+
+Two intentional, minor refinements of the spec made while planning — both
+strengthen the design and are flagged here for the plan review:
+
+1. **`test_real_chrome_launch_flags` patch seam.** Spec §8 lists it under "must
+   NOT change". Its *assertions* are unchanged, but because `real_chrome.py` no
+   longer drives Playwright directly, its mock target moves from
+   `playwright.async_api.async_playwright` to a direct mock of
+   `verify_flow_session`. This is mechanical plumbing, not a behaviour change.
+2. **`FlowSessionStatus.detail` is a derived property**, not a stored field
+   (spec §4.1 lists it as a field). Deriving it from `outcome` makes it
+   structurally impossible to set `detail` to anything outside the fixed set —
+   a strict strengthening of the spec's "never interpolated" security rule.
+3. **`_fetch_session` uses an explicit retry loop**, not a `tenacity` decorator.
+   The spec §4.1 explicitly sanctions either; the loop is chosen so the final
+   `(status_code, body)` is preserved for the durability WARNING log (spec §10).

--- a/docs/superpowers/plans/2026-05-17-issue-15-auth-verification-fix.md
+++ b/docs/superpowers/plans/2026-05-17-issue-15-auth-verification-fix.md
@@ -442,7 +442,9 @@ class TestVerifyFlowSession:
         assert mock_ctx.request.get.await_count == 3
 
     @pytest.mark.asyncio
-    async def test_retryable_status_retried_then_returned(self, gflow_home: Path) -> None:
+    async def test_retryable_status_retried_then_verification_error(
+        self, gflow_home: Path
+    ) -> None:
         profile = gflow_home / "profile_default"
         profile.mkdir()
         # HTTP 503 every time -> retried 3x, then evaluated as VERIFICATION_ERROR.
@@ -742,6 +744,7 @@ from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
 with:
 
 ```python
+from gflow_cli.auth.real_chrome import GEMINI_URL
 from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
 from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
 from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
@@ -791,6 +794,7 @@ def _status(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessio
         assert f"--user-data-dir={profile_dir}" in args_list
         assert "--enable-automation" not in args_list
         assert not any("--remote-debugging-port" in a for a in args_list)
+        assert GEMINI_URL in args_list  # Chrome opens directly on the Flow page
 ```
 
 (e) Replace `test_real_chrome_success_verified_via_sapisid` with:
@@ -1131,6 +1135,7 @@ In `tests/auth/strategies/test_strategies.py`, replace `test_internal_chromium_s
 
         _, kwargs = mock_launch_pctx.call_args
         assert "channel" not in kwargs or kwargs["channel"] != "chrome"
+        assert "--disable-blink-features=AutomationControlled" not in kwargs.get("args", [])
         mock_page.request.get.assert_awaited()
 
     @pytest.mark.asyncio
@@ -1315,6 +1320,11 @@ with:
                         ),
                     )
 ```
+
+> **Note:** the replacement above ends at the `if not success:` raise. The two
+> lines that follow it in the current file — the `# Small delay to ensure state
+> is flushed to disk` comment and `await asyncio.sleep(1)` — are intentionally
+> left untouched (a harmless pre-close flush).
 
 - [ ] **Step 4: Run the tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-05-17-issue-15-i2v-bearer-auth.md
+++ b/docs/superpowers/plans/2026-05-17-issue-15-i2v-bearer-auth.md
@@ -1,0 +1,811 @@
+# Issue #15 — i2v `uploadImage` 401 Bearer-Auth Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gflow video i2v` work by attaching the `Authorization: Bearer` token that `aisandbox-pa.googleapis.com` REST routes require.
+
+**Architecture:** A new pure module `api/bearer_auth.py` captures the Flow OAuth Bearer token by observing a Playwright page's own requests. `FlowApiClient` captures it during bootstrap, attaches it host-scoped via a single `_with_bearer` helper, and re-captures once (single-flight) on a 401. A new `ApiAuthError` replaces the misleading `AuthExpiredError` for genuine API-auth failures.
+
+**Tech Stack:** Python 3.11+, Playwright (`page.request`, `page.on`), `asyncio`, `structlog`, `pytest` + `pytest-asyncio`.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md` (v2, council-reviewed).
+
+**Branch:** `fix/issue-15-i2v-bearer-auth` — all commits land here; merges to `main` via PR.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/gflow_cli/api/bearer_auth.py` | Create | Capture the Bearer token from a live page (pure module) |
+| `tests/api/test_bearer_auth.py` | Create | Unit tests for the capture module |
+| `src/gflow_cli/errors.py` | Modify | Add `ApiAuthError` + `EXIT_CODE_MAP` entry |
+| `tests/test_errors.py` | Modify | `ApiAuthError` taxonomy + exit-code-uniqueness tests |
+| `src/gflow_cli/api/client.py` | Modify | Fields, `_with_bearer`, `_redact_headers_for_log`, bootstrap capture, re-capture retry, error classification |
+| `tests/api/test_client.py` | Modify | Header-attach, host-scoping, re-capture, redaction tests |
+| `tests/live/test_i2v_live.py` | Create | `@pytest.mark.live` end-to-end i2v regression guard |
+| `PLAN.md` | Modify | Backlog pointer to the spec's alternatives |
+| `CHANGELOG.md` | Modify | `[Unreleased]` entry |
+
+**Convention reminders:** `from __future__ import annotations` at the top of every module; `structlog` (never `print`/`logging`); `@dataclass(frozen=True)` for value objects; run the 5 quality gates before every commit (`uv run python scripts/ci/check_repo_hygiene.py`, `uv run ruff check src tests`, `uv run ruff format --check src tests`, `uv run pyright src`, `uv run python -m pytest -q -m "not e2e and not live"`).
+
+---
+
+## Task 1: Phase 1 — Live verification gate (BLOCKING)
+
+Confirms the root cause empirically before any fix code. This task ends with a maintainer decision — do not start Task 2 until this gate returns **PASS**.
+
+**Files:**
+- Modify: `src/gflow_cli/api/client.py` (request helpers — temporary diagnostic logging)
+
+- [ ] **Step 1: Add env-flagged outgoing-header logging**
+
+In `client.py`, add this module-level helper near `_redact_for_log` (after line 962):
+
+```python
+def _redact_headers_for_log(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of `headers` with any `authorization` value masked.
+
+    The SOLE permitted way to log a headers dict — `_redact_for_log` covers
+    request bodies only, not headers. Spec §4.5.
+    """
+    redacted = dict(headers)
+    auth = redacted.get("authorization")
+    if auth is not None:
+        redacted["authorization"] = f"Bearer <len={len(auth)}>"
+    return redacted
+```
+
+In each of the three `attempt()` closures (`_post_json` ~line 322, `_patch_json` ~line 354, `generate_video` ~line 600), immediately before the `page.request.{post,patch}(...)` call, add:
+
+```python
+                if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
+                    logger.info(
+                        "request_headers",
+                        url=url,  # in generate_video use: routes.GENERATE_VIDEO
+                        headers=_redact_headers_for_log({"content-type": content_type}),
+                    )
+```
+
+(Use the literal headers dict each call site passes. Add `import os` to the imports if absent.)
+
+- [ ] **Step 2: Run the gates and commit the diagnostic**
+
+Run: `uv run ruff check src tests && uv run ruff format --check src tests && uv run pyright src`
+Expected: all pass.
+
+```bash
+git add src/gflow_cli/api/client.py
+git commit -m "feat(api): env-flagged outgoing request-header logging (issue #15 Phase 1)"
+```
+
+- [ ] **Step 3: Maintainer — capture the live diff**
+
+The maintainer (human) runs, on a profile with a verified session:
+
+```bash
+GFLOW_CLI_LOG_REQUEST_HEADERS=1 uv run gflow video i2v <image> "<prompt>" --profile <name> -o tmp/issue-15-phase1/out
+```
+
+Then, in a browser DevTools → Network, performs an image upload in the Flow UI and "copy as cURL" of the `POST /v1/flow/uploadImage` request. Save both header sets (CLI redacted log + browser cURL with the Bearer value redacted by hand) under `tmp/issue-15-phase1/`.
+
+- [ ] **Step 4: Diff every header and decide**
+
+Compare the **full** header set of the working browser request against the CLI request. Apply the outcome matrix (spec §5.1):
+
+| Outcome | Action |
+|---|---|
+| Only `Authorization` differs (browser has `Bearer`, CLI has none) | **PASS** → proceed to Task 2 |
+| A non-`Authorization` header also differs (`origin`, `referer`, `sec-fetch-*`, …) | **STOP** — revise the spec to copy the full required header set, re-plan |
+| CLI already sends `Authorization` and still 401s | **STOP** — spec is void; open a fresh investigation issue |
+
+Record the redacted diff and the decision in `tmp/issue-15-phase1/RESULT.md`. **Only a PASS unblocks Task 2.**
+
+---
+
+## Task 2: `ApiAuthError` error class
+
+**Files:**
+- Modify: `src/gflow_cli/errors.py` (add class after `AuthExpiredError` ~line 115; add to `EXIT_CODE_MAP` ~line 280)
+- Test: `tests/test_errors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_errors.py`:
+
+```python
+def test_api_auth_error_exit_code_is_14():
+    from gflow_cli.errors import ApiAuthError, EXIT_CODE_MAP
+    assert EXIT_CODE_MAP[ApiAuthError] == 14
+
+
+def test_api_auth_error_is_flow_api_error():
+    from gflow_cli.errors import ApiAuthError, FlowApiError
+    assert issubclass(ApiAuthError, FlowApiError)
+
+
+def test_api_auth_error_remediation_is_not_a_login_loop():
+    from gflow_cli.errors import ApiAuthError
+    hint = ApiAuthError().remediation_hint.lower()
+    # Must not send users straight into a blind re-login loop.
+    assert "gflow auth login" not in hint or "bug" in hint
+
+
+def test_api_auth_error_detail_carries_no_token_data():
+    from gflow_cli.errors import ApiAuthError
+    err = ApiAuthError(detail="HTTP 401", status=401, route="uploadImage")
+    pd = err.to_problem_details()
+    assert pd["detail"] == "HTTP 401"
+    assert "Bearer" not in repr(pd)
+
+
+def test_exit_code_map_values_are_unique():
+    from gflow_cli.errors import EXIT_CODE_MAP
+    values = list(EXIT_CODE_MAP.values())
+    assert len(values) == len(set(values)), "duplicate exit code in EXIT_CODE_MAP"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_errors.py -q -k "api_auth or exit_code_map_values"`
+Expected: FAIL — `ImportError: cannot import name 'ApiAuthError'`.
+
+- [ ] **Step 3: Add the `ApiAuthError` class**
+
+In `errors.py`, after the `AuthExpiredError` class (line 115):
+
+```python
+class ApiAuthError(FlowApiError):
+    """Raised when an aisandbox-pa.googleapis.com route returns 401 even after
+    a Bearer-token re-capture. Distinct from AuthExpiredError: the session
+    login is fine — the API rejected the request's bearer token.
+
+    `detail` MUST carry no token-derived data (spec §4.3) — a fixed string
+    only.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/api-auth"
+    title = "Flow API authorization failed"
+    _default_remediation = (
+        "The Flow API rejected the request's authorization after a token "
+        "re-capture. If you signed out elsewhere, run "
+        "`gflow auth login --profile <name>`; otherwise this is likely a "
+        "token-capture regression — please file a bug at "
+        "https://github.com/ffroliva/gflow-cli/issues (do NOT include tokens)."
+    )
+```
+
+- [ ] **Step 4: Register the exit code**
+
+In `errors.py`, inside `EXIT_CODE_MAP` (line 280), add this entry alongside the other `FlowApiError` subclasses (placement among siblings is immaterial — they are not ancestors of each other):
+
+```python
+    ApiAuthError: 14,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_errors.py -q`
+Expected: PASS (all error tests, new and existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/errors.py tests/test_errors.py
+git commit -m "feat(errors): add ApiAuthError (exit 14) for genuine API-auth failures"
+```
+
+---
+
+## Task 3: `bearer_auth.py` capture module
+
+**Files:**
+- Create: `src/gflow_cli/api/bearer_auth.py`
+- Test: `tests/api/test_bearer_auth.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/api/test_bearer_auth.py`:
+
+```python
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from gflow_cli.api.bearer_auth import BearerToken, capture_bearer_token
+from gflow_cli.errors import ApiAuthError
+
+
+class FakeRequest:
+    """Minimal stand-in for a Playwright Request."""
+
+    def __init__(self, url: str, headers: dict[str, str]) -> None:
+        self.url = url
+        self.headers = headers
+
+
+class FakePage:
+    """Fake Playwright Page. `goto` fires `requests` through the listeners."""
+
+    def __init__(self, requests: list[FakeRequest] | None = None) -> None:
+        self._requests = requests or []
+        self._listeners: dict[str, list] = {}
+
+    def on(self, event: str, cb) -> None:
+        self._listeners.setdefault(event, []).append(cb)
+
+    def remove_listener(self, event: str, cb) -> None:
+        self._listeners.get(event, []).remove(cb)
+
+    async def goto(self, url: str, **kwargs: object) -> None:
+        for req in self._requests:
+            for cb in list(self._listeners.get("request", [])):
+                cb(req)
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_token_from_aisandbox_bearer_request():
+    page = FakePage([
+        FakeRequest(
+            "https://aisandbox-pa.googleapis.com/v1/flow/uploadImage",
+            {"authorization": "Bearer abc123"},
+        )
+    ])
+    token = await capture_bearer_token(page, timeout_s=1.0)
+    assert isinstance(token, BearerToken)
+    assert token.value == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_capture_ignores_non_aisandbox_and_non_bearer_requests():
+    page = FakePage([
+        FakeRequest("https://labs.google/whatever", {"authorization": "Bearer x"}),
+        FakeRequest(
+            "https://aisandbox-pa.googleapis.com/v1/flow/uploadImage",
+            {"authorization": "SAPISIDHASH nope"},
+        ),
+    ])
+    with pytest.raises(ApiAuthError):
+        await capture_bearer_token(page, timeout_s=0.05)
+
+
+@pytest.mark.asyncio
+async def test_capture_times_out_fast_when_no_bearer_seen():
+    page = FakePage(requests=[])  # goto fires nothing
+    start = time.monotonic()
+    with pytest.raises(ApiAuthError):
+        await capture_bearer_token(page, timeout_s=0.001)
+    assert time.monotonic() - start < 1.0  # no real 30s sleep
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/api/test_bearer_auth.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gflow_cli.api.bearer_auth'`.
+
+- [ ] **Step 3: Create the module**
+
+Create `src/gflow_cli/api/bearer_auth.py`:
+
+```python
+"""Capture the Flow OAuth Bearer token from a live Playwright page.
+
+aisandbox-pa.googleapis.com REST endpoints require an `Authorization: Bearer
+<token>` header. Playwright's `page.request` is a separate HTTP client that
+shares only the browser cookie jar — it never receives the OAuth token the
+Flow web app mints in-page. This module captures that token by observing the
+page's own outgoing requests during a navigation.
+
+Security: the token is held in memory only — never written to disk, never
+logged. The intercepting closure clears its capture buffer on any error exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import structlog
+
+from gflow_cli.api import routes
+from gflow_cli.errors import ApiAuthError
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+    from playwright.async_api import Request as PlaywrightRequest
+
+log = structlog.get_logger(__name__)
+
+AISANDBOX_HOST = "aisandbox-pa.googleapis.com"
+_BEARER_PREFIX = "Bearer "
+
+
+@dataclass(frozen=True)
+class BearerToken:
+    """An OAuth Bearer token captured from a live Flow page."""
+
+    value: str
+
+
+async def capture_bearer_token(page: "Page", *, timeout_s: float = 30.0) -> BearerToken:
+    """Navigate `page` to the Flow editor and return the first
+    `Authorization: Bearer` token it sends to aisandbox-pa.googleapis.com.
+
+    Raises:
+        ApiAuthError: if no Bearer token is observed within `timeout_s`.
+    """
+    captured: list[str] = []  # mutable container — cleared on error exit
+    done = asyncio.Event()
+
+    def _on_request(req: "PlaywrightRequest") -> None:
+        if captured or AISANDBOX_HOST not in req.url:
+            return
+        auth = req.headers.get("authorization", "")
+        if auth.startswith(_BEARER_PREFIX):
+            captured.append(auth[len(_BEARER_PREFIX) :])
+            done.set()
+
+    page.on("request", _on_request)
+    try:
+        await page.goto(
+            routes.EDITOR_BOOTSTRAP_URL, wait_until="domcontentloaded", timeout=60_000
+        )
+        await asyncio.wait_for(done.wait(), timeout=timeout_s)
+        log.info("bearer_auth.captured")
+        return BearerToken(value=captured[0])
+    except TimeoutError:
+        captured.clear()  # never leave a token reachable from an exception
+        raise ApiAuthError(
+            detail="bearer token capture timed out",
+            route="bearer_auth.capture",
+        ) from None
+    finally:
+        page.remove_listener("request", _on_request)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/api/test_bearer_auth.py -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run type + lint gates**
+
+Run: `uv run ruff check src tests && uv run pyright src`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/api/bearer_auth.py tests/api/test_bearer_auth.py
+git commit -m "feat(api): add bearer_auth module — capture Flow OAuth Bearer token"
+```
+
+---
+
+## Task 4: `FlowApiClient` — fields, helpers, bootstrap capture
+
+**Files:**
+- Modify: `src/gflow_cli/api/client.py` (`__init__` ~line 142, `__aenter__` ~line 199, new helpers)
+- Test: `tests/api/test_client.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/api/test_client.py`:
+
+```python
+def test_with_bearer_attaches_only_for_aisandbox_host():
+    from gflow_cli.api.bearer_auth import BearerToken
+    from gflow_cli.api.client import FlowApiClient
+    from pathlib import Path
+
+    client = FlowApiClient(Path("x"))
+    client._bearer = BearerToken(value="tok123")
+
+    aisandbox = client._with_bearer(
+        "https://aisandbox-pa.googleapis.com/v1/flow/uploadImage",
+        {"content-type": "text/plain"},
+    )
+    assert aisandbox["authorization"] == "Bearer tok123"
+
+    labs = client._with_bearer(
+        "https://labs.google/fx/api/trpc/project.createProject",
+        {"content-type": "application/json"},
+    )
+    assert "authorization" not in labs
+
+
+def test_redact_headers_for_log_masks_authorization():
+    from gflow_cli.api.client import _redact_headers_for_log
+
+    out = _redact_headers_for_log({"authorization": "Bearer secrettokenvalue"})
+    assert out["authorization"] == "Bearer <len=24>"
+    assert "secrettokenvalue" not in repr(out)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest tests/api/test_client.py -q -k "with_bearer or redact_headers"`
+Expected: FAIL — `AttributeError: 'FlowApiClient' object has no attribute '_with_bearer'`.
+
+- [ ] **Step 3: Add imports and `__init__` fields**
+
+In `client.py` imports, add:
+
+```python
+from gflow_cli.api.bearer_auth import AISANDBOX_HOST, BearerToken, capture_bearer_token
+from gflow_cli.errors import ApiAuthError  # add to the existing errors import
+```
+
+In `__init__`, after `self._page: Page | None = None` (line 142):
+
+```python
+        # issue #15: Bearer token for aisandbox-pa REST routes — captured on
+        # bootstrap, held in memory only. The lock makes re-capture single-flight.
+        self._bearer: BearerToken | None = None
+        self._bearer_lock = asyncio.Lock()
+```
+
+- [ ] **Step 4: Add the `_with_bearer` helper**
+
+In `client.py`, add as a method on `FlowApiClient` near `_post_json` (before line 293):
+
+```python
+    def _with_bearer(self, url: str, headers: dict[str, str]) -> dict[str, str]:
+        """Return `headers` plus an `Authorization: Bearer` header IFF `url`
+        targets aisandbox-pa.googleapis.com and a token has been captured.
+
+        This is the SOLE place the Authorization header is added (spec §4.6).
+        """
+        if AISANDBOX_HOST in url and self._bearer is not None:
+            return {**headers, "authorization": f"Bearer {self._bearer.value}"}
+        return headers
+```
+
+- [ ] **Step 5: Add `_redact_headers_for_log`** (if Task 1 was reverted/not merged)
+
+If `_redact_headers_for_log` is not already present from Task 1, add it as a module-level function after `_redact_for_log` (see Task 1 Step 1 for the exact code). Otherwise skip.
+
+- [ ] **Step 6: Capture the Bearer during bootstrap**
+
+In `__aenter__`, replace the existing bootstrap navigation (lines 199-201):
+
+```python
+        await self._page.goto(
+            routes.EDITOR_BOOTSTRAP_URL, wait_until="domcontentloaded", timeout=60_000
+        )
+```
+
+with:
+
+```python
+        # Bootstrap navigation + Bearer capture (issue #15). capture_bearer_token
+        # navigates to the editor and observes the page's own aisandbox-pa
+        # request to lift the OAuth Bearer. A miss here is non-fatal — the first
+        # aisandbox 401 triggers a re-capture (see _post_json).
+        try:
+            self._bearer = await capture_bearer_token(self._page)
+        except ApiAuthError:
+            log.warning("bearer_capture_failed_on_bootstrap")
+            await self._page.goto(
+                routes.EDITOR_BOOTSTRAP_URL,
+                wait_until="domcontentloaded",
+                timeout=60_000,
+            )
+```
+
+(`log` is the module `structlog` logger — confirm it exists; `client.py` already binds `logger`. Use whichever name the module already defines for the structlog logger.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/api/test_client.py -q -k "with_bearer or redact_headers"`
+Expected: PASS.
+
+- [ ] **Step 8: Run the full client test file (no regressions)**
+
+Run: `uv run python -m pytest tests/api/ -q -m "not e2e and not live"`
+Expected: PASS — all existing api tests still green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/gflow_cli/api/client.py tests/api/test_client.py
+git commit -m "feat(api): capture Bearer token on bootstrap; add _with_bearer helper"
+```
+
+---
+
+## Task 5: `FlowApiClient` — attach header + single-flight re-capture
+
+**Files:**
+- Modify: `src/gflow_cli/api/client.py` (`_post_json`, `_patch_json`, `generate_video`, new `_recapture_bearer`)
+- Test: `tests/api/test_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/api/test_client.py` (these use the existing Playwright-mock fixtures in that file — follow the established `_patch_playwright` / `fake_context` pattern; the assertions below describe the required behaviour):
+
+```python
+@pytest.mark.asyncio
+async def test_post_json_attaches_bearer_for_aisandbox(monkeypatch):
+    """A _post_json call to an aisandbox-pa URL sends Authorization: Bearer."""
+    # Arrange a FlowApiClient with a stubbed page whose request.post records
+    # the headers it was called with, and client._bearer set to a known token.
+    # Assert the recorded headers contain authorization == "Bearer <token>".
+
+
+@pytest.mark.asyncio
+async def test_post_json_omits_bearer_for_labs_host(monkeypatch):
+    """create_project (labs.google) must NOT receive an Authorization header."""
+    # Same harness; call create_project; assert "authorization" not in headers.
+
+
+@pytest.mark.asyncio
+async def test_single_recapture_on_401_then_retry(monkeypatch):
+    """A 401 from aisandbox triggers exactly one capture_bearer_token call."""
+    # Stub page.request.post to return 401 once, then 200.
+    # Patch gflow_cli.api.client.capture_bearer_token with a Mock.
+    # Call upload_image; assert capture mock call_count == 1 and the call
+    # ultimately succeeds.
+
+
+@pytest.mark.asyncio
+async def test_second_401_raises_api_auth_error(monkeypatch):
+    """A 401 that survives the re-capture retry raises ApiAuthError, not
+    AuthExpiredError."""
+    # Stub page.request.post to return 401 on every call.
+    # Call upload_image; assert pytest.raises(ApiAuthError).
+
+
+@pytest.mark.asyncio
+async def test_concurrent_401s_recapture_once(monkeypatch):
+    """N concurrent aisandbox calls hitting 401 trigger ONE re-capture."""
+    # Run several _post_json calls concurrently with asyncio.gather, all
+    # getting 401-then-200. Assert capture_bearer_token mock call_count == 1.
+
+
+@pytest.mark.asyncio
+async def test_no_bearer_value_in_logs(monkeypatch):
+    """structlog output never contains a raw 'Bearer <token>' string."""
+    # Use structlog.testing.capture_logs(); make an aisandbox POST with
+    # GFLOW_CLI_LOG_REQUEST_HEADERS=1; assert no entry repr contains the
+    # literal token value.
+```
+
+Write these as concrete tests following the existing harness in `tests/api/test_client.py`. Each must fail before Step 3.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/api/test_client.py -q -k "bearer or recapture or 401 or api_auth"`
+Expected: FAIL — headers lack `authorization`; no re-capture occurs.
+
+- [ ] **Step 3: Add the single-flight re-capture method**
+
+In `client.py`, add to `FlowApiClient`:
+
+```python
+    async def _recapture_bearer(self, stale: BearerToken | None) -> None:
+        """Re-capture the Bearer token, single-flight.
+
+        `stale` is the token the caller saw fail. Under the lock we re-check:
+        if another worker already refreshed it, we do nothing.
+        """
+        async with self._bearer_lock:
+            if self._bearer is not stale:
+                return  # another worker already refreshed
+            page = await self._checkout_page()
+            try:
+                self._bearer = await capture_bearer_token(page)
+            finally:
+                self._checkin_page(page)
+```
+
+- [ ] **Step 4: Wire the header + retry into `_post_json`**
+
+In `_post_json`, replace the `attempt()` closure (lines 319-328) with:
+
+```python
+        async def attempt() -> Any:
+            page = await self._checkout_page()
+            try:
+                return await page.request.post(
+                    url,
+                    data=body_str,
+                    headers=self._with_bearer(url, {"content-type": content_type}),
+                )
+            finally:
+                self._checkin_page(page)
+```
+
+Then, after `resp = await self._run_with_retry(attempt, route=route)` (line 330), insert the re-capture retry **before** `text = await resp.text()`:
+
+```python
+        if resp.status == 401 and AISANDBOX_HOST in url:
+            stale = self._bearer
+            await self._recapture_bearer(stale)
+            resp = await self._run_with_retry(attempt, route=route)
+            if resp.status == 401:
+                raise ApiAuthError(
+                    detail=f"HTTP {resp.status}",
+                    status=resp.status,
+                    instance=_make_instance(),
+                    route=route,
+                )
+```
+
+- [ ] **Step 5: Wire `_patch_json` and `generate_video`**
+
+In `_patch_json`'s `attempt()` (line 354), change the `headers=` argument to:
+
+```python
+                    headers=self._with_bearer(url, {"content-type": _AISANDBOX_CONTENT_TYPE}),
+```
+
+and add the same re-capture-retry block after its `resp = await self._run_with_retry(...)`.
+
+In `generate_video`'s `attempt()` (line 600), change the `headers=` argument to:
+
+```python
+                    headers=self._with_bearer(
+                        routes.GENERATE_VIDEO, {"content-type": _AISANDBOX_CONTENT_TYPE}
+                    ),
+```
+
+and add the same re-capture-retry block after its `response = await self._run_with_retry(...)` (line 608), using `routes.GENERATE_VIDEO` as the URL in the `AISANDBOX_HOST in ...` check.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/api/test_client.py -q`
+Expected: PASS — all new and existing client tests.
+
+- [ ] **Step 7: Run the full suite (no regressions)**
+
+Run: `uv run python -m pytest -q -m "not e2e and not live" --cov=gflow_cli`
+Expected: PASS — 577+ tests, coverage ≥ 80%.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gflow_cli/api/client.py tests/api/test_client.py
+git commit -m "fix(api): attach Bearer to aisandbox routes; single-flight re-capture on 401"
+```
+
+---
+
+## Task 6: Live E2E regression test
+
+**Files:**
+- Create: `tests/live/test_i2v_live.py`
+
+- [ ] **Step 1: Create the live test**
+
+Create `tests/live/test_i2v_live.py`:
+
+```python
+"""End-to-end i2v regression guard for issue #15.
+
+OPT-IN ONLY — requires a real logged-in profile and live Flow auth. Never
+runs in CI. Run with: `uv run python -m pytest tests/live/ -m live`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.live
+
+
+@pytest.mark.asyncio
+async def test_i2v_uploads_image_without_401(tmp_path: Path) -> None:
+    """`upload_image` to aisandbox-pa /v1/flow/uploadImage returns 200 — the
+    issue #15 regression: it must NOT raise ApiAuthError / AuthExpiredError."""
+    profile = os.environ.get("GFLOW_CLI_E2E_PROFILE")
+    if not profile:
+        pytest.skip("GFLOW_CLI_E2E_PROFILE not set")
+
+    from gflow_cli.api.client import FlowApiClient
+    from gflow_cli.config import get_settings
+
+    profile_dir = get_settings().profile_subdir(profile)
+    fixture = Path("test_assets/fixtures") / "i2v_source.png"
+    assert fixture.exists(), "commit a small PNG fixture at test_assets/fixtures/"
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=False) as client:
+        project = await client.create_project(title="issue-15 live test")
+        asset = await client.upload_image(project.project_id, fixture)
+        assert asset.name  # a non-empty asset UUID proves the 200
+```
+
+- [ ] **Step 2: Verify it is excluded from the default run**
+
+Run: `uv run python -m pytest tests/live/test_i2v_live.py -q -m "not e2e and not live"`
+Expected: `1 deselected` (the `live` marker keeps it out of the default suite).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/live/test_i2v_live.py
+git commit -m "test(live): add opt-in i2v end-to-end regression guard (issue #15)"
+```
+
+---
+
+## Task 7: Backlog pointer, changelog, verification & PR
+
+**Files:**
+- Modify: `PLAN.md` (the issue #15 section ~line 443)
+- Modify: `CHANGELOG.md` (`[Unreleased]`)
+
+- [ ] **Step 1: Add the PLAN.md backlog pointer for Approaches B/C**
+
+In `PLAN.md`, append to the issue #15 section (after line 501, before the `---`):
+
+```markdown
+**Alternative auth-attachment strategies — BACKLOG (deferred):**
+Approaches B (inline capture in `client.py`) and C (`page.evaluate(fetch())`)
+were considered and deferred. Full rationale:
+`docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md` §8.
+```
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]`, add:
+
+```markdown
+### Fixed
+
+- **`gflow video i2v` no longer fails with a 401** — `aisandbox-pa.googleapis.com`
+  REST routes now carry the `Authorization: Bearer` token they require
+  (captured from the live Flow page, in memory only). A genuine API-auth
+  failure now raises the new `ApiAuthError` (exit 14) instead of a misleading
+  `AuthExpiredError` that looped users through `gflow auth login`. (#15)
+```
+
+- [ ] **Step 3: Remove the Phase 1 diagnostic decision**
+
+Confirm whether the env-flagged header logging from Task 1 stays (spec §5 — it ships permanently behind `GFLOW_CLI_LOG_REQUEST_HEADERS`). It stays. Verify `_redact_headers_for_log` is its only formatting path.
+
+- [ ] **Step 4: Run all five quality gates**
+
+```bash
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run python -m pytest -q -m "not e2e and not live" --cov=gflow_cli --cov-fail-under=80
+```
+Expected: all pass; coverage ≥ 80%.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add PLAN.md CHANGELOG.md
+git commit -m "docs: record issue #15 fix in CHANGELOG + PLAN backlog pointer"
+git push
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+gh pr create --base main --head fix/issue-15-i2v-bearer-auth \
+  --title "fix(i2v): attach Bearer auth to aisandbox-pa routes (#15)" \
+  --body "Implements docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md. Closes #15."
+```
+
+CI must pass all 5 required checks. Merge via the PR (the `main` branch is protected — no direct pushes).
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** §2 root cause → Task 1 verifies it. §4.1 module → Task 3. §4.2 client wiring + single-flight → Tasks 4-5. §4.3 `ApiAuthError` + route discrimination → Task 2 + Task 5 Step 4. §4.5 `_redact_headers_for_log` → Task 1/4. §4.6 invariants → enforced by Task 4-5 tests. §5 Phase 1 gate → Task 1. §6 test plan → Tasks 2-6 (fixtures in Task 3, `call_count`/negative/uniqueness/redaction tests in Tasks 2&5). §7 non-regression → Step "full suite" in Tasks 4,5,7. §8 alternatives → Task 7 Step 1. §10 phasing → task order matches.
+
+**Placeholder scan:** Task 5 Step 1 intentionally describes tests as behavioural specs to be written against the existing `tests/api/test_client.py` Playwright-mock harness (that harness is large and project-specific); every other code step shows complete code. The executing engineer must write Task 5's test bodies concretely before Step 2 — this is called out explicitly.
+
+**Type consistency:** `BearerToken.value: str`, `capture_bearer_token(page, *, timeout_s) -> BearerToken`, `_with_bearer(url, headers) -> dict`, `_recapture_bearer(stale)`, `ApiAuthError`, `AISANDBOX_HOST`, `_redact_headers_for_log` — names are consistent across Tasks 2-5.

--- a/docs/superpowers/plans/2026-05-17-issue-15-orchestration.md
+++ b/docs/superpowers/plans/2026-05-17-issue-15-orchestration.md
@@ -1,0 +1,118 @@
+# Issue #15 Auth-Verification Fix — Orchestration Plan
+
+> **Purpose:** define *which subagent does what, in what order, with which
+> model, and how each is reviewed* — before any dispatch. This is the
+> execution schedule for the implementation plan.
+
+## Inputs
+
+- **Spec:** `docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md` (Rev 2).
+- **Implementation plan:** `docs/superpowers/plans/2026-05-17-issue-15-auth-verification-fix.md` — 7 tasks, complete code and tests inline.
+- Both are twice-reviewed by agent councils and committed.
+
+## Branch & workspace
+
+- Execute on the **existing** branch `fix/issue-15-i2v-bearer-auth` (already cut from `develop`). No new worktree — the branch already isolates the work.
+- Each task produces one or more **atomic commits** on that branch (the plan's tasks each end with a `git commit`).
+- On completion: PR into `develop` (never `main`). `main` is protected.
+
+## Roles
+
+| Role | Who | Job |
+|---|---|---|
+| **Orchestrator** | This session (me) | Extracts each task's full text, dispatches subagents, answers their questions, runs the review loop, handles failures, tracks progress. Never edits code directly. |
+| **Implementer** | Fresh `general-purpose` subagent, one per task | Implements one task TDD-style (test → red → code → green → commit), self-reviews, reports a status. |
+| **Spec reviewer** | Fresh subagent, one per task | Confirms the code matches the task spec — nothing missing, nothing extra. |
+| **Code-quality reviewer** | `everything-claude-code:python-reviewer`, one per task | Reviews the diff for quality, idioms, types, safety. |
+| **Final reviewer** | `everything-claude-code:code-reviewer` | One whole-implementation review after all 7 tasks. |
+
+Each subagent starts with **zero session history** — the orchestrator hands it exactly the context it needs (full task text, spec references, conventions, prior-task outcomes). Subagents never read the plan file themselves.
+
+## Task inventory
+
+| # | Task | Files | Implementer model | Depends on |
+|---|---|---|---|---|
+| T1 | `verification.py` — evaluation core (`FlowSessionOutcome`, `FlowSessionStatus`, `evaluate_session_response`) | create `verification.py`, `test_verification.py` | sonnet | — |
+| T2 | `verification.py` — `verify_flow_session` async probe | modify `verification.py`, `test_verification.py` | sonnet | T1 |
+| T3 | `errors.py` — `AuthMissingError` docstring refresh | modify `errors.py` | haiku | — |
+| T4 | `real_chrome.py` — verify the Flow app session | modify `real_chrome.py`, `test_strategies.py` | sonnet | T2 |
+| T5 | `internal_chromium.py` — live `/api/auth/session` poll | modify `internal_chromium.py`, `test_strategies.py` | sonnet | T1 |
+| T6 | `KNOWN_ISSUES.md` — record the endpoint coupling | modify `KNOWN_ISSUES.md` | haiku | — |
+| T7 | Full verification gate (5 CI gates + BDD + CHANGELOG) | modify `CHANGELOG.md` | sonnet | T1–T6 |
+
+Reviewer subagents run on **sonnet**; the final whole-implementation review on **opus**.
+
+## Dependency graph
+
+```
+T1 ──┬──> T2 ──> T4 ──┐
+     │                ├──> T7
+     └──> T5 ─────────┘
+T3 ───────────────────┘   (independent)
+T6 ───────────────────┘   (independent)
+```
+
+- **T2 needs T1** — same module; `verify_flow_session` builds on T1's enum/dataclass/`evaluate_session_response`.
+- **T4 needs T2** — `real_chrome.py` imports `verify_flow_session`.
+- **T5 needs T1** — `internal_chromium.py` imports `SESSION_API_URL`, `FlowSessionOutcome`, `evaluate_session_response`.
+- **T4 and T5 both modify `test_strategies.py`** — they must not overlap; T4 runs before T5.
+- **T3, T6** depend on nothing — isolated files.
+- **T7 needs everything** — it runs the full quality gate over the finished code.
+
+## Execution sequence
+
+Implementation is **strictly sequential** — one implementer subagent at a time (parallel implementers would conflict on shared files and interleave commits). The order **T1 → T2 → T3 → T4 → T5 → T6 → T7** satisfies every dependency:
+
+1. **T1** — foundation: the verification module's pure core.
+2. **T2** — extends T1's module with the async probe.
+3. **T3** — `errors.py` docstring (independent; slotted here so the `errors.py` touch precedes T4's new use of `AuthMissingError`).
+4. **T4** — `real_chrome.py`, consuming `verify_flow_session`.
+5. **T5** — `internal_chromium.py` (after T4 — shared `test_strategies.py`).
+6. **T6** — `KNOWN_ISSUES.md` (independent; isolated file).
+7. **T7** — full quality gate over the complete change, plus the `CHANGELOG.md` entry.
+
+T3 and T6 are dependency-free; their slots are flexible, but they still run in the single sequential lane.
+
+## Per-task protocol
+
+For each task, in order:
+
+1. **Dispatch implementer.** The orchestrator hands a fresh `general-purpose` subagent: the task's **full verbatim text** from the implementation plan (every step, every code block); scene-setting context (§ below); and the instruction to follow TDD and end with a status of `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`.
+2. **Answer questions.** If the implementer asks anything before/during work, the orchestrator answers fully, then the implementer proceeds.
+3. **Implementer works:** writes the failing test → runs it (confirms red) → writes minimal code → runs it (confirms green) → lint/type-check → commits → self-reviews. Reports status + the commit SHA(s).
+4. **Spec-compliance review.** Dispatch a fresh reviewer with the task spec + the commit diff. It confirms the code does exactly what the task specifies — nothing missing, nothing extra.
+   - Issues found → re-dispatch the **same** implementer with the issue list → it fixes → re-review. Loop until ✅.
+5. **Code-quality review.** Only after spec ✅. Dispatch `python-reviewer` on the diff.
+   - Issues found → implementer fixes → re-review. Loop until ✅.
+6. **Mark the task complete.** Proceed to the next task.
+
+After T7: dispatch the **final whole-implementation reviewer** (opus) over the full branch diff, then invoke `superpowers:finishing-a-development-branch` to present merge/PR options.
+
+## Context handed to each subagent
+
+The orchestrator constructs, per subagent (they inherit nothing):
+
+- **Implementer:** project one-liner (gflow-cli, Python CLI for Google Flow); the spec path for reference; the task's full text; the relevant conventions — TDD red→green→commit, `uv run` for all commands, `ruff` + `pyright --strict` on `src/`, Conventional Commits, **no `Co-Authored-By` trailer**, runtime output only under `tmp/`; and the **state from prior tasks** (e.g. for T2: "`verification.py` already exists with `FlowSessionOutcome`, `FlowSessionStatus`, `evaluate_session_response` from T1").
+- **Spec reviewer:** the task's spec text + the commit SHA(s) to inspect. Read-only.
+- **Code-quality reviewer:** the commit SHA range + the project conventions. Read-only.
+
+## Failure handling
+
+| Implementer status | Orchestrator action |
+|---|---|
+| `DONE` | Proceed to spec review. |
+| `DONE_WITH_CONCERNS` | Read concerns; if about correctness/scope, resolve before review; if observational, note and proceed. |
+| `NEEDS_CONTEXT` | Supply the missing context, re-dispatch the same task. |
+| `BLOCKED` | Diagnose: context gap → re-dispatch with more context; needs deeper reasoning → re-dispatch on a stronger model; task too large → split it; **plan itself is wrong → stop and escalate to the human.** |
+
+A reviewer finding issues is **not** a failure — it triggers the fix→re-review loop. Never proceed with an open issue from either review.
+
+## Human checkpoints
+
+- **Now:** review and approve this orchestration plan.
+- **During execution:** none — once approved, all 7 tasks run **continuously**, no check-ins between tasks. The only mid-run stop is an unresolvable `BLOCKED` or a discovered plan defect.
+- **End:** the final whole-implementation review, then `finishing-a-development-branch` presents the merge/PR decision for approval.
+
+## Estimated subagent count
+
+7 implementers + ~7 spec reviewers + ~7 code-quality reviewers + review-loop re-dispatches + 1 final reviewer ≈ **22–30 subagent invocations**. Cost is front-loaded into review; it catches issues before they compound.

--- a/docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md
@@ -1,0 +1,113 @@
+# E2E Test Coverage — Auth Verification & Integration Ergonomics — Design
+
+> **Status:** Approved design · **Date:** 2026-05-17
+> **Branch:** `fix/issue-15-i2v-bearer-auth` (folds into PR #22 → `develop`)
+> **Related:** issue #15 auth-verification fix (this branch); PR #20 integration
+> ergonomics (already merged to `develop`).
+
+## 1. Goal
+
+Two things:
+
+1. **Run** the existing e2e suite against a real authenticated profile and
+   record a truthful baseline of what passes — including PR #20's two e2e
+   tests, which were merged unexecuted.
+2. **Add** e2e coverage for the issue-#15 auth-verification feature (which has
+   none today) and fill obvious gaps in PR #20's integration-ergonomics e2e
+   coverage.
+
+## 2. Constraints (these shape the design)
+
+- **`gflow auth login` cannot be e2e-automated.** It opens a browser and waits
+  for interactive Google sign-in; Google blocks scripted login. So the
+  issue-#15 e2e tests exercise the **`verify_flow_session` probe directly**
+  against real profiles — the honest, feasible seam. It still makes a real
+  call to Google's `/api/auth/session`.
+- **e2e never runs in CI** — unchanged. CI keeps `-m "not e2e and not live"`.
+  These tests only ever run locally, from a machine with a real profile.
+- **Credit cost.** Transport/image tests spend real Flow credits; a full
+  baseline run is 60+ image generations. Approved. The new auth-verification
+  tests cost **zero credits** — they only probe the session endpoint.
+- **Profile.** `GFLOW_CLI_E2E_PROFILE=denon82` is the authenticated profile
+  for all live runs. (`profile_issue15` was deleted — invalid; do not rely on
+  any Google-only profile existing.)
+
+## 3. Part A — Baseline run
+
+Run the existing `tests/e2e/test_transports_e2e.py` (criteria C2–C5 across the
+three transport strategies, plus PR #20's `test_e2e_generate_image_without_project_id`
+and `test_e2e_health_check_returns_true_when_active`):
+
+```
+GFLOW_CLI_E2E_PROFILE=denon82  uv run python -m pytest tests/e2e -m e2e -v -p no:cov
+```
+
+Record pass/fail/skip per test. This is reconnaissance — it tells us what
+currently works (some parametrized transport strategies may be obsolete after
+issue #15) before we add anything. No code changes in this part.
+
+## 4. Part B — Issue-#15 auth-verification e2e
+
+New module: **`tests/e2e/test_auth_verification_e2e.py`**, marked
+`pytestmark = pytest.mark.e2e`.
+
+| Test | What it does | Cost |
+|---|---|---|
+| `test_e2e_verify_flow_session_authenticated` | `verify_flow_session(<denon82 profile>, channel="chrome", source="chrome")` → asserts `outcome is AUTHENTICATED`, `user_email` is a non-empty `str`, `authenticated is True`. Proves the issue-#15 fix works against the real Google endpoint. | 0 credits |
+| `test_e2e_verify_flow_session_no_session` | Creates a fresh empty profile dir inside the gflow home, probes it → asserts `outcome is NO_SESSION` (empty profile: real headless Chrome launches, no `SAPISID`, `/api/auth/session` returns `200 {}`). Deterministic; the temp dir is removed in teardown. | 0 credits |
+
+**Out of e2e scope (deliberate):** `GOOGLE_SESSION_ONLY` needs a
+Google-signed-in-but-not-Flow profile and `VERIFICATION_ERROR` needs an
+injected network fault — neither is cleanly producible live. Both remain
+covered by the existing unit tests in `tests/auth/test_verification.py`.
+
+## 5. Part C — Additional PR #20 e2e coverage
+
+PR #20's two e2e tests are *run* in Part A. For *new* coverage, the
+implementation plan's first step inspects the auto-project-creation and
+`FlowApiClient.health_check()` surface, then adds **≤3 targeted tests** for
+gaps the existing two do not cover. Candidate tests (finalized after that
+inspection):
+
+- `health_check()` returns `False` on a closed / unusable client context.
+- An explicit `project_id` is honoured (no spurious project auto-created).
+- A second generation reuses an auto-created project rather than making a new
+  one — if the feature is specified to do so.
+
+These land in `tests/e2e/test_transports_e2e.py` or a sibling module,
+whichever the inspection shows is the better home.
+
+## 6. Shared support
+
+Add **`tests/e2e/conftest.py`** providing an `e2e_profile_dir` pytest fixture
+that resolves `GFLOW_CLI_E2E_PROFILE` and `pytest.skip()`s when it is unset or
+the directory is absent — the same gate logic `test_transports_e2e.py`
+currently inlines as `_profile_dir()`. New tests use the fixture. The existing
+`test_transports_e2e.py` is left untouched (refactoring its private helper to
+the fixture is optional and out of scope).
+
+## 7. Execution order
+
+1. Part A — baseline run with `denon82`; record results.
+2. Inspect PR #20's feature surface (for Part C).
+3. Write Part B module + `conftest.py`; write Part C tests.
+4. Full e2e run (`-m e2e`, `denon82`) — confirm Part B/C green and no
+   regression in the existing suite.
+5. `ruff` / `pyright` on the new test files; commit to
+   `fix/issue-15-i2v-bearer-auth`.
+
+## 8. Non-goals
+
+- No change to CI (e2e stays excluded).
+- No automation of `gflow auth login` / the interactive browser sign-in.
+- No refactor of the existing `test_transports_e2e.py` beyond optionally
+  adopting the shared fixture.
+- No new production code — this is test-only work.
+
+## 9. Verification
+
+- New e2e files pass `ruff check`, `ruff format --check`, `pyright`.
+- Part B tests pass against `denon82` (positive) and a fresh empty profile
+  (`NO_SESSION`).
+- The baseline and final full e2e runs are recorded so any pre-existing
+  failures are distinguished from regressions.

--- a/docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md
@@ -1,9 +1,12 @@
 # E2E Test Coverage — Auth Verification & Integration Ergonomics — Design
 
-> **Status:** Approved design · **Date:** 2026-05-17
+> **Status:** Approved design · **Date:** 2026-05-17 · **Revision:** 2
 > **Branch:** `fix/issue-15-i2v-bearer-auth` (folds into PR #22 → `develop`)
-> **Related:** issue #15 auth-verification fix (this branch); PR #20 integration
-> ergonomics (already merged to `develop`).
+> **Reviewed by:** a 4-agent council — implementability, codebase-accuracy,
+> test-strategy, risk/operations. All returned APPROVE-WITH-CHANGES (none
+> NEEDS-REWORK); findings folded into Rev 2 (see §10).
+> **Related:** issue #15 auth-verification fix (this branch); PR #20
+> integration ergonomics (already merged to `develop`).
 
 ## 1. Goal
 
@@ -24,10 +27,12 @@ Two things:
   against real profiles — the honest, feasible seam. It still makes a real
   call to Google's `/api/auth/session`.
 - **e2e never runs in CI** — unchanged. CI keeps `-m "not e2e and not live"`.
-  These tests only ever run locally, from a machine with a real profile.
+  These tests only ever run locally, from a machine with a real profile (and,
+  by definition of how that profile is created, with system Chrome installed).
 - **Credit cost.** Transport/image tests spend real Flow credits; a full
-  baseline run is 60+ image generations. Approved. The new auth-verification
-  tests cost **zero credits** — they only probe the session endpoint.
+  baseline run is ≈69 image generations (criterion C3 alone is 60). Approved.
+  The new auth-verification tests cost **zero credits** — they only probe the
+  session endpoint and call `health_check()`.
 - **Profile.** `GFLOW_CLI_E2E_PROFILE=denon82` is the authenticated profile
   for all live runs. (`profile_issue15` was deleted — invalid; do not rely on
   any Google-only profile existing.)
@@ -44,54 +49,93 @@ GFLOW_CLI_E2E_PROFILE=denon82  uv run python -m pytest tests/e2e -m e2e -v -p no
 
 Record pass/fail/skip per test. This is reconnaissance — it tells us what
 currently works (some parametrized transport strategies may be obsolete after
-issue #15) before we add anything. No code changes in this part.
+issue #15) before we add anything. No code changes in this part. **Do not run
+e2e with `pytest-xdist` (`-n`)** — parallel real-Chrome instances risk OOM on
+this machine.
 
 ## 4. Part B — Issue-#15 auth-verification e2e
 
 New module: **`tests/e2e/test_auth_verification_e2e.py`**, marked
-`pytestmark = pytest.mark.e2e`.
+`pytestmark = pytest.mark.e2e`. Async tests need no `@pytest.mark.asyncio`
+decorator (`asyncio_mode = "auto"` is set).
+
+`verify_flow_session(profile_dir, *, channel="chrome", source="chrome")`
+returns a frozen `FlowSessionStatus` with fields `outcome`, `user_email`,
+`source`, and a derived `authenticated` property
+(`outcome is FlowSessionOutcome.AUTHENTICATED`).
 
 | Test | What it does | Cost |
 |---|---|---|
-| `test_e2e_verify_flow_session_authenticated` | `verify_flow_session(<denon82 profile>, channel="chrome", source="chrome")` → asserts `outcome is AUTHENTICATED`, `user_email` is a non-empty `str`, `authenticated is True`. Proves the issue-#15 fix works against the real Google endpoint. | 0 credits |
-| `test_e2e_verify_flow_session_no_session` | Creates a fresh empty profile dir inside the gflow home, probes it → asserts `outcome is NO_SESSION` (empty profile: real headless Chrome launches, no `SAPISID`, `/api/auth/session` returns `200 {}`). Deterministic; the temp dir is removed in teardown. | 0 credits |
+| `test_e2e_verify_flow_session_authenticated` | Two assertions in one test: (1) `verify_flow_session(<denon82 profile>, channel="chrome", source="chrome")` → `outcome is AUTHENTICATED`, `user_email` is a non-empty `str`, `authenticated is True`; (2) **same profile** — open `FlowApiClient` on it and call `health_check()` → `True`. This proves the real issue-#15 invariant: a profile pronounced `AUTHENTICATED` is actually *usable* by the API client, not just probe-positive. | 0 credits |
+| `test_e2e_verify_flow_session_no_session` | Creates a fresh empty profile dir **inside the gflow home** (`get_settings().home / "profile_e2e_nosession_<uuid4>"`), asserts it does not pre-exist, then `verify_flow_session(..., channel="chrome", source="chrome")` → `outcome is NO_SESSION` (empty profile: real headless Chrome launches, no `SAPISID`, `/api/auth/session` returns `200 {}`). | 0 credits |
+
+**Browser channel.** `verify_flow_session` only accepts branded Playwright
+channels and always passes `channel`; the bundled-Chromium path (channel
+omitted) is not reachable through it. e2e therefore uses `channel="chrome"` —
+the exact path the product uses, and the e2e prerequisite (a profile from
+`gflow auth login`) already implies system Chrome is installed.
+
+**`NO_SESSION` environmental caveat.** The probe needs outbound network to
+`labs.google`. If the network is unreachable the probe returns
+`VERIFICATION_ERROR`, not `NO_SESSION`. The test asserts `NO_SESSION`; a
+`VERIFICATION_ERROR` result must be read as an environmental failure (no
+connectivity), not a code regression — the test surfaces that distinction in
+its failure message.
+
+**Temp-dir safety.** The `NO_SESSION` profile dir must be inside
+`get_settings().home` (a `tmp_path` dir is outside it and would trip
+`verify_flow_session`'s `SecurityError` boundary check). It is UUID-named so it
+can never collide with a real profile (`profile_denon82` etc.), and torn down
+in a `finally`/fixture with a brief delay + `shutil.rmtree(..., ignore_errors=True)`
+to tolerate the Windows Chrome profile lock. A leftover `profile_e2e_nosession_*`
+dir is harmless and safe to delete manually.
 
 **Out of e2e scope (deliberate):** `GOOGLE_SESSION_ONLY` needs a
 Google-signed-in-but-not-Flow profile and `VERIFICATION_ERROR` needs an
 injected network fault — neither is cleanly producible live. Both remain
-covered by the existing unit tests in `tests/auth/test_verification.py`.
+covered by the existing unit tests in `tests/auth/test_verification.py`
+(verified by the council: `GOOGLE_SESSION_ONLY` and seven `VERIFICATION_ERROR`
+cases are unit-covered).
 
 ## 5. Part C — Additional PR #20 e2e coverage
 
 PR #20's two e2e tests are *run* in Part A. For *new* coverage, the
 implementation plan's first step inspects the auto-project-creation and
 `FlowApiClient.health_check()` surface, then adds **≤3 targeted tests** for
-gaps the existing two do not cover. Candidate tests (finalized after that
-inspection):
+gaps the existing two do not cover:
 
 - `health_check()` returns `False` on a closed / unusable client context.
 - An explicit `project_id` is honoured (no spurious project auto-created).
-- A second generation reuses an auto-created project rather than making a new
-  one — if the feature is specified to do so.
+- *(Contingent)* A second generation reuses an auto-created project rather
+  than making a new one — **only if** the feature is specified to behave that
+  way. This candidate may require a light instrumentation hook in
+  `FlowApiClient` (e.g. a `create_project` call counter) to be assertable;
+  it is dropped if inspection shows no such guarantee or no clean seam.
 
 These land in `tests/e2e/test_transports_e2e.py` or a sibling module,
 whichever the inspection shows is the better home.
 
 ## 6. Shared support
 
-Add **`tests/e2e/conftest.py`** providing an `e2e_profile_dir` pytest fixture
-that resolves `GFLOW_CLI_E2E_PROFILE` and `pytest.skip()`s when it is unset or
-the directory is absent — the same gate logic `test_transports_e2e.py`
-currently inlines as `_profile_dir()`. New tests use the fixture. The existing
-`test_transports_e2e.py` is left untouched (refactoring its private helper to
-the fixture is optional and out of scope).
+Add **`tests/e2e/conftest.py`** providing:
+
+- An `e2e_profile_dir` pytest fixture that resolves `GFLOW_CLI_E2E_PROFILE` and
+  `pytest.skip()`s when it is unset or the directory is absent — the same gate
+  logic `test_transports_e2e.py` currently inlines as `_profile_dir()`.
+- A fixture for the `NO_SESSION` temp profile: creates a UUID-named dir inside
+  `get_settings().home`, asserts non-existence before creating, and tears it
+  down Windows-lock-safely (brief delay + `rmtree(ignore_errors=True)`).
+
+New tests use these fixtures. The existing `test_transports_e2e.py` is left
+untouched (refactoring its private `_profile_dir()` to the fixture is optional
+and out of scope).
 
 ## 7. Execution order
 
 1. Part A — baseline run with `denon82`; record results.
 2. Inspect PR #20's feature surface (for Part C).
 3. Write Part B module + `conftest.py`; write Part C tests.
-4. Full e2e run (`-m e2e`, `denon82`) — confirm Part B/C green and no
+4. Full e2e run (`-m e2e`, `denon82`, no `-n`) — confirm Part B/C green and no
    regression in the existing suite.
 5. `ruff` / `pyright` on the new test files; commit to
    `fix/issue-15-i2v-bearer-auth`.
@@ -102,12 +146,45 @@ the fixture is optional and out of scope).
 - No automation of `gflow auth login` / the interactive browser sign-in.
 - No refactor of the existing `test_transports_e2e.py` beyond optionally
   adopting the shared fixture.
-- No new production code — this is test-only work.
+- No new production code — this is test-only work, with the one possible
+  exception of a small, clearly-scoped `FlowApiClient` instrumentation hook
+  **only if** Part C's contingent third test is retained after inspection.
 
 ## 9. Verification
 
 - New e2e files pass `ruff check`, `ruff format --check`, `pyright`.
-- Part B tests pass against `denon82` (positive) and a fresh empty profile
-  (`NO_SESSION`).
+- Part B tests pass against `denon82` (positive + usable-chain) and a fresh
+  empty profile (`NO_SESSION`).
 - The baseline and final full e2e runs are recorded so any pre-existing
   failures are distinguished from regressions.
+- If the final run shows failures clustered on auth-shaped errors (HTTP 401,
+  `AuthExpiredError`), re-run `gflow auth login --profile denon82` to refresh
+  the session and re-run before declaring a regression — a mid-run session
+  expiry is indistinguishable from a code fault in the raw output.
+
+## 10. Council review
+
+A 4-agent council reviewed Rev 1. Verdicts: implementability
+APPROVE-WITH-CHANGES, codebase-accuracy INACCURACIES-FOUND, test-strategy
+APPROVE-WITH-CHANGES, risk/operations APPROVE-WITH-CHANGES. Folded into Rev 2:
+
+- Positive test extended to chain `verify_flow_session` → `FlowApiClient.health_check()`
+  (proves "verified ⇒ usable", the true issue-#15 invariant).
+- `NO_SESSION` temp dir pinned inside `GFLOW_CLI_HOME`, UUID-named,
+  non-existence-asserted, Windows-lock-safe teardown.
+- `NO_SESSION` environmental caveat (network → `VERIFICATION_ERROR`) documented.
+- `FlowSessionStatus`'s `source` field and the derived `authenticated`
+  property described accurately.
+- Part C's third test marked contingent and possibly needing an instrumentation
+  hook; `§8` non-goals updated accordingly.
+- `pytest-xdist` (`-n`) prohibited for e2e; auth-expiry re-run guidance added.
+
+**One council recommendation partially rejected, with reason:** the
+implementability reviewer suggested running the `NO_SESSION` test with
+`channel="chromium"` to avoid depending on system Chrome. `chromium` is not a
+valid Playwright *channel* value (channels are branded distributions —
+`chrome`, `msedge`, …), and `verify_flow_session` always passes `channel`, so
+`channel="chromium"` would itself raise and yield `VERIFICATION_ERROR`. The
+e2e suite runs only on a machine that has already completed `gflow auth login`
+(hence has system Chrome), so `channel="chrome"` is both correct and the
+genuine product path. Kept `channel="chrome"` — see §4.

--- a/docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md
+++ b/docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md
@@ -1,0 +1,210 @@
+# Design — Issue #15: i2v `uploadImage` 401 (Bearer-auth mismatch)
+
+> **Status:** Draft for review · **Date:** 2026-05-17 · **Issue:** [#15](https://github.com/ffroliva/gflow-cli/issues/15)
+> **Decision:** Implement **Approach A**; track Approaches B & C as future alternatives.
+
+---
+
+## 1. Problem
+
+`gflow video i2v <image> <prompt>` fails: `POST /v1/flow/uploadImage` returns HTTP 401,
+surfaced as `AuthExpiredError` (exit 3) — even seconds after a verified fresh login.
+`t2i` and batch image generation work on the same session in the same window.
+
+The 401 also produces a **misleading remediation hint** (`Run gflow auth login`),
+sending users into a login loop when login was never the problem.
+
+## 2. Root-cause investigation
+
+Investigation was **static** (PLAN.md gates 1 & 2 + the captured sample for gate 3).
+Findings, from three independent sources:
+
+1. **Captured working request** (`samples/captured/01_upload_image.json`):
+   request header `authorization: "Bearer <REDACTED_BEARER>"`. The string
+   `sapisidhash` appears **nowhere** in the captured traffic.
+2. **`api/transports/experimental/bearer.py`** intercepts requests to
+   `aisandbox-pa.googleapis.com` looking for exactly an `Authorization: Bearer`
+   header — confirming Flow's web app sends one.
+3. **`FlowApiClient._post_json`** (and `_patch_json`, and the inline
+   `generate_video` POST) call `page.request.post(...)` with **only a
+   `content-type` header — no `Authorization`**. `page.request`
+   (Playwright `APIRequestContext`) attaches session cookies but never runs
+   page JS, so it omits the Bearer token the Flow app adds.
+
+**Root cause:** REST calls to `aisandbox-pa.googleapis.com` carry no
+`Authorization` header. The host rejects cookie-only requests with 401.
+`t2i` works because `UiAutomationTransport` drives real UI clicks — the
+page's own JS issues the fetch *with* the Bearer. `create_project` works
+because it targets the `labs.google` tRPC host, which accepts cookie auth.
+
+**Disproven hypothesis:** PLAN.md and issue #15 guessed a missing
+*SAPISIDHASH* header. The captured traffic contradicts this; additionally,
+`experimental/sapisidhash.py` cannot read modern encrypted SAPISID cookies
+(its own docstring says so). SAPISIDHASH is a dead end for this bug.
+
+> **Confidence:** high, but evidence is static and the captured sample is
+> dated 2026-05-08. **Phase 1 (below) is a blocking live-verification gate**
+> that must confirm the root cause empirically before any fix code lands.
+
+## 3. Goals / non-goals
+
+**Goals**
+- `gflow video i2v` completes end-to-end (upload → generate → poll → download).
+- All `aisandbox-pa.googleapis.com` REST routes carry valid `Authorization`.
+- A 401 that survives a token re-capture is reported as a distinct,
+  accurately-worded error — not `AuthExpiredError`.
+- Zero regression to working paths.
+
+**Non-goals**
+- Rewriting i2v to use UI drag-and-drop upload.
+- Promoting the experimental httpx transports to production.
+- Proactive token-TTL refresh (reactive re-capture only; see §9).
+- Touching the 403 → error mapping (tracked separately).
+
+## 4. Design — Approach A (capture the Bearer, attach the header)
+
+### 4.1 New module — `src/gflow_cli/api/bearer_auth.py`
+
+Single responsibility: obtain the Flow OAuth Bearer token from a live
+Playwright page. Token is held **in memory only** — never written to disk,
+never logged.
+
+```python
+@dataclass(frozen=True)
+class BearerToken:
+    value: str
+    captured_at: float
+
+async def capture_bearer_token(page: Page, *, timeout_s: float = 30.0) -> BearerToken:
+    """Observe `page`'s outgoing requests; return the first
+    `Authorization: Bearer` token sent to aisandbox-pa.googleapis.com.
+    Raises ApiAuthError if none appears within timeout_s."""
+```
+
+Mechanism is the proven `page.on("request")` interception from `bearer.py`,
+extracted and trimmed: **no `_BearerCache`, no disk persistence, no httpx**.
+
+### 4.2 `FlowApiClient` changes (`api/client.py`)
+
+- Hold `self._bearer: BearerToken | None`.
+- **Capture during the existing bootstrap navigation** — register the
+  request observer around the bootstrap `goto`, so capture costs ~0 extra.
+- Request helpers (`_post_json`, `_patch_json`, inline `generate_video`
+  POST) attach `authorization: f"Bearer {token}"` **only for routes whose
+  host is `aisandbox-pa.googleapis.com`** — `labs.google` tRPC calls
+  (`create_project`) are left exactly as-is.
+- A `_with_bearer` helper centralizes header construction so the rule lives
+  in one place.
+- **Reactive refresh:** on a 401 from an aisandbox-pa route, re-capture the
+  token once and retry the call. A second 401 raises `ApiAuthError` (§4.3).
+
+### 4.3 Error taxonomy (`errors.py`)
+
+New `ApiAuthError(FlowApiError)`:
+- `problem_type = "https://gflow-cli.dev/errors/api-auth"`, `title = "Flow API authorization failed"`.
+- `EXIT_CODE_MAP` entry **`14`** — the next free exit code (3–13 are in use).
+- Remediation hint that does **not** force a login loop — it states the API
+  rejected the request's bearer token after a re-capture, and offers login
+  *and* "likely a token-capture regression — file a bug" as branches.
+
+`_raise_for_non_retryable` in `client.py`: a 401 from an aisandbox-pa route
+(after re-capture+retry is exhausted) maps to `ApiAuthError`, not
+`AuthExpiredError`. The 401→`AuthExpiredError` mapping is retained for any
+non-aisandbox-pa 401. 403 handling is unchanged.
+
+### 4.4 Data flow
+
+```
+FlowApiClient.__aenter__
+  └─ bootstrap goto(FLOW_URL)  ──observe──▶  capture_bearer_token() ▶ self._bearer
+upload_image / get_video_status / generate_video / _patch_json
+  └─ page.request.{post,patch}(url, headers={content-type, authorization: Bearer …})
+        ├─ 200 ▶ ok
+        └─ 401 ▶ recapture_bearer() ▶ retry once ▶ 401 again ▶ raise ApiAuthError
+```
+
+### 4.5 Security
+
+- Token lives only in `FlowApiClient._bearer` for the client's lifetime;
+  dropped on `__aexit__`. No `transport_bearer.json`-style disk cache.
+- Token is never logged: `_redact_for_log` already covers bodies; header
+  logging (added for Phase 1) must redact `authorization`.
+- A **security-review** pass (skill / `security-reviewer` agent) is a plan
+  gate before merge.
+
+## 5. Phase 1 — live verification gate (blocking)
+
+Before any fix code is written:
+1. Add opt-in outgoing-request-header logging to the request helpers
+   (`authorization` value redacted to `Bearer <len=N>`).
+2. Maintainer runs `gflow video i2v` once and captures a fresh working
+   `uploadImage` from browser DevTools ("copy as cURL").
+3. Diff: confirm the CLI request is missing `Authorization` and the working
+   request carries `Bearer`. **If the diff shows anything else, stop and
+   re-design.**
+
+This gate converts the high-confidence static hypothesis into proof.
+
+## 6. Test plan (TDD — red → green → refactor)
+
+- **Unit** `tests/api/test_bearer_auth.py`: `capture_bearer_token` returns
+  the token from a mocked `page.on("request")`; raises `ApiAuthError` when
+  no Bearer is seen within the timeout.
+- **Unit** `tests/api/test_client.py`: aisandbox-pa requests carry
+  `Authorization: Bearer …`; `labs.google` requests do **not**; a 401
+  triggers exactly one re-capture + retry; a second 401 raises `ApiAuthError`.
+- **Unit** error-taxonomy tests: `ApiAuthError` → exit code 14, correct
+  problem-type, remediation hint contains no blind "re-login" loop.
+- **Live** `@pytest.mark.live` `tests/...`: `gflow video i2v` end-to-end on
+  a real session without 401 (the permanent regression guard).
+- Coverage floor unchanged: 80% overall, 90% domain/application.
+
+## 7. Non-regression guarantees
+
+- `create_project` / any `labs.google` tRPC call: header rule is host-scoped
+  to `aisandbox-pa.googleapis.com` → untouched.
+- `UiAutomationTransport` (t2i): untouched.
+- Experimental transports (`bearer`/`sapisidhash`/`evaluate_fetch`): untouched.
+- All 577 existing tests stay green; CI gates (ruff, format, pyright, pytest,
+  hygiene) must pass.
+
+## 8. Alternatives & future exploration
+
+Approaches B and C are **not implemented now** but recorded for future work.
+The implementation plan includes a task to add a one-line PLAN.md backlog
+pointer to this section (matching the existing
+`CDP Attach Transport — BACKLOG (deferred)` pattern).
+
+- **Approach B — inline the capture in `client.py`.** Avoids a new module.
+  Rejected now: `client.py` is already large and the capture logic would not
+  be independently unit-testable. Revisit only if the module boundary proves
+  to add no value.
+- **Approach C — issue the POST inside page JS via `page.evaluate(fetch())`.**
+  Would let the browser attach auth itself. Rejected now: a raw in-page
+  `fetch` to aisandbox-pa does **not** automatically carry the Bearer (Flow's
+  own JS networking layer adds it) — making it work means reusing Flow's
+  undocumented internal client. Worth exploring if Flow ever ships a stable
+  app-level fetch wrapper, or alongside the `evaluate_fetch` transport.
+- **Disproven — SAPISIDHASH header** (original PLAN.md / issue guess):
+  contradicted by captured traffic; kept here so it is not re-attempted.
+
+## 9. Open questions / risks
+
+- **Capture reliability:** Approach A assumes the bootstrap navigation
+  surfaces an interceptable aisandbox-pa Bearer request. If a bare editor
+  load does not, the capture step must trigger a lightweight action or fail
+  loudly. **Phase 1 verifies this.**
+- **Token TTL:** reactive re-capture-on-401 is the chosen strategy. If live
+  testing shows mid-run expiry is common, proactive TTL refresh becomes a
+  fast follow-up (the `bearer.py` `_CachedAuth.is_expired` pattern).
+- **Route enumeration:** the implementation plan's first task enumerates
+  every `aisandbox-pa.googleapis.com` route in `routes.py` / `client.py`
+  (`uploadImage`, video generate, video status, `_patch_json` workflow PATCH).
+
+## 10. Skills / quality gates for implementation
+
+The implementation plan (produced next via the writing-plans skill) will
+schedule: **systematic-debugging** discipline for Phase 1, **TDD** for every
+unit, a **security-review** pass on token handling, an **architecture**
+check on the `bearer_auth` module boundary, **code-review** before merge,
+and **sub-agent orchestration** to run the independent reviews in parallel.

--- a/docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md
+++ b/docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md
@@ -1,7 +1,9 @@
 # Design — Issue #15: i2v `uploadImage` 401 (Bearer-auth mismatch)
 
-> **Status:** Draft for review · **Date:** 2026-05-17 · **Issue:** [#15](https://github.com/ffroliva/gflow-cli/issues/15)
+> **Status:** Draft v2 (post-council-review) · **Date:** 2026-05-17 · **Issue:** [#15](https://github.com/ffroliva/gflow-cli/issues/15)
 > **Decision:** Implement **Approach A**; track Approaches B & C as future alternatives.
+> **Revision:** v2 incorporates a 5-dimension review council (architecture, security,
+> testing, plan-readiness, independent root-cause verification).
 
 ---
 
@@ -25,26 +27,38 @@ Findings, from three independent sources:
 2. **`api/transports/experimental/bearer.py`** intercepts requests to
    `aisandbox-pa.googleapis.com` looking for exactly an `Authorization: Bearer`
    header — confirming Flow's web app sends one.
-3. **`FlowApiClient._post_json`** (and `_patch_json`, and the inline
-   `generate_video` POST) call `page.request.post(...)` with **only a
-   `content-type` header — no `Authorization`**. `page.request`
-   (Playwright `APIRequestContext`) attaches session cookies but never runs
-   page JS, so it omits the Bearer token the Flow app adds.
+3. **`FlowApiClient._post_json`**, `_patch_json`, and the inline `generate_video`
+   POST all call `page.request.{post,patch}(...)` with **only a `content-type`
+   header — no `Authorization`**.
 
 **Root cause:** REST calls to `aisandbox-pa.googleapis.com` carry no
-`Authorization` header. The host rejects cookie-only requests with 401.
-`t2i` works because `UiAutomationTransport` drives real UI clicks — the
-page's own JS issues the fetch *with* the Bearer. `create_project` works
-because it targets the `labs.google` tRPC host, which accepts cookie auth.
+`Authorization` header. `page.request` (Playwright `APIRequestContext`) is a
+**separate HTTP client that shares only the browser's cookie jar** — the Bearer
+is an app-minted OAuth token that Flow's in-page JS attaches to its *own*
+`fetch` calls, and an out-of-band `page.request` call never receives it. The
+host rejects cookie-only requests with 401. `t2i` works because
+`UiAutomationTransport` drives real UI clicks — the request is issued *by Flow's
+own JS*, carrying the Bearer. `create_project` works because it targets the
+`labs.google` tRPC host, which accepts cookie auth.
 
-**Disproven hypothesis:** PLAN.md and issue #15 guessed a missing
-*SAPISIDHASH* header. The captured traffic contradicts this; additionally,
-`experimental/sapisidhash.py` cannot read modern encrypted SAPISID cookies
-(its own docstring says so). SAPISIDHASH is a dead end for this bug.
+**Rival hypotheses considered and rejected:**
+- *Expired/rotated session cookie* — rejected: `t2i` succeeds on the **same
+  session in the same window**; the session is the one genuinely controlled
+  variable and it is valid.
+- *Wrong content-type* — rejected: the captured working request already uses
+  `text/plain;charset=UTF-8`, exactly what `_post_json` sends.
+- *Quota / rate limit* — rejected: the failure is 401, not 429/403.
+- *SAPISIDHASH header missing* (the original PLAN.md / issue guess) —
+  rejected: captured traffic carries `Bearer`, not SAPISIDHASH; additionally
+  `experimental/sapisidhash.py` cannot read modern encrypted SAPISID cookies
+  (its own docstring says so).
 
 > **Confidence:** high, but evidence is static and the captured sample is
-> dated 2026-05-08. **Phase 1 (below) is a blocking live-verification gate**
-> that must confirm the root cause empirically before any fix code lands.
+> dated 2026-05-08. The **one thing provable only by a live test** is that a
+> `page.request.post` carrying *just* a Bearer (no other in-page headers) is
+> *sufficient* to get 200 — Flow's JS client may also set `origin` /
+> `sec-fetch-*`. **Phase 1 (§5) is a blocking live-verification gate** that
+> must confirm this before any fix code lands.
 
 ## 3. Goals / non-goals
 
@@ -66,14 +80,14 @@ because it targets the `labs.google` tRPC host, which accepts cookie auth.
 ### 4.1 New module — `src/gflow_cli/api/bearer_auth.py`
 
 Single responsibility: obtain the Flow OAuth Bearer token from a live
-Playwright page. Token is held **in memory only** — never written to disk,
-never logged.
+Playwright page. A **pure module** — free functions plus a frozen
+`BearerToken` value object; it holds **no `Page` state** (Page lifetime
+belongs to `FlowApiClient`), so capture is unit-testable with a fake page.
 
 ```python
 @dataclass(frozen=True)
 class BearerToken:
     value: str
-    captured_at: float
 
 async def capture_bearer_token(page: Page, *, timeout_s: float = 30.0) -> BearerToken:
     """Observe `page`'s outgoing requests; return the first
@@ -84,33 +98,52 @@ async def capture_bearer_token(page: Page, *, timeout_s: float = 30.0) -> Bearer
 Mechanism is the proven `page.on("request")` interception from `bearer.py`,
 extracted and trimmed: **no `_BearerCache`, no disk persistence, no httpx**.
 
+**Token-handling rules (security-critical):**
+- The intercepting closure holds the captured value in a single mutable
+  container that is explicitly cleared in a `finally` block on any error exit,
+  so the token is never reachable from a surviving exception's traceback locals.
+- `capture_bearer_token` **never** passes the token value (or any
+  token-derived value, e.g. its length) into an exception's arguments.
+
 ### 4.2 `FlowApiClient` changes (`api/client.py`)
 
-- Hold `self._bearer: BearerToken | None`.
-- **Capture during the existing bootstrap navigation** — register the
-  request observer around the bootstrap `goto`, so capture costs ~0 extra.
-- Request helpers (`_post_json`, `_patch_json`, inline `generate_video`
-  POST) attach `authorization: f"Bearer {token}"` **only for routes whose
-  host is `aisandbox-pa.googleapis.com`** — `labs.google` tRPC calls
-  (`create_project`) are left exactly as-is.
-- A `_with_bearer` helper centralizes header construction so the rule lives
-  in one place.
-- **Reactive refresh:** on a 401 from an aisandbox-pa route, re-capture the
-  token once and retry the call. A second 401 raises `ApiAuthError` (§4.3).
+- Hold `self._bearer: BearerToken | None` and `self._bearer_lock: asyncio.Lock`.
+- **Capture during the existing bootstrap navigation** — register the request
+  observer around the bootstrap `goto`, so capture costs ~0 extra.
+- **Single header source.** A new `_with_bearer(url, base_headers) -> dict`
+  helper is the **only** place the `Authorization` header is added. It attaches
+  `authorization: f"Bearer {token}"` **only when the URL host is
+  `aisandbox-pa.googleapis.com`**. `_post_json`, `_patch_json`, **and the
+  inline `generate_video` POST** all build their headers through it — no other
+  call site constructs request headers directly.
+- **Single-flight re-capture.** On a 401 from an aisandbox-pa route, acquire
+  `self._bearer_lock`; **re-check token freshness inside the lock** (another
+  worker may have already refreshed it); if still stale, re-capture once and
+  retry the call. This prevents N concurrent workers from launching N redundant
+  captures under the per-worker Page pool. A second 401 raises `ApiAuthError`.
 
 ### 4.3 Error taxonomy (`errors.py`)
 
 New `ApiAuthError(FlowApiError)`:
 - `problem_type = "https://gflow-cli.dev/errors/api-auth"`, `title = "Flow API authorization failed"`.
-- `EXIT_CODE_MAP` entry **`14`** — the next free exit code (3–13 are in use).
-- Remediation hint that does **not** force a login loop — it states the API
+- `EXIT_CODE_MAP` gains `ApiAuthError: 14` (codes 3–13 are in use). Placement
+  among the existing `FlowApiError` subclasses is immaterial — they are
+  siblings, not ancestors — but it is grouped with the other 4xx-auth entries
+  to honour the file's most-specific-first convention.
+- **`detail` contract:** `ApiAuthError.detail` is always exactly
+  `f"HTTP {status}"`. No token value, no token-length integer, no captured
+  data appears in `detail`, `route`, `instance`, or `remediation_hint`.
+- Remediation hint does **not** force a login loop — it states the API
   rejected the request's bearer token after a re-capture, and offers login
   *and* "likely a token-capture regression — file a bug" as branches.
 
-`_raise_for_non_retryable` in `client.py`: a 401 from an aisandbox-pa route
-(after re-capture+retry is exhausted) maps to `ApiAuthError`, not
-`AuthExpiredError`. The 401→`AuthExpiredError` mapping is retained for any
-non-aisandbox-pa 401. 403 handling is unchanged.
+**Route discrimination.** `_raise_for_non_retryable` receives only a sanitized
+route *name*, not a URL. The `ApiAuthError`-vs-`AuthExpiredError` decision is
+therefore made by membership in an **enumerated set of aisandbox-pa route
+names** (the set built by the §9 route-enumeration task), passed/known at the
+classification site. A 401 from an aisandbox-pa route, after re-capture+retry
+is exhausted, maps to `ApiAuthError`; any non-aisandbox-pa 401 keeps the
+existing `AuthExpiredError` mapping. 403 handling is unchanged.
 
 ### 4.4 Data flow
 
@@ -118,55 +151,111 @@ non-aisandbox-pa 401. 403 handling is unchanged.
 FlowApiClient.__aenter__
   └─ bootstrap goto(FLOW_URL)  ──observe──▶  capture_bearer_token() ▶ self._bearer
 upload_image / get_video_status / generate_video / _patch_json
-  └─ page.request.{post,patch}(url, headers={content-type, authorization: Bearer …})
+  └─ headers = _with_bearer(url, {content-type})        # only header source
+  └─ page.request.{post,patch}(url, headers=headers)
         ├─ 200 ▶ ok
-        └─ 401 ▶ recapture_bearer() ▶ retry once ▶ 401 again ▶ raise ApiAuthError
+        └─ 401 ▶ async with _bearer_lock:
+                    if token unchanged since call started:
+                        recapture_bearer()              # single-flight
+                 retry once ▶ 401 again ▶ raise ApiAuthError
 ```
 
 ### 4.5 Security
 
 - Token lives only in `FlowApiClient._bearer` for the client's lifetime;
   dropped on `__aexit__`. No `transport_bearer.json`-style disk cache.
-- Token is never logged: `_redact_for_log` already covers bodies; header
-  logging (added for Phase 1) must redact `authorization`.
+- **`_redact_headers_for_log(headers) -> dict`** — a new helper, the **only**
+  permitted way to log any dict that may contain an `authorization` key. It
+  returns a copy with the value replaced by `Bearer <len=N>`. Every
+  header-logging site, including the Phase-1 diagnostic path, must use it.
+  (`_redact_for_log` covers bodies only — it does not touch headers.)
+- **Threat model scope:** the in-memory-only guarantee assumes a
+  **single-user host** with OS-level process isolation as the trust boundary.
+  Process-memory inspection by another local user is out of scope (and is no
+  worse than any browser holding the same token).
 - A **security-review** pass (skill / `security-reviewer` agent) is a plan
   gate before merge.
 
+### 4.6 Invariants (enforced by review + tests)
+
+1. `_with_bearer` is the **sole** constructor of request headers for
+   `aisandbox-pa.googleapis.com` routes.
+2. Re-capture is **single-flight** — guarded by `self._bearer_lock` with a
+   post-lock freshness re-check.
+3. The Bearer token **never** appears in a log line, an exception argument,
+   `ProblemDetails`, or on disk.
+4. `ApiAuthError.detail` is a static `HTTP {status}` string.
+5. The `Authorization` header is attached to aisandbox-pa hosts **only** —
+   `labs.google` tRPC requests are byte-for-byte unchanged.
+
 ## 5. Phase 1 — live verification gate (blocking)
 
-Before any fix code is written:
-1. Add opt-in outgoing-request-header logging to the request helpers
-   (`authorization` value redacted to `Bearer <len=N>`).
-2. Maintainer runs `gflow video i2v` once and captures a fresh working
-   `uploadImage` from browser DevTools ("copy as cURL").
-3. Diff: confirm the CLI request is missing `Authorization` and the working
-   request carries `Bearer`. **If the diff shows anything else, stop and
-   re-design.**
+Before any fix code is written. **Owner:** the maintainer (human) runs the
+live steps; the executing agent prepares the tooling and performs the diff.
 
-This gate converts the high-confidence static hypothesis into proof.
+1. Add **opt-in** outgoing-request-header logging to `_with_bearer`'s call
+   sites, routed through `_redact_headers_for_log` (so `authorization` logs as
+   `Bearer <len=N>`). This logging ships permanently behind an env flag
+   (`GFLOW_CLI_LOG_REQUEST_HEADERS=1`) — useful for future transport debugging.
+2. Maintainer runs `gflow video i2v` once (capturing the CLI's redacted
+   outgoing headers) and captures a fresh working `uploadImage` from browser
+   DevTools ("copy as cURL" — the **full** header set).
+3. Diff **every header**, not just `Authorization`. Record the redacted diff
+   as an evidence artifact under `tmp/issue-15-phase1/`.
+
+### 5.1 Phase 1 outcome matrix
+
+| Outcome | Meaning | Action |
+|---|---|---|
+| **PASS** | Only difference is `Authorization` (CLI missing, browser has `Bearer`) | Proceed to §4 implementation |
+| **FAIL — extra header delta** | A non-`Authorization` header also differs (`origin`, `referer`, `sec-fetch-*`, …) | Re-design: extend §4.2 to copy the full required header set; revise spec before coding |
+| **FAIL — auth present, still 401** | CLI already sends an `Authorization` and still 401s | This spec is **void**; open a fresh investigation issue — the root cause is elsewhere |
 
 ## 6. Test plan (TDD — red → green → refactor)
 
-- **Unit** `tests/api/test_bearer_auth.py`: `capture_bearer_token` returns
-  the token from a mocked `page.on("request")`; raises `ApiAuthError` when
-  no Bearer is seen within the timeout.
-- **Unit** `tests/api/test_client.py`: aisandbox-pa requests carry
-  `Authorization: Bearer …`; `labs.google` requests do **not**; a 401
-  triggers exactly one re-capture + retry; a second 401 raises `ApiAuthError`.
-- **Unit** error-taxonomy tests: `ApiAuthError` → exit code 14, correct
-  problem-type, remediation hint contains no blind "re-login" loop.
-- **Live** `@pytest.mark.live` `tests/...`: `gflow video i2v` end-to-end on
-  a real session without 401 (the permanent regression guard).
+**Test fixtures** (defined once, in `tests/api/`): a `FakePage` exposing an
+`on(event, callback)` that records listeners, plus a `FakeRequest` with
+`url` and `headers`; a test fires a recorded listener with a `FakeRequest` to
+simulate a captured Bearer — mirroring the helper style in existing
+`tests/api/` tests.
+
+Implement the three test files **in this order** (each red before its code):
+
+1. **`tests/api/test_bearer_auth.py`** (pure module, no client dependency):
+   - `capture_bearer_token` returns the token when the fake page fires a
+     request carrying `Authorization: Bearer …` to aisandbox-pa.
+   - raises `ApiAuthError` when no Bearer is seen — driven with
+     `timeout_s=0.001` and a fake page that never fires, asserting the raise
+     completes within ~1 s wall time (no real 30 s sleep in CI).
+2. **Error-taxonomy tests** (pure, no Playwright):
+   - `ApiAuthError` → exit code 14, correct problem-type, remediation hint
+     contains no blind "re-login" loop, `detail` is `HTTP {status}` only.
+   - structural uniqueness: `len(EXIT_CODE_MAP.values()) == len(set(...))`.
+3. **`tests/api/test_client.py`** (depends on both):
+   - aisandbox-pa requests carry `Authorization: Bearer …`.
+   - **negative fixture:** a `create_project` (labs.google) call's headers
+     contain **no** `authorization` key.
+   - a 401 triggers **exactly one** re-capture: patch
+     `bearer_auth.capture_bearer_token`, assert `call_count == 1` after the
+     first 401; a second 401 raises `ApiAuthError`.
+   - concurrent 401s across pooled Pages trigger **one** re-capture, not N
+     (single-flight lock).
+   - `structlog.testing.capture_logs`: no log line contains a raw `Bearer `
+     value when an aisandbox-pa POST is made with header logging on.
+- **Live** `@pytest.mark.live` `tests/live/test_i2v_live.py`: `gflow video
+  i2v` end-to-end on a real session without 401 — the permanent regression
+  guard (cannot run in CI; opt-in).
 - Coverage floor unchanged: 80% overall, 90% domain/application.
 
 ## 7. Non-regression guarantees
 
 - `create_project` / any `labs.google` tRPC call: header rule is host-scoped
-  to `aisandbox-pa.googleapis.com` → untouched.
+  to `aisandbox-pa.googleapis.com` → untouched (verified by the §6 negative
+  fixture).
 - `UiAutomationTransport` (t2i): untouched.
 - Experimental transports (`bearer`/`sapisidhash`/`evaluate_fetch`): untouched.
 - All 577 existing tests stay green; CI gates (ruff, format, pyright, pytest,
-  hygiene) must pass.
+  hygiene) must pass. The `main` branch is protected — this work merges via PR.
 
 ## 8. Alternatives & future exploration
 
@@ -183,28 +272,59 @@ pointer to this section (matching the existing
   Would let the browser attach auth itself. Rejected now: a raw in-page
   `fetch` to aisandbox-pa does **not** automatically carry the Bearer (Flow's
   own JS networking layer adds it) — making it work means reusing Flow's
-  undocumented internal client. Worth exploring if Flow ever ships a stable
+  undocumented internal client. Worth exploring if Flow ships a stable
   app-level fetch wrapper, or alongside the `evaluate_fetch` transport.
 - **Disproven — SAPISIDHASH header** (original PLAN.md / issue guess):
   contradicted by captured traffic; kept here so it is not re-attempted.
 
 ## 9. Open questions / risks
 
+- **Bearer alone may be insufficient.** Flow's in-page client may set more
+  than the token (`origin`, `sec-fetch-*`). **Phase 1 must confirm a
+  Bearer-only `page.request.post` returns 200**; if not, the §5.1 matrix
+  routes to "extend to the full header set". This is the single highest
+  design risk and is provable only by the live gate.
 - **Capture reliability:** Approach A assumes the bootstrap navigation
   surfaces an interceptable aisandbox-pa Bearer request. If a bare editor
   load does not, the capture step must trigger a lightweight action or fail
-  loudly. **Phase 1 verifies this.**
+  loudly within `timeout_s`. Phase 1 verifies this.
+- **Concurrent re-capture:** N pooled workers hitting parallel 401s — mitigated
+  by the single-flight `_bearer_lock` (§4.2); covered by a §6 test.
 - **Token TTL:** reactive re-capture-on-401 is the chosen strategy. If live
   testing shows mid-run expiry is common, proactive TTL refresh becomes a
   fast follow-up (the `bearer.py` `_CachedAuth.is_expired` pattern).
-- **Route enumeration:** the implementation plan's first task enumerates
-  every `aisandbox-pa.googleapis.com` route in `routes.py` / `client.py`
+- **Route enumeration (plan task 1):** enumerate every
+  `aisandbox-pa.googleapis.com` route in `routes.py` / `client.py`
   (`uploadImage`, video generate, video status, `_patch_json` workflow PATCH).
+  This set feeds both `_with_bearer`'s host check and §4.3's route
+  discrimination.
 
-## 10. Skills / quality gates for implementation
+## 10. Implementation phasing & quality gates
 
-The implementation plan (produced next via the writing-plans skill) will
-schedule: **systematic-debugging** discipline for Phase 1, **TDD** for every
-unit, a **security-review** pass on token handling, an **architecture**
-check on the `bearer_auth` module boundary, **code-review** before merge,
-and **sub-agent orchestration** to run the independent reviews in parallel.
+Suggested phase order for the implementation plan (writing-plans skill):
+
+1. **Phase 1** — live verification gate (§5) — *blocking*.
+2. **Phase 2** — `api/bearer_auth.py` module + `test_bearer_auth.py` (TDD).
+3. **Phase 3** — `ApiAuthError` + `EXIT_CODE_MAP` + error-taxonomy tests
+   (precedes client wiring, since `client.py` will import `ApiAuthError`).
+4. **Phase 4** — `FlowApiClient` wiring (`_with_bearer`, single-flight
+   re-capture) + `test_client.py` (TDD).
+5. **Phase 5** — live E2E test, PLAN.md backlog pointer, docs/CHANGELOG.
+
+Quality gates the plan will schedule: **systematic-debugging** discipline for
+Phase 1, **TDD** for every unit, a **security-review** pass on token handling,
+an **architecture** check on the `bearer_auth` boundary, **code-review**
+before the PR merges, and **sub-agent orchestration** to run independent
+reviews in parallel.
+
+## 11. Review history
+
+- **2026-05-17 — v1** drafted.
+- **2026-05-17 — v2** — revised after a 5-dimension review council
+  (architecture, security, testing/TDD, plan-readiness, independent
+  root-cause verification). All five returned "Approve with changes" /
+  "Confirmed pending live gate"; this revision incorporates every actionable
+  finding (single-flight re-capture, single header source, route
+  discrimination, token-leak hardening, `_redact_headers_for_log`, the Phase-1
+  outcome matrix and full-header diff, the test-fixture and coverage gaps,
+  and the rival-hypothesis enumeration).

--- a/docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
+++ b/docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
@@ -1,0 +1,350 @@
+# Issue #15 — Auth-Layer Verification Fix — Design
+
+> **Status:** Approved design · **Date:** 2026-05-17
+> **Supersedes:** `2026-05-17-i2v-uploadimage-401-bearer-auth-design.md` (the v2
+> bearer-auth spec) and its plan, in full.
+> **Corrects:** `2026-05-17-issue-15-root-cause-findings.md` §3 & §5 — the
+> "session cookie is not flushed to disk" mechanism is **disproven** (see §2).
+> **Reviewed by:** an architecture / security / regression agent council (§11).
+
+## 1. Problem
+
+`gflow video i2v` fails at its first API call — `createProject` — with HTTP
+401, and never reaches `uploadImage`.
+
+Root cause: `gflow auth login` cannot tell a completed Flow sign-in from a
+half-finished one. Its `RealChromeStrategy` gates success on the presence of
+the Google **`SAPISID`** cookie. `SAPISID` is set the moment a user signs into
+their *Google account* — independently of, and before, the *Flow app's* own
+NextAuth sign-in that mints `__Secure-next-auth.session-token`. Any login that
+signs into Google but does not carry the Flow app sign-in through to completion
+is still reported `[OK] Session captured and verified`, leaving a profile that
+is signed into Google but **signed out of Flow**. The Flow tRPC API
+authenticates on the NextAuth session cookie, so `createProject` 401s.
+
+`InternalChromiumStrategy` (the fallback) has the same flavour of bug, milder:
+it checks `SAPISID` plus a UI-text scrape (`"New project"` / `"Your projects"`
+visible) — fragile and not authoritative.
+
+## 2. Evidence & corrected mechanism
+
+Confirmed by live probes (`tmp/issue-15-phase2/`, exploratory, untracked):
+
+- A **completed** Flow sign-in mints `__Secure-next-auth.session-token` as a
+  **persistent** cookie (~30-day expiry) that **survives a normal Chrome close**
+  and lands in the profile's on-disk cookie DB. *(probe step 1)*
+- A `gflow auth login` run that did not complete the Flow app sign-in exited
+  `0`, printed `verified`, yet `GET /api/auth/session` on that profile returned
+  `200 {}` — signed out. *(`issue15` profile)*
+
+This **corrects** the phase-1 findings doc: the session-token is **not** a
+session-scoped cookie and **is not** lost on browser close. The capture
+mechanism (the passive-capture pattern's post-close cookie read) is mechanically
+sound. **The defect is the verification step**, which checks the wrong cookie —
+and a UX that does not reliably land users on a completed Flow sign-in.
+
+## 3. Goal & non-goals
+
+**Goal:** `gflow auth login` must never report success unless the profile holds
+a real, usable Flow app session — verified against the same surface
+`FlowApiClient` authenticates on.
+
+**In scope:**
+
+- A new, self-contained verification module.
+- `RealChromeStrategy` and `InternalChromiumStrategy` both adopt it (one
+  consistent definition of "signed in").
+- Both strategies open the browser at the Flow URL with guidance that
+  distinguishes Google sign-in from Flow sign-in.
+- An honest, actionable failure when the Flow sign-in was not completed.
+
+**Non-goals (YAGNI / explicitly out of scope):**
+
+- `FlowApiClient` — unchanged; it already works once a profile is genuinely
+  signed in.
+- `auth status` — stays a lightweight file-existence check.
+- CDP / `--remote-debugging-port` / `storage_state` / live-detection — the
+  no-debug-port stealth ADR is kept (Approach C rejected).
+- reCAPTCHA / video-generation routes — unrelated.
+- A configurable verification-timeout knob — fixed sensible defaults; a knob
+  can come later.
+
+## 4. Design
+
+Approach **A** — *honest post-close verification* — chosen because it keeps the
+no-debug-port stealth ADR fully intact. Net change: **1 new file, 2 edited
+files, 1 docstring touch-up.**
+
+### 4.1 New module — `src/gflow_cli/auth/verification.py`
+
+Single responsibility: answer "does this profile hold a usable Flow app
+session?"
+
+Constant:
+
+- `SESSION_API_URL = "https://labs.google/fx/api/auth/session"`
+
+`FlowSessionOutcome(str, Enum)` — four mutually-exclusive outcomes:
+
+| Value | Meaning |
+|---|---|
+| `AUTHENTICATED` | `/api/auth/session` returned an authenticated user — a usable Flow session. |
+| `GOOGLE_SESSION_ONLY` | No Flow session, but the Google `SAPISID` cookie is present. |
+| `NO_SESSION` | No Flow session and no Google sign-in detected. |
+| `VERIFICATION_ERROR` | The check could not be completed (network / timeout / non-200 / malformed). |
+
+`FlowSessionStatus` — `@dataclass(frozen=True)`:
+
+- `outcome: FlowSessionOutcome`
+- `user_email: str | None` — from the session payload, only when `AUTHENTICATED`.
+- `source: str` — originating strategy (`"chrome"` / `"internal"`), for log
+  filtering.
+- `detail: str` — a short, **static** human-readable string chosen from a fixed
+  set keyed by `outcome`. Never built from response-body, cookie, or exception
+  content.
+- `authenticated` — `@property` → `outcome is FlowSessionOutcome.AUTHENTICATED`.
+
+`evaluate_session_response(status_code: int, body: str, *, google_session: bool,
+source: str) -> FlowSessionStatus` — **pure, total** function (no I/O, no
+exceptions for control flow). Mapping:
+
+- `status_code == 200` and body parses to a dict with a non-empty `user` object
+  carrying an `email` → `AUTHENTICATED` (extract `user_email`; the
+  `image`/profile-URL field is ignored).
+- `status_code == 200` and body parses to `{}` / no `user` →
+  `GOOGLE_SESSION_ONLY` if `google_session` else `NO_SESSION`.
+- `status_code != 200`, or the body does not parse as JSON → `VERIFICATION_ERROR`.
+
+This is the well-bounded testable core — exercised with zero mocks.
+
+`async verify_flow_session(profile_dir: Path, *, channel: str | None,
+source: str) -> FlowSessionStatus` — thin I/O wrapper, used by
+`RealChromeStrategy`:
+
+1. **Precondition:** `profile_dir.resolve(strict=True)` must be inside
+   `get_settings().home.resolve()`; otherwise raise `SecurityError`
+   (defense-in-depth — symlink-resistant).
+2. Lazily `from .strategies import async_playwright` (inside the function —
+   breaks a module-load circular import and preserves the test-patch seam).
+3. Launch a headless `launch_persistent_context(user_data_dir=str(profile_dir),
+   channel=channel, headless=True)`.
+4. In `try`: read cookies → `google_session = any(c["name"] == "SAPISID")`;
+   `GET SESSION_API_URL` via a page, with a **15s per-request timeout** and
+   **up to 3 attempts** (initial + 2 `tenacity` retries, exponential backoff)
+   on transient network / timeout errors; pass status + body to
+   `evaluate_session_response`.
+5. On any unrecovered exception (launch failure, retries exhausted) → return
+   `FlowSessionStatus(VERIFICATION_ERROR, …)`. **Fail-closed: never returns
+   `AUTHENTICATED` on uncertainty.**
+6. `finally`: `await ctx.close()` — fully awaited, so the profile's SQLite lock
+   is released before the function returns.
+
+`verify_flow_session` is **side-effect-free** beyond the browser probe — it
+writes no files and emits no marker; callers own those side effects.
+
+### 4.2 `src/gflow_cli/auth/real_chrome.py` — edit
+
+- Append the Flow URL (the existing `GEMINI_URL` constant) to `chrome_args` so
+  Chrome opens directly on the Flow page.
+- Rewrite the console guidance: state explicitly that signing into the Google
+  account is **not** sufficient — the user must continue until the working Flow
+  editor (prompt box / their projects) is loaded, *then* close Chrome.
+- Replace the inline post-close verification block (the direct `async_playwright`
+  import, `launch_persistent_context`, `cookies()`, `has_sapisid` check) with a
+  single call: `status = await verify_flow_session(profile_dir,
+  channel="chrome", source="chrome")`. This runs **after** `proc.wait()` returns
+  (the login Chrome has exited and released the profile lock — sequencing
+  preserved).
+  - `status.authenticated` → emit structlog `auth_flow_session_verified`
+    (`outcome`, `source`, `user_email`); **write the `.gflow_browser_strategy`
+    marker** (`"chrome"`); print `[OK] Flow session verified (<email>).`
+  - else → emit a structlog warning; raise `AuthMissingError` (exit code 8) with
+    an `outcome`-tailored message + `remediation_hint` (see §6).
+
+> The `.gflow_browser_strategy` marker write is **load-bearing** —
+> `browser_manager.channel_for_profile` reads it; dropping it makes
+> `FlowApiClient` open a Chrome-130+ profile with bundled Chromium and fail. It
+> is preserved in the success branch.
+
+### 4.3 `src/gflow_cli/auth/internal_chromium.py` — edit
+
+`InternalChromiumStrategy` already polls *live* (it controls the browser via
+Playwright and auto-detects success without waiting for a close). Change only
+*what* it checks:
+
+- In the poll loop, replace the `SAPISID` + `get_by_text("New project")` /
+  `("Your projects")` test with: `resp = await
+  page.request.get(SESSION_API_URL)`, then `evaluate_session_response(
+  resp.status, await resp.text(), google_session=<SAPISID present>,
+  source="internal")`; success when `outcome is AUTHENTICATED`.
+- Query `/api/auth/session` at a modest cadence (every ~3s, not every 1s) to
+  avoid hammering the endpoint.
+- The existing timeout / "closed before verified" branches stay, raising
+  `AuthLoginTimeoutError`; their wording is refreshed to mention reaching the
+  Flow editor.
+- Internal does not write `.gflow_browser_strategy` (absence ⇒ bundled
+  Chromium ⇒ correct) — unchanged.
+
+### 4.4 `src/gflow_cli/errors.py` — edit
+
+No class or behaviour change. `AuthMissingError` is reused (it already maps to
+**exit code 8** and carries `remediation_hint`). Only its docstring is
+refreshed — it currently describes a `SAPISID` / `SapisidhashTransport`
+scenario that no longer reflects how the error is used.
+
+## 5. Data flow
+
+```
+gflow auth login
+  └─ auth.login() → factory.create(mode) → strategy.login(profile_dir, headless)
+       ├─ RealChromeStrategy:
+       │     launch system Chrome (raw subprocess, no debug port) at the Flow URL
+       │     → user signs in & closes Chrome → proc.wait()
+       │     → verify_flow_session(channel="chrome", source="chrome")
+       │           → headless context → GET /api/auth/session
+       │           → evaluate_session_response
+       │     → AUTHENTICATED ? write marker + log + success
+       │                     : raise AuthMissingError (exit 8)
+       └─ InternalChromiumStrategy:
+             launch bundled Chromium (Playwright-controlled) at the Flow URL
+             → live poll: GET /api/auth/session → evaluate_session_response
+             → AUTHENTICATED ? success
+                             : (timeout / closed) raise AuthLoginTimeoutError
+```
+
+`FlowApiClient` later opens the profile and authenticates on the now-guaranteed
+`__Secure-next-auth.session-token` — no change.
+
+## 6. Error handling & fail-closed semantics
+
+Only `FlowSessionOutcome.AUTHENTICATED` green-lights a login. Every other
+outcome fails the login — the verification never reports success under
+uncertainty.
+
+`VERIFICATION_ERROR` is a **distinct fail-closed outcome**, not conflated with
+`NO_SESSION`: a network timeout is not evidence that the user is signed out. It
+produces a connectivity-flavoured remediation rather than a "you didn't sign in"
+message, and only after the retry budget is spent — so a *correct* login on a
+slow link is not falsely failed without recourse.
+
+`AuthMissingError` messages (`real_chrome.py` call site), by `outcome`:
+
+- `GOOGLE_SESSION_ONLY` → "Signed in to your Google account, but the Flow app
+  sign-in wasn't completed. Re-run `gflow auth login` and continue until the
+  Flow editor (the prompt box / your projects) loads before closing Chrome."
+- `NO_SESSION` → "No sign-in detected. Re-run `gflow auth login`, sign in to
+  Google, and continue until the Flow editor loads."
+- `VERIFICATION_ERROR` → "Could not verify the Flow session — this is often a
+  network problem. Check your connection and re-run `gflow auth login`."
+
+## 7. Security considerations
+
+Folded in from the council's security review (must-fix items):
+
+- **No secret in logs or `detail`.** `__Secure-next-auth.session-token` and all
+  raw cookie values are never logged. `FlowSessionStatus.detail` is a static
+  string from a fixed set — never interpolated from response-body, cookie, or
+  exception content. The raw `/api/auth/session` body is never logged or stored,
+  at any level.
+- **Minimal payload extraction.** `evaluate_session_response` reads only the
+  keys it needs (`user.email`); the profile-image URL is discarded.
+- **`user_email`** may be logged at INFO on success (the user's own email;
+  consistent with the existing `auth_login_success_verified` event) — never
+  inside a body dump.
+- **Fail-closed.** Any uncertainty → `VERIFICATION_ERROR`; never
+  `AUTHENTICATED`. Non-200 / malformed body are uncertainty, not
+  "unauthenticated".
+- **No `storage_state`.** Deliberately not used — it would serialise the session
+  token into a plaintext JSON file. The session stays inside Chrome's own cookie
+  store (encrypted at rest by the OS — DPAPI on Windows). No new credential file
+  is written.
+- **Profile-dir boundary.** `verify_flow_session` re-validates `profile_dir`
+  with `resolve(strict=True)` against `GFLOW_CLI_HOME`, raising `SecurityError`
+  — symlink-resistant defense-in-depth.
+- **No new untrusted surface.** `SESSION_API_URL` is a hard-coded constant — no
+  SSRF surface; TLS via Chromium's stack.
+
+## 8. Testing strategy (TDD — red → green → refactor)
+
+`evaluate_session_response` — **pure unit tests, zero mocks:**
+
+- `200` + authenticated `user` body → `AUTHENTICATED`, email extracted.
+- `200` + `{}`, `google_session=True` → `GOOGLE_SESSION_ONLY`.
+- `200` + `{}`, `google_session=False` → `NO_SESSION`.
+- non-200 (401 / 500 / 302) → `VERIFICATION_ERROR`.
+- malformed / non-JSON body → `VERIFICATION_ERROR`.
+
+`verify_flow_session` — **mock the `.strategies` `async_playwright` shim:**
+
+- authenticated probe → `AUTHENTICATED`.
+- unauthenticated probe → `GOOGLE_SESSION_ONLY` / `NO_SESSION`.
+- transient error → retried → exhausted → `VERIFICATION_ERROR`.
+- launch failure → `VERIFICATION_ERROR`.
+- `ctx.close()` awaited in `finally` even on the error path.
+- profile dir outside `GFLOW_CLI_HOME` → `SecurityError`.
+
+Strategy tests — `tests/auth/strategies/test_strategies.py`:
+
+- **Update** (behaviour legitimately changed): the real-chrome "success verified
+  via SAPISID" test and its verify-probe mock helper; the internal-chromium
+  standard + timeout tests (they mock `get_by_text` + SAPISID — repoint to
+  `/api/auth/session`).
+- **Must NOT change:** `test_real_chrome_launch_flags` (launch flags),
+  `test_real_chrome_privacy_guard` (`SecurityError` boundary),
+  `test_real_chrome_timeout_raises` (`AuthLoginTimeoutError`).
+
+Regression — `tests/test_browser_manager.py`:
+
+- **Must NOT change**, and **add** a test asserting a successful real-chrome
+  login still writes `.gflow_browser_strategy`.
+
+BDD — `tests/**/*.feature` for auth login / status: **must NOT change**; step
+mocks updated to produce a verifiable session where needed.
+
+Coverage: ≥80% overall maintained; `verification.py` targeted near-100% (the
+pure core makes this cheap).
+
+## 9. Regression guardrails (what must not break)
+
+From the council's regression review:
+
+- **`.gflow_browser_strategy` marker** — must still be written on a successful
+  real-chrome login (HIGH risk; covered by a new test).
+- **Exit code 8** — verification failure must raise `AuthMissingError` (a
+  `GFlowError` subclass), not fall through to the catch-all exit 1.
+- **`FlowApiClient`** — confirmed unchanged; a profile from the fixed flow is a
+  strict superset of today's.
+- **Sequencing** — `verify_flow_session` runs only after the login Chrome
+  process has exited (`proc.wait()`), so there is no SQLite-lock contention.
+- **Slow-network correctness** — the retry budget + `VERIFICATION_ERROR`
+  classification ensure a correct login on a flaky link is not falsely failed.
+- structlog event renames are safe (no code or test asserts on the event
+  strings).
+
+## 10. Known limitation
+
+In environments without an OS keystore (some CI / Docker containers), Chrome
+cannot decrypt its cookie store, so verification may always fail. Such
+environments should use `InternalChromiumStrategy` (`--browser internal`), whose
+bundled Chromium profile does not depend on DPAPI / keychain. This is
+documented, not fixed.
+
+## 11. Council review
+
+This design was reviewed by three parallel agents before approval:
+
+- **Architecture** — verified single-responsibility, module decomposition, the
+  circular-import fix, and `AuthMissingError` reuse.
+- **Security** — verified credential handling, the fail-closed posture, and the
+  no-`storage_state` decision; its must-fix items are folded into §7.
+- **Regression** — verified the blast radius; its guardrails are folded into §9
+  and §8.
+
+## 12. References
+
+- `docs/superpowers/specs/2026-05-17-issue-15-root-cause-findings.md` —
+  investigation evidence (mechanism in §3 / §5 corrected here).
+- `docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md`
+  — superseded v2 spec.
+- `docs/superpowers/2026-05-17-issue-15-handover.md` — prior handover.
+- Probes: `tmp/issue-15-phase2/` (exploratory, untracked).

--- a/docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
+++ b/docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
@@ -1,11 +1,19 @@
 # Issue #15 — Auth-Layer Verification Fix — Design
 
-> **Status:** Approved design · **Date:** 2026-05-17
+> **Status:** Approved design · **Date:** 2026-05-17 · **Revision:** 2
 > **Supersedes:** `2026-05-17-i2v-uploadimage-401-bearer-auth-design.md` (the v2
 > bearer-auth spec) and its plan, in full.
 > **Corrects:** `2026-05-17-issue-15-root-cause-findings.md` §3 & §5 — the
 > "session cookie is not flushed to disk" mechanism is **disproven** (see §2).
-> **Reviewed by:** an architecture / security / regression agent council (§11).
+> **Reviewed by:** a design-stage architecture / security / regression council,
+> then a spec-stage implementability / security / accuracy / test-strategy
+> council. Both sets of findings are folded in (§11).
+>
+> **Rev 2 changelog:** precise `tenacity` retry contract; full
+> `evaluate_session_response` decision table; enumerated `detail` literals;
+> named log events; `InternalChromiumStrategy` exception handling specified;
+> profile-dir `strict` divergence documented; durability hardening (§10);
+> expanded test strategy (§8).
 
 ## 1. Problem
 
@@ -61,7 +69,8 @@ a real, usable Flow app session — verified against the same surface
 **Non-goals (YAGNI / explicitly out of scope):**
 
 - `FlowApiClient` — unchanged; it already works once a profile is genuinely
-  signed in.
+  signed in (verified: it loads the session purely via `launch_persistent_context`
+  on the profile dir, no cookie/token parsing).
 - `auth status` — stays a lightweight file-existence check.
 - CDP / `--remote-debugging-port` / `storage_state` / live-detection — the
   no-debug-port stealth ADR is kept (Approach C rejected).
@@ -73,12 +82,17 @@ a real, usable Flow app session — verified against the same surface
 
 Approach **A** — *honest post-close verification* — chosen because it keeps the
 no-debug-port stealth ADR fully intact. Net change: **1 new file, 2 edited
-files, 1 docstring touch-up.**
+files, 1 docstring touch-up**, plus a test fixture and a `KNOWN_ISSUES.md` note.
 
 ### 4.1 New module — `src/gflow_cli/auth/verification.py`
 
 Single responsibility: answer "does this profile hold a usable Flow app
 session?"
+
+**Import rule:** `verification.py` has **no top-level import of `.strategies`**.
+The cycle `strategies.py → real_chrome.py → verification.py → strategies.py`
+would trigger at module load; the `async_playwright` shim is imported **lazily,
+inside `verify_flow_session`**.
 
 Constant:
 
@@ -91,7 +105,7 @@ Constant:
 | `AUTHENTICATED` | `/api/auth/session` returned an authenticated user — a usable Flow session. |
 | `GOOGLE_SESSION_ONLY` | No Flow session, but the Google `SAPISID` cookie is present. |
 | `NO_SESSION` | No Flow session and no Google sign-in detected. |
-| `VERIFICATION_ERROR` | The check could not be completed (network / timeout / non-200 / malformed). |
+| `VERIFICATION_ERROR` | The check could not be completed or returned an unexpected shape. |
 
 `FlowSessionStatus` — `@dataclass(frozen=True)`:
 
@@ -99,48 +113,75 @@ Constant:
 - `user_email: str | None` — from the session payload, only when `AUTHENTICATED`.
 - `source: str` — originating strategy (`"chrome"` / `"internal"`), for log
   filtering.
-- `detail: str` — a short, **static** human-readable string chosen from a fixed
-  set keyed by `outcome`. Never built from response-body, cookie, or exception
-  content.
+- `detail: str` — a short, **static** human-readable label, one of a fixed set
+  keyed by `outcome` (below). Never built from response-body, cookie, or
+  exception content.
 - `authenticated` — `@property` → `outcome is FlowSessionOutcome.AUTHENTICATED`.
 
+The four `detail` literals (the only permitted values):
+
+| Outcome | `detail` |
+|---|---|
+| `AUTHENTICATED` | `"Flow app session verified."` |
+| `GOOGLE_SESSION_ONLY` | `"Signed in to Google, but not to the Flow app."` |
+| `NO_SESSION` | `"No sign-in detected."` |
+| `VERIFICATION_ERROR` | `"Could not verify the Flow session."` |
+
+#### `evaluate_session_response`
+
 `evaluate_session_response(status_code: int, body: str, *, google_session: bool,
-source: str) -> FlowSessionStatus` — **pure, total** function (no I/O, no
-exceptions for control flow). Mapping:
+source: str) -> FlowSessionStatus` — **pure, total** function: no I/O, no
+exceptions raised or used for control flow; every `(status_code, body)` maps to
+exactly one outcome. Decision table (first match wins):
 
-- `status_code == 200` and body parses to a dict with a non-empty `user` object
-  carrying an `email` → `AUTHENTICATED` (extract `user_email`; the
-  `image`/profile-URL field is ignored).
-- `status_code == 200` and body parses to `{}` / no `user` →
-  `GOOGLE_SESSION_ONLY` if `google_session` else `NO_SESSION`.
-- `status_code != 200`, or the body does not parse as JSON → `VERIFICATION_ERROR`.
+| Condition | Outcome |
+|---|---|
+| `status_code != 200` | `VERIFICATION_ERROR` |
+| `200`, `body` is not a JSON **object** (malformed, partial, empty, whitespace, JSON array, JSON scalar) | `VERIFICATION_ERROR` |
+| `200`, JSON object, `user` key absent / `null` / `{}` | `GOOGLE_SESSION_ONLY` if `google_session` else `NO_SESSION` |
+| `200`, JSON object, `user` is a dict with a non-empty string `email` | `AUTHENTICATED` (`user_email` = that email) |
+| `200`, JSON object, `user` present but malformed (not a dict, or no non-empty string `email`) | `VERIFICATION_ERROR` (unexpected shape — see §10) |
 
-This is the well-bounded testable core — exercised with zero mocks.
+Only `user.email` is read; `user.name`, `user.image`, and `expires` are
+ignored. The parsed JSON dict is **never** attached to any exception object or
+log field — only the extracted scalar `email` is retained beyond the parsing
+call site.
 
-`async verify_flow_session(profile_dir: Path, *, channel: str | None,
-source: str) -> FlowSessionStatus` — thin I/O wrapper, used by
+#### `verify_flow_session`
+
+`async verify_flow_session(profile_dir: Path, *, channel: str = "chrome",
+source: str = "chrome") -> FlowSessionStatus` — the I/O wrapper used by
 `RealChromeStrategy`:
 
-1. **Precondition:** `profile_dir.resolve(strict=True)` must be inside
-   `get_settings().home.resolve()`; otherwise raise `SecurityError`
-   (defense-in-depth — symlink-resistant).
-2. Lazily `from .strategies import async_playwright` (inside the function —
-   breaks a module-load circular import and preserves the test-patch seam).
+1. **Boundary recheck.** `profile_dir.resolve(strict=True)` must be inside
+   `get_settings().home.resolve()`; otherwise raise `SecurityError`. `strict=True`
+   is safe and correct here — the profile dir already exists by the time this
+   runs (see §4.2 for why `RealChromeStrategy.login`'s own pre-`mkdir` check
+   deliberately stays `strict=False`).
+2. Lazily `from .strategies import async_playwright` **inside the function**.
 3. Launch a headless `launch_persistent_context(user_data_dir=str(profile_dir),
    channel=channel, headless=True)`.
-4. In `try`: read cookies → `google_session = any(c["name"] == "SAPISID")`;
-   `GET SESSION_API_URL` via a page, with a **15s per-request timeout** and
-   **up to 3 attempts** (initial + 2 `tenacity` retries, exponential backoff)
-   on transient network / timeout errors; pass status + body to
-   `evaluate_session_response`.
-5. On any unrecovered exception (launch failure, retries exhausted) → return
-   `FlowSessionStatus(VERIFICATION_ERROR, …)`. **Fail-closed: never returns
-   `AUTHENTICATED` on uncertainty.**
+4. In `try`: read cookies → `google_session = any(c["name"] == "SAPISID")`; fetch
+   the session via `ctx.request.get(SESSION_API_URL, timeout=15000)` (15 s
+   per-request timeout; no extra page is created). **Retry contract:** up to **3
+   attempts total**, exponential backoff (~1 s → 2 s, cap 8 s). An attempt is
+   retried **only** if the fetch raises a Playwright network/timeout error **or**
+   returns HTTP status ∈ `{429, 503, 504}`. Any other non-200 (401/403/404/500/
+   3xx/…) is **not** retried — it is passed straight to `evaluate_session_response`
+   (→ `VERIFICATION_ERROR`). The plan may implement this as a `tenacity`-decorated
+   inner `_fetch_session` helper or an explicit loop.
+5. Pass the final `(status_code, body)` to `evaluate_session_response`. If no
+   response was ever obtained (retries exhausted, launch failure, unexpected
+   exception) → return `FlowSessionStatus(VERIFICATION_ERROR, …)`. **Fail-closed:
+   `verify_flow_session` never returns `AUTHENTICATED` on uncertainty.**
+   When the `VERIFICATION_ERROR` is caused by a definite non-200 response, log
+   the `status_code` (never the body) at WARNING — see §10.
 6. `finally`: `await ctx.close()` — fully awaited, so the profile's SQLite lock
-   is released before the function returns.
+   is released before the function returns, on both the success and error paths.
 
-`verify_flow_session` is **side-effect-free** beyond the browser probe — it
-writes no files and emits no marker; callers own those side effects.
+`verify_flow_session` is **side-effect-free** beyond the browser probe and that
+one WARNING log — it writes no files and emits no marker; callers own those
+side effects.
 
 ### 4.2 `src/gflow_cli/auth/real_chrome.py` — edit
 
@@ -149,17 +190,31 @@ writes no files and emits no marker; callers own those side effects.
 - Rewrite the console guidance: state explicitly that signing into the Google
   account is **not** sufficient — the user must continue until the working Flow
   editor (prompt box / their projects) is loaded, *then* close Chrome.
+- **Profile-dir boundary check — deliberate `strict` divergence.**
+  `RealChromeStrategy.login`'s existing pre-`mkdir` boundary check stays
+  `resolve(strict=False)`. It **must** run before `mkdir` — if `mkdir` ran first,
+  a path-traversal profile name (`../../evil`) would have its directory created
+  *outside* `GFLOW_CLI_HOME` before being rejected. `strict=False` is **not**
+  weaker against symlink attacks: `Path.resolve()` resolves existing symlinks
+  regardless of the `strict` flag; `strict` only controls whether resolution
+  errors on a *non-existent* final component. The deeper `strict=True` check
+  lives in `verify_flow_session` (§4.1 step 1), which runs after the directory
+  exists. This divergence is intentional.
 - Replace the inline post-close verification block (the direct `async_playwright`
   import, `launch_persistent_context`, `cookies()`, `has_sapisid` check) with a
   single call: `status = await verify_flow_session(profile_dir,
   channel="chrome", source="chrome")`. This runs **after** `proc.wait()` returns
   (the login Chrome has exited and released the profile lock — sequencing
   preserved).
-  - `status.authenticated` → emit structlog `auth_flow_session_verified`
+  - `status.authenticated` → emit structlog **`auth_flow_session_verified`**
     (`outcome`, `source`, `user_email`); **write the `.gflow_browser_strategy`
     marker** (`"chrome"`); print `[OK] Flow session verified (<email>).`
-  - else → emit a structlog warning; raise `AuthMissingError` (exit code 8) with
-    an `outcome`-tailored message + `remediation_hint` (see §6).
+  - else → emit structlog WARNING **`auth_flow_session_unverified`** (`outcome`,
+    `source`); raise `AuthMissingError` (exit code 8) with an `outcome`-tailored
+    message + `remediation_hint` (see §6).
+- The old structlog events `auth_login_success_verified` and
+  `auth_login_no_cookies` are **replaced** by `auth_flow_session_verified` /
+  `auth_flow_session_unverified`.
 
 > The `.gflow_browser_strategy` marker write is **load-bearing** —
 > `browser_manager.channel_for_profile` reads it; dropping it makes
@@ -173,15 +228,23 @@ Playwright and auto-detects success without waiting for a close). Change only
 *what* it checks:
 
 - In the poll loop, replace the `SAPISID` + `get_by_text("New project")` /
-  `("Your projects")` test with: `resp = await
-  page.request.get(SESSION_API_URL)`, then `evaluate_session_response(
-  resp.status, await resp.text(), google_session=<SAPISID present>,
-  source="internal")`; success when `outcome is AUTHENTICATED`.
-- Query `/api/auth/session` at a modest cadence (every ~3s, not every 1s) to
-  avoid hammering the endpoint.
-- The existing timeout / "closed before verified" branches stay, raising
-  `AuthLoginTimeoutError`; their wording is refreshed to mention reaching the
-  Flow editor.
+  `("Your projects")` test with: `resp = await page.request.get(SESSION_API_URL,
+  timeout=15000)`, then `evaluate_session_response(resp.status, await
+  resp.text(), google_session=<SAPISID present>, source="internal")`; success
+  when `outcome is AUTHENTICATED`.
+- Query `/api/auth/session` on a modest cadence — `asyncio.sleep(3)` between
+  polls (not every 1 s) — within the existing time-budget `while` loop;
+  otherwise the loop structure is unchanged.
+- **Non-`AUTHENTICATED` outcomes mid-poll — including `VERIFICATION_ERROR` —
+  are not surfaced distinctly: the loop keeps polling until the time budget is
+  exhausted** (the user may still be completing sign-in). On budget exhaustion
+  or browser close the existing `AuthLoginTimeoutError` is raised; its wording
+  is refreshed to mention reaching the Flow editor.
+- **Replace the loop's bare `except Exception: break`** with differentiated
+  handling: re-raise `asyncio.CancelledError`; treat Playwright
+  "target/context/browser closed" errors as the browser-closed signal (break to
+  the closed-handling branch); log any other unexpected exception at WARNING
+  before breaking.
 - Internal does not write `.gflow_browser_strategy` (absence ⇒ bundled
   Chromium ⇒ correct) — unchanged.
 
@@ -201,15 +264,16 @@ gflow auth login
        │     launch system Chrome (raw subprocess, no debug port) at the Flow URL
        │     → user signs in & closes Chrome → proc.wait()
        │     → verify_flow_session(channel="chrome", source="chrome")
-       │           → headless context → GET /api/auth/session
+       │           → headless context → ctx.request.get(/api/auth/session)
        │           → evaluate_session_response
        │     → AUTHENTICATED ? write marker + log + success
        │                     : raise AuthMissingError (exit 8)
        └─ InternalChromiumStrategy:
              launch bundled Chromium (Playwright-controlled) at the Flow URL
-             → live poll: GET /api/auth/session → evaluate_session_response
+             → live poll (~3s): page.request.get(/api/auth/session)
+                                 → evaluate_session_response
              → AUTHENTICATED ? success
-                             : (timeout / closed) raise AuthLoginTimeoutError
+                             : (budget exhausted / closed) raise AuthLoginTimeoutError
 ```
 
 `FlowApiClient` later opens the profile and authenticates on the now-guaranteed
@@ -218,8 +282,7 @@ gflow auth login
 ## 6. Error handling & fail-closed semantics
 
 Only `FlowSessionOutcome.AUTHENTICATED` green-lights a login. Every other
-outcome fails the login — the verification never reports success under
-uncertainty.
+outcome fails the login — verification never reports success under uncertainty.
 
 `VERIFICATION_ERROR` is a **distinct fail-closed outcome**, not conflated with
 `NO_SESSION`: a network timeout is not evidence that the user is signed out. It
@@ -237,108 +300,179 @@ slow link is not falsely failed without recourse.
 - `VERIFICATION_ERROR` → "Could not verify the Flow session — this is often a
   network problem. Check your connection and re-run `gflow auth login`."
 
+**Strategy asymmetry (deliberate).** `RealChromeStrategy` verifies *after* the
+browser closes, so it surfaces the `outcome`-tailored `AuthMissingError` above.
+`InternalChromiumStrategy` verifies *live* and simply keeps polling until it
+either sees `AUTHENTICATED` or the time budget runs out — its failure surface is
+the existing `AuthLoginTimeoutError`. Both are fail-closed; only the message
+shape differs.
+
 ## 7. Security considerations
 
-Folded in from the council's security review (must-fix items):
+Folded in from the council security reviews (must-fix items):
 
 - **No secret in logs or `detail`.** `__Secure-next-auth.session-token` and all
-  raw cookie values are never logged. `FlowSessionStatus.detail` is a static
-  string from a fixed set — never interpolated from response-body, cookie, or
-  exception content. The raw `/api/auth/session` body is never logged or stored,
-  at any level.
-- **Minimal payload extraction.** `evaluate_session_response` reads only the
-  keys it needs (`user.email`); the profile-image URL is discarded.
+  raw cookie values are never logged. `FlowSessionStatus.detail` is one of the
+  four static literals in §4.1 — never interpolated from response-body, cookie,
+  or exception content. The raw `/api/auth/session` body is never logged or
+  stored, at any level. The parsed JSON dict is never attached to an exception
+  object; only the scalar `email` survives the parsing call site.
+- **Minimal payload extraction.** `evaluate_session_response` reads only
+  `user.email`; `user.name`, `user.image` (a signed CDN URL), and `expires` are
+  discarded.
 - **`user_email`** may be logged at INFO on success (the user's own email;
-  consistent with the existing `auth_login_success_verified` event) — never
-  inside a body dump.
+  consistent with the prior `auth_login_success_verified` event) — never inside
+  a body dump or at DEBUG.
 - **Fail-closed.** Any uncertainty → `VERIFICATION_ERROR`; never
-  `AUTHENTICATED`. Non-200 / malformed body are uncertainty, not
-  "unauthenticated".
+  `AUTHENTICATED`. Non-200 and malformed/unexpected bodies are uncertainty, not
+  "unauthenticated". `evaluate_session_response`'s total, exception-free design
+  means no exceptional path can bypass the outcome enum.
 - **No `storage_state`.** Deliberately not used — it would serialise the session
   token into a plaintext JSON file. The session stays inside Chrome's own cookie
-  store (encrypted at rest by the OS — DPAPI on Windows). No new credential file
-  is written.
+  store, encrypted at rest by the OS (DPAPI on Windows). **Scope of that
+  protection:** DPAPI protects the cookie store against processes running under
+  a *different* Windows user account; it does not protect against code running
+  in the *same* user session — consistent with `docs/SECURITY.md`'s single-user
+  local-CLI threat model. No new credential file is written.
 - **Profile-dir boundary.** `verify_flow_session` re-validates `profile_dir`
-  with `resolve(strict=True)` against `GFLOW_CLI_HOME`, raising `SecurityError`
-  — symlink-resistant defense-in-depth.
+  with `resolve(strict=True)` against `GFLOW_CLI_HOME`, raising `SecurityError`.
+  `RealChromeStrategy.login`'s own pre-`mkdir` check stays `strict=False` for the
+  reason given in §4.2 — `resolve()` follows symlinks regardless of `strict`, so
+  this is not a weakening.
 - **No new untrusted surface.** `SESSION_API_URL` is a hard-coded constant — no
-  SSRF surface; TLS via Chromium's stack.
+  SSRF surface; TLS via Chromium's stack (same trust surface as `FlowApiClient`).
 
 ## 8. Testing strategy (TDD — red → green → refactor)
 
-`evaluate_session_response` — **pure unit tests, zero mocks:**
+**Wave 1 — `evaluate_session_response` (pure, zero mocks).** One case per
+decision-table row, plus boundary cases the audit surfaced:
 
-- `200` + authenticated `user` body → `AUTHENTICATED`, email extracted.
-- `200` + `{}`, `google_session=True` → `GOOGLE_SESSION_ONLY`.
-- `200` + `{}`, `google_session=False` → `NO_SESSION`.
-- non-200 (401 / 500 / 302) → `VERIFICATION_ERROR`.
-- malformed / non-JSON body → `VERIFICATION_ERROR`.
+- `200` + authenticated `user` with `email` → `AUTHENTICATED`, email extracted;
+  `.authenticated` property is `True`.
+- `200` + `{}` , `google_session=True` → `GOOGLE_SESSION_ONLY`.
+- `200` + `{}` , `google_session=False` → `NO_SESSION`.
+- `200` + `{"user": null}` → `GOOGLE_SESSION_ONLY` / `NO_SESSION` per
+  `google_session` (must not crash).
+- `200` + `{"user": {"name": "x"}}` (no `email`) → `VERIFICATION_ERROR`.
+- `200` + `{"user": {"email": ""}}` (empty email) → `VERIFICATION_ERROR`.
+- `200` + JSON array `"[]"` → `VERIFICATION_ERROR`.
+- `200` + malformed / partial JSON, empty string, whitespace-only → `VERIFICATION_ERROR`.
+- non-200 (401 / 500 / 302) → `VERIFICATION_ERROR`, regardless of `google_session`.
+- `source` argument is passed through to `FlowSessionStatus.source`.
+- An **endpoint-contract fixture** capturing the real authenticated `200` body
+  shape (see §10) is used here, so a future Google shape change fails this test.
 
-`verify_flow_session` — **mock the `.strategies` `async_playwright` shim:**
+**Wave 2 — `verify_flow_session` (mock the `.strategies` `async_playwright`
+shim).** The correct patch target is `gflow_cli.auth.strategies.async_playwright`
+(where the lazy import resolves) — **not** `playwright.async_api.async_playwright`.
+The mock must stub `ctx.request.get` returning an object with `.status` and an
+async `.text()`:
 
 - authenticated probe → `AUTHENTICATED`.
-- unauthenticated probe → `GOOGLE_SESSION_ONLY` / `NO_SESSION`.
-- transient error → retried → exhausted → `VERIFICATION_ERROR`.
-- launch failure → `VERIFICATION_ERROR`.
-- `ctx.close()` awaited in `finally` even on the error path.
-- profile dir outside `GFLOW_CLI_HOME` → `SecurityError`.
+- unauthenticated probe, SAPISID present / absent → `GOOGLE_SESSION_ONLY` / `NO_SESSION`.
+- retryable error (timeout, then 503) retried up to 3 attempts → exhausted →
+  `VERIFICATION_ERROR`.
+- non-retryable non-200 (401) → not retried → `VERIFICATION_ERROR` in one attempt.
+- `launch_persistent_context` raises → `VERIFICATION_ERROR`.
+- `ctx.close()` is awaited in `finally` on both success and error paths.
+- `profile_dir` outside `GFLOW_CLI_HOME` → `SecurityError`.
 
-Strategy tests — `tests/auth/strategies/test_strategies.py`:
+**Wave 3 — strategy integration** (`tests/auth/strategies/test_strategies.py`):
 
-- **Update** (behaviour legitimately changed): the real-chrome "success verified
-  via SAPISID" test and its verify-probe mock helper; the internal-chromium
-  standard + timeout tests (they mock `get_by_text` + SAPISID — repoint to
-  `/api/auth/session`).
-- **Must NOT change:** `test_real_chrome_launch_flags` (launch flags),
-  `test_real_chrome_privacy_guard` (`SecurityError` boundary),
-  `test_real_chrome_timeout_raises` (`AuthLoginTimeoutError`).
+- **Rework** the shared `_build_verify_pw_mock` helper: patch
+  `gflow_cli.auth.strategies.async_playwright`, and stub `request.get` (with
+  configurable status/body) instead of `goto`.
+- **Update + rename** `test_real_chrome_success_verified_via_sapisid` →
+  `..._via_flow_session`, repointed to the `/api/auth/session` flow.
+- **Add** `test_real_chrome_writes_gflow_browser_strategy_on_success` — asserts
+  the marker file contains `"chrome"` (the load-bearing regression guard; lives
+  here because the *write* is a `RealChromeStrategy.login` side effect).
+- **Add** parametrized tests: each non-`AUTHENTICATED` outcome
+  (`GOOGLE_SESSION_ONLY`, `NO_SESSION`, `VERIFICATION_ERROR`) raises
+  `AuthMissingError` with the matching §6 message.
+- **Update** the internal-chromium tests (`test_internal_chromium_standard_behavior`,
+  `test_internal_chromium_timeout_raises`): replace the `get_by_text` + `SAPISID`
+  mocks with a `page.request.get` mock; confirm a timeout still raises
+  `AuthLoginTimeoutError` and `ctx.close()` is still called.
+- **Must NOT change:** `test_real_chrome_launch_flags`,
+  `test_real_chrome_privacy_guard`, `test_real_chrome_timeout_raises`.
 
-Regression — `tests/test_browser_manager.py`:
-
-- **Must NOT change**, and **add** a test asserting a successful real-chrome
-  login still writes `.gflow_browser_strategy`.
-
-BDD — `tests/**/*.feature` for auth login / status: **must NOT change**; step
-mocks updated to produce a verifiable session where needed.
+**Wave 4 — BDD.** `tests/test_browser_manager.py` and the auth `.feature` files
+**must NOT change**; before relying on that, **verify** the feature step
+definitions / `conftest.py` do not assert on the renamed structlog event
+strings. Step mocks are updated to produce a verifiable session where needed.
 
 Coverage: ≥80% overall maintained; `verification.py` targeted near-100% (the
 pure core makes this cheap).
 
 ## 9. Regression guardrails (what must not break)
 
-From the council's regression review:
+From the council regression review:
 
 - **`.gflow_browser_strategy` marker** — must still be written on a successful
-  real-chrome login (HIGH risk; covered by a new test).
+  real-chrome login (HIGH risk; covered by the new Wave-3 test).
 - **Exit code 8** — verification failure must raise `AuthMissingError` (a
   `GFlowError` subclass), not fall through to the catch-all exit 1.
 - **`FlowApiClient`** — confirmed unchanged; a profile from the fixed flow is a
   strict superset of today's.
 - **Sequencing** — `verify_flow_session` runs only after the login Chrome
-  process has exited (`proc.wait()`), so there is no SQLite-lock contention.
+  process has exited (`proc.wait()`), so there is no SQLite-lock contention; its
+  own context is fully closed (`await ctx.close()` in `finally`) before return.
 - **Slow-network correctness** — the retry budget + `VERIFICATION_ERROR`
   classification ensure a correct login on a flaky link is not falsely failed.
-- structlog event renames are safe (no code or test asserts on the event
-  strings).
+- **`InternalChromiumStrategy`** — `ctx.close()` is still reached on the timeout
+  path after the polling replacement.
+- structlog event renames are safe **once Wave-4 confirms** no test/step
+  definition asserts on the old event strings.
 
-## 10. Known limitation
+## 10. Durability & known limitations
 
-In environments without an OS keystore (some CI / Docker containers), Chrome
-cannot decrypt its cookie store, so verification may always fail. Such
-environments should use `InternalChromiumStrategy` (`--browser internal`), whose
-bundled Chromium profile does not depend on DPAPI / keychain. This is
-documented, not fixed.
+**Durability against Google hardening Flow.** The design depends on two external
+Google surfaces. Its fail-closed posture means every plausible change degrades
+gracefully — it never yields a silent false success:
+
+- *Endpoint path moved / removed* → non-200 or non-JSON → `VERIFICATION_ERROR` →
+  honest, recoverable error.
+- *Response shape changed* (`user` nesting / `email` renamed) → falls to
+  `VERIFICATION_ERROR` or a non-`AUTHENTICATED` outcome — annoying but never a
+  false positive.
+- *`SAPISID` renamed* → only changes which remediation message is shown, never
+  the authenticated decision.
+- *`__Secure-next-auth.session-token` renamed* → not referenced by name in the
+  verification logic; the session is checked transitively via the endpoint —
+  the design's biggest durability strength.
+
+Hardening folded in to make this brittleness **observable** rather than silent:
+
+1. **Endpoint-contract fixture.** A unit-test fixture (Wave 1) captures the real
+   authenticated `200` body shape, and `verification.py` carries a code comment
+   documenting the expected contract. A Google shape change then surfaces as a
+   *failing test*, not a field of bug reports.
+2. **Observable failures.** On a `VERIFICATION_ERROR` caused by a non-200, the
+   `status_code` is logged at WARNING (never the body) — distinguishing a moved
+   endpoint (a CLI bug) from a flaky link (the user's network).
+3. **Documented coupling.** `KNOWN_ISSUES.md` gets an entry recording the
+   `/api/auth/session` endpoint and the `SAPISID` cookie name as external
+   couplings, so the next maintainer knows where to look when Google changes
+   Flow's auth. (The probes under `tmp/` are untracked and will not survive.)
+
+**Known limitation.** In environments without an OS keystore (some CI / Docker
+containers), Chrome cannot decrypt its cookie store, so verification may always
+fail. Such environments should use `InternalChromiumStrategy`
+(`--browser internal`), whose bundled Chromium profile does not depend on
+DPAPI / keychain. This is documented, not fixed.
 
 ## 11. Council review
 
-This design was reviewed by three parallel agents before approval:
+This design was reviewed in two rounds of parallel agent review before approval:
 
-- **Architecture** — verified single-responsibility, module decomposition, the
-  circular-import fix, and `AuthMissingError` reuse.
-- **Security** — verified credential handling, the fail-closed posture, and the
-  no-`storage_state` decision; its must-fix items are folded into §7.
-- **Regression** — verified the blast radius; its guardrails are folded into §9
-  and §8.
+- **Design stage** — architecture, security, and regression agents validated
+  Approach A, the module decomposition, and the blast radius.
+- **Spec stage** — implementability, security, codebase-accuracy, and
+  test-strategy agents audited this written spec. The accuracy audit confirmed
+  all 17 codebase claims; the other three produced the refinements folded into
+  Rev 2. One security suggestion (upgrading `RealChromeStrategy.login`'s check to
+  `strict=True`) was **partially rejected** with technical reasoning — see §4.2.
 
 ## 12. References
 
@@ -347,4 +481,5 @@ This design was reviewed by three parallel agents before approval:
 - `docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md`
   — superseded v2 spec.
 - `docs/superpowers/2026-05-17-issue-15-handover.md` — prior handover.
+- `KNOWN_ISSUES.md` — to receive the external-endpoint coupling note (§10).
 - Probes: `tmp/issue-15-phase2/` (exploratory, untracked).

--- a/docs/superpowers/specs/2026-05-17-issue-15-root-cause-findings.md
+++ b/docs/superpowers/specs/2026-05-17-issue-15-root-cause-findings.md
@@ -1,0 +1,87 @@
+# Issue #15 — Root-Cause Findings (supersedes the v2 spec hypothesis)
+
+> **Status:** Investigation complete · **Date:** 2026-05-17
+> The v2 design spec's hypothesis ("aisandbox-pa REST routes need a `Bearer`
+> header") is **INVALIDATED**. The real bug is upstream, in the auth layer.
+> No production fix is planned yet — see §5.
+
+## 1. Summary
+
+`gflow video i2v` fails at its FIRST API call — `POST .../trpc/project.createProject`
+on `labs.google` — with `401 UNAUTHORIZED`. It never reaches `uploadImage`
+(the route issue #15 and the v2 spec targeted).
+
+**Root cause:** `gflow auth login` does not produce a usable `labs.google`
+*application* session in the profile. The profile holds Google SSO cookies but
+not the NextAuth session cookie that the Flow app's tRPC API authenticates on.
+The CLI is, in effect, signed out of the Flow app.
+
+## 2. Evidence
+
+Live reproduction on profile `denon82`, session verified fresh 22 s prior:
+
+1. **Phase-1 gate** — `gflow video i2v` 401s at `createProject`, not `uploadImage`.
+2. **`createProject` 401 body** — clean tRPC error:
+   `{"error":{"json":{"message":"UNAUTHORIZED","code":-32001,...}}}`.
+3. **HAR network trace** (`tmp/issue-15-phase1/trace.har`, 72 entries):
+   - The editor URL loads the **logged-out Flow landing page** — hero gallery
+     images, marketing video — not the authenticated editor.
+   - **No `/api/auth/session` request** — the app session is decided
+     server-side; the server saw no valid session.
+   - `createProject` sent cookies `_ga, __Secure-next-auth.callback-url,
+     __Host-next-auth.csrf-token, _ga_X2GNH8R5NS` — **no session token**.
+   - **Nothing on the wire ever `set-cookie`'d a `*session-token`.**
+4. **Profile cookie DB** (`profile_denon82/Default/Network/Cookies`, 85 cookies):
+   - `labs.google` cookies present: `__Host-next-auth.csrf-token` and
+     `__Secure-next-auth.callback-url` — both `is_persistent=0` (session
+     cookies) — plus 2 `_ga` analytics cookies.
+   - **`__Secure-next-auth.session-token` is absent from the DB entirely**
+     (`SELECT ... WHERE name LIKE '%session-token%'` → 0 rows, all hosts).
+   - Google SSO cookies (`SAPISID`, `__Secure-1PSID`, …) ARE present.
+5. Captured working `samples/captured/05_createProject.json` uses cookies only
+   (no `Authorization`) and returns 200 — so the failure is a missing
+   *session cookie*, not a missing *header*. The v2 spec's `Bearer` fix would
+   not address it.
+
+## 3. Mechanism
+
+`labs.google` runs its own NextAuth session layer on top of Google SSO. Its
+tRPC API requires `__Secure-next-auth.session-token`. That cookie is
+session-scoped (its NextAuth siblings are `is_persistent=0`) and is **not
+persisted into the profile by `gflow auth login`** — even though the user
+signs in "to the Flow editor." Re-loading the editor does not re-establish it
+(no silent SSO → app-session upgrade on a plain page load).
+
+The `auth_login_success_verified` check only confirms the persistent `SAPISID`
+Google cookie exists — it never checks the `labs.google` app session, so it
+reports success while the profile is functionally signed out of Flow.
+
+## 4. Impact
+
+- Blocks `gflow video i2v` (and any REST flow that starts with
+  `create_project` — likely `t2v` and others).
+- Issue #15's v2 spec and 7-task plan are **superseded** — do not implement
+  them as written.
+
+## 5. Open question for the fix (one probe still outstanding)
+
+Exactly *why* the session-token is not persisted — candidates:
+(a) it is an in-memory session cookie not flushed before the Passive-Capture
+    browser closes; (b) the Passive-Capture sign-in never completes the
+    NextAuth callback that mints it. Finding 2.4 rules a decryption problem
+    OUT (the name is simply not in the DB).
+
+The fix likely belongs in the **auth layer** — capture the full session
+(e.g. Playwright `storage_state`, or the live cookie jar including session
+cookies) at the moment sign-in completes, *before* the browser closes, and
+restore it into the client context. The `auth_login` verification should also
+assert a real `labs.google` app session, not just `SAPISID` presence. This
+needs its own brainstorm → spec → plan cycle.
+
+## 6. Artifacts
+
+- `tmp/issue-15-phase1/` — probes (`probe_createproject.py`, `har_trace.py`,
+  `probe_cookiedb.py`), HAR trace, run logs. Exploratory; `tmp/` is untracked.
+- This document supersedes
+  `docs/superpowers/specs/2026-05-17-i2v-uploadimage-401-bearer-auth-design.md`
+  and its plan `docs/superpowers/plans/2026-05-17-issue-15-i2v-bearer-auth.md`.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import secrets
 import time
 import uuid
@@ -319,6 +320,12 @@ class FlowApiClient:
         async def attempt() -> Any:
             page = await self._checkout_page()
             try:
+                if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
+                    logger.info(
+                        "request_headers",
+                        url=url,
+                        headers=_redact_headers_for_log({"content-type": content_type}),
+                    )
                 return await page.request.post(
                     url,
                     data=body_str,
@@ -351,6 +358,12 @@ class FlowApiClient:
         async def attempt() -> Any:
             page = await self._checkout_page()
             try:
+                if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
+                    logger.info(
+                        "request_headers",
+                        url=url,
+                        headers=_redact_headers_for_log({"content-type": _AISANDBOX_CONTENT_TYPE}),
+                    )
                 return await page.request.patch(
                     url,
                     data=body_str,
@@ -597,6 +610,12 @@ class FlowApiClient:
                     url=routes.GENERATE_VIDEO,
                     body=_redact_for_log(json.dumps(body))[:300],
                 )
+                if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
+                    logger.info(
+                        "request_headers",
+                        url=routes.GENERATE_VIDEO,
+                        headers=_redact_headers_for_log({"content-type": _AISANDBOX_CONTENT_TYPE}),
+                    )
                 return await page.request.post(
                     routes.GENERATE_VIDEO,
                     data=json.dumps(body),
@@ -946,6 +965,19 @@ def _redact_for_log(body_str: str) -> str:
                 _redact_in_client_context(cast(dict[str, Any], item).get("clientContext"))
 
     return json.dumps(parsed_dict)
+
+
+def _redact_headers_for_log(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of `headers` with any `authorization` value masked.
+
+    The SOLE permitted way to log a headers dict — `_redact_for_log` covers
+    request bodies only, not headers. Spec §4.5.
+    """
+    redacted = dict(headers)
+    auth = redacted.get("authorization")
+    if auth is not None:
+        redacted["authorization"] = f"Bearer <len={len(auth)}>"
+    return redacted
 
 
 def _redact_in_client_context(client_context: Any) -> None:

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -4,12 +4,14 @@ import asyncio
 from pathlib import Path
 
 import structlog
+from playwright.async_api import Error as PlaywrightError
 from rich.console import Console
 
 from gflow_cli.config import get_settings
 from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
 
 from .base import AuthStrategy
+from .verification import SESSION_API_URL, FlowSessionOutcome, evaluate_session_response
 
 logger = structlog.get_logger(__name__)
 _console = Console()
@@ -64,45 +66,63 @@ class InternalChromiumStrategy(AuthStrategy):
                         "success and exit.\n"
                     )
 
-                # Polling for success (SAPISID cookie + UI signal).
+                # Poll the NextAuth session endpoint live until the Flow app
+                # sign-in completes. Non-AUTHENTICATED outcomes (including a
+                # transient VERIFICATION_ERROR) just mean "keep waiting" — the
+                # user may still be signing in.
                 timeout_at = asyncio.get_running_loop().time() + self._timeout_seconds
                 success = False
 
                 while asyncio.get_running_loop().time() < timeout_at:
                     try:
                         cookies = await ctx.cookies()
-                        has_sapisid = any(c.get("name") == "SAPISID" for c in cookies)
-
-                        if has_sapisid:
-                            # Final confirmation via UI signal
-                            if (
-                                await page.get_by_text("New project").is_visible()
-                                or await page.get_by_text("Your projects").is_visible()
-                            ):
-                                logger.info("auth_login_success_detected", strategy=self.name)
-                                success = True
-                                break
-                    except Exception:
-                        # Browser or context is gone — exit loop without success
+                        google_session = any(c.get("name") == "SAPISID" for c in cookies)
+                        resp = await page.request.get(SESSION_API_URL, timeout=15_000)
+                        status = evaluate_session_response(
+                            resp.status,
+                            await resp.text(),
+                            google_session=google_session,
+                            source=self.name,
+                        )
+                        if status.outcome is FlowSessionOutcome.AUTHENTICATED:
+                            logger.info(
+                                "auth_flow_session_verified",
+                                strategy=self.name,
+                                source=status.source,
+                                user_email=status.user_email,
+                            )
+                            success = True
+                            break
+                    except asyncio.CancelledError:
+                        raise
+                    except PlaywrightError:
+                        # Browser / page / context closed — stop polling.
+                        break
+                    except Exception as exc:  # noqa: BLE001 - unexpected; log and stop
+                        logger.warning(
+                            "auth_flow_session_poll_error",
+                            strategy=self.name,
+                            error=type(exc).__name__,
+                        )
                         break
 
-                    await asyncio.sleep(1)
+                    await asyncio.sleep(3)
                 else:
                     raise AuthLoginTimeoutError(
-                        f"Sign-in not completed within {self._timeout_seconds}s.",
+                        f"Flow sign-in not completed within {self._timeout_seconds}s.",
                         remediation_hint=(
-                            "Run `gflow auth login` again and complete sign-in promptly. "
-                            f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to a higher value if needed "
-                            f"(current: {self._timeout_seconds}s)."
+                            "Run `gflow auth login` again and continue until the Flow "
+                            "editor loads. Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT higher if "
+                            f"needed (current: {self._timeout_seconds}s)."
                         ),
                     )
 
                 if not success:
                     raise AuthLoginTimeoutError(
-                        "Browser closed before authentication was verified.",
+                        "Browser closed before the Flow editor sign-in was verified.",
                         remediation_hint=(
-                            "Complete the full sign-in flow before closing the browser. "
-                            "Run `gflow auth login` to try again."
+                            "Complete the Flow sign-in — until the editor loads — "
+                            "before closing the browser. Run `gflow auth login` to retry."
                         ),
                     )
 

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -98,7 +98,8 @@ class InternalChromiumStrategy(AuthStrategy):
                     except PlaywrightError:
                         # Browser / page / context closed — stop polling.
                         break
-                    except Exception as exc:  # noqa: BLE001 - unexpected; log and stop
+                    # Unexpected error — log it and stop polling.
+                    except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "auth_flow_session_poll_error",
                             strategy=self.name,

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -12,11 +12,33 @@ from gflow_cli.config import get_settings
 from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
 
 from .base import AuthStrategy
+from .verification import FlowSessionOutcome, verify_flow_session
 
 logger = structlog.get_logger(__name__)
 _console = Console()
 
 GEMINI_URL = "https://labs.google/fx/tools/flow?hl=en"
+
+# User-facing guidance per non-authenticated verification outcome (issue #15).
+_UNVERIFIED_MESSAGE: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: (
+        "Signed in to your Google account, but the Flow app sign-in wasn't completed."
+    ),
+    FlowSessionOutcome.NO_SESSION: "No sign-in detected.",
+    FlowSessionOutcome.VERIFICATION_ERROR: (
+        "Could not verify the Flow session — this is often a network problem."
+    ),
+}
+_UNVERIFIED_HINT: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: (
+        "Re-run `gflow auth login` and continue until the Flow editor "
+        "(the prompt box / your projects) loads before closing Chrome."
+    ),
+    FlowSessionOutcome.NO_SESSION: (
+        "Re-run `gflow auth login`, sign in to Google, and continue until the Flow editor loads."
+    ),
+    FlowSessionOutcome.VERIFICATION_ERROR: ("Check your connection and re-run `gflow auth login`."),
+}
 
 
 def find_chrome_executable() -> str | None:
@@ -90,6 +112,7 @@ class RealChromeStrategy(AuthStrategy):
             "--no-default-browser-check",
             "--window-size=1280,800",
             # No --remote-debugging-port: zero automation surface.
+            GEMINI_URL,  # open straight on the Flow sign-in page
         ]
 
         if headless:
@@ -105,12 +128,18 @@ class RealChromeStrategy(AuthStrategy):
             _console.print("\n" + "=" * 60)
             _console.print("[bold cyan]PASSIVE AUTHENTICATION[/bold cyan]")
             _console.print("=" * 60)
-            _console.print("1. A Google Chrome window will open.")
-            _console.print(f"2. Sign in at: [bold]{GEMINI_URL}[/bold]")
-            _console.print("3. Complete sign-in until you reach the Flow editor.")
+            _console.print("1. A Google Chrome window opens at the Flow sign-in page.")
+            _console.print("2. Sign in with your Google account.")
             _console.print(
-                "4. [bold yellow]CLOSE THE BROWSER[/bold yellow] when done — "
-                "gflow will verify your session automatically."
+                "3. [bold yellow]Keep going until the Flow editor itself loads[/bold yellow] "
+                "— the prompt box and your projects."
+            )
+            _console.print(
+                "   Signing in to Google is NOT enough; gflow needs a completed Flow app sign-in."
+            )
+            _console.print(
+                "4. Then [bold yellow]CLOSE THE BROWSER[/bold yellow] — gflow verifies "
+                "the Flow session automatically."
             )
             _console.print("-" * 60)
             _console.print("Launching Chrome...")
@@ -143,35 +172,29 @@ class RealChromeStrategy(AuthStrategy):
                 ),
             ) from None
 
-        _console.print("\n[bold green]Browser closed.[/bold green] Verifying session...")
+        _console.print("\n[bold green]Browser closed.[/bold green] Verifying Flow session...")
 
-        # Headless probe: read persisted cookies from the isolated profile dir.
-        # channel="chrome" uses the system Chrome binary so verification avoids
-        # Playwright's own automation flags (belt-and-suspenders stealth).
-        from playwright.async_api import async_playwright
+        # Verify the real Flow app session — not just the Google SSO cookie.
+        status = await verify_flow_session(profile_dir, channel="chrome", source=self.name)
 
-        async with async_playwright() as pw:
-            ctx = await pw.chromium.launch_persistent_context(
-                user_data_dir=str(profile_dir),
-                channel="chrome",
-                headless=True,
+        if status.authenticated:
+            logger.info(
+                "auth_flow_session_verified",
+                strategy=self.name,
+                source=status.source,
+                user_email=status.user_email,
             )
-            try:
-                cookies = await ctx.cookies()
-                has_sapisid = any(c.get("name") == "SAPISID" for c in cookies)
-
-                if has_sapisid:
-                    logger.info("auth_login_success_verified", strategy=self.name)
-                    # Write strategy marker before any output that might fail on
-                    # narrow Windows codepages — FlowApiClient reads this to select
-                    # the matching Chrome channel for launch_persistent_context.
-                    (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
-                    _console.print("[green][OK] Session captured and verified.[/green]")
-                else:
-                    logger.warning("auth_login_no_cookies", strategy=self.name)
-                    raise AuthMissingError(
-                        "No session cookies found after sign-in. "
-                        "Did you complete the sign-in before closing Chrome?"
-                    )
-            finally:
-                await ctx.close()
+            # Marker read by browser_manager.channel_for_profile so FlowApiClient
+            # selects the system Chrome channel. Load-bearing — must persist here.
+            (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
+            _console.print(f"[green][OK] Flow session verified ({status.user_email}).[/green]")
+        else:
+            logger.warning(
+                "auth_flow_session_unverified",
+                strategy=self.name,
+                outcome=status.outcome.value,
+            )
+            raise AuthMissingError(
+                _UNVERIFIED_MESSAGE[status.outcome],
+                remediation_hint=_UNVERIFIED_HINT[status.outcome],
+            )

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -108,7 +108,8 @@ def evaluate_session_response(
 
     try:
         parsed: Any = json.loads(body)
-    except (json.JSONDecodeError, ValueError):
+    except ValueError:
+        # json.JSONDecodeError is a subclass of ValueError, so this catches both.
         return _result(FlowSessionOutcome.VERIFICATION_ERROR)
 
     if not isinstance(parsed, dict):
@@ -151,7 +152,8 @@ async def _fetch_session(ctx: BrowserContext) -> tuple[int, str]:
         try:
             resp = await ctx.request.get(SESSION_API_URL, timeout=_REQUEST_TIMEOUT_MS)
             body = await resp.text()
-        except Exception as exc:  # noqa: BLE001 - retried below, or re-raised
+        # A network/timeout error is retried below, or re-raised on the final attempt.
+        except Exception as exc:  # noqa: BLE001
             last_exc = exc
             if attempt == _MAX_ATTEMPTS:
                 raise
@@ -207,7 +209,8 @@ async def verify_flow_session(
                 status_code, body = await _fetch_session(ctx)
             finally:
                 await ctx.close()
-    except Exception as exc:  # noqa: BLE001 - fail-closed: any failure -> VERIFICATION_ERROR
+    # Fail-closed: any failure here yields VERIFICATION_ERROR, never AUTHENTICATED.
+    except Exception as exc:  # noqa: BLE001
         logger.warning("auth_flow_session_probe_error", source=source, error=type(exc).__name__)
         return FlowSessionStatus(
             outcome=FlowSessionOutcome.VERIFICATION_ERROR, user_email=None, source=source

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -12,10 +12,22 @@ See docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import structlog
+
+from gflow_cli.config import get_settings
+from gflow_cli.errors import SecurityError
+
+if TYPE_CHECKING:
+    from playwright.async_api import BrowserContext
+
+logger = structlog.get_logger(__name__)
 
 # The NextAuth session endpoint. Expected authenticated 200 body shape:
 #   {"user": {"name": ..., "email": ..., "image": ...}, "expires": "..."}
@@ -23,6 +35,13 @@ from typing import Any, cast
 # AUTHENTICATED_BODY fixture in tests/auth/test_verification.py — if Google
 # changes the shape, that test fails rather than the change going silent.
 SESSION_API_URL = "https://labs.google/fx/api/auth/session"
+
+# Per-request timeout for the session probe (milliseconds).
+_REQUEST_TIMEOUT_MS = 15_000
+# Total fetch attempts (initial + retries) before giving up.
+_MAX_ATTEMPTS = 3
+# HTTP statuses worth retrying — transient server-side conditions only.
+_RETRYABLE_STATUSES = frozenset({429, 503, 504})
 
 
 class FlowSessionOutcome(StrEnum):
@@ -113,3 +132,94 @@ def evaluate_session_response(
 
     # `user` present but no usable email — unexpected shape (see spec §10).
     return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+
+async def _fetch_session(ctx: BrowserContext) -> tuple[int, str]:
+    """Fetch /api/auth/session, retrying transient failures.
+
+    Returns the final (status_code, body). Makes up to `_MAX_ATTEMPTS`
+    attempts; an attempt is retried only on a network/timeout error or an
+    HTTP status in `_RETRYABLE_STATUSES`, with exponential backoff (1s, 2s;
+    capped at 8s). Re-raises the last error if no attempt produced a response.
+
+    An explicit loop (rather than a `tenacity` decorator) is used so the final
+    `(status_code, body)` survives — the caller logs the real status code as a
+    durability signal (spec §10). The spec (§4.1) sanctions either form.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            resp = await ctx.request.get(SESSION_API_URL, timeout=_REQUEST_TIMEOUT_MS)
+            body = await resp.text()
+        except Exception as exc:  # noqa: BLE001 - retried below, or re-raised
+            last_exc = exc
+            if attempt == _MAX_ATTEMPTS:
+                raise
+        else:
+            if resp.status not in _RETRYABLE_STATUSES or attempt == _MAX_ATTEMPTS:
+                return resp.status, body
+        await asyncio.sleep(float(min(2 ** (attempt - 1), 8)))
+    # Unreachable — the loop always returns or raises by the final attempt.
+    raise last_exc or RuntimeError("session probe produced no response")
+
+
+async def verify_flow_session(
+    profile_dir: Path,
+    *,
+    channel: str = "chrome",
+    source: str = "chrome",
+) -> FlowSessionStatus:
+    """Headlessly probe `profile_dir` for a usable Flow app session.
+
+    Launches a headless persistent context on the profile, reads cookies, and
+    calls the NextAuth session endpoint. Fail-closed: any failure — boundary
+    violation aside — yields VERIFICATION_ERROR, never AUTHENTICATED.
+
+    Precondition: `profile_dir` must resolve inside GFLOW_CLI_HOME. The check
+    uses `strict=True` (the directory exists by the time verification runs);
+    `RealChromeStrategy.login`'s own pre-`mkdir` check deliberately stays
+    `strict=False` — see the design spec §4.2.
+    """
+    home = get_settings().home.resolve()
+    try:
+        profile_dir.resolve(strict=True).relative_to(home)
+    except (ValueError, OSError):
+        raise SecurityError(
+            f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME ({home})."
+        ) from None
+
+    # Lazy import — a top-level `from .strategies import ...` would create the
+    # cycle strategies -> real_chrome -> verification -> strategies.
+    from .strategies import async_playwright
+
+    status_code: int
+    body: str
+    try:
+        async with async_playwright() as pw:
+            ctx = await pw.chromium.launch_persistent_context(
+                user_data_dir=str(profile_dir),
+                channel=channel,
+                headless=True,
+            )
+            try:
+                cookies = await ctx.cookies()
+                google_session = any(c.get("name") == "SAPISID" for c in cookies)
+                status_code, body = await _fetch_session(ctx)
+            finally:
+                await ctx.close()
+    except Exception as exc:  # noqa: BLE001 - fail-closed: any failure -> VERIFICATION_ERROR
+        logger.warning("auth_flow_session_probe_error", source=source, error=type(exc).__name__)
+        return FlowSessionStatus(
+            outcome=FlowSessionOutcome.VERIFICATION_ERROR, user_email=None, source=source
+        )
+
+    result = evaluate_session_response(
+        status_code, body, google_session=google_session, source=source
+    )
+    if result.outcome is FlowSessionOutcome.VERIFICATION_ERROR:
+        # Observable durability signal — distinguishes a moved/changed endpoint
+        # from a flaky link. The status code is safe to log; the body is not.
+        logger.warning(
+            "auth_flow_session_unexpected_response", source=source, status_code=status_code
+        )
+    return result

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -54,7 +54,7 @@ class FlowSessionStatus:
 
     outcome: FlowSessionOutcome
     user_email: str | None
-    source: str
+    source: str  # caller-supplied log label ("chrome"/"internal"); never from response/cookie data
 
     @property
     def detail(self) -> str:

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -1,0 +1,115 @@
+"""Flow app-session verification — the single source of truth for
+"is this profile signed in to the Flow app?".
+
+A profile can hold Google SSO cookies (e.g. SAPISID) without holding the Flow
+app's NextAuth session (`__Secure-next-auth.session-token`). Only the latter
+authenticates Flow's tRPC API. This module probes the same surface
+`FlowApiClient` authenticates on — the NextAuth session endpoint — so a login
+is never reported successful unless a real, usable Flow session exists.
+
+See docs/superpowers/specs/2026-05-17-issue-15-auth-verification-fix-design.md
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, cast
+
+# The NextAuth session endpoint. Expected authenticated 200 body shape:
+#   {"user": {"name": ..., "email": ..., "image": ...}, "expires": "..."}
+# An unauthenticated request returns `200 {}`. This contract is pinned by the
+# AUTHENTICATED_BODY fixture in tests/auth/test_verification.py — if Google
+# changes the shape, that test fails rather than the change going silent.
+SESSION_API_URL = "https://labs.google/fx/api/auth/session"
+
+
+class FlowSessionOutcome(StrEnum):
+    """Mutually-exclusive results of probing a profile for a Flow session."""
+
+    AUTHENTICATED = "authenticated"
+    GOOGLE_SESSION_ONLY = "google_session_only"
+    NO_SESSION = "no_session"
+    VERIFICATION_ERROR = "verification_error"
+
+
+_DETAIL_BY_OUTCOME: dict[FlowSessionOutcome, str] = {
+    FlowSessionOutcome.AUTHENTICATED: "Flow app session verified.",
+    FlowSessionOutcome.GOOGLE_SESSION_ONLY: "Signed in to Google, but not to the Flow app.",
+    FlowSessionOutcome.NO_SESSION: "No sign-in detected.",
+    FlowSessionOutcome.VERIFICATION_ERROR: "Could not verify the Flow session.",
+}
+
+
+@dataclass(frozen=True)
+class FlowSessionStatus:
+    """The verdict of a Flow-session probe.
+
+    `detail` is a derived property — always one of the four fixed strings in
+    `_DETAIL_BY_OUTCOME`, never built from response, cookie, or exception
+    content. Deriving it (rather than storing a free string) makes it
+    structurally impossible to leak a secret through this field.
+    """
+
+    outcome: FlowSessionOutcome
+    user_email: str | None
+    source: str
+
+    @property
+    def detail(self) -> str:
+        return _DETAIL_BY_OUTCOME[self.outcome]
+
+    @property
+    def authenticated(self) -> bool:
+        return self.outcome is FlowSessionOutcome.AUTHENTICATED
+
+
+def evaluate_session_response(
+    status_code: int,
+    body: str,
+    *,
+    google_session: bool,
+    source: str,
+) -> FlowSessionStatus:
+    """Map a raw /api/auth/session response to a FlowSessionStatus.
+
+    Pure and total: no I/O, no exceptions raised or used for control flow.
+    Every (status_code, body) maps to exactly one outcome. Fail-closed — only
+    a 200 carrying a usable `user.email` yields AUTHENTICATED. Only `email` is
+    read; `name`, `image`, and `expires` are ignored, and the parsed dict is
+    never retained beyond this function.
+    """
+
+    def _result(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessionStatus:
+        return FlowSessionStatus(outcome=outcome, user_email=email, source=source)
+
+    if status_code != 200:
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    try:
+        parsed: Any = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    if not isinstance(parsed, dict):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    parsed_dict = cast(dict[str, Any], parsed)
+    user = parsed_dict.get("user")
+    if user is None or user == {}:
+        # Authenticated-shaped endpoint reachable, but no Flow session.
+        if google_session:
+            return _result(FlowSessionOutcome.GOOGLE_SESSION_ONLY)
+        return _result(FlowSessionOutcome.NO_SESSION)
+
+    if not isinstance(user, dict):
+        return _result(FlowSessionOutcome.VERIFICATION_ERROR)
+
+    user_dict = cast(dict[str, Any], user)
+    email = user_dict.get("email")
+    if isinstance(email, str) and email:
+        return _result(FlowSessionOutcome.AUTHENTICATED, email)
+
+    # `user` present but no usable email — unexpected shape (see spec §10).
+    return _result(FlowSessionOutcome.VERIFICATION_ERROR)

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -263,14 +263,18 @@ class SecurityError(GFlowError):
 
 
 class AuthMissingError(GFlowError):
-    """Raised when a strategy lacks a required prerequisite credential
-    (e.g. SAPISID cookie missing from profile dir for SapisidhashTransport)."""
+    """Raised when a profile lacks a usable session for the requested action.
+
+    Covers both a wholly absent session and the issue-#15 case: a profile
+    signed in to Google but not to the Flow app (no NextAuth session). The
+    raising site supplies a message and `remediation_hint` describing which.
+    """
 
     problem_type = "https://gflow-cli.dev/errors/auth-missing"
     title = "Authentication credential missing"
     _default_remediation = (
-        "A required credential (e.g. SAPISID cookie) is absent from the profile. "
-        "Run `gflow auth login --profile <name>` to capture a fresh session."
+        "No usable Flow session was found in the profile. "
+        "Run `gflow auth login --profile <name>` and complete the Flow sign-in."
     )
 
 

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -5,42 +5,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from gflow_cli.auth.real_chrome import GEMINI_URL
 from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
-from gflow_cli.errors import AuthLoginTimeoutError, SecurityError
-
-# ---------------------------------------------------------------------------
-# Shared Playwright mock factory — verification-probe (launch_persistent_context)
-# ---------------------------------------------------------------------------
+from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
+from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
 
 
-def _build_verify_pw_mock(
-    cookies: list[dict] | None = None,
-) -> tuple[MagicMock, MagicMock, MagicMock]:
-    """Return (mock_async_playwright, mock_ctx, mock_page) for the headless verification probe.
-
-    RealChromeStrategy (Passive Capture) uses launch_persistent_context(channel="chrome")
-    after the user closes Chrome to verify the persisted cookies.
-    """
-    if cookies is None:
-        cookies = [{"name": "SAPISID", "value": "dummy"}]
-
-    mock_page = MagicMock(name="page")
-    mock_page.goto = AsyncMock()
-
-    mock_ctx = MagicMock(name="ctx")
-    mock_ctx.pages = [mock_page]
-    mock_ctx.cookies = AsyncMock(return_value=cookies)
-    mock_ctx.close = AsyncMock()
-
-    mock_pw_obj = MagicMock(name="pw")
-    mock_pw_obj.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
-
-    mock_cm = MagicMock(name="cm")
-    mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
-    mock_cm.__aexit__ = AsyncMock(return_value=False)
-
-    mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
-    return mock_ap, mock_ctx, mock_page
+def _status(outcome: FlowSessionOutcome, email: str | None = None) -> FlowSessionStatus:
+    """Build a FlowSessionStatus for mocking verify_flow_session."""
+    return FlowSessionStatus(outcome=outcome, user_email=email, source="chrome")
 
 
 def _build_mock_proc() -> MagicMock:
@@ -70,36 +43,81 @@ class TestRealChromeStrategy:
         profile_dir = gflow_home / "profile_default"
         gflow_home.mkdir()
 
-        mock_ap, _, _ = _build_verify_pw_mock()
         mock_proc = _build_mock_proc()
         mock_create = AsyncMock(return_value=mock_proc)
         fake_chrome = r"C:\fake\chrome.exe"
+        verified = _status(FlowSessionOutcome.AUTHENTICATED, "test@example.com")
 
         with (
             patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
             patch("gflow_cli.auth.real_chrome.find_chrome_executable", return_value=fake_chrome),
             patch("gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec", mock_create),
-            patch("playwright.async_api.async_playwright", mock_ap),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=verified),
+            ),
         ):
             mock_settings.return_value.home = gflow_home
             await strategy.login(profile_dir, headless=False)
 
-        # create_subprocess_exec(*chrome_args, ...) — Chrome args are positional.
         args_list = mock_create.call_args.args
         assert args_list[0] == fake_chrome
         assert f"--user-data-dir={profile_dir}" in args_list
         assert "--enable-automation" not in args_list
         assert not any("--remote-debugging-port" in a for a in args_list)
+        assert GEMINI_URL in args_list  # Chrome opens directly on the Flow page
 
     @pytest.mark.asyncio
-    async def test_real_chrome_success_verified_via_sapisid(self, tmp_path: Path) -> None:
-        """After proc.wait(), verify headless probe detects SAPISID and exits cleanly."""
+    async def test_real_chrome_success_writes_marker(self, tmp_path: Path) -> None:
+        """On an authenticated Flow session, login writes the .gflow_browser_strategy marker."""
         strategy = RealChromeStrategy()
         gflow_home = tmp_path / "gflow_home"
         profile_dir = gflow_home / "profile_default"
         gflow_home.mkdir()
 
-        mock_ap, mock_ctx, _ = _build_verify_pw_mock(cookies=[{"name": "SAPISID", "value": "abc"}])
+        mock_proc = _build_mock_proc()
+        verified = _status(FlowSessionOutcome.AUTHENTICATED, "test@example.com")
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch(
+                "gflow_cli.auth.real_chrome.find_chrome_executable",
+                return_value=r"C:\fake\chrome.exe",
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=verified),
+            ),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await strategy.login(profile_dir, headless=False)
+
+        marker = profile_dir / ".gflow_browser_strategy"
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8") == "chrome"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome",
+        [
+            FlowSessionOutcome.GOOGLE_SESSION_ONLY,
+            FlowSessionOutcome.NO_SESSION,
+            FlowSessionOutcome.VERIFICATION_ERROR,
+        ],
+    )
+    async def test_real_chrome_unverified_raises_auth_missing(
+        self, tmp_path: Path, outcome: FlowSessionOutcome
+    ) -> None:
+        """A non-authenticated outcome fails the login with AuthMissingError."""
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        gflow_home.mkdir()
+
         mock_proc = _build_mock_proc()
 
         with (
@@ -112,13 +130,16 @@ class TestRealChromeStrategy:
                 "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
                 AsyncMock(return_value=mock_proc),
             ),
-            patch("playwright.async_api.async_playwright", mock_ap),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_session",
+                AsyncMock(return_value=_status(outcome)),
+            ),
         ):
             mock_settings.return_value.home = gflow_home
-            await strategy.login(profile_dir, headless=False)
+            with pytest.raises(AuthMissingError):
+                await strategy.login(profile_dir, headless=False)
 
-        mock_ctx.cookies.assert_called_once()
-        mock_ctx.close.assert_called_once()
+        assert not (profile_dir / ".gflow_browser_strategy").exists()
 
     @pytest.mark.asyncio
     async def test_real_chrome_privacy_guard(self, tmp_path: Path) -> None:

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -209,22 +209,23 @@ class TestRealChromeStrategy:
 class TestInternalChromiumStrategy:
     @pytest.mark.asyncio
     async def test_internal_chromium_standard_behavior(self, tmp_path: Path) -> None:
-        """Verify Internal Chromium uses standard Playwright (no stealth flags)."""
+        """Internal Chromium detects success via the /api/auth/session probe."""
         strategy = InternalChromiumStrategy()
         gflow_home = tmp_path / "gflow_home"
         gflow_home.mkdir()
         profile_dir = gflow_home / "profile_internal"
 
-        mock_success_loc = MagicMock()
-        mock_success_loc.is_visible = AsyncMock(return_value=True)
+        mock_resp = MagicMock(name="resp")
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value='{"user": {"email": "test@example.com"}}')
 
         mock_page = MagicMock(name="page")
         mock_page.goto = AsyncMock()
-        mock_page.get_by_text.return_value = mock_success_loc
+        mock_page.request.get = AsyncMock(return_value=mock_resp)
 
         mock_ctx = MagicMock(name="ctx")
         mock_ctx.pages = [mock_page]
-        mock_ctx.cookies = AsyncMock(return_value=[{"name": "SAPISID", "value": "dummy"}])
+        mock_ctx.cookies = AsyncMock(return_value=[{"name": "SAPISID", "value": "x"}])
         mock_ctx.close = AsyncMock()
         mock_ctx.new_page = AsyncMock(return_value=mock_page)
 
@@ -248,21 +249,23 @@ class TestInternalChromiumStrategy:
         _, kwargs = mock_launch_pctx.call_args
         assert "channel" not in kwargs or kwargs["channel"] != "chrome"
         assert "--disable-blink-features=AutomationControlled" not in kwargs.get("args", [])
+        mock_page.request.get.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_internal_chromium_timeout_raises(self, tmp_path: Path) -> None:
-        """Verify AuthLoginTimeoutError is raised when polling loop exceeds deadline."""
+        """AuthLoginTimeoutError is raised when the session never authenticates."""
         strategy = InternalChromiumStrategy(timeout_seconds=0)
         gflow_home = tmp_path / "gflow_home"
         gflow_home.mkdir()
         profile_dir = gflow_home / "profile_internal"
 
-        mock_success_loc = MagicMock()
-        mock_success_loc.is_visible = AsyncMock(return_value=False)
+        mock_resp = MagicMock(name="resp")
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value="{}")
 
         mock_page = MagicMock(name="page")
         mock_page.goto = AsyncMock()
-        mock_page.get_by_text.return_value = mock_success_loc
+        mock_page.request.get = AsyncMock(return_value=mock_resp)
 
         mock_ctx = MagicMock(name="ctx")
         mock_ctx.pages = [mock_page]

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gflow_cli.auth.real_chrome import GEMINI_URL
+from gflow_cli.auth.real_chrome import _UNVERIFIED_HINT, _UNVERIFIED_MESSAGE, GEMINI_URL
 from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
 from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
 from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
@@ -136,9 +136,11 @@ class TestRealChromeStrategy:
             ),
         ):
             mock_settings.return_value.home = gflow_home
-            with pytest.raises(AuthMissingError):
+            with pytest.raises(AuthMissingError) as exc_info:
                 await strategy.login(profile_dir, headless=False)
 
+        assert exc_info.value.detail == _UNVERIFIED_MESSAGE[outcome]
+        assert exc_info.value.remediation_hint == _UNVERIFIED_HINT[outcome]
         assert not (profile_dir / ".gflow_browser_strategy").exists()
 
     @pytest.mark.asyncio

--- a/tests/auth/test_verification.py
+++ b/tests/auth/test_verification.py
@@ -238,6 +238,30 @@ class TestVerifyFlowSession:
         assert mock_ctx.request.get.await_count == 3
 
     @pytest.mark.asyncio
+    async def test_mixed_transient_failures_exhaust_to_verification_error(
+        self, gflow_home: Path
+    ) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # Sequence: exception -> retryable 503 -> exception.
+        # All three retry branches are exercised in one pass.
+        resp_503 = MagicMock(name="resp_503")
+        resp_503.status = 503
+        resp_503.text = AsyncMock(return_value="{}")
+        mock_ap, mock_ctx = _build_verify_mock(
+            get_side_effect=[RuntimeError("net::ERR"), resp_503, RuntimeError("net::ERR")]
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 3
+
+    @pytest.mark.asyncio
     async def test_non_retryable_status_not_retried(self, gflow_home: Path) -> None:
         profile = gflow_home / "profile_default"
         profile.mkdir()

--- a/tests/auth/test_verification.py
+++ b/tests/auth/test_verification.py
@@ -51,6 +51,12 @@ class TestEvaluateSessionResponse:
         )
         assert status.outcome is FlowSessionOutcome.NO_SESSION
 
+    def test_null_user_with_google_cookie(self) -> None:
+        status = evaluate_session_response(
+            200, '{"user": null}', google_session=True, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY
+
     @pytest.mark.parametrize(
         "body",
         [

--- a/tests/auth/test_verification.py
+++ b/tests/auth/test_verification.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -8,7 +10,9 @@ from gflow_cli.auth.verification import (
     FlowSessionOutcome,
     FlowSessionStatus,  # noqa: F401 — imported to assert it's part of the public API
     evaluate_session_response,
+    verify_flow_session,
 )
+from gflow_cli.errors import SecurityError
 
 # Representative authenticated /api/auth/session body. Sanitised — no real
 # PII. Pins the endpoint contract: if Google changes the response shape, the
@@ -86,3 +90,188 @@ class TestEvaluateSessionResponse:
     def test_source_is_passed_through(self) -> None:
         status = evaluate_session_response(200, "{}", google_session=False, source="internal")
         assert status.source == "internal"
+
+
+# ---------------------------------------------------------------------------
+# verify_flow_session — async headless probe
+# ---------------------------------------------------------------------------
+
+
+def _build_verify_mock(
+    *,
+    cookies: list[dict] | None = None,
+    response_status: int = 200,
+    response_body: str = "{}",
+    get_side_effect: object = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Return (mock_async_playwright, mock_ctx) for verify_flow_session.
+
+    Mocks the headless persistent context: ctx.cookies(), ctx.request.get()
+    (an APIResponse-like object with `.status` and async `.text()`), and
+    ctx.close(). Patch target for the shim is gflow_cli.auth.strategies.
+    """
+    if cookies is None:
+        cookies = [{"name": "SAPISID", "value": "x"}]
+
+    mock_resp = MagicMock(name="resp")
+    mock_resp.status = response_status
+    mock_resp.text = AsyncMock(return_value=response_body)
+
+    mock_request = MagicMock(name="request")
+    if get_side_effect is not None:
+        mock_request.get = AsyncMock(side_effect=get_side_effect)
+    else:
+        mock_request.get = AsyncMock(return_value=mock_resp)
+
+    mock_ctx = MagicMock(name="ctx")
+    mock_ctx.cookies = AsyncMock(return_value=cookies)
+    mock_ctx.request = mock_request
+    mock_ctx.close = AsyncMock()
+
+    mock_pw_obj = MagicMock(name="pw")
+    mock_pw_obj.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
+
+    mock_cm = MagicMock(name="cm")
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_pw_obj)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_ap = MagicMock(name="async_playwright", return_value=mock_cm)
+    return mock_ap, mock_ctx
+
+
+class TestVerifyFlowSession:
+    @pytest.fixture
+    def gflow_home(self, tmp_path: Path) -> Path:
+        home = tmp_path / "gflow_home"
+        home.mkdir()
+        return home
+
+    @pytest.mark.asyncio
+    async def test_authenticated_profile(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, mock_ctx = _build_verify_mock(response_body=AUTHENTICATED_BODY)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, channel="chrome", source="chrome")
+        assert status.outcome is FlowSessionOutcome.AUTHENTICATED
+        assert status.user_email == "test.user@example.com"
+        mock_ctx.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_google_session_only(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock(
+            cookies=[{"name": "SAPISID", "value": "x"}], response_body="{}"
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY
+
+    @pytest.mark.asyncio
+    async def test_no_session(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock(cookies=[], response_body="{}")
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    @pytest.mark.asyncio
+    async def test_launch_failure_is_verification_error(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, _ = _build_verify_mock()
+        mock_ap.return_value.__aenter__.return_value.chromium.launch_persistent_context = AsyncMock(
+            side_effect=RuntimeError("launch failed")
+        )
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+
+    @pytest.mark.asyncio
+    async def test_transient_errors_exhaust_to_verification_error(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # Every fetch attempt raises a network error -> retries exhausted.
+        mock_ap, mock_ctx = _build_verify_mock(get_side_effect=[RuntimeError("net::ERR")] * 3)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retryable_status_retried_then_verification_error(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # HTTP 503 every time -> retried 3x, then evaluated as VERIFICATION_ERROR.
+        mock_ap, mock_ctx = _build_verify_mock(response_status=503)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_status_not_retried(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        # HTTP 401 -> not retried; one attempt, then VERIFICATION_ERROR.
+        mock_ap, mock_ctx = _build_verify_mock(response_status=401)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            status = await verify_flow_session(profile, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert mock_ctx.request.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ctx_closed_on_error_path(self, gflow_home: Path) -> None:
+        profile = gflow_home / "profile_default"
+        profile.mkdir()
+        mock_ap, mock_ctx = _build_verify_mock(get_side_effect=[RuntimeError("net::ERR")] * 3)
+        with (
+            patch("gflow_cli.auth.verification.get_settings") as mock_settings,
+            patch("gflow_cli.auth.strategies.async_playwright", mock_ap),
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_settings.return_value.home = gflow_home
+            await verify_flow_session(profile, source="chrome")
+        mock_ctx.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_profile_outside_home_raises_security_error(self, gflow_home: Path) -> None:
+        outside = gflow_home.parent / "outside_profile"
+        outside.mkdir()
+        with patch("gflow_cli.auth.verification.get_settings") as mock_settings:
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(SecurityError):
+                await verify_flow_session(outside, source="chrome")

--- a/tests/auth/test_verification.py
+++ b/tests/auth/test_verification.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gflow_cli.auth.verification import (
+    FlowSessionOutcome,
+    FlowSessionStatus,  # noqa: F401 — imported to assert it's part of the public API
+    evaluate_session_response,
+)
+
+# Representative authenticated /api/auth/session body. Sanitised — no real
+# PII. Pins the endpoint contract: if Google changes the response shape, the
+# AUTHENTICATED assertions below fail loudly instead of the change going silent.
+AUTHENTICATED_BODY = json.dumps(
+    {
+        "user": {
+            "name": "Test User",
+            "email": "test.user@example.com",
+            "image": "https://lh3.googleusercontent.com/a/fake",
+        },
+        "expires": "2026-06-16T08:39:21.000Z",
+    }
+)
+
+
+class TestEvaluateSessionResponse:
+    def test_authenticated_user_with_email(self) -> None:
+        status = evaluate_session_response(
+            200, AUTHENTICATED_BODY, google_session=True, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.AUTHENTICATED
+        assert status.authenticated is True
+        assert status.user_email == "test.user@example.com"
+        assert status.detail == "Flow app session verified."
+
+    def test_empty_session_with_google_cookie(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=True, source="chrome")
+        assert status.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY
+        assert status.authenticated is False
+        assert status.user_email is None
+
+    def test_empty_session_no_google_cookie(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=False, source="chrome")
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    def test_null_user_does_not_crash(self) -> None:
+        status = evaluate_session_response(
+            200, '{"user": null}', google_session=False, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.NO_SESSION
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"user": {"name": "x"}}',  # user present, no email key
+            '{"user": {"email": ""}}',  # empty-string email
+            '{"user": ["not", "a", "dict"]}',  # user is not a dict
+            "[]",  # JSON array, not an object
+            '{"user":',  # truncated JSON
+            "",  # empty body
+            "   ",  # whitespace only
+            "not json at all",  # garbage
+        ],
+    )
+    def test_unexpected_or_malformed_body_is_verification_error(self, body: str) -> None:
+        status = evaluate_session_response(200, body, google_session=True, source="chrome")
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        assert status.detail == "Could not verify the Flow session."
+
+    @pytest.mark.parametrize("status_code", [302, 401, 403, 404, 500, 503])
+    def test_non_200_is_verification_error(self, status_code: int) -> None:
+        # google_session is irrelevant on the error path.
+        status = evaluate_session_response(
+            status_code, AUTHENTICATED_BODY, google_session=True, source="chrome"
+        )
+        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+
+    def test_source_is_passed_through(self) -> None:
+        status = evaluate_session_response(200, "{}", google_session=False, source="internal")
+        assert status.source == "internal"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for the e2e test suite.
+
+e2e tests hit the real Flow API / real Google auth endpoints and are opt-in:
+run with `-m e2e` and `GFLOW_CLI_E2E_PROFILE=<profile_name>` set. See
+docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.config import get_settings
+
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+
+
+@pytest.fixture
+def e2e_profile_dir() -> Path:
+    """Resolve the authenticated Chromium profile from GFLOW_CLI_E2E_PROFILE.
+
+    Skips the test when the env var is unset or the profile dir is absent.
+    """
+    name = os.environ.get(_E2E_PROFILE_ENV, "")
+    if not name:
+        pytest.skip(
+            f"E2E tests require {_E2E_PROFILE_ENV} - set it to a logged-in "
+            "profile name and re-run with -m e2e"
+        )
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+
+    candidate = _resolve_profile_dir(name)
+    if not candidate.exists():
+        pytest.skip(
+            f"Profile directory not found: {candidate}. "
+            f"Run `gflow auth login --profile {name}` to create it."
+        )
+    return candidate
+
+
+@pytest.fixture
+def e2e_nosession_profile() -> Iterator[Path]:
+    """Yield a fresh, empty profile dir INSIDE the gflow home.
+
+    `verify_flow_session` enforces a boundary check that the profile dir
+    resolves inside GFLOW_CLI_HOME, so a pytest `tmp_path` dir (system temp)
+    cannot be used. The dir is UUID-named so it can never collide with a real
+    `profile_<name>` dir, and is removed in teardown - `ignore_errors=True`
+    plus a short delay tolerate the Windows Chrome profile lock that may
+    briefly outlive `ctx.close()`.
+    """
+    home = get_settings().home
+    home.mkdir(parents=True, exist_ok=True)
+    path = home / f"profile_e2e_nosession_{uuid.uuid4().hex}"
+    assert not path.exists(), f"temp profile dir unexpectedly already exists: {path}"
+    path.mkdir()
+    try:
+        yield path
+    finally:
+        time.sleep(0.5)  # let Chrome release the Windows profile lock
+        shutil.rmtree(path, ignore_errors=True)

--- a/tests/e2e/test_auth_verification_e2e.py
+++ b/tests/e2e/test_auth_verification_e2e.py
@@ -1,0 +1,65 @@
+"""E2E tests for the issue-#15 Flow-session verification feature.
+
+These probe the REAL Google `/api/auth/session` endpoint via
+`verify_flow_session`, and (positive case) confirm a verified profile is
+actually usable by `FlowApiClient`. Opt-in: `-m e2e` + `GFLOW_CLI_E2E_PROFILE`.
+Zero Flow credits are spent - no image generation.
+
+Async tests need no `@pytest.mark.asyncio` decorator: `asyncio_mode = "auto"`
+is set in pyproject.toml.
+
+See docs/superpowers/specs/2026-05-17-e2e-test-coverage-design.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.auth.verification import FlowSessionOutcome, verify_flow_session
+
+pytestmark = pytest.mark.e2e
+
+
+async def test_e2e_verify_flow_session_authenticated(e2e_profile_dir: Path) -> None:
+    """A logged-in profile verifies as AUTHENTICATED and is usable by the client.
+
+    Two linked assertions - the real issue-#15 invariant:
+      1. verify_flow_session pronounces the profile AUTHENTICATED.
+      2. the SAME profile actually works: FlowApiClient.health_check() is True.
+    """
+    status = await verify_flow_session(e2e_profile_dir, channel="chrome", source="chrome")
+    assert status.outcome is FlowSessionOutcome.AUTHENTICATED, (
+        f"expected AUTHENTICATED, got {status.outcome} - is the profile's "
+        "Flow session still valid? Re-run `gflow auth login` if not."
+    )
+    assert isinstance(status.user_email, str) and status.user_email, (
+        "an AUTHENTICATED status must carry a non-empty user_email"
+    )
+    assert status.authenticated is True
+
+    # Verified => usable: a profile pronounced AUTHENTICATED must actually work.
+    async with FlowApiClient(profile_dir=e2e_profile_dir, transport="evaluate_fetch") as client:
+        assert await client.health_check() is True, (
+            "a verified profile must pass FlowApiClient.health_check()"
+        )
+
+
+async def test_e2e_verify_flow_session_no_session(
+    e2e_nosession_profile: Path,
+) -> None:
+    """A fresh, empty profile verifies as NO_SESSION.
+
+    Empty profile dir -> real headless Chrome launches -> no SAPISID cookie ->
+    `/api/auth/session` returns `200 {}` -> NO_SESSION. Zero credits.
+
+    Environmental caveat: the probe needs outbound network to labs.google.
+    A VERIFICATION_ERROR result indicates no connectivity, not a bug.
+    """
+    status = await verify_flow_session(e2e_nosession_profile, channel="chrome", source="chrome")
+    assert status.outcome is FlowSessionOutcome.NO_SESSION, (
+        f"expected NO_SESSION for an empty profile, got {status.outcome}. "
+        "If VERIFICATION_ERROR: check network connectivity to labs.google."
+    )

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -353,3 +353,33 @@ async def test_e2e_health_check_returns_true_when_active(strategy: str) -> None:
         result = await client.health_check()
 
     assert result is True, "health_check() must return True for an active Google-domain page"
+
+
+# ---------------------------------------------------------------------------
+# health_check() false path (Issue #16 — new method)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_health_check_false_after_close() -> None:
+    """health_check() returns False (never raises) once the client is closed.
+
+    A long-lived worker holding a client whose context has been torn down must
+    get a clean False, not an exception. Zero credits — no image generation.
+
+    Not parametrized over STRATEGIES: health_check is transport-agnostic, and
+    the bearer / sapisidhash experimental transports fail at setup() (obsolete —
+    see KNOWN_ISSUES.md). evaluate_fetch is the live transport.
+    """
+    profile = _profile_dir()
+    client = _make_client("evaluate_fetch", profile)
+
+    async with client:
+        assert await client.health_check() is True, (
+            "health_check() must be True while the context is live"
+        )
+
+    # Context is now closed.
+    assert await client.health_check() is False, (
+        "health_check() must return False (not raise) on a closed client"
+    )


### PR DESCRIPTION
## Summary

**Issue #15** — `gflow video i2v` failed with HTTP 401 on `createProject` because `gflow auth login` accepted a profile signed in to Google but not to the Flow app (Google SSO sets `SAPISID` independently of the Flow NextAuth session). The fix verifies a real Flow app session against `/api/auth/session` — the surface the API client authenticates on — before reporting login success.

This PR also adds **e2e test coverage** and documents a separate, newly-discovered issue.

## Issue #15 fix

- New `auth/verification.py` — `FlowSessionOutcome`, `FlowSessionStatus`, pure/total `evaluate_session_response`, async fail-closed `verify_flow_session`.
- `RealChromeStrategy` and `InternalChromiumStrategy` rewired to verify via `/api/auth/session`; `AuthMissingError` raised with per-outcome remediation.
- `AuthMissingError` docstring refresh; `KNOWN_ISSUES.md` endpoint-coupling note; CHANGELOG entry.
- 7-task TDD implementation; each task spec- + code-quality-reviewed; final whole-implementation review: ready to merge. SonarCloud code smells resolved.

## E2E test coverage

- `tests/e2e/conftest.py` — shared `e2e_profile_dir` / `e2e_nosession_profile` fixtures.
- `tests/e2e/test_auth_verification_e2e.py` — verifies the issue-#15 fix against the real `/api/auth/session` endpoint (`AUTHENTICATED` + usable-by-`FlowApiClient`; `NO_SESSION`). Both pass live.
- `test_e2e_health_check_false_after_close` — `FlowApiClient.health_check()` false-path.
- e2e design (Rev 2) + implementation plan under `docs/superpowers/`.

## Known issue documented — separate from #15

`KNOWN_ISSUES.md` records a distinct, **pre-existing HTTP 401 on the `aisandbox-pa` image-generation endpoint**, discovered during the e2e work. `verify_flow_session`, `createProject`, and `health_check` all succeed; image *generation* does not. It affects every image-generation test and needs its own investigation — not in scope here.

## Verification

Five-gate CI green on Python 3.11 / 3.12 / 3.13; SonarCloud clean. E2E tests are excluded from CI (`-m "not e2e and not live"`) and run locally only.