### PR TITLE
feat(ui-automation): UiAutomationTransport with onboarding bypass

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -111,17 +111,25 @@ gflow video batch manifest.remaining.tsv
 
 ---
 
-### REST API 401 unauthorized on project creation
+### REST API 401 — all `aisandbox-pa.googleapis.com` generation endpoints blocked
 
 - **Status:** Open (Mitigated) · **Severity:** High · **Affects:** v0.2.0a1+ · **Fixed in:** v0.6.0a5 (planned)
 
-Even with a valid browser session (cookies present), calling Flow's REST API directly via `fetch` or `page.request` (e.g., `project.createProject`) may return HTTP 401. This blocks the CLI's standard "pre-flight" sequence for generations.
+Even with a valid browser session (cookies present), calling Flow's REST API directly via `fetch` or `page.request` against `aisandbox-pa.googleapis.com` returns HTTP 401. This blocks **all** generation routes:
 
-**Root cause:** Google's backend has tightened security on its private trpc/REST endpoints, likely requiring specific headers (`Origin`, `Referer`) or a more complete browser fingerprint that raw script-driven requests lack.
+| Endpoint | Status |
+|---|---|
+| `flowMedia:batchGenerateImages` (image gen) | ❌ 401 |
+| `video:batchAsyncGenerateVideoText` (T2V + I2V) | ❌ 401 (confirmed 2026-05-18 e2e run) |
+| `flow/uploadImage` (image upload for I2V) | ❓ untested (blocked before reaching this step) |
 
-**Workaround:** Use the **UI Mimicry** approach (used by the `scripts/smoke_worker_style.py` diagnostic). This strategy performs actions by clicking real buttons in the Flow editor instead of making raw REST calls.
+`project.createProject` (on `labs.google/fx/api/trpc`) **does** work — it uses a different domain and auth model.
 
-**Roadmap:** v0.6.0a5 will refactor the `ui_automation` transport to handle its own project creation via the UI, bypassing the REST-based `create_project` blocker entirely for image generation.
+**Root cause:** Google's backend has tightened security on `aisandbox-pa.googleapis.com`, requiring a browser fingerprint, `Origin`/`Referer` headers, and reCAPTCHA token that raw script-driven requests cannot provide.
+
+**Workaround:** Use the **UI Mimicry** approach — drive the Flow editor by clicking real buttons so the browser itself issues the generation requests with full auth context.
+
+**Roadmap:** v0.6.0a5 will add video generation (T2V + I2V) to the `UiAutomationTransport`, making it the single transport that covers both image and video generation. I2V requires driving the Flow UI's image-upload button so the browser calls `uploadImage` with its own session cookies.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-18-ui-automation-video-generation-design.md
+++ b/docs/superpowers/specs/2026-05-18-ui-automation-video-generation-design.md
@@ -1,0 +1,327 @@
+# Design: Video Generation via UiAutomationTransport
+
+**Date:** 2026-05-18  
+**Status:** Awaiting council review  
+**Branch:** `feat/ui-automation-onboarding-bypass`
+
+---
+
+## 1. Problem Statement
+
+All `aisandbox-pa.googleapis.com` generation endpoints return HTTP 401 when called from
+the existing HTTP transports (evaluate_fetch, bearer, sapisidhash). This was confirmed
+e2e on 2026-05-18 for both image generation (`batchGenerateImages`) and video generation
+(`batchAsyncGenerateVideoText`). The `UiAutomationTransport` is the sole working path for
+generation — it drives the real browser so requests carry correct auth context. Currently
+it only handles image generation; video generation is unimplemented.
+
+---
+
+## 2. Wire Format Evidence
+
+Three distinct video modes confirmed from HAR captures (labs.google8–10.har):
+
+| Mode | Model key | `videoGenerationMode` | Capability | Image input type |
+|---|---|---|---|---|
+| T2V | `veo_3_1_t2v_{tier}_{aspect}` | `TEXT_TO_VIDEO` | — | none |
+| I2V (Frames) | `veo_3_1_interpolation_lite` | `IMAGE_TO_VIDEO` | `START_AND_END_IMAGE` | `START_IMAGE` / `END_IMAGE` |
+| R2V (Elementos) | `veo_3_1_r2v_lite` | `REFERENCE_TO_VIDEO` | `MULTI_REFERENCE` | `ASSET_IMAGE` (array) |
+
+All three share the same `batchAsyncGenerateVideoText` endpoint. Image inputs are always in
+`videoGenerationImageInputs: [{mediaGenerationId, imageUsageType, mediaId}]` where
+`mediaGenerationId == mediaId` (both set to the asset UUID).
+
+`uploadImage` returns 200 when called from the Playwright browser context
+(`page.request.post`) — auth is carried by the browser's session cookies. This is the
+upload mechanism for attaching local files.
+
+Status lifecycle: `QUEUED → ACTIVE → COMPLETED | FAILED`.
+
+---
+
+## 3. Scope
+
+**In:** T2V, I2V (Frames — start + optional end), R2V (Elementos — multiple reference
+images). All via `UiAutomationTransport`. Polling blocks until terminal status.
+
+**Out of scope:** voice elements (experimental, different domain model), video download
+(caller responsibility, same pattern as image `fife_url`), Veo tier/quality selection
+beyond Fast/Lite (future knob).
+
+---
+
+## 4. Domain Changes — `src/gflow_cli/api/video.py`
+
+### 4.1 New Mode enum value
+
+```python
+class Mode(StrEnum):
+    T2V = "t2v"
+    I2V = "i2v"   # Frames
+    R2V = "r2v"   # Elementos / Reference-to-Video
+```
+
+### 4.2 Extended `GenerateVideoRequest`
+
+```python
+@dataclass(frozen=True)
+class GenerateVideoRequest:
+    prompt: str
+    aspect: Aspect = Aspect.PORTRAIT
+    tier: Tier = Tier.FAST
+    # Frames mode (I2V)
+    start_frame_id: str | None = None   # asset UUID → IMAGE_USAGE_TYPE_START_IMAGE
+    end_frame_id: str | None = None     # asset UUID → IMAGE_USAGE_TYPE_END_IMAGE
+    # Elementos mode (R2V)
+    reference_image_ids: list[str] = dataclasses.field(default_factory=list)
+    # Legacy — kept for HTTP transport parity, maps to start_frame_id internally
+    start_asset_uuid: str | None = None
+
+    @property
+    def mode(self) -> Mode:
+        if self.reference_image_ids:
+            return Mode.R2V
+        if self.start_frame_id or self.end_frame_id or self.start_asset_uuid:
+            return Mode.I2V
+        return Mode.T2V
+```
+
+### 4.3 Updated `model_key()`
+
+```python
+def model_key(mode: Mode, tier: Tier, aspect: Aspect) -> str:
+    if mode == Mode.I2V:
+        return "veo_3_1_interpolation_lite"
+    if mode == Mode.R2V:
+        return "veo_3_1_r2v_lite"
+    return f"veo_3_1_{mode.value}_{tier.value}_{aspect.value}"
+```
+
+### 4.4 Updated `build_generate_body()`
+
+Add `videoGenerationImageInputs` construction:
+
+```python
+def _image_inputs(req: GenerateVideoRequest) -> list[dict]:
+    inputs = []
+    start = req.start_frame_id or req.start_asset_uuid
+    if start:
+        inputs.append({"mediaGenerationId": start, "imageUsageType": "IMAGE_USAGE_TYPE_START_IMAGE", "mediaId": start})
+    if req.end_frame_id:
+        inputs.append({"mediaGenerationId": req.end_frame_id, "imageUsageType": "IMAGE_USAGE_TYPE_END_IMAGE", "mediaId": req.end_frame_id})
+    for uid in req.reference_image_ids:
+        inputs.append({"mediaGenerationId": uid, "imageUsageType": "IMAGE_USAGE_TYPE_ASSET_IMAGE", "mediaId": uid})
+    return inputs
+```
+
+Wire: include `"videoGenerationImageInputs": _image_inputs(req)` in `requests[0]` when
+non-empty. Add `"videoModelCapabilities"` to `videoModelControlInput` based on mode:
+- I2V: `["VIDEO_MODEL_CAPABILITY_START_AND_END_IMAGE"]`
+- R2V: `["VIDEO_MODEL_CAPABILITY_MULTI_REFERENCE"]`
+
+---
+
+## 5. Transport Changes — `UiAutomationTransport`
+
+### 5.1 New public method
+
+```python
+async def generate_video(
+    self,
+    *,
+    request: GenerateVideoRequest,
+    out_dir: Path | None = None,
+    poll_timeout_s: float = 300.0,
+) -> VideoStatus:
+```
+
+Raises `RuntimeError` if setup() not called. Acquires `_generate_lock` (shared with
+`generate_images` — same Page, same serialization requirement).
+
+Returns `VideoStatus` with `status == "MEDIA_GENERATION_STATUS_COMPLETED"` or raises
+`TimeoutError` / `ContentPolicyError` (FAILED status).
+
+### 5.2 Upload helper
+
+```python
+@staticmethod
+async def _upload_asset(page: Page, project_id: str, image_path: Path) -> str:
+    """Upload a local image into the project via page.request.post.
+    Returns the asset media UUID (media.name).
+    """
+```
+
+Reads the file, base64-encodes it, POSTs to `aisandbox-pa.googleapis.com/v1/flow/uploadImage`
+via `page.request.post(url, data=json_body, headers={"content-type": "text/plain;charset=UTF-8"})`.
+The browser's session cookies are automatically attached. Returns `response_body["media"]["name"]`.
+
+### 5.3 Video mode navigation
+
+**Two strategies — both implemented, verified live, weaker one removed:**
+
+**Strategy A — UI-driven attachment** (primary):
+```
+_enter_editor(page)
+→ click Video tab
+→ click Frames or Elementos sub-tab  
+→ for each image: click Inicial/Final/+ → catalog opens → upload or select
+→ _send_prompt(page, prompt)
+```
+Relies on Playwright file_chooser for uploads inside the catalog dialog. Fragile if
+selectors change but requires no knowledge of internal React state.
+
+**Strategy B — HTTP-upload + prompt-area injection** (candidate):
+```
+_enter_editor(page)
+→ _upload_asset(page, project_id, image_path) → uuid
+→ click Video tab + sub-tab
+→ _send_prompt(page, prompt)  [without image chip; rely on batchAsyncGenerateVideoText body]
+```
+Skip the catalog entirely; the video body is built programmatically with the uploaded
+asset UUIDs. The UI prompt area shows no image chip, but the network request body is
+correct. **Only valid if Flow server accepts the request regardless of the UI chip state.**
+Must be verified e2e — if the server requires the chip to be in the DOM before the submit
+button fires the correct body, Strategy B fails silently.
+
+### 5.4 Response capture
+
+```python
+@staticmethod
+def _attach_video_response_listener(page: Page, *, project_id: str | None = None) -> list[dict]:
+    """Register page.on('response') for batchAsyncGenerateVideoText.
+    Same pattern as _attach_batch_response_listener for images.
+    Returns the shared capture list.
+    """
+```
+
+### 5.5 Polling
+
+```python
+@staticmethod
+async def _poll_video_status(
+    page: Page,
+    media_name: str,
+    project_id: str,
+    *,
+    timeout_s: float = 300.0,
+    poll_interval_s: float = 5.0,
+) -> VideoStatus:
+```
+
+Intercepts browser's own `batchCheckAsyncVideoGenerationStatus` responses (passive) OR
+calls the endpoint via `page.request.post()` (active). Both are implemented; the passive
+approach is preferred since the Flow UI already polls and we just listen.
+
+Terminal conditions: `MEDIA_GENERATION_STATUS_COMPLETED` → return `VideoStatus`.
+`MEDIA_GENERATION_STATUS_FAILED` → raise `ContentPolicyError`. Timeout → raise `TimeoutError`.
+
+---
+
+## 6. New Selectors Required
+
+```python
+# Mode switcher
+VIDEO_MODE_TAB_SELECTORS = (
+    "button:has(i:text('play_circle'))",
+    "button:has-text('Vídeo')",
+    "button:has-text('Video')",
+    "[role='tab']:has-text('Vídeo')",
+    "[role='tab']:has-text('Video')",
+)
+
+FRAMES_SUBTAB_SELECTORS = (
+    "button:has-text('Frames')",
+    "[role='tab']:has-text('Frames')",
+)
+
+ELEMENTOS_SUBTAB_SELECTORS = (
+    "button:has-text('Elementos')",
+    "button:has-text('Elements')",
+    "[role='tab']:has-text('Elementos')",
+)
+
+# Image attachment in Frames mode
+INITIAL_FRAME_SELECTORS = (
+    "button:has-text('Inicial')",
+    "button:has-text('Initial')",
+    "button:has-text('Start')",
+)
+
+FINAL_FRAME_SELECTORS = (
+    "button:has-text('Final')",
+    "button:has-text('End')",
+)
+
+# Add element button in Elementos mode (the "+" chip adder)
+ADD_ELEMENT_SELECTORS = (
+    "button[aria-label*='Add']",
+    "button:has(i:text('add'))",
+)
+
+# Catalog upload button
+CATALOG_UPLOAD_SELECTORS = (
+    "button:has-text('Faça upload')",
+    "button:has-text('Upload')",
+    "[aria-label*='upload' i]",
+)
+```
+
+---
+
+## 7. Error Handling
+
+| Condition | Raised error |
+|---|---|
+| `setup()` not called | `RuntimeError` |
+| `batchAsyncGenerateVideoText` → 401 | `AuthExpiredError` |
+| `batchAsyncGenerateVideoText` → 403 | `WafRejectionError` |
+| Status → `FAILED` | `ContentPolicyError` |
+| No response within timeout | `TimeoutError` |
+| Upload fails (non-200) | `WireFormatError` |
+| Mode tab not found | `RuntimeError` (debug screenshot written to `out_dir`) |
+
+---
+
+## 8. Testing Strategy
+
+**Unit tests** (in `tests/api/transports/test_ui_automation.py`):
+- `_upload_asset` — mock `page.request.post`, verify base64 encoding + headers
+- `_switch_to_video_mode` — selector fallback cascade
+- `_attach_video_response_listener` — mirrors `test_attach_batch_response_listener`
+- `_poll_video_status` — QUEUED→ACTIVE→COMPLETED happy path; FAILED path; timeout path
+- `generate_video` protocol conformance — signature, pre-setup guard
+
+**E2E tests** (in `tests/e2e/test_video_ui_automation_e2e.py`):
+- T2V: enter editor → switch to video → submit prompt → poll → `VideoStatus.succeeded`
+- I2V Frames: upload test image → attach as Inicial → submit → poll
+- R2V Elementos: upload 2 test images → attach as references → submit → poll
+- Strategy A vs Strategy B verification (both run; weaker one identified and removed)
+
+All e2e tests marked `@pytest.mark.e2e`, opt-in via `GFLOW_CLI_E2E_PROFILE`.
+
+---
+
+## 9. Files Changed
+
+| File | Change |
+|---|---|
+| `src/gflow_cli/api/video.py` | Add `Mode.R2V`, extend `GenerateVideoRequest`, update `model_key()` and `build_generate_body()` |
+| `src/gflow_cli/api/transports/ui_automation.py` | Add `generate_video()`, `_upload_asset()`, `_switch_to_video_mode()`, `_attach_video_response_listener()`, `_poll_video_status()`, new selector constants |
+| `tests/api/transports/test_ui_automation.py` | Unit tests for all new methods |
+| `tests/e2e/test_video_ui_automation_e2e.py` | New e2e test file |
+| `tests/e2e/test_video_i2v_e2e.py` | Mark HTTP CV1/CV2/CV3 tests `xfail` (401 confirmed) |
+| `PLAN.md` | Add phase entry for this feature |
+| `KNOWN_ISSUES.md` | Already updated (2026-05-18) |
+
+---
+
+## 10. Open Questions for Council Review
+
+1. **Strategy A vs B precedence**: Should the transport try Strategy B first (faster, no UI
+   navigation) and fall back to Strategy A on failure — or always use A?
+2. **Polling method**: Passive interception of browser-fired status requests vs active
+   `page.request.post()` polling — both need e2e verification before deciding.
+3. **`start_asset_uuid` deprecation**: The legacy field on `GenerateVideoRequest` is kept
+   for HTTP transport parity. Should it be deprecated with a warning, or silently mapped?
+4. **Credit cost guard**: Frames (I2V) costs 10 credits per video (confirmed from HAR).
+   R2V and T2V costs differ. Should the CLI warn before submitting?

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -153,6 +153,21 @@ NEW_PROJECT_SELECTORS = (
     "[aria-label*='Project' i]",
 )
 
+# Onboarding bypass selectors — cookie banners, terms, landing pages.
+# Handled gracefully if not found; localized variants included.
+ONBOARDING_SELECTORS = (
+    "button:has-text('Agree')",
+    "button:has-text('Aceitar')",
+    "button:has-text('I agree')",
+    "button:has-text('Concordo')",
+    "button:has-text('Accept')",
+    "button:has-text('Create with Flow')",
+    "button:has-text('Criar com o Flow')",
+    "button:has-text('Get Started')",
+    "button:has-text('Começar')",
+)
+
+
 # Generation settings trigger — the button shows the current ratio icon.
 # All 5 ratio icon names are enumerated so the selector is ratio-invariant.
 GEN_SETTINGS_BUTTON_SELECTORS = (
@@ -404,6 +419,18 @@ class UiAutomationTransport:
     # Internal helpers — gallery → editor navigation (unit 3.4)
     # ------------------------------------------------------------------
 
+    async def _bypass_onboarding(self, page: Page) -> None:
+        """Click through cookie banners and 'Get Started' pages if they appear."""
+        for selector in ONBOARDING_SELECTORS:
+            try:
+                loc = page.locator(selector).first
+                if await loc.is_visible(timeout=1000):
+                    await loc.click(force=True)
+                    log.info("ui_automation.onboarding_bypassed", selector=selector)
+                    await page.wait_for_timeout(1000)
+            except Exception:
+                continue
+
     async def _enter_editor(self, page: Page, out_dir: Path | None = None) -> None:
         """Always create a fresh project — click "+ New project" on the gallery
         and wait for ``/project/`` navigation.
@@ -431,8 +458,10 @@ class UiAutomationTransport:
             # readiness gate.
             log.info("ui_automation.navigating_to_gallery", restored_url=page.url)
             await page.goto(FLOW_URL, timeout=45_000)
+            await self._bypass_onboarding(page)
 
         await page.wait_for_timeout(3000)
+        await self._bypass_onboarding(page)
         for selector in NEW_PROJECT_SELECTORS:
             try:
                 loc = page.locator(selector).first

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -446,9 +446,14 @@ class TestEnterEditor:
         t = UiAutomationTransport()
         page = _make_editor_page()
         await t._enter_editor(page)  # type: ignore[attr-defined]
-        # locator called at least once with the first (icon-class) selector.
-        first_call_sel = page.locator.call_args_list[0].args[0]
-        assert "google-symbols" in first_call_sel
+        # The icon-class (google-symbols) selector — the editor's first
+        # declared candidate — must be probed. `_bypass_onboarding` runs
+        # first and tries its own selectors, so we check presence anywhere
+        # in the call list rather than at index 0.
+        all_selectors = [c.args[0] for c in page.locator.call_args_list]
+        assert any("google-symbols" in s for s in all_selectors), (
+            f"Expected icon-class selector probed; saw {all_selectors}"
+        )
         assert "/project/" in page.url
 
     @pytest.mark.asyncio

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -20,7 +20,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
-from gflow_cli.api.transports.ui_automation import FLOW_URL, UiAutomationTransport
+from gflow_cli.api.transports.ui_automation import (
+    FLOW_URL,
+    ONBOARDING_SELECTORS,
+    UiAutomationTransport,
+)
 from gflow_cli.errors import ContentPolicyError, WafRejectionError
 
 # ---------------------------------------------------------------------------
@@ -510,6 +514,103 @@ class TestEnterEditor:
         with pytest.raises(RuntimeError):
             await t._enter_editor(page)  # type: ignore[attr-defined]
         page.screenshot.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Unit 3.4b — _bypass_onboarding(page)
+# ---------------------------------------------------------------------------
+
+
+def _make_onboarding_page(
+    *,
+    visible_selectors: set[str] | None = None,
+    is_visible_raises: bool = False,
+    click_raises: bool = False,
+) -> tuple[MagicMock, list[tuple[str, dict[str, object]]]]:
+    """Build a fake page for _bypass_onboarding tests.
+
+    Returns ``(page, clicked)`` where ``clicked`` accumulates
+    ``(selector, click_kwargs)`` for every locator that received a click.
+    A selector reports visible iff it is in ``visible_selectors``.
+    """
+    visible = visible_selectors or set()
+    clicked: list[tuple[str, dict[str, object]]] = []
+    page = MagicMock()
+    page.wait_for_timeout = AsyncMock()
+
+    def _locator(sel: str) -> MagicMock:
+        loc = MagicMock()
+        if is_visible_raises:
+            loc.is_visible = AsyncMock(side_effect=RuntimeError("probe boom"))
+        else:
+            loc.is_visible = AsyncMock(return_value=sel in visible)
+
+        async def _click(*_args: object, **kwargs: object) -> None:
+            if click_raises:
+                raise RuntimeError("click boom")
+            clicked.append((sel, dict(kwargs)))
+
+        loc.click = AsyncMock(side_effect=_click)
+        wrapper = MagicMock()
+        wrapper.first = loc
+        return wrapper
+
+    page.locator = MagicMock(side_effect=_locator)
+    return page, clicked
+
+
+class TestBypassOnboarding:
+    """_bypass_onboarding force-clicks visible cookie/onboarding CTAs and
+    tolerates every miss — the gallery often loads with no interstitial."""
+
+    @pytest.mark.asyncio
+    async def test_clicks_visible_onboarding_cta_with_force(self) -> None:
+        """A visible onboarding CTA is force-clicked (overlays intercept
+        pointer events, so force=True is required) and a settle delay runs."""
+        target = ONBOARDING_SELECTORS[0]
+        t = UiAutomationTransport()
+        page, clicked = _make_onboarding_page(visible_selectors={target})
+        await t._bypass_onboarding(page)  # type: ignore[attr-defined]
+        assert [sel for sel, _ in clicked] == [target]
+        assert clicked[0][1].get("force") is True
+        page.wait_for_timeout.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_interstitial_is_a_noop(self) -> None:
+        """When nothing matches, _bypass_onboarding clicks nothing and does
+        not raise — the common case where the gallery loads clean."""
+        t = UiAutomationTransport()
+        page, clicked = _make_onboarding_page(visible_selectors=set())
+        await t._bypass_onboarding(page)  # type: ignore[attr-defined]
+        assert clicked == []
+
+    @pytest.mark.asyncio
+    async def test_clicks_every_visible_selector(self) -> None:
+        """The loop does not stop at the first hit — a page stacking a
+        cookie banner and a 'Get Started' CTA has both dismissed."""
+        targets = {ONBOARDING_SELECTORS[0], ONBOARDING_SELECTORS[-1]}
+        t = UiAutomationTransport()
+        page, clicked = _make_onboarding_page(visible_selectors=targets)
+        await t._bypass_onboarding(page)  # type: ignore[attr-defined]
+        assert {sel for sel, _ in clicked} == targets
+
+    @pytest.mark.asyncio
+    async def test_is_visible_failure_is_swallowed(self) -> None:
+        """A transient DOM error from is_visible() must not abort the sweep
+        — the selector is skipped and no exception escapes."""
+        t = UiAutomationTransport()
+        page, clicked = _make_onboarding_page(is_visible_raises=True)
+        await t._bypass_onboarding(page)  # type: ignore[attr-defined]  # must not raise
+        assert clicked == []
+
+    @pytest.mark.asyncio
+    async def test_click_failure_is_swallowed(self) -> None:
+        """A click that raises (overlay vanished mid-sweep) is swallowed —
+        onboarding bypass is best-effort, never fatal."""
+        target = ONBOARDING_SELECTORS[0]
+        t = UiAutomationTransport()
+        page, _ = _make_onboarding_page(visible_selectors={target}, click_raises=True)
+        await t._bypass_onboarding(page)  # type: ignore[attr-defined]  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_video_i2v_e2e.py
+++ b/tests/e2e/test_video_i2v_e2e.py
@@ -1,0 +1,190 @@
+"""E2E tests for video generation: T2V (text-to-video) and I2V (image-to-video).
+
+These tests hit the **real Flow API** and therefore:
+  - Are NOT collected by default ``pytest`` runs.
+  - Opt-in: ``GFLOW_CLI_E2E_PROFILE=<profile_name> pytest -m e2e -k video``
+  - Require the named Chromium profile to be logged-in (a Pro/Ultra account).
+
+Criteria covered:
+  CV1 — T2V: submitting a text prompt returns a pending VideoOperation
+  CV2 — I2V: uploading an image then submitting a prompt returns a pending
+             VideoOperation whose model key reflects i2v mode
+  CV3 — upload: upload_image() returns an AssetInfo with a non-empty UUID
+               and correct pixel dimensions
+
+All three tests use the same strategy set as the image e2e suite.  Their
+primary purpose is to tell us definitively whether the REST transport routes
+(batchAsyncGenerateVideoText, uploadImage) are 401-blocked or working — the
+UiAutomationTransport path for video will be built next once we know.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.video import Aspect, GenerateVideoRequest, Tier
+
+# ---------------------------------------------------------------------------
+# Module-level marker — every test in this file inherits e2e
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.e2e
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STRATEGIES = ["evaluate_fetch", "bearer", "sapisidhash"]
+
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+
+# Committed PNG used as the reference image for I2V tests.
+_TEST_IMAGE = Path(__file__).parent.parent.parent / "test_assets" / "image_00.png"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_transports_e2e.py)
+# ---------------------------------------------------------------------------
+
+
+def _profile_dir() -> Path:
+    name = os.environ.get(_E2E_PROFILE_ENV, "")
+    if not name:
+        pytest.skip(
+            f"E2E tests require {_E2E_PROFILE_ENV} env var — "
+            "set it to a logged-in Chromium profile name and re-run with -m e2e"
+        )
+    from gflow_cli.auth import profile_dir as _resolve
+
+    candidate = _resolve(name)
+    if not candidate.exists():
+        pytest.skip(
+            f"Profile directory not found: {candidate}. "
+            f"Run `gflow auth login --profile {name}` to create it."
+        )
+    return candidate
+
+
+def _make_client(strategy: str, profile: Path) -> FlowApiClient:
+    return FlowApiClient(profile_dir=profile, transport=strategy)
+
+
+# ---------------------------------------------------------------------------
+# CV1 — T2V: text prompt → pending VideoOperation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_t2v_returns_pending_operation(strategy: str) -> None:
+    """CV1: generate_video() with a text-only request returns a VideoOperation.
+
+    Asserts:
+    - operation_name is non-empty (server accepted the job)
+    - media_name is non-empty (asset slot created in the project)
+    - model key in the request body reflects t2v mode (checked indirectly via
+      no exception being raised — the client validates the mode internally)
+
+    If this test returns HTTP 401 the test will raise AuthExpiredError or
+    WireFormatError, confirming the video route is also 401-blocked.
+    """
+    profile = _profile_dir()
+    req = GenerateVideoRequest(
+        prompt="slow cinematic zoom over a foggy mountain lake at dawn",
+        aspect=Aspect.PORTRAIT,
+        tier=Tier.FAST,
+    )
+    async with _make_client(strategy, profile) as client:
+        project = await client.create_project(title=f"e2e-cv1-{strategy}")
+        op = await client.generate_video(project_id=project.project_id, req=req)
+
+    assert op.operation_name, "operation_name must be non-empty (server must have accepted job)"
+    assert op.media_name, "media_name must be non-empty"
+    assert op.project_id == project.project_id
+
+
+# ---------------------------------------------------------------------------
+# CV2 — I2V: upload image → generate video with start_asset_uuid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_i2v_upload_then_generate(strategy: str) -> None:
+    """CV2: upload_image() → generate_video(start_asset_uuid=...) returns a
+    pending VideoOperation in I2V mode.
+
+    This is the core verification: does Flow accept an imageInput referencing
+    the uploaded asset UUID and return a valid operation?
+
+    Step 1 — upload the committed test PNG into the project.
+    Step 2 — submit a GenerateVideoRequest with start_asset_uuid = asset.name.
+    Step 3 — assert we receive a pending VideoOperation.
+
+    The test does NOT poll for completion — generation can take 2-3 minutes
+    and e2e tests should complete within seconds. Pending status is sufficient
+    evidence that the route is functional.
+    """
+    if not _TEST_IMAGE.exists():
+        pytest.skip(f"Test image not found: {_TEST_IMAGE}")
+
+    profile = _profile_dir()
+    async with _make_client(strategy, profile) as client:
+        project = await client.create_project(title=f"e2e-cv2-{strategy}")
+
+        # Step 1: upload reference image
+        asset = await client.upload_image(project.project_id, _TEST_IMAGE)
+
+        assert asset.name, "upload_image() must return a non-empty asset UUID"
+        assert asset.project_id == project.project_id
+        assert asset.width > 0 and asset.height > 0, (
+            f"upload must return valid dimensions, got {asset.width}x{asset.height}"
+        )
+
+        # Step 2: I2V generation using the uploaded asset
+        req = GenerateVideoRequest(
+            prompt="gentle camera pan revealing the scene",
+            aspect=Aspect.PORTRAIT,
+            tier=Tier.FAST,
+            start_asset_uuid=asset.name,  # triggers Mode.I2V
+        )
+        assert req.mode.value == "i2v", "start_asset_uuid must set mode to I2V"
+
+        op = await client.generate_video(project_id=project.project_id, req=req)
+
+    # Step 3: verify operation is pending
+    assert op.operation_name, "operation_name must be non-empty"
+    assert op.media_name, "media_name must be non-empty"
+    assert op.project_id == project.project_id
+
+
+# ---------------------------------------------------------------------------
+# CV3 — upload-only: verify upload route is independently reachable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.asyncio
+async def test_e2e_upload_image_returns_asset_info(strategy: str) -> None:
+    """CV3: upload_image() alone — confirms the upload route is reachable before
+    the video generation route is exercised.
+
+    Useful for isolating failures: if CV2 fails but CV3 passes, the problem
+    is in the video generation route, not in upload.  If CV3 also fails we
+    know upload is 401-blocked too.
+    """
+    if not _TEST_IMAGE.exists():
+        pytest.skip(f"Test image not found: {_TEST_IMAGE}")
+
+    profile = _profile_dir()
+    async with _make_client(strategy, profile) as client:
+        project = await client.create_project(title=f"e2e-cv3-{strategy}")
+        asset = await client.upload_image(project.project_id, _TEST_IMAGE)
+
+    assert asset.name, "asset UUID must be non-empty"
+    assert asset.project_id == project.project_id
+    assert asset.workflow_id, "workflow_id must be non-empty"
+    assert asset.width > 0 and asset.height > 0


### PR DESCRIPTION
## Summary

Lands `UiAutomationTransport` with an onboarding-bypass helper that clicks past Flow's cookie banners and onboarding interstitials before reaching the editor. Also lands the video-generation design spec docs that PR #23 builds on.

- `UiAutomationTransport` + `_bypass_onboarding(page)` + `ONBOARDING_SELECTORS` constant (`ce0ad6c`)
- Design spec + video-401 findings under `docs/superpowers/` (`f71f962`)
- `TestBypassOnboarding` unit tests — 5 tests covering visible CTA, multi-selector fallback, and exception tolerance (`3ddca9e`)
- Repair stale `TestEnterEditor::test_first_selector_works` assertion now that `_bypass_onboarding` runs first (`4290eb6`)
- Merge `develop` into the branch to sync (`f842275`)

PR #23 (Phase A video generation) currently stacks on top of this branch and will be re-targeted to `develop` once this lands.

## Test plan

- [x] ` pyright src` clean (0 errors, 0 warnings)
- [x] ` pytest -q` green — **632 passed / 32 skipped / 0 failed** in 181s
- [x] ` ruff check src tests` clean
- [x] ` ruff format --check src tests` clean
- [x] ` python scripts/ci/check_repo_hygiene.py` clean (207 tracked files)
- [ ] Live validation of the image-gen 401 workaround (UI-driven image generation against real Flow) — deferred to a follow-up; not blocking this PR per the user's ship-now decision