### PR TITLE
feat(ui-automation): dismiss Flow changelog overlays at interaction boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `gflow_cli.exceptions` module as a standard alias for `gflow_cli.errors` — both module names resolve identically.
 - `FlowApiClient.health_check()` async method — returns `True` if browser context is alive and on a Google domain; safe to call from long-lived workers without try/except.
+- `UiAutomationTransport._dismiss_blocking_overlays(page)` — generic overlay-dismiss helper that detects Flow changelog ("What's new") iframes and dismisses them via a close-button selector cascade with an Escape-key fallback. Invoked after editor entry on both image and video flows so first-run profiles no longer fail on the next click. Closes [#26](https://github.com/ffroliva/gflow-cli/issues/26).
 
 ### Changed
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -154,9 +154,9 @@ Flow shows a one-time "Aviso" / "Notice" terms-of-use confirmation on the first 
 
 ### Flow's release-notes ("What's new") changelog popup blocks first-run UI automation
 
-- **Status:** Open · **Severity:** Medium · **Affects:** v0.6.0a5+ (Phase A T2V on `UiAutomationTransport`) · **Tracked:** Phase B
+- **Status:** Mitigated · **Severity:** Medium · **Tracked:** [#26](https://github.com/ffroliva/gflow-cli/issues/26)
 
-Google Flow ships a release-notes / "What's new" iframe (`changelogs/YYYY-MM-DD-...html`) the first time a logged-in profile visits the page after a Flow deployment. The iframe sits on top of the editor and intercepts pointer events on Flow's own controls — Playwright finds the right selector but cannot click it because the changelog is in the way. `_switch_to_video_mode` then times out at 30 s.
+Google Flow ships a release-notes / "What's new" iframe (`changelogs/YYYY-MM-DD-...html`) the first time a logged-in profile visits the page after a Flow deployment. The iframe sits on top of the editor and intercepts pointer events on Flow's own controls — Playwright finds the right selector but cannot click it because the changelog is in the way. Issue [#26](https://github.com/ffroliva/gflow-cli/issues/26) confirmed the same iframe also blocks the settings menu after project navigation.
 
 **Symptom:**
 ```
@@ -165,9 +165,9 @@ playwright._impl._errors.TimeoutError: Locator.click: Timeout 30000ms exceeded.
   - retrying click action (57 retries, then timeout)
 ```
 
-**Workaround:** open Flow in Chrome with the same profile once, click the `X` on the "What's new" popup, then close Chrome cleanly. The dismissal persists in the profile until Google deploys the next changelog.
+**Mitigation:** `UiAutomationTransport._dismiss_blocking_overlays(page)` detects Flow changelog iframes (`iframe[src*='/flow/changelogs/']`, `iframe[src*='/changelogs/']`) and dismisses them via a close-button selector cascade with an Escape-key fallback. Invoked after `_enter_editor` (image flow) and after `_wait_video_editor_ready` (video flow) so downstream clicks aren't intercepted. Structured logs identify what was dismissed; a debug screenshot is captured if dismissal cannot be confirmed.
 
-**Roadmap:** Phase B will add a generic overlay-dismiss helper to `UiAutomationTransport` so the orchestration handles changelog popups, A/B-test banners, and consent dialogs without manual intervention.
+**Legacy workaround (no longer required):** open Flow in Chrome with the same profile once, click the `X` on the "What's new" popup, then close Chrome cleanly.
 
 ---
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -168,6 +168,30 @@ ONBOARDING_SELECTORS = (
     "button:has-text('Começar')",
 )
 
+# Changelog / "What's new" iframe selectors — these src patterns match the
+# gstatic CDN paths Flow uses for its release-note overlays. Two patterns are
+# included: the /flow/ prefix form and the bare /changelogs/ form.
+CHANGELOG_IFRAME_SELECTORS = (
+    "iframe[src*='/flow/changelogs/']",
+    "iframe[src*='/changelogs/']",
+)
+
+# Close-button selectors tried after a changelog iframe is detected.
+# Ordered from most-specific to most-generic so a precise match wins first.
+# All are tried before the Escape fallback.
+OVERLAY_CLOSE_BUTTON_SELECTORS = (
+    "[aria-label='Close']",
+    "[aria-label='close']",
+    "[aria-label='Dismiss']",
+    "[aria-label='dismiss']",
+    "[aria-label='Cancel']",
+    "button:has(i.google-symbols:text('close'))",
+    "button:has(i:text('close'))",
+    "[role='dialog'] button:has(i:text('close'))",
+    "[role='dialog'] button[aria-label*='close' i]",
+    "button[data-dismiss]",
+)
+
 
 # Generation settings trigger — the button shows the current ratio icon.
 # All 5 ratio icon names are enumerated so the selector is ratio-invariant.
@@ -431,6 +455,87 @@ class UiAutomationTransport(VideoGenerationMixin):
                     await page.wait_for_timeout(1000)
             except Exception:
                 continue
+
+    async def _dismiss_blocking_overlays(
+        self,
+        page: Page,
+        out_dir: Path | None = None,
+    ) -> bool:
+        """Dismiss Flow changelog / "What's new" iframes and any blocking overlays.
+
+        Called at stable interaction boundaries (after editor navigation, before
+        UI interactions that could be intercepted by a changelog popup).
+
+        Strategy:
+        1. Check whether any changelog iframe is currently visible.
+        2. If none found, return False immediately (cheap; no log noise).
+        3. If found, try each close-button selector in OVERLAY_CLOSE_BUTTON_SELECTORS.
+           On first visible match: force-click it, log the selector used, return True.
+        4. If no close button is discoverable, press Escape as a fallback and return True.
+        5. If Escape raises (extremely rare — keyboard unavailable), capture a debug
+           screenshot (if out_dir provided) and return False so the caller can decide
+           how to proceed. The structured warning carries enough info to identify the
+           blocking element.
+
+        Returns True if a dismissal action was taken, False if the page was
+        clear (no overlay) or if dismissal could not be confirmed.
+        """
+        # Step 1 — detect whether a changelog iframe is blocking the UI.
+        iframe_found = False
+        for sel in CHANGELOG_IFRAME_SELECTORS:
+            try:
+                if await page.locator(sel).first.is_visible(timeout=1500):
+                    iframe_found = True
+                    log.info("ui_automation.overlay_detected", selector=sel)
+                    break
+            except Exception:  # noqa: BLE001 — probe failure means no match
+                continue
+
+        if not iframe_found:
+            return False
+
+        # Step 2 — try explicit close buttons first.
+        for close_sel in OVERLAY_CLOSE_BUTTON_SELECTORS:
+            try:
+                loc = page.locator(close_sel).first
+                if await loc.is_visible(timeout=500):
+                    await loc.click(force=True)
+                    await page.wait_for_timeout(500)
+                    log.info(
+                        "ui_automation.overlay_dismissed",
+                        selector=close_sel,
+                        method="close_button",
+                    )
+                    return True
+            except Exception:  # noqa: BLE001 — selector miss or stale element
+                continue
+
+        # Step 3 — Escape fallback (regression test case: iframe present, no close button).
+        try:
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(500)
+            log.info(
+                "ui_automation.overlay_dismissed",
+                selector="<none>",
+                method="escape",
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — keyboard unavailable in some sandboxes
+            shot_path = await _capture_debug_screenshot(
+                page, out_dir, "debug_overlay_dismiss_failed.png"
+            )
+            log.warning(
+                "ui_automation.overlay_dismiss_failed",
+                error=str(exc),
+                screenshot=str(shot_path),
+                note=(
+                    "A changelog iframe was detected but could not be dismissed — "
+                    "no close button found and Escape raised. Manual intervention "
+                    "may be needed (open Flow in Chrome, dismiss the 'What's new' "
+                    "popup, close Chrome cleanly)."
+                ),
+            )
+            return False
 
     async def _enter_editor(self, page: Page, out_dir: Path | None = None) -> None:
         """Always create a fresh project — click "+ New project" on the gallery
@@ -822,6 +927,9 @@ class UiAutomationTransport(VideoGenerationMixin):
         page: Page = self._page  # type: ignore[assignment]  # guard in caller
 
         await self._enter_editor(page)
+        # Dismiss any Flow changelog / "What's new" overlay that may be on top
+        # of the editor before we click into settings / submit (#26).
+        await self._dismiss_blocking_overlays(page)
 
         # Resolve the project_id from the URL now that we're in the editor.
         nav_project_id = _extract_project_id(page.url)

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -137,6 +137,9 @@ class VideoGenerationMixin:
         async def _send_prompt(
             self, page: Page, prompt_text: str, out_dir: Path | None = None
         ) -> None: ...
+        async def _dismiss_blocking_overlays(
+            self, page: Page, out_dir: Path | None = None
+        ) -> bool: ...
 
     @staticmethod
     def _attach_video_response_listener(page: Page) -> tuple[list[dict[str, Any]], Any]:
@@ -423,6 +426,9 @@ class VideoGenerationMixin:
 
         await self._enter_editor(page, out_dir)
         await VideoGenerationMixin._wait_video_editor_ready(page)
+        # Dismiss any Flow changelog / "What's new" overlay that may be on top
+        # of the editor before we click into mode-switch / settings / submit (#26).
+        await self._dismiss_blocking_overlays(page, out_dir)
         await VideoGenerationMixin._switch_to_video_mode(page, out_dir=out_dir)
         await VideoGenerationMixin._select_video_aspect(page, request.aspect)
         await VideoGenerationMixin._set_output_count_one(page)

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1113,3 +1113,135 @@ class TestTeardown:
         t._pw_cm = pw_cm  # type: ignore[attr-defined]
         # Should NOT raise.
         await t.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Unit 3.12 — _dismiss_blocking_overlays(page, out_dir)
+# ---------------------------------------------------------------------------
+
+
+def _make_overlay_page(
+    *,
+    iframe_visible: bool = False,
+    close_button_visible: bool = False,
+    keyboard_press_raises: bool = False,
+) -> MagicMock:
+    """Build a fake page for _dismiss_blocking_overlays tests.
+
+    When ``iframe_visible=True`` a changelog iframe selector is visible.
+    When ``close_button_visible=True`` a close-button locator is also visible.
+    """
+    page = MagicMock()
+    page.wait_for_timeout = AsyncMock()
+    page.screenshot = AsyncMock()
+
+    if keyboard_press_raises:
+        page.keyboard = MagicMock()
+        page.keyboard.press = AsyncMock(side_effect=RuntimeError("keyboard boom"))
+    else:
+        page.keyboard = MagicMock()
+        page.keyboard.press = AsyncMock()
+
+    # Track click calls per selector for assertions.
+    clicked: list[str] = []
+
+    def _locator(sel: str) -> MagicMock:
+        loc = MagicMock()
+        # Changelog iframe selectors
+        is_iframe = "changelogs" in sel
+        # Close-button selectors: aria-label close / role=button with close icon
+        is_close = any(
+            k in sel.lower() for k in ("aria-label", "close", "dialog", "dismiss", "cancel")
+        )
+
+        if is_iframe and iframe_visible:
+            loc.is_visible = AsyncMock(return_value=True)
+        elif is_close and close_button_visible:
+            loc.is_visible = AsyncMock(return_value=True)
+        else:
+            loc.is_visible = AsyncMock(return_value=False)
+
+        async def _click(**kwargs: object) -> None:
+            clicked.append(sel)
+
+        loc.click = AsyncMock(side_effect=_click)
+        wrapper = MagicMock()
+        wrapper.first = loc
+        return wrapper
+
+    page.locator = MagicMock(side_effect=_locator)
+    page._clicked = clicked  # type: ignore[attr-defined]
+    return page
+
+
+class TestDismissBlockingOverlays:
+    """_dismiss_blocking_overlays handles changelog iframes and close buttons.
+
+    Acceptance criteria from issue #26:
+    - No overlay → returns False, no clicks, no log noise.
+    - Iframe + visible close button → clicked (force=True), returns True.
+    - Iframe + NO close button → Escape pressed, returns True (regression test).
+    - Iframe + close cascade + Escape both fail → returns False, debug screenshot.
+    - Non-changelog iframes are ignored.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_overlay_returns_false_and_no_clicks(self) -> None:
+        """When no changelog iframe is visible, returns False and makes no clicks."""
+        t = UiAutomationTransport()
+        page = _make_overlay_page(iframe_visible=False)
+        result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
+        assert result is False
+        assert page._clicked == []  # type: ignore[attr-defined]
+        page.keyboard.press.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_iframe_with_close_button_clicks_and_returns_true(self) -> None:
+        """A changelog iframe + visible close button → close button clicked
+        (force=True) and True returned."""
+        t = UiAutomationTransport()
+        page = _make_overlay_page(iframe_visible=True, close_button_visible=True)
+        result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
+        assert result is True
+        # A close-related selector was clicked.
+        assert len(page._clicked) >= 1  # type: ignore[attr-defined]
+        page.keyboard.press.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_iframe_no_close_button_uses_escape_fallback(self) -> None:
+        """Regression test (issue #26 AC): iframe present, no close button →
+        Escape is pressed as fallback and True is returned."""
+        t = UiAutomationTransport()
+        page = _make_overlay_page(iframe_visible=True, close_button_visible=False)
+        result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
+        assert result is True
+        page.keyboard.press.assert_called_once_with("Escape")
+        # No close button was clicked.
+        assert page._clicked == []  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_escape_failure_captures_screenshot_and_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        """If the close cascade AND Escape both fail, a debug screenshot is
+        captured and False is returned — diagnostic output is preserved."""
+        t = UiAutomationTransport()
+        page = _make_overlay_page(
+            iframe_visible=True,
+            close_button_visible=False,
+            keyboard_press_raises=True,
+        )
+        result = await t._dismiss_blocking_overlays(  # type: ignore[attr-defined]
+            page, out_dir=tmp_path
+        )
+        assert result is False
+        page.screenshot.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_changelog_iframes_are_ignored(self) -> None:
+        """Selectors that do NOT match changelog iframes produce no dismissal."""
+        t = UiAutomationTransport()
+        # Page where no changelog iframe is visible but other elements might be.
+        page = _make_overlay_page(iframe_visible=False)
+        result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
+        assert result is False


### PR DESCRIPTION
## Summary

Closes #26. Adds `UiAutomationTransport._dismiss_blocking_overlays(page)` and wires it after `_enter_editor` (image flow) and after `_wait_video_editor_ready` (video flow).

- Detects: `iframe[src*='/flow/changelogs/']`, `iframe[src*='/changelogs/']`
- Dismiss strategy: 10-selector close-button cascade (specific aria-labels first, then generic) → Escape-key fallback if no close button is discoverable
- Logging: structured events on detection, dismissal-via-close-button, dismissal-via-escape, and a `warning` event with a debug screenshot if dismissal cannot be confirmed
- Returns `True` when a dismissal action was taken, `False` when the page was clear or dismissal could not be confirmed

## Test plan

- [x] 5 new unit tests in `tests/api/transports/test_ui_automation.py::TestDismissBlockingOverlays`:
  - `test_no_overlay_returns_false_and_no_clicks`
  - `test_iframe_with_close_button_clicks_and_returns_true`
  - `test_iframe_no_close_button_uses_escape_fallback` ← **the regression test #26 explicitly requires**
  - `test_escape_failure_captures_screenshot_and_returns_false`
  - `test_non_changelog_iframes_are_ignored`
- [x] `pyright src` clean (0/0/0)
- [x] `pytest -q` green — 673 passed / 24 skipped / 0 failed
- [x] `ruff check src tests` + `ruff format --check src tests` clean
- [x] `check_repo_hygiene.py` clean (214 files)
- [ ] Live re-validation on a profile with a fresh changelog (deferred — the next time Flow ships a new changelog overlay)

## Docs

- `KNOWN_ISSUES.md` — moves the Flow changelog popup entry to **Mitigated** with a link to this issue
- `CHANGELOG.md [Unreleased]` — adds the new helper under **Added**