### PR TITLE
chore(release): v0.7.0 (bump pyproject + CHANGELOG footer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,7 +685,8 @@ shell-script template that branches on these codes.
 
 First skeleton. Not functional end-to-end yet.
 
-[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.6.0a6...HEAD
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/ffroliva/gflow-cli/compare/v0.6.0a6...v0.7.0
 [0.6.0a6]: https://github.com/ffroliva/gflow-cli/compare/v0.6.0a5...v0.6.0a6
 [0.6.0a5]: https://github.com/ffroliva/gflow-cli/compare/v0.6.0a4...v0.6.0a5
 [0.6.0a1]: https://github.com/ffroliva/gflow-cli/compare/v0.5.0a1...v0.6.0a1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.6.0a6"
+version = "0.7.0"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.6.0a6"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "gflow-cli"
-version = "0.6.0a6"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Land the version-bump commit (already pointed at by the `v0.7.0` tag) onto `main` so the branch stays in lock-step with the released artifacts.

- `pyproject.toml`: `0.6.0a6` → `0.7.0`
- `src/gflow_cli/__init__.py`: `__version__` bump
- `uv.lock`: matching pin
- `CHANGELOG.md`: `[Unreleased]` link footer rewired to compare from `v0.7.0`; new `[0.7.0]` link line added.

The `v0.7.0` tag was pushed first because direct push to `main` is (correctly) blocked by branch protection. CI's release workflow is firing against the tag commit (which carries this exact diff). This PR ensures `main` HEAD == tag commit after merge.

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run pyright src` — 0/0/0
- [ ] CI green on this PR
- [ ] release.yml succeeded on `v0.7.0` tag (in flight)