### PR TITLE
refactor: fix SonarCloud issues — function length, exception types, unused params

### DIFF
--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1389,7 +1389,7 @@ class UiAutomationTransport(VideoGenerationMixin):
     async def generate_images(
         self,
         *,
-        project_id: str | None,
+        project_id: str | None,  # noqa: ARG002
         request: GenerateImageRequest,
     ) -> list[GeneratedImage]:
         """Submit ``request.prompt`` through Flow's editor and return the
@@ -1405,7 +1405,8 @@ class UiAutomationTransport(VideoGenerationMixin):
         ``batchGenerateImages`` response is non-200, or the response is
         200 but contains no image URLs.
         """
-        _ = project_id  # accepted for Protocol parity; UI creates its own project
+        # project_id is accepted for Protocol parity; the UI transport creates
+        # its own Flow project on each call rather than reusing a supplied one.
         if not self._setup_done or self._page is None:
             raise RuntimeError(
                 "UiAutomationTransport.setup() must be called before generate_images()"

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 import structlog
 from playwright.async_api import Error as PlaywrightError
@@ -18,6 +19,80 @@ _console = Console()
 
 GEMINI_URL = "https://labs.google/fx/tools/flow?hl=en"
 GOOGLE_REJECTED_BROWSER_ROUTE = "accounts.google.com/v3/signin/rejected"
+
+
+async def _poll_session_until_authenticated(
+    ctx: Any,
+    page: Any,
+    timeout_seconds: int,
+    strategy_name: str,
+) -> None:
+    """Poll the Flow NextAuth session endpoint until the sign-in completes.
+
+    Raises ``AuthBrowserRejectedError`` if Google rejects the browser.
+    Raises ``AuthLoginTimeoutError`` if the timeout elapses or the browser
+    closes before authentication is verified.
+    """
+    timeout_at = asyncio.get_running_loop().time() + timeout_seconds
+    success = False
+
+    while asyncio.get_running_loop().time() < timeout_at:
+        try:
+            if _is_google_rejected_browser_page(page):
+                raise AuthBrowserRejectedError()
+
+            cookies = await ctx.cookies()
+            google_session = any(c.get("name") == "SAPISID" for c in cookies)
+            resp = await page.request.get(SESSION_API_URL, timeout=15_000)
+            status = evaluate_session_response(
+                resp.status,
+                await resp.text(),
+                google_session=google_session,
+                source=strategy_name,
+            )
+            if status.outcome is FlowSessionOutcome.AUTHENTICATED:
+                logger.info(
+                    "auth_flow_session_verified",
+                    strategy=strategy_name,
+                    source=status.source,
+                    user_email=status.user_email,
+                )
+                success = True
+                break
+        except asyncio.CancelledError:
+            raise
+        except AuthBrowserRejectedError:
+            raise
+        except PlaywrightError:
+            # Browser / page / context closed — stop polling.
+            break
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "auth_flow_session_poll_error",
+                strategy=strategy_name,
+                error=type(exc).__name__,
+            )
+            break
+
+        await asyncio.sleep(3)
+    else:
+        raise AuthLoginTimeoutError(
+            f"Flow sign-in not completed within {timeout_seconds}s.",
+            remediation_hint=(
+                "Run `gflow auth login` again and continue until the Flow "
+                "editor loads. Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT higher if "
+                f"needed (current: {timeout_seconds}s)."
+            ),
+        )
+
+    if not success:
+        raise AuthLoginTimeoutError(
+            "Browser closed before the Flow editor sign-in was verified.",
+            remediation_hint=(
+                "Complete the Flow sign-in — until the editor loads — "
+                "before closing the browser. Run `gflow auth login` to retry."
+            ),
+        )
 
 
 def _is_google_rejected_browser_page(page: object) -> bool:
@@ -74,72 +149,8 @@ class InternalChromiumStrategy(AuthStrategy):
                         "success and exit.\n"
                     )
 
-                # Poll the NextAuth session endpoint live until the Flow app
-                # sign-in completes. Non-AUTHENTICATED outcomes (including a
-                # transient VERIFICATION_ERROR) just mean "keep waiting" — the
-                # user may still be signing in.
-                timeout_at = asyncio.get_running_loop().time() + self._timeout_seconds
-                success = False
-
-                while asyncio.get_running_loop().time() < timeout_at:
-                    try:
-                        if _is_google_rejected_browser_page(page):
-                            raise AuthBrowserRejectedError()
-
-                        cookies = await ctx.cookies()
-                        google_session = any(c.get("name") == "SAPISID" for c in cookies)
-                        resp = await page.request.get(SESSION_API_URL, timeout=15_000)
-                        status = evaluate_session_response(
-                            resp.status,
-                            await resp.text(),
-                            google_session=google_session,
-                            source=self.name,
-                        )
-                        if status.outcome is FlowSessionOutcome.AUTHENTICATED:
-                            logger.info(
-                                "auth_flow_session_verified",
-                                strategy=self.name,
-                                source=status.source,
-                                user_email=status.user_email,
-                            )
-                            success = True
-                            break
-                    except asyncio.CancelledError:
-                        raise
-                    except AuthBrowserRejectedError:
-                        raise
-                    except PlaywrightError:
-                        # Browser / page / context closed — stop polling.
-                        break
-                    # Unexpected error — log it and stop polling.
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "auth_flow_session_poll_error",
-                            strategy=self.name,
-                            error=type(exc).__name__,
-                        )
-                        break
-
-                    await asyncio.sleep(3)
-                else:
-                    raise AuthLoginTimeoutError(
-                        f"Flow sign-in not completed within {self._timeout_seconds}s.",
-                        remediation_hint=(
-                            "Run `gflow auth login` again and continue until the Flow "
-                            "editor loads. Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT higher if "
-                            f"needed (current: {self._timeout_seconds}s)."
-                        ),
-                    )
-
-                if not success:
-                    raise AuthLoginTimeoutError(
-                        "Browser closed before the Flow editor sign-in was verified.",
-                        remediation_hint=(
-                            "Complete the Flow sign-in — until the editor loads — "
-                            "before closing the browser. Run `gflow auth login` to retry."
-                        ),
-                    )
-
+                # Poll until the Flow app sign-in completes; raises on timeout/rejection.
+                await _poll_session_until_authenticated(ctx, page, self._timeout_seconds, self.name)
                 # Small delay to ensure state is flushed to disk
                 await asyncio.sleep(1)
 

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import structlog
 from rich.console import Console
 
-from gflow_cli.config import get_settings
+from gflow_cli.config import Settings, get_settings
 from gflow_cli.errors import AuthLoginTimeoutError, AuthMissingError, SecurityError
 
 from .base import AuthStrategy
@@ -39,6 +39,79 @@ _UNVERIFIED_HINT: dict[FlowSessionOutcome, str] = {
     ),
     FlowSessionOutcome.VERIFICATION_ERROR: ("Check your connection and re-run `gflow auth login`."),
 }
+
+
+def _validate_profile_dir(profile_dir: Path, settings: Settings) -> None:
+    """Raise SecurityError if profile_dir is outside GFLOW_CLI_HOME."""
+    try:
+        profile_dir.resolve(strict=False).relative_to(settings.home.resolve())
+    except ValueError:
+        raise SecurityError(
+            f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME "
+            f"({settings.home}) boundaries."
+        ) from None
+
+
+def _build_chrome_args(chrome_exe: str, profile_dir: Path, headless: bool) -> list[str]:
+    """Build the Chrome command-line argument list for passive-capture login."""
+    args = [
+        chrome_exe,
+        f"--user-data-dir={profile_dir}",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--window-size=1280,800",
+        "--password-store=basic",
+        # No --remote-debugging-port: zero automation surface.
+        GEMINI_URL,  # open straight on the Flow sign-in page
+    ]
+    if headless:
+        args.append("--headless=new")
+    # Open Flow directly so the user lands on the sign-in / app surface
+    # instead of a blank new-tab page.
+    args.append(GEMINI_URL)
+    return args
+
+
+def _print_login_instructions() -> None:
+    """Print the passive-capture login steps to the console."""
+    _console.print("\n" + "=" * 60)
+    _console.print("[bold cyan]PASSIVE AUTHENTICATION[/bold cyan]")
+    _console.print("=" * 60)
+    _console.print("1. A Google Chrome window opens at the Flow sign-in page.")
+    _console.print("2. Sign in with your Google account.")
+    _console.print(
+        "3. [bold yellow]Keep going until the Flow editor itself loads[/bold yellow] "
+        "— the prompt box and your projects."
+    )
+    _console.print(
+        "   Signing in to Google is NOT enough; gflow needs a completed Flow app sign-in."
+    )
+    _console.print(
+        "4. Then [bold yellow]CLOSE THE BROWSER[/bold yellow] — gflow verifies "
+        "the Flow session automatically."
+    )
+    _console.print("-" * 60)
+    _console.print("Launching Chrome...")
+
+
+async def _await_chrome_close(proc: asyncio.subprocess.Process, timeout_seconds: int) -> None:
+    """Wait for Chrome to exit; terminate/kill it when the timeout elapses."""
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=float(timeout_seconds))
+    except TimeoutError:
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except TimeoutError:
+            proc.kill()
+        raise AuthLoginTimeoutError(
+            f"Sign-in timed out after {timeout_seconds}s; Chrome was stopped.",
+            remediation_hint=(
+                "Run `gflow auth login` again and complete sign-in before the time limit. "
+                f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to raise the limit "
+                f"(current: {timeout_seconds}s)."
+            ),
+        ) from None
 
 
 def find_chrome_executable() -> str | None:
@@ -88,14 +161,7 @@ class RealChromeStrategy(AuthStrategy):
     async def login(self, profile_dir: Path, headless: bool) -> None:
         """Execute the login flow using Passive Capture on Real Chrome."""
         settings = get_settings()
-        try:
-            profile_dir.resolve(strict=False).relative_to(settings.home.resolve())
-        except ValueError:
-            raise SecurityError(
-                f"Profile directory {profile_dir} is outside of GFLOW_CLI_HOME "
-                f"({settings.home}) boundaries."
-            ) from None
-
+        _validate_profile_dir(profile_dir, settings)
         profile_dir.mkdir(parents=True, exist_ok=True)
 
         chrome_exe = find_chrome_executable()
@@ -105,49 +171,15 @@ class RealChromeStrategy(AuthStrategy):
                 "Please install Chrome or use '--browser internal'."
             )
 
-        chrome_args = [
-            chrome_exe,
-            f"--user-data-dir={profile_dir}",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "--window-size=1280,800",
-            "--password-store=basic",
-            # No --remote-debugging-port: zero automation surface.
-            GEMINI_URL,  # open straight on the Flow sign-in page
-        ]
-
-        if headless:
-            chrome_args.append("--headless=new")
-
-        # Open Flow directly so the user lands on the sign-in / app surface
-        # instead of a blank new-tab page.
-        chrome_args.append(GEMINI_URL)
+        chrome_args = _build_chrome_args(chrome_exe, profile_dir, headless)
 
         logger.info(
             "auth_passive_capture_started",
             profile_dir=str(profile_dir),
             strategy=self.name,
         )
-
         if not headless:
-            _console.print("\n" + "=" * 60)
-            _console.print("[bold cyan]PASSIVE AUTHENTICATION[/bold cyan]")
-            _console.print("=" * 60)
-            _console.print("1. A Google Chrome window opens at the Flow sign-in page.")
-            _console.print("2. Sign in with your Google account.")
-            _console.print(
-                "3. [bold yellow]Keep going until the Flow editor itself loads[/bold yellow] "
-                "— the prompt box and your projects."
-            )
-            _console.print(
-                "   Signing in to Google is NOT enough; gflow needs a completed Flow app sign-in."
-            )
-            _console.print(
-                "4. Then [bold yellow]CLOSE THE BROWSER[/bold yellow] — gflow verifies "
-                "the Flow session automatically."
-            )
-            _console.print("-" * 60)
-            _console.print("Launching Chrome...")
+            _print_login_instructions()
 
         # Tests MUST patch asyncio.create_subprocess_exec itself — patching
         # subprocess.Popen instead lets the real asyncio transport run against a
@@ -157,31 +189,12 @@ class RealChromeStrategy(AuthStrategy):
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
         )
-
-        # Wait for the user to close Chrome.  Chrome holds an exclusive lock on
-        # its SQLite cookie store while running, so we must wait before probing.
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=float(self._timeout_seconds))
-        except TimeoutError:
-            proc.terminate()
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=5)
-            except TimeoutError:
-                proc.kill()
-            raise AuthLoginTimeoutError(
-                f"Sign-in timed out after {self._timeout_seconds}s; Chrome was stopped.",
-                remediation_hint=(
-                    "Run `gflow auth login` again and complete sign-in before the time limit. "
-                    f"Set GFLOW_CLI_AUTH_LOGIN_TIMEOUT to raise the limit "
-                    f"(current: {self._timeout_seconds}s)."
-                ),
-            ) from None
-
+        # Chrome holds an exclusive lock on its SQLite cookie store while running,
+        # so we must wait for it to close before probing the session.
+        await _await_chrome_close(proc, self._timeout_seconds)
         _console.print("\n[bold green]Browser closed.[/bold green] Verifying Flow session...")
 
-        # Verify the real Flow app session — not just the Google SSO cookie.
         status = await verify_flow_session(profile_dir, channel="chrome", source=self.name)
-
         if status.authenticated:
             logger.info(
                 "auth_flow_session_verified",

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -93,7 +93,7 @@ def _pid_alive(pid: int) -> bool:
                 timeout=5,
             )
             return str(pid) in result.stdout
-        except Exception:
+        except (subprocess.SubprocessError, OSError, ValueError):
             return False
     else:
         # POSIX: os.kill(pid, 0) raises if PID doesn't exist / no permission
@@ -105,7 +105,7 @@ def _pid_alive(pid: int) -> bool:
         except PermissionError:
             # Process exists but we don't own it — still alive
             return True
-        except Exception:
+        except OSError:
             return False
 
 
@@ -233,7 +233,7 @@ def is_browser_running(port: int = 9222) -> bool:
             return True
         except httpx.TimeoutException:
             raise  # re-raise so caller can retry
-        except Exception:
+        except (httpx.HTTPError, ValueError, OSError):
             return False
 
     try:
@@ -242,7 +242,7 @@ def is_browser_running(port: int = 9222) -> bool:
         # ONE retry on timeout
         try:
             return _attempt()
-        except Exception:
+        except (httpx.HTTPError, httpx.TimeoutException, ValueError, OSError):
             return False
 
 
@@ -402,19 +402,12 @@ def _write_lock(lock_path: Path, pid: int, port: int, profile_name: str) -> None
     # path while keeping the write itself crash-safe.
     try:
         os.link(str(tmp_path), str(lock_path))
-    except BaseException:
-        # Race lost (or hardlink unsupported) — clean up tmp and propagate
-        try:
-            tmp_path.unlink()
-        except FileNotFoundError:
-            pass
+    except OSError:
+        # Race lost (or hardlink unsupported) — clean up tmp and propagate.
+        tmp_path.unlink(missing_ok=True)
         raise
-    else:
-        # Success: drop the tmp hardlink; the lockfile now stands alone
-        try:
-            tmp_path.unlink()
-        except FileNotFoundError:
-            pass
+    # Success: drop the tmp hardlink; the lockfile now stands alone.
+    tmp_path.unlink(missing_ok=True)
 
 
 def _read_lock(lock_path: Path) -> dict[str, Any] | None:
@@ -494,9 +487,7 @@ async def _is_logged_in_to_flow(page: Any) -> bool:
         sign_in_count = await page.locator('button:has-text("Sign in")').count()
         if sign_in_count and sign_in_count > 0:
             return False
-    except Exception:
-        # If the locator call fails for any reason, assume logged in
-        # (fail-open is safer than blocking every session on a DOM race)
+    except Exception:  # noqa: BLE001 — fail-open: DOM race must not block every session
         pass
 
     return True

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -57,6 +57,7 @@ from gflow_cli.image_batch import (
     MAX_COUNT as _MAX_COUNT,
 )
 from gflow_cli.image_batch import (
+    BatchPromptItem,
     MAX_PROMPT_FILE_BYTES,
     parse_manifest_file,
     parse_prompt_lines,
@@ -220,10 +221,6 @@ async def _run_upload(
 # t2i subcommand
 # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# t2i subcommand
-# ---------------------------------------------------------------------------
-
 
 @image.command(
     "t2i",
@@ -352,18 +349,29 @@ def t2i(
         )
         return
 
+    batch_prompts = _build_t2i_batch_prompts(
+        prompts, prompts_file, read_stdin, aspect, model, count
+    )
+    _execute_t2i_batch(batch_prompts, count, continue_on_error, profile, out, transport)
+
+
+def _build_t2i_batch_prompts(
+    prompts: tuple[str, ...],
+    prompts_file: Path | None,
+    read_stdin: bool,
+    aspect: str,
+    model: str,
+    count: int,
+) -> tuple[BatchPromptItem, ...]:
+    """Build batch prompt items from whichever input source was given.
+
+    Raises click.UsageError on stdin size overflow or malformed file content.
+    """
     try:
         if prompts_file is not None:
             parsed = read_prompt_file(prompts_file)
-            batch_prompts = prompt_items_from_parsed(
-                parsed,
-                aspect_ratio=aspect,
-                model=model,
-                count=count,
-            )
-        elif read_stdin:
-            # Security: implement a bounded read for standard input to prevent OOM
-            # crashes if a massive stream is piped to the CLI.
+            return prompt_items_from_parsed(parsed, aspect_ratio=aspect, model=model, count=count)
+        if read_stdin:
             raw_stdin = sys.stdin.read(MAX_PROMPT_FILE_BYTES + 1)
             if len(raw_stdin) > MAX_PROMPT_FILE_BYTES:
                 raise click.UsageError(
@@ -371,23 +379,27 @@ def t2i(
                     f"{MAX_PROMPT_FILE_BYTES // 1024} KiB."
                 )
             parsed = parse_prompt_lines(raw_stdin, source_label="--stdin")
-            batch_prompts = prompt_items_from_parsed(
-                parsed,
-                aspect_ratio=aspect,
-                model=model,
-                count=count,
-            )
-        else:
-            batch_prompts = prompt_items_from_texts(
-                prompts,
-                aspect_ratio=aspect,
-                model=model,
-                count=count,
-                source_label="positional",
-            )
+            return prompt_items_from_parsed(parsed, aspect_ratio=aspect, model=model, count=count)
+        return prompt_items_from_texts(
+            prompts,
+            aspect_ratio=aspect,
+            model=model,
+            count=count,
+            source_label="positional",
+        )
     except ConfigurationError as exc:
         raise _as_usage_error(exc) from exc
 
+
+def _execute_t2i_batch(
+    batch_prompts: tuple[BatchPromptItem, ...],
+    count: int,
+    continue_on_error: bool,
+    profile: str | None,
+    out: Path | None,
+    transport: str | None,
+) -> None:
+    """Run a multi-prompt t2i batch and print the summary table."""
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     settings = get_settings()
@@ -401,7 +413,6 @@ def t2i(
     console.print(f"  output_dir: [dim]{safe_path_text(output_dir)}[/dim]")
     if not continue_on_error:
         console.print("  mode: [yellow]fail-fast[/yellow]")
-
     outcomes = asyncio.run(
         run_image_batch(
             profile_dir=provider_dir,

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -57,8 +57,8 @@ from gflow_cli.image_batch import (
     MAX_COUNT as _MAX_COUNT,
 )
 from gflow_cli.image_batch import (
-    BatchPromptItem,
     MAX_PROMPT_FILE_BYTES,
+    BatchPromptItem,
     parse_manifest_file,
     parse_prompt_lines,
     prompt_items_from_parsed,


### PR DESCRIPTION
## Summary

Addresses SonarCloud findings across 6 files. All quality gates pass (ruff clean, pyright 0 errors, 673 tests, 87% coverage).

### S138 — Functions too long (>100 lines)

Extracted private helpers to bring each function under the threshold:

- **`auth/real_chrome.py`** `login()` 117→47 lines: extracted `_validate_profile_dir`, `_build_chrome_args`, `_print_login_instructions`, `_await_chrome_close`
- **`auth/internal_chromium.py`** `login()` 107→38 lines: extracted `_poll_session_until_authenticated` (the session-polling loop)
- **`cli_image.py`** `t2i()` 109→38 lines: extracted `_build_t2i_batch_prompts` and `_execute_t2i_batch`

### BLE001 / S5754 — Broad exception catches

Narrowed to the specific exception types each site can actually receive:

- `browser_manager._pid_alive` Windows: `Exception` → `(subprocess.SubprocessError, OSError, ValueError)`
- `browser_manager._pid_alive` POSIX: `Exception` → `OSError`
- `browser_manager.is_browser_running`: `Exception` → `(httpx.HTTPError, ValueError, OSError)`
- `browser_manager._write_lock`: `BaseException` → `OSError`; cleanup simplified with `unlink(missing_ok=True)`
- `browser_manager._is_logged_in_to_flow`: intentional fail-open catch annotated with `# noqa: BLE001`

### S1481 / S1172 — Unused variable / parameter patterns

- `api/client.py` `_drive_image_generation`: removed `_ = seed, batch_id` suppressor; added `# noqa: ARG002` to the parameter declarations with an explanatory comment
- `api/transports/ui_automation.py` `generate_images`: removed `_ = project_id`; replaced with a comment explaining Protocol-parity intent; added `# noqa: ARG002` on the parameter

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run pyright src` — 0 errors
- [x] `uv run pytest -q -m "not e2e and not live" --cov=gflow_cli` — 673 passed, 87% coverage

---
_Generated by [Claude Code](https://claude.ai/code/session_013qHQbg4F64zsiKWcnAK8EV)_