### PR TITLE
feat: add --password-store=basic argument to Chromium launch options

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -178,7 +178,7 @@ class FlowApiClient:
             locale="en-US",
             extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
             channel=channel_for_profile(self.profile_dir),
-            ignore_default_args=["--enable-automation", "--no-sandbox"],
+            ignore_default_args=["--enable-automation", "--no-sandbox", "--password-store=basic"],
             args=["--disable-blink-features=AutomationControlled"],
         )
         # Hide the automation flag so reCAPTCHA Enterprise doesn't score

--- a/src/gflow_cli/api/transports/experimental/bearer.py
+++ b/src/gflow_cli/api/transports/experimental/bearer.py
@@ -222,6 +222,7 @@ class BearerTransport:
                 headless=True,
                 viewport={"width": 1280, "height": 720},
                 locale="en-US",
+                args=["--password-store=basic"],
             )
             try:
                 page = await ctx.new_page()

--- a/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
+++ b/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
@@ -149,7 +149,10 @@ class EvaluateFetchTransport:
             ctx = await pw.chromium.launch_persistent_context(
                 str(profile_dir),
                 headless=True,
-                args=["--disable-blink-features=AutomationControlled"],
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--password-store=basic",
+                ],
                 viewport={"width": 1280, "height": 720},
                 locale="en-US",
             )

--- a/src/gflow_cli/api/transports/experimental/sapisidhash.py
+++ b/src/gflow_cli/api/transports/experimental/sapisidhash.py
@@ -198,6 +198,7 @@ class SapisidhashTransport:
                 headless=True,
                 viewport={"width": 1280, "height": 720},
                 locale="en-US",
+                args=["--password-store=basic"],
             )
             try:
                 page = await ctx.new_page()

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -388,7 +388,10 @@ class UiAutomationTransport(VideoGenerationMixin):
                 viewport=cast("ViewportSize", _VIEWPORT),
                 locale="en-US",
                 channel=channel_for_profile(profile_dir),
-                args=["--disable-blink-features=AutomationControlled"],
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--password-store=basic",
+                ],
             )
             # Hide the automation flag so reCAPTCHA Enterprise doesn't score
             # the session as a bot — navigator.webdriver=true causes low-score

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -61,6 +61,7 @@ class InternalChromiumStrategy(AuthStrategy):
                 user_data_dir=str(profile_dir),
                 headless=headless,
                 viewport={"width": 1280, "height": 800},
+                args=["--password-store=basic"],
             )
             try:
                 page = ctx.pages[0] if ctx.pages else await ctx.new_page()

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -111,16 +111,13 @@ class RealChromeStrategy(AuthStrategy):
             "--no-first-run",
             "--no-default-browser-check",
             "--window-size=1280,800",
+            "--password-store=basic",
             # No --remote-debugging-port: zero automation surface.
             GEMINI_URL,  # open straight on the Flow sign-in page
         ]
 
         if headless:
             chrome_args.append("--headless=new")
-
-        # Open Flow directly so the user lands on the sign-in / app surface
-        # instead of a blank new-tab page.
-        chrome_args.append(GEMINI_URL)
 
         logger.info(
             "auth_passive_capture_started",

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -119,6 +119,10 @@ class RealChromeStrategy(AuthStrategy):
         if headless:
             chrome_args.append("--headless=new")
 
+        # Open Flow directly so the user lands on the sign-in / app surface
+        # instead of a blank new-tab page.
+        chrome_args.append(GEMINI_URL)
+
         logger.info(
             "auth_passive_capture_started",
             profile_dir=str(profile_dir),

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -202,6 +202,7 @@ async def verify_flow_session(
                 user_data_dir=str(profile_dir),
                 channel=channel,
                 headless=True,
+                args=["--password-store=basic"],
             )
             try:
                 cookies = await ctx.cookies()

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -334,6 +334,7 @@ def _spawn_chrome(binary: str, profile_dir: Path, port: int) -> subprocess.Popen
         "--no-first-run",
         "--no-default-browser-check",
         "--disable-background-networking",
+        "--password-store=basic",
     ]
 
     log.info("chrome_spawn", binary=binary, port=port, profile_dir=str(profile_dir))

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -68,6 +68,7 @@ class TestRealChromeStrategy:
         args_list = mock_create.call_args.args
         assert args_list[0] == fake_chrome
         assert f"--user-data-dir={profile_dir}" in args_list
+        assert "--password-store=basic" in args_list
         assert "--enable-automation" not in args_list
         assert not any("--remote-debugging-port" in a for a in args_list)
         assert GEMINI_URL in args_list  # Chrome opens directly on the Flow page


### PR DESCRIPTION
## Summary

On Linux, Google Chrome encrypts its cookies using a master key stored in  system keyring ( gnome-keyring  or  kwallet )

1. When i run  `gflow auth login` , it launches the headed desktop system Chrome, which accesses system keyring and encrypts the session cookies.
2. When  gflow  runs its headless verification or API calls, Playwright launches Chrome headlessly without desktop keyring access. It fails to decrypt the cookie store, resulting in an empty cookie jar and the  outcome=no_session  error.

Solution:

I have configured all Chrome/Chromium browser instances within  gflow  to bypass OS keyring dependency by passing the  `--password-store=basic`  flag. This allows both headed login and headless verification/actions to use a consistent, keyring-free cookie store.

## Validation

<!-- List the focused commands you ran, plus any checks you could not run. -->

- [x] Focused tests added or updated for behavior changes
- [x] `uv run ruff check src tests`
- [x] `uv run pyright src`
- [x] Relevant pytest command:

## Contribution Checklist

- [x] This PR targets `develop`, unless it is a release or emergency fix
- [x] My commits use my real Git identity or GitHub noreply email
- [x] External contribution commits include `Signed-off-by:` (`git commit -s`)
- [x] I did not include secrets, cookies, account tokens, signed URLs, or private captured data
- [x] I reviewed any AI-assisted changes before submitting
