### PR TITLE
docs: add branch naming and attribution rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Dependency rule: **`domain/` depends on nothing**. `application/` depends on `do
 
 - **Never commit secrets.** `.gitignore` excludes `auth/`, `profile_*/`, `*.cookies.json`, `storage_state.json`, `secrets.json`, `.env`, `.env.local`, `.env.*.local`. If you see one of these staged, abort and tell the user.
 - **Never add `Co-Authored-By: Claude` (or any AI co-author) to commit messages.** Author attribution is the human user's only.
+- **Branch names must not use a `claude/` prefix.** Use descriptive names like `feat/topic`, `fix/topic`, or `chore/topic` following Conventional Commits style.
 - **Sessions belong outside the repo.** Default location is `$LOCALAPPDATA/gflow-cli/profile_*` (Windows) or `~/.local/share/gflow-cli/profile_*` (POSIX) via [`platformdirs`](https://github.com/platformdirs/platformdirs). Never store sessions in `/tmp`, `%TEMP%`, or anywhere the OS auto-reaps.
 - **No raw `print()` and no `import logging` in `src/`** — use `structlog` for structured events, or Rich `console.print(...)` for user-facing output.
 - **Domain layer is pure** — `src/gflow_cli/domain/*` must not import `application/`, `infrastructure/`, or `interfaces/`. No I/O, no frameworks.


### PR DESCRIPTION
## Summary

- Adds a CRITICAL rule to CLAUDE.md: branch names must not use a `claude/` prefix — use `feat/`, `fix/`, `chore/` etc. following Conventional Commits style
- Attribution suppressed globally via `~/.claude/settings.json` (`attribution.commit` and `attribution.pr` set to `""`) — no Claude session URLs or co-author trailers in commits or PRs

## Test plan

- [ ] Verify `~/.claude/settings.json` contains `"attribution": {"commit": "", "pr": ""}` on the machine running Claude Code
- [ ] Verify future branches created by Claude follow `feat/`, `fix/`, `chore/` naming
- [ ] Verify future commits contain no `Co-authored-by` or session URL trailers

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLyAUgGJzNf9FxSmVtLMod)_