### PR TITLE
docs(readme): restore Stats section + extra badges (for v0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/gflow-cli.svg)](https://pypi.org/project/gflow-cli/)
 [![CI](https://github.com/ffroliva/gflow-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ffroliva/gflow-cli/actions/workflows/ci.yml)
+[![Release](https://github.com/ffroliva/gflow-cli/actions/workflows/release.yml/badge.svg)](https://github.com/ffroliva/gflow-cli/actions/workflows/release.yml)
 [![Python versions](https://img.shields.io/pypi/pyversions/gflow-cli.svg)](https://pypi.org/project/gflow-cli/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](docs/PROJECT_STATUS.md)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
+[![Type checked: pyright](https://img.shields.io/badge/type%20checked-pyright-blue.svg)](https://github.com/microsoft/pyright)
+[![Tests: TDD](https://img.shields.io/badge/tests-TDD-brightgreen.svg)](CONTRIBUTING.md)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli)
 
 > ⚠️ **Unofficial. Reverse-engineered. Not affiliated with Google.** Endpoints can change at any time. Full [DISCLAIMER](DISCLAIMER.md).
 >
@@ -112,5 +117,16 @@ gflow CLI  →  Provider (interchangeable)  →  Flow (ui_automation) / Mock (te
 - [Keysight — *Google Labs – Flow AI with Veo3: A Network Traffic Analysis*](https://www.keysight.com/blogs/en/tech/nwvs/2025/08/04/google-flow-ai-har-analysis) — independent capture that helped validate the captured route patterns.
 
 ---
+
+## Stats
+
+[![GitHub stars](https://img.shields.io/github/stars/ffroliva/gflow-cli?style=social)](https://github.com/ffroliva/gflow-cli/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/ffroliva/gflow-cli?style=social)](https://github.com/ffroliva/gflow-cli/network/members)
+[![GitHub watchers](https://img.shields.io/github/watchers/ffroliva/gflow-cli?style=social)](https://github.com/ffroliva/gflow-cli/watchers)
+[![GitHub issues](https://img.shields.io/github/issues/ffroliva/gflow-cli)](https://github.com/ffroliva/gflow-cli/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/ffroliva/gflow-cli)](https://github.com/ffroliva/gflow-cli/pulls)
+[![GitHub last commit](https://img.shields.io/github/last-commit/ffroliva/gflow-cli)](https://github.com/ffroliva/gflow-cli/commits/main)
+[![GitHub repo size](https://img.shields.io/github/repo-size/ffroliva/gflow-cli)](https://github.com/ffroliva/gflow-cli)
+[![PyPI downloads](https://img.shields.io/pypi/dm/gflow-cli.svg)](https://pypi.org/project/gflow-cli/)
 
 If `gflow-cli` saves you time, please ⭐ the repo — it is the cheapest way to support the project.


### PR DESCRIPTION
## Summary

Restore the Stats section and four additional badges that were trimmed in the v0.8.1 README rewrite. The minimalist 5-badge layout that shipped to PyPI for v0.8.1 stays on `main`; this PR brings the richer version to `develop` so it ships with the next minor release.

## Changes

- **+4 badges** below the existing 5 (PyPI / CI / Python / License / Status):
  - `Release` workflow badge
  - `Code style: ruff`
  - `Type checked: pyright`
  - `Tests: TDD` → links to `CONTRIBUTING.md`
  - `Quality Gate Status` (SonarCloud — `ffroliva_gflow-cli`)
- **+ Stats section** at the bottom (above the "⭐ the repo" line): GitHub stars, forks, watchers, issues, PRs, last commit, repo size, PyPI downloads.

Both blocks are ported verbatim from the pre-v0.8.1 README. README grew from 116 to 132 lines — still well under the 200-line governance cap.

## Test plan

- [x] `scripts/ci/check_doc_links.py` — All links resolved across 9 files.
- [ ] CI passes on this PR.
- [ ] Next release (v0.9.0) carries these badges + Stats to PyPI.

## Why on develop, not a separate patch release

The badges and Stats are cosmetic / discoverability improvements, not a fix. Per the v0.8.1 release pattern, ship with the next feature release rather than burn another patch number.