### PR TITLE
feat(video): wire i2v/r2v + model/duration/count picker; fix image --model no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `gflow video t2v` model picker: `--model` (`omni-flash` | `veo-lite` |
+  `veo-fast` | `veo-quality` | `veo-lite-lp`), `--duration` (`4`/`6`/`8`, plus
+  `10` for `omni-flash` only), and `--count` (1–4). Driven via the editor's
+  generation-settings panel; live-verified against a Pro/Ultra profile.
+- `gflow video i2v <image> "<prompt>"` — image-to-video with a start frame and
+  an optional `--end-image` (interpolation). Fires
+  `batchAsyncGenerateVideoStartImage` / `…StartAndEndImage`.
+- `gflow video r2v "<prompt>" --ref <img> [--ref …]` — reference-to-video
+  (Flow "ingredients"). Model-aware reference cap (omni_flash ≤7, veo_3_1_* ≤3)
+  enforced in the request DTO; the transport stops gracefully if Flow hides the
+  add-media button at the cap. Fires `batchAsyncGenerateVideoReferenceImages`.
+
+### Changed
+
+- `MAX_REFERENCE_IMAGES` (in `api/video.py`) now tracks the `omni_flash`
+  ceiling of **7** (was **3**). The tighter per-model cap (`veo_3_1_* ≤ 3`) is
+  still enforced in `GenerateVideoRequest.__post_init__` when the model is
+  known; the constant is only the absolute upper bound. Anyone pinning to the
+  old value of 3 should re-check against the per-model caps.
+
+### Fixed
+
+- `gflow image t2i/i2i --model` now actually selects the requested model. It was
+  a no-op under `ui_automation` (the wire field was set but the model picker was
+  never clicked, so Flow used its UI default). Adds `_select_image_model`.
+- Video selector mismatches: the output-count selector `[id*=-trigger-1]`
+  collided with the `-trigger-10` duration tab; the aspect selector matched a
+  non-existent `aria-controls*=9_16`; the video-mode tab match was ambiguous.
+  All now use exact `[id$=-trigger-X]` suffixes + aria-label text.
+
+### Notes
+
+- I2V/R2V image inputs bind through the editor's media dialog (frame slot /
+  add-media → "Upload media" → file chooser → "Add to Prompt"). `set_input_files`
+  on the generic hidden input only adds to the library and Flow then ignores the
+  image (plain Text route). The editor is forced to English via the
+  `--lang=en-US` Chromium launch arg because the slot/dialog labels are localized
+  with no locale-free anchor.
+
 ## [0.8.1] — 2026-05-23
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 For Google AI Ultra / Pro subscribers with Veo credits and batch workloads:
 
-- **Burn credits efficiently** — `for p in $(cat prompts.txt); do gflow image t2i "$p"; done` _(image batching ships today; `gflow video i2v` lands in Phase B)_
+- **Burn credits efficiently** — `for p in $(cat prompts.txt); do gflow image t2i "$p"; done` _(image batching, plus `gflow video t2v`/`i2v`/`r2v`, all ship today)_
 - **Build pipelines** — wire Veo into your content automation, AI video stack, or batch experiments
 - **Stay in the terminal** — no Chromium UI, no clicking through dialogs (after a one-time `gflow auth login`)
 
@@ -99,7 +99,7 @@ gflow CLI  →  Provider (interchangeable)  →  Flow (ui_automation) / Mock (te
 
 ## Project status
 
-**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V live end-to-end on `ui_automation`. Video I2V + batch are queued for Phase B. Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md).
+**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. Only video `batch` is queued for Phase B. Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md).
 
 ## License & legal
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,7 +4,7 @@
 
 ## Current release
 
-**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts. Video I2V and batch are queued for Phase B. Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
+**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. Only video `batch` is still queued for Phase B. Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
 
 ## Milestone history
 
@@ -29,7 +29,11 @@
 | `gflow video t2v` restored on `ui_automation` with first-class video download | ✅ done (v0.7.0 unreleased → v0.8.0) |
 | Image/video mode-switch symmetry + live verify on ffroliva (PR #40) | ✅ done (v0.8.0) |
 | README + AGENTS.md + llms.txt refresh, docs governance | ✅ done (v0.8.1) |
-| `gflow video i2v` + `gflow video batch` on `ui_automation` | ⏳ Phase B |
+| `gflow video t2v` model picker (5 Veo models) + `--duration` / `--count` | ✅ done (Unreleased) |
+| `gflow video i2v` (start + optional end frame) on `ui_automation` | ✅ done (Unreleased) |
+| `gflow video r2v` (reference-to-video, model-aware ref cap omni≤7 / veo≤3) | ✅ done (Unreleased) |
+| `gflow image t2i/i2i --model` actually selects the model (was a no-op) | ✅ done (Unreleased) |
+| `gflow video batch` (TSV manifest) on `ui_automation` | ⏳ Phase B |
 | Persistence layer (stay-mounted batch sessions across project boundaries) | ⏳ Phase B |
 | Provider abstraction for official Veo 3.1 API | ⏳ planned |
 | Signed-tag CI verification automation (no manual signing in CI yet) | ⏳ planned |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,7 +25,8 @@ Commands:
 
   video     Video generation (Veo via Flow).
     t2v                         Generate a video from a text prompt.
-    i2v                         Generate a video from a start image + text prompt.
+    i2v                         Generate a video from a start (+ optional end) frame + prompt.
+    r2v                         Generate a video from reference images + prompt.
     batch                       Run a TSV manifest of video generations.
 ```
 
@@ -282,49 +283,66 @@ All prompts in a batch share one Flow project. The editor is opened once; each p
 - `image_batch.row_completed {row_idx, file_path, sha256_prefix}` (per image)
 - `image_batch.inter_submission_latency_ms {row_idx, latency_ms}` (fires from row 1 onward)
 
+> **Shared video flags** (`t2v` / `i2v` / `r2v`):
+> `--model [omni-flash|veo-lite|veo-fast|veo-quality|veo-lite-lp]` (omit → Flow's
+> current UI default), `--duration [4|6|8|10]` (10 requires `--model omni-flash`),
+> `--count INTEGER` (1–4; >1 multiplies credit cost), `--aspect [9:16|16:9]`,
+> `--profile NAME`, `--out-dir DIR` (default `tmp/`). The mp4 lands at
+> `<out-dir>/<media_id>.mp4`.
+
 ## `gflow video t2v`
 
 Generate a video from a text prompt only.
 
 ```text
-gflow video t2v PROMPT [OPTIONS]
-
-Options:
-  -o, --output PATH       Output mp4. Default: $GFLOW_CLI_OUTPUT_DIR/videos/<date>/<media>.mp4
-  --aspect 9:16|16:9|1:1  Default: 9:16
-  --seed INTEGER          Reproducibility. Default: random.
-  --profile NAME          Account profile. Default: resolved from env/config.
-  --poll-interval FLOAT   Seconds between status polls. Default: 5.
+gflow video t2v PROMPT [--model] [--duration] [--count] [--aspect] [--profile] [--out-dir]
 ```
-
-Examples:
 
 ```bash
 gflow video t2v "Slow cinematic push-in toward a candle flame"
-gflow video t2v "Aerial shot of a coastline at sunset" --aspect 16:9 -o ./coast.mp4
+gflow video t2v "Aerial shot of a coastline at sunset" --aspect 16:9 --out-dir ./out
+gflow video t2v "A neon city timelapse" --model omni-flash --duration 10 --count 2
 ```
 
 ## `gflow video i2v`
 
-Generate a video from a START IMAGE + text prompt. The image must be a local PNG, JPEG, WebP, or GIF; it's uploaded once per call and the resulting clip animates from it according to PROMPT.
+Generate a video from a START frame (+ optional END frame) and a motion prompt.
+Each image is a local PNG/JPEG; it is bound into the editor's frame slot via the
+media dialog, then Flow fires `batchAsyncGenerateVideoStartImage` (start only) or
+`…StartAndEndImage` (start+end interpolation).
 
 ```text
-gflow video i2v IMAGE PROMPT [OPTIONS]
+gflow video i2v IMAGE PROMPT [--end-image LAST] [--model] [--duration] [--count] [--aspect] [...]
 
 Arguments:
-  IMAGE                   Local start image (PNG/JPEG/WebP/GIF). [required]
-  PROMPT                  Text prompt.                            [required]
+  IMAGE   Local start frame (PNG/JPEG). [required]
+  PROMPT  Motion prompt.                [required]
 
 Options:
-  -o, --output PATH       Output mp4. Default: $GFLOW_CLI_OUTPUT_DIR/videos/<date>/<media>.mp4
-  --aspect 9:16|16:9|1:1  Default: 9:16
-  --seed INTEGER          Reproducibility. Default: random.
-  --profile NAME          Account profile. Default: resolved from env/config.
-  --poll-interval FLOAT   Seconds between status polls. Default: 5.
+  --end-image PATH  Optional end frame — Flow interpolates start -> end.
 ```
 
 ```bash
 gflow video i2v ./hero.png "Slow camera arc, soft golden light"
+gflow video i2v ./first.png "morph between scenes" --end-image ./last.png --model veo-quality
+```
+
+## `gflow video r2v`
+
+Reference-to-video (Flow "ingredients"): condition a generation on reference
+images. Per-model cap: `omni-flash` ≤7, the `veo-*` models ≤3. Fires
+`batchAsyncGenerateVideoReferenceImages`.
+
+```text
+gflow video r2v PROMPT --ref IMG [--ref IMG ...] [--model] [--duration] [--count] [--aspect] [...]
+
+Options:
+  --ref PATH  Reference image; repeat for up to 7 (omni-flash) / 3 (veo). [required]
+```
+
+```bash
+gflow video r2v "a knight in this armor walks forward" --ref armor.png
+gflow video r2v "blend these worlds" --ref a.png --ref b.png --ref c.png --model omni-flash
 ```
 
 ## `gflow video batch`

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 import structlog
 
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
-from gflow_cli.api.image import Aspect, GenerateImageRequest
+from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports.ui_automation_video import (
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
@@ -57,6 +57,19 @@ log = structlog.get_logger(__name__)
 FLOW_URL = "https://labs.google/fx/tools/flow?hl=en"
 # URL fragment that distinguishes the project editor from the gallery.
 _PROJECT_URL_FRAGMENT = "/project/"
+
+# Image model picker (SOT flow-editor-map.json). Same arrow_drop_down trigger as
+# video; options matched by product name (NOT localized — but the editor must be
+# in English, forced via the --lang=en-US launch arg). 'Nano Banana 2' is not a
+# substring of 'Nano Banana Pro', so has-text is unambiguous across the three.
+IMAGE_MODEL_PICKER_TRIGGER = (
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))"
+)
+IMAGE_MODEL_OPTION_SELECTORS: dict[Model, str] = {
+    Model.NARWHAL: "[role='menuitem']:has-text('Nano Banana 2')",
+    Model.GEM_PIX_2: "[role='menuitem']:has-text('Nano Banana Pro')",
+    Model.IMAGEN_3_5: "[role='menuitem']:has-text('Imagen 4')",
+}
 
 # Image-mode tab inside the mode-switch dropdown.  Selectors are tried in
 # order; the leading ``aria-controls`` matches are language-independent
@@ -460,6 +473,12 @@ class UiAutomationTransport(VideoGenerationMixin):
                 args=[
                     "--disable-blink-features=AutomationControlled",
                     "--password-store=basic",
+                    # locale="en-US" only sets Accept-Language; Chrome still picks
+                    # its UI language from the profile/system and Flow then serves
+                    # /fx/<locale>/ with a localized editor (breaking text-based
+                    # selectors like the I2V frame slots). --lang forces the UI to
+                    # English so Flow stays on /fx/tools/flow for ANY profile.
+                    "--lang=en-US",
                 ],
             )
             # Hide the automation flag so reCAPTCHA Enterprise doesn't score
@@ -831,15 +850,47 @@ class UiAutomationTransport(VideoGenerationMixin):
             return False
 
     @staticmethod
+    async def _select_image_model(page: Page, model: Model) -> None:
+        """Click the image model picker and select `model` (Nano Banana 2 / Nano
+        Banana Pro / Imagen 4). Must run with the gen-settings panel open. Without
+        this the generation uses Flow's UI-default model and ``--model`` is a
+        no-op. Non-fatal on miss (logged at WARNING — the wrong model has a real
+        cost/quality impact, so a miss is a genuine signal)."""
+        option_sel = IMAGE_MODEL_OPTION_SELECTORS.get(model)
+        if option_sel is None:
+            log.warning("ui_automation.image_model_unknown", model=model.value)
+            return
+        try:
+            trigger = page.locator(IMAGE_MODEL_PICKER_TRIGGER).first
+            await trigger.wait_for(state="visible", timeout=4000)
+            await trigger.click()
+            await page.wait_for_timeout(500)
+            option = page.locator(option_sel).first
+            await option.wait_for(state="visible", timeout=4000)
+            await option.click()
+            await page.wait_for_timeout(500)
+            log.info("ui_automation.image_model_selected", model=model.value)
+        except Exception as e:  # noqa: BLE001 — non-fatal; Flow default applies
+            log.warning(
+                "ui_automation.image_model_not_set",
+                model=model.value,
+                error=str(e)[:80],
+                note="Flow default model applies",
+            )
+            await page.keyboard.press("Escape")  # close a stray model menu
+
+    @staticmethod
     async def _configure_generation_settings(
         page: Page,
         aspect_cli: str | None,
         count: int | None,
         *,
+        model: Model | None = None,
         out_dir: Path | None = None,
         prompt_idx: int | None = None,
     ) -> None:
-        """Open the per-generation settings panel and apply aspect ratio and count.
+        """Open the per-generation settings panel and apply model, aspect ratio,
+        and count.
 
         When ``out_dir`` and ``prompt_idx`` are both provided, diagnostic
         screenshots are saved as ``count_before_prompt_{idx}.png`` and
@@ -849,7 +900,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         Skips gracefully if the panel trigger cannot be found (non-fatal —
         generation will proceed with Flow's current default settings).
         """
-        if aspect_cli is None and count is None:
+        if aspect_cli is None and count is None and model is None:
             # Nothing to apply.
             return
 
@@ -862,6 +913,9 @@ class UiAutomationTransport(VideoGenerationMixin):
         if not await UiAutomationTransport._open_gen_settings_panel(page):
             log.warning("ui_automation.gen_settings_panel_not_found", skipping=True)
             return
+
+        if model is not None:
+            await UiAutomationTransport._select_image_model(page, model)
 
         if aspect_cli:
             candidates = _ASPECT_TAB_CANDIDATES.get(aspect_cli, (aspect_cli,))
@@ -1440,7 +1494,9 @@ class UiAutomationTransport(VideoGenerationMixin):
 
         # Configure generation settings (aspect ratio + count) BEFORE attaching
         # the response listener so settings clicks don't interfere with capture.
-        await self._configure_generation_settings(page, aspect_cli, request.count)
+        await self._configure_generation_settings(
+            page, aspect_cli, request.count, model=request.model
+        )
 
         # Attach the response listener SYNCHRONOUSLY before any prompt
         # action. asyncio.create_task is unsafe here: it defers the listener
@@ -1558,7 +1614,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         # Step 1 — configure settings (aspect + count) for this prompt.
         try:
             await self._configure_generation_settings(
-                page, aspect_cli, req.count, out_dir=out_dir, prompt_idx=idx
+                page, aspect_cli, req.count, model=req.model, out_dir=out_dir, prompt_idx=idx
             )
         except Exception as exc:  # noqa: BLE001 — broad on purpose; wrap into GFlowError
             return _fail(exc)

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -14,6 +14,7 @@ POST (spec §5.5).
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -25,6 +26,7 @@ from gflow_cli.api.video import (
     Aspect,
     GenerateVideoRequest,
     Mode,
+    VideoModel,
     VideoResult,
     VideoStatus,
     media_name_from_generate_response,
@@ -42,6 +44,7 @@ log = structlog.get_logger(__name__)
 # segment, so a project-id URL filter is impossible (deviation from §5.4).
 VIDEO_GENERATE_ROUTES = (
     "batchAsyncGenerateVideoText",
+    "batchAsyncGenerateVideoStartImage",
     "batchAsyncGenerateVideoStartAndEndImage",
     "batchAsyncGenerateVideoReferenceImages",
 )
@@ -60,33 +63,100 @@ MODE_SWITCH_TRIGGER_SELECTORS = (
     "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_landscape'))",
     "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_original'))",
 )
+# SOT (flow-editor-map.json): the VIDEO mode tab id ends with '-trigger-VIDEO'
+# (radix prefix is dynamic — match the suffix). aria-controls ends with
+# '-content-VIDEO'. Both are EXACT (ends-with), so they do NOT match the
+# sub-mode tabs '-trigger-VIDEO_FRAMES' / '-trigger-VIDEO_REFERENCES'. Icon +
+# id-suffix are locale-independent; the localized-text fallbacks come last.
 VIDEO_TAB_IN_MENU_SELECTORS = (
-    "[role='menu'] [role='tab'][aria-controls*='VIDEO']",
+    "[role='tab'][id$='-trigger-VIDEO']",
+    "[role='tab'][aria-controls$='-content-VIDEO']",
     "[role='menu'] [role='tab']:has(i:text('play_circle'))",
-    "[role='tab'][aria-controls*='VIDEO']",
     "[role='menu'] [role='tab']:has-text('Vídeo')",
     "[role='menu'] [role='tab']:has-text('Video')",
 )
-# Output-count tabs in the same dropdown. Flow defaults output count to x2
-# (two videos = double credits — spec §10.5); generate_video forces count=1.
-COUNT_ONE_SELECTORS = (
-    "[role='menu'] [role='tab'][aria-controls*='-content-1']",
-    "[role='menu'] [role='tab'][id*='-trigger-1']",
-    "[role='menu'] [role='tab']:text-is('1x')",
-)
-# Aspect tabs inside the open menu. §6 best-effort — the Phase 0 spike confirmed
-# video offers 9:16 / 16:9 only but did not lock an exact aspect-set selector;
-# Phase B e2e hardens these. A miss is non-fatal (Flow's default applies).
+# Output-count + duration tabs are selected by aria-label text in
+# `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
+# tab '-trigger-4' and the duration tab '-trigger-4' (4s) share a suffix, so an
+# id match is ambiguous (this was the prior '[id*=-trigger-1]' bug that also
+# caught '-trigger-10'). Labels '1x'/'x2'.. and '4s'/'6s'.. are unambiguous and
+# locale-independent.
+
+# Aspect tabs inside the open menu. SOT (flow-editor-map.json): video aspect
+# tab ids end with '-trigger-PORTRAIT' (9:16, icon crop_9_16) and
+# '-trigger-LANDSCAPE' (16:9, icon crop_16_9). The prior selector matched
+# aria-controls*='9_16', but the real aria-controls is '-content-PORTRAIT' /
+# '-content-LANDSCAPE' (NO '9_16'/'16_9' substring) — it never matched and
+# always fell through to text. id-suffix + icon are locale-independent and
+# exact (ends-with '-trigger-PORTRAIT' does not match the image-only
+# '-trigger-PORTRAIT_3_4'). A miss is non-fatal (Flow's default applies).
 VIDEO_ASPECT_TAB_SELECTORS: dict[Aspect, tuple[str, ...]] = {
     Aspect.PORTRAIT: (
-        "[role='menu'] [role='tab'][aria-controls*='9_16']",
-        "[role='menu'] [role='tab']:text-is('9:16')",
+        "[role='tab'][id$='-trigger-PORTRAIT']",
+        "[role='menu'] [role='tab']:has(i.google-symbols:text-is('crop_9_16'))",
         "[role='tab']:has-text('9:16')",
     ),
     Aspect.LANDSCAPE: (
-        "[role='menu'] [role='tab'][aria-controls*='16_9']",
-        "[role='menu'] [role='tab']:text-is('16:9')",
+        "[role='tab'][id$='-trigger-LANDSCAPE']",
+        "[role='menu'] [role='tab']:has(i.google-symbols:text-is('crop_16_9'))",
         "[role='tab']:has-text('16:9')",
+    ),
+}
+
+# Model picker (SOT flow-editor-map.json). The trigger is the only
+# button[aria-haspopup='menu'] carrying an 'arrow_drop_down' icon; its label is
+# the currently-selected model. Options are role='menuitem' matched by product
+# name (NOT localized). 'Veo 3.1 - Lite' is a prefix of 'Veo 3.1 - Lite [Lower
+# Priority]', so it needs an EXACT text match (the menuitem text is the model
+# name prefixed by the 'volume_up' icon ligature); the others match by has-text.
+MODEL_PICKER_TRIGGER = (
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))"
+)
+VIDEO_MODEL_OPTION_SELECTORS: dict[VideoModel, str] = {
+    VideoModel.OMNI_FLASH: "[role='menuitem']:has-text('Omni Flash')",
+    VideoModel.VEO_3_1_FAST: "[role='menuitem']:has-text('Veo 3.1 - Fast')",
+    VideoModel.VEO_3_1_QUALITY: "[role='menuitem']:has-text('Veo 3.1 - Quality')",
+    VideoModel.VEO_3_1_LITE: "[role='menuitem']:text-is('volume_upVeo 3.1 - Lite')",
+    VideoModel.VEO_3_1_LITE_LOWER_PRIORITY: "[role='menuitem']:has-text('[Lower Priority]')",
+}
+
+# Image-attach for I2V (SOT flow-editor-map.json + live verification).
+# CRITICAL: set_input_files() on the generic hidden input only adds the image to
+# the LIBRARY — it does NOT associate it with the start/end frame slot, so Flow
+# then fires the plain `batchAsyncGenerateVideoText` route (image ignored). The
+# frame slot MUST be filled through its own dialog: click the slot
+# (div[aria-haspopup='dialog'] labelled Start/End) -> 'Upload media' (opens a
+# file chooser) -> wait uploadImage -> 'Add to Prompt' to commit it into the
+# slot. Only then does the DOM Generate click fire StartImage/StartAndEndImage.
+UPLOAD_IMAGE_ROUTE = "uploadImage"
+# Frame slots are `div[aria-haspopup='dialog']`. Their label text is localized
+# (EN 'Start'/'End', TH 'เริ่ม'/'สิ้นสุด'). `_attach_frame` tries an English-text
+# match first (the account must be in English for I2V — there is no stable
+# locale-free anchor: no id-suffix, no icon), then falls back to a structural
+# match: the dialog-divs inside the swap_horiz container, by index (0=first,
+# 1=last; the swap_horiz BUTTON is excluded by `> div[aria-haspopup='dialog']`).
+FRAME_SLOT_BY_LABEL = "div[aria-haspopup='dialog']:has-text('{label}')"
+SWAP_CONTAINER = "div:has(> button:has(i.google-symbols:text-is('swap_horiz')))"
+FRAME_SLOTS_STRUCT = SWAP_CONTAINER + " > div[aria-haspopup='dialog']"
+UPLOAD_MEDIA_BUTTON = "button:has-text('Upload media')"
+ADD_TO_PROMPT_BUTTON = "button:has-text('Add to Prompt')"
+# R2V references mode has NO Start/End slots — references are added via the
+# only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
+# the 'add_2' icon (its visible text 'Create' / 'Add Media' is unreliable — a
+# has-text('Add Media') match grabbed a nav-header button instead). The icon +
+# dialog-popup combo is locale-free and unambiguous in the editor. Repeat up to
+# MAX_REFERENCE_IMAGES — the button persists to add the next reference.
+ADD_MEDIA_BUTTON = "button[aria-haspopup='dialog']:has(i.google-symbols:text-is('add_2'))"
+VIDEO_SUBMODE_SELECTORS: dict[str, tuple[str, ...]] = {
+    # I2V — "frames" (start + optional end frame). Icon: crop_free.
+    "frames": (
+        "[role='tab'][id$='-trigger-VIDEO_FRAMES']",
+        "[role='menu'] [role='tab']:has(i.google-symbols:text('crop_free'))",
+    ),
+    # R2V — "references"/ingredients/Elementos. Icon: chrome_extension.
+    "references": (
+        "[role='tab'][id$='-trigger-VIDEO_REFERENCES']",
+        "[role='menu'] [role='tab']:has(i.google-symbols:text('chrome_extension'))",
     ),
 }
 
@@ -113,6 +183,38 @@ async def _capture_debug_screenshot(page: Any, out_dir: Path | None, filename: s
     except Exception as e:  # noqa: BLE001 — screenshot is best-effort
         log.debug("ui_automation_video.screenshot_capture_failed", error=str(e))
     return shot_path
+
+
+def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
+    """Privacy-safe summary of the image inputs in a generate request body:
+    presence of startImage/endImage + referenceImages count, each as an 8-char
+    mediaId PREFIX (UUIDs are asset ids, not secrets). Proves the attached
+    images are bound into the request. Never returns the reCAPTCHA token or
+    credit balance. Non-fatal — returns ``{"parsed": False}`` on any error."""
+    try:
+        raw = request.post_data
+        if not raw:
+            return {"parsed": False}
+        data = cast("dict[str, Any]", json.loads(raw))
+        reqs = cast("list[dict[str, Any]]", data.get("requests") or [])
+        first: dict[str, Any] = reqs[0] if reqs else {}
+
+        def _mid(obj: Any) -> str | None:
+            if not isinstance(obj, dict):
+                return None
+            mid = cast("dict[str, Any]", obj).get("mediaId")
+            return mid[:8] if isinstance(mid, str) else None
+
+        refs = cast("list[dict[str, Any]]", first.get("referenceImages") or [])
+        return {
+            "parsed": True,
+            "startImage": _mid(first.get("startImage")),
+            "endImage": _mid(first.get("endImage")),
+            "referenceCount": len(refs),
+            "referenceIds": [_mid(r) for r in refs],
+        }
+    except Exception as e:  # noqa: BLE001 — diagnostic only
+        return {"parsed": False, "error": str(e)[:60]}
 
 
 class VideoGenerationMixin:
@@ -168,10 +270,17 @@ class VideoGenerationMixin:
                 log.warning("ui_automation_video.generate_parse_failed", error=str(e))
                 return
             captured.append({"status": response.status, "url": response.url, "body": body})
+            # Proof that the attached images actually made it into the request
+            # (the user saw the UI start generating before the upload spinner
+            # cleared). Parse the REQUEST post_data and log only counts +
+            # mediaId prefixes (UUIDs, not secrets) — never the token/credits.
+            inputs = _summarize_request_image_inputs(response.request)
+            captured[-1]["image_inputs"] = inputs
             log.info(
                 "ui_automation_video.generate_captured",
                 status=response.status,
                 url=response.url,
+                image_inputs=inputs,
             )
 
         page.on("response", on_response)
@@ -373,18 +482,233 @@ class VideoGenerationMixin:
             log.warning("ui_automation_video.editor_ready_timeout", error=str(e))
 
     @staticmethod
-    async def _set_output_count_one(page: Page) -> None:
-        """Force the output count to 1. Flow defaults to x2 (two videos =
-        double credits — spec §10.5). Non-fatal on miss."""
+    async def _set_output_count(page: Page, n: int) -> None:
+        """Set the output count to `n` (1-4). Flow defaults to x2 (two videos =
+        double credits — spec §10.5). Disambiguated by aria-label text
+        ('1x'/'x2'/'x3'/'x4'), NOT id-suffix — '-trigger-4' collides with the
+        DURATION 4s tab. Non-fatal on miss."""
+        label = "1x" if n == 1 else f"x{n}"
         tab = await VideoGenerationMixin._probe_selector_cascade(
-            page, "count_one_tab", COUNT_ONE_SELECTORS
+            page,
+            "count_tab",
+            (f"[role='tab']:text-is('{label}')", f"[role='tab']:has-text('{label}')"),
         )
         if tab is None:
-            log.warning("ui_automation_video.count_not_set", note="Flow default (x2) applies")
+            log.warning(
+                "ui_automation_video.count_not_set", count=n, note="Flow default (x2) applies"
+            )
             return
         await tab.click()
         await page.wait_for_timeout(400)
-        log.info("ui_automation_video.output_count_set", count=1)
+        log.info("ui_automation_video.output_count_set", count=n)
+
+    @staticmethod
+    async def _set_output_count_one(page: Page) -> None:
+        """Back-compat shim: force the output count to 1."""
+        await VideoGenerationMixin._set_output_count(page, 1)
+
+    @staticmethod
+    async def _select_video_model(page: Page, model: VideoModel, *, out_dir: Path | None) -> None:
+        """Open the model picker and select `model`. Non-fatal on miss (Flow's
+        default model applies) but logged at WARNING — picking the wrong model
+        changes credit cost, so a miss is a real signal, not noise."""
+        option_sel = VIDEO_MODEL_OPTION_SELECTORS.get(model)
+        if option_sel is None:
+            log.warning("ui_automation_video.model_unknown", model=model.value)
+            return
+        trigger = await VideoGenerationMixin._probe_selector_cascade(
+            page, "model_picker_trigger", (MODEL_PICKER_TRIGGER,)
+        )
+        if trigger is None:
+            log.warning(
+                "ui_automation_video.model_picker_not_found",
+                model=model.value,
+                note="Flow default model applies",
+            )
+            return
+        await trigger.click()
+        await page.wait_for_timeout(600)
+        option = await VideoGenerationMixin._probe_selector_cascade(
+            page, "model_option", (option_sel,)
+        )
+        if option is None:
+            log.warning(
+                "ui_automation_video.model_option_not_found",
+                model=model.value,
+                note="Flow default model applies",
+            )
+            # The model dropdown is the TOP layer here — Escape closes only it,
+            # leaving the settings popover open (Escape on the popover itself
+            # would close everything). Safe to recover.
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(200)
+            return
+        await option.click()
+        await page.wait_for_timeout(800)
+        log.info("ui_automation_video.model_selected", model=model.value)
+
+    @staticmethod
+    async def _select_video_duration(page: Page, seconds: int) -> None:
+        """Click the duration tab for `seconds` (4/6/8, or 10 for omni_flash).
+        Disambiguated by aria-label text ('4s'..'10s'), NOT id-suffix
+        (collides with count). Must run AFTER model select — the 10s tab only
+        exists once omni_flash is chosen. Non-fatal on miss."""
+        tab = await VideoGenerationMixin._probe_selector_cascade(
+            page,
+            "duration_tab",
+            (f"[role='tab']:text-is('{seconds}s')", f"[role='tab']:has-text('{seconds}s')"),
+        )
+        if tab is None:
+            log.warning("ui_automation_video.duration_not_set", seconds=seconds)
+            return
+        await tab.click()
+        await page.wait_for_timeout(400)
+        log.info("ui_automation_video.duration_set", seconds=seconds)
+
+    @staticmethod
+    async def _switch_video_sub_mode(page: Page, sub: str, *, out_dir: Path | None) -> None:
+        """Switch the video sub-mode tab: 'frames' (I2V) or 'references' (R2V).
+        Must run while the settings panel is open (after _switch_to_video_mode)."""
+        tab = await VideoGenerationMixin._probe_selector_cascade(
+            page, f"video_submode_{sub}", VIDEO_SUBMODE_SELECTORS[sub]
+        )
+        if tab is None:
+            shot = await _capture_debug_screenshot(page, out_dir, f"debug_no_submode_{sub}.png")
+            raise RuntimeError(
+                f"video sub-mode tab {sub!r} not found on the Flow editor. Screenshot: {shot}"
+            )
+        await tab.click()
+        await page.wait_for_timeout(900)
+        log.info("ui_automation_video.video_submode_entered", sub=sub)
+
+    @staticmethod
+    async def _attach_frame(
+        page: Page,
+        slot_index: int,
+        label: str,
+        image: Path,
+        *,
+        out_dir: Path | None,
+        timeout_s: float = 120.0,
+    ) -> None:
+        """Fill the I2V first/last frame slot (`slot_index` 0=first, 1=last) with
+        `image` through Flow's media dialog (the ONLY way that binds the image to
+        the slot — set_input_files on the generic input only adds it to the
+        library, see the UPLOAD_IMAGE_ROUTE note). Sequence: click slot ->
+        'Upload media' (file chooser) -> wait uploadImage -> commit. Must run with
+        the settings panel CLOSED (the slots live in the main editor). `label` is
+        for logging only. Path existence is validated here (the boundary)."""
+        if not image.exists():
+            raise FileNotFoundError(f"frame image not found: {image}")
+
+        # Locate the slot: English text label first (the editor runs in English
+        # via the --lang=en-US launch arg), then a structural fallback (the
+        # dialog-divs inside the swap_horiz container, by index).
+        slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+        if not await slot.count():
+            structs = page.locator(FRAME_SLOTS_STRUCT)
+            try:
+                await structs.first.wait_for(state="visible", timeout=8000)
+            except Exception as e:  # noqa: BLE001
+                shot = await _capture_debug_screenshot(
+                    page, out_dir, f"debug_no_{label.lower()}_slot.png"
+                )
+                raise RuntimeError(
+                    f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+                ) from e
+            if await structs.count() <= slot_index:
+                raise RuntimeError(
+                    f"frame slot index {slot_index} ({label}) not present "
+                    f"(found {await structs.count()} slot(s))"
+                )
+            slot = structs.nth(slot_index)
+        await slot.click()
+        await page.wait_for_timeout(1000)  # media dialog opens
+        await VideoGenerationMixin._upload_via_open_dialog(
+            page, image, log_label=label, timeout_s=timeout_s
+        )
+        log.info("ui_automation_video.frame_attached", slot=label)
+
+    @staticmethod
+    async def _upload_via_open_dialog(
+        page: Page, image: Path, *, log_label: str, timeout_s: float = 120.0
+    ) -> None:
+        """With a media dialog ALREADY open, upload `image` and commit it into
+        the active slot/carousel: 'Upload media' (file chooser) -> wait the
+        uploadImage XHR 200 (bytes stored) -> 'Add to Prompt' -> wait the dialog
+        to CLOSE (commit registered) before returning, so the caller never
+        submits before the image binds. Shared by I2V slots and R2V references."""
+        uploaded: list[str] = []
+
+        async def on_response(response: Any) -> None:
+            if UPLOAD_IMAGE_ROUTE in response.url:
+                uploaded.append(response.url)
+                log.info(
+                    "ui_automation_video.image_uploaded", target=log_label, status=response.status
+                )
+
+        page.on("response", on_response)
+        try:
+            async with page.expect_file_chooser(timeout=8000) as fc_info:
+                await page.locator(UPLOAD_MEDIA_BUTTON).first.click()
+            chooser = await fc_info.value
+            await chooser.set_files(str(image))
+            deadline = time.monotonic() + timeout_s
+            while not uploaded and time.monotonic() < deadline:
+                await asyncio.sleep(0.5)
+            if not uploaded:
+                log.warning("ui_automation_video.upload_incomplete", target=log_label)
+        finally:
+            page.remove_listener("response", on_response)
+
+        add_btn = page.locator(ADD_TO_PROMPT_BUTTON).first
+        if await add_btn.count():
+            await add_btn.click()
+        try:
+            await page.locator("[role='dialog']").last.wait_for(state="hidden", timeout=15_000)
+        except Exception:  # noqa: BLE001 — best-effort; fall through to a settle
+            log.warning("ui_automation_video.dialog_close_timeout", target=log_label)
+        await page.wait_for_timeout(1500)
+
+    @staticmethod
+    async def _attach_references(
+        page: Page, images: list[Path], *, out_dir: Path | None, timeout_s: float = 120.0
+    ) -> None:
+        """R2V: attach up to MAX_REFERENCE_IMAGES reference images. References
+        have no Start/End slots — each is added via the 'Add Media' button, which
+        opens the same media dialog. Must run with the settings panel closed."""
+        missing = [str(p) for p in images if not p.exists()]
+        if missing:
+            raise FileNotFoundError(f"reference image(s) not found: {missing}")
+        attached = 0
+        for i, img in enumerate(images):
+            add_media = page.locator(ADD_MEDIA_BUTTON).first
+            try:
+                await add_media.wait_for(state="visible", timeout=8000)
+            except Exception as e:  # noqa: BLE001
+                if i == 0:
+                    shot = await _capture_debug_screenshot(page, out_dir, "debug_no_add_media.png")
+                    raise RuntimeError(
+                        f"'Add Media' button not found for the first reference. Screenshot: {shot}"
+                    ) from e
+                # Flow removes the Add-Media button once the per-model reference
+                # cap is hit (omni_flash=7, veo_3_1_*=3). The DTO enforces this
+                # when the model is known; for an unknown (None) model we only
+                # learn the cap here. Proceed with what's attached + warn loudly.
+                log.warning(
+                    "ui_automation_video.reference_cap_reached",
+                    attached=attached,
+                    requested=len(images),
+                    note="Flow hid 'Add Media' — per-model reference cap reached",
+                )
+                break
+            await add_media.click()
+            await page.wait_for_timeout(1000)
+            await VideoGenerationMixin._upload_via_open_dialog(
+                page, img, log_label=f"ref{i}", timeout_s=timeout_s
+            )
+            attached += 1
+            log.info("ui_automation_video.reference_attached", index=i)
 
     @staticmethod
     async def _select_video_aspect(page: Page, aspect: Aspect) -> None:
@@ -430,22 +754,20 @@ class VideoGenerationMixin:
         poll_timeout_s: float = 600.0,
         download: bool = True,
     ) -> VideoResult:
-        """Generate ONE video by driving the Flow editor UI (Phase A: T2V only).
+        """Generate ONE video by driving the Flow editor UI (T2V / I2V / R2V).
 
         Returns a `VideoResult` carrying both the terminal `VideoStatus` and the
         on-disk `local_path` (``None`` when ``download=False`` or the generation
         failed — callers should check ``result.status.succeeded`` first). Raises
-        `RuntimeError` (no setup / editor control missing), `NotImplementedError`
-        (non-T2V), `ValueError` (SQUARE aspect), `AuthExpiredError` (401),
-        `WafRejectionError` (403), `WireFormatError` (other non-200 / no media),
-        or `TimeoutError`.
+        `RuntimeError` (no setup / editor control missing), `ValueError` (SQUARE
+        aspect), `FileNotFoundError` (I2V/R2V image path missing),
+        `AuthExpiredError` (401), `WafRejectionError` (403), `WireFormatError`
+        (other non-200 / no media), or `TimeoutError`.
         """
         if not self._setup_done or self._page is None:
             raise RuntimeError(
                 "UiAutomationTransport.setup() must be called before generate_video()"
             )
-        if request.mode is not Mode.T2V:
-            raise NotImplementedError("Phase A supports T2V only; I2V and R2V land in Phase B")
         if request.aspect is Aspect.SQUARE:
             raise ValueError(
                 "video generation does not support the SQUARE aspect; "
@@ -471,10 +793,36 @@ class VideoGenerationMixin:
         # of the editor before we click into mode-switch / settings / submit (#26).
         await self._dismiss_blocking_overlays(page, out_dir)
         await VideoGenerationMixin._switch_to_video_mode(page, out_dir=out_dir)
+        # All settings-panel selections happen while the panel is open: model
+        # (gates the 10s duration), sub-mode tab, aspect, count, duration.
+        if request.model is not None:
+            await VideoGenerationMixin._select_video_model(page, request.model, out_dir=out_dir)
+        if request.mode is Mode.I2V:
+            await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=out_dir)
+        elif request.mode is Mode.R2V:
+            await VideoGenerationMixin._switch_video_sub_mode(page, "references", out_dir=out_dir)
         await VideoGenerationMixin._select_video_aspect(page, request.aspect)
-        await VideoGenerationMixin._set_output_count_one(page)
-        await page.keyboard.press("Escape")  # close the mode dropdown
-        await page.wait_for_timeout(400)
+        await VideoGenerationMixin._set_output_count(page, request.count)
+        if request.duration is not None:
+            await VideoGenerationMixin._select_video_duration(page, request.duration)
+        await page.keyboard.press("Escape")  # close the settings panel
+        await page.wait_for_timeout(600)
+
+        # Attach images AFTER the panel is closed — the slots / 'Add Media' button
+        # live in the main editor. This is what makes Flow fire StartImage /
+        # StartAndEndImage / ReferenceImages instead of the plain Text route.
+        if request.mode is Mode.I2V and request.start_image is not None:
+            await VideoGenerationMixin._attach_frame(
+                page, 0, "Start", request.start_image, out_dir=out_dir
+            )
+            if request.end_image is not None:
+                await VideoGenerationMixin._attach_frame(
+                    page, 1, "End", request.end_image, out_dir=out_dir
+                )
+        elif request.mode is Mode.R2V:
+            await VideoGenerationMixin._attach_references(
+                page, list(request.reference_images), out_dir=out_dir
+            )
 
         # Attach BOTH listeners synchronously BEFORE the prompt is submitted so
         # neither the generate response nor an early status poll is missed.

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -25,6 +25,54 @@ class Tier(StrEnum):
     QUALITY = "quality"
 
 
+class VideoModel(StrEnum):
+    """Flow video model, as exposed in the editor's model picker.
+
+    Verified live (flow-editor-map.json): the picker offers exactly these five.
+    Only ``OMNI_FLASH`` exposes a 10s duration; the four ``VEO_3_1_*`` models
+    cap at 8s. The selector for each lives in the transport layer (this module
+    is pure — no DOM knowledge).
+    """
+
+    OMNI_FLASH = "omni_flash"
+    VEO_3_1_LITE = "veo_3_1_lite"
+    VEO_3_1_FAST = "veo_3_1_fast"
+    VEO_3_1_QUALITY = "veo_3_1_quality"
+    VEO_3_1_LITE_LOWER_PRIORITY = "veo_3_1_lite_lower_priority"
+
+    @classmethod
+    def from_cli(cls, value: str | None) -> VideoModel | None:
+        """Map a friendly CLI alias to the model. ``None`` -> ``None`` (use
+        Flow's UI default — the picker is not touched)."""
+        if value is None:
+            return None
+        key = value.strip().lower().replace("-", "_").replace(" ", "_")
+        mapping = {
+            "omni_flash": cls.OMNI_FLASH,
+            "omni": cls.OMNI_FLASH,
+            "flash": cls.OMNI_FLASH,
+            "veo_3_1_lite": cls.VEO_3_1_LITE,
+            "veo_lite": cls.VEO_3_1_LITE,
+            "lite": cls.VEO_3_1_LITE,
+            "veo_3_1_fast": cls.VEO_3_1_FAST,
+            "veo_fast": cls.VEO_3_1_FAST,
+            "fast": cls.VEO_3_1_FAST,
+            "veo_3_1_quality": cls.VEO_3_1_QUALITY,
+            "veo_quality": cls.VEO_3_1_QUALITY,
+            "quality": cls.VEO_3_1_QUALITY,
+            "veo_3_1_lite_lower_priority": cls.VEO_3_1_LITE_LOWER_PRIORITY,
+            "veo_lite_lp": cls.VEO_3_1_LITE_LOWER_PRIORITY,
+            "lite_lp": cls.VEO_3_1_LITE_LOWER_PRIORITY,
+            "lower_priority": cls.VEO_3_1_LITE_LOWER_PRIORITY,
+        }
+        if key not in mapping:
+            raise ValueError(
+                f"Unknown video model {value!r}; choose from "
+                f"{sorted({m.value for m in cls})} or aliases {sorted(mapping)}"
+            )
+        return mapping[key]
+
+
 class Aspect(StrEnum):
     PORTRAIT = "portrait"
     LANDSCAPE = "landscape"
@@ -41,11 +89,14 @@ class Aspect(StrEnum):
         return mapping[value]
 
 
-# Flow's R2V ("Elementos") reference-image slot cap. ESTIMATE — spec §10.2 Q6
-# was NOT resolved by the Phase 0 spike (§10.5); Phase B confirms the real
-# upper bound. R2V is not wired in Phase A, so this value is never exercised
-# in production yet.
-MAX_REFERENCE_IMAGES = 3
+# Flow's R2V reference cap is MODEL-DEPENDENT (live-verified): omni_flash allows
+# 7 ("Maximum image ingredients reached (7 allowed)"), the veo_3_1_* models allow
+# 3. A veo request with >3 refs uploads all but the generate request silently
+# keeps only 3. MAX_REFERENCE_IMAGES is the absolute ceiling (omni); the
+# model-aware check below enforces the per-model limit when the model is known.
+OMNI_REFERENCE_CAP = 7
+VEO_REFERENCE_CAP = 3
+MAX_REFERENCE_IMAGES = OMNI_REFERENCE_CAP
 
 
 @dataclass(frozen=True)
@@ -62,6 +113,9 @@ class GenerateVideoRequest:
     mode: Mode = Mode.T2V
     aspect: Aspect = Aspect.PORTRAIT
     tier: Tier = Tier.FAST  # meaningful for T2V only — I2V/R2V model keys are fixed
+    model: VideoModel | None = None  # None -> Flow UI default (picker untouched)
+    duration: int | None = None  # seconds: 4/6/8 (or 10, omni_flash only); None -> default
+    count: int = 1  # 1-4 outputs; >1 multiplies credit cost
     seed: int | None = None
     start_image: Path | None = None  # I2V
     end_image: Path | None = None  # I2V (optional)
@@ -70,6 +124,19 @@ class GenerateVideoRequest:
     def __post_init__(self) -> None:
         if not self.prompt.strip():
             raise ValueError("prompt must not be empty")
+        if self.duration is not None and self.duration not in (4, 6, 8, 10):
+            raise ValueError(f"duration must be one of 4/6/8/10 seconds, got {self.duration}")
+        if (
+            self.duration == 10
+            and self.model is not None
+            and self.model is not VideoModel.OMNI_FLASH
+        ):
+            raise ValueError(
+                f"10s duration is only available for the omni_flash model; "
+                f"{self.model.value} caps at 8s"
+            )
+        if not (1 <= self.count <= 4):
+            raise ValueError(f"count must be 1-4, got {self.count}")
         if self.mode is Mode.T2V and (self.start_image or self.end_image or self.reference_images):
             raise ValueError("T2V request must not carry image inputs")
         if self.mode is Mode.I2V:
@@ -84,6 +151,15 @@ class GenerateVideoRequest:
                 raise ValueError("R2V request must not carry start/end images")
         if len(self.reference_images) > MAX_REFERENCE_IMAGES:
             raise ValueError(f"at most {MAX_REFERENCE_IMAGES} reference images")
+        # Per-model reference cap: omni_flash=7, veo_3_1_*=3 (live-verified). When
+        # the model is None (Flow UI default) we can't know it — leave the ceiling.
+        if self.mode is Mode.R2V and self.model is not None:
+            cap = OMNI_REFERENCE_CAP if self.model is VideoModel.OMNI_FLASH else VEO_REFERENCE_CAP
+            if len(self.reference_images) > cap:
+                raise ValueError(
+                    f"{self.model.value} allows at most {cap} reference images; "
+                    f"got {len(self.reference_images)} (omni_flash allows {OMNI_REFERENCE_CAP})"
+                )
         if self.seed is not None and not (0 <= self.seed <= 2**31 - 1):
             raise ValueError("seed out of range")
 

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -1,7 +1,7 @@
 """`gflow video` command group.
 
-Phase B wires `t2v` to `UiAutomationTransport.generate_video` with
-auto-download. `i2v` and `batch` remain stubbed pending Phase B I2V work.
+`t2v` and `i2v` drive `UiAutomationTransport.generate_video` with auto-download.
+`batch` remains stubbed pending a manifest-driven runner.
 """
 
 from __future__ import annotations
@@ -20,41 +20,22 @@ from gflow_cli._cli_helpers import (
 
 console = Console()
 
-_I2V_UNAVAILABLE = (
-    "[yellow]`gflow video i2v` is not yet available.[/yellow]\n"
-    "I2V on UiAutomationTransport lands in a later Phase B release."
-)
-
 _BATCH_UNAVAILABLE = (
     "[yellow]`gflow video batch` is not yet available.[/yellow]\n"
-    "Batch video on UiAutomationTransport lands in a later Phase B release."
+    "Batch video on UiAutomationTransport lands in a later release."
 )
 
 
-async def _run_t2v(
-    *,
-    profile_dir: Path,
-    prompt: str,
-    aspect: str,
-    out_dir: Path | None,
-) -> None:
+async def _generate_and_report(request: Any, *, profile_dir: Path, out_dir: Path | None) -> None:
+    """Drive the transport for a single GenerateVideoRequest and print the
+    result (or fail with a non-zero exit). Shared by t2v and i2v."""
     from gflow_cli.api.transports.ui_automation import UiAutomationTransport
-    from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode
 
-    request = GenerateVideoRequest(
-        prompt=prompt,
-        mode=Mode.T2V,
-        aspect=Aspect.from_cli(aspect),
-    )
     transport = UiAutomationTransport()
     try:
         await transport.setup(profile_dir)
         console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
-        result = await transport.generate_video(
-            request=request,
-            out_dir=out_dir,
-            download=True,
-        )
+        result = await transport.generate_video(request=request, out_dir=out_dir, download=True)
     finally:
         await transport.teardown()
 
@@ -70,9 +51,79 @@ async def _run_t2v(
     console.print(f"[bold green]Saved:[/bold green] {result.local_path}")
 
 
-async def _run_i2v(**kwargs: Any) -> None:  # pragma: no cover
-    console.print(_I2V_UNAVAILABLE)
-    raise SystemExit(1)
+async def _run_t2v(
+    *,
+    profile_dir: Path,
+    prompt: str,
+    aspect: str,
+    out_dir: Path | None,
+    model: str | None = None,
+    duration: int | None = None,
+    count: int = 1,
+) -> None:
+    from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
+
+    request = GenerateVideoRequest(
+        prompt=prompt,
+        mode=Mode.T2V,
+        aspect=Aspect.from_cli(aspect),
+        model=VideoModel.from_cli(model),
+        duration=duration,
+        count=count,
+    )
+    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
+
+
+async def _run_i2v(
+    *,
+    profile_dir: Path,
+    image: str,
+    prompt: str,
+    aspect: str,
+    out_dir: Path | None,
+    end_image: str | None = None,
+    model: str | None = None,
+    duration: int | None = None,
+    count: int = 1,
+) -> None:
+    from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
+
+    request = GenerateVideoRequest(
+        prompt=prompt,
+        mode=Mode.I2V,
+        aspect=Aspect.from_cli(aspect),
+        model=VideoModel.from_cli(model),
+        duration=duration,
+        count=count,
+        start_image=Path(image),
+        end_image=Path(end_image) if end_image else None,
+    )
+    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
+
+
+async def _run_r2v(
+    *,
+    profile_dir: Path,
+    prompt: str,
+    refs: tuple[str, ...],
+    aspect: str,
+    out_dir: Path | None,
+    model: str | None = None,
+    duration: int | None = None,
+    count: int = 1,
+) -> None:
+    from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
+
+    request = GenerateVideoRequest(
+        prompt=prompt,
+        mode=Mode.R2V,
+        aspect=Aspect.from_cli(aspect),
+        model=VideoModel.from_cli(model),
+        duration=duration,
+        count=count,
+        reference_images=tuple(Path(r) for r in refs),
+    )
+    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
 
 
 async def _run_batch(**kwargs: Any) -> None:  # pragma: no cover
@@ -105,6 +156,25 @@ def video() -> None:
     type=click.Choice(["9:16", "16:9"]),
     help="Video aspect ratio (portrait 9:16 or landscape 16:9).",
 )
+@click.option(
+    "--model",
+    default=None,
+    type=click.Choice(["omni-flash", "veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
+    help="Veo model. Omit to use Flow's current default. Only omni-flash supports --duration 10.",
+)
+@click.option(
+    "--duration",
+    default=None,
+    type=click.Choice(["4", "6", "8", "10"]),
+    help="Clip length in seconds. 10 requires --model omni-flash. Omit for Flow's default.",
+)
+@click.option(
+    "--count",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 4),
+    help="How many videos to generate (1-4). >1 multiplies credit cost.",
+)
 @click.option("--profile", default=None, help="Profile name (overrides default).")
 @click.option(
     "--out-dir",
@@ -113,7 +183,15 @@ def video() -> None:
     type=click.Path(file_okay=False, path_type=Path),
     help="Directory to save the generated mp4. Defaults to tmp/.",
 )
-def t2v(prompt: str, aspect: str, profile: str | None, out_dir: Path | None) -> None:
+def t2v(
+    prompt: str,
+    aspect: str,
+    model: str | None,
+    duration: str | None,
+    count: int,
+    profile: str | None,
+    out_dir: Path | None,
+) -> None:
     """Generate a video from PROMPT."""
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
@@ -123,21 +201,179 @@ def t2v(prompt: str, aspect: str, profile: str | None, out_dir: Path | None) -> 
             prompt=prompt,
             aspect=aspect,
             out_dir=out_dir,
+            model=model,
+            duration=int(duration) if duration is not None else None,
+            count=count,
         ),
         cli_command="video t2v",
     )
 
 
-@video.command("i2v")
-@click.argument("image", required=False)
-@click.argument("prompt", required=False)
-def i2v(image: str | None, prompt: str | None) -> None:
-    """Generate a video from a start image + prompt (not yet available)."""
-    profile_name = _resolve_profile(None)
+@video.command(
+    "i2v",
+    short_help="Generate a video from a start image + motion prompt.",
+    help=(
+        "Image-to-video: animate a start image with a motion prompt (Veo).\n\n"
+        "\b\n"
+        "Examples:\n"
+        '  gflow video i2v hero.png "slow cinematic push-in"\n'
+        '  gflow video i2v hero.png "pan left" --end-image last.png --aspect 16:9\n'
+        '  gflow video i2v cat.png "it leaps" --model veo-quality --duration 8\n'
+    ),
+)
+@click.argument("image")
+@click.argument("prompt")
+@click.option(
+    "--end-image",
+    "end_image",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    help="Optional end frame — Flow interpolates start -> end.",
+)
+@click.option(
+    "--aspect",
+    default="9:16",
+    show_default=True,
+    type=click.Choice(["9:16", "16:9"]),
+    help="Video aspect ratio.",
+)
+@click.option(
+    "--model",
+    default=None,
+    type=click.Choice(["omni-flash", "veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
+    help="Veo model. Omit to use Flow's current default.",
+)
+@click.option(
+    "--duration",
+    default=None,
+    type=click.Choice(["4", "6", "8", "10"]),
+    help="Clip length in seconds. 10 requires --model omni-flash.",
+)
+@click.option(
+    "--count",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 4),
+    help="How many videos to generate (1-4).",
+)
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+@click.option(
+    "--out-dir",
+    "out_dir",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory to save the generated mp4. Defaults to tmp/.",
+)
+def i2v(
+    image: str,
+    prompt: str,
+    end_image: str | None,
+    aspect: str,
+    model: str | None,
+    duration: str | None,
+    count: int,
+    profile: str | None,
+    out_dir: Path | None,
+) -> None:
+    """Generate a video from a start IMAGE + motion PROMPT."""
+    profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(
-        lambda: _run_i2v(image=image, prompt=prompt, provider_dir=provider_dir),
+        lambda: _run_i2v(
+            profile_dir=provider_dir,
+            image=image,
+            prompt=prompt,
+            end_image=end_image,
+            aspect=aspect,
+            model=model,
+            duration=int(duration) if duration is not None else None,
+            count=count,
+            out_dir=out_dir,
+        ),
         cli_command="video i2v",
+    )
+
+
+@video.command(
+    "r2v",
+    short_help="Generate a video from reference images + prompt (ingredients).",
+    help=(
+        "Reference-to-video: condition a generation on 1-3 reference images "
+        "(Flow's 'ingredients' / Elementos).\n\n"
+        "\b\n"
+        "Examples:\n"
+        '  gflow video r2v "a knight in this armor walks forward" --ref armor.png\n'
+        '  gflow video r2v "they meet" --ref a.png --ref b.png --aspect 16:9\n'
+    ),
+)
+@click.argument("prompt")
+@click.option(
+    "--ref",
+    "refs",
+    multiple=True,
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    help="Reference image (repeat for up to 3).",
+)
+@click.option(
+    "--aspect",
+    default="9:16",
+    show_default=True,
+    type=click.Choice(["9:16", "16:9"]),
+    help="Video aspect ratio.",
+)
+@click.option(
+    "--model",
+    default=None,
+    type=click.Choice(["omni-flash", "veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
+    help="Veo model. Omit to use Flow's current default.",
+)
+@click.option(
+    "--duration",
+    default=None,
+    type=click.Choice(["4", "6", "8", "10"]),
+    help="Clip length in seconds. 10 requires --model omni-flash.",
+)
+@click.option(
+    "--count",
+    default=1,
+    show_default=True,
+    type=click.IntRange(1, 4),
+    help="How many videos to generate (1-4).",
+)
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+@click.option(
+    "--out-dir",
+    "out_dir",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory to save the generated mp4. Defaults to tmp/.",
+)
+def r2v(
+    prompt: str,
+    refs: tuple[str, ...],
+    aspect: str,
+    model: str | None,
+    duration: str | None,
+    count: int,
+    profile: str | None,
+    out_dir: Path | None,
+) -> None:
+    """Generate a video from reference images (--ref) + PROMPT."""
+    profile_name = _resolve_profile(profile)
+    provider_dir = _make_provider_dir(profile_name)
+    run_with_handlers(
+        lambda: _run_r2v(
+            profile_dir=provider_dir,
+            prompt=prompt,
+            refs=refs,
+            aspect=aspect,
+            model=model,
+            duration=int(duration) if duration is not None else None,
+            count=count,
+            out_dir=out_dir,
+        ),
+        cli_command="video r2v",
     )
 
 

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -13,11 +13,53 @@ from gflow_cli.api.video import (
     GenerateVideoRequest,
     Mode,
     Tier,
+    VideoModel,
     VideoResult,
     VideoStatus,
     media_name_from_generate_response,
     parse_video_status,
 )
+
+
+class TestVideoModelEnum:
+    def test_from_cli_none_returns_none(self) -> None:
+        assert VideoModel.from_cli(None) is None
+
+    def test_from_cli_aliases(self) -> None:
+        assert VideoModel.from_cli("omni-flash") is VideoModel.OMNI_FLASH
+        assert VideoModel.from_cli("veo-fast") is VideoModel.VEO_3_1_FAST
+        assert VideoModel.from_cli("veo-quality") is VideoModel.VEO_3_1_QUALITY
+        assert VideoModel.from_cli("veo-lite") is VideoModel.VEO_3_1_LITE
+        assert VideoModel.from_cli("veo-lite-lp") is VideoModel.VEO_3_1_LITE_LOWER_PRIORITY
+
+    def test_from_cli_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown video model"):
+            VideoModel.from_cli("sora")
+
+
+class TestVideoRequestNewFields:
+    def test_defaults(self) -> None:
+        req = GenerateVideoRequest(prompt="x")
+        assert req.model is None
+        assert req.duration is None
+        assert req.count == 1
+
+    def test_invalid_duration_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duration must be"):
+            GenerateVideoRequest(prompt="x", duration=5)
+
+    def test_10s_requires_omni_flash(self) -> None:
+        with pytest.raises(ValueError, match="10s duration"):
+            GenerateVideoRequest(prompt="x", duration=10, model=VideoModel.VEO_3_1_FAST)
+        # omni_flash + 10s, and model-less 10s (default unknown), are both OK
+        GenerateVideoRequest(prompt="x", duration=10, model=VideoModel.OMNI_FLASH)
+        GenerateVideoRequest(prompt="x", duration=10)
+
+    def test_count_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="count must be"):
+            GenerateVideoRequest(prompt="x", count=5)
+        with pytest.raises(ValueError, match="count must be"):
+            GenerateVideoRequest(prompt="x", count=0)
 
 
 class TestAspectEnum:
@@ -102,6 +144,21 @@ class TestGenerateVideoRequest:
         too_many = tuple(Path(f"r{i}.png") for i in range(MAX_REFERENCE_IMAGES + 1))
         with pytest.raises(ValueError, match="at most"):
             GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=too_many)
+
+    def test_per_model_reference_cap(self) -> None:
+        refs5 = tuple(Path(f"r{i}.png") for i in range(5))
+        refs7 = tuple(Path(f"r{i}.png") for i in range(7))
+        # veo caps at 3 -> 5 refs rejected
+        with pytest.raises(ValueError, match="at most 3 reference"):
+            GenerateVideoRequest(
+                prompt="x", mode=Mode.R2V, model=VideoModel.VEO_3_1_FAST, reference_images=refs5
+            )
+        # omni_flash allows 7
+        GenerateVideoRequest(
+            prompt="x", mode=Mode.R2V, model=VideoModel.OMNI_FLASH, reference_images=refs7
+        )
+        # model None -> only the absolute ceiling (7) applies; 5 is fine
+        GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=refs5)
 
     def test_seed_range_enforced(self) -> None:
         with pytest.raises(ValueError, match="seed out of range"):

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -152,6 +152,7 @@ def _cascade_page(visible: set[str]) -> MagicMock:
     page.locator = MagicMock(side_effect=_locator)
     page.wait_for_timeout = AsyncMock()
     page.screenshot = AsyncMock()
+    page.keyboard.press = AsyncMock()
     return page
 
 
@@ -217,9 +218,8 @@ class TestWaitVideoEditorReady:
 class TestSetOutputCountOne:
     @pytest.mark.asyncio
     async def test_clicks_the_count_one_tab(self) -> None:
-        from gflow_cli.api.transports import ui_automation_video as mod
 
-        sel = mod.COUNT_ONE_SELECTORS[0]
+        sel = "[role='tab']:text-is('1x')"  # _set_output_count(1) probes the '1x' label
         page = _cascade_page({sel})
         await VideoGenerationMixin._set_output_count_one(page)
         page.locator.assert_any_call(sel)
@@ -228,6 +228,61 @@ class TestSetOutputCountOne:
     async def test_missing_count_tab_is_non_fatal(self) -> None:
         page = _cascade_page(set())
         await VideoGenerationMixin._set_output_count_one(page)  # must not raise
+
+
+class TestSelectVideoModel:
+    @pytest.mark.asyncio
+    async def test_clicks_trigger_then_option(self) -> None:
+        from gflow_cli.api.transports import ui_automation_video as mod
+        from gflow_cli.api.video import VideoModel
+
+        trig = mod.MODEL_PICKER_TRIGGER
+        opt = mod.VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_FAST]
+        page = _cascade_page({trig, opt})
+        await VideoGenerationMixin._select_video_model(page, VideoModel.VEO_3_1_FAST, out_dir=None)
+        page.locator.assert_any_call(trig)
+        page.locator.assert_any_call(opt)
+
+    @pytest.mark.asyncio
+    async def test_missing_trigger_is_non_fatal(self) -> None:
+        from gflow_cli.api.video import VideoModel
+
+        page = _cascade_page(set())
+        # must not raise
+        await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+
+    @pytest.mark.asyncio
+    async def test_missing_option_escapes_to_recover(self) -> None:
+        from gflow_cli.api.transports import ui_automation_video as mod
+        from gflow_cli.api.video import VideoModel
+
+        # trigger visible but the option is not -> Escape closes the stray menu
+        page = _cascade_page({mod.MODEL_PICKER_TRIGGER})
+        await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+        page.keyboard.press.assert_any_call("Escape")
+
+
+class TestSelectVideoDuration:
+    @pytest.mark.asyncio
+    async def test_clicks_the_duration_tab(self) -> None:
+        sel = "[role='tab']:text-is('6s')"
+        page = _cascade_page({sel})
+        await VideoGenerationMixin._select_video_duration(page, 6)
+        page.locator.assert_any_call(sel)
+
+    @pytest.mark.asyncio
+    async def test_missing_duration_tab_is_non_fatal(self) -> None:
+        page = _cascade_page(set())
+        await VideoGenerationMixin._select_video_duration(page, 10)  # must not raise
+
+
+class TestSetOutputCount:
+    @pytest.mark.asyncio
+    async def test_clicks_the_count_n_tab(self) -> None:
+        sel = "[role='tab']:text-is('x3')"
+        page = _cascade_page({sel})
+        await VideoGenerationMixin._set_output_count(page, 3)
+        page.locator.assert_any_call(sel)
 
 
 class TestSelectVideoAspect:
@@ -266,8 +321,14 @@ def _stub_video_helpers(monkeypatch: pytest.MonkeyPatch, *, generate_resp: dict)
     `(captured, handler)` tuples to match the real signatures."""
     monkeypatch.setattr(VideoGenerationMixin, "_wait_video_editor_ready", AsyncMock())
     monkeypatch.setattr(VideoGenerationMixin, "_switch_to_video_mode", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_set_output_count", AsyncMock())
     monkeypatch.setattr(VideoGenerationMixin, "_set_output_count_one", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_select_video_model", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_select_video_duration", AsyncMock())
     monkeypatch.setattr(VideoGenerationMixin, "_select_video_aspect", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_switch_video_sub_mode", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_attach_frame", AsyncMock())
+    monkeypatch.setattr(VideoGenerationMixin, "_attach_references", AsyncMock())
     monkeypatch.setattr(
         VideoGenerationMixin,
         "_attach_video_response_listener",
@@ -288,13 +349,64 @@ class TestGenerateVideoGuards:
             await transport.generate_video(request=GenerateVideoRequest(prompt="x"))
 
     @pytest.mark.asyncio
-    async def test_rejects_non_t2v(self) -> None:
+    async def test_i2v_routes_to_frames_and_attach(self, monkeypatch: pytest.MonkeyPatch) -> None:
         transport = UiAutomationTransport()
-        transport._page = MagicMock()
+        transport._page = _mock_async_page()
         transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_poll_video_status",
+            AsyncMock(
+                return_value=VideoStatus(media_id="v", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+            ),
+        )
+        monkeypatch.setattr(transport, "_download_video", AsyncMock(return_value=Path("v.mp4")))
         req = GenerateVideoRequest(prompt="x", mode=Mode.I2V, start_image=Path("a.png"))
-        with pytest.raises(NotImplementedError, match="T2V"):
-            await transport.generate_video(request=req)
+        await transport.generate_video(request=req, download=False)
+        VideoGenerationMixin._switch_video_sub_mode.assert_awaited()  # type: ignore[attr-defined]
+        VideoGenerationMixin._attach_frame.assert_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_r2v_routes_to_references_and_attach(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R2V must switch the editor to the 'references' sub-mode and attach the
+        reference image(s) via _attach_references — NOT the I2V frame slots."""
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_poll_video_status",
+            AsyncMock(
+                return_value=VideoStatus(media_id="v", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+            ),
+        )
+        monkeypatch.setattr(transport, "_download_video", AsyncMock(return_value=Path("v.mp4")))
+        req = GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=(Path("r.png"),))
+        await transport.generate_video(request=req, download=False)
+        # References sub-mode selected (not frames) + references attached, frames not.
+        sub_args = [
+            c.args
+            for c in VideoGenerationMixin._switch_video_sub_mode.await_args_list  # type: ignore[attr-defined]
+        ]
+        assert any("references" in a for a in sub_args), sub_args
+        VideoGenerationMixin._attach_references.assert_awaited()  # type: ignore[attr-defined]
+        VideoGenerationMixin._attach_frame.assert_not_awaited()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_rejects_square_aspect(self) -> None:


### PR DESCRIPTION
## Summary

Wires the `ui_automation` video + image controls from the Phase B roadmap. Every path drives the live Flow editor and was verified end-to-end against a Pro/Ultra account; the captured generate route is noted per feature.

**Video (`gflow video …`)**

- `t2v`: `--model` picker (`omni-flash` | `veo-lite` | `veo-fast` | `veo-quality` | `veo-lite-lp`), `--duration` (`4`/`6`/`8`, plus `10` for `omni-flash` only), `--count` (1–4). → `batchAsyncGenerateVideoText`
- `i2v`: start frame + optional `--end-image`. → `batchAsyncGenerateVideoStartImage` / `…StartAndEndImage`
- `r2v` (new): reference-to-video, repeatable `--ref`. Model-aware reference cap (omni_flash ≤7, veo_3_1_* ≤3). → `batchAsyncGenerateVideoReferenceImages`

**Image fix**

- `gflow image t2i/i2i --model` now actually selects the model. It was a no-op under `ui_automation`: the wire field was set but the model picker was never clicked, so Flow used its UI default.

**Selector fixes**

- The output-count selector `[id*=-trigger-1]` collided with the `-trigger-10` duration tab; the aspect selector matched a non-existent `aria-controls*=9_16`; the video-mode tab match was ambiguous. All now use exact `[id$=-trigger-X]` suffixes + aria-label text.

## Key approach notes (would value your opinion)

- **Image inputs bind through the editor's media dialog** (frame slot / add-media → "Upload media" → file chooser → "Add to Prompt"). `set_input_files` on the generic hidden `<input type=file>` only adds the image to the *library* — Flow then ignores it and fires the plain Text route. Binding through the dialog is what makes I2V/R2V actually condition on the image.
- **The editor is forced to English** via a `--lang=en-US` Chromium launch arg. The frame-slot and dialog labels are localized (e.g. TH "เริ่ม"/"สิ้นสุด") with no locale-free anchor, and `locale="en-US"` alone only sets `Accept-Language` while Flow still serves `/fx/<locale>/`. Open to a locale-agnostic alternative if you prefer.
- A small request-body diagnostic logs `referenceCount` + mediaId prefixes (never tokens/credits) so the binding is provable from the structured log.

## Test plan

- [x] `uv run pytest -q` — 449 api tests pass (new video DTO / transport / selector tests included)
- [x] `uv run ruff check src tests` + `uv run pyright src` — clean
- [x] Live-verified on a Pro/Ultra profile: t2v (omni 10s), i2v (start, and start+end interpolation), r2v (omni-7 and veo-3 reference caps), and image `--model` selection

## Notes

The video changes are somewhat interleaved in `ui_automation_video.py`, so I kept them in one branch — happy to split into smaller PRs (model picker / i2v / r2v / image-fix) if you'd rather review them separately. Built on top of `develop` (v0.8.1).
