### PR TITLE
feat(image): i2i local-ref attach via media dialog (closes #39) + __aenter__ teardown guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `FlowApiClient.__aenter__` now tears down a partially-launched browser if any
+  step after the Playwright driver starts raises (e.g. the persistent-context
+  launch, the bootstrap navigation, or `transport.setup`). Python does not call
+  `__aexit__` when `__aenter__` raises, so an unguarded failure orphaned the
+  chrome process, which then held the profile's user-data-dir lock — the next
+  run could not acquire it and spiralled into rapid `about:blank` tabs +
+  `TargetClosedError`. Context close + driver stop are now shared by
+  `__aenter__`'s guard and `__aexit__` via `_close_browser_resources`.
 - `gflow image i2i --ref <local-file>` now binds the reference through the
   editor's media dialog instead of the REST `uploadImage` endpoint (which 401s —
   same root as #15/#39). Local-path refs ride a new `GenerateImageRequest.ref_paths`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gflow image i2i --ref <local-file>` now binds the reference through the
+  editor's media dialog instead of the REST `uploadImage` endpoint (which 401s —
+  same root as #15/#39). Local-path refs ride a new `GenerateImageRequest.ref_paths`
+  field and are attached via the inherited R2V `_attach_references` (the image-mode
+  add-media dialog is the same `add_2` surface). Live-verified end-to-end: upload
+  200, `imageInputs[]` populated, image returned. Bare-UUID `--ref` still flows
+  through `refs` unchanged.
 - `gflow image t2i/i2i --model` now actually selects the requested model. It was
   a no-op under `ui_automation` (the wire field was set but the model picker was
   never clicked, so Flow used its UI default). Adds `_select_image_model`.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -166,6 +166,26 @@ class FlowApiClient:
         # opening a second Playwright process against the same profile dir
         # (which would conflict on the Chromium lockfile — spec § 5.4.4).
         self._pw = await async_playwright().start()
+        # Partial-setup leak guard: __aexit__ is NOT invoked when __aenter__
+        # raises, so a launched persistent context (and its chrome process)
+        # would leak and lock the profile dir — the next run then fails to
+        # acquire it and spirals into about:blank / TargetClosedError. Tear
+        # down everything opened after the driver starts on any failure.
+        try:
+            await self._enter_setup()
+        except BaseException:
+            await self._close_browser_resources()
+            raise
+        return self
+
+    async def _enter_setup(self) -> None:
+        """Body of __aenter__ after the Playwright driver starts.
+
+        Extracted so __aenter__ can wrap it in a partial-setup leak guard
+        (a failed launch must not orphan a chrome process).
+        """
+        # Invariant: __aenter__ sets self._pw immediately before calling us.
+        assert self._pw is not None
         from gflow_cli.browser_manager import channel_for_profile
 
         self._context = await self._pw.chromium.launch_persistent_context(
@@ -241,8 +261,6 @@ class FlowApiClient:
             self._owns_transport = False
             self._plumb_out_dir(self.transport)
 
-        return self
-
     def _plumb_out_dir(self, transport: FlowTransportStrategy) -> None:
         """Forward ``self._out_dir`` onto a transport that exposes the slot.
 
@@ -257,33 +275,43 @@ class FlowApiClient:
         transport._out_dir = self._out_dir  # type: ignore[attr-defined]
 
     async def __aexit__(self, *exc: object) -> None:
-        try:
-            if self._context:
-                try:
-                    await self._context.close()
-                except Exception:
-                    # Browser cleanup is best-effort but MUST be surfaced for
-                    # diagnosis (CLAUDE.md: never silently swallow errors).
-                    logger.warning("browser_context_close_error", exc_info=True)
-            if self._pw:
-                try:
-                    await self._pw.stop()
-                except Exception:
-                    logger.warning("playwright_stop_error", exc_info=True)
-            if self._owns_transport and self.transport is not None:
-                try:
-                    await self.transport.teardown()
-                except Exception:
-                    logger.warning("transport_teardown_error", exc_info=True)
-        finally:
-            # Always reset pool state — even if close() raised — so a
-            # reused client instance doesn't keep dangling references to a
-            # dead BrowserContext's Pages.
-            self._pages = []
-            self._page_queue = None
-            self._page = None
-            self._context = None
-            self._pw = None
+        # _close_browser_resources is fully guarded internally and always resets
+        # the pool fields (even if context.close raises), so the client is left
+        # in a clean state without a separate finally block here.
+        await self._close_browser_resources()
+        if self._owns_transport and self.transport is not None:
+            try:
+                await self.transport.teardown()
+            except Exception:
+                logger.warning("transport_teardown_error", exc_info=True)
+
+    async def _close_browser_resources(self) -> None:
+        """Close the BrowserContext and stop the Playwright driver, best-effort.
+
+        Shared by :meth:`__aexit__` and :meth:`__aenter__`'s partial-setup
+        guard so a failed launch can't orphan a chrome process that then locks
+        the profile dir. Each step is independently guarded so one failure
+        still runs the next; errors surface as warnings (CLAUDE.md: never
+        silently swallow). Resets the browser fields so a reused client never
+        holds references to a dead BrowserContext.
+        """
+        if self._context is not None:
+            try:
+                await self._context.close()
+            except Exception:
+                # Browser cleanup is best-effort but MUST be surfaced for
+                # diagnosis (CLAUDE.md: never silently swallow errors).
+                logger.warning("browser_context_close_error", exc_info=True)
+        if self._pw is not None:
+            try:
+                await self._pw.stop()
+            except Exception:
+                logger.warning("playwright_stop_error", exc_info=True)
+        self._pages = []
+        self._page_queue = None
+        self._page = None
+        self._context = None
+        self._pw = None
 
     async def _checkout_page(self) -> Page:
         """Block until a Page is available from the pool; FIFO.

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -181,6 +182,10 @@ class GenerateImageRequest:
     aspect: Aspect = Aspect.PORTRAIT
     model: Model = Model.NARWHAL
     refs: tuple[ImageRef, ...] = ()
+    # Local reference-image files for I2I — attached through the editor's media
+    # dialog by the ui_automation transport (the REST uploadImage path 401s).
+    # The common i2i case; `refs` (pre-uploaded UUIDs) would need library-select.
+    ref_paths: tuple[Path, ...] = ()
     recaptcha_token: str = ""  # populated by caller right before send; "" means unminted
     # number of images to generate (1–4); UI transport uses this to set Flow's count tab
     count: int = 1

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1499,6 +1499,13 @@ class UiAutomationTransport(VideoGenerationMixin):
             page, aspect_cli, request.count, model=request.model
         )
 
+        # I2I: bind local reference images through the editor's media dialog —
+        # the same add_2 dialog as video R2V, via the inherited _attach_references.
+        # The REST uploadImage path 401s, and passive capture needs the refs IN
+        # the UI (not just a wire body), so we attach + let Flow's JS include them.
+        if request.ref_paths:
+            await self._attach_references(page, list(request.ref_paths), out_dir=out_dir)
+
         # Attach the response listener SYNCHRONOUSLY before any prompt
         # action. asyncio.create_task is unsafe here: it defers the listener
         # registration until the new task gets event-loop scheduling, which

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -102,9 +102,9 @@ def _classify_ref(ref: str) -> ImageRef | Path:
       (raised by ``strict=True``) which we re-raise as :class:`click.UsageError`
       for an exit-2 + friendly message.
 
-    Centralized here so the ``i2i`` Click callback (upfront validation) and
-    the ``_resolve_refs`` async helper (dispatch) share one implementation
-    instead of duplicating the UUID regex check.
+    Centralized here so the ``i2i`` Click callback validates upfront and
+    ``_run_i2i`` can split UUID refs (wire) from local paths (UI-attached)
+    without duplicating the UUID regex check.
 
     Raises:
         click.UsageError: if *ref* is neither a UUID nor an existing path.
@@ -761,38 +761,6 @@ def i2i(
     )
 
 
-async def _resolve_refs(
-    client: FlowApiClient,
-    project_id: str,
-    classified_refs: list[ImageRef | Path],
-) -> tuple[ImageRef, ...]:
-    """Resolve a pre-classified ref list into a tuple of :class:`ImageRef`.
-
-    The input list is produced by :func:`_classify_ref` at the CLI boundary,
-    so this helper only has to dispatch on type:
-
-    * :class:`ImageRef` — append verbatim (already-uploaded asset).
-    * :class:`Path` — upload and wrap the returned UUID.
-
-    Uploads are sequential — parallel uploads are tempting but Flow's web UI
-    uploads serially and we don't want to surprise the rate limiter. Order is
-    preserved so the resulting ``imageInputs[]`` matches the order the user
-    specified on the command line.
-    """
-    resolved: list[ImageRef] = []
-    for item in classified_refs:
-        if isinstance(item, ImageRef):
-            resolved.append(item)
-            continue
-        # Per-file progress feedback. Acceptable Rich `console.print` inside
-        # this async helper because cli_image.py *is* the CLI layer; structlog
-        # will replace this when it lands in Phase 1.
-        console.print(f"  Uploading {item.name}...")
-        asset = await client.upload_image(project_id, item)
-        resolved.append(ImageRef(name=asset.name))
-    return tuple(resolved)
-
-
 async def _run_i2i(
     *,
     profile_dir: Path,
@@ -815,16 +783,23 @@ async def _run_i2i(
         project = await client.create_project(title="gflow-cli i2i")
         console.print(f"  Project: [dim]{project.project_id}[/dim]")
 
-        resolved_refs = await _resolve_refs(client, project.project_id, classified_refs)
+        # Local-file refs are attached through the editor's media dialog by the
+        # ui_automation transport (the REST uploadImage path 401s — see #15/#39).
+        # Already-uploaded UUID refs go on `refs` (best-effort; binding a library
+        # asset by UUID via the UI is not wired yet — local files are the path).
+        uuid_refs = tuple(r for r in classified_refs if isinstance(r, ImageRef))
+        local_ref_paths = tuple(r for r in classified_refs if isinstance(r, Path))
         req = GenerateImageRequest(
             prompt=prompt,
             aspect=aspect,
             model=model,
-            refs=resolved_refs,
+            refs=uuid_refs,
+            ref_paths=local_ref_paths,
         )
 
+        n_refs = len(uuid_refs) + len(local_ref_paths)
         console.print(
-            f"  Generating {count} image(s) with {len(resolved_refs)} ref(s) "
+            f"  Generating {count} image(s) with {n_refs} ref(s) "
             f"({req.model.value}, {req.aspect.value})..."
         )
         if count == 1:

--- a/tests/api/test_concurrency.py
+++ b/tests/api/test_concurrency.py
@@ -198,3 +198,30 @@ async def test_aexit_resets_pool_even_when_close_raises(
         assert client._page is None
         assert client._context is None
         assert client._pw is None
+
+
+@pytest.mark.asyncio
+async def test_aenter_partial_failure_tears_down_browser(
+    tmp_path: Path, settings_n4: Settings, fake_context: MagicMock
+) -> None:
+    """If __aenter__ fails AFTER launching the persistent context, the browser
+    MUST be torn down. __aexit__ is NOT invoked when __aenter__ raises, so an
+    unguarded failure would orphan the chrome process and lock the profile dir
+    (regression: next run spirals into about:blank spam + TargetClosedError).
+    The partial-setup guard owns cleanup here."""
+    fake_context.add_init_script = AsyncMock(side_effect=RuntimeError("boom mid-setup"))
+    with patch("gflow_cli.api.client.async_playwright") as mock_pw_factory:
+        pw = MagicMock()
+        pw.stop = AsyncMock()
+        pw.chromium.launch_persistent_context = AsyncMock(return_value=fake_context)
+        mock_pw_factory.return_value.start = AsyncMock(return_value=pw)
+        client = FlowApiClient(profile_dir=tmp_path, settings=settings_n4)
+        with pytest.raises(RuntimeError, match="boom mid-setup"):
+            await client.__aenter__()
+        # The launched context + driver were closed even though __aexit__ never ran:
+        fake_context.close.assert_awaited()
+        pw.stop.assert_awaited()
+        # Fields reset to a clean state so a retry/reuse starts fresh.
+        assert client._context is None
+        assert client._pw is None
+        assert client._page_queue is None

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1049,6 +1049,49 @@ class TestGenerateImages:
         ):
             await t.generate_images(project_id="x", request=_req())
 
+    @pytest.mark.asyncio
+    async def test_i2i_ref_paths_bound_via_attach_references(self) -> None:
+        """I2I local refs (request.ref_paths) bind through the editor media
+        dialog — _generate_images_locked awaits the inherited _attach_references
+        with the local paths. Without this, the i2i bind is only covered at the
+        CLI layer (mirrors the R2V transport-attach coverage)."""
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+        ref = Path("hero.png")
+        req = GenerateImageRequest(prompt="stylize", model=Model.NARWHAL, ref_paths=(ref,))
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_references", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=req)
+
+        attach.assert_awaited_once()
+        call = attach.await_args
+        assert call is not None
+        # The local path is forwarded to the attach helper (positional arg 1).
+        assert list(call.args[1]) == [ref]
+
+    @pytest.mark.asyncio
+    async def test_t2i_without_ref_paths_skips_attach(self) -> None:
+        """T2I (no ref_paths) must NOT touch _attach_references."""
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_references", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=_req())
+
+        attach.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Unit 3.10 — refresh_auth (no-op)

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -312,13 +312,12 @@ def _make_i2i_client(
 
 
 class TestImageI2I:
-    def test_i2i_uploads_local_ref_paths(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Local --ref path triggers upload_image; the returned UUID lands in
-        the GenerateImageRequest.refs and downstream imageInputs[]."""
+    def test_i2i_attaches_local_ref_paths(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Local --ref path lands on req.ref_paths for UI media-dialog attach —
+        it must NOT hit the REST uploadImage endpoint (which 401s, see #15/#39)."""
         png = tmp_path / "hero.png"
         png.write_bytes(b"\x89PNG\r\n\x1a\n")
-        upload_uuid = "ddb6ef97-262d-49f4-8269-4a28c0fae6a2"
-        client = _make_i2i_client(upload_uuid=upload_uuid)
+        client = _make_i2i_client(upload_uuid="should-not-be-used")
         out_dir = tmp_path / "out"
 
         with (
@@ -335,14 +334,14 @@ class TestImageI2I:
             )
 
         assert result.exit_code == 0, result.output
-        client.upload_image.assert_awaited_once()
-        # Inspect the GenerateImageRequest passed to generate_image — UUID
-        # from upload_image should appear in req.refs.
+        client.upload_image.assert_not_called()
+        # Local file goes to req.ref_paths (UI-attached); refs (wire UUIDs) stays empty.
         call = client.generate_image.await_args
         assert call is not None
         req = call.kwargs["req"]
-        assert len(req.refs) == 1
-        assert req.refs[0].name == upload_uuid
+        assert req.refs == ()
+        assert len(req.ref_paths) == 1
+        assert req.ref_paths[0] == png.resolve()
 
     def test_i2i_passes_through_uuid_refs(self, runner: CliRunner, tmp_path: Path) -> None:
         """Bare-UUID --ref must NOT trigger upload_image and must be used verbatim."""
@@ -371,13 +370,13 @@ class TestImageI2I:
         assert len(req.refs) == 1
         assert req.refs[0].name == uuid_str
 
-    def test_i2i_mixes_paths_and_uuids(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Mixed `--ref path --ref uuid` → one upload, two ordered entries."""
+    def test_i2i_splits_paths_and_uuids(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Mixed `--ref path --ref uuid` → local path on ref_paths (UI-attached),
+        bare UUID on refs (wire). No REST upload for either."""
         png = tmp_path / "hero.png"
         png.write_bytes(b"\x89PNG\r\n\x1a\n")
-        uploaded_uuid = "11111111-1111-1111-1111-111111111111"
         passthrough_uuid = "22222222-2222-2222-2222-222222222222"
-        client = _make_i2i_client(upload_uuid=uploaded_uuid)
+        client = _make_i2i_client(upload_uuid="should-not-be-used")
         out_dir = tmp_path / "out"
 
         with (
@@ -404,13 +403,13 @@ class TestImageI2I:
             )
 
         assert result.exit_code == 0, result.output
-        # Exactly one upload (for the path) — the bare UUID must be passed through.
-        assert client.upload_image.await_count == 1
+        client.upload_image.assert_not_called()
         call = client.generate_image.await_args
         assert call is not None
         req = call.kwargs["req"]
-        # Order matters: path → uploaded_uuid first, then passthrough_uuid.
-        assert [r.name for r in req.refs] == [uploaded_uuid, passthrough_uuid]
+        # Local path → ref_paths; bare UUID → refs.
+        assert [p for p in req.ref_paths] == [png.resolve()]
+        assert [r.name for r in req.refs] == [passthrough_uuid]
 
     def test_i2i_errors_on_no_refs(self, runner: CliRunner) -> None:
         """`image i2i` without any --ref must exit 2 with a clear message."""


### PR DESCRIPTION
## Summary

Two focused follow-ups on top of #48 (now merged):

- **`gflow image i2i --ref <local-file>`** now binds the reference through the editor's media dialog — the same `add_2` dialog + the inherited `_attach_references` that #48 added for R2V — instead of the REST `uploadImage` endpoint, which 401s. **Closes #39** (same root as #15). Bare-UUID `--ref` still flows through `refs` unchanged; the CLI splits local paths (UI-attached) from pre-uploaded UUIDs.
- **`FlowApiClient.__aenter__` teardown guard** — if any step after the Playwright driver starts raises (persistent-context launch, bootstrap nav, or `transport.setup`), the browser is now torn down. Python does not call `__aexit__` when `__aenter__` raises, so an unguarded failure orphaned the chrome process; the orphan held the profile's user-data-dir lock and the next run spiralled into rapid `about:blank` tabs + `TargetClosedError`. Context-close + driver-stop are now shared by the guard and `__aexit__` via `_close_browser_resources`.

## Test plan

- [x] `gflow image i2i --ref <png>` live-verified via the real CLI: `uploadImage` 200, `imageInputs[]` populated, image returned (single ref and `--count 2`, fresh session).
- [x] CLI-layer tests (`test_cli_image.py`: local paths → `ref_paths`, UUIDs → `refs`, no REST upload) + transport-layer test (`test_ui_automation.py`: `_generate_images_locked` awaits `_attach_references` with the paths when `ref_paths` is set, and not for plain t2i).
- [x] Regression test for the teardown guard (`test_concurrency.py`: `__aenter__` failure still closes context + stops the driver).
- [x] `uv run ruff check src tests` + `uv run ruff format --check src tests` + `uv run pyright src` clean; full `uv run pytest -m "not e2e and not live"` green (806 passed).
- [x] Commits DCO-signed.

## Notes

Built on the `_attach_references` helper merged in #48. While here I noticed 3 pre-existing `pyright` errors in `tests/` (`test_concurrency.py`, `test_ui_automation.py` helper return types) — they aren't CI-gated (the workflow runs `pyright src`, not `tests`), so I left them out to keep this PR focused. Happy to send a separate `fix(tests)` cleanup if you'd like.