### PR TITLE
docs: post-PR-48/#51 council audit fixes (T1+T2)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -77,3 +77,12 @@
 # (Google's bot-detection sometimes refuses headless Chromium but accepts a
 # visible window). The session is still reused from the persistent profile.
 # GFLOW_CLI_HEADLESS=true
+
+# BCP-47 locale tag passed to Playwright's launch `locale=` parameter
+# (controls Accept-Language only — Chrome's UI language is forced to
+# en-US via the `--lang=en-US` launch arg regardless of this setting, so
+# Flow stays on /fx/tools/flow/ instead of /fx/<locale>/). Default:
+# `en-US`. Override to capture locale-invariant DOM via
+# scripts/dev/capture_locale_invariants.py or to live-verify a non-EN
+# language end-to-end (see KNOWN_ISSUES § issue #24).
+# GFLOW_CLI_LOCALE=en-US

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Flow "ingredients"). Model-aware reference cap (omni_flash ≤7, veo_3_1_* ≤3)
   enforced in the request DTO; the transport stops gracefully if Flow hides the
   add-media button at the cap. Fires `batchAsyncGenerateVideoReferenceImages`.
+- `GFLOW_CLI_LOCALE` env var — overrides Playwright's launch `locale=` parameter
+  (default: `en-US`). Controls `Accept-Language` only; Chrome's UI language is
+  still forced to en-US via `--lang=en-US`. Prep for issue #24 (locale-agnostic
+  selectors); live-verified end-to-end with `GFLOW_CLI_LOCALE=pt-BR` against a
+  Pro/Ultra account. See `docs/CONFIGURATION.md § GFLOW_CLI_LOCALE`.
 
 ### Changed
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -319,7 +319,21 @@ issue and not blocked by any code change in this repo.
 
 - **Status:** Mitigated · **Severity:** Medium · **Tracking:** [issue #24](https://github.com/ffroliva/gflow-cli/issues/24)
 
-The Phase 7 multi-image-prompt work addressed the count-tab selectors:
+**Progress (2026-05-24, develop / post-v0.8.1, unreleased):**
+
+- **PR #51** — Playwright's launch `locale=` is now env-overridable via
+  `GFLOW_CLI_LOCALE` (default: `en-US`). Live-verified end-to-end with
+  `GFLOW_CLI_LOCALE=pt-BR uv run pytest -m e2e tests/e2e/test_video_t2v_e2e.py`
+  (1 credit, ~2.5 MB mp4, `MEDIA_GENERATION_STATUS_SUCCESSFUL`).
+- **PR #48** — added the `--lang=en-US` Chromium launch arg so the editor UI
+  itself stays in English regardless of the user's profile/system language.
+  Currently mandatory because the I2V frame-slot labels and parts of
+  `ONBOARDING_SELECTORS` / `NEW_PROJECT_SELECTORS` / `SUBMIT_BUTTON_SELECTORS`
+  still match by localized text. Dropping `--lang=en-US` is the goal but
+  requires invariant capture across the remaining text-matched selectors
+  (`scripts/dev/capture_locale_invariants.py` is the diagnostic).
+
+**Earlier — Phase 7 multi-image-prompt work** addressed the count-tab selectors:
 - `_COUNT_TAB_TEXT_RE = ^(1x|x[2-4])$` only matches the digit+x format Flow
   renders identically in every locale (numbers/symbols are not translated).
 - `_set_count` falls back to positional `.nth(count - 1)` when the read-back
@@ -363,6 +377,23 @@ change surfaces there as a failing test. Start any investigation of a sudden
 ---
 
 ## Resolved
+
+### `gflow image t2i/i2i --model` was a silent no-op on `ui_automation`
+
+- **Status:** Resolved · **Severity:** Was-Medium (wrong model = wrong cost + quality, silently) · **Was-affecting:** v0.7.0 through v0.8.1 · **Fixed in:** develop post-v0.8.1 via PR #48 (2026-05-24)
+
+Pre-fix, `gflow image t2i --model nano-banana-2` (or any other model) under
+`ui_automation` would set the wire-level model field correctly but **never
+click the model picker in the editor UI**, so Flow used whichever model the
+UI's dropdown was last set to (typically the account default). Users got
+their requested model silently substituted for the default — no error, just
+wrong output and wrong credit cost. Fixed by `_select_image_model` in
+`src/gflow_cli/api/transports/ui_automation.py` which mirrors the new
+`_select_video_model` helper. If you ran `gflow image t2i --model <X>`
+against v0.7.0–v0.8.1 and noticed the output didn't match `<X>`, this is
+why; re-run on the next release (≥ v0.9.0).
+
+---
 
 ### aisandbox-pa generation 401 — bypassed by the `ui_automation` transport
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 > **Status:** Living document. Updated as phases complete.
 > **Owner:** [@ffroliva](https://github.com/ffroliva)
-> **Last revised:** 2026-05-16 (v0.6.0a5 — Bug A/B transport fixes + issue-tracked work)
+> **Last revised:** 2026-05-24 (develop — post-PR #48 i2v/r2v/model-picker, PR #51 locale env-override)
 
 This plan turns the v0.1 scaffold into a production-grade CLI for Google AI Ultra/Pro subscribers who want to spend their Flow credits via batch automation. The plan is opinionated, treating this repo as a portfolio-grade benchmark.
 
@@ -339,13 +339,13 @@ The video-generation feature has its own sub-phase plan (spike → Phase A → P
 - ⚠️ Q7 — status poll `page.request.post` → 401; the spec §5.5 polling design must be reworked in Phase A (capture Flow's own status responses).
 - ⏭️ Q1 / Q3 / Q6 — image attachment is an in-page catalog dialog; driving it, the start-only-I2V check, and the R2V slot cap are deferred to Phase B.
 
-**Next:** Phase A (T2V transport), once §5.5 is revised for the Q7 401. ✅ Issue #24 (locale-agnostic selectors) completed in v0.8.1.
+**Next:** Phase A (T2V transport), once §5.5 is revised for the Q7 401. Issue #24 (locale-agnostic selectors): Phase 1 (env override via `GFLOW_CLI_LOCALE`) landed via PR #51 on develop 2026-05-24 (post-v0.8.1, unreleased); live-verified end-to-end in pt-BR (1 credit, mp4 downloaded). Full removal of the `--lang=en-US` Chromium arg is gated on a selector-invariant capture across the remaining onboarding/new-project text selectors.
 
 ---
 
 ### Phase 7 — Protocol Extensions (v0.8.1, 2026-05-23)
 
-- [x] **Issue #24: Locale-Agnostic Selectors.** Refactored `UiAutomationTransport` to use locale-invariant selectors (ARIA, Radix tokens, icon ligatures), ensuring compatibility across all Google account languages. Verified E2E in English, Portuguese, and Spanish.
+- [~] **Issue #24: Locale-Agnostic Selectors — Phase 1 shipped, Phase 2 pending.** PR #51 (develop, 2026-05-24, post-v0.8.1) added the `GFLOW_CLI_LOCALE` env override on Playwright's launch `locale=` parameter, and live-verified `gflow video t2v` end-to-end under `pt-BR`. Some selectors are already locale-invariant (count tabs use `^(1x|x[2-4])$`, video aspect/duration use id-suffix + icon ligatures from PR #48); others — notably `ONBOARDING_SELECTORS`, parts of `NEW_PROJECT_SELECTORS` / `SUBMIT_BUTTON_SELECTORS`, and the I2V frame-slot text labels — are still localized and currently rely on the `--lang=en-US` Chromium launch arg added by PR #48. Tracked under [KNOWN_ISSUES § issue #24](KNOWN_ISSUES.md). Dropping `--lang=en-US` requires invariant capture across the remaining text selectors.
 - [ ] **Model Context Protocol (MCP) Server.** (Backlog) Expose core gflow-cli tools via MCP for language-agnostic agentic access.
 
 ---

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ gflow CLI  →  Provider (interchangeable)  →  Flow (ui_automation) / Mock (te
 
 ## Project status
 
-**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. Only video `batch` is queued for Phase B. Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md).
+**v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](docs/USAGE.md#gflow-video-batch)). The next release will pick up everything in `[Unreleased]` (i2v/r2v wiring, t2v model picker, `GFLOW_CLI_LOCALE` env override). Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md).
 
 ## License & legal
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -116,6 +116,15 @@ GFLOW_CLI_AUTH_LOGIN_TIMEOUT=120 gflow auth login   # abort after 2 minutes
 **Default:** `true`
 **When to flip to `false`:** if reCAPTCHA Enterprise refuses to mint tokens (Google's bot-detection sometimes refuses headless Chromium but accepts a visible window). Set to `false` and re-run; the browser will appear during generation but the session is still reused from the persistent profile.
 
+### `GFLOW_CLI_LOCALE`
+
+**What:** BCP-47 locale tag passed to Playwright's `launch_persistent_context(locale=...)` — controls the `Accept-Language` HTTP header only.
+**Values:** any BCP-47 tag (e.g. `en-US`, `pt-BR`, `es-ES`, `ja-JP`)
+**Default:** `en-US`
+**Shipped in:** post-v0.8.1 develop (PR #51).
+**When to set it:** capturing locale-invariant DOM via `scripts/dev/capture_locale_invariants.py`, or live-verifying a generation under a non-EN account language.
+**Important:** Chrome's *UI* language is independently forced to `en-US` via the `--lang=en-US` launch arg (so Flow keeps serving `/fx/tools/flow/` and the editor's localized text selectors keep working). This env var only affects request headers — not the editor UI you see. See [KNOWN_ISSUES § issue #24](../KNOWN_ISSUES.md) for the path to dropping `--lang=en-US`.
+
 ## Output paths
 
 The default output scheme keeps generated assets sortable, dated, and grouped by job:

--- a/docs/LIVE_VERIFICATION_video_download.md
+++ b/docs/LIVE_VERIFICATION_video_download.md
@@ -81,9 +81,11 @@ the new download-enabled path.
 - `--aspect 1:1` (SQUARE) — the transport raises `ValueError` for SQUARE
   on the video path (Flow doesn't offer it); the CLI only accepts
   `9:16` / `16:9`.
-- I2V (image-to-video) and R2V (reference-to-video) modes — still raise
-  `NotImplementedError` on `UiAutomationTransport`; tracked under
-  Phase B follow-ups.
+- I2V (image-to-video) and R2V (reference-to-video) modes — were not
+  exercised in *this* verification (T2V download only). I2V/R2V shipped
+  later via PR #48 (2026-05-24, develop) and were live-verified by the
+  contributor against a Pro/Ultra account; see CHANGELOG `[Unreleased]`.
+  Earlier `NotImplementedError` stubs are gone as of PR #48.
 - `--download=False` opt-out — covered by unit tests
   (`tests/api/transports/test_ui_automation_video.py`); not exercised
   live because the goal of this verification is the download path.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,7 +4,9 @@
 
 ## Current release
 
-**v0.8.1 — alpha (docs refresh).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. Only video `batch` is still queued for Phase B. Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
+**v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](USAGE.md#gflow-video-batch)). Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
+
+**Develop (unreleased, post-v0.8.1):** PR #37 (Sonar refactor), PR #46 (README badges), PR #48 (i2v/r2v + t2v `--model`/`--duration`/`--count` + image `--model` no-op fix), PR #51 (`GFLOW_CLI_LOCALE` env override, prep for issue #24). Targets v0.9.0.
 
 ## Milestone history
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -347,28 +347,38 @@ gflow video r2v "blend these worlds" --ref a.png --ref b.png --ref c.png --model
 
 ## `gflow video batch`
 
-Run a TSV manifest of generations against ONE shared project.
+> ⚠️ **Not yet implemented.** The `batch` subcommand currently exits with
+> `[yellow]gflow video batch is not yet available.[/yellow]` (exit 1).
+> Manifest-driven batching on `UiAutomationTransport` is queued for a later
+> release (see Phase B follow-ups).
 
-```text
-gflow video batch MANIFEST [--out-dir DIR] [--profile NAME] [--poll-interval SEC]
+### Workaround — shell for-loop
+
+Until the manifest runner lands, you can drive sequential video generations
+through a plain shell loop. Each `gflow video t2v` / `i2v` / `r2v` call opens
+its **own Flow project**, so the resulting videos will NOT share a
+`project_id` (unlike `gflow image batch`, which mounts one project across
+all prompts) — but they DO get generated and downloaded:
+
+```bash
+# bash / WSL / macOS — one prompt per line
+while IFS= read -r prompt; do
+  gflow video t2v "$prompt" --aspect 9:16
+done < prompts.txt
 ```
 
-Manifest format (tab-separated; `# `-prefixed lines are comments):
-
-```tsv
-# start_image	prompt	end_image	aspect	output_path
-	A serene mountain lake at sunset		9:16	./out/lake.mp4
-hero.png	Slow camera arc		9:16	./out/hero.mp4
-	Aerial coastline		16:9	./out/coast.mp4
+```powershell
+# PowerShell — one prompt per line
+Get-Content prompts.txt | ForEach-Object {
+  gflow video t2v $_ --aspect 9:16
+}
 ```
 
-| Column | Required | Default |
-|---|---|---|
-| `start_image` | no (empty -> T2V) | - |
-| `prompt` | **yes** | - |
-| `end_image` | no (reserved, not yet wired) | - |
-| `aspect` | no | `9:16` |
-| `output_path` | no | `<out_dir>/videos/<date>/<media>.mp4` |
+The trade-off vs. a true manifest runner: separate `project_id`s mean each
+generation re-mints a reCAPTCHA (a few extra seconds per shot) and the
+videos won't appear together in your Flow gallery. The files on disk are
+identical to what `batch` would produce. The same pattern works for
+`gflow video i2v <image> "<prompt>"` and `gflow video r2v "<prompt>" --ref <img>`.
 
 ## `gflow run`
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # gflow-cli
 
-> Unofficial Python CLI for Google Flow — drives Veo (image-to-video, text-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at aisandbox-pa.googleapis.com. Requires a Google AI Ultra or Pro subscription with Flow access. Uses Playwright Chromium under the hood (one-time real-Chrome auth, then a persistent Chrome session driven via ui_automation). Production-stable for image generation and video T2V; video I2V and batch are queued for Phase B. MIT licensed, not affiliated with Google.
+> Unofficial Python CLI for Google Flow — drives Veo (image-to-video, text-to-video, reference-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at aisandbox-pa.googleapis.com. Requires a Google AI Ultra or Pro subscription with Flow access. Uses Playwright Chromium under the hood (one-time real-Chrome auth, then a persistent Chrome session driven via ui_automation). Production-stable for image generation and video T2V/I2V/R2V with a `--model`/`--duration`/`--count` picker; only `gflow video batch` (manifest runner) is still queued for Phase B — use a shell for-loop in the meantime. MIT licensed, not affiliated with Google.
 
 This file is forward-staged for a future docs site at https://ffroliva.github.io/gflow-cli/llms.txt and is also usable today by LLM agents that read the repo directly.
 


### PR DESCRIPTION
## Summary

Doc-drift fixes flagged by the 3-agent `/gflow:doc-review` council after PR #48 (i2v/r2v + model picker) and PR #51 (GFLOW_CLI_LOCALE env override) landed on `develop`. No code touched — only `.md`, `.txt`, `.template`.

## Tier 1 — fictional / stale claims (4 fixed + 1 retracted doc claim)

- **`llms.txt:3`** — "video I2V and batch queued for Phase B" was false post-PR #48. Updated; only `gflow video batch` (manifest runner) is still queued.
- **`PLAN.md:342` + `:348`** — "Issue #24 completed in v0.8.1" was false. PR #51 landed today, post-v0.8.1, on develop only. Updated to state Phase 1 (env override) shipped + live-verified in pt-BR; locale-invariant selector capture still pending.
- **`KNOWN_ISSUES.md` (#24)** — added Progress block citing PR #51 + PR #48 and the path to dropping `--lang=en-US`.
- **`docs/LIVE_VERIFICATION_video_download.md`** — dropped stale "I2V/R2V raise NotImplementedError" (they shipped in PR #48).
- **`docs/USAGE.md § gflow video batch`** — was documenting a full TSV manifest as if working. Replaced with a not-yet-implemented warning + a shell for-loop workaround (separate `project_id` per shot, but videos still get generated).

## Tier 2 — important polish

- **`GFLOW_CLI_LOCALE`** documented in `.env.template` and `docs/CONFIGURATION.md` (was code-only after PR #51).
- **`CHANGELOG.md [Unreleased] § Added`** entry for `GFLOW_CLI_LOCALE`.
- **README + PROJECT_STATUS** opening lines reframed — v0.8.1 is the latest PyPI release but `develop` has moved on (PR #37 / #46 / #48 / #51).
- **`KNOWN_ISSUES.md § Resolved`** — added entry for the silent `gflow image t2i --model` no-op fixed in PR #48 (gives users who hit it on v0.7.0–v0.8.1 a breadcrumb).

## Evidence

- Live-verification of PR #51's `GFLOW_CLI_LOCALE=pt-BR` happy-path: 1 credit, ~2.5 MB mp4, `MEDIA_GENERATION_STATUS_SUCCESSFUL`. Magic bytes `ftypisom` confirmed.
- Mid-audit, the e2e test ran the full pipeline but asserted on the pre-PR-#36 `VideoStatus` return type (now wrapped in `VideoResult`). Filed as a separate follow-up; not in this PR.

## Test plan

- [x] Doc-link checker — `All links resolved across 9 files.`
- [x] Repo hygiene — `255 tracked files checked — no violations.`
- [x] Ruff check — clean
- [ ] CI matrix (3.11 / 3.12 / 3.13) green
