### PR TITLE
feat(data): local SQLite data layer + T2V client normalization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -91,6 +91,13 @@ src/gflow_cli/
 ├── observability.py    ← Phase 4 — structlog bootstrap + event emitters
 ├── paths.py            ← XDG-aware default paths
 ├── profile_store.py    ← profile inventory + default-profile config.toml
+├── data/               ← Phase 6 — local SQLite provenance layer
+│   ├── __init__.py
+│   ├── store.py        ← DataStore (connection + migration runner)
+│   ├── repository.py   ← read queries (get_by_media_id, list_by_profile, …)
+│   ├── recorder.py     ← OperationRecorder (write path + redact_metadata)
+│   └── migrations/
+│       └── 0001_initial.sql
 └── api/
     ├── __init__.py
     ├── _retry.py       ← Phase 4 — tenacity AsyncRetrying + Retry-After cap
@@ -108,7 +115,7 @@ src/gflow_cli/
 
 Documented in [docs/CONFIGURATION.md](docs/CONFIGURATION.md) and [.env.template](.env.template). Variables:
 
-`GFLOW_CLI_HOME`, `GFLOW_CLI_OUTPUT_DIR`, `GFLOW_CLI_PROFILE`, `GFLOW_CLI_PROVIDER`, `GFLOW_CLI_GEMINI_API_KEY`, `GFLOW_CLI_TIMEOUT_SECONDS`, `GFLOW_CLI_LOG_LEVEL`, `GFLOW_CLI_LOG_FORMAT`, `GFLOW_CLI_CONCURRENCY`.
+`GFLOW_CLI_HOME`, `GFLOW_CLI_OUTPUT_DIR`, `GFLOW_CLI_PROFILE`, `GFLOW_CLI_PROVIDER`, `GFLOW_CLI_GEMINI_API_KEY`, `GFLOW_CLI_TIMEOUT_SECONDS`, `GFLOW_CLI_LOG_LEVEL`, `GFLOW_CLI_LOG_FORMAT`, `GFLOW_CLI_CONCURRENCY`, `GFLOW_CLI_DB_PATH`, `GFLOW_CLI_HISTORY_PROMPTS`.
 
 Default paths via `platformdirs`:
 
@@ -585,17 +592,22 @@ gates on the same header.
 
 ---
 
-### Phase 6 — Operations history & cost tracking — BACKLOG
+### Phase 6 — Local SQLite data layer — IMPLEMENTED (PR #TBD)
 
-Foundation laid by Phase 4's structured `error_raised` events + Problem Details. Phase 6 adds a local persistence layer so users can answer "what did I generate last week and what did it cost?".
+Records new image, batch, and T2V provenance in a local SQLite database. Read-only `gflow data media <id>` command exposed.
 
-- Local SQLite (or DuckDB if analytical queries dominate) at `$GFLOW_CLI_HOME/operations.db`
-- Schema: `operations(id, timestamp, profile, cli_command, project_id, media_uuids, prompt, model, aspect, seed_count, status, error_class, error_problem, duration_ms, output_paths)` — every CLI invocation appends one row
-- Schema versioned via Alembic-style migrations
-- New CLI: `gflow history list/show/search` — query operations by date / profile / command / status
-- Cost tracking: best-effort credit estimation per call (Veo 3.1 ≈ X credits/sec, Imagen ≈ Y credits/image — tabulate from observation)
-- Privacy: prompts are user-generated content; persist locally only, never transmit
-- Out of scope until Phase 6 ships: cloud sync, multi-user history
+- `gflow_cli/data/` — `DataStore` + repository + `OperationRecorder` + `redact_metadata`
+- Default DB path: `<GFLOW_CLI_HOME>/gflow.db`; override via `GFLOW_CLI_DB_PATH`
+- Schema versioned via SHA-256-checksummed migrations (`0001_initial.sql`); newer-schema detection raises `DataStoreError` (exit 16) with a clear upgrade hint
+- Privacy: `GFLOW_CLI_HISTORY_PROMPTS=redacted` stores only SHA-256 prompt hash; signed CDN URLs, reCAPTCHA tokens, and auth headers are stripped by `redact_metadata` before any DB write
+- `gflow data media <id> [--profile]` prints profile, media ID, project ID, kind, and local file paths
+- T2V now flows through `FlowApiClient.generate_video`, sharing the client boundary with image commands
+
+**Backlog follow-ons (not in this PR):**
+
+- `gflow data import` / `gflow data repair` — back-fill older operations not recorded by this version
+- Richer management UI: `gflow data list`, `gflow data search`, cost/credit estimation
+- `gflow history` alias for the data subcommand
 
 ### CDP Attach Transport — BACKLOG (deferred)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ The hexagonal target above is the steady state. The **current** package — and 
 
 **Per-module rules:**
 
-- Each top-level package or file under `src/gflow_cli/` is a module with one clear domain (`auth`, `api`, `cli`, `errors`, `observability`, `manifest`, `paths`, `config`, `profile_store`).
+- Each top-level package or file under `src/gflow_cli/` is a module with one clear domain (`auth`, `api`, `cli`, `errors`, `observability`, `manifest`, `paths`, `config`, `profile_store`, `data`).
 - Each module exposes a public interface via `__init__.py` and (where applicable) explicit `__all__`.
 - Internals are prefixed with `_` (single leading underscore) and never imported across modules.
 - Cross-module communication goes through public interfaces, never private internals.
@@ -49,6 +49,10 @@ The hexagonal target above is the steady state. The **current** package — and 
 
 - `gflow_cli.errors` — exception taxonomy aligned with [RFC 9457 Problem Details](https://datatracker.ietf.org/doc/html/rfc9457). Each `GFlowError` subclass carries `type` (URI), `title`, `status`, `detail`, `instance`, `remediation_hint`. The `to_problem_details()` method serializes to the RFC 9457 JSON shape and is the stable contract for telemetry consumers.
 - `gflow_cli.observability` — structlog configuration + the `error_raised` event emitter. This is the future home for metrics + tracing (Phase 5+) too.
+
+**Data layer module (feature/data-layer, targeting v0.9.0):**
+
+- `gflow_cli/data/` — local SQLite persistence layer (`DataStore` + repository + `OperationRecorder` + redaction). Records all new image/video operations, asset provenance, and local file metadata. Default path `<GFLOW_CLI_HOME>/gflow.db`. Migrations versioned via SHA-256 checksums; safe forward-only semantics with newer-schema detection. T2V now flows through `FlowApiClient.generate_video`, sharing the client boundary with image commands.
 
 **Why RFC 9457 for errors:** Problem Details is the IETF-standard shape for machine-readable HTTP error responses. Even though gflow-cli is a CLI (not an HTTP server), adopting the same vocabulary means: (a) the error log shape is greppable by stable `type` URI, (b) future cloud-edge integrations (e.g., a `gflow serve` HTTP front-end) can return our errors directly without translation, (c) downstream telemetry tools recognize the shape immediately.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,6 +109,31 @@ GFLOW_CLI_AUTH_LOGIN_TIMEOUT=120 gflow auth login   # abort after 2 minutes
 **Recommended starting point:** `4`. Each Page costs ~30–60 MiB of memory on Chromium headless; don't exceed `8` without measuring resident-set size. Cookies and storage state are shared at Context level, so every Page inherits the signed-in profile for free.
 **Shipped in:** v0.4.0a2.
 
+### `GFLOW_CLI_DB_PATH`
+
+**What:** Override the path to the local SQLite operations database.
+**Default:** `<GFLOW_CLI_HOME>/gflow.db`
+**Override examples:**
+```bash
+export GFLOW_CLI_DB_PATH=/secure-volume/gflow.db       # POSIX
+$env:GFLOW_CLI_DB_PATH = "D:\gflow-data\gflow.db"     # PowerShell
+```
+
+Use this when you want the DB on a different volume, outside `GFLOW_CLI_HOME`, or when running multiple isolated environments that share the same home dir.
+
+### `GFLOW_CLI_HISTORY_PROMPTS`
+
+**What:** Controls how prompt text is persisted in the local database.
+**Values:**
+- `store` (default) — the full prompt text is saved to the database alongside the operation record.
+- `redacted` — only the SHA-256 hash of the prompt is stored; the prompt text itself is never written to disk. Use this when prompts may contain sensitive content.
+
+**Default:** `store`
+
+```bash
+GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
+```
+
 ### `GFLOW_CLI_HEADLESS`
 
 **What:** Run Playwright in headless mode for non-`auth login` commands.

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -1,0 +1,370 @@
+# Data Layer
+
+`gflow-cli` keeps a local SQLite catalog of every new image, batch, and video operation. This document explains what it stores, why, and how to use it.
+
+If you only need quick lookup syntax, jump to [Querying the data layer](#querying-the-data-layer). For env vars, see [`CONFIGURATION.md`](CONFIGURATION.md#gflow_cli_db_path). For exit codes and recovery, see [`USAGE.md`](USAGE.md#exit-codes).
+
+---
+
+## Goals
+
+The data layer exists to answer three questions that the CLI alone cannot:
+
+1. **"What generated this file?"** — given a local `.png` / `.mp4`, find the prompt, model, aspect ratio, profile, project, and Flow media ID that produced it.
+2. **"Which seed image can I reuse for I2V?"** — given a profile, resolve a candidate image to the Flow `media_id` + `project_id` the video transport needs, without rewalking the Flow UI library.
+3. **"What happened during that batch?"** — given a batch run, list every output with success/failure status and the operation provenance.
+
+It is also the foundation for future history browsing, cost tracking, repair/import tooling, and (eventually) a management UI.
+
+### Explicit non-goals (v1)
+
+- No Postgres / cloud / `DATABASE_URL` runtime support — SQLite only.
+- No event sourcing, ORM, or remote multi-user semantics.
+- No backfill of existing output folders — only NEW operations are recorded.
+- No user-facing history browser — only the minimal `gflow data media <id>` lookup.
+
+The schema is adapter-shaped so a future Postgres backend can slot in without changing call sites, but that work is backlog.
+
+---
+
+## What is recorded
+
+| Table | Holds | When written |
+|---|---|---|
+| `profiles` | Logical profile name (e.g. `default`), profile dir, first/last-seen timestamps | First operation per profile |
+| `projects` | Flow project ID + display title per profile | First operation that touches the project |
+| `assets` | One row per Flow media ID (image OR video) — model, aspect, dimensions, seed, generation ID, status | Upload response, image generation response, video start, video completion |
+| `operations` | One row per CLI command invocation — mode (`upload_image`/`t2i`/`i2i`/`t2v`/`i2v`/`r2v`), prompt, model, aspect, started/completed timestamps, error type/detail, Flow operation/batch IDs | Each command run |
+| `operation_assets` | Many-to-many between operations and assets, with role (`input`/`output`/`seed_start`/`seed_end`/`reference`) and ordered position | When the operation links its inputs/outputs |
+| `local_files` | One row per downloaded file — path, sha256, byte count, media type | After each download completes |
+
+Schema lives in [`src/gflow_cli/data/migrations/0001_initial.sql`](../src/gflow_cli/data/migrations/0001_initial.sql).
+
+### What is NOT recorded
+
+- Signed CDN URLs (e.g., `fifeUrl?Signature=...`) — they expire and contain bearer-style tokens.
+- reCAPTCHA tokens, `Authorization` headers, cookies — stripped by [`redact_metadata`](#privacy-and-redaction).
+- Thumbnails or preview blobs — only the local file path is recorded.
+- Anything from Flow's anonymous gallery — only operations issued by gflow.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ CLI commands (cli_image.py, cli_video.py, image_batch)  │
+│         opens OperationRecorder.open(settings)          │
+│         passes recorder to runner, closes in finally    │
+└─────────────────────┬───────────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────┐
+│ OperationRecorder (gflow_cli/data/recorder.py)          │
+│ Public methods:                                         │
+│   record_upload_image(...)                              │
+│   record_generated_images(...)                          │
+│   record_started_video(...)                             │
+│   record_completed_video(...)                           │
+│ Owns redact_metadata + prompt_fields (prompt privacy)   │
+└─────────────────────┬───────────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────┐
+│ DataRepository (gflow_cli/data/repository.py)           │
+│ Row-level upserts + read queries                        │
+│ Wraps sqlite3.IntegrityError → DataIntegrityError       │
+│ All writes use ON CONFLICT(...) upserts                 │
+│ Seed resolvers: by_media_id / by_path / latest / list   │
+└─────────────────────┬───────────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────┐
+│ DataStore (gflow_cli/data/store.py)                     │
+│ Opens connection with foreign_keys=ON, WAL, busy=5000   │
+│ Applies SHA-256-checksummed migrations via              │
+│   importlib.resources (works in wheels + sdists)        │
+│ transaction(immediate=True) context manager             │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Boundary rules:**
+
+- The `gflow_cli.data` package never imports `playwright`, `click`, or `rich`.
+- Raw `sqlite3.Error` never crosses the package boundary — all failures are wrapped in `DataStoreError` / `DataMigrationError` / `DataIntegrityError`.
+- The recorder is composed at the CLI/client boundary, not inside transports.
+
+---
+
+## Recording flow
+
+A typical `gflow image t2i` invocation records this sequence:
+
+1. `OperationRecorder.open(settings)` opens the DB and applies pending migrations. **This happens BEFORE any Flow call** — a DB failure fails fast with exit code 16, so we never bill the user for a generation we can't track.
+2. `FlowApiClient` creates the project and generates the image.
+3. Outputs are downloaded.
+4. After all downloads complete, `recorder.record_generated_images(...)` writes:
+   - `profiles` upsert
+   - `projects` upsert (`source="generated"`)
+   - One `operations` row (mode=`t2i`, prompt + hash + redacted flag)
+   - One `assets` row per generated image (kind=`image`, status=`ready`, dimensions, seed, model, aspect, `flow_media_generation_id`)
+   - `operation_assets` link as `output` per position
+   - `local_files` row per downloaded file with sha256 + bytes + media type
+5. `recorder.close()` is called in a `finally` block.
+
+For T2V the sequence is split: `record_started_video(...)` fires the moment the generation response yields a media ID (via the `on_started` callback in `FlowApiClient.generate_video`), then `record_completed_video(...)` updates status + inserts the local file after long polling finishes. This way a paid video is recorded with `status="pending"` even if the long poll later fails.
+
+For batches, each row is recorded individually in a per-row `try/except DataStoreError`, so one row's persistence failure does not stop the rest of the batch.
+
+---
+
+## Persistence-failure handling
+
+The data layer follows a "fail fast before billing, warn after success" contract:
+
+| When | Behavior | Exit code |
+|---|---|---|
+| DB cannot be opened (permission, path) | Raise `DataStoreError` BEFORE Flow call | 16 |
+| Migration fails or detects checksum drift | Raise `DataMigrationError` BEFORE Flow call | 16 |
+| DB has a NEWER schema than installed gflow-cli | Raise `DataMigrationError` BEFORE Flow call | 16 |
+| Recorder write fails AFTER successful paid generation | Emit `data.persistence_failed_after_success` structlog event with `flow_media_id` + `local_path`; print yellow warning; **return 0** | 0 |
+| Batch row N fails to persist | Same warning; later rows still recorded | 0 (or 1 if other failure modes apply) |
+
+**Why "warn and continue" after success?** If your `gflow video t2v` succeeds and the file lands on disk, exiting non-zero solely because the local catalog could not be updated would teach scripts to retry the paid generation. The catalog can be reconciled later by a future `gflow data repair`; the file cannot be un-billed.
+
+Recovery for "newer schema" failures: either upgrade `gflow-cli` to a version that knows the schema, or set `GFLOW_CLI_DB_PATH` to a compatible database.
+
+---
+
+## Privacy and redaction
+
+### Prompt storage
+
+Controlled by `GFLOW_CLI_HISTORY_PROMPTS`:
+
+| Value | Stored | Why |
+|---|---|---|
+| `store` (default) | Full prompt text + SHA-256 hash + `prompt_redacted=0` | Provenance — "what prompt produced this image" is the most asked question |
+| `redacted` | NULL prompt text + SHA-256 hash + `prompt_redacted=1` | Local privacy — share the DB without leaking prompts |
+
+The hash is always stored so you can correlate without the plaintext.
+
+### Metadata redaction
+
+[`redact_metadata`](../src/gflow_cli/data/redaction.py) is applied to every dict that lands in `assets.metadata_json`. It strips:
+
+| Key (case-insensitive) | Replacement |
+|---|---|
+| `fifeUrl`, `signedUrl`, `downloadUrl`, `mediaUrl` | `<redacted:url>` |
+| `token`, `recaptchaToken` | `<redacted:token>` |
+| `authorization`, `cookie`, `set-cookie` | `<redacted:secret>` |
+| Any string value containing `signature=`, `x-goog-signature=`, `x-goog-credential=`, or `expires=` | `<redacted:url>` |
+
+This means the recorder OWNS redaction — call sites cannot leak signed URLs into the DB even by accident, because `OperationRecorder` always pipes metadata through `redact_metadata` before writing.
+
+### What the DB still contains
+
+Even with `redacted` mode and metadata stripping, the DB stores: profile names, Flow project/media/workflow/operation IDs, local file paths, asset dimensions/seeds/timestamps, model and aspect choices, and prompt hashes. If your threat model requires hiding even profile-level activity, exclude `<GFLOW_CLI_HOME>/gflow.db` from backups or set `GFLOW_CLI_DB_PATH` to a per-task ephemeral location.
+
+See [`SECURITY.md`](SECURITY.md) for the broader threat model.
+
+---
+
+## Querying the data layer
+
+### `gflow data media <media_id>` — read a single asset
+
+```
+gflow data media MEDIA_ID [--profile NAME]
+```
+
+Returns a Rich-formatted table:
+
+```
+gflow data media
+┌────────────────┬─────────────────────────────────┐
+│ field          │ value                           │
+├────────────────┼─────────────────────────────────┤
+│ profile        │ default                         │
+│ media_id       │ project.../media-abc-123        │
+│ project_id     │ project-xyz-456                 │
+│ kind           │ image                           │
+│ local_path_1   │ C:\out\image.png                │
+└────────────────┴─────────────────────────────────┘
+```
+
+Exits with code 16 if the media ID is not in the DB. Exits 0 with the table if found.
+
+### Direct SQL inspection
+
+The DB is a plain SQLite file. For ad-hoc reads:
+
+```bash
+sqlite3 ~/.gflow/gflow.db
+sqlite> SELECT mode, prompt, model, status, started_at
+        FROM operations
+        ORDER BY started_at DESC LIMIT 10;
+```
+
+The schema is fixed at v1; future migrations will be additive (new tables, new nullable columns).
+
+### Programmatic access from your own scripts
+
+```python
+from gflow_cli.config import get_settings
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+with DataStore.open(get_settings().resolved_db_path()) as store:
+    repo = DataRepository(store)
+    # Resolve a seed image candidate by Flow media ID:
+    seed = repo.resolve_seed_image("default", "project.../media-abc-123")
+    if seed:
+        print(seed.flow_project_id, seed.local_path)
+
+    # Latest image for a profile (optionally scoped):
+    latest = repo.resolve_latest_image("default", flow_project_id=None,
+                                       model=None, aspect_ratio=None)
+
+    # Resolve by local path:
+    by_path = repo.resolve_seed_image_by_path("default", Path("C:/out/image.png"))
+```
+
+The public read API is documented in [`src/gflow_cli/data/repository.py`](../src/gflow_cli/data/repository.py); all read methods return typed `SeedImage` / `AssetLookup` dataclasses, not raw SQLite rows.
+
+---
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `GFLOW_CLI_DB_PATH` | `<GFLOW_CLI_HOME>/gflow.db` | Override the SQLite file location. Useful for tests, per-account isolation, or shared filesystems. |
+| `GFLOW_CLI_HISTORY_PROMPTS` | `store` | `store` keeps prompt text, `redacted` keeps only the SHA-256 hash. |
+
+The DB file is created on first run. Parent directory is auto-created.
+
+See [`CONFIGURATION.md`](CONFIGURATION.md) for the full env-var precedence chain.
+
+---
+
+## Migrations
+
+All schema changes are SQL files under [`src/gflow_cli/data/migrations/`](../src/gflow_cli/data/migrations/), named `NNNN_description.sql` with a 4+ digit zero-padded prefix.
+
+**How they're applied:**
+
+1. On `DataStore.open()`, the runner scans the migrations package via `importlib.resources` (so it works in installed wheels, not just editable installs).
+2. Each file is SHA-256-checksummed (with normalized line endings — CRLF → LF, trailing whitespace trimmed) so contributor newline differences don't trigger drift.
+3. The `schema_migrations` table records `version`, `filename`, `checksum`, `applied_at`.
+4. Pending migrations are applied in a single `BEGIN IMMEDIATE` transaction each.
+5. The highest applied version is mirrored into `PRAGMA user_version` as a convenience — `schema_migrations` remains the source of truth.
+
+**Safety guarantees:**
+
+- **Checksum drift** — if an applied migration's file has changed on disk, `DataMigrationError("checksum drift")` is raised. Migrations are immutable once shipped.
+- **Newer schema** — if the DB contains a migration version higher than any installed in the package, `DataMigrationError("newer")` is raised. Upgrade gflow-cli or point at a compatible DB.
+- **Transactional** — each migration's statements run inside a single transaction. A failure rolls back the entire migration.
+- **Statement splitter** — the runner uses a small SQL tokenizer that respects `'`-quoted string literals and `--` line comments, so semicolons inside `'a;b'` don't split prematurely.
+
+**Adding a migration:** drop a new `NNNN_description.sql` file into `src/gflow_cli/data/migrations/`. The packaging test (`tests/data/test_packaging.py`) automatically verifies it ships in the wheel.
+
+---
+
+## Connection settings
+
+Every SQLite connection opened by `DataStore` enables:
+
+| PRAGMA | Value | Why |
+|---|---|---|
+| `foreign_keys` | `ON` | The schema declares FK constraints; SQLite ignores them by default |
+| `journal_mode` | `WAL` | Allows parallel CLI processes to read while one writes |
+| `busy_timeout` | `5000` (ms) | Two CLI processes upserting concurrently retry briefly instead of failing immediately with `database is locked` |
+
+Writes are explicitly grouped with `BEGIN IMMEDIATE` via `DataStore.transaction(immediate=True)` to avoid deferred-writer deadlocks under WAL. Connections use `isolation_level=None` so the transaction context manager controls boundaries explicitly.
+
+---
+
+## Error taxonomy
+
+All three errors map to **exit code 16**:
+
+| Class | When raised |
+|---|---|
+| `DataStoreError` | Generic DB open / read / write failure |
+| `DataMigrationError` | Migration apply, checksum drift, or newer-schema |
+| `DataIntegrityError` | Constraint violation surfaced from `sqlite3.IntegrityError` (e.g., natural-key conflict on `(profile_name, flow_media_id)`) |
+
+All three are subclasses of `GFlowError` and re-exported through `gflow_cli.exceptions`. They follow the project's RFC 9457 Problem Details pattern.
+
+See [`errors.py::EXIT_CODE_MAP`](../src/gflow_cli/errors.py) for the complete exit-code mapping.
+
+---
+
+## Extending the data layer
+
+### Adding a new operation kind
+
+1. Add the enum value to `OperationKind` in [`data/models.py`](../src/gflow_cli/data/models.py).
+2. Add a `record_<kind>(...)` method to `OperationRecorder` following the existing patterns (upsert profile → project → asset → insert operation → link → local files).
+3. Wire it into the CLI call site, mirroring the `_run_t2i` / `record_completed_video` patterns: open recorder BEFORE Flow, close in `finally`, wrap the `record_*` call in `try/except DataStoreError` calling `_warn_persistence_failed_after_success(...)`.
+
+### Adding a new column
+
+1. Write a new migration file `NNNN_description.sql` with `ALTER TABLE ... ADD COLUMN`. Keep the column nullable so old rows still validate.
+2. Add the field to the relevant `*Record` dataclass with a `None` default at the end.
+3. Update `DataRepository` upsert/read methods to handle the new field.
+4. Add a test in `tests/data/test_repository.py`.
+
+### Why no ORM
+
+We deliberately use stdlib `sqlite3` with hand-written SQL. Reasons:
+
+- The schema is small (7 tables) and stable.
+- Migrations are simpler to reason about as raw SQL.
+- No dependency on SQLAlchemy / Alembic adds zero binary weight.
+- `importlib.resources` packaging of SQL files is straightforward.
+
+If we ever need Postgres, the migration story changes — but the call sites won't, because they go through `DataRepository`, not raw SQL.
+
+---
+
+## Testing
+
+- **Unit tests** at `tests/data/` use temporary SQLite files and exercise migrations, repository, recorder, redaction.
+- **CLI tests** at `tests/cli/test_cli_data.py`, `test_cli_image.py`, `test_cli_video.py` use a `FakeRecorder` to assert the right kwargs reach the recorder without touching SQLite.
+- **Batch tests** at `tests/image_batch/test_image_manifest.py` cover the per-row recorder + salvage paths.
+- **Packaging test** at `tests/data/test_packaging.py::test_migration_resource_is_discoverable` verifies `0001_initial.sql` is reachable via `importlib.resources`. The `@pytest.mark.integration` companion builds a wheel + sdist and inspects them.
+
+Run the focused data-layer suite:
+
+```bash
+PYTHONUTF8=1 uv run python -m pytest tests/data \
+    tests/cli/test_cli_data.py tests/cli/test_cli_image.py tests/cli/test_cli_video.py \
+    tests/api/test_client.py tests/api/test_video.py \
+    tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py -q
+```
+
+Live tests (`@pytest.mark.live`) and E2E tests (`@pytest.mark.e2e`) are opt-in and do exercise the real data layer end-to-end.
+
+---
+
+## Backlog (future enhancements)
+
+- **`gflow data import` / `gflow data repair`** — backfill rows from existing output folders.
+- **`gflow data ls` / `gflow data show <operation_id>`** — richer browsing without leaving the terminal.
+- **Cost tracking** — once enough operation metadata is reliable, surface "credits spent this month" per profile / model / aspect.
+- **Postgres / Supabase adapter** — for users running gflow on shared workers or wanting cross-machine sync. The repository surface is already designed for this swap.
+- **`gflow data export`** — dump the catalog as JSON / Parquet for downstream analytics.
+
+These are tracked in [`PLAN.md`](../PLAN.md) under the data-layer phase backlog.
+
+---
+
+## See also
+
+- [Spec](superpowers/specs/2026-05-24-data-layer-design.md) — original design document with goals, non-goals, and architectural rationale.
+- [Plan](superpowers/plans/2026-05-24-data-layer.md) — task-by-task implementation plan.
+- [`CONFIGURATION.md`](CONFIGURATION.md) — env-var reference.
+- [`USAGE.md`](USAGE.md) — `gflow data media` command reference.
+- [`SECURITY.md`](SECURITY.md) — threat model for stored prompts and metadata.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — how `gflow_cli.data` fits into the modular monolith.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | **[docs/USAGE.md](USAGE.md)** | Command-by-command reference, manifest format, recipes, exit-code table | Day-to-day CLI use — look up specific commands / flags |
 | **[docs/ARCHITECTURE.md](ARCHITECTURE.md)** | Modular monolith, per-worker Page pool, RFC 9457 Problem Details, retry layer | Adding a feature or a new provider |
 | **[docs/SECURITY.md](SECURITY.md)** | What secrets are stored where, threat model, hardening | Audit, code review, multi-user machines |
+| **[docs/DATA_LAYER.md](DATA_LAYER.md)** | Local SQLite catalog: goals, schema, recording flow, redaction, `gflow data` CLI, migrations, extension guide | Anything touching `gflow_cli.data`, debugging missing rows, building I2V/repair tooling, auditing what is stored |
 | **[tasks/lessons.md](../tasks/lessons.md)** | Running notebook of patterns + reviewer findings, dated and traced to commits | Starting a new phase; debugging "why did the council flag this?" |
 
 ## Agent commands
@@ -58,6 +59,10 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"How do I run with multiple Google accounts?"** → [AUTHENTICATION § Multiple accounts](AUTHENTICATION.md#multiple-accounts)
 **"How does the layered structure work?"** → [ARCHITECTURE § Layers](ARCHITECTURE.md#layers)
 **"What env var should I set for X?"** → [CONFIGURATION § Reference](CONFIGURATION.md#reference)
+**"What does gflow remember after a generation finishes?"** → [DATA_LAYER § What is recorded](DATA_LAYER.md#what-is-recorded)
+**"Where can I look up a media ID I generated yesterday?"** → [DATA_LAYER § Querying the data layer](DATA_LAYER.md#querying-the-data-layer)
+**"How do I stop gflow from storing my prompts?"** → [DATA_LAYER § Privacy and redaction](DATA_LAYER.md#privacy-and-redaction)
+**"What does exit code 16 mean and how do I recover?"** → [DATA_LAYER § Persistence-failure handling](DATA_LAYER.md#persistence-failure-handling)
 **"How do I report a security issue?"** → [SECURITY § Reporting](SECURITY.md#reporting)
 **"What branch do I work on? How do I name it?"** → [DEVELOPMENT § Branching model](DEVELOPMENT.md#branching-model)
 **"How do I handle an external GitHub PR?"** → [GITHUB § Scenario Matrix](GITHUB.md#scenario-matrix)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -77,6 +77,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"Flow's UI broke a selector — how do I diagnose it?"** → [DEBUGGING § Inspecting Flow's live UI](DEBUGGING.md#inspecting-flows-live-ui)
 **"What does each `ui_automation.*` log event mean?"** → [DEBUGGING § Listener & HTTP-layer debugging](DEBUGGING.md#listener--http-layer-debugging)
 **"What was actually live-verified for the latest release?"** → [LIVE_VERIFICATION_v0.8.1](LIVE_VERIFICATION_v0.8.1.md) · prior: [v0.7.0](LIVE_VERIFICATION_v0.7.0.md)
+**"What was live-verified for the data layer (PR #58)?"** → [LIVE_VERIFICATION_data_layer](LIVE_VERIFICATION_data_layer.md) — 1 Imagen + 1 Veo credit on denon82, 6-layer ledger (file + magic + Pillow + DB rows + CLI round-trip + structlog)
 **"What was live-verified for the video-download feature (#29)?"** → [LIVE_VERIFICATION_video_download](LIVE_VERIFICATION_video_download.md)
 **"What is the jitter matrix evidence for `gflow image batch`?"** → [`LIVE_VERIFICATION_image_batch.md`](LIVE_VERIFICATION_image_batch.md) — jitter matrix evidence for `gflow image batch` (always-same-project mode)
 

--- a/docs/LIVE_VERIFICATION_data_layer.md
+++ b/docs/LIVE_VERIFICATION_data_layer.md
@@ -1,0 +1,209 @@
+# Live Verification — Data Layer (PR #58)
+
+**Date:** 2026-05-24
+**Branch / commit at run time:** `feature/data-layer` @ `bcd29ec` + uncommitted data-layer `completed_at` fix
+**Account / profile:** `denon82` (active default per `gflow auth list`)
+**Spend:** 1 Imagen credit (t2i) + 1 Veo credit (omni-flash, 4s, count=1, landscape)
+**Driver:** `tests/e2e/test_data_layer_e2e.py`
+**Spec:** [`docs/superpowers/specs/2026-05-24-data-layer-design.md`](superpowers/specs/2026-05-24-data-layer-design.md)
+**Plan:** [`docs/superpowers/plans/2026-05-24-data-layer.md`](superpowers/plans/2026-05-24-data-layer.md)
+**Doc:** [`docs/DATA_LAYER.md`](DATA_LAYER.md)
+
+This document is the credit-spending evidence ledger for PR #58. Mirrors the project's existing pattern (see [LIVE_VERIFICATION_v0.8.1](LIVE_VERIFICATION_v0.8.1.md), [LIVE_VERIFICATION_video_download](LIVE_VERIFICATION_video_download.md)). Per [[verification-ledger-5-layer]] every credit-spending feature must have file-cardinality + magic-bytes + Pillow-dimensions + structlog-invariants + user-gallery confirmation — for the data layer we add a 6th layer: **persisted-row verification**.
+
+---
+
+## Summary
+
+| Layer | t2i | t2v |
+|---|---|---|
+| Subprocess exit code | 0 ✅ | 0 ✅ |
+| File present | 1 PNG, 735 434 B ✅ | 1 MP4, 621 429 B ✅ |
+| Magic bytes | `89 50 4E 47` (PNG) ✅ | `66 74 79 70 69 73 6F 6D` (ftypisom) ✅ |
+| Pillow dimensions | 1024 × 1024 (1:1) ✅ | n/a (video) |
+| Data-layer profile row | denon82 ✅ | denon82 ✅ |
+| Data-layer project row | source=generated ✅ | source=generated ✅ |
+| Data-layer asset row | kind=image, status=ready, 1024×1024 ✅ | kind=video, status=MEDIA_GENERATION_STATUS_SUCCESSFUL, duration=4.0s ✅ |
+| Data-layer operation row | status=succeeded, completed_at set ✅ | status=succeeded, completed_at set ✅ |
+| Prompt round-trip | full text + sha256 ✅ | full text + sha256 ✅ |
+| Operation_assets link | output, position 0 ✅ | output, position 0 ✅ |
+| local_files row | absolute path + sha256 + 735 KB ✅ | absolute path + sha256 + 621 KB ✅ |
+| `gflow data media <id>` round-trip | media_id + project_id + kind in output ✅ | media_id + project_id + kind in output ✅ |
+| `gflow data media <unknown>` exit | 16 (DataStoreError) ✅ | 16 (DataStoreError) ✅ |
+
+**Result: ALL six layers pass for both image and video.**
+
+Wall-clock: t2i ~52 s, t2v ~52 s, both well below their generous timeouts (240 s / 600 s).
+
+---
+
+## Bug uncovered (and fixed in-band)
+
+The first live t2i run failed on the assertion `op["completed_at"] is not None`. The data layer had successfully persisted the `started_at` (the moment recording began) but left `completed_at` NULL for image operations.
+
+**Root cause:** `OperationRecorder.record_generated_images` and `record_upload_image` inserted the SUCCEEDED operation row in one shot via `insert_operation(...)`, which only stamps `started_at`. `completed_at` was reserved for the video lifecycle's later `update_operation_status(...)` call. But for image generation, recording happens AFTER the file is downloaded — the operation is already terminal at insert time. Leaving `completed_at` NULL would have broken any query like `SELECT * FROM operations WHERE completed_at IS NULL` (which should surface only pending operations).
+
+**Fix:** After the SUCCEEDED `insert_operation(...)`, immediately call `repo.update_operation_status(op_id, SUCCEEDED, _now_utc_iso(), None, None)` to stamp `completed_at = now`. Lifted the `datetime`/`UTC` import to module scope and extracted a `_now_utc_iso()` helper. Two operations affected: `record_upload_image`, `record_generated_images`.
+
+Without the E2E live test, this gap would have shipped silently — every existing unit test passed because they didn't assert on `completed_at` round-trip.
+
+---
+
+## Known observation: `flow_operation_id` is NULL for omni-flash
+
+The Task 7 transport refactor wired `operation_name_from_generate_response(body)` into the `on_started` callback so `flow_operation_id` could be stored separately from `flow_media_id` (per spec). The live `omni-flash` t2v response did NOT carry `operations[0].operation.name` — the helper returned None, which the recorder persisted as NULL.
+
+This is consistent with the spec's wording: *"In current captures this appears to match the generated media ID, but it should be stored separately **when observed**."* The recorder correctly stores `None` when not observed. Verified for `omni-flash`; behavior on `veo-quality` / `veo-fast` / `veo-lite` is not yet observed live. The E2E test's assertion was loosened to "if present, equals media_id" so future model coverage can tighten without API changes.
+
+This is **not** a data-layer bug; the data layer stored what the transport surfaced. Filed for follow-up investigation when a richer Flow capture is available.
+
+---
+
+## Out-dir env-var observation
+
+`gflow image t2i` honors `GFLOW_CLI_OUTPUT_DIR`. `gflow video t2v` does NOT — it defaults to `./tmp` and requires `--out-dir` explicitly. The E2E test passes `--out-dir` for the video path. Not part of this PR's scope, but worth noting for future env-var-coverage work.
+
+---
+
+## Evidence — t2i
+
+```text
+$ pytest tests/e2e/test_data_layer_e2e.py::test_t2i_records_full_provenance -m e2e -v
+tests/e2e/test_data_layer_e2e.py::test_t2i_records_full_provenance PASSED [100%]
+============================= 1 passed in 38.00s ==============================
+```
+
+### File ledger
+
+```text
+out/images/2026-05-24/57f8a03c-e46b-4ef3-9339-73096e78cd9b_1.png
+  size:   735 434 bytes
+  magic:  89 50 4E 47   (PNG)
+  Pillow: 1024 × 1024   (1:1 within ±2%)
+```
+
+### DB ledger
+
+```text
+profiles
+  name=denon82
+  profile_dir=C:\Users\ffrol\AppData\Local\ffroliva\gflow-cli\profile_denon82
+
+projects
+  flow_project_id=404f2af8-a0af-4161-8d80-7daeb4cb92b4
+  source=generated
+
+assets
+  flow_media_id=57f8a03c-e46b-4ef3-9339-73096e78cd9b
+  flow_project_id=404f2af8-a0af-4161-8d80-7daeb4cb92b4
+  kind=image  status=ready
+  width=1024  height=1024
+  model=NARWHAL  aspect_ratio=IMAGE_ASPECT_RATIO_SQUARE
+
+operations
+  mode=t2i  status=succeeded
+  prompt="a single red apple on a wooden table, soft daylight"
+  prompt_hash=1ff72c3b…687642   (SHA-256, 64 hex)
+  prompt_redacted=0  (GFLOW_CLI_HISTORY_PROMPTS=store)
+  model=NARWHAL  aspect_ratio=IMAGE_ASPECT_RATIO_SQUARE
+  started_at=2026-05-24T11:33:00.054Z
+  completed_at=2026-05-24T11:33:00.055Z   ← post-fix; was NULL before
+  flow_operation_id=NULL  flow_batch_id=NULL
+
+operation_assets
+  role=output  position=0
+
+local_files
+  path=…\57f8a03c-e46b-4ef3-9339-73096e78cd9b_1.png   (absolute)
+  sha256=<64-char hex>
+  bytes=735434
+  media_type=image/png
+```
+
+---
+
+## Evidence — t2v
+
+```text
+$ pytest tests/e2e/test_data_layer_e2e.py::test_t2v_records_started_and_completed_lifecycle -m e2e -v
+tests/e2e/test_data_layer_e2e.py::test_t2v_records_started_and_completed_lifecycle PASSED [100%]
+============================= 1 passed in 52.39s ==============================
+```
+
+### File ledger
+
+```text
+out/c0608f5e-1af8-4113-8cfe-859aea9a951f.mp4
+  size:   621 429 bytes
+  magic:  00 00 00 20 66 74 79 70 69 73 6F 6D   (ftypisom — ISO BMFF mp4)
+```
+
+### DB ledger
+
+```text
+projects
+  flow_project_id=35e0dac8-6922-49ad-a8a9-4d37beb66b56
+  source=generated
+
+assets
+  flow_media_id=c0608f5e-1af8-4113-8cfe-859aea9a951f
+  flow_project_id=35e0dac8-6922-49ad-a8a9-4d37beb66b56
+  kind=video
+  status=MEDIA_GENERATION_STATUS_SUCCESSFUL    ← raw Flow status string
+  duration_seconds=4.0
+
+operations
+  mode=t2v  status=succeeded
+  prompt="a single red apple on a wooden table, soft daylight"
+  prompt_hash=1ff72c3b…687642
+  model=omni_flash  aspect_ratio=landscape
+  started_at=2026-05-24T11:31:22.506Z
+  completed_at=2026-05-24T11:31:56.414Z
+  flow_operation_id=NULL    ← see "Known observation" above
+
+operation_assets
+  role=output  position=0
+
+local_files
+  path=…\c0608f5e-1af8-4113-8cfe-859aea9a951f.mp4   (absolute)
+  sha256=<64-char hex>
+  bytes=621429
+  media_type=video/mp4
+```
+
+---
+
+## Evidence — `gflow data media` round-trip
+
+Both live tests assert that `gflow data media <flow_media_id> --profile denon82` returns the persisted row with `media_id`, `project_id`, and `kind` present in stdout. Both pass.
+
+Negative-path: `gflow data media does-not-exist --profile denon82` exits **16** (`DataStoreError`) with the message `No local media record found: does-not-exist`. The CLI structured log emits `error_raised` carrying the RFC 9457 Problem Details payload.
+
+---
+
+## Reproducing
+
+```bash
+export GFLOW_CLI_E2E_PROFILE=denon82
+export PYTHONUTF8=1
+uv run python -m pytest tests/e2e/test_data_layer_e2e.py -m e2e -v --basetemp=tmp/e2e-evidence
+```
+
+For the cheap subset (no Veo spend), set `GFLOW_CLI_E2E_RUN_VIDEO=0`.
+
+DB inspection after the run:
+
+```bash
+sqlite3 tmp/e2e-evidence/test_*_records_*/gflow.db \
+  -header -column \
+  "SELECT mode, status, started_at, completed_at FROM operations;"
+```
+
+---
+
+## See also
+
+- [DATA_LAYER.md](DATA_LAYER.md) — user-facing reference for the data layer.
+- [USAGE.md § exit codes](USAGE.md#exit-codes) — exit code 16 (DataStoreError) row.
+- [tests/e2e/test_data_layer_e2e.py](../tests/e2e/test_data_layer_e2e.py) — the verifier itself.
+- Memory: [[verification-ledger-5-layer]] · [[data-layer-overview]] · [[on-started-callback-recorder-safety]].

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,6 +8,7 @@
 |---|---|---|
 | Google session cookies (in `$GFLOW_CLI_HOME/profile_<name>/Default/Cookies`) | Theft → full access to user's Google account | **High** |
 | Generated outputs (`$GFLOW_CLI_OUTPUT_DIR/...`) | Unwanted disclosure | Medium (depends on content) |
+| Local database (`$GFLOW_CLI_HOME/gflow.db`) | Disclosure of prompt history and asset provenance | Low–Medium (depends on prompt content; use `GFLOW_CLI_HISTORY_PROMPTS=redacted` to reduce) |
 | `.env` file with `GFLOW_CLI_GEMINI_API_KEY` | Theft → API quota theft, billing | Medium |
 | Project-internal logs | Leaking prompts / asset IDs | Low |
 
@@ -40,6 +41,38 @@ Not used by v0.4.0a2's reverse-engineered Flow provider. Documented here in adva
 
 - **Location:** stdout/stderr by default. No log file unless you redirect.
 - **Content scrubbing:** Prompts, asset UUIDs, job IDs, profile names. No cookies, no tokens, no API keys.
+
+## Local data layer
+
+`gflow-cli` maintains a local SQLite database at `<GFLOW_CLI_HOME>/gflow.db` (default) that records provenance for every new image and video operation.
+
+### What is stored
+
+| Field | Stored? |
+|---|---|
+| Profile name | Yes |
+| Flow project ID, media ID, workflow ID, operation ID | Yes |
+| Local file paths of downloaded assets | Yes |
+| Prompt text | Yes (default) — set `GFLOW_CLI_HISTORY_PROMPTS=redacted` to store hash only |
+| Prompt SHA-256 hash | Yes (always) |
+| Asset metadata: model, aspect ratio, dimensions, seed, timestamps | Yes |
+| Signed CDN URLs | **Never** — stripped by `redact_metadata` before DB write |
+| reCAPTCHA tokens | **Never** — stripped by `redact_metadata` before DB write |
+| Authorization headers and cookies | **Never** — stripped by `redact_metadata` before DB write |
+
+### Privacy controls
+
+- **`GFLOW_CLI_HISTORY_PROMPTS=redacted`** — store only the SHA-256 hash of the prompt, never the plain text. Useful when prompts contain sensitive or confidential content.
+- The database is local-only. No cloud sync, no telemetry upload. It lives on your filesystem and never leaves the machine unless you explicitly copy it.
+- `GFLOW_CLI_DB_PATH` lets you redirect the database to any path (e.g. an encrypted volume). A fresh path creates an empty database automatically.
+
+### Redaction guarantee
+
+The `OperationRecorder.redact_metadata` method explicitly strips `signedUrl`, `cdnUrl`, `token`, `recaptchaToken`, `authorization`, and `cookie` keys (case-insensitive, including nested structures) before any data reaches the database. This is covered by unit tests in `tests/data/test_recorder.py`.
+
+### Database file permissions
+
+The database is created with standard OS file permissions. On POSIX systems this means it is readable by the current user (mode `0600` is not enforced — use filesystem-level controls if you need strict isolation). On Windows, ACLs follow the `GFLOW_CLI_HOME` directory defaults. Use full-disk encryption (FileVault / BitLocker / LUKS) if you store sensitive prompts and need at-rest protection.
 
 ## CI / Repository security controls (v0.6.0a5+)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,6 +28,9 @@ Commands:
     i2v                         Generate a video from a start (+ optional end) frame + prompt.
     r2v                         Generate a video from reference images + prompt.
     batch                       Run a TSV manifest of video generations.
+
+  data      Local provenance database (read-only queries).
+    media MEDIA_ID              Show stored record for a Flow media ID.
 ```
 
 Global flags:
@@ -370,6 +373,34 @@ hero.png	Slow camera arc		9:16	./out/hero.mp4
 | `aspect` | no | `9:16` |
 | `output_path` | no | `<out_dir>/videos/<date>/<media>.mp4` |
 
+## `gflow data media`
+
+Look up a recorded operation by its Flow media ID. Prints a summary of the stored provenance record: profile, media ID, Flow project ID, kind (image/video), and the local file paths that were written for that operation.
+
+```text
+gflow data media MEDIA_ID [--profile NAME]
+
+Arguments:
+  MEDIA_ID              Flow media UUID (e.g. ddb6ef97-262d-49f4-8269-4a28c0fae6a2). [required]
+
+Options:
+  --profile NAME        Profile name (overrides default).
+```
+
+**Example output:**
+
+```text
+Profile:    default
+Media ID:   ddb6ef97-262d-49f4-8269-4a28c0fae6a2
+Project ID: f1a2b3c4-0000-0000-0000-000000000001
+Kind:       image
+Paths:
+  /home/user/Downloads/gflow-cli/images/2026-05-24/ddb6ef97_1.png
+  /home/user/Downloads/gflow-cli/images/2026-05-24/ddb6ef97_2.png
+```
+
+Exit codes: `0` success, `2` media ID not found in the local database, `16` database error (see exit code table below).
+
 ## `gflow run`
 
 Sequential JSON-described batch image generation. New in v0.5.0a1.
@@ -498,7 +529,16 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `12` | `AuthLoginTimeoutError` | Browser sign-in was not completed in time       | Re-run login or raise `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`       |
 | `13` | `SecurityError`       | Unsafe local profile or secret handling blocked   | Follow the error's safety guidance                         |
 | `14` | `AuthBrowserRejectedError` | Google rejected the login browser             | `gflow auth login --browser chrome`                        |
+| `16` | `DataStoreError`      | Local database cannot be opened, a migration failed, or the DB schema is newer than the installed gflow-cli | See below                                  |
 | `130`| SIGINT                | User-interrupted (Ctrl-C)                        | —                                                          |
+
+**Exit code 16 — data store / migration error.** Fires when:
+
+- The database file cannot be opened (filesystem permission or path issues).
+- A migration fails or the migration checksum drifts from what the installed version expects.
+- The database has a **newer schema** than the installed gflow-cli (i.e. you downgraded after a migration already ran).
+
+Recovery for the "newer schema" case: upgrade gflow-cli to a version that understands the schema (`uv tool upgrade gflow-cli`), OR point `GFLOW_CLI_DB_PATH` to a different database location (a fresh path creates a new empty database automatically).
 
 All errors emit a structured `error_raised` event (or `error_unhandled` for
 exit code 1) with stable fields — `error_class`, `problem` (RFC 9457 Problem
@@ -528,6 +568,7 @@ if [ "$rc" -ne 0 ]; then
     11)  echo "Configuration error — fix the option or env var shown above"; exit 1 ;;
     13)  echo "Security guard blocked unsafe local state — follow the error guidance"; exit 1 ;;
     14)  echo "Google rejected the login browser — run: gflow auth login --browser chrome"; exit 1 ;;
+    16)  echo "Database error — check permissions or upgrade gflow-cli"; exit 1 ;;
     130) echo "Cancelled with Ctrl-C"; exit 130 ;;
     *)   echo "Unknown failure (exit $rc)"; exit 1 ;;
   esac

--- a/docs/superpowers/plans/2026-05-24-data-layer.md
+++ b/docs/superpowers/plans/2026-05-24-data-layer.md
@@ -1,0 +1,2172 @@
+# Data Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local SQLite data layer that records profiles, Flow projects, generated or uploaded media, local files, and operation provenance for new gflow operations.
+
+**Architecture:** Introduce `gflow_cli.data` as a small SQLite-backed repository plus an `OperationRecorder` facade. CLI/API call sites record through the facade after successful Flow operations, while DB open and migrations fail fast before paid remote calls. Video generation is normalized behind a `FlowApiClient.generate_video` method so image and video persistence share one client boundary.
+
+**Tech Stack:** Python 3.11 stdlib `sqlite3`, `importlib.resources`, Pydantic settings, Click, structlog, pytest, ruff, pyright strict.
+
+---
+
+Source spec: `docs/superpowers/specs/2026-05-24-data-layer-design.md`
+
+## File Structure
+
+- Create `src/gflow_cli/data/__init__.py`: public data-layer exports.
+- Create `src/gflow_cli/data/models.py`: enum and dataclass value objects used by repositories and recorder.
+- Create `src/gflow_cli/data/store.py`: SQLite connection setup, PRAGMAs, explicit transactions, and migration runner.
+- Create `src/gflow_cli/data/repository.py`: row-level upsert/query methods.
+- Create `src/gflow_cli/data/redaction.py`: prompt hashing and metadata redaction.
+- Create `src/gflow_cli/data/recorder.py`: high-level operation recording facade.
+- Create `src/gflow_cli/data/migrations/__init__.py`: package marker for `importlib.resources`.
+- Create `src/gflow_cli/data/migrations/001_initial.sql`: v1 schema.
+- Create `src/gflow_cli/cli_data.py`: minimal read-only `gflow data` commands.
+- Modify `src/gflow_cli/config.py`: add `db_path`, `history_prompts`, and `resolved_db_path()`.
+- Modify `src/gflow_cli/errors.py`: add data-layer error classes and exit code 16.
+- Modify `src/gflow_cli/paths.py`: add `database_path(home)`.
+- Modify `src/gflow_cli/api/dto.py`: carry image `mediaGenerationId`.
+- Modify `src/gflow_cli/api/video.py`: carry video `project_id` and `flow_operation_id`.
+- Modify `src/gflow_cli/api/client.py`: add `generate_video` and data-layer-neutral result plumbing.
+- Modify `src/gflow_cli/api/transports/base.py`: expose a video-capable protocol without forcing every transport to support video.
+- Modify `src/gflow_cli/api/transports/_common.py`: move project-ID URL extraction here.
+- Modify `src/gflow_cli/api/transports/ui_automation.py`: import the shared project-ID extractor.
+- Modify `src/gflow_cli/api/transports/ui_automation_video.py`: populate video project and operation IDs.
+- Modify `src/gflow_cli/cli.py`: register the new `data` command group.
+- Modify `src/gflow_cli/cli_image.py`: record upload, t2i, and i2i operations.
+- Modify `src/gflow_cli/cli_video.py`: route T2V through `FlowApiClient` and record video operations.
+- Modify `src/gflow_cli/image_batch.py`: record image batch rows and partial-result salvage.
+- Modify `pyproject.toml`: include SQL migrations in built wheels.
+- Create tests under `tests/data/`.
+- Modify existing CLI/API tests for new arguments and video client boundary.
+- Modify docs: `docs/CONFIGURATION.md`, `docs/USAGE.md`, `docs/SECURITY.md`, `docs/ARCHITECTURE.md`, and `PLAN.md`.
+
+## Task 1: Settings, Paths, and Error Taxonomy
+
+**Files:**
+- Modify: `src/gflow_cli/config.py`
+- Modify: `src/gflow_cli/errors.py`
+- Modify: `src/gflow_cli/paths.py`
+- Create: `tests/data/test_settings_and_errors.py`
+
+- [ ] **Step 1: Write failing settings and error tests**
+
+Create `tests/data/test_settings_and_errors.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.config import Settings
+from gflow_cli.errors import (
+    EXIT_CODE_MAP,
+    DataIntegrityError,
+    DataMigrationError,
+    DataStoreError,
+    GFlowError,
+)
+from gflow_cli.paths import database_path
+
+
+def test_database_path_defaults_under_home(tmp_path: Path) -> None:
+    assert database_path(tmp_path) == tmp_path / "gflow.db"
+
+
+def test_settings_resolves_default_db_path(tmp_path: Path) -> None:
+    settings = Settings(home=tmp_path)
+    assert settings.resolved_db_path() == tmp_path / "gflow.db"
+
+
+def test_settings_respects_db_path_override(tmp_path: Path) -> None:
+    override = tmp_path / "custom.db"
+    settings = Settings(home=tmp_path, db_path=override)
+    assert settings.resolved_db_path() == override
+
+
+def test_settings_accepts_prompt_redaction_modes(tmp_path: Path) -> None:
+    assert Settings(home=tmp_path, history_prompts="full").history_prompts == "full"
+    assert Settings(home=tmp_path, history_prompts="redacted").history_prompts == "redacted"
+
+
+def test_data_errors_extend_gflow_error() -> None:
+    assert issubclass(DataStoreError, GFlowError)
+    assert issubclass(DataMigrationError, DataStoreError)
+    assert issubclass(DataIntegrityError, DataStoreError)
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [DataStoreError, DataMigrationError, DataIntegrityError],
+)
+def test_data_errors_use_exit_code_16(exc_type: type[DataStoreError]) -> None:
+    assert next(code for cls, code in EXIT_CODE_MAP.items() if issubclass(exc_type, cls)) == 16
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_settings_and_errors.py -q
+```
+
+Expected: failures for missing `database_path`, missing `Settings.db_path`, missing `Settings.history_prompts`, and missing data error classes.
+
+- [ ] **Step 3: Add path and settings fields**
+
+Modify `src/gflow_cli/paths.py`:
+
+```python
+def database_path(home: Path) -> Path:
+    """SQLite DB path under GFLOW_CLI_HOME."""
+    return home / "gflow.db"
+```
+
+Modify `src/gflow_cli/config.py` imports:
+
+```python
+from typing import Literal
+```
+
+Add these fields to `Settings` under the path/profile section:
+
+```python
+    db_path: Path | None = Field(
+        default=None,
+        description=(
+            "SQLite data-layer path. Defaults to <GFLOW_CLI_HOME>/gflow.db. "
+            "Override with GFLOW_CLI_DB_PATH for tests or advanced local setups."
+        ),
+    )
+    history_prompts: Literal["full", "redacted"] = Field(
+        default="full",
+        description=(
+            "Controls prompt persistence in the local DB. 'full' stores prompt text; "
+            "'redacted' stores only prompt_hash and prompt_redacted=1."
+        ),
+    )
+```
+
+Add this method to `Settings`:
+
+```python
+    def resolved_db_path(self) -> Path:
+        return self.db_path or paths.database_path(self.home)
+```
+
+- [ ] **Step 4: Add data-layer errors**
+
+Modify `src/gflow_cli/errors.py`:
+
+```python
+class DataStoreError(GFlowError):
+    """Raised when the local data layer cannot open, read, or write SQLite."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-store"
+    title = "Data store error"
+    _default_remediation = (
+        "Check GFLOW_CLI_DB_PATH and filesystem permissions. "
+        "If the DB was created by a newer gflow-cli, upgrade gflow-cli or "
+        "point GFLOW_CLI_DB_PATH at a compatible database."
+    )
+
+
+class DataMigrationError(DataStoreError):
+    """Raised when local SQLite schema migration cannot proceed safely."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-migration"
+    title = "Data migration error"
+
+
+class DataIntegrityError(DataStoreError):
+    """Raised when repository writes violate expected local DB constraints."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-integrity"
+    title = "Data integrity error"
+```
+
+Add the new classes to `__all__`, and add the exit-code entries before `BrowserSessionClosedError`:
+
+```python
+    DataMigrationError: 16,
+    DataIntegrityError: 16,
+    DataStoreError: 16,
+```
+
+- [ ] **Step 5: Run the task tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_settings_and_errors.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/gflow_cli/config.py src/gflow_cli/errors.py src/gflow_cli/paths.py tests/data/test_settings_and_errors.py
+git commit -m "feat(data): add settings and errors"
+```
+
+## Task 2: SQLite Store and Migrations
+
+**Files:**
+- Create: `src/gflow_cli/data/__init__.py`
+- Create: `src/gflow_cli/data/migrations/__init__.py`
+- Create: `src/gflow_cli/data/migrations/001_initial.sql`
+- Create: `src/gflow_cli/data/store.py`
+- Modify: `pyproject.toml`
+- Create: `tests/data/test_store_migrations.py`
+
+- [ ] **Step 1: Write failing migration tests**
+
+Create `tests/data/test_store_migrations.py`:
+
+```python
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.store import (
+    DataStore,
+    _checksum_sql,
+    _normalize_sql_for_checksum,
+)
+from gflow_cli.errors import DataMigrationError
+
+
+def test_normalize_sql_for_checksum_trims_line_endings() -> None:
+    assert _normalize_sql_for_checksum("CREATE TABLE x(id);\r\n  \r\n") == "CREATE TABLE x(id);"
+
+
+def test_checksum_sql_uses_sha256() -> None:
+    checksum = _checksum_sql("CREATE TABLE x(id);\n")
+    assert len(checksum) == 64
+    assert checksum == _checksum_sql("CREATE TABLE x(id);\r\n")
+
+
+def test_open_creates_schema_and_migration_row(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with DataStore.open(db) as store:
+        rows = store.conn.execute("SELECT version FROM schema_migrations").fetchall()
+        assert [row["version"] for row in rows] == [1]
+        assert store.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert store.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+        assert store.conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+
+def test_newer_schema_raises(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, filename TEXT, "
+            "checksum TEXT, applied_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
+            "VALUES (999, '999.sql', 'abc', '2026-05-24T00:00:00Z')"
+        )
+    with pytest.raises(DataMigrationError, match="newer"):
+        DataStore.open(db)
+
+
+def test_checksum_drift_raises(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with DataStore.open(db):
+        pass
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE schema_migrations SET checksum='bad' WHERE version=1")
+    with pytest.raises(DataMigrationError, match="checksum"):
+        DataStore.open(db)
+
+
+def test_foreign_keys_reject_orphan_rows(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with pytest.raises(sqlite3.IntegrityError):
+            store.conn.execute(
+                "INSERT INTO local_files(id, asset_id, path, media_kind, created_at) "
+                "VALUES ('file-1', 'missing', 'C:/missing.png', 'image', '2026-05-24T00:00:00Z')"
+            )
+
+
+def test_transaction_uses_begin_immediate_for_writes(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with store.transaction(immediate=True):
+            store.conn.execute(
+                "INSERT INTO profiles(name, profile_dir, created_at, updated_at) "
+                "VALUES ('default', 'C:/profiles/default', '2026-05-24T00:00:00Z', "
+                "'2026-05-24T00:00:00Z')"
+            )
+        row = store.conn.execute("SELECT name FROM profiles").fetchone()
+        assert row["name"] == "default"
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_store_migrations.py -q
+```
+
+Expected: import failures for `gflow_cli.data.store`.
+
+- [ ] **Step 3: Add package markers**
+
+Create `src/gflow_cli/data/__init__.py`:
+
+```python
+"""SQLite-backed local data layer for gflow-cli."""
+
+from gflow_cli.data.store import DataStore
+
+__all__ = ["DataStore"]
+```
+
+Create `src/gflow_cli/data/migrations/__init__.py`:
+
+```python
+"""Packaged SQL migrations for gflow-cli's local SQLite data layer."""
+```
+
+- [ ] **Step 4: Add the initial SQL schema**
+
+Create `src/gflow_cli/data/migrations/001_initial.sql`:
+
+```sql
+CREATE TABLE schema_migrations (
+  version INTEGER PRIMARY KEY,
+  filename TEXT NOT NULL,
+  checksum TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
+CREATE TABLE profiles (
+  name TEXT PRIMARY KEY,
+  profile_dir TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  UNIQUE(profile_name, flow_project_id)
+);
+
+CREATE TABLE assets (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  project_id TEXT,
+  flow_media_id TEXT NOT NULL,
+  flow_workflow_id TEXT,
+  flow_media_generation_id TEXT,
+  media_kind TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  prompt TEXT,
+  prompt_hash TEXT,
+  prompt_redacted INTEGER NOT NULL DEFAULT 0,
+  model TEXT,
+  aspect_ratio TEXT,
+  seed INTEGER,
+  width INTEGER,
+  height INTEGER,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  FOREIGN KEY(project_id) REFERENCES projects(id),
+  UNIQUE(profile_name, flow_media_id)
+);
+
+CREATE TABLE operations (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  project_id TEXT,
+  operation_kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  flow_operation_id TEXT,
+  flow_media_id TEXT,
+  prompt TEXT,
+  prompt_hash TEXT,
+  prompt_redacted INTEGER NOT NULL DEFAULT 0,
+  model TEXT,
+  aspect_ratio TEXT,
+  seed INTEGER,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  FOREIGN KEY(project_id) REFERENCES projects(id),
+  UNIQUE(profile_name, flow_operation_id)
+);
+
+CREATE TABLE operation_assets (
+  operation_id TEXT NOT NULL,
+  asset_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY(operation_id) REFERENCES operations(id),
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
+  UNIQUE(operation_id, role, position),
+  PRIMARY KEY(operation_id, asset_id, role, position)
+);
+
+CREATE TABLE local_files (
+  id TEXT PRIMARY KEY,
+  asset_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  media_kind TEXT NOT NULL,
+  mime_type TEXT,
+  bytes_size INTEGER,
+  sha256 TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(asset_id) REFERENCES assets(id) ON DELETE CASCADE,
+  UNIQUE(asset_id, path)
+);
+
+CREATE INDEX idx_projects_profile_flow ON projects(profile_name, flow_project_id);
+CREATE INDEX idx_assets_profile_media ON assets(profile_name, flow_media_id);
+CREATE INDEX idx_assets_project_created ON assets(project_id, created_at);
+CREATE INDEX idx_assets_kind_created ON assets(media_kind, created_at);
+CREATE INDEX idx_operations_profile_created ON operations(profile_name, started_at);
+CREATE INDEX idx_operation_assets_asset ON operation_assets(asset_id);
+CREATE INDEX idx_local_files_asset ON local_files(asset_id);
+```
+
+- [ ] **Step 5: Implement `DataStore`**
+
+Create `src/gflow_cli/data/store.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib import resources
+from pathlib import Path
+
+from gflow_cli.errors import DataMigrationError, DataStoreError
+
+MIGRATION_PACKAGE = "gflow_cli.data.migrations"
+BUSY_TIMEOUT_MS = 5000
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _normalize_sql_for_checksum(sql: str) -> str:
+    normalized = sql.replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.rstrip() for line in normalized.split("\n")).rstrip()
+
+
+def _checksum_sql(sql: str) -> str:
+    return hashlib.sha256(_normalize_sql_for_checksum(sql).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    filename: str
+    sql: str
+    checksum: str
+
+
+def _load_migrations() -> list[Migration]:
+    files = []
+    for item in resources.files(MIGRATION_PACKAGE).iterdir():
+        if item.name.endswith(".sql"):
+            files.append(item)
+    migrations: list[Migration] = []
+    for file_ref in sorted(files, key=lambda p: p.name):
+        prefix = file_ref.name.split("_", 1)[0]
+        version = int(prefix)
+        sql = file_ref.read_text(encoding="utf-8")
+        migrations.append(
+            Migration(
+                version=version,
+                filename=file_ref.name,
+                sql=sql,
+                checksum=_checksum_sql(sql),
+            )
+        )
+    return migrations
+
+
+class DataStore:
+    def __init__(self, conn: sqlite3.Connection, path: Path) -> None:
+        self.conn = conn
+        self.path = path
+
+    @classmethod
+    def open(cls, path: Path) -> DataStore:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(path, isolation_level=None)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+            store = cls(conn=conn, path=path)
+            store.apply_migrations()
+            return store
+        except DataMigrationError:
+            raise
+        except sqlite3.Error as exc:
+            raise DataStoreError(detail=str(exc), route="data.open") from exc
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> DataStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    @contextmanager
+    def transaction(self, *, immediate: bool = False) -> Iterator[None]:
+        try:
+            self.conn.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
+            yield
+            self.conn.execute("COMMIT")
+        except Exception:
+            self.conn.execute("ROLLBACK")
+            raise
+
+    def apply_migrations(self) -> None:
+        migrations = _load_migrations()
+        if not migrations:
+            raise DataMigrationError(detail="no SQL migrations packaged", route="data.migrate")
+
+        table_exists = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+        ).fetchone()
+        latest_known = migrations[-1].version
+        if table_exists is not None:
+            row = self.conn.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
+            current = int(row[0] or 0)
+            if current > latest_known:
+                raise DataMigrationError(
+                    detail=f"database schema {current} is newer than installed schema {latest_known}",
+                    route="data.migrate",
+                )
+
+        applied = {
+            int(row["version"]): str(row["checksum"])
+            for row in self.conn.execute(
+                "SELECT version, checksum FROM schema_migrations"
+            ).fetchall()
+        } if table_exists is not None else {}
+
+        for migration in migrations:
+            existing = applied.get(migration.version)
+            if existing is not None:
+                if existing != migration.checksum:
+                    raise DataMigrationError(
+                        detail=f"migration {migration.version} checksum drift",
+                        route="data.migrate",
+                    )
+                continue
+            with self.transaction():
+                self.conn.executescript(migration.sql)
+                self.conn.execute(
+                    "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (migration.version, migration.filename, migration.checksum, _utc_now()),
+                )
+                self.conn.execute(f"PRAGMA user_version = {migration.version}")
+```
+
+- [ ] **Step 6: Include SQL migrations in wheels**
+
+Modify `pyproject.toml`:
+
+```toml
+[tool.hatch.build.targets.wheel.force-include]
+"src/gflow_cli/data/migrations" = "gflow_cli/data/migrations"
+```
+
+- [ ] **Step 7: Run migration tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_store_migrations.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add pyproject.toml src/gflow_cli/data tests/data/test_store_migrations.py
+git commit -m "feat(data): add sqlite store and migrations"
+```
+
+## Task 3: Repository and Read Queries
+
+**Files:**
+- Create: `src/gflow_cli/data/models.py`
+- Create: `src/gflow_cli/data/repository.py`
+- Create: `tests/data/test_repository.py`
+
+- [ ] **Step 1: Write failing repository tests**
+
+Create `tests/data/test_repository.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+    SourceKind,
+)
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataIntegrityError
+
+
+def test_upserts_project_asset_operation_and_file(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="gflow-cli t2i",
+                metadata_json={},
+            )
+        )
+        asset = repo.upsert_asset(
+            AssetRecord(
+                id="asset-local",
+                profile_name="default",
+                project_id=project.id,
+                flow_media_id="media-1",
+                flow_workflow_id="workflow-1",
+                flow_media_generation_id="generation-1",
+                media_kind=AssetKind.IMAGE,
+                source_kind=SourceKind.GENERATED,
+                status="ready",
+                prompt="a prompt",
+                prompt_hash=None,
+                prompt_redacted=False,
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                seed=123,
+                width=1024,
+                height=1792,
+                metadata_json={},
+            )
+        )
+        operation = repo.insert_operation(
+            OperationRecord(
+                id="operation-local",
+                profile_name="default",
+                project_id=project.id,
+                operation_kind=OperationKind.T2I,
+                status=OperationStatus.SUCCEEDED,
+                flow_operation_id=None,
+                flow_media_id="media-1",
+                prompt="a prompt",
+                prompt_hash=None,
+                prompt_redacted=False,
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                seed=123,
+                metadata_json={},
+            )
+        )
+        repo.link_operation_asset(operation.id, asset.id, OperationAssetRole.OUTPUT, 0)
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-local",
+                asset_id=asset.id,
+                path=tmp_path / "media-1.png",
+                media_kind=AssetKind.IMAGE,
+                mime_type="image/png",
+                bytes_size=10,
+                sha256="a" * 64,
+            )
+        )
+
+        found = repo.get_asset_by_flow_media_id("default", "media-1")
+        assert found is not None
+        assert found.flow_project_id == "flow-project-1"
+        assert found.local_files[0].path == tmp_path / "media-1.png"
+
+
+def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                metadata_json={},
+            )
+        )
+        asset_one = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-1",
+                profile_name="default",
+                project_id=project.id,
+                flow_media_id="media-1",
+            )
+        )
+        asset_two = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-2",
+                profile_name="default",
+                project_id=project.id,
+                flow_media_id="media-2",
+            )
+        )
+        operation = repo.insert_operation(
+            OperationRecord.minimal(
+                id="operation-1",
+                profile_name="default",
+                project_id=project.id,
+                operation_kind=OperationKind.I2I,
+            )
+        )
+        repo.link_operation_asset(operation.id, asset_one.id, OperationAssetRole.INPUT, 0)
+        with pytest.raises(DataIntegrityError):
+            repo.link_operation_asset(operation.id, asset_two.id, OperationAssetRole.INPUT, 0)
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_repository.py -q
+```
+
+Expected: import failures for `models` and `repository`.
+
+- [ ] **Step 3: Add model dataclasses**
+
+Create `src/gflow_cli/data/models.py` with these definitions:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+JsonObject = dict[str, Any]
+
+
+class AssetKind(StrEnum):
+    IMAGE = "image"
+    VIDEO = "video"
+
+
+class SourceKind(StrEnum):
+    UPLOADED = "uploaded"
+    GENERATED = "generated"
+
+
+class OperationKind(StrEnum):
+    UPLOAD_IMAGE = "upload_image"
+    T2I = "t2i"
+    I2I = "i2i"
+    T2V = "t2v"
+    I2V = "i2v"
+    R2V = "r2v"
+
+
+class OperationStatus(StrEnum):
+    STARTED = "started"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class OperationAssetRole(StrEnum):
+    INPUT = "input"
+    OUTPUT = "output"
+    SEED_START = "seed_start"
+    SEED_END = "seed_end"
+    REFERENCE = "reference"
+
+
+@dataclass(frozen=True)
+class ProjectRecord:
+    id: str
+    profile_name: str
+    flow_project_id: str
+    title: str
+    metadata_json: JsonObject
+
+
+@dataclass(frozen=True)
+class AssetRecord:
+    id: str
+    profile_name: str
+    project_id: str | None
+    flow_media_id: str
+    flow_workflow_id: str | None
+    flow_media_generation_id: str | None
+    media_kind: AssetKind
+    source_kind: SourceKind
+    status: str
+    prompt: str | None
+    prompt_hash: str | None
+    prompt_redacted: bool
+    model: str | None
+    aspect_ratio: str | None
+    seed: int | None
+    width: int | None
+    height: int | None
+    metadata_json: JsonObject
+
+    @classmethod
+    def minimal_image(
+        cls,
+        *,
+        id: str,
+        profile_name: str,
+        project_id: str | None,
+        flow_media_id: str,
+    ) -> AssetRecord:
+        return cls(
+            id=id,
+            profile_name=profile_name,
+            project_id=project_id,
+            flow_media_id=flow_media_id,
+            flow_workflow_id=None,
+            flow_media_generation_id=None,
+            media_kind=AssetKind.IMAGE,
+            source_kind=SourceKind.GENERATED,
+            status="ready",
+            prompt=None,
+            prompt_hash=None,
+            prompt_redacted=False,
+            model=None,
+            aspect_ratio=None,
+            seed=None,
+            width=None,
+            height=None,
+            metadata_json={},
+        )
+
+
+@dataclass(frozen=True)
+class OperationRecord:
+    id: str
+    profile_name: str
+    project_id: str | None
+    operation_kind: OperationKind
+    status: OperationStatus
+    flow_operation_id: str | None
+    flow_media_id: str | None
+    prompt: str | None
+    prompt_hash: str | None
+    prompt_redacted: bool
+    model: str | None
+    aspect_ratio: str | None
+    seed: int | None
+    metadata_json: JsonObject
+
+    @classmethod
+    def minimal(
+        cls,
+        *,
+        id: str,
+        profile_name: str,
+        project_id: str | None,
+        operation_kind: OperationKind,
+    ) -> OperationRecord:
+        return cls(
+            id=id,
+            profile_name=profile_name,
+            project_id=project_id,
+            operation_kind=operation_kind,
+            status=OperationStatus.SUCCEEDED,
+            flow_operation_id=None,
+            flow_media_id=None,
+            prompt=None,
+            prompt_hash=None,
+            prompt_redacted=False,
+            model=None,
+            aspect_ratio=None,
+            seed=None,
+            metadata_json={},
+        )
+
+
+@dataclass(frozen=True)
+class LocalFileRecord:
+    id: str
+    asset_id: str
+    path: Path
+    media_kind: AssetKind
+    mime_type: str | None
+    bytes_size: int | None
+    sha256: str | None
+
+
+@dataclass(frozen=True)
+class AssetLookup:
+    id: str
+    profile_name: str
+    flow_project_id: str | None
+    flow_media_id: str
+    media_kind: AssetKind
+    local_files: list[LocalFileRecord]
+```
+
+- [ ] **Step 4: Implement repository methods**
+
+Create `src/gflow_cli/data/repository.py`. Use `json.dumps(value, sort_keys=True)`, UUIDs supplied by callers, and wrap `sqlite3.IntegrityError` as `DataIntegrityError`.
+
+The repository must include these methods:
+
+- `__init__(store: DataStore) -> None`
+- `upsert_profile(name: str, profile_dir: Path) -> None`
+- `upsert_project(record: ProjectRecord) -> ProjectRecord`
+- `upsert_asset(record: AssetRecord) -> AssetRecord`
+- `insert_operation(record: OperationRecord) -> OperationRecord`
+- `link_operation_asset(operation_id: str, asset_id: str, role: OperationAssetRole, position: int) -> None`
+- `upsert_local_file(record: LocalFileRecord) -> LocalFileRecord`
+- `get_asset_by_flow_media_id(profile_name: str, flow_media_id: str) -> AssetLookup | None`
+
+Use `ON CONFLICT` for `profiles`, `projects`, `assets`, and `local_files`. Use plain `INSERT` for `operations` because operation rows are event records.
+
+- [ ] **Step 5: Run repository tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_repository.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/gflow_cli/data/models.py src/gflow_cli/data/repository.py tests/data/test_repository.py
+git commit -m "feat(data): add repositories"
+```
+
+## Task 4: Redaction and Operation Recorder
+
+**Files:**
+- Create: `src/gflow_cli/data/redaction.py`
+- Create: `src/gflow_cli/data/recorder.py`
+- Create: `tests/data/test_redaction.py`
+- Create: `tests/data/test_recorder.py`
+
+- [ ] **Step 1: Write failing redaction tests**
+
+Create `tests/data/test_redaction.py`:
+
+```python
+from gflow_cli.data.redaction import prompt_fields, redact_metadata
+
+
+def test_prompt_fields_full_mode_stores_text_and_hash() -> None:
+    fields = prompt_fields("hello", mode="full")
+    assert fields.prompt == "hello"
+    assert fields.prompt_hash is not None
+    assert fields.prompt_redacted is False
+
+
+def test_prompt_fields_redacted_mode_stores_hash_only() -> None:
+    fields = prompt_fields("hello", mode="redacted")
+    assert fields.prompt is None
+    assert fields.prompt_hash is not None
+    assert fields.prompt_redacted is True
+
+
+def test_redact_metadata_removes_signed_urls_and_tokens() -> None:
+    raw = {
+        "fifeUrl": "https://flow-content.google/path?Signature=abc",
+        "clientContext": {"recaptchaContext": {"token": "secret"}},
+        "nested": [{"authorization": "Bearer abc"}],
+        "safe": "kept",
+    }
+    redacted = redact_metadata(raw)
+    assert redacted["fifeUrl"] == "<redacted:url>"
+    assert redacted["clientContext"]["recaptchaContext"]["token"] == "<redacted:token>"
+    assert redacted["nested"][0]["authorization"] == "<redacted:secret>"
+    assert redacted["safe"] == "kept"
+```
+
+- [ ] **Step 2: Write failing recorder tests**
+
+Create `tests/data/test_recorder.py`:
+
+```python
+from pathlib import Path
+
+from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
+from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def test_record_upload_persists_project_asset_and_file(tmp_path: Path) -> None:
+    image_path = tmp_path / "seed.png"
+    image_path.write_bytes(b"png-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="full")
+        project = ProjectInfo(project_id="flow-project-1", title="gflow-cli upload")
+        asset = AssetInfo(
+            name="media-upload-1",
+            project_id="flow-project-1",
+            workflow_id="workflow-upload-1",
+            display_name="seed.png",
+            width=640,
+            height=480,
+        )
+        recorder.record_upload_image(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=project,
+            asset=asset,
+            image_path=image_path,
+        )
+        found = recorder.repository.get_asset_by_flow_media_id("default", "media-upload-1")
+        assert found is not None
+        assert found.flow_project_id == "flow-project-1"
+        assert found.local_files[0].path == image_path.resolve()
+
+
+def test_record_generated_images_persists_generation_metadata(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="redacted")
+        project = ProjectInfo(project_id="flow-project-1", title="gflow-cli t2i")
+        image = GeneratedImage(
+            media_name="media-generated-1",
+            workflow_id="workflow-generated-1",
+            seed=123,
+            prompt="prompt text",
+            model_name_type="NARWHAL",
+            aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+            fife_url="https://flow-content.google/path?Signature=abc",
+            dimensions=(1024, 1792),
+            media_generation_id="generation-1",
+        )
+        req = GenerateImageRequest(
+            prompt="prompt text",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=project,
+            request=req,
+            images=[image],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        row = store.conn.execute(
+            "SELECT prompt, prompt_hash, prompt_redacted, flow_media_generation_id, "
+            "metadata_json FROM assets WHERE flow_media_id='media-generated-1'"
+        ).fetchone()
+        assert row["prompt"] is None
+        assert row["prompt_hash"]
+        assert row["prompt_redacted"] == 1
+        assert row["flow_media_generation_id"] == "generation-1"
+        assert "Signature=abc" not in row["metadata_json"]
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_redaction.py tests/data/test_recorder.py -q
+```
+
+Expected: import failures for redaction and recorder; `GeneratedImage.media_generation_id` is also missing.
+
+- [ ] **Step 4: Add `GeneratedImage.media_generation_id`**
+
+Modify `src/gflow_cli/api/dto.py`:
+
+```python
+    media_generation_id: str | None = None
+```
+
+In `GeneratedImage.from_response_item`, read:
+
+```python
+                media_generation_id=generated.get("mediaGenerationId"),
+```
+
+Update tests that construct `GeneratedImage` so the optional field is accepted without further changes.
+
+- [ ] **Step 5: Implement redaction helpers**
+
+Create `src/gflow_cli/data/redaction.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+PromptMode = Literal["full", "redacted"]
+
+
+@dataclass(frozen=True)
+class PromptFields:
+    prompt: str | None
+    prompt_hash: str | None
+    prompt_redacted: bool
+
+
+def prompt_fields(prompt: str | None, *, mode: PromptMode) -> PromptFields:
+    if prompt is None:
+        return PromptFields(prompt=None, prompt_hash=None, prompt_redacted=False)
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    if mode == "redacted":
+        return PromptFields(prompt=None, prompt_hash=digest, prompt_redacted=True)
+    return PromptFields(prompt=prompt, prompt_hash=digest, prompt_redacted=False)
+
+
+def redact_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = key.lower()
+            if lowered in {"token", "recaptchatoken"}:
+                out[key] = "<redacted:token>"
+            elif lowered in {"authorization", "cookie", "set-cookie"}:
+                out[key] = "<redacted:secret>"
+            elif "url" in lowered and isinstance(item, str):
+                out[key] = "<redacted:url>"
+            else:
+                out[key] = redact_metadata(item)
+        return out
+    if isinstance(value, list):
+        return [redact_metadata(item) for item in value]
+    return value
+```
+
+- [ ] **Step 6: Implement `OperationRecorder`**
+
+Create `src/gflow_cli/data/recorder.py`. It must:
+
+- Generate local IDs with `uuid.uuid4()`.
+- Use `DataStore.transaction(immediate=True)` for grouped writes.
+- Call `redact_metadata(value)` before storing `metadata_json`.
+- Store resolved absolute paths in `local_files.path`.
+- Use prompt mode from settings.
+
+Core constructor and factory:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import uuid
+from pathlib import Path
+
+from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
+from gflow_cli.api.image import GenerateImageRequest
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult
+from gflow_cli.config import Settings
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+    SourceKind,
+)
+from gflow_cli.data.redaction import PromptMode, prompt_fields, redact_metadata
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _file_sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+class OperationRecorder:
+    def __init__(self, repository: DataRepository, *, prompt_mode: PromptMode) -> None:
+        self.repository = repository
+        self.prompt_mode = prompt_mode
+
+    @classmethod
+    def open(cls, settings: Settings) -> OperationRecorder:
+        store = DataStore.open(settings.resolved_db_path())
+        return cls(DataRepository(store), prompt_mode=settings.history_prompts)
+
+    def close(self) -> None:
+        self.repository.store.close()
+```
+
+Implement these public methods:
+
+- `record_upload_image(profile_name, profile_dir, project, asset, image_path) -> None`
+- `record_generated_images(profile_name, profile_dir, project, request, images, saved_paths, input_media_ids, operation_kind) -> None`
+- `record_generated_video(profile_name, profile_dir, request, result) -> None`
+
+For REST-created image projects, build a `ProjectRecord` with a generated local ID, the current profile name, and `flow_project_id=project.project_id`. For video projects, `VideoResult.project_id` is the Flow project ID and the display title is `"gflow-cli video"`.
+
+- [ ] **Step 7: Run recorder tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/api/test_image_dto.py tests/data/test_redaction.py tests/data/test_recorder.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add src/gflow_cli/api/dto.py src/gflow_cli/data/redaction.py src/gflow_cli/data/recorder.py tests/data/test_redaction.py tests/data/test_recorder.py tests/api/test_image_dto.py
+git commit -m "feat(data): add operation recorder"
+```
+
+## Task 5: Image Command Recording
+
+**Files:**
+- Modify: `src/gflow_cli/cli_image.py`
+- Modify: `tests/cli/test_cli_image.py`
+- Modify: `tests/cli/test_t2i_multi_prompt.py`
+
+- [ ] **Step 1: Write failing CLI tests for image recording**
+
+Add tests that monkeypatch `OperationRecorder.open` with a fake recorder:
+
+```python
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.uploads = []
+        self.generated = []
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def record_upload_image(self, **kwargs):
+        self.uploads.append(kwargs)
+
+    def record_generated_images(self, **kwargs):
+        self.generated.append(kwargs)
+```
+
+Test cases:
+
+- `_run_upload` passes `profile_name`, `profile_dir`, `project`, `asset`, and `image_path`.
+- `_run_t2i` records generated images after downloads complete.
+- `_run_i2i` records uploaded local references as input assets and generated images as outputs.
+- A recorder exception after download logs `data.persistence_failed_after_success` and does not raise when saved files exist.
+
+- [ ] **Step 2: Run the image CLI tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/cli/test_cli_image.py tests/cli/test_t2i_multi_prompt.py -q
+```
+
+Expected: failures because `_run_upload`, `_run_t2i`, and `_run_i2i` do not accept `profile_name` or record data.
+
+- [ ] **Step 3: Add recorder helpers to `cli_image.py`**
+
+Add imports:
+
+```python
+import structlog
+
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.errors import DataStoreError
+```
+
+Add logger:
+
+```python
+logger = structlog.get_logger(__name__)
+```
+
+Add helper:
+
+```python
+def _warn_persistence_failed_after_success(
+    *,
+    exc: Exception,
+    flow_media_id: str | None,
+    local_path: Path | None,
+) -> None:
+    logger.warning(
+        "data.persistence_failed_after_success",
+        error_class=type(exc).__name__,
+        flow_media_id=flow_media_id,
+        local_path=str(local_path) if local_path is not None else None,
+    )
+    console.print(
+        "[yellow]Generated media was saved, but local history was not updated.[/yellow]"
+    )
+```
+
+- [ ] **Step 4: Open the recorder before remote calls**
+
+Modify `upload`, `t2i`, and `i2i` command bodies to pass `profile_name` into async runners.
+
+In each async runner, open the recorder before `FlowApiClient`:
+
+```python
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with FlowApiClient(
+            profile_dir=profile_dir,
+            headless=settings.headless,
+            out_dir=out_dir,
+        ) as client:
+            project = await client.create_project(title=title)
+    finally:
+        recorder.close()
+```
+
+This ordering makes `DataMigrationError` and `DataStoreError` fail before the paid Flow operation begins.
+
+- [ ] **Step 5: Record upload and generated image outputs**
+
+For `_run_upload`, after `client.upload_image` succeeds:
+
+```python
+        recorder.record_upload_image(
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            project=project,
+            asset=asset,
+            image_path=image_path,
+        )
+```
+
+For `_run_t2i`, after all downloads:
+
+```python
+        try:
+            recorder.record_generated_images(
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                project=project,
+                request=req,
+                images=images,
+                saved_paths=saved_paths,
+                input_media_ids=[],
+                operation_kind="t2i",
+            )
+        except DataStoreError as exc:
+            first_image = images[0] if images else None
+            first_path = saved_paths[0] if saved_paths else None
+            _warn_persistence_failed_after_success(
+                exc=exc,
+                flow_media_id=first_image.media_name if first_image else None,
+                local_path=first_path,
+            )
+```
+
+For `_run_i2i`, pass `input_media_ids=[ref.name for ref in resolved_refs]` and `operation_kind="i2i"`.
+
+- [ ] **Step 6: Run image CLI tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/cli/test_cli_image.py tests/cli/test_t2i_multi_prompt.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/gflow_cli/cli_image.py tests/cli/test_cli_image.py tests/cli/test_t2i_multi_prompt.py
+git commit -m "feat(data): record image commands"
+```
+
+## Task 6: Image Batch Recording
+
+**Files:**
+- Modify: `src/gflow_cli/image_batch.py`
+- Modify: `src/gflow_cli/cli_image.py`
+- Modify: `tests/image_batch/test_image_manifest.py`
+- Modify: `tests/image_batch/test_observability_events.py`
+
+- [ ] **Step 1: Write failing batch recording tests**
+
+Add tests that run `run_image_batch` and `run_manifest_image_batch` with fake clients and fake recorders. Assert:
+
+- `profile_name` is accepted and passed to the recorder.
+- The shared Flow `project_id` from `BatchSubmissionResult.project_id` is recorded.
+- Each successful row records output assets and local files.
+- Partial-result salvage records already-downloaded assets before re-raising `BatchPartialError`.
+
+- [ ] **Step 2: Run batch tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/image_batch/test_image_manifest.py tests/image_batch/test_observability_events.py -q
+```
+
+Expected: failures because image batch has no recorder dependency.
+
+- [ ] **Step 3: Add recorder dependency to batch runners**
+
+Modify `run_image_batch` and `run_manifest_image_batch` signatures:
+
+```python
+    profile_name: str,
+    recorder: OperationRecorder | None = None,
+```
+
+Pass `profile_name` from `cli_image.t2i` multi-prompt mode and `cli_image.batch`.
+
+- [ ] **Step 4: Record successful batch outcomes**
+
+In `_download_results`, add optional `recorder`, `profile_name`, and `profile_dir`. After each row downloads, call:
+
+```python
+recorder.record_generated_images(
+    profile_name=profile_name,
+    profile_dir=profile_dir,
+    project=ProjectInfo(project_id=result.project_id, title="gflow-cli image batch"),
+    request=_to_request(item),
+    images=list(result.images),
+    saved_paths=saved,
+    input_media_ids=[],
+    operation_kind="t2i",
+)
+```
+
+Wrap only this post-download recorder call in `except DataStoreError` and emit `data.persistence_failed_after_success` with the first output media ID and first saved path.
+
+- [ ] **Step 5: Preserve fail-fast salvage semantics**
+
+In the `BatchPartialError` branch, pass the recorder into `_download_results` before creating the replacement `BatchPartialError`. The recorder must not prevent already-paid images from being downloaded or returned in `partial_results`.
+
+- [ ] **Step 6: Run batch tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/image_batch/test_image_manifest.py tests/image_batch/test_observability_events.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/gflow_cli/image_batch.py src/gflow_cli/cli_image.py tests/image_batch/test_image_manifest.py tests/image_batch/test_observability_events.py
+git commit -m "feat(data): record image batches"
+```
+
+## Task 7: Normalize Video Generation Through FlowApiClient
+
+**Files:**
+- Modify: `src/gflow_cli/api/transports/_common.py`
+- Modify: `src/gflow_cli/api/transports/base.py`
+- Modify: `src/gflow_cli/api/transports/ui_automation.py`
+- Modify: `src/gflow_cli/api/transports/ui_automation_video.py`
+- Modify: `src/gflow_cli/api/video.py`
+- Modify: `src/gflow_cli/api/client.py`
+- Modify: `src/gflow_cli/cli_video.py`
+- Modify: `tests/api/test_video.py`
+- Modify: `tests/api/test_client.py`
+- Modify: `tests/api/transports/test_common.py`
+- Modify: `tests/api/transports/test_ui_automation_video.py`
+- Modify: `tests/cli/test_cli_video.py`
+
+- [ ] **Step 1: Write failing project-ID extraction tests**
+
+In `tests/api/transports/test_common.py`, add:
+
+```python
+from gflow_cli.api.transports._common import extract_project_id
+
+
+def test_extract_project_id_from_flow_url() -> None:
+    assert (
+        extract_project_id("https://labs.google/fx/tools/flow/project/abc-123?x=1")
+        == "abc-123"
+    )
+
+
+def test_extract_project_id_returns_none_for_gallery_url() -> None:
+    assert extract_project_id("https://labs.google/fx/tools/flow") is None
+```
+
+- [ ] **Step 2: Write failing video DTO parser tests**
+
+In `tests/api/test_video.py`, add fixture-driven tests:
+
+```python
+from gflow_cli.api.video import operation_name_from_generate_response
+
+
+def test_operation_name_from_generate_response_reads_operation_name() -> None:
+    body = {
+        "media": [{"name": "media-1"}],
+        "operations": [{"operation": {"name": "media-1"}}],
+    }
+    assert operation_name_from_generate_response(body) == "media-1"
+
+
+def test_operation_name_matches_current_media_id_in_fixture() -> None:
+    body = {
+        "media": [{"name": "media-1"}],
+        "operations": [{"operation": {"name": "media-1"}}],
+    }
+    assert operation_name_from_generate_response(body) == body["media"][0]["name"]
+```
+
+- [ ] **Step 3: Write failing client-boundary tests**
+
+In `tests/cli/test_cli_video.py`, assert `_run_t2v` constructs `FlowApiClient` and does not instantiate `UiAutomationTransport` directly.
+
+In `tests/api/test_client.py`, add a fake transport with `generate_video` and assert:
+
+```python
+result = await client.generate_video(req=request, out_dir=tmp_path, download=True)
+assert result.status.media_id == "media-1"
+```
+
+- [ ] **Step 4: Run video tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/api/test_video.py tests/api/test_client.py tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py tests/cli/test_cli_video.py -q
+```
+
+Expected: failures for missing common extractor, missing operation parser, missing `FlowApiClient.generate_video`, and direct transport use in `cli_video.py`.
+
+- [ ] **Step 5: Move project-ID extraction to `_common.py`**
+
+Add to `src/gflow_cli/api/transports/_common.py`:
+
+```python
+PROJECT_URL_FRAGMENT = "/project/"
+
+
+def extract_project_id(url: str) -> str | None:
+    if PROJECT_URL_FRAGMENT not in url:
+        return None
+    try:
+        return url.split(PROJECT_URL_FRAGMENT)[1].split("?")[0]
+    except (IndexError, ValueError):
+        return None
+```
+
+Modify `ui_automation.py` to import and use `extract_project_id`. Leave a thin private alias only if existing tests import `_extract_project_id`:
+
+```python
+def _extract_project_id(url: str) -> str | None:
+    return extract_project_id(url)
+```
+
+- [ ] **Step 6: Add video result metadata**
+
+Modify `src/gflow_cli/api/video.py`:
+
+```python
+@dataclass(frozen=True)
+class VideoResult:
+    status: VideoStatus
+    local_path: Path | None
+    project_id: str | None = None
+    flow_operation_id: str | None = None
+```
+
+Add:
+
+```python
+def operation_name_from_generate_response(response_json: dict[str, Any]) -> str | None:
+    operations = response_json.get("operations")
+    if not isinstance(operations, list) or not operations:
+        return None
+    first = operations[0]
+    if not isinstance(first, dict):
+        return None
+    operation = first.get("operation")
+    if not isinstance(operation, dict):
+        return None
+    name = operation.get("name")
+    return str(name) if name is not None else None
+```
+
+- [ ] **Step 7: Populate project and operation IDs in UI video transport**
+
+Modify `src/gflow_cli/api/transports/ui_automation_video.py`:
+
+- Import `extract_project_id`.
+- After `_enter_editor`, set `project_id = extract_project_id(page.url)`.
+- Parse `flow_operation_id = operation_name_from_generate_response(generate_resp.get("body") or {})`.
+- Return a `VideoResult` with the existing status and local path plus `project_id=project_id` and `flow_operation_id=flow_operation_id`.
+
+The generated media ID remains `status.media_id`. The operation ID is stored separately even though current captures show the same value.
+
+- [ ] **Step 8: Add video-capable client method**
+
+Modify `src/gflow_cli/api/client.py`:
+
+```python
+    async def generate_video(
+        self,
+        *,
+        req: GenerateVideoRequest,
+        out_dir: Path | None = None,
+        poll_timeout_s: float = 600.0,
+        download: bool = True,
+    ) -> VideoResult:
+        if self.transport is None:
+            raise RuntimeError(
+                "FlowApiClient.transport is None - call generate_video inside 'async with client'"
+            )
+        generate_video = getattr(self.transport, "generate_video", None)
+        if generate_video is None:
+            raise ConfigurationError(
+                f"transport {type(self.transport).__name__} does not support video generation"
+            )
+        try:
+            return await generate_video(
+                request=req,
+                out_dir=out_dir,
+                poll_timeout_s=poll_timeout_s,
+                download=download,
+            )
+        except Exception as e:
+            if _is_target_closed(e):
+                raise BrowserSessionClosedError() from e
+            raise
+```
+
+Add imports for `GenerateVideoRequest`, `VideoResult`, and `ConfigurationError`.
+
+- [ ] **Step 9: Route `gflow video t2v` through FlowApiClient**
+
+Modify `src/gflow_cli/cli_video.py`:
+
+- Remove direct `UiAutomationTransport` construction.
+- Resolve `settings = get_settings()` in `t2v`.
+- Pass `headless=settings.headless`, `profile_name`, and `transport=None` into `_run_t2v`.
+- In `_run_t2v`, use `async with FlowApiClient(profile_dir=profile_dir, headless=headless, out_dir=out_dir) as client:`.
+- Call `result = await client.generate_video(req=request, out_dir=out_dir, download=True)`.
+
+- [ ] **Step 10: Run video tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/api/test_video.py tests/api/test_client.py tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py tests/cli/test_cli_video.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```powershell
+git add src/gflow_cli/api src/gflow_cli/cli_video.py tests/api tests/cli/test_cli_video.py
+git commit -m "refactor(video): route t2v through client"
+```
+
+## Task 8: Video Recording
+
+**Files:**
+- Modify: `src/gflow_cli/cli_video.py`
+- Modify: `src/gflow_cli/data/recorder.py`
+- Modify: `tests/cli/test_cli_video.py`
+- Modify: `tests/data/test_recorder.py`
+
+- [ ] **Step 1: Write failing video recorder tests**
+
+In `tests/data/test_recorder.py`, add:
+
+```python
+from gflow_cli.api.video import Aspect as VideoAspect
+from gflow_cli.api.video import GenerateVideoRequest, Mode, VideoResult, VideoStatus
+
+
+def test_record_generated_video_persists_media_operation_and_file(tmp_path: Path) -> None:
+    saved = tmp_path / "video.mp4"
+    saved.write_bytes(b"video-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="full")
+        request = GenerateVideoRequest(
+            prompt="video prompt",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+        )
+        result = VideoResult(
+            status=VideoStatus(
+                media_id="media-video-1",
+                status="MEDIA_GENERATION_STATUS_SUCCESSFUL",
+            ),
+            local_path=saved,
+            project_id="flow-project-video-1",
+            flow_operation_id="media-video-1",
+        )
+        recorder.record_generated_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            result=result,
+        )
+        asset = recorder.repository.get_asset_by_flow_media_id("default", "media-video-1")
+        assert asset is not None
+        assert asset.flow_project_id == "flow-project-video-1"
+        assert asset.local_files[0].path == saved.resolve()
+```
+
+In `tests/cli/test_cli_video.py`, add a fake recorder and assert `_run_t2v` records the successful `VideoResult`.
+
+- [ ] **Step 2: Run video recording tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_recorder.py tests/cli/test_cli_video.py -q
+```
+
+Expected: failures until `record_generated_video` and CLI wiring are complete.
+
+- [ ] **Step 3: Complete `record_generated_video`**
+
+In `src/gflow_cli/data/recorder.py`, implement `record_generated_video`:
+
+- Upsert the profile.
+- Upsert a project with `flow_project_id=result.project_id` when present.
+- Upsert a video asset with `flow_media_id=result.status.media_id`, `media_kind=AssetKind.VIDEO`, `source_kind=SourceKind.GENERATED`, `status=result.status.status`, `prompt`, `model=request.tier.value`, and `aspect_ratio=request.aspect.value`.
+- Insert an operation with `operation_kind=OperationKind.T2V`, `flow_operation_id=result.flow_operation_id`, and `flow_media_id=result.status.media_id`.
+- Link the output asset at position 0.
+- Insert the local file when `result.local_path` is not `None`.
+
+- [ ] **Step 4: Wire recorder into `cli_video.py`**
+
+Open `OperationRecorder` before `FlowApiClient`. After successful video generation, call:
+
+```python
+        try:
+            recorder.record_generated_video(
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                request=request,
+                result=result,
+            )
+        except DataStoreError as exc:
+            logger.warning(
+                "data.persistence_failed_after_success",
+                error_class=type(exc).__name__,
+                flow_media_id=result.status.media_id,
+                local_path=str(result.local_path) if result.local_path else None,
+            )
+            console.print(
+                "[yellow]Generated media was saved, but local history was not updated.[/yellow]"
+            )
+```
+
+Keep the existing generation-failure exit behavior unchanged.
+
+- [ ] **Step 5: Run video recording tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_recorder.py tests/cli/test_cli_video.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/gflow_cli/cli_video.py src/gflow_cli/data/recorder.py tests/cli/test_cli_video.py tests/data/test_recorder.py
+git commit -m "feat(data): record video commands"
+```
+
+## Task 9: Read-Only Data CLI and Seed Resolver
+
+**Files:**
+- Create: `src/gflow_cli/cli_data.py`
+- Modify: `src/gflow_cli/cli.py`
+- Modify: `src/gflow_cli/data/repository.py`
+- Create: `tests/cli/test_cli_data.py`
+- Modify: `tests/data/test_repository.py`
+
+- [ ] **Step 1: Write failing seed resolver tests**
+
+Add to `tests/data/test_repository.py`:
+
+```python
+def test_resolve_seed_image_returns_project_media_and_path(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", tmp_path / "profile_default")
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                metadata_json={},
+            )
+        )
+        asset = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-local",
+                profile_name="default",
+                project_id=project.id,
+                flow_media_id="media-image-1",
+            )
+        )
+        image_path = tmp_path / "image.png"
+        image_path.write_bytes(b"image-bytes")
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-local",
+                asset_id=asset.id,
+                path=image_path,
+                media_kind=AssetKind.IMAGE,
+                mime_type="image/png",
+                bytes_size=11,
+                sha256="b" * 64,
+            )
+        )
+        seed = repo.resolve_seed_image("default", "media-image-1")
+        assert seed is not None
+        assert seed.flow_project_id == "flow-project-1"
+        assert seed.flow_media_id == "media-image-1"
+        assert seed.local_path == image_path.resolve()
+```
+
+- [ ] **Step 2: Write failing CLI data tests**
+
+Create `tests/cli/test_cli_data.py` with Click runner tests for:
+
+- `gflow data media media-image-1 --profile default` prints media ID, project ID, kind, and local path.
+- Missing media exits non-zero with a user-facing not-found message.
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_repository.py tests/cli/test_cli_data.py -q
+```
+
+Expected: missing `resolve_seed_image` and missing `cli_data`.
+
+- [ ] **Step 4: Add seed resolver model and repository method**
+
+Add to `models.py`:
+
+```python
+@dataclass(frozen=True)
+class SeedImage:
+    flow_media_id: str
+    flow_project_id: str
+    local_path: Path | None
+```
+
+Add to `DataRepository`:
+
+```python
+    def resolve_seed_image(self, profile_name: str, flow_media_id: str) -> SeedImage | None:
+        row = self.store.conn.execute(
+            "SELECT a.flow_media_id, p.flow_project_id "
+            "FROM assets a LEFT JOIN projects p ON p.id = a.project_id "
+            "WHERE a.profile_name=? AND a.flow_media_id=? AND a.media_kind='image'",
+            (profile_name, flow_media_id),
+        ).fetchone()
+        if row is None or row["flow_project_id"] is None:
+            return None
+        file_row = self.store.conn.execute(
+            "SELECT path FROM local_files lf JOIN assets a ON a.id = lf.asset_id "
+            "WHERE a.profile_name=? AND a.flow_media_id=? ORDER BY lf.created_at DESC LIMIT 1",
+            (profile_name, flow_media_id),
+        ).fetchone()
+        local_path = Path(file_row["path"]) if file_row is not None else None
+        return SeedImage(
+            flow_media_id=row["flow_media_id"],
+            flow_project_id=row["flow_project_id"],
+            local_path=local_path,
+        )
+```
+
+- [ ] **Step 5: Add `gflow data` command group**
+
+Create `src/gflow_cli/cli_data.py`:
+
+```python
+from __future__ import annotations
+
+import sys
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gflow_cli._cli_helpers import _resolve_profile, run_with_handlers, safe_path_text
+from gflow_cli.config import get_settings
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+console = Console()
+
+
+@click.group()
+def data() -> None:
+    """Read local gflow media history."""
+
+
+@data.command("media")
+@click.argument("media_id")
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+def media(media_id: str, profile: str | None) -> None:
+    profile_name = _resolve_profile(profile)
+    run_with_handlers(
+        lambda: _run_media(profile_name=profile_name, media_id=media_id),
+        cli_command="data media",
+    )
+
+
+async def _run_media(*, profile_name: str, media_id: str) -> None:
+    settings = get_settings()
+    with DataStore.open(settings.resolved_db_path()) as store:
+        repo = DataRepository(store)
+        asset = repo.get_asset_by_flow_media_id(profile_name, media_id)
+        if asset is None:
+            console.print(f"[red]No local media record found:[/red] {media_id}")
+            sys.exit(1)
+        table = Table(title="gflow data media")
+        table.add_column("field")
+        table.add_column("value", overflow="fold")
+        table.add_row("profile", profile_name)
+        table.add_row("media_id", asset.flow_media_id)
+        table.add_row("project_id", asset.flow_project_id or "")
+        table.add_row("kind", asset.media_kind.value)
+        for idx, local_file in enumerate(asset.local_files, start=1):
+            table.add_row(f"local_path_{idx}", safe_path_text(local_file.path))
+        console.print(table)
+```
+
+Register it in `src/gflow_cli/cli.py`:
+
+```python
+from gflow_cli.cli_data import data as _data_group
+
+main.add_command(_data_group)
+```
+
+- [ ] **Step 6: Run data CLI tests**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_repository.py tests/cli/test_cli_data.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/gflow_cli/cli.py src/gflow_cli/cli_data.py src/gflow_cli/data/repository.py src/gflow_cli/data/models.py tests/cli/test_cli_data.py tests/data/test_repository.py
+git commit -m "feat(data): add read-only media lookup"
+```
+
+## Task 10: Packaging, Docs, and Verification
+
+**Files:**
+- Modify: `docs/CONFIGURATION.md`
+- Modify: `docs/USAGE.md`
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `PLAN.md`
+- Create: `tests/data/test_packaging.py`
+
+- [ ] **Step 1: Write packaging test**
+
+Create `tests/data/test_packaging.py`:
+
+```python
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+def test_wheel_contains_sql_migrations(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+        check=True,
+    )
+    wheel = next(dist_dir.glob("gflow_cli-*.whl"))
+    with zipfile.ZipFile(wheel) as archive:
+        assert "gflow_cli/data/migrations/001_initial.sql" in archive.namelist()
+```
+
+- [ ] **Step 2: Run packaging test and verify it passes**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data/test_packaging.py -q
+```
+
+Expected: wheel inspection confirms `001_initial.sql` is packaged.
+
+- [ ] **Step 3: Update configuration docs**
+
+In `docs/CONFIGURATION.md`, document:
+
+- `GFLOW_CLI_DB_PATH`: optional SQLite DB path override.
+- Default DB location: `<GFLOW_CLI_HOME>/gflow.db`.
+- `GFLOW_CLI_HISTORY_PROMPTS=full|redacted`.
+
+- [ ] **Step 4: Update usage docs**
+
+In `docs/USAGE.md`, document:
+
+- `gflow data media <media_id>`.
+- Exit code `16` for data store and migration failures.
+- Newer-schema recovery: upgrade `gflow-cli` or set `GFLOW_CLI_DB_PATH` to a compatible database.
+
+- [ ] **Step 5: Update security docs**
+
+In `docs/SECURITY.md`, document:
+
+- The DB stores profile names, Flow project/media IDs, local file paths, prompts by default, and prompt hashes.
+- `GFLOW_CLI_HISTORY_PROMPTS=redacted` stores prompt hashes without prompt text.
+- Signed CDN URLs, reCAPTCHA tokens, authorization headers, and cookies must not be stored in `metadata_json`.
+
+- [ ] **Step 6: Update architecture and roadmap docs**
+
+In `docs/ARCHITECTURE.md`, add `gflow_cli.data` to the modular monolith description.
+
+In `PLAN.md`, replace the broad Phase 6 SQLite operations-history item with the concrete data-layer phase. Keep `gflow data import` and richer management UI as separate backlog entries.
+
+- [ ] **Step 7: Run focused test suite**
+
+Run:
+
+```powershell
+uv run python -m pytest tests/data tests/cli/test_cli_data.py tests/cli/test_cli_image.py tests/cli/test_cli_video.py tests/api/test_client.py tests/api/test_video.py tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py -q
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 8: Run lint and type gates**
+
+Run:
+
+```powershell
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+```
+
+Expected: all gates pass.
+
+- [ ] **Step 9: Run repository hygiene**
+
+Run:
+
+```powershell
+uv run python scripts/ci/check_repo_hygiene.py
+```
+
+Expected: hygiene check passes.
+
+- [ ] **Step 10: Commit**
+
+```powershell
+git add docs/CONFIGURATION.md docs/USAGE.md docs/SECURITY.md docs/ARCHITECTURE.md PLAN.md tests/data/test_packaging.py
+git commit -m "docs(data): document local provenance layer"
+```
+
+## Self-Review Checklist
+
+- [ ] Migration runner applies SQL through `importlib.resources` and checks SHA-256 drift.
+- [ ] Every SQLite connection enables `foreign_keys`, `WAL`, and `busy_timeout`.
+- [ ] Recorder grouped writes use `BEGIN IMMEDIATE`.
+- [ ] `OperationRecorder` owns metadata redaction.
+- [ ] Prompt storage honors `GFLOW_CLI_HISTORY_PROMPTS`.
+- [ ] Post-success persistence failure logs `data.persistence_failed_after_success` with `flow_media_id` and local path when known.
+- [ ] `gflow video t2v` no longer instantiates `UiAutomationTransport` directly.
+- [ ] Video result stores `flow_operation_id` separately from `flow_media_id`.
+- [ ] Seed-image read path returns Flow project ID, Flow media ID, and local path.
+- [ ] SQL migrations are present in built wheels.
+- [ ] Docs include newer-schema recovery and prompt privacy behavior.
+
+## Final Verification
+
+Run the full local routine before merging:
+
+```powershell
+$env:PYTHONUTF8=1
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run python -m pytest -q --cov=gflow_cli
+```
+
+Expected: all commands pass. If local memory is constrained, run `uv run python -m pytest -m "not live and not e2e" -q` and let CI run the full suite.

--- a/docs/superpowers/plans/2026-05-24-data-layer.md
+++ b/docs/superpowers/plans/2026-05-24-data-layer.md
@@ -21,7 +21,7 @@ Source spec: `docs/superpowers/specs/2026-05-24-data-layer-design.md`
 - Create `src/gflow_cli/data/redaction.py`: prompt hashing and metadata redaction.
 - Create `src/gflow_cli/data/recorder.py`: high-level operation recording facade.
 - Create `src/gflow_cli/data/migrations/__init__.py`: package marker for `importlib.resources`.
-- Create `src/gflow_cli/data/migrations/001_initial.sql`: v1 schema.
+- Create `src/gflow_cli/data/migrations/0001_initial.sql`: v1 schema.
 - Create `src/gflow_cli/cli_data.py`: minimal read-only `gflow data` commands.
 - Modify `src/gflow_cli/config.py`: add `db_path`, `history_prompts`, and `resolved_db_path()`.
 - Modify `src/gflow_cli/errors.py`: add data-layer error classes and exit code 16.
@@ -86,7 +86,7 @@ def test_settings_respects_db_path_override(tmp_path: Path) -> None:
 
 
 def test_settings_accepts_prompt_redaction_modes(tmp_path: Path) -> None:
-    assert Settings(home=tmp_path, history_prompts="full").history_prompts == "full"
+    assert Settings(home=tmp_path, history_prompts="store").history_prompts == "store"
     assert Settings(home=tmp_path, history_prompts="redacted").history_prompts == "redacted"
 
 
@@ -140,10 +140,10 @@ Add these fields to `Settings` under the path/profile section:
             "Override with GFLOW_CLI_DB_PATH for tests or advanced local setups."
         ),
     )
-    history_prompts: Literal["full", "redacted"] = Field(
-        default="full",
+    history_prompts: Literal["store", "redacted"] = Field(
+        default="store",
         description=(
-            "Controls prompt persistence in the local DB. 'full' stores prompt text; "
+            "Controls prompt persistence in the local DB. 'store' stores prompt text; "
             "'redacted' stores only prompt_hash and prompt_redacted=1."
         ),
     )
@@ -217,7 +217,7 @@ git commit -m "feat(data): add settings and errors"
 **Files:**
 - Create: `src/gflow_cli/data/__init__.py`
 - Create: `src/gflow_cli/data/migrations/__init__.py`
-- Create: `src/gflow_cli/data/migrations/001_initial.sql`
+- Create: `src/gflow_cli/data/migrations/0001_initial.sql`
 - Create: `src/gflow_cli/data/store.py`
 - Modify: `pyproject.toml`
 - Create: `tests/data/test_store_migrations.py`
@@ -235,6 +235,7 @@ import pytest
 from gflow_cli.data.store import (
     DataStore,
     _checksum_sql,
+    _iter_sql_statements,
     _normalize_sql_for_checksum,
 )
 from gflow_cli.errors import DataMigrationError
@@ -254,7 +255,7 @@ def test_open_creates_schema_and_migration_row(tmp_path: Path) -> None:
     db = tmp_path / "gflow.db"
     with DataStore.open(db) as store:
         rows = store.conn.execute("SELECT version FROM schema_migrations").fetchall()
-        assert [row["version"] for row in rows] == [1]
+        assert [row["version"] for row in rows] == ["0001"]
         assert store.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert store.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
         assert store.conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
@@ -264,12 +265,12 @@ def test_newer_schema_raises(tmp_path: Path) -> None:
     db = tmp_path / "gflow.db"
     with sqlite3.connect(db) as conn:
         conn.execute(
-            "CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, filename TEXT, "
+            "CREATE TABLE schema_migrations(version TEXT PRIMARY KEY, filename TEXT, "
             "checksum TEXT, applied_at TEXT)"
         )
         conn.execute(
             "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
-            "VALUES (999, '999.sql', 'abc', '2026-05-24T00:00:00Z')"
+            "VALUES ('9999', '9999_future.sql', 'abc', '2026-05-24T00:00:00Z')"
         )
     with pytest.raises(DataMigrationError, match="newer"):
         DataStore.open(db)
@@ -280,7 +281,7 @@ def test_checksum_drift_raises(tmp_path: Path) -> None:
     with DataStore.open(db):
         pass
     with sqlite3.connect(db) as conn:
-        conn.execute("UPDATE schema_migrations SET checksum='bad' WHERE version=1")
+        conn.execute("UPDATE schema_migrations SET checksum='bad' WHERE version='0001'")
     with pytest.raises(DataMigrationError, match="checksum"):
         DataStore.open(db)
 
@@ -289,8 +290,9 @@ def test_foreign_keys_reject_orphan_rows(tmp_path: Path) -> None:
     with DataStore.open(tmp_path / "gflow.db") as store:
         with pytest.raises(sqlite3.IntegrityError):
             store.conn.execute(
-                "INSERT INTO local_files(id, asset_id, path, media_kind, created_at) "
-                "VALUES ('file-1', 'missing', 'C:/missing.png', 'image', '2026-05-24T00:00:00Z')"
+                "INSERT INTO local_files(id, profile_name, asset_id, path, media_type, created_at) "
+                "VALUES ('file-1', 'default', 'missing', 'C:/missing.png', "
+                "'image/png', '2026-05-24T00:00:00Z')"
             )
 
 
@@ -298,12 +300,34 @@ def test_transaction_uses_begin_immediate_for_writes(tmp_path: Path) -> None:
     with DataStore.open(tmp_path / "gflow.db") as store:
         with store.transaction(immediate=True):
             store.conn.execute(
-                "INSERT INTO profiles(name, profile_dir, created_at, updated_at) "
+                "INSERT INTO profiles(name, profile_dir, first_seen_at, last_used_at) "
                 "VALUES ('default', 'C:/profiles/default', '2026-05-24T00:00:00Z', "
                 "'2026-05-24T00:00:00Z')"
             )
         row = store.conn.execute("SELECT name FROM profiles").fetchone()
         assert row["name"] == "default"
+
+
+def test_migration_statement_batch_rolls_back_on_failure(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with pytest.raises(sqlite3.Error):
+            with store.transaction(immediate=True):
+                for statement in _iter_sql_statements(
+                    "CREATE TABLE rollback_probe(id INTEGER); "
+                    "INSERT INTO missing_table(id) VALUES (1);"
+                ):
+                    store.conn.execute(statement)
+        row = store.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_probe'"
+        ).fetchone()
+        assert row is None
+
+
+def test_iter_sql_statements_preserves_semicolon_inside_string_literal() -> None:
+    statements = list(
+        _iter_sql_statements("CREATE TABLE x(v TEXT); INSERT INTO x(v) VALUES ('a;b');")
+    )
+    assert statements == ["CREATE TABLE x(v TEXT)", "INSERT INTO x(v) VALUES ('a;b')"]
 ```
 
 - [ ] **Step 2: Run the tests and verify they fail**
@@ -336,11 +360,11 @@ Create `src/gflow_cli/data/migrations/__init__.py`:
 
 - [ ] **Step 4: Add the initial SQL schema**
 
-Create `src/gflow_cli/data/migrations/001_initial.sql`:
+Create `src/gflow_cli/data/migrations/0001_initial.sql`:
 
 ```sql
 CREATE TABLE schema_migrations (
-  version INTEGER PRIMARY KEY,
+  version TEXT PRIMARY KEY,
   filename TEXT NOT NULL,
   checksum TEXT NOT NULL,
   applied_at TEXT NOT NULL
@@ -348,19 +372,18 @@ CREATE TABLE schema_migrations (
 
 CREATE TABLE profiles (
   name TEXT PRIMARY KEY,
-  profile_dir TEXT NOT NULL,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
+  profile_dir TEXT,
+  first_seen_at TEXT NOT NULL,
+  last_used_at TEXT
 );
 
 CREATE TABLE projects (
   id TEXT PRIMARY KEY,
   profile_name TEXT NOT NULL,
   flow_project_id TEXT NOT NULL,
-  title TEXT NOT NULL,
+  title TEXT,
+  source TEXT NOT NULL,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  metadata_json TEXT NOT NULL DEFAULT '{}',
   FOREIGN KEY(profile_name) REFERENCES profiles(name),
   UNIQUE(profile_name, flow_project_id)
 );
@@ -368,49 +391,43 @@ CREATE TABLE projects (
 CREATE TABLE assets (
   id TEXT PRIMARY KEY,
   profile_name TEXT NOT NULL,
-  project_id TEXT,
+  flow_project_id TEXT,
   flow_media_id TEXT NOT NULL,
   flow_workflow_id TEXT,
   flow_media_generation_id TEXT,
-  media_kind TEXT NOT NULL,
-  source_kind TEXT NOT NULL,
+  kind TEXT NOT NULL,
   status TEXT NOT NULL,
-  prompt TEXT,
-  prompt_hash TEXT,
-  prompt_redacted INTEGER NOT NULL DEFAULT 0,
   model TEXT,
   aspect_ratio TEXT,
-  seed INTEGER,
   width INTEGER,
   height INTEGER,
+  duration_seconds REAL,
+  seed INTEGER,
   created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL,
-  metadata_json TEXT NOT NULL DEFAULT '{}',
+  metadata_json TEXT,
   FOREIGN KEY(profile_name) REFERENCES profiles(name),
-  FOREIGN KEY(project_id) REFERENCES projects(id),
   UNIQUE(profile_name, flow_media_id)
 );
 
 CREATE TABLE operations (
   id TEXT PRIMARY KEY,
   profile_name TEXT NOT NULL,
-  project_id TEXT,
-  operation_kind TEXT NOT NULL,
-  status TEXT NOT NULL,
-  flow_operation_id TEXT,
-  flow_media_id TEXT,
+  flow_project_id TEXT,
+  command TEXT,
+  mode TEXT NOT NULL,
   prompt TEXT,
   prompt_hash TEXT,
   prompt_redacted INTEGER NOT NULL DEFAULT 0,
   model TEXT,
   aspect_ratio TEXT,
-  seed INTEGER,
+  status TEXT NOT NULL,
   started_at TEXT NOT NULL,
   completed_at TEXT,
-  metadata_json TEXT NOT NULL DEFAULT '{}',
-  FOREIGN KEY(profile_name) REFERENCES profiles(name),
-  FOREIGN KEY(project_id) REFERENCES projects(id),
-  UNIQUE(profile_name, flow_operation_id)
+  error_type TEXT,
+  error_detail TEXT,
+  flow_operation_id TEXT,
+  flow_batch_id TEXT,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name)
 );
 
 CREATE TABLE operation_assets (
@@ -426,24 +443,26 @@ CREATE TABLE operation_assets (
 
 CREATE TABLE local_files (
   id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
   asset_id TEXT NOT NULL,
   path TEXT NOT NULL,
-  media_kind TEXT NOT NULL,
-  mime_type TEXT,
-  bytes_size INTEGER,
   sha256 TEXT,
+  bytes INTEGER,
+  media_type TEXT,
   created_at TEXT NOT NULL,
-  FOREIGN KEY(asset_id) REFERENCES assets(id) ON DELETE CASCADE,
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
   UNIQUE(asset_id, path)
 );
 
 CREATE INDEX idx_projects_profile_flow ON projects(profile_name, flow_project_id);
 CREATE INDEX idx_assets_profile_media ON assets(profile_name, flow_media_id);
-CREATE INDEX idx_assets_project_created ON assets(project_id, created_at);
-CREATE INDEX idx_assets_kind_created ON assets(media_kind, created_at);
+CREATE INDEX idx_assets_project_created ON assets(profile_name, flow_project_id, created_at);
+CREATE INDEX idx_assets_kind_created ON assets(kind, created_at);
 CREATE INDEX idx_operations_profile_created ON operations(profile_name, started_at);
+CREATE INDEX idx_operations_project_created ON operations(profile_name, flow_project_id, started_at);
 CREATE INDEX idx_operation_assets_asset ON operation_assets(asset_id);
-CREATE INDEX idx_local_files_asset ON local_files(asset_id);
+CREATE INDEX idx_local_files_asset ON local_files(profile_name, asset_id);
+CREATE INDEX idx_local_files_path ON local_files(path);
 ```
 
 - [ ] **Step 5: Implement `DataStore`**
@@ -454,6 +473,7 @@ Create `src/gflow_cli/data/store.py`:
 from __future__ import annotations
 
 import hashlib
+import re
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -466,6 +486,7 @@ from gflow_cli.errors import DataMigrationError, DataStoreError
 
 MIGRATION_PACKAGE = "gflow_cli.data.migrations"
 BUSY_TIMEOUT_MS = 5000
+MIGRATION_RE = re.compile(r"^(?P<version>\d{4,})_.+\.sql$")
 
 
 def _utc_now() -> str:
@@ -483,7 +504,8 @@ def _checksum_sql(sql: str) -> str:
 
 @dataclass(frozen=True)
 class Migration:
-    version: int
+    version: str
+    version_number: int
     filename: str
     sql: str
     checksum: str
@@ -496,18 +518,65 @@ def _load_migrations() -> list[Migration]:
             files.append(item)
     migrations: list[Migration] = []
     for file_ref in sorted(files, key=lambda p: p.name):
-        prefix = file_ref.name.split("_", 1)[0]
-        version = int(prefix)
+        match = MIGRATION_RE.match(file_ref.name)
+        if match is None:
+            raise DataMigrationError(
+                detail=f"invalid migration filename {file_ref.name!r}",
+                route="data.migrate",
+            )
+        version = match.group("version")
         sql = file_ref.read_text(encoding="utf-8")
         migrations.append(
             Migration(
                 version=version,
+                version_number=int(version),
                 filename=file_ref.name,
                 sql=sql,
                 checksum=_checksum_sql(sql),
             )
         )
     return migrations
+
+
+def _iter_sql_statements(sql: str) -> Iterator[str]:
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    in_line_comment = False
+    i = 0
+    while i < len(sql):
+        char = sql[i]
+        nxt = sql[i + 1] if i + 1 < len(sql) else ""
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            buf.append(char)
+            i += 1
+            continue
+        if not in_single and not in_double and char == "-" and nxt == "-":
+            in_line_comment = True
+            buf.extend([char, nxt])
+            i += 2
+            continue
+        if in_single and char == "'" and nxt == "'":
+            buf.extend([char, nxt])
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        if char == ";" and not in_single and not in_double:
+            statement = "".join(buf).strip()
+            if statement:
+                yield statement
+            buf.clear()
+        else:
+            buf.append(char)
+        i += 1
+    statement = "".join(buf).strip()
+    if statement:
+        yield statement
 
 
 class DataStore:
@@ -559,10 +628,10 @@ class DataStore:
         table_exists = self.conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
         ).fetchone()
-        latest_known = migrations[-1].version
+        latest_known = migrations[-1].version_number
         if table_exists is not None:
-            row = self.conn.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
-            current = int(row[0] or 0)
+            rows = self.conn.execute("SELECT version FROM schema_migrations").fetchall()
+            current = max((int(str(row["version"])) for row in rows), default=0)
             if current > latest_known:
                 raise DataMigrationError(
                     detail=f"database schema {current} is newer than installed schema {latest_known}",
@@ -570,7 +639,7 @@ class DataStore:
                 )
 
         applied = {
-            int(row["version"]): str(row["checksum"])
+            str(row["version"]): str(row["checksum"])
             for row in self.conn.execute(
                 "SELECT version, checksum FROM schema_migrations"
             ).fetchall()
@@ -585,23 +654,27 @@ class DataStore:
                         route="data.migrate",
                     )
                 continue
-            with self.transaction():
-                self.conn.executescript(migration.sql)
+            with self.transaction(immediate=True):
+                for statement in _iter_sql_statements(migration.sql):
+                    self.conn.execute(statement)
                 self.conn.execute(
                     "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
                     "VALUES (?, ?, ?, ?)",
                     (migration.version, migration.filename, migration.checksum, _utc_now()),
                 )
-                self.conn.execute(f"PRAGMA user_version = {migration.version}")
+                self.conn.execute(f"PRAGMA user_version = {migration.version_number}")
 ```
 
-- [ ] **Step 6: Include SQL migrations in wheels**
+- [ ] **Step 6: Include SQL migrations in wheels and sdists**
 
 Modify `pyproject.toml`:
 
 ```toml
 [tool.hatch.build.targets.wheel.force-include]
 "src/gflow_cli/data/migrations" = "gflow_cli/data/migrations"
+
+[tool.hatch.build.targets.sdist.force-include]
+"src/gflow_cli/data/migrations" = "src/gflow_cli/data/migrations"
 ```
 
 - [ ] **Step 7: Run migration tests**
@@ -646,7 +719,6 @@ from gflow_cli.data.models import (
     OperationRecord,
     OperationStatus,
     ProjectRecord,
-    SourceKind,
 )
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
@@ -663,28 +735,25 @@ def test_upserts_project_asset_operation_and_file(tmp_path: Path) -> None:
                 profile_name="default",
                 flow_project_id="flow-project-1",
                 title="gflow-cli t2i",
-                metadata_json={},
+                source="generated",
             )
         )
         asset = repo.upsert_asset(
             AssetRecord(
                 id="asset-local",
                 profile_name="default",
-                project_id=project.id,
+                flow_project_id=project.flow_project_id,
                 flow_media_id="media-1",
                 flow_workflow_id="workflow-1",
                 flow_media_generation_id="generation-1",
-                media_kind=AssetKind.IMAGE,
-                source_kind=SourceKind.GENERATED,
+                kind=AssetKind.IMAGE,
                 status="ready",
-                prompt="a prompt",
-                prompt_hash=None,
-                prompt_redacted=False,
                 model="NARWHAL",
                 aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
-                seed=123,
                 width=1024,
                 height=1792,
+                duration_seconds=None,
+                seed=123,
                 metadata_json={},
             )
         )
@@ -692,29 +761,30 @@ def test_upserts_project_asset_operation_and_file(tmp_path: Path) -> None:
             OperationRecord(
                 id="operation-local",
                 profile_name="default",
-                project_id=project.id,
-                operation_kind=OperationKind.T2I,
+                flow_project_id=project.flow_project_id,
+                command="gflow image t2i",
+                mode=OperationKind.T2I,
                 status=OperationStatus.SUCCEEDED,
                 flow_operation_id=None,
-                flow_media_id="media-1",
+                flow_batch_id=None,
                 prompt="a prompt",
                 prompt_hash=None,
                 prompt_redacted=False,
                 model="NARWHAL",
                 aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
-                seed=123,
-                metadata_json={},
+                error_type=None,
+                error_detail=None,
             )
         )
         repo.link_operation_asset(operation.id, asset.id, OperationAssetRole.OUTPUT, 0)
         repo.upsert_local_file(
             LocalFileRecord(
                 id="file-local",
+                profile_name="default",
                 asset_id=asset.id,
                 path=tmp_path / "media-1.png",
-                media_kind=AssetKind.IMAGE,
-                mime_type="image/png",
-                bytes_size=10,
+                media_type="image/png",
+                bytes=10,
                 sha256="a" * 64,
             )
         )
@@ -735,14 +805,14 @@ def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
                 profile_name="default",
                 flow_project_id="flow-project-1",
                 title="title",
-                metadata_json={},
+                source="generated",
             )
         )
         asset_one = repo.upsert_asset(
             AssetRecord.minimal_image(
                 id="asset-1",
                 profile_name="default",
-                project_id=project.id,
+                flow_project_id=project.flow_project_id,
                 flow_media_id="media-1",
             )
         )
@@ -750,7 +820,7 @@ def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
             AssetRecord.minimal_image(
                 id="asset-2",
                 profile_name="default",
-                project_id=project.id,
+                flow_project_id=project.flow_project_id,
                 flow_media_id="media-2",
             )
         )
@@ -758,8 +828,8 @@ def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
             OperationRecord.minimal(
                 id="operation-1",
                 profile_name="default",
-                project_id=project.id,
-                operation_kind=OperationKind.I2I,
+                flow_project_id=project.flow_project_id,
+                mode=OperationKind.I2I,
             )
         )
         repo.link_operation_asset(operation.id, asset_one.id, OperationAssetRole.INPUT, 0)
@@ -798,11 +868,6 @@ class AssetKind(StrEnum):
     VIDEO = "video"
 
 
-class SourceKind(StrEnum):
-    UPLOADED = "uploaded"
-    GENERATED = "generated"
-
-
 class OperationKind(StrEnum):
     UPLOAD_IMAGE = "upload_image"
     T2I = "t2i"
@@ -831,30 +896,29 @@ class ProjectRecord:
     id: str
     profile_name: str
     flow_project_id: str
-    title: str
-    metadata_json: JsonObject
+    title: str | None
+    source: str
+    created_at: str | None = None
 
 
 @dataclass(frozen=True)
 class AssetRecord:
     id: str
     profile_name: str
-    project_id: str | None
+    flow_project_id: str | None
     flow_media_id: str
     flow_workflow_id: str | None
     flow_media_generation_id: str | None
-    media_kind: AssetKind
-    source_kind: SourceKind
+    kind: AssetKind
     status: str
-    prompt: str | None
-    prompt_hash: str | None
-    prompt_redacted: bool
     model: str | None
     aspect_ratio: str | None
-    seed: int | None
     width: int | None
     height: int | None
+    duration_seconds: float | None
+    seed: int | None
     metadata_json: JsonObject
+    created_at: str | None = None
 
     @classmethod
     def minimal_image(
@@ -862,27 +926,24 @@ class AssetRecord:
         *,
         id: str,
         profile_name: str,
-        project_id: str | None,
+        flow_project_id: str | None,
         flow_media_id: str,
     ) -> AssetRecord:
         return cls(
             id=id,
             profile_name=profile_name,
-            project_id=project_id,
+            flow_project_id=flow_project_id,
             flow_media_id=flow_media_id,
             flow_workflow_id=None,
             flow_media_generation_id=None,
-            media_kind=AssetKind.IMAGE,
-            source_kind=SourceKind.GENERATED,
+            kind=AssetKind.IMAGE,
             status="ready",
-            prompt=None,
-            prompt_hash=None,
-            prompt_redacted=False,
             model=None,
             aspect_ratio=None,
-            seed=None,
             width=None,
             height=None,
+            duration_seconds=None,
+            seed=None,
             metadata_json={},
         )
 
@@ -891,18 +952,21 @@ class AssetRecord:
 class OperationRecord:
     id: str
     profile_name: str
-    project_id: str | None
-    operation_kind: OperationKind
+    flow_project_id: str | None
+    command: str | None
+    mode: OperationKind
     status: OperationStatus
     flow_operation_id: str | None
-    flow_media_id: str | None
+    flow_batch_id: str | None
     prompt: str | None
     prompt_hash: str | None
     prompt_redacted: bool
     model: str | None
     aspect_ratio: str | None
-    seed: int | None
-    metadata_json: JsonObject
+    error_type: str | None
+    error_detail: str | None
+    started_at: str | None = None
+    completed_at: str | None = None
 
     @classmethod
     def minimal(
@@ -910,36 +974,38 @@ class OperationRecord:
         *,
         id: str,
         profile_name: str,
-        project_id: str | None,
-        operation_kind: OperationKind,
+        flow_project_id: str | None,
+        mode: OperationKind,
     ) -> OperationRecord:
         return cls(
             id=id,
             profile_name=profile_name,
-            project_id=project_id,
-            operation_kind=operation_kind,
+            flow_project_id=flow_project_id,
+            command=None,
+            mode=mode,
             status=OperationStatus.SUCCEEDED,
             flow_operation_id=None,
-            flow_media_id=None,
+            flow_batch_id=None,
             prompt=None,
             prompt_hash=None,
             prompt_redacted=False,
             model=None,
             aspect_ratio=None,
-            seed=None,
-            metadata_json={},
+            error_type=None,
+            error_detail=None,
         )
 
 
 @dataclass(frozen=True)
 class LocalFileRecord:
     id: str
+    profile_name: str
     asset_id: str
     path: Path
-    media_kind: AssetKind
-    mime_type: str | None
-    bytes_size: int | None
+    media_type: str | None
+    bytes: int | None
     sha256: str | None
+    created_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -948,8 +1014,24 @@ class AssetLookup:
     profile_name: str
     flow_project_id: str | None
     flow_media_id: str
-    media_kind: AssetKind
+    kind: AssetKind
     local_files: list[LocalFileRecord]
+
+
+@dataclass(frozen=True)
+class SeedImage:
+    profile_name: str
+    flow_project_id: str
+    flow_media_id: str
+    flow_workflow_id: str | None
+    kind: AssetKind
+    width: int | None
+    height: int | None
+    local_path: Path | None
+    prompt: str | None
+    model: str | None
+    aspect_ratio: str | None
+    created_at: str
 ```
 
 - [ ] **Step 4: Implement repository methods**
@@ -963,11 +1045,20 @@ The repository must include these methods:
 - `upsert_project(record: ProjectRecord) -> ProjectRecord`
 - `upsert_asset(record: AssetRecord) -> AssetRecord`
 - `insert_operation(record: OperationRecord) -> OperationRecord`
+- `get_operation_for_output_asset(profile_name: str, flow_media_id: str, mode: OperationKind) -> OperationRecord | None`
+- `update_operation_status(operation_id: str, status: OperationStatus, completed_at: str | None, error_type: str | None, error_detail: str | None) -> None`
+- `update_asset_status(profile_name: str, flow_media_id: str, status: str) -> None`
 - `link_operation_asset(operation_id: str, asset_id: str, role: OperationAssetRole, position: int) -> None`
-- `upsert_local_file(record: LocalFileRecord) -> LocalFileRecord`
+- `upsert_local_file(record: LocalFileRecord) -> LocalFileRecord` using `ON CONFLICT(asset_id, path)`
 - `get_asset_by_flow_media_id(profile_name: str, flow_media_id: str) -> AssetLookup | None`
+- `resolve_seed_image(profile_name: str, flow_media_id: str) -> SeedImage | None`
+- `resolve_seed_image_by_path(profile_name: str, path: Path) -> SeedImage | None`
+- `resolve_latest_image(profile_name: str, flow_project_id: str | None, model: str | None, aspect_ratio: str | None) -> SeedImage | None`
+- `list_project_images(profile_name: str, flow_project_id: str) -> list[SeedImage]`
+- `candidate_image_exists(profile_name: str, flow_media_id: str) -> bool`
 
-Use `ON CONFLICT` for `profiles`, `projects`, `assets`, and `local_files`. Use plain `INSERT` for `operations` because operation rows are event records.
+Use `ON CONFLICT` for `profiles`, `projects`, `assets`, and `local_files`. Use plain `INSERT` for creating `operations` because operation rows are event records, and use explicit update methods for long-running operation status transitions.
+Repository methods should populate `created_at` and `started_at` with `_utc_now()` when callers omit them. `completed_at` must remain `NULL` unless the caller supplies it during a completion or failure update. Return dataclasses that include the persisted timestamp values.
 
 - [ ] **Step 5: Run repository tests**
 
@@ -1002,8 +1093,8 @@ Create `tests/data/test_redaction.py`:
 from gflow_cli.data.redaction import prompt_fields, redact_metadata
 
 
-def test_prompt_fields_full_mode_stores_text_and_hash() -> None:
-    fields = prompt_fields("hello", mode="full")
+def test_prompt_fields_store_mode_stores_text_and_hash() -> None:
+    fields = prompt_fields("hello", mode="store")
     assert fields.prompt == "hello"
     assert fields.prompt_hash is not None
     assert fields.prompt_redacted is False
@@ -1019,12 +1110,14 @@ def test_prompt_fields_redacted_mode_stores_hash_only() -> None:
 def test_redact_metadata_removes_signed_urls_and_tokens() -> None:
     raw = {
         "fifeUrl": "https://flow-content.google/path?Signature=abc",
+        "publicUrl": "https://example.com/public.png",
         "clientContext": {"recaptchaContext": {"token": "secret"}},
         "nested": [{"authorization": "Bearer abc"}],
         "safe": "kept",
     }
     redacted = redact_metadata(raw)
     assert redacted["fifeUrl"] == "<redacted:url>"
+    assert redacted["publicUrl"] == "https://example.com/public.png"
     assert redacted["clientContext"]["recaptchaContext"]["token"] == "<redacted:token>"
     assert redacted["nested"][0]["authorization"] == "<redacted:secret>"
     assert redacted["safe"] == "kept"
@@ -1048,7 +1141,7 @@ def test_record_upload_persists_project_asset_and_file(tmp_path: Path) -> None:
     image_path = tmp_path / "seed.png"
     image_path.write_bytes(b"png-bytes")
     with DataStore.open(tmp_path / "gflow.db") as store:
-        recorder = OperationRecorder(DataRepository(store), prompt_mode="full")
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
         project = ProjectInfo(project_id="flow-project-1", title="gflow-cli upload")
         asset = AssetInfo(
             name="media-upload-1",
@@ -1103,15 +1196,19 @@ def test_record_generated_images_persists_generation_metadata(tmp_path: Path) ->
             input_media_ids=[],
             operation_kind="t2i",
         )
-        row = store.conn.execute(
-            "SELECT prompt, prompt_hash, prompt_redacted, flow_media_generation_id, "
-            "metadata_json FROM assets WHERE flow_media_id='media-generated-1'"
+        asset_row = store.conn.execute(
+            "SELECT flow_media_generation_id, metadata_json "
+            "FROM assets WHERE flow_media_id='media-generated-1'"
         ).fetchone()
-        assert row["prompt"] is None
-        assert row["prompt_hash"]
-        assert row["prompt_redacted"] == 1
-        assert row["flow_media_generation_id"] == "generation-1"
-        assert "Signature=abc" not in row["metadata_json"]
+        operation_row = store.conn.execute(
+            "SELECT prompt, prompt_hash, prompt_redacted "
+            "FROM operations WHERE mode='t2i'"
+        ).fetchone()
+        assert operation_row["prompt"] is None
+        assert operation_row["prompt_hash"]
+        assert operation_row["prompt_redacted"] == 1
+        assert asset_row["flow_media_generation_id"] == "generation-1"
+        assert "Signature=abc" not in asset_row["metadata_json"]
 ```
 
 - [ ] **Step 3: Run the tests and verify they fail**
@@ -1152,7 +1249,9 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 
-PromptMode = Literal["full", "redacted"]
+PromptMode = Literal["store", "redacted"]
+SENSITIVE_URL_KEYS = {"fifeurl", "signedurl", "downloadurl", "mediaurl"}
+SENSITIVE_QUERY_KEYS = ("signature=", "x-goog-signature=", "x-goog-credential=", "expires=")
 
 
 @dataclass(frozen=True)
@@ -1180,13 +1279,15 @@ def redact_metadata(value: Any) -> Any:
                 out[key] = "<redacted:token>"
             elif lowered in {"authorization", "cookie", "set-cookie"}:
                 out[key] = "<redacted:secret>"
-            elif "url" in lowered and isinstance(item, str):
+            elif lowered in SENSITIVE_URL_KEYS and isinstance(item, str):
                 out[key] = "<redacted:url>"
             else:
                 out[key] = redact_metadata(item)
         return out
     if isinstance(value, list):
         return [redact_metadata(item) for item in value]
+    if isinstance(value, str) and any(marker in value.lower() for marker in SENSITIVE_QUERY_KEYS):
+        return "<redacted:url>"
     return value
 ```
 
@@ -1222,7 +1323,6 @@ from gflow_cli.data.models import (
     OperationRecord,
     OperationStatus,
     ProjectRecord,
-    SourceKind,
 )
 from gflow_cli.data.redaction import PromptMode, prompt_fields, redact_metadata
 from gflow_cli.data.repository import DataRepository
@@ -1258,9 +1358,10 @@ Implement these public methods:
 
 - `record_upload_image(profile_name, profile_dir, project, asset, image_path) -> None`
 - `record_generated_images(profile_name, profile_dir, project, request, images, saved_paths, input_media_ids, operation_kind) -> None`
-- `record_generated_video(profile_name, profile_dir, request, result) -> None`
+- `record_started_video(profile_name, profile_dir, request, started) -> None`
+- `record_completed_video(profile_name, profile_dir, request, result) -> None`
 
-For REST-created image projects, build a `ProjectRecord` with a generated local ID, the current profile name, and `flow_project_id=project.project_id`. For video projects, `VideoResult.project_id` is the Flow project ID and the display title is `"gflow-cli video"`.
+For REST-created image projects, build a `ProjectRecord` with a generated local ID, the current profile name, `flow_project_id=project.project_id`, and `source="generated"` or `source="uploaded"` depending on the operation. For video projects, `VideoResult.project_id` is the Flow project ID and the display title is `"gflow-cli video"`.
 
 - [ ] **Step 7: Run recorder tests**
 
@@ -1480,7 +1581,7 @@ Pass `profile_name` from `cli_image.t2i` multi-prompt mode and `cli_image.batch`
 
 - [ ] **Step 4: Record successful batch outcomes**
 
-In `_download_results`, add optional `recorder`, `profile_name`, and `profile_dir`. After each row downloads, call:
+In `_download_results`, add optional `recorder`, `profile_name`, and `profile_dir`. After each row downloads, call the recorder inside a per-row `try/except DataStoreError` block:
 
 ```python
 recorder.record_generated_images(
@@ -1496,6 +1597,7 @@ recorder.record_generated_images(
 ```
 
 Wrap only this post-download recorder call in `except DataStoreError` and emit `data.persistence_failed_after_success` with the first output media ID and first saved path.
+One row's persistence failure must not prevent later downloaded rows from being recorded.
 
 - [ ] **Step 5: Preserve fail-fast salvage semantics**
 
@@ -1628,6 +1730,13 @@ Modify `src/gflow_cli/api/video.py`:
 
 ```python
 @dataclass(frozen=True)
+class VideoStarted:
+    media_id: str
+    project_id: str | None = None
+    flow_operation_id: str | None = None
+
+
+@dataclass(frozen=True)
 class VideoResult:
     status: VideoStatus
     local_path: Path | None
@@ -1635,9 +1744,14 @@ class VideoResult:
     flow_operation_id: str | None = None
 ```
 
-Add:
+Add a callback type and parser helper:
 
 ```python
+from collections.abc import Awaitable, Callable
+
+VideoStartedCallback = Callable[[VideoStarted], Awaitable[None] | None]
+
+
 def operation_name_from_generate_response(response_json: dict[str, Any]) -> str | None:
     operations = response_json.get("operations")
     if not isinstance(operations, list) or not operations:
@@ -1659,11 +1773,36 @@ Modify `src/gflow_cli/api/transports/ui_automation_video.py`:
 - Import `extract_project_id`.
 - After `_enter_editor`, set `project_id = extract_project_id(page.url)`.
 - Parse `flow_operation_id = operation_name_from_generate_response(generate_resp.get("body") or {})`.
+- Build `VideoStarted(media_id=status.media_id, project_id=project_id, flow_operation_id=flow_operation_id)` as soon as the generation response yields a media ID, before polling begins.
+- If `on_started` is provided, call it immediately and await the result when it returns an awaitable.
 - Return a `VideoResult` with the existing status and local path plus `project_id=project_id` and `flow_operation_id=flow_operation_id`.
 
 The generated media ID remains `status.media_id`. The operation ID is stored separately even though current captures show the same value.
 
 - [ ] **Step 8: Add video-capable client method**
+
+Define a video-capable protocol in `src/gflow_cli/api/transports/base.py` so `pyright` can type-check the transport capability:
+
+```python
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStartedCallback
+
+
+@runtime_checkable
+class VideoCapableTransport(Protocol):
+    async def generate_video(
+        self,
+        *,
+        request: GenerateVideoRequest,
+        out_dir: Path | None,
+        poll_timeout_s: float,
+        download: bool,
+        on_started: VideoStartedCallback | None = None,
+    ) -> VideoResult:
+        raise NotImplementedError
+```
 
 Modify `src/gflow_cli/api/client.py`:
 
@@ -1675,22 +1814,23 @@ Modify `src/gflow_cli/api/client.py`:
         out_dir: Path | None = None,
         poll_timeout_s: float = 600.0,
         download: bool = True,
+        on_started: VideoStartedCallback | None = None,
     ) -> VideoResult:
         if self.transport is None:
             raise RuntimeError(
                 "FlowApiClient.transport is None - call generate_video inside 'async with client'"
             )
-        generate_video = getattr(self.transport, "generate_video", None)
-        if generate_video is None:
-            raise ConfigurationError(
+        if not isinstance(self.transport, VideoCapableTransport):
+            raise RuntimeError(
                 f"transport {type(self.transport).__name__} does not support video generation"
             )
         try:
-            return await generate_video(
+            return await self.transport.generate_video(
                 request=req,
                 out_dir=out_dir,
                 poll_timeout_s=poll_timeout_s,
                 download=download,
+                on_started=on_started,
             )
         except Exception as e:
             if _is_target_closed(e):
@@ -1698,7 +1838,7 @@ Modify `src/gflow_cli/api/client.py`:
             raise
 ```
 
-Add imports for `GenerateVideoRequest`, `VideoResult`, and `ConfigurationError`.
+Add imports for `GenerateVideoRequest`, `VideoResult`, `VideoStartedCallback`, and `VideoCapableTransport`. This is an internal capability error; do not map it to user-facing `ConfigurationError`.
 
 - [ ] **Step 9: Route `gflow video t2v` through FlowApiClient**
 
@@ -1708,7 +1848,7 @@ Modify `src/gflow_cli/cli_video.py`:
 - Resolve `settings = get_settings()` in `t2v`.
 - Pass `headless=settings.headless`, `profile_name`, and `transport=None` into `_run_t2v`.
 - In `_run_t2v`, use `async with FlowApiClient(profile_dir=profile_dir, headless=headless, out_dir=out_dir) as client:`.
-- Call `result = await client.generate_video(req=request, out_dir=out_dir, download=True)`.
+- Call `result = await client.generate_video(req=request, out_dir=out_dir, download=True, on_started=on_started)`.
 
 - [ ] **Step 10: Run video tests**
 
@@ -1741,18 +1881,55 @@ In `tests/data/test_recorder.py`, add:
 
 ```python
 from gflow_cli.api.video import Aspect as VideoAspect
-from gflow_cli.api.video import GenerateVideoRequest, Mode, VideoResult, VideoStatus
+from gflow_cli.api.video import GenerateVideoRequest, Mode, VideoResult, VideoStarted, VideoStatus
 
 
-def test_record_generated_video_persists_media_operation_and_file(tmp_path: Path) -> None:
-    saved = tmp_path / "video.mp4"
-    saved.write_bytes(b"video-bytes")
+def test_record_started_video_persists_pending_media_and_operation(tmp_path: Path) -> None:
     with DataStore.open(tmp_path / "gflow.db") as store:
-        recorder = OperationRecorder(DataRepository(store), prompt_mode="full")
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
         request = GenerateVideoRequest(
             prompt="video prompt",
             mode=Mode.T2V,
             aspect=VideoAspect.PORTRAIT,
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="operation-video-1",
+            ),
+        )
+        asset = recorder.repository.get_asset_by_flow_media_id("default", "media-video-1")
+        assert asset is not None
+        row = store.conn.execute(
+            "SELECT status, flow_operation_id FROM operations WHERE mode='t2v'"
+        ).fetchone()
+        assert row["status"] == "started"
+        assert row["flow_operation_id"] == "operation-video-1"
+
+
+def test_record_completed_video_updates_media_operation_and_file(tmp_path: Path) -> None:
+    saved = tmp_path / "video.mp4"
+    saved.write_bytes(b"video-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="video prompt",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="media-video-1",
+            ),
         )
         result = VideoResult(
             status=VideoStatus(
@@ -1763,7 +1940,7 @@ def test_record_generated_video_persists_media_operation_and_file(tmp_path: Path
             project_id="flow-project-video-1",
             flow_operation_id="media-video-1",
         )
-        recorder.record_generated_video(
+        recorder.record_completed_video(
             profile_name="default",
             profile_dir=tmp_path / "profile_default",
             request=request,
@@ -1773,9 +1950,12 @@ def test_record_generated_video_persists_media_operation_and_file(tmp_path: Path
         assert asset is not None
         assert asset.flow_project_id == "flow-project-video-1"
         assert asset.local_files[0].path == saved.resolve()
+        row = store.conn.execute("SELECT status, completed_at FROM operations WHERE mode='t2v'").fetchone()
+        assert row["status"] == "succeeded"
+        assert row["completed_at"] is not None
 ```
 
-In `tests/cli/test_cli_video.py`, add a fake recorder and assert `_run_t2v` records the successful `VideoResult`.
+In `tests/cli/test_cli_video.py`, add a fake recorder and fake client. Assert `_run_t2v` passes `on_started` into `FlowApiClient.generate_video`, records the pending `VideoStarted` before completion, and records the successful `VideoResult` after polling.
 
 - [ ] **Step 2: Run video recording tests and verify they fail**
 
@@ -1785,40 +1965,65 @@ Run:
 uv run python -m pytest tests/data/test_recorder.py tests/cli/test_cli_video.py -q
 ```
 
-Expected: failures until `record_generated_video` and CLI wiring are complete.
+Expected: failures until `record_started_video`, `record_completed_video`, `on_started`, and CLI wiring are complete.
 
-- [ ] **Step 3: Complete `record_generated_video`**
+- [ ] **Step 3: Complete video start and completion recording**
 
-In `src/gflow_cli/data/recorder.py`, implement `record_generated_video`:
+In `src/gflow_cli/data/recorder.py`, implement `record_started_video`:
 
 - Upsert the profile.
-- Upsert a project with `flow_project_id=result.project_id` when present.
-- Upsert a video asset with `flow_media_id=result.status.media_id`, `media_kind=AssetKind.VIDEO`, `source_kind=SourceKind.GENERATED`, `status=result.status.status`, `prompt`, `model=request.tier.value`, and `aspect_ratio=request.aspect.value`.
-- Insert an operation with `operation_kind=OperationKind.T2V`, `flow_operation_id=result.flow_operation_id`, and `flow_media_id=result.status.media_id`.
+- Upsert a project with `flow_project_id=started.project_id` when present.
+- Upsert a pending video asset with `flow_media_id=started.media_id`, `kind=AssetKind.VIDEO`, `status="pending"`, `model=request.tier.value`, and `aspect_ratio=request.aspect.value`.
+- Insert a started operation with `mode=OperationKind.T2V`, `command="gflow video t2v"`, `flow_operation_id=started.flow_operation_id`, prompt fields, model, and aspect ratio.
 - Link the output asset at position 0.
+
+Implement `record_completed_video`:
+
+- Upsert the same video asset with `flow_media_id=result.status.media_id`, `status=result.status.status`, model, aspect ratio, and `duration_seconds` when known.
+- Locate the pending operation through `get_operation_for_output_asset(profile_name, result.status.media_id, OperationKind.T2V)`.
+- Update the matching operation through `update_operation_status(...)` to `status=OperationStatus.SUCCEEDED`, set `completed_at`, and preserve `flow_operation_id`.
+- If the pending write failed and no matching operation exists, insert a completed operation and link it to the output asset so the final successful result is still tracked.
+- Update the asset status through `update_asset_status(profile_name, result.status.media_id, result.status.status)`.
 - Insert the local file when `result.local_path` is not `None`.
 
 - [ ] **Step 4: Wire recorder into `cli_video.py`**
 
-Open `OperationRecorder` before `FlowApiClient`. After successful video generation, call:
+Open `OperationRecorder` before `FlowApiClient`. Define an `on_started` callback and pass it to `client.generate_video` so the pending media and operation are recorded immediately after Flow returns the generation response and before long polling:
 
 ```python
+        async def on_started(started: VideoStarted) -> None:
+            try:
+                recorder.record_started_video(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    request=request,
+                    started=started,
+                )
+            except DataStoreError as exc:
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=started.media_id,
+                    local_path=None,
+                )
+
+        result = await client.generate_video(
+            req=request,
+            out_dir=out_dir,
+            download=True,
+            on_started=on_started,
+        )
         try:
-            recorder.record_generated_video(
+            recorder.record_completed_video(
                 profile_name=profile_name,
                 profile_dir=profile_dir,
                 request=request,
                 result=result,
             )
         except DataStoreError as exc:
-            logger.warning(
-                "data.persistence_failed_after_success",
-                error_class=type(exc).__name__,
+            _warn_persistence_failed_after_success(
+                exc=exc,
                 flow_media_id=result.status.media_id,
-                local_path=str(result.local_path) if result.local_path else None,
-            )
-            console.print(
-                "[yellow]Generated media was saved, but local history was not updated.[/yellow]"
+                local_path=result.local_path,
             )
 ```
 
@@ -1850,7 +2055,7 @@ git commit -m "feat(data): record video commands"
 - Create: `tests/cli/test_cli_data.py`
 - Modify: `tests/data/test_repository.py`
 
-- [ ] **Step 1: Write failing seed resolver tests**
+- [ ] **Step 1: Write failing seed resolver and read API tests**
 
 Add to `tests/data/test_repository.py`:
 
@@ -1865,14 +2070,14 @@ def test_resolve_seed_image_returns_project_media_and_path(tmp_path: Path) -> No
                 profile_name="default",
                 flow_project_id="flow-project-1",
                 title="title",
-                metadata_json={},
+                source="generated",
             )
         )
         asset = repo.upsert_asset(
             AssetRecord.minimal_image(
                 id="asset-local",
                 profile_name="default",
-                project_id=project.id,
+                flow_project_id=project.flow_project_id,
                 flow_media_id="media-image-1",
             )
         )
@@ -1881,11 +2086,11 @@ def test_resolve_seed_image_returns_project_media_and_path(tmp_path: Path) -> No
         repo.upsert_local_file(
             LocalFileRecord(
                 id="file-local",
+                profile_name="default",
                 asset_id=asset.id,
                 path=image_path,
-                media_kind=AssetKind.IMAGE,
-                mime_type="image/png",
-                bytes_size=11,
+                media_type="image/png",
+                bytes=11,
                 sha256="b" * 64,
             )
         )
@@ -1894,6 +2099,52 @@ def test_resolve_seed_image_returns_project_media_and_path(tmp_path: Path) -> No
         assert seed.flow_project_id == "flow-project-1"
         assert seed.flow_media_id == "media-image-1"
         assert seed.local_path == image_path.resolve()
+
+
+def test_seed_read_api_resolves_by_path_latest_project_and_candidate(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", tmp_path / "profile_default")
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        image_path = tmp_path / "latest.png"
+        image_path.write_bytes(b"image-bytes")
+        asset = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-latest",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                flow_media_id="media-latest",
+            )
+        )
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-latest",
+                profile_name="default",
+                asset_id=asset.id,
+                path=image_path,
+                media_type="image/png",
+                bytes=11,
+                sha256=None,
+            )
+        )
+        by_path = repo.resolve_seed_image_by_path("default", image_path)
+        latest = repo.resolve_latest_image("default", None, None, None)
+        assert by_path is not None
+        assert latest is not None
+        assert by_path.flow_media_id == "media-latest"
+        assert latest.flow_media_id == "media-latest"
+        assert [item.flow_media_id for item in repo.list_project_images("default", "flow-project-1")] == [
+            "media-latest"
+        ]
+        assert repo.candidate_image_exists("default", "media-latest") is True
 ```
 
 - [ ] **Step 2: Write failing CLI data tests**
@@ -1911,28 +2162,22 @@ Run:
 uv run python -m pytest tests/data/test_repository.py tests/cli/test_cli_data.py -q
 ```
 
-Expected: missing `resolve_seed_image` and missing `cli_data`.
+Expected: missing seed read API methods and missing `cli_data`.
 
-- [ ] **Step 4: Add seed resolver model and repository method**
-
-Add to `models.py`:
-
-```python
-@dataclass(frozen=True)
-class SeedImage:
-    flow_media_id: str
-    flow_project_id: str
-    local_path: Path | None
-```
+- [ ] **Step 4: Add seed resolver repository methods**
 
 Add to `DataRepository`:
 
 ```python
     def resolve_seed_image(self, profile_name: str, flow_media_id: str) -> SeedImage | None:
         row = self.store.conn.execute(
-            "SELECT a.flow_media_id, p.flow_project_id "
-            "FROM assets a LEFT JOIN projects p ON p.id = a.project_id "
-            "WHERE a.profile_name=? AND a.flow_media_id=? AND a.media_kind='image'",
+            "SELECT a.profile_name, a.flow_media_id, a.flow_project_id, "
+            "a.flow_workflow_id, a.kind, a.width, a.height, a.model, "
+            "a.aspect_ratio, a.created_at, o.prompt "
+            "FROM assets a "
+            "LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role='output' "
+            "LEFT JOIN operations o ON o.id = oa.operation_id "
+            "WHERE a.profile_name=? AND a.flow_media_id=? AND a.kind='image'",
             (profile_name, flow_media_id),
         ).fetchone()
         if row is None or row["flow_project_id"] is None:
@@ -1944,11 +2189,27 @@ Add to `DataRepository`:
         ).fetchone()
         local_path = Path(file_row["path"]) if file_row is not None else None
         return SeedImage(
+            profile_name=row["profile_name"],
             flow_media_id=row["flow_media_id"],
             flow_project_id=row["flow_project_id"],
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
             local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=row["created_at"],
         )
 ```
+
+Also implement:
+
+- `resolve_seed_image_by_path(profile_name, path)`: resolve the absolute path through `local_files`, then return the same typed `SeedImage`.
+- `resolve_latest_image(profile_name, project_id, model, aspect_ratio)`: return the newest image asset for the active profile, optionally filtered by Flow project ID, model, and aspect ratio.
+- `list_project_images(profile_name, flow_project_id)`: return typed image candidates for a Flow project.
+- `candidate_image_exists(profile_name, flow_media_id)`: return true only when the active profile has an image asset with a non-null `flow_project_id`.
 
 - [ ] **Step 5: Add `gflow data` command group**
 
@@ -1956,8 +2217,6 @@ Create `src/gflow_cli/cli_data.py`:
 
 ```python
 from __future__ import annotations
-
-import sys
 
 import click
 from rich.console import Console
@@ -1967,6 +2226,7 @@ from gflow_cli._cli_helpers import _resolve_profile, run_with_handlers, safe_pat
 from gflow_cli.config import get_settings
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataStoreError
 
 console = Console()
 
@@ -1993,19 +2253,23 @@ async def _run_media(*, profile_name: str, media_id: str) -> None:
         repo = DataRepository(store)
         asset = repo.get_asset_by_flow_media_id(profile_name, media_id)
         if asset is None:
-            console.print(f"[red]No local media record found:[/red] {media_id}")
-            sys.exit(1)
+            raise DataStoreError(
+                detail=f"No local media record found: {media_id}",
+                route="data.media",
+            )
         table = Table(title="gflow data media")
         table.add_column("field")
         table.add_column("value", overflow="fold")
         table.add_row("profile", profile_name)
         table.add_row("media_id", asset.flow_media_id)
         table.add_row("project_id", asset.flow_project_id or "")
-        table.add_row("kind", asset.media_kind.value)
+        table.add_row("kind", asset.kind.value)
         for idx, local_file in enumerate(asset.local_files, start=1):
             table.add_row(f"local_path_{idx}", safe_path_text(local_file.path))
         console.print(table)
 ```
+
+This follows the existing `_cli_helpers.run_with_handlers` coroutine-factory contract (`asyncio.run(coro_factory())`), even though `_run_media` does not currently need awaits.
 
 Register it in `src/gflow_cli/cli.py`:
 
@@ -2047,20 +2311,36 @@ git commit -m "feat(data): add read-only media lookup"
 Create `tests/data/test_packaging.py`:
 
 ```python
+from importlib import resources
 import subprocess
+import tarfile
 import zipfile
 from pathlib import Path
 
+import pytest
 
-def test_wheel_contains_sql_migrations(tmp_path: Path) -> None:
+
+def test_migration_resource_is_discoverable() -> None:
+    migration = resources.files("gflow_cli.data.migrations").joinpath("0001_initial.sql")
+    assert migration.is_file()
+
+
+@pytest.mark.integration
+def test_built_distributions_contain_sql_migrations(tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+        ["uv", "build", "--wheel", "--sdist", "--out-dir", str(dist_dir)],
         check=True,
     )
     wheel = next(dist_dir.glob("gflow_cli-*.whl"))
     with zipfile.ZipFile(wheel) as archive:
-        assert "gflow_cli/data/migrations/001_initial.sql" in archive.namelist()
+        assert "gflow_cli/data/migrations/0001_initial.sql" in archive.namelist()
+    sdist = next(dist_dir.glob("gflow_cli-*.tar.gz"))
+    with tarfile.open(sdist) as archive:
+        assert any(
+            name.endswith("src/gflow_cli/data/migrations/0001_initial.sql")
+            for name in archive.getnames()
+        )
 ```
 
 - [ ] **Step 2: Run packaging test and verify it passes**
@@ -2071,7 +2351,7 @@ Run:
 uv run python -m pytest tests/data/test_packaging.py -q
 ```
 
-Expected: wheel inspection confirms `001_initial.sql` is packaged.
+Expected: resource discovery passes, and wheel/sdist inspection confirms `0001_initial.sql` is packaged.
 
 - [ ] **Step 3: Update configuration docs**
 
@@ -2079,7 +2359,7 @@ In `docs/CONFIGURATION.md`, document:
 
 - `GFLOW_CLI_DB_PATH`: optional SQLite DB path override.
 - Default DB location: `<GFLOW_CLI_HOME>/gflow.db`.
-- `GFLOW_CLI_HISTORY_PROMPTS=full|redacted`.
+- `GFLOW_CLI_HISTORY_PROMPTS=store|redacted`.
 
 - [ ] **Step 4: Update usage docs**
 
@@ -2144,7 +2424,7 @@ git commit -m "docs(data): document local provenance layer"
 
 ## Self-Review Checklist
 
-- [ ] Migration runner applies SQL through `importlib.resources` and checks SHA-256 drift.
+- [ ] Migration runner applies SQL through `importlib.resources`, checks SHA-256 drift, validates zero-padded filenames, and never wraps `executescript` inside an explicit transaction.
 - [ ] Every SQLite connection enables `foreign_keys`, `WAL`, and `busy_timeout`.
 - [ ] Recorder grouped writes use `BEGIN IMMEDIATE`.
 - [ ] `OperationRecorder` owns metadata redaction.
@@ -2152,13 +2432,13 @@ git commit -m "docs(data): document local provenance layer"
 - [ ] Post-success persistence failure logs `data.persistence_failed_after_success` with `flow_media_id` and local path when known.
 - [ ] `gflow video t2v` no longer instantiates `UiAutomationTransport` directly.
 - [ ] Video result stores `flow_operation_id` separately from `flow_media_id`.
-- [ ] Seed-image read path returns Flow project ID, Flow media ID, and local path.
-- [ ] SQL migrations are present in built wheels.
+- [ ] Seed-image read path returns Flow project ID, Flow media ID, and local path by media ID, local path, latest-image query, and project listing.
+- [ ] SQL migrations are present in built wheels and sdists.
 - [ ] Docs include newer-schema recovery and prompt privacy behavior.
 
 ## Final Verification
 
-Run the full local routine before merging:
+Run the local verification routine before opening an implementation PR:
 
 ```powershell
 $env:PYTHONUTF8=1
@@ -2166,7 +2446,7 @@ uv run python scripts/ci/check_repo_hygiene.py
 uv run ruff check src tests
 uv run ruff format --check src tests
 uv run pyright src
-uv run python -m pytest -q --cov=gflow_cli
+uv run python -m pytest tests/data tests/cli/test_cli_data.py tests/cli/test_cli_image.py tests/cli/test_cli_video.py tests/api/test_client.py tests/api/test_video.py tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py -q
 ```
 
-Expected: all commands pass. If local memory is constrained, run `uv run python -m pytest -m "not live and not e2e" -q` and let CI run the full suite.
+Expected: all commands pass. CI should run `uv run python -m pytest -q --cov=gflow_cli` for the full coverage gate because the complete suite can OOM on smaller local machines.

--- a/docs/superpowers/specs/2026-05-24-data-layer-design.md
+++ b/docs/superpowers/specs/2026-05-24-data-layer-design.md
@@ -93,6 +93,7 @@ Migration behavior:
 - Run pending migrations automatically when `DataStore.open()` is called.
 - Apply each migration in a transaction.
 - Calculate a checksum for each SQL file.
+- Use SHA-256 for migration checksums. Normalize SQL before hashing by converting CRLF to LF and trimming trailing whitespace/newlines so contributor line endings do not cause false drift.
 - If a migration already applied with a different checksum, raise `DataMigrationError`.
 - If the DB contains a migration version newer than the installed package, raise `DataMigrationError`.
 - Mirror the highest numeric migration into `PRAGMA user_version` as a convenience only; `schema_migrations` remains the source of truth.
@@ -110,7 +111,8 @@ SQLite connection requirements:
 - Enable foreign key enforcement on every connection: `PRAGMA foreign_keys = ON`.
 - Enable safer concurrent CLI usage: `PRAGMA journal_mode = WAL`.
 - Set a busy timeout, for example `PRAGMA busy_timeout = 5000`, so parallel profile/process runs do not fail immediately with `database is locked`.
-- Use Python `sqlite3` with `isolation_level=None` and explicit `BEGIN` / `COMMIT` blocks so connection-level pragmas and transaction boundaries behave predictably.
+- Use Python `sqlite3` with `isolation_level=None` and explicit transaction blocks so connection-level pragmas and transaction boundaries behave predictably.
+- Use `BEGIN IMMEDIATE` for grouped recorder writes; this avoids deferred-writer deadlocks under WAL when two CLI processes try to upgrade read transactions to writes.
 - Open write transactions explicitly around grouped recorder operations.
 
 ## Error Taxonomy Impact
@@ -157,6 +159,7 @@ Known Flow IDs from captured responses:
 Naming rule:
 
 - `id`: local database primary key.
+- Local database primary keys are app-generated text IDs for `operations.id`, `projects.id`, `assets.id`, and `local_files.id`. v1 may use UUID4 from the standard library; chronological reads must use `created_at` indexes rather than relying on ID ordering.
 - `flow_media_id`: Google Flow `media[].name`.
 - `flow_workflow_id`: Google Flow `workflowId`.
 - `flow_project_id`: Google Flow `projectId`.
@@ -238,6 +241,7 @@ operation_assets(
   position INTEGER NOT NULL DEFAULT 0,
   FOREIGN KEY(operation_id) REFERENCES operations(id),
   FOREIGN KEY(asset_id) REFERENCES assets(id),
+  UNIQUE(operation_id, role, position),
   PRIMARY KEY(operation_id, asset_id, role, position)
 )
 
@@ -261,8 +265,10 @@ Important constraints:
 - `profile_name` is duplicated on key tables to keep common queries simple and future cross-profile scheduling efficient.
 - `metadata_json` can hold route-specific fields without requiring a migration for every observed Flow nuance.
 - `metadata_json` must not store signed CDN URLs such as `fifeUrl`; those expire and contain bearer-style query tokens.
+- `OperationRecorder` owns response redaction before writing `metadata_json`; call sites must not be trusted to strip signed URLs, bearer-style query params, reCAPTCHA tokens, or authorization material correctly.
 - Prompt redaction stores `prompt = NULL`, `prompt_redacted = 1`, and `prompt_hash` for correlation.
 - `local_files.path` stores the resolved absolute local path in v1. Moving output directories or sharing the DB across Windows/WSL path schemes is out of scope until `gflow data repair` can relink files.
+- `operation_assets` includes `position` deliberately so ordered input lists are round-trippable. Reusing the same asset in multiple roles or positions is allowed when it reflects the user's request; `UNIQUE(operation_id, role, position)` prevents two assets occupying the same slot.
 
 ## Prompt Privacy
 
@@ -294,6 +300,7 @@ Persistence failure handling:
 - Before any remote Flow action, DB open/migration failures fail fast with exit code `16`.
 - After a successful paid remote generation, persistence failures must not discard generated media or skip downloads that can still complete.
 - If media was generated and downloaded but the final persistence write fails, keep the local file, emit a visible warning plus a structured `data.persistence_failed_after_success` event, and preserve the command's generation result exit semantics. A successful paid generation with a saved file should not exit non-zero solely because local tracking failed.
+- The `data.persistence_failed_after_success` event must include the unpersisted `flow_media_id` when known and the local file path when available, so future repair tooling can reconcile the saved asset.
 - No data-layer failure should be silently swallowed. If a write is intentionally deferred or retried, emit a structured event with the operation ID and failure class.
 
 ## T2V Client-Boundary Normalization
@@ -356,14 +363,17 @@ Required tests:
 - Checksum drift raises `DataMigrationError`.
 - Newer DB schema raises `DataMigrationError`.
 - Built wheels/sdists contain SQL migration files and the runner reads them through `importlib.resources`.
+- The packaging check must inspect a built wheel in a clean environment or extracted wheel, not an editable install, because editable installs can hide missing package-data declarations.
 - New SQLite connections enable `foreign_keys`, `WAL`, and `busy_timeout`.
 - Foreign key enforcement rejects orphaned `operation_assets` and `local_files` rows.
+- Recorder write transactions use `BEGIN IMMEDIATE` and are covered by a concurrent-writer test that does not fail with immediate `database is locked`.
 - SQLite exceptions are mapped to `DataStoreError` subclasses.
 - Repository upserts are idempotent.
 - Prompt redaction stores hash and no prompt text.
 - Recording an upload persists profile, project, asset, and operation linkage.
 - Recording generated images persists Flow media IDs, workflow IDs, model/aspect/seed, and local files.
 - Recording T2V through `FlowApiClient` persists the pending media ID, terminal status, and local file path.
+- Fixture-driven video tests store `flow_operation_id` separately and assert the current observed invariant that it matches `flow_media_id`; if Flow diverges those IDs later, the test should fail and force an explicit parser/schema decision.
 - I2V seed queries resolve by media ID and local path.
 - `gflow video t2v` no longer instantiates `UiAutomationTransport` directly.
 
@@ -375,6 +385,7 @@ Update:
 
 - `docs/CONFIGURATION.md`: `GFLOW_CLI_DB_PATH`, `GFLOW_CLI_HISTORY_PROMPTS`, DB location.
 - `docs/USAGE.md`: exit code `16`, local history/provenance note, and any new minimal `gflow data` command if implemented.
+- `docs/USAGE.md`: document newer-schema recovery: upgrade `gflow-cli` or repoint `GFLOW_CLI_DB_PATH` to a compatible DB.
 - `docs/SECURITY.md`: prompts are stored locally by default; redaction option; DB may contain profile names and asset IDs.
 - `docs/ARCHITECTURE.md`: add `gflow_cli.data` to modular monolith modules and note SQLite local persistence.
 - `PLAN.md`: replace the broad Phase 6 entry with this concrete data-layer phase and keep import/history UI as backlog.

--- a/docs/superpowers/specs/2026-05-24-data-layer-design.md
+++ b/docs/superpowers/specs/2026-05-24-data-layer-design.md
@@ -1,0 +1,366 @@
+# gflow-cli Data Layer Design
+
+**Date:** 2026-05-24
+**Status:** Draft for user review
+**Scope:** Local SQLite persistence for new gflow operations, asset provenance, and I2V seed-image reuse.
+
+## Context
+
+`gflow-cli` can generate and download images and T2V videos, but it does not keep a durable catalog of what happened. The CLI prints IDs and writes files, then loses important provenance:
+
+- which profile generated or uploaded an asset;
+- which Flow project owns the asset;
+- which Flow media ID and workflow ID should be reused later;
+- which prompt, model, aspect ratio, and source images produced an output;
+- whether an operation completed, failed, or only partially downloaded.
+
+This is now blocking pragmatic I2V work. To generate a video from a seed image, the system needs a reliable way to resolve a seed image to the Flow media ID, project ID, and profile that own it. Rewalking Flow's UI library every time is slower, brittle, and hard to verify. A local data layer also becomes the foundation for future history, repair/import tooling, cost tracking, and a management UI.
+
+The current code has a related boundary problem: image operations mostly flow through `FlowApiClient`, while `gflow video t2v` directly instantiates `UiAutomationTransport`. The data layer should improve that architecture rather than persist from scattered CLI and Playwright paths.
+
+## Goals
+
+1. Persist new upload, image, batch-image, and T2V operations automatically.
+2. Record enough provenance to answer "what generated this file/media ID?" and "which seed image can I reuse for I2V?".
+3. Provide an internal read API that can resolve seed images by Flow media ID, local path, or "latest matching image" for the active profile.
+4. Normalize T2V behind `FlowApiClient` so image and video orchestration follow the same pattern.
+5. Use local SQLite with conservative automatic migrations.
+6. Keep the design adapter-shaped so a future Postgres/Supabase backend is possible without changing call sites.
+
+## Non-Goals
+
+- No Postgres or `DATABASE_URL` runtime support in v1.
+- No backfill of existing output folders in v1.
+- No management UI in v1.
+- No full user-facing history browser required in v1, though the schema should support one later.
+- No event sourcing, ORM, cloud sync, or remote multi-user database semantics.
+
+Backlog items:
+
+- `gflow data import` or `gflow data repair` to backfill partial records from existing output files.
+- Postgres/Supabase adapter and migration dialect after the SQLite schema has settled.
+- `gflow history` / `gflow assets` browsing commands.
+- Cost tracking once enough operation metadata is reliable.
+
+## Storage Boundary
+
+Add a top-level `gflow_cli.data` module. It owns persistence only. It must not call Flow, Playwright, Click, or Rich.
+
+Public surface:
+
+- `DataStore`: opens the configured SQLite DB, applies migrations, and exposes repositories.
+- `OperationRecorder`: higher-level write helper used by `FlowApiClient` and batch/workflow orchestration.
+- Read/query helpers for internal flows, especially I2V seed-image resolution.
+
+Rules:
+
+- SQLite is the only v1 runtime backend.
+- The default DB path is `$GFLOW_CLI_HOME/gflow.db`.
+- Add `GFLOW_CLI_DB_PATH` for tests and advanced local override.
+- No direct `sqlite3` usage outside `gflow_cli.data`.
+- No global mutable singleton. CLI/client composition passes a store/recorder explicitly or constructs it at the client boundary.
+- Store all timestamps as UTC ISO-8601 text.
+- Store JSON metadata as text with application-side serialization.
+- Use app-generated local IDs for operation rows; use Flow IDs only for Flow resources.
+
+## Migration Strategy
+
+Use checked-in SQL migrations:
+
+```text
+src/gflow_cli/data/
+├── __init__.py
+├── store.py
+├── migrations.py
+├── recorder.py
+├── repositories.py
+└── migrations/
+    └── 0001_initial.sql
+```
+
+The SQLite DB tracks applied migrations in:
+
+```sql
+schema_migrations(
+  version TEXT PRIMARY KEY,
+  checksum TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+)
+```
+
+Migration behavior:
+
+- Run pending migrations automatically when `DataStore.open()` is called.
+- Apply each migration in a transaction.
+- Calculate a checksum for each SQL file.
+- If a migration already applied with a different checksum, raise `DataMigrationError`.
+- If the DB contains a migration version newer than the installed package, raise `DataMigrationError`.
+- Mirror the highest numeric migration into `PRAGMA user_version` as a convenience only; `schema_migrations` remains the source of truth.
+
+This mirrors the useful part of Supabase-style migrations: migration files live in source control, and the database records what has run. We avoid Alembic for v1 because the project does not need SQLAlchemy or multi-dialect migration machinery yet.
+
+## Error Taxonomy Impact
+
+The persistence layer needs typed project errors; raw `sqlite3.Error` must not cross the `gflow_cli.data` boundary.
+
+Add:
+
+```python
+class DataStoreError(GFlowError): ...
+class DataMigrationError(DataStoreError): ...
+class DataIntegrityError(DataStoreError): ...
+```
+
+Usage:
+
+- `DataStoreError`: parent for persistence open/read/write failures.
+- `DataMigrationError`: migration apply, checksum drift, or newer-schema failures.
+- `DataIntegrityError`: impossible local-record states, duplicate conflicting Flow IDs, malformed persisted JSON.
+- `ConfigurationError`: still used for invalid user configuration before opening SQLite, such as an unusable `GFLOW_CLI_DB_PATH`.
+
+Impact:
+
+- Add the classes to `errors.py::__all__`.
+- Re-export them through `gflow_cli.exceptions`.
+- Add a new stable exit code, `16`, for `DataStoreError`.
+- Update `EXIT_CODE_MAP`, tests, and the docs exit-code table.
+- Keep data errors compatible with RFC 9457 Problem Details logging.
+
+## Flow ID Semantics
+
+The schema must distinguish local IDs from Flow IDs.
+
+Known Flow IDs from captured responses:
+
+- Flow media ID: `media[].name`. This is the operational asset handle. It is used for image refs and `media.getMediaUrlRedirect?name=...`.
+- Flow workflow ID: `workflowId`. This identifies the Flow workflow/library item and is used for archive/cleanup.
+- Flow project ID: `projectId`. This scopes media in Flow.
+- Flow media generation ID: `media[].image.generatedImage.mediaGenerationId`. Observed for generated images as a separate opaque generation identifier.
+- Flow operation ID: video `operations[].operation.name` and `video.operation.name`. In current captures this appears to match the generated media ID, but it should be stored separately when observed.
+- Flow batch ID: `mediaGenerationContext.batchId` and workflow metadata `batchId`; useful for grouping submissions.
+
+Naming rule:
+
+- `id`: local database primary key.
+- `flow_media_id`: Google Flow `media[].name`.
+- `flow_workflow_id`: Google Flow `workflowId`.
+- `flow_project_id`: Google Flow `projectId`.
+- `flow_media_generation_id`: nullable opaque Flow generation ID.
+- `flow_operation_id`: nullable Flow operation ID.
+- `flow_batch_id`: nullable Flow batch ID.
+
+I2V must resolve and use `flow_media_id`; `flow_media_generation_id` is provenance unless a future capture proves Flow requires it for a specific route.
+
+## Schema
+
+Initial tables:
+
+```sql
+profiles(
+  name TEXT PRIMARY KEY,
+  profile_dir TEXT,
+  first_seen_at TEXT NOT NULL,
+  last_used_at TEXT
+)
+
+projects(
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT NOT NULL,
+  title TEXT,
+  source TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(profile_name, flow_project_id)
+)
+
+operations(
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT,
+  command TEXT,
+  mode TEXT NOT NULL,
+  prompt TEXT,
+  prompt_hash TEXT,
+  prompt_redacted INTEGER NOT NULL DEFAULT 0,
+  model TEXT,
+  aspect_ratio TEXT,
+  status TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  error_type TEXT,
+  error_detail TEXT,
+  flow_operation_id TEXT,
+  flow_batch_id TEXT
+)
+
+assets(
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT,
+  flow_media_id TEXT NOT NULL,
+  flow_workflow_id TEXT,
+  flow_media_generation_id TEXT,
+  kind TEXT NOT NULL,
+  model TEXT,
+  aspect_ratio TEXT,
+  width INTEGER,
+  height INTEGER,
+  duration_seconds REAL,
+  seed INTEGER,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  metadata_json TEXT,
+  UNIQUE(profile_name, flow_media_id)
+)
+
+operation_assets(
+  operation_id TEXT NOT NULL,
+  asset_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY(operation_id, asset_id, role, position)
+)
+
+local_files(
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  asset_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  sha256 TEXT,
+  bytes INTEGER,
+  media_type TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(asset_id, path)
+)
+```
+
+Important constraints:
+
+- Flow IDs are unique only within a profile for v1: use `(profile_name, flow_media_id)` and `(profile_name, flow_project_id)`.
+- `profile_name` is duplicated on key tables to keep common queries simple and future cross-profile scheduling efficient.
+- `metadata_json` can hold route-specific fields without requiring a migration for every observed Flow nuance.
+- `metadata_json` must not store signed CDN URLs such as `fifeUrl`; those expire and contain bearer-style query tokens.
+- Prompt redaction stores `prompt = NULL`, `prompt_redacted = 1`, and `prompt_hash` for correlation.
+
+## Prompt Privacy
+
+Store full prompts locally by default because provenance is weak without them.
+
+Add `GFLOW_CLI_HISTORY_PROMPTS`:
+
+- `store` default: persist full prompt text.
+- `redacted`: persist `prompt = NULL`, `prompt_redacted = 1`, and a stable prompt hash.
+
+Prompts remain local. No cloud sync or telemetry upload is introduced by this feature.
+
+## Recording Flow
+
+Record facts when they become reliable:
+
+1. At CLI/client boundary, resolve `profile_name` and upsert `profiles`.
+2. On `create_project()` response or observed UI editor URL, upsert `projects`.
+3. On upload response, upsert an `uploaded_image` asset with `flow_media_id`, `flow_workflow_id`, dimensions, project, and profile.
+4. On image generation response, create/update an operation, upsert generated image assets, link input refs and outputs via `operation_assets`, and record model/aspect/seed/prompt.
+5. On image download, insert/update `local_files` with path, byte count, and SHA-256 if cheap to compute.
+6. On video generation response, record the pending `flow_media_id` immediately.
+7. On video status response, update the video asset and operation to success or failure.
+8. On video download, insert/update `local_files`.
+9. On batch image operations, create one parent operation with multiple output assets rather than treating each output as a separate CLI command.
+
+Persistence failure handling:
+
+- Before any remote Flow action, DB open/migration failures fail fast with exit code `16`.
+- After a successful paid remote generation, persistence failures must not discard generated media or skip downloads that can still complete.
+- If media was generated and downloaded but the final persistence write fails, keep the local file and exit with `DataStoreError` after reporting the saved path where the current command UX allows it.
+- No data-layer failure should be silently swallowed. If a write is intentionally deferred or retried, emit a structured event with the operation ID and failure class.
+
+## T2V Client-Boundary Normalization
+
+The data layer includes a required refactor: T2V must move behind `FlowApiClient`.
+
+Current state:
+
+- Image upload/generation uses `FlowApiClient`.
+- `gflow video t2v` directly creates `UiAutomationTransport`.
+
+Target state:
+
+- Add `FlowApiClient.generate_video(...)` as the public orchestration boundary.
+- Keep `UiAutomationTransport.generate_video(...)` as the transport implementation detail.
+- Update `gflow video t2v` to use `FlowApiClient`, matching image commands.
+- Compose the `OperationRecorder` at the client/workflow layer, not inside Click callbacks or low-level Playwright selector methods.
+
+Benefits:
+
+- One boundary for profile, output directory, transport setup, and data recording.
+- Fewer special cases before persistence spreads through the codebase.
+- A cleaner foundation for `video i2v`, which needs data reads before transport work and data writes after generation.
+
+## Internal Read API For I2V
+
+Add query methods for the first I2V consumers:
+
+- resolve image by `(profile_name, flow_media_id)`;
+- resolve image by local file path;
+- resolve latest generated/uploaded image for a profile, optionally filtered by project/model/aspect;
+- list images in a Flow project for a profile;
+- verify that a candidate image exists in the active profile and has a `flow_project_id`.
+
+Return typed dataclasses, not raw SQLite rows. A seed candidate should include:
+
+- `profile_name`;
+- `flow_project_id`;
+- `flow_media_id`;
+- `flow_workflow_id`;
+- `kind`;
+- dimensions if known;
+- local path if downloaded;
+- prompt/model/aspect if known.
+
+The first `video i2v` implementation can then accept a local path or Flow media ID, resolve it through the data layer, and pass the operational `flow_media_id` to the transport/API path.
+
+## Backfill And Import
+
+v1 records new operations only.
+
+Backfilling old output files is deferred because historical files usually lack profile, project, prompt, model, aspect, workflow ID, and operation status. A future `gflow data import` or `gflow data repair` command may create partial records marked with an `imported_partial` source/status.
+
+## Testing Strategy
+
+Required tests:
+
+- Migration runner applies `0001_initial.sql` to an empty DB.
+- Migration runner is idempotent.
+- Checksum drift raises `DataMigrationError`.
+- Newer DB schema raises `DataMigrationError`.
+- SQLite exceptions are mapped to `DataStoreError` subclasses.
+- Repository upserts are idempotent.
+- Prompt redaction stores hash and no prompt text.
+- Recording an upload persists profile, project, asset, and operation linkage.
+- Recording generated images persists Flow media IDs, workflow IDs, model/aspect/seed, and local files.
+- Recording T2V through `FlowApiClient` persists the pending media ID, terminal status, and local file path.
+- I2V seed queries resolve by media ID and local path.
+- `gflow video t2v` no longer instantiates `UiAutomationTransport` directly.
+
+Use unit tests with temporary SQLite files for the data layer. Integration tests should mock Flow responses and assert data records without live Playwright. Live tests remain opt-in.
+
+## Documentation Impact
+
+Update:
+
+- `docs/CONFIGURATION.md`: `GFLOW_CLI_DB_PATH`, `GFLOW_CLI_HISTORY_PROMPTS`, DB location.
+- `docs/USAGE.md`: exit code `16`, local history/provenance note, and any new minimal `gflow data` command if implemented.
+- `docs/SECURITY.md`: prompts are stored locally by default; redaction option; DB may contain profile names and asset IDs.
+- `docs/ARCHITECTURE.md`: add `gflow_cli.data` to modular monolith modules and note SQLite local persistence.
+- `PLAN.md`: replace the broad Phase 6 entry with this concrete data-layer phase and keep import/history UI as backlog.
+
+## Acceptance Criteria
+
+- New operations are recorded in `$GFLOW_CLI_HOME/gflow.db` without user action.
+- Migrations run automatically and safely.
+- Data-layer failures raise typed `GFlowError` subclasses and map to exit code `16`.
+- T2V is invoked via `FlowApiClient`, not direct transport construction in the CLI.
+- Image/video asset rows distinguish local IDs from Flow media IDs, workflow IDs, media generation IDs, operation IDs, and batch IDs.
+- I2V code can query the data layer for a seed image candidate without opening Flow's library UI.
+- Existing generation and download behavior remains compatible when the DB is empty.
+- No existing output folders are backfilled by default.

--- a/docs/superpowers/specs/2026-05-24-data-layer-design.md
+++ b/docs/superpowers/specs/2026-05-24-data-layer-design.md
@@ -99,6 +99,20 @@ Migration behavior:
 
 This mirrors the useful part of Supabase-style migrations: migration files live in source control, and the database records what has run. We avoid Alembic for v1 because the project does not need SQLAlchemy or multi-dialect migration machinery yet.
 
+Packaging requirements:
+
+- Read migration SQL via `importlib.resources.files(...)`, not filesystem paths relative to the current working directory.
+- Update the Hatchling build configuration in `pyproject.toml` so `gflow_cli/data/migrations/*.sql` is included in wheels and sdists.
+- Add a packaging test or build check that verifies the installed or built package can discover `0001_initial.sql`.
+
+SQLite connection requirements:
+
+- Enable foreign key enforcement on every connection: `PRAGMA foreign_keys = ON`.
+- Enable safer concurrent CLI usage: `PRAGMA journal_mode = WAL`.
+- Set a busy timeout, for example `PRAGMA busy_timeout = 5000`, so parallel profile/process runs do not fail immediately with `database is locked`.
+- Use Python `sqlite3` with `isolation_level=None` and explicit `BEGIN` / `COMMIT` blocks so connection-level pragmas and transaction boundaries behave predictably.
+- Open write transactions explicitly around grouped recorder operations.
+
 ## Error Taxonomy Impact
 
 The persistence layer needs typed project errors; raw `sqlite3.Error` must not cross the `gflow_cli.data` boundary.
@@ -125,6 +139,7 @@ Impact:
 - Add a new stable exit code, `16`, for `DataStoreError`.
 - Update `EXIT_CODE_MAP`, tests, and the docs exit-code table.
 - Keep data errors compatible with RFC 9457 Problem Details logging.
+- Exit code `16` applies to pre-Flow persistence setup failures and explicit future `gflow data ...` command failures. A tracking failure after a paid generation already succeeded must not turn the command into a retry-shaped failure.
 
 ## Flow ID Semantics
 
@@ -170,6 +185,7 @@ projects(
   title TEXT,
   source TEXT NOT NULL,
   created_at TEXT NOT NULL,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
   UNIQUE(profile_name, flow_project_id)
 )
 
@@ -190,7 +206,8 @@ operations(
   error_type TEXT,
   error_detail TEXT,
   flow_operation_id TEXT,
-  flow_batch_id TEXT
+  flow_batch_id TEXT,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name)
 )
 
 assets(
@@ -210,6 +227,7 @@ assets(
   status TEXT NOT NULL,
   created_at TEXT NOT NULL,
   metadata_json TEXT,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
   UNIQUE(profile_name, flow_media_id)
 )
 
@@ -218,6 +236,8 @@ operation_assets(
   asset_id TEXT NOT NULL,
   role TEXT NOT NULL,
   position INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY(operation_id) REFERENCES operations(id),
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
   PRIMARY KEY(operation_id, asset_id, role, position)
 )
 
@@ -230,6 +250,7 @@ local_files(
   bytes INTEGER,
   media_type TEXT,
   created_at TEXT NOT NULL,
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
   UNIQUE(asset_id, path)
 )
 ```
@@ -241,6 +262,7 @@ Important constraints:
 - `metadata_json` can hold route-specific fields without requiring a migration for every observed Flow nuance.
 - `metadata_json` must not store signed CDN URLs such as `fifeUrl`; those expire and contain bearer-style query tokens.
 - Prompt redaction stores `prompt = NULL`, `prompt_redacted = 1`, and `prompt_hash` for correlation.
+- `local_files.path` stores the resolved absolute local path in v1. Moving output directories or sharing the DB across Windows/WSL path schemes is out of scope until `gflow data repair` can relink files.
 
 ## Prompt Privacy
 
@@ -271,7 +293,7 @@ Persistence failure handling:
 
 - Before any remote Flow action, DB open/migration failures fail fast with exit code `16`.
 - After a successful paid remote generation, persistence failures must not discard generated media or skip downloads that can still complete.
-- If media was generated and downloaded but the final persistence write fails, keep the local file and exit with `DataStoreError` after reporting the saved path where the current command UX allows it.
+- If media was generated and downloaded but the final persistence write fails, keep the local file, emit a visible warning plus a structured `data.persistence_failed_after_success` event, and preserve the command's generation result exit semantics. A successful paid generation with a saved file should not exit non-zero solely because local tracking failed.
 - No data-layer failure should be silently swallowed. If a write is intentionally deferred or retried, emit a structured event with the operation ID and failure class.
 
 ## T2V Client-Boundary Normalization
@@ -333,6 +355,9 @@ Required tests:
 - Migration runner is idempotent.
 - Checksum drift raises `DataMigrationError`.
 - Newer DB schema raises `DataMigrationError`.
+- Built wheels/sdists contain SQL migration files and the runner reads them through `importlib.resources`.
+- New SQLite connections enable `foreign_keys`, `WAL`, and `busy_timeout`.
+- Foreign key enforcement rejects orphaned `operation_assets` and `local_files` rows.
 - SQLite exceptions are mapped to `DataStoreError` subclasses.
 - Repository upserts are idempotent.
 - Prompt redaction stores hash and no prompt text.
@@ -358,7 +383,8 @@ Update:
 
 - New operations are recorded in `$GFLOW_CLI_HOME/gflow.db` without user action.
 - Migrations run automatically and safely.
-- Data-layer failures raise typed `GFlowError` subclasses and map to exit code `16`.
+- Pre-Flow data-layer failures raise typed `GFlowError` subclasses and map to exit code `16`.
+- Post-success tracking failures warn and log without causing paid generations to be blindly retried by generic non-zero-exit automation.
 - T2V is invoked via `FlowApiClient`, not direct transport construction in the CLI.
 - Image/video asset rows distinguish local IDs from Flow media IDs, workflow IDs, media generation IDs, operation IDs, and batch IDs.
 - I2V code can query the data layer for a seed image candidate without opening Flow's library UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/gflow_cli"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/gflow_cli/data/migrations" = "gflow_cli/data/migrations"
+
+[tool.hatch.build.targets.sdist.force-include]
+"src/gflow_cli/data/migrations" = "src/gflow_cli/data/migrations"
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -32,7 +32,8 @@ from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
 from gflow_cli.api.image import GenerateImageRequest
 from gflow_cli.api.recaptcha import TokenMinter
 from gflow_cli.api.transports import make_transport
-from gflow_cli.api.transports.base import FlowTransportStrategy
+from gflow_cli.api.transports.base import FlowTransportStrategy, VideoCapableTransport
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStartedCallback
 from gflow_cli.config import Settings
 from gflow_cli.errors import (
     AuthExpiredError,
@@ -767,6 +768,46 @@ class FlowApiClient:
                 project_id=resolved_project_id,
                 req=req_with_count,
                 recaptcha_action=recaptcha_action,
+            )
+        except Exception as e:
+            if _is_target_closed(e):
+                raise BrowserSessionClosedError() from e
+            raise
+
+    async def generate_video(
+        self,
+        *,
+        req: GenerateVideoRequest,
+        out_dir: Path | None = None,
+        poll_timeout_s: float = 600.0,
+        download: bool = True,
+        on_started: VideoStartedCallback | None = None,
+    ) -> VideoResult:
+        """Generate a video via the transport's ``generate_video`` method.
+
+        Routes all video generation through a single client boundary so the
+        data-layer recorder (Task 8) can hook in at one place.
+
+        Raises:
+            RuntimeError: transport is None (client not entered) or the transport
+                doesn't implement :class:`VideoCapableTransport`.
+            BrowserSessionClosedError: Playwright target was closed mid-call.
+        """
+        if self.transport is None:
+            raise RuntimeError(
+                "FlowApiClient.transport is None - call generate_video inside 'async with client'"
+            )
+        if not isinstance(self.transport, VideoCapableTransport):
+            raise RuntimeError(
+                f"transport {type(self.transport).__name__} does not support video generation"
+            )
+        try:
+            return await self.transport.generate_video(
+                request=req,
+                out_dir=out_dir,
+                poll_timeout_s=poll_timeout_s,
+                download=download,
+                on_started=on_started,
             )
         except Exception as e:
             if _is_target_closed(e):

--- a/src/gflow_cli/api/dto.py
+++ b/src/gflow_cli/api/dto.py
@@ -124,6 +124,7 @@ class GeneratedImage:
     aspect_ratio: str  # e.g. "IMAGE_ASPECT_RATIO_PORTRAIT"
     fife_url: str  # CDN URL — usually expires after ~6 hours
     dimensions: tuple[int, int]  # (width, height)
+    media_generation_id: str | None = None
 
     @property
     def is_signed_url(self) -> bool:
@@ -146,6 +147,7 @@ class GeneratedImage:
                 aspect_ratio=generated["aspectRatio"],
                 fife_url=generated["fifeUrl"],
                 dimensions=(int(dims["width"]), int(dims["height"])),
+                media_generation_id=generated.get("mediaGenerationId"),
             )
         except (KeyError, TypeError) as e:
             raise ValueError(f"unexpected batchGenerateImages media item shape: {e}") from e

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -45,6 +45,22 @@ def mint_batch_id() -> str:
     return str(uuid.uuid4())
 
 
+PROJECT_URL_FRAGMENT = "/project/"
+
+
+def extract_project_id(url: str) -> str | None:
+    """Pull the project UUID out of a Flow editor URL, or None if absent.
+
+    Handles both ``/project/<uuid>`` and ``/project/<uuid>?query`` forms.
+    """
+    if PROJECT_URL_FRAGMENT not in url:
+        return None
+    try:
+        return url.split(PROJECT_URL_FRAGMENT)[1].split("?")[0]
+    except (IndexError, ValueError):
+        return None
+
+
 def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
     """Map an httpx-like response (status_code + text) to images or raise.
 

--- a/src/gflow_cli/api/transports/base.py
+++ b/src/gflow_cli/api/transports/base.py
@@ -6,13 +6,14 @@ See docs/superpowers/specs/2026-05-11-gflow-cli-b007-transport-strategy-design.m
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from playwright.async_api import Page
 
 from gflow_cli.api.dto import GeneratedImage
 from gflow_cli.api.image import GenerateImageRequest
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStartedCallback
 
 
 class FlowTransportStrategy(Protocol):
@@ -58,3 +59,26 @@ class FlowTransportStrategy(Protocol):
     async def teardown(self) -> None:
         """Release resources. Idempotent. Safe to call multiple times."""
         ...
+
+
+@runtime_checkable
+class VideoCapableTransport(Protocol):
+    """Mixin protocol for transports that support video generation.
+
+    ``isinstance(transport, VideoCapableTransport)`` returns True at runtime
+    iff the transport provides ``generate_video`` — used by
+    :meth:`FlowApiClient.generate_video` to fail fast with a clear error
+    rather than an AttributeError.
+    """
+
+    async def generate_video(
+        self,
+        *,
+        request: GenerateVideoRequest,
+        out_dir: Path | None,
+        poll_timeout_s: float,
+        download: bool,
+        on_started: VideoStartedCallback | None = None,
+    ) -> VideoResult:
+        """Drive the Flow editor UI to generate a video and return the result."""
+        raise NotImplementedError

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -28,6 +28,7 @@ import structlog
 
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.api.transports._common import extract_project_id
 from gflow_cli.api.transports.ui_automation_video import (
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
@@ -317,13 +318,12 @@ def _prompt_hash_stable(text: str) -> str:
 
 
 def _extract_project_id(url: str) -> str | None:
-    """Pull the project UUID out of a Flow editor URL, or None if absent."""
-    if _PROJECT_URL_FRAGMENT not in url:
-        return None
-    try:
-        return url.split(_PROJECT_URL_FRAGMENT)[1].split("?")[0]
-    except (IndexError, ValueError):
-        return None
+    """Thin alias for `extract_project_id` from `_common`.
+
+    Kept for back-compat with any existing call sites and tests that import
+    the private name directly from this module.
+    """
+    return extract_project_id(url)
 
 
 def _collect_images_from_body(body: dict[str, Any], images: list[GeneratedImage]) -> None:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -94,6 +94,8 @@ VIDEO_TAB_IN_MENU_SELECTORS = (
 # always fell through to text. id-suffix + icon are locale-independent and
 # exact (ends-with '-trigger-PORTRAIT' does not match the image-only
 # '-trigger-PORTRAIT_3_4'). A miss is non-fatal (Flow's default applies).
+_DICT_STR_ANY = "dict[str, Any]"
+
 VIDEO_ASPECT_TAB_SELECTORS: dict[Aspect, tuple[str, ...]] = {
     Aspect.PORTRAIT: (
         "[role='tab'][id$='-trigger-PORTRAIT']",
@@ -199,14 +201,14 @@ def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
         raw = request.post_data
         if not raw:
             return {"parsed": False}
-        data = cast("dict[str, Any]", json.loads(raw))
+        data = cast(_DICT_STR_ANY, json.loads(raw))
         reqs = cast("list[dict[str, Any]]", data.get("requests") or [])
         first: dict[str, Any] = reqs[0] if reqs else {}
 
         def _mid(obj: Any) -> str | None:
             if not isinstance(obj, dict):
                 return None
-            mid = cast("dict[str, Any]", obj).get("mediaId")
+            mid = cast(_DICT_STR_ANY, obj).get("mediaId")
             return mid[:8] if isinstance(mid, str) else None
 
         refs = cast("list[dict[str, Any]]", first.get("referenceImages") or [])
@@ -787,6 +789,67 @@ class VideoGenerationMixin:
                 request, out_dir, poll_timeout_s, download, on_started
             )
 
+    @staticmethod
+    def _parse_generate_response(
+        generate_resp: dict[str, Any],
+    ) -> tuple[str, str | None]:
+        """Validate HTTP status, extract media_name and flow_operation_id.
+
+        Raises AuthExpiredError, WafRejectionError, or WireFormatError on bad
+        status codes or missing media id. Returns (media_name, flow_operation_id).
+        """
+        http_status = generate_resp.get("status")
+        url = str(generate_resp.get("url", ""))
+        # errors.py documents `route` as a sanitized route NAME, not a URL.
+        route = next((r for r in VIDEO_GENERATE_ROUTES if r in url), "video:generate")
+        if http_status == 401:
+            raise AuthExpiredError(
+                detail="batchAsyncGenerateVideo* returned HTTP 401 — session expired",
+                status=401,
+                route=route,
+            )
+        if http_status == 403:
+            raise WafRejectionError(
+                detail="batchAsyncGenerateVideo* returned HTTP 403 — WAF / reCAPTCHA rejection",
+                status=403,
+                route=route,
+            )
+        if http_status != 200:
+            raise WireFormatError(
+                detail=f"batchAsyncGenerateVideo* returned HTTP {http_status}",
+                status=http_status if isinstance(http_status, int) else None,
+                route=route,
+            )
+        # A video 200 ALWAYS carries media[0] (the asset slot — capture 02);
+        # content rejection surfaces later as a FAILED *status*, not empty media.
+        # So a missing media[0] here is a genuine wire anomaly — WireFormatError.
+        body: dict[str, Any] = cast(_DICT_STR_ANY, generate_resp.get("body") or {})
+        try:
+            media_name = media_name_from_generate_response(body)
+        except ValueError as e:
+            # discovery carries only route + top-level KEY NAMES (not values).
+            raise WireFormatError(
+                detail=f"video generate response carries no media id: {e}",
+                route=route,
+                discovery={"route": route, "top_level_keys": sorted(body)},
+            ) from e
+        # Stored SEPARATELY from media_name even when they currently match —
+        # spec explicitly keeps them distinct for future divergence.
+        flow_operation_id: str | None = operation_name_from_generate_response(body)
+        return media_name, flow_operation_id
+
+    @staticmethod
+    async def _fire_on_started(
+        on_started: VideoStartedCallback,
+        started: VideoStarted,
+    ) -> None:
+        """Invoke the on_started callback, awaiting it if it returns a coroutine."""
+        import inspect
+
+        result_or_coro = on_started(started)
+        if inspect.isawaitable(result_or_coro):
+            await result_or_coro
+
     async def _generate_video_locked(
         self,
         request: GenerateVideoRequest,
@@ -853,52 +916,8 @@ class VideoGenerationMixin:
             await self._send_prompt(page, request.prompt, out_dir)
 
             generate_resp = await VideoGenerationMixin._await_generate_response(generate_captured)
-            http_status = generate_resp.get("status")
-            url = str(generate_resp.get("url", ""))
-            # errors.py documents `route` as a sanitized route NAME, not a URL.
-            route = next((r for r in VIDEO_GENERATE_ROUTES if r in url), "video:generate")
-            if http_status == 401:
-                raise AuthExpiredError(
-                    detail="batchAsyncGenerateVideo* returned HTTP 401 — session expired",
-                    status=401,
-                    route=route,
-                )
-            if http_status == 403:
-                raise WafRejectionError(
-                    detail=(
-                        "batchAsyncGenerateVideo* returned HTTP 403 — WAF / reCAPTCHA rejection"
-                    ),
-                    status=403,
-                    route=route,
-                )
-            if http_status != 200:
-                raise WireFormatError(
-                    detail=f"batchAsyncGenerateVideo* returned HTTP {http_status}",
-                    status=http_status if isinstance(http_status, int) else None,
-                    route=route,
-                )
-            # A video 200 ALWAYS carries media[0] (the asset slot — capture 02);
-            # content rejection surfaces later as a FAILED *status*, not empty
-            # media. So a missing media[0] here is a genuine wire anomaly —
-            # WireFormatError, NOT ContentPolicyError (the image-flow pattern).
-            try:
-                media_name = media_name_from_generate_response(generate_resp.get("body") or {})
-            except ValueError as e:
-                # discovery carries only the route + the body's top-level KEY
-                # NAMES (not values) — enough to diagnose the anomaly without
-                # logging `remainingCredits`, media UUIDs, or any token.
-                anomaly_body = cast("dict[str, Any]", generate_resp.get("body") or {})
-                raise WireFormatError(
-                    detail=f"video generate response carries no media id: {e}",
-                    route=route,
-                    discovery={"route": route, "top_level_keys": sorted(anomaly_body)},
-                ) from e
-
-            # Parse the flow_operation_id from the generate response body.
-            # Stored SEPARATELY from media_name even when they currently match —
-            # spec explicitly keeps them distinct for future divergence.
-            flow_operation_id: str | None = operation_name_from_generate_response(
-                cast("dict[str, Any]", generate_resp.get("body") or {})
+            media_name, flow_operation_id = VideoGenerationMixin._parse_generate_response(
+                generate_resp
             )
 
             # Fire on_started BEFORE polling so the recorder can insert a STARTED
@@ -909,27 +928,19 @@ class VideoGenerationMixin:
                     project_id=project_id,
                     flow_operation_id=flow_operation_id,
                 )
-                result_or_coro = on_started(started)
-                if hasattr(result_or_coro, "__await__"):
-                    import inspect
-
-                    if inspect.isawaitable(result_or_coro):
-                        await result_or_coro
+                await VideoGenerationMixin._fire_on_started(on_started, started)
 
             status = await VideoGenerationMixin._poll_video_status(
                 page, status_captured, media_name, timeout_s=poll_timeout_s
             )
-            if download and status.succeeded:
-                local_path = await self._download_video(status.media_id, out_dir, page)
-                return VideoResult(
-                    status=status,
-                    local_path=local_path,
-                    project_id=project_id,
-                    flow_operation_id=flow_operation_id,
-                )
+            local_path = (
+                await self._download_video(status.media_id, out_dir, page)
+                if download and status.succeeded
+                else None
+            )
             return VideoResult(
                 status=status,
-                local_path=None,
+                local_path=local_path,
                 project_id=project_id,
                 flow_operation_id=flow_operation_id,
             )

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -22,14 +22,18 @@ from typing import TYPE_CHECKING, Any, cast
 import structlog
 
 from gflow_cli.api import routes
+from gflow_cli.api.transports._common import extract_project_id
 from gflow_cli.api.video import (
     Aspect,
     GenerateVideoRequest,
     Mode,
     VideoModel,
     VideoResult,
+    VideoStarted,
+    VideoStartedCallback,
     VideoStatus,
     media_name_from_generate_response,
+    operation_name_from_generate_response,
     parse_video_status,
 )
 from gflow_cli.errors import AuthExpiredError, WafRejectionError, WireFormatError
@@ -753,6 +757,7 @@ class VideoGenerationMixin:
         out_dir: Path | None = None,
         poll_timeout_s: float = 600.0,
         download: bool = True,
+        on_started: VideoStartedCallback | None = None,
     ) -> VideoResult:
         """Generate ONE video by driving the Flow editor UI (T2V / I2V / R2V).
 
@@ -763,6 +768,10 @@ class VideoGenerationMixin:
         aspect), `FileNotFoundError` (I2V/R2V image path missing),
         `AuthExpiredError` (401), `WafRejectionError` (403), `WireFormatError`
         (other non-200 / no media), or `TimeoutError`.
+
+        ``on_started`` is called with a :class:`VideoStarted` as soon as the
+        media_id is known (before polling completes) so the recorder can insert
+        a STARTED row even if the long poll later fails.
         """
         if not self._setup_done or self._page is None:
             raise RuntimeError(
@@ -774,7 +783,9 @@ class VideoGenerationMixin:
                 "use PORTRAIT (9:16) or LANDSCAPE (16:9)"
             )
         async with self._generate_lock:
-            return await self._generate_video_locked(request, out_dir, poll_timeout_s, download)
+            return await self._generate_video_locked(
+                request, out_dir, poll_timeout_s, download, on_started
+            )
 
     async def _generate_video_locked(
         self,
@@ -782,6 +793,7 @@ class VideoGenerationMixin:
         out_dir: Path | None,
         poll_timeout_s: float,
         download: bool,
+        on_started: VideoStartedCallback | None,
     ) -> VideoResult:
         """Serialized body of `generate_video` — runs under `self._generate_lock`
         (shared with `generate_images`: one Page, one DOM)."""
@@ -793,6 +805,11 @@ class VideoGenerationMixin:
         # of the editor before we click into mode-switch / settings / submit (#26).
         await self._dismiss_blocking_overlays(page, out_dir)
         await VideoGenerationMixin._switch_to_video_mode(page, out_dir=out_dir)
+
+        # Capture project_id from the editor URL as soon as we have it —
+        # needed for VideoStarted provenance and recorded before the generate request.
+        project_id: str | None = extract_project_id(page.url)
+
         # All settings-panel selections happen while the panel is open: model
         # (gates the 10s duration), sub-mode tab, aspect, count, duration.
         if request.model is not None:
@@ -877,13 +894,45 @@ class VideoGenerationMixin:
                     discovery={"route": route, "top_level_keys": sorted(anomaly_body)},
                 ) from e
 
+            # Parse the flow_operation_id from the generate response body.
+            # Stored SEPARATELY from media_name even when they currently match —
+            # spec explicitly keeps them distinct for future divergence.
+            flow_operation_id: str | None = operation_name_from_generate_response(
+                cast("dict[str, Any]", generate_resp.get("body") or {})
+            )
+
+            # Fire on_started BEFORE polling so the recorder can insert a STARTED
+            # row even if the long poll later fails.
+            if on_started is not None:
+                started = VideoStarted(
+                    media_id=media_name,
+                    project_id=project_id,
+                    flow_operation_id=flow_operation_id,
+                )
+                result_or_coro = on_started(started)
+                if hasattr(result_or_coro, "__await__"):
+                    import inspect
+
+                    if inspect.isawaitable(result_or_coro):
+                        await result_or_coro
+
             status = await VideoGenerationMixin._poll_video_status(
                 page, status_captured, media_name, timeout_s=poll_timeout_s
             )
             if download and status.succeeded:
                 local_path = await self._download_video(status.media_id, out_dir, page)
-                return VideoResult(status=status, local_path=local_path)
-            return VideoResult(status=status, local_path=None)
+                return VideoResult(
+                    status=status,
+                    local_path=local_path,
+                    project_id=project_id,
+                    flow_operation_id=flow_operation_id,
+                )
+            return VideoResult(
+                status=status,
+                local_path=None,
+                project_id=project_id,
+                flow_operation_id=flow_operation_id,
+            )
         finally:
             # The Page is pooled and persistent — remove both listeners so they
             # never leak across calls.

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -94,8 +94,6 @@ VIDEO_TAB_IN_MENU_SELECTORS = (
 # always fell through to text. id-suffix + icon are locale-independent and
 # exact (ends-with '-trigger-PORTRAIT' does not match the image-only
 # '-trigger-PORTRAIT_3_4'). A miss is non-fatal (Flow's default applies).
-_DICT_STR_ANY = "dict[str, Any]"
-
 VIDEO_ASPECT_TAB_SELECTORS: dict[Aspect, tuple[str, ...]] = {
     Aspect.PORTRAIT: (
         "[role='tab'][id$='-trigger-PORTRAIT']",
@@ -201,14 +199,14 @@ def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
         raw = request.post_data
         if not raw:
             return {"parsed": False}
-        data = cast(_DICT_STR_ANY, json.loads(raw))
+        data = cast(dict[str, Any], json.loads(raw))
         reqs = cast("list[dict[str, Any]]", data.get("requests") or [])
         first: dict[str, Any] = reqs[0] if reqs else {}
 
         def _mid(obj: Any) -> str | None:
             if not isinstance(obj, dict):
                 return None
-            mid = cast(_DICT_STR_ANY, obj).get("mediaId")
+            mid = cast(dict[str, Any], obj).get("mediaId")
             return mid[:8] if isinstance(mid, str) else None
 
         refs = cast("list[dict[str, Any]]", first.get("referenceImages") or [])
@@ -823,7 +821,7 @@ class VideoGenerationMixin:
         # A video 200 ALWAYS carries media[0] (the asset slot — capture 02);
         # content rejection surfaces later as a FAILED *status*, not empty media.
         # So a missing media[0] here is a genuine wire anomaly — WireFormatError.
-        body: dict[str, Any] = cast(_DICT_STR_ANY, generate_resp.get("body") or {})
+        body: dict[str, Any] = cast(dict[str, Any], generate_resp.get("body") or {})
         try:
             media_name = media_name_from_generate_response(body)
         except ValueError as e:

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -233,9 +233,7 @@ def operation_name_from_generate_response(response_json: dict[str, Any]) -> str 
     if not isinstance(operations, list) or not operations:
         return None
     first: dict[str, Any] = cast("dict[str, Any]", operations[0])
-    operation: dict[str, Any] | None = cast(
-        "dict[str, Any] | None", first.get("operation")
-    )
+    operation: dict[str, Any] | None = cast("dict[str, Any] | None", first.get("operation"))
     if not isinstance(operation, dict):
         return None
     name_val: str | None = cast("str | None", operation.get("name"))

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -8,6 +8,7 @@ retired — see the Phase A plan).
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -186,15 +187,59 @@ class VideoStatus:
 
 
 @dataclass(frozen=True)
+class VideoStarted:
+    """Fired as soon as a media_id/project_id/operation_id are known, BEFORE
+    polling completes — allows a recorder to insert a STARTED row even if the
+    long poll later fails.
+    """
+
+    media_id: str
+    project_id: str | None = None
+    flow_operation_id: str | None = None
+
+
+@dataclass(frozen=True)
 class VideoResult:
     """Return value of :meth:`generate_video` after Phase B download wiring.
 
     ``local_path`` is ``None`` when ``download=False`` was passed, or when
     the generation failed — callers should check ``status.succeeded`` first.
+
+    ``project_id`` and ``flow_operation_id`` are populated by the transport
+    when available, for use by the data-layer recorder (Task 8).
     """
 
     status: VideoStatus
     local_path: Path | None
+    project_id: str | None = None
+    flow_operation_id: str | None = None
+
+
+# Callback type: invoked by the transport the moment a media_id becomes known,
+# before polling completes. May be sync or async.
+VideoStartedCallback = Callable[[VideoStarted], Awaitable[None] | None]
+
+
+def operation_name_from_generate_response(response_json: dict[str, Any]) -> str | None:
+    """Return the operation name from ``operations[0].operation.name`` in a
+    batchAsyncGenerateVideo* response, or None if absent.
+
+    The T2V response body carries both ``media[0].name`` AND
+    ``operations[0].operation.name``. The spec stores them SEPARATELY even when
+    they currently happen to match — use :func:`media_name_from_generate_response`
+    for the media id and this function for the operation id.
+    """
+    operations = response_json.get("operations")
+    if not isinstance(operations, list) or not operations:
+        return None
+    first: dict[str, Any] = cast("dict[str, Any]", operations[0])
+    operation: dict[str, Any] | None = cast(
+        "dict[str, Any] | None", first.get("operation")
+    )
+    if not isinstance(operation, dict):
+        return None
+    name_val: str | None = cast("str | None", operation.get("name"))
+    return name_val if name_val is not None else None
 
 
 def media_name_from_generate_response(response_json: dict[str, Any]) -> str:

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from gflow_cli import __version__, profile_store
 from gflow_cli import auth as auth_mod
+from gflow_cli.cli_data import data as _data_group
 from gflow_cli.cli_image import image as _image_group
 from gflow_cli.cli_run import run as _run_command
 from gflow_cli.cli_video import video as _video_group
@@ -237,6 +238,7 @@ def _resolve_or_prompt(default_for_first_run: str) -> str:
         )
 
 
+main.add_command(_data_group)
 main.add_command(_video_group)
 main.add_command(_image_group)
 main.add_command(_run_command)

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -30,7 +30,7 @@ def media(media_id: str, profile: str | None) -> None:
     )
 
 
-async def _run_media(*, profile_name: str, media_id: str) -> None:
+async def _run_media(*, profile_name: str, media_id: str) -> None:  # NOSONAR S7503
     settings = get_settings()
     with DataStore.open(settings.resolved_db_path()) as store:
         repo = DataRepository(store)

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gflow_cli._cli_helpers import _resolve_profile, run_with_handlers, safe_path_text
+from gflow_cli.config import get_settings
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataStoreError
+
+console = Console()
+
+
+@click.group()
+def data() -> None:
+    """Read local gflow media history."""
+
+
+@data.command("media")
+@click.argument("media_id")
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+def media(media_id: str, profile: str | None) -> None:
+    """Show local metadata for a media asset by its Flow media ID."""
+    profile_name = _resolve_profile(profile)
+    run_with_handlers(
+        lambda: _run_media(profile_name=profile_name, media_id=media_id),
+        cli_command="data media",
+    )
+
+
+async def _run_media(*, profile_name: str, media_id: str) -> None:
+    settings = get_settings()
+    with DataStore.open(settings.resolved_db_path()) as store:
+        repo = DataRepository(store)
+        asset = repo.get_asset_by_flow_media_id(profile_name, media_id)
+        if asset is None:
+            raise DataStoreError(
+                detail=f"No local media record found: {media_id}",
+                route="data.media",
+            )
+        table = Table(title="gflow data media")
+        table.add_column("field")
+        table.add_column("value", overflow="fold")
+        table.add_row("profile", profile_name)
+        table.add_row("media_id", asset.flow_media_id)
+        table.add_row("project_id", asset.flow_project_id or "")
+        table.add_row("kind", asset.kind.value)
+        for idx, local_file in enumerate(asset.local_files, start=1):
+            table.add_row(f"local_path_{idx}", safe_path_text(local_file.path))
+        console.print(table)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 import click
+import structlog
 from rich.console import Console
 from rich.table import Table
 
@@ -34,7 +35,8 @@ from gflow_cli.api.dto import GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, ImageRef, Model
 from gflow_cli.api.transports import transport_choices
 from gflow_cli.config import get_settings
-from gflow_cli.errors import ConfigurationError
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.errors import ConfigurationError, DataStoreError
 from gflow_cli.image_batch import (
     ALLOWED_ASPECT_RATIOS as _ALLOWED_ASPECT_RATIOS,
 )
@@ -86,6 +88,22 @@ _CREATING_PROJECT_MSG = "  Creating project..."
 _T2I_PROJECT_TITLE = "gflow-cli t2i"
 
 console = Console()
+logger = structlog.get_logger(__name__)
+
+
+def _warn_persistence_failed_after_success(
+    *,
+    exc: Exception,
+    flow_media_id: str | None,
+    local_path: Path | None,
+) -> None:
+    logger.warning(
+        "data.persistence_failed_after_success",
+        error_class=type(exc).__name__,
+        flow_media_id=flow_media_id,
+        local_path=str(local_path) if local_path is not None else None,
+    )
+    console.print("[yellow]Generated media was saved, but local history was not updated.[/yellow]")
 
 
 def _classify_ref(ref: str) -> ImageRef | Path:
@@ -185,6 +203,7 @@ def upload(path: Path, profile: str | None, transport: str | None) -> None:
     settings = get_settings()
     run_with_handlers(
         lambda: _run_upload(
+            profile_name=profile_name,
             profile_dir=provider_dir,
             headless=settings.headless,
             image_path=path,
@@ -196,25 +215,45 @@ def upload(path: Path, profile: str | None, transport: str | None) -> None:
 
 async def _run_upload(
     *,
+    profile_name: str,
     profile_dir: Path,
     headless: bool,
     image_path: Path,
     transport: str | None = None,
 ) -> None:
-    async with FlowApiClient(
-        profile_dir=profile_dir, headless=headless, transport=transport
-    ) as client:
-        console.print(_CREATING_PROJECT_MSG)
-        project = await client.create_project(title="gflow-cli upload")
-        console.print(f"  Project: [dim]{project.project_id}[/dim]")
-        console.print(f"  Uploading {image_path.name}...")
-        asset = await client.upload_image(project.project_id, image_path)
-        # Render the UUID prominently — that's the load-bearing output.
-        console.print(f"[bold green]Asset UUID:[/bold green] [bold]{asset.name}[/bold]")
-        console.print(
-            f"[dim]Dimensions:[/dim] {asset.width} x {asset.height}  "
-            f"[dim]Project:[/dim] {project.project_id}"
-        )
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with FlowApiClient(
+            profile_dir=profile_dir, headless=headless, transport=transport
+        ) as client:
+            console.print(_CREATING_PROJECT_MSG)
+            project = await client.create_project(title="gflow-cli upload")
+            console.print(f"  Project: [dim]{project.project_id}[/dim]")
+            console.print(f"  Uploading {image_path.name}...")
+            asset = await client.upload_image(project.project_id, image_path)
+            # Render the UUID prominently — that's the load-bearing output.
+            console.print(f"[bold green]Asset UUID:[/bold green] [bold]{asset.name}[/bold]")
+            console.print(
+                f"[dim]Dimensions:[/dim] {asset.width} x {asset.height}  "
+                f"[dim]Project:[/dim] {project.project_id}"
+            )
+            try:
+                recorder.record_upload_image(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    project=project,
+                    asset=asset,
+                    image_path=image_path,
+                )
+            except DataStoreError as exc:
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=asset.name,
+                    local_path=image_path,
+                )
+    finally:
+        recorder.close()
 
 
 # ---------------------------------------------------------------------------
@@ -333,6 +372,7 @@ def t2i(
         settings = get_settings()
         run_with_handlers(
             lambda: _run_t2i(
+                profile_name=profile_name,
                 profile_dir=provider_dir,
                 headless=settings.headless,
                 req=GenerateImageRequest(
@@ -461,6 +501,7 @@ def _as_usage_error(exc: ConfigurationError) -> click.UsageError:
 
 async def _run_t2i(
     *,
+    profile_name: str,
     profile_dir: Path,
     headless: bool,
     req: GenerateImageRequest,
@@ -469,34 +510,61 @@ async def _run_t2i(
     output_root: Path,
     transport: str | None = None,
 ) -> None:
-    async with FlowApiClient(
-        profile_dir=profile_dir, headless=headless, transport=transport
-    ) as client:
-        console.print(_CREATING_PROJECT_MSG)
-        # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
-        # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-        project = await client.create_project(title=_T2I_PROJECT_TITLE)
-        console.print(f"  Project: [dim]{project.project_id}[/dim]")
-        console.print(f"  Generating {count} image(s) ({req.model.value}, {req.aspect.value})...")
-        if count == 1:
-            img = await client.generate_image(project_id=project.project_id, req=req)
-            images: list[GeneratedImage] = [img]
-        else:
-            images = await client.generate_images_batch(
-                project_id=project.project_id, req=req, count=count
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with FlowApiClient(
+            profile_dir=profile_dir, headless=headless, transport=transport
+        ) as client:
+            console.print(_CREATING_PROJECT_MSG)
+            # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
+            # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
+            project = await client.create_project(title=_T2I_PROJECT_TITLE)
+            console.print(f"  Project: [dim]{project.project_id}[/dim]")
+            console.print(
+                f"  Generating {count} image(s) ({req.model.value}, {req.aspect.value})..."
             )
+            if count == 1:
+                img = await client.generate_image(project_id=project.project_id, req=req)
+                images: list[GeneratedImage] = [img]
+            else:
+                images = await client.generate_images_batch(
+                    project_id=project.project_id, req=req, count=count
+                )
 
-        saved_paths: list[Path] = []
-        for i, img in enumerate(images, start=1):
-            target = (
-                out / f"{img.media_name}_{i}.png"
-                if out is not None
-                else image_output_path(output_root, job_id=img.media_name, index=i)
-            )
-            saved = await client.download_image(img, target)
-            saved_paths.append(saved)
+            saved_paths: list[Path] = []
+            for i, img in enumerate(images, start=1):
+                target = (
+                    out / f"{img.media_name}_{i}.png"
+                    if out is not None
+                    else image_output_path(output_root, job_id=img.media_name, index=i)
+                )
+                saved = await client.download_image(img, target)
+                saved_paths.append(saved)
 
-        _print_t2i_summary(images, saved_paths)
+            _print_t2i_summary(images, saved_paths)
+
+            try:
+                recorder.record_generated_images(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    project=project,
+                    request=req,
+                    images=images,
+                    saved_paths=saved_paths,
+                    input_media_ids=[],
+                    operation_kind="t2i",
+                )
+            except DataStoreError as exc:
+                first_image = images[0] if images else None
+                first_path = saved_paths[0] if saved_paths else None
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=first_image.media_name if first_image else None,
+                    local_path=first_path,
+                )
+    finally:
+        recorder.close()
 
 
 def _print_t2i_summary(images: list[GeneratedImage], saved_paths: list[Path]) -> None:
@@ -746,6 +814,7 @@ def i2i(
     settings = get_settings()
     run_with_handlers(
         lambda: _run_i2i(
+            profile_name=profile_name,
             profile_dir=provider_dir,
             headless=settings.headless,
             prompt=prompt,
@@ -795,6 +864,7 @@ async def _resolve_refs(
 
 async def _run_i2i(
     *,
+    profile_name: str,
     profile_dir: Path,
     headless: bool,
     prompt: str,
@@ -806,46 +876,71 @@ async def _run_i2i(
     output_root: Path,
     transport: str | None = None,
 ) -> None:
-    async with FlowApiClient(
-        profile_dir=profile_dir, headless=headless, transport=transport
-    ) as client:
-        console.print(_CREATING_PROJECT_MSG)
-        # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
-        # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-        project = await client.create_project(title="gflow-cli i2i")
-        console.print(f"  Project: [dim]{project.project_id}[/dim]")
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with FlowApiClient(
+            profile_dir=profile_dir, headless=headless, transport=transport
+        ) as client:
+            console.print(_CREATING_PROJECT_MSG)
+            # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
+            # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
+            project = await client.create_project(title="gflow-cli i2i")
+            console.print(f"  Project: [dim]{project.project_id}[/dim]")
 
-        resolved_refs = await _resolve_refs(client, project.project_id, classified_refs)
-        req = GenerateImageRequest(
-            prompt=prompt,
-            aspect=aspect,
-            model=model,
-            refs=resolved_refs,
-        )
-
-        console.print(
-            f"  Generating {count} image(s) with {len(resolved_refs)} ref(s) "
-            f"({req.model.value}, {req.aspect.value})..."
-        )
-        if count == 1:
-            img = await client.generate_image(project_id=project.project_id, req=req)
-            images: list[GeneratedImage] = [img]
-        else:
-            images = await client.generate_images_batch(
-                project_id=project.project_id, req=req, count=count
+            resolved_refs = await _resolve_refs(client, project.project_id, classified_refs)
+            req = GenerateImageRequest(
+                prompt=prompt,
+                aspect=aspect,
+                model=model,
+                refs=resolved_refs,
             )
 
-        saved_paths: list[Path] = []
-        for i, img in enumerate(images, start=1):
-            target = (
-                out / f"{img.media_name}_{i}.png"
-                if out is not None
-                else image_output_path(output_root, job_id=img.media_name, index=i)
+            console.print(
+                f"  Generating {count} image(s) with {len(resolved_refs)} ref(s) "
+                f"({req.model.value}, {req.aspect.value})..."
             )
-            saved = await client.download_image(img, target)
-            saved_paths.append(saved)
+            if count == 1:
+                img = await client.generate_image(project_id=project.project_id, req=req)
+                images: list[GeneratedImage] = [img]
+            else:
+                images = await client.generate_images_batch(
+                    project_id=project.project_id, req=req, count=count
+                )
 
-        _print_i2i_summary(images, saved_paths)
+            saved_paths: list[Path] = []
+            for i, img in enumerate(images, start=1):
+                target = (
+                    out / f"{img.media_name}_{i}.png"
+                    if out is not None
+                    else image_output_path(output_root, job_id=img.media_name, index=i)
+                )
+                saved = await client.download_image(img, target)
+                saved_paths.append(saved)
+
+            _print_i2i_summary(images, saved_paths)
+
+            try:
+                recorder.record_generated_images(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    project=project,
+                    request=req,
+                    images=images,
+                    saved_paths=saved_paths,
+                    input_media_ids=[ref.name for ref in resolved_refs],
+                    operation_kind="i2i",
+                )
+            except DataStoreError as exc:
+                first_image = images[0] if images else None
+                first_path = saved_paths[0] if saved_paths else None
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=first_image.media_name if first_image else None,
+                    local_path=first_path,
+                )
+    finally:
+        recorder.close()
 
 
 def _print_i2i_summary(images: list[GeneratedImage], saved_paths: list[Path]) -> None:

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -464,8 +464,8 @@ def _execute_t2i_batch(
                 output_dir=output_dir,
                 continue_on_error=continue_on_error,
                 project_title=_T2I_PROJECT_TITLE,
-                profile_name=profile_name,
-                recorder=recorder,
+                _profile_name=profile_name,
+                _recorder=recorder,
             )
         )
     finally:

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -453,17 +453,23 @@ def _execute_t2i_batch(
     console.print(f"  output_dir: [dim]{safe_path_text(output_dir)}[/dim]")
     if not continue_on_error:
         console.print("  mode: [yellow]fail-fast[/yellow]")
-    outcomes = asyncio.run(
-        run_image_batch(
-            profile_dir=provider_dir,
-            headless=settings.headless,
-            transport=transport,
-            prompts=batch_prompts,
-            output_dir=output_dir,
-            continue_on_error=continue_on_error,
-            project_title=_T2I_PROJECT_TITLE,
+    recorder = OperationRecorder.open(settings)
+    try:
+        outcomes = asyncio.run(
+            run_image_batch(
+                profile_dir=provider_dir,
+                headless=settings.headless,
+                transport=transport,
+                prompts=batch_prompts,
+                output_dir=output_dir,
+                continue_on_error=continue_on_error,
+                project_title=_T2I_PROJECT_TITLE,
+                profile_name=profile_name,
+                recorder=recorder,
+            )
         )
-    )
+    finally:
+        recorder.close()
     exit_code = render_image_batch_summary(outcomes, title=_T2I_PROJECT_TITLE)
     if exit_code != 0:
         sys.exit(exit_code)
@@ -698,16 +704,22 @@ def batch(
     if not continue_on_error:
         console.print("  mode: [yellow]fail-fast[/yellow]")
 
-    outcomes = asyncio.run(
-        run_manifest_image_batch(
-            profile_dir=provider_dir,
-            headless=settings.headless,
-            transport=transport,
-            prompts=prompts,
-            output_dir=output_dir,
-            continue_on_error=continue_on_error,
+    recorder = OperationRecorder.open(settings)
+    try:
+        outcomes = asyncio.run(
+            run_manifest_image_batch(
+                profile_dir=provider_dir,
+                headless=settings.headless,
+                transport=transport,
+                prompts=prompts,
+                output_dir=output_dir,
+                continue_on_error=continue_on_error,
+                profile_name=profile_name,
+                recorder=recorder,
+            )
         )
-    )
+    finally:
+        recorder.close()
     exit_code = render_image_batch_summary(outcomes, title=_BATCH_TITLE)
     if exit_code != 0:
         sys.exit(exit_code)

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -27,17 +27,18 @@ _BATCH_UNAVAILABLE = (
 
 
 async def _generate_and_report(request: Any, *, profile_dir: Path, out_dir: Path | None) -> None:
-    """Drive the transport for a single GenerateVideoRequest and print the
-    result (or fail with a non-zero exit). Shared by t2v and i2v."""
-    from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+    """Drive FlowApiClient for a single GenerateVideoRequest and print the
+    result (or fail with a non-zero exit). Shared by t2v, i2v, and r2v."""
+    from gflow_cli.api.client import FlowApiClient
 
-    transport = UiAutomationTransport()
-    try:
-        await transport.setup(profile_dir)
-        console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
-        result = await transport.generate_video(request=request, out_dir=out_dir, download=True)
-    finally:
-        await transport.teardown()
+    console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
+    async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+        result = await client.generate_video(
+            req=request,
+            out_dir=out_dir,
+            download=True,
+            on_started=None,  # Task 8 will wire the recorder callback here
+        )
 
     if not result.status.succeeded:
         reasons = (

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import click
+import structlog
 from rich.console import Console
 
 from gflow_cli._cli_helpers import (
@@ -17,8 +18,27 @@ from gflow_cli._cli_helpers import (
     _resolve_profile,
     run_with_handlers,
 )
+from gflow_cli.config import get_settings
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.errors import DataStoreError
 
 console = Console()
+logger = structlog.get_logger(__name__)
+
+
+def _warn_persistence_failed_after_success(
+    *,
+    exc: Exception,
+    flow_media_id: str | None,
+    local_path: Path | None,
+) -> None:
+    logger.warning(
+        "data.persistence_failed_after_success",
+        error_class=type(exc).__name__,
+        flow_media_id=flow_media_id,
+        local_path=str(local_path) if local_path is not None else None,
+    )
+
 
 _BATCH_UNAVAILABLE = (
     "[yellow]`gflow video batch` is not yet available.[/yellow]\n"
@@ -26,19 +46,61 @@ _BATCH_UNAVAILABLE = (
 )
 
 
-async def _generate_and_report(request: Any, *, profile_dir: Path, out_dir: Path | None) -> None:
+async def _generate_and_report(
+    request: Any,
+    *,
+    profile_name: str,
+    profile_dir: Path,
+    out_dir: Path | None,
+) -> None:
     """Drive FlowApiClient for a single GenerateVideoRequest and print the
     result (or fail with a non-zero exit). Shared by t2v, i2v, and r2v."""
     from gflow_cli.api.client import FlowApiClient
+    from gflow_cli.api.video import VideoStarted
 
     console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
-    async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
-        result = await client.generate_video(
-            req=request,
-            out_dir=out_dir,
-            download=True,
-            on_started=None,  # Task 8 will wire the recorder callback here
-        )
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+
+            async def on_started(started: VideoStarted) -> None:
+                try:
+                    recorder.record_started_video(
+                        profile_name=profile_name,
+                        profile_dir=profile_dir,
+                        request=request,
+                        started=started,
+                    )
+                except DataStoreError as exc:
+                    _warn_persistence_failed_after_success(
+                        exc=exc,
+                        flow_media_id=started.media_id,
+                        local_path=None,
+                    )
+
+            result = await client.generate_video(
+                req=request,
+                out_dir=out_dir,
+                download=True,
+                on_started=on_started,
+            )
+
+        try:
+            recorder.record_completed_video(
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                request=request,
+                result=result,
+            )
+        except DataStoreError as exc:
+            _warn_persistence_failed_after_success(
+                exc=exc,
+                flow_media_id=result.status.media_id,
+                local_path=result.local_path,
+            )
+    finally:
+        recorder.close()
 
     if not result.status.succeeded:
         reasons = (
@@ -54,6 +116,7 @@ async def _generate_and_report(request: Any, *, profile_dir: Path, out_dir: Path
 
 async def _run_t2v(
     *,
+    profile_name: str,
     profile_dir: Path,
     prompt: str,
     aspect: str,
@@ -72,11 +135,14 @@ async def _run_t2v(
         duration=duration,
         count=count,
     )
-    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
+    await _generate_and_report(
+        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+    )
 
 
 async def _run_i2v(
     *,
+    profile_name: str,
     profile_dir: Path,
     image: str,
     prompt: str,
@@ -99,11 +165,14 @@ async def _run_i2v(
         start_image=Path(image),
         end_image=Path(end_image) if end_image else None,
     )
-    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
+    await _generate_and_report(
+        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+    )
 
 
 async def _run_r2v(
     *,
+    profile_name: str,
     profile_dir: Path,
     prompt: str,
     refs: tuple[str, ...],
@@ -124,7 +193,9 @@ async def _run_r2v(
         count=count,
         reference_images=tuple(Path(r) for r in refs),
     )
-    await _generate_and_report(request, profile_dir=profile_dir, out_dir=out_dir)
+    await _generate_and_report(
+        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+    )
 
 
 async def _run_batch(**kwargs: Any) -> None:  # pragma: no cover
@@ -198,6 +269,7 @@ def t2v(
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(
         lambda: _run_t2v(
+            profile_name=profile_name,
             profile_dir=provider_dir,
             prompt=prompt,
             aspect=aspect,
@@ -281,6 +353,7 @@ def i2v(
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(
         lambda: _run_i2v(
+            profile_name=profile_name,
             profile_dir=provider_dir,
             image=image,
             prompt=prompt,
@@ -365,6 +438,7 @@ def r2v(
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(
         lambda: _run_r2v(
+            profile_name=profile_name,
             profile_dir=provider_dir,
             prompt=prompt,
             refs=refs,

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -64,7 +64,7 @@ async def _generate_and_report(
     try:
         async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
 
-            async def on_started(started: VideoStarted) -> None:
+            def on_started(started: VideoStarted) -> None:
                 try:
                     recorder.record_started_video(
                         profile_name=profile_name,
@@ -89,7 +89,7 @@ async def _generate_and_report(
         try:
             recorder.record_completed_video(
                 profile_name=profile_name,
-                profile_dir=profile_dir,
+                _profile_dir=profile_dir,
                 request=request,
                 result=result,
             )

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -25,6 +25,7 @@ import warnings
 from enum import StrEnum
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -98,6 +99,21 @@ class Settings(BaseSettings):
         description="Where generated assets land.",
     )
 
+    db_path: Path | None = Field(
+        default=None,
+        description=(
+            "SQLite data-layer path. Defaults to <GFLOW_CLI_HOME>/gflow.db. "
+            "Override with GFLOW_CLI_DB_PATH for tests or advanced local setups."
+        ),
+    )
+    history_prompts: Literal["store", "redacted"] = Field(
+        default="store",
+        description=(
+            "Controls prompt persistence in the local DB. 'store' stores prompt text; "
+            "'redacted' stores only prompt_hash and prompt_redacted=1."
+        ),
+    )
+
     # --- profile ----------------------------------------------------------
     profile: str | None = Field(
         default=None,
@@ -154,6 +170,9 @@ class Settings(BaseSettings):
     log_format: LogFormat = LogFormat.AUTO
 
     # --- derived path helpers --------------------------------------------
+
+    def resolved_db_path(self) -> Path:
+        return self.db_path or paths.database_path(self.home)
 
     def profile_subdir(self, name: str) -> Path:
         return paths.profile_subdir(self.home, name)

--- a/src/gflow_cli/data/__init__.py
+++ b/src/gflow_cli/data/__init__.py
@@ -1,0 +1,5 @@
+"""SQLite-backed local data layer for gflow-cli."""
+
+from gflow_cli.data.store import DataStore
+
+__all__ = ["DataStore"]

--- a/src/gflow_cli/data/migrations/0001_initial.sql
+++ b/src/gflow_cli/data/migrations/0001_initial.sql
@@ -1,0 +1,100 @@
+CREATE TABLE schema_migrations (
+  version TEXT PRIMARY KEY,
+  filename TEXT NOT NULL,
+  checksum TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
+CREATE TABLE profiles (
+  name TEXT PRIMARY KEY,
+  profile_dir TEXT,
+  first_seen_at TEXT NOT NULL,
+  last_used_at TEXT
+);
+
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT NOT NULL,
+  title TEXT,
+  source TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  UNIQUE(profile_name, flow_project_id)
+);
+
+CREATE TABLE assets (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT,
+  flow_media_id TEXT NOT NULL,
+  flow_workflow_id TEXT,
+  flow_media_generation_id TEXT,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  model TEXT,
+  aspect_ratio TEXT,
+  width INTEGER,
+  height INTEGER,
+  duration_seconds REAL,
+  seed INTEGER,
+  created_at TEXT NOT NULL,
+  metadata_json TEXT,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  UNIQUE(profile_name, flow_media_id)
+);
+
+CREATE TABLE operations (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  flow_project_id TEXT,
+  command TEXT,
+  mode TEXT NOT NULL,
+  prompt TEXT,
+  prompt_hash TEXT,
+  prompt_redacted INTEGER NOT NULL DEFAULT 0,
+  model TEXT,
+  aspect_ratio TEXT,
+  status TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  error_type TEXT,
+  error_detail TEXT,
+  flow_operation_id TEXT,
+  flow_batch_id TEXT,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name)
+);
+
+CREATE TABLE operation_assets (
+  operation_id TEXT NOT NULL,
+  asset_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  FOREIGN KEY(operation_id) REFERENCES operations(id),
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
+  UNIQUE(operation_id, role, position),
+  PRIMARY KEY(operation_id, asset_id, role, position)
+);
+
+CREATE TABLE local_files (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  asset_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  sha256 TEXT,
+  bytes INTEGER,
+  media_type TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(asset_id) REFERENCES assets(id),
+  UNIQUE(asset_id, path)
+);
+
+CREATE INDEX idx_projects_profile_flow ON projects(profile_name, flow_project_id);
+CREATE INDEX idx_assets_profile_media ON assets(profile_name, flow_media_id);
+CREATE INDEX idx_assets_project_created ON assets(profile_name, flow_project_id, created_at);
+CREATE INDEX idx_assets_kind_created ON assets(kind, created_at);
+CREATE INDEX idx_operations_profile_created ON operations(profile_name, started_at);
+CREATE INDEX idx_operations_project_created ON operations(profile_name, flow_project_id, started_at);
+CREATE INDEX idx_operation_assets_asset ON operation_assets(asset_id);
+CREATE INDEX idx_local_files_asset ON local_files(profile_name, asset_id);
+CREATE INDEX idx_local_files_path ON local_files(path);

--- a/src/gflow_cli/data/migrations/__init__.py
+++ b/src/gflow_cli/data/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged SQL migrations for gflow-cli's local SQLite data layer."""

--- a/src/gflow_cli/data/models.py
+++ b/src/gflow_cli/data/models.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+class AssetKind(StrEnum):
+    IMAGE = "image"
+    VIDEO = "video"
+
+
+class OperationKind(StrEnum):
+    UPLOAD_IMAGE = "upload_image"
+    T2I = "t2i"
+    I2I = "i2i"
+    T2V = "t2v"
+    I2V = "i2v"
+    R2V = "r2v"
+
+
+class OperationStatus(StrEnum):
+    STARTED = "started"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class OperationAssetRole(StrEnum):
+    INPUT = "input"
+    OUTPUT = "output"
+    SEED_START = "seed_start"
+    SEED_END = "seed_end"
+    REFERENCE = "reference"
+
+
+@dataclass(frozen=True)
+class ProjectRecord:
+    id: str
+    profile_name: str
+    flow_project_id: str
+    title: str | None
+    source: str
+    created_at: str | None = None
+
+
+@dataclass(frozen=True)
+class AssetRecord:
+    id: str
+    profile_name: str
+    flow_project_id: str | None
+    flow_media_id: str
+    flow_workflow_id: str | None
+    flow_media_generation_id: str | None
+    kind: AssetKind
+    status: str
+    model: str | None
+    aspect_ratio: str | None
+    width: int | None
+    height: int | None
+    duration_seconds: float | None
+    seed: int | None
+    metadata_json: JsonObject
+    created_at: str | None = None
+
+    @classmethod
+    def minimal_image(
+        cls,
+        *,
+        id: str,
+        profile_name: str,
+        flow_project_id: str | None,
+        flow_media_id: str,
+    ) -> AssetRecord:
+        return cls(
+            id=id,
+            profile_name=profile_name,
+            flow_project_id=flow_project_id,
+            flow_media_id=flow_media_id,
+            flow_workflow_id=None,
+            flow_media_generation_id=None,
+            kind=AssetKind.IMAGE,
+            status="ready",
+            model=None,
+            aspect_ratio=None,
+            width=None,
+            height=None,
+            duration_seconds=None,
+            seed=None,
+            metadata_json={},
+        )
+
+
+@dataclass(frozen=True)
+class OperationRecord:
+    id: str
+    profile_name: str
+    flow_project_id: str | None
+    command: str | None
+    mode: OperationKind
+    status: OperationStatus
+    flow_operation_id: str | None
+    flow_batch_id: str | None
+    prompt: str | None
+    prompt_hash: str | None
+    prompt_redacted: bool
+    model: str | None
+    aspect_ratio: str | None
+    error_type: str | None
+    error_detail: str | None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+    @classmethod
+    def minimal(
+        cls,
+        *,
+        id: str,
+        profile_name: str,
+        flow_project_id: str | None,
+        mode: OperationKind,
+    ) -> OperationRecord:
+        return cls(
+            id=id,
+            profile_name=profile_name,
+            flow_project_id=flow_project_id,
+            command=None,
+            mode=mode,
+            status=OperationStatus.SUCCEEDED,
+            flow_operation_id=None,
+            flow_batch_id=None,
+            prompt=None,
+            prompt_hash=None,
+            prompt_redacted=False,
+            model=None,
+            aspect_ratio=None,
+            error_type=None,
+            error_detail=None,
+        )
+
+
+@dataclass(frozen=True)
+class LocalFileRecord:
+    id: str
+    profile_name: str
+    asset_id: str
+    path: Path
+    media_type: str | None
+    bytes: int | None
+    sha256: str | None
+    created_at: str | None = None
+
+
+@dataclass(frozen=True)
+class AssetLookup:
+    id: str
+    profile_name: str
+    flow_project_id: str | None
+    flow_media_id: str
+    kind: AssetKind
+    local_files: list[LocalFileRecord]
+
+
+@dataclass(frozen=True)
+class SeedImage:
+    profile_name: str
+    flow_project_id: str
+    flow_media_id: str
+    flow_workflow_id: str | None
+    kind: AssetKind
+    width: int | None
+    height: int | None
+    local_path: Path | None
+    prompt: str | None
+    model: str | None
+    aspect_ratio: str | None
+    created_at: str

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import mimetypes
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
@@ -33,6 +34,11 @@ def _file_sha256(path: Path) -> str | None:
         return hashlib.sha256(path.read_bytes()).hexdigest()
     except OSError:
         return None
+
+
+def _now_utc_iso() -> str:
+    """UTC timestamp matching the format used elsewhere in the data layer."""
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _file_bytes(path: Path) -> int | None:
@@ -126,6 +132,9 @@ class OperationRecorder:
                 error_detail=None,
             )
         )
+        # Upload is synchronous from the recorder's POV: by the time we're here
+        # the upload already succeeded, so completed_at = started_at = now.
+        repo.update_operation_status(op_id, OperationStatus.SUCCEEDED, _now_utc_iso(), None, None)
         repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, 0)
 
         repo.upsert_local_file(
@@ -190,6 +199,11 @@ class OperationRecorder:
                 error_detail=None,
             )
         )
+        # Image generation is recorded AFTER all downloads complete, so the
+        # operation is already terminal at insert time. Stamp completed_at so
+        # downstream queries like "SELECT * FROM operations WHERE completed_at
+        # IS NULL" don't surface successful runs.
+        repo.update_operation_status(op_id, OperationStatus.SUCCEEDED, _now_utc_iso(), None, None)
 
         # Link input assets (I2I seed images)
         for i, media_id in enumerate(input_media_ids):
@@ -315,7 +329,6 @@ class OperationRecorder:
         result: VideoResult,
     ) -> None:
         # VideoResult carries status.media_id (the flow_media_id) and local_path
-        from datetime import UTC, datetime
 
         repo = self.repository
         flow_media_id = result.status.media_id
@@ -344,7 +357,7 @@ class OperationRecorder:
         )
 
         # Update the STARTED operation for this asset to SUCCEEDED
-        completed_at = datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        completed_at = _now_utc_iso()
         op = repo.get_operation_for_output_asset(
             profile_name, flow_media_id, OperationKind(request.mode.value)
         )

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
 from gflow_cli.api.image import GenerateImageRequest
-from gflow_cli.api.video import GenerateVideoRequest, VideoResult
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStarted
 from gflow_cli.config import Settings
 from gflow_cli.data.models import (
     AssetKind,
@@ -246,30 +246,29 @@ class OperationRecorder:
         profile_name: str,
         profile_dir: Path,
         request: GenerateVideoRequest,
-        flow_media_id: str,
-        flow_project_id: str,
-        flow_operation_id: str | None,
+        started: VideoStarted,
     ) -> None:
         repo = self.repository
 
         repo.upsert_profile(profile_name, profile_dir)
-        repo.upsert_project(
-            ProjectRecord(
-                id=_new_id(),
-                profile_name=profile_name,
-                flow_project_id=flow_project_id,
-                title="gflow-cli video",
-                source="generated",
+        if started.project_id is not None:
+            repo.upsert_project(
+                ProjectRecord(
+                    id=_new_id(),
+                    profile_name=profile_name,
+                    flow_project_id=started.project_id,
+                    title="gflow-cli video",
+                    source="generated",
+                )
             )
-        )
 
         asset_id = _new_id()
         repo.upsert_asset(
             AssetRecord(
                 id=asset_id,
                 profile_name=profile_name,
-                flow_project_id=flow_project_id,
-                flow_media_id=flow_media_id,
+                flow_project_id=started.project_id,
+                flow_media_id=started.media_id,
                 flow_workflow_id=None,
                 flow_media_generation_id=None,
                 kind=AssetKind.VIDEO,
@@ -290,11 +289,11 @@ class OperationRecorder:
             OperationRecord(
                 id=op_id,
                 profile_name=profile_name,
-                flow_project_id=flow_project_id,
+                flow_project_id=started.project_id,
                 command=f"video {request.mode.value}",
                 mode=OperationKind(request.mode.value),
                 status=OperationStatus.STARTED,
-                flow_operation_id=flow_operation_id,
+                flow_operation_id=started.flow_operation_id,
                 flow_batch_id=None,
                 prompt=pf.prompt,
                 prompt_hash=pf.prompt_hash,
@@ -316,20 +315,67 @@ class OperationRecorder:
         result: VideoResult,
     ) -> None:
         # VideoResult carries status.media_id (the flow_media_id) and local_path
+        from datetime import UTC, datetime
+
         repo = self.repository
         flow_media_id = result.status.media_id
 
-        repo.update_asset_status(profile_name, flow_media_id, "ready")
+        # Upsert the asset (idempotent) — reuse existing id if already inserted by on_started
+        existing_asset = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)
+        asset_id = existing_asset.id if existing_asset is not None else _new_id()
+        repo.upsert_asset(
+            AssetRecord(
+                id=asset_id,
+                profile_name=profile_name,
+                flow_project_id=result.project_id,
+                flow_media_id=flow_media_id,
+                flow_workflow_id=None,
+                flow_media_generation_id=None,
+                kind=AssetKind.VIDEO,
+                status=result.status.status,
+                model=request.model.value if request.model is not None else None,
+                aspect_ratio=request.aspect.value,
+                width=None,
+                height=None,
+                duration_seconds=float(request.duration) if request.duration is not None else None,
+                seed=request.seed,
+                metadata_json={},
+            )
+        )
 
         # Update the STARTED operation for this asset to SUCCEEDED
-        from datetime import UTC, datetime
-
         completed_at = datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
         op = repo.get_operation_for_output_asset(
             profile_name, flow_media_id, OperationKind(request.mode.value)
         )
         if op is not None:
             repo.update_operation_status(op.id, OperationStatus.SUCCEEDED, completed_at, None, None)
+        else:
+            # on_started may have failed — insert a fresh completed operation
+            pf = prompt_fields(request.prompt, mode=self.prompt_mode)
+            op_id = _new_id()
+            repo.insert_operation(
+                OperationRecord(
+                    id=op_id,
+                    profile_name=profile_name,
+                    flow_project_id=result.project_id,
+                    command=f"video {request.mode.value}",
+                    mode=OperationKind(request.mode.value),
+                    status=OperationStatus.SUCCEEDED,
+                    flow_operation_id=result.flow_operation_id,
+                    flow_batch_id=None,
+                    prompt=pf.prompt,
+                    prompt_hash=pf.prompt_hash,
+                    prompt_redacted=pf.prompt_redacted,
+                    model=request.model.value if request.model is not None else None,
+                    aspect_ratio=request.aspect.value,
+                    error_type=None,
+                    error_detail=None,
+                )
+            )
+            asset_lookup = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)
+            if asset_lookup is not None:
+                repo.link_operation_asset(op_id, asset_lookup.id, OperationAssetRole.OUTPUT, 0)
 
         if result.local_path is not None:
             asset_lookup = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -310,7 +310,7 @@ class OperationRecorder:
         self,
         *,
         profile_name: str,
-        profile_dir: Path,
+        _profile_dir: Path,
         request: GenerateVideoRequest,
         result: VideoResult,
     ) -> None:

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+import uuid
+from pathlib import Path
+
+from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
+from gflow_cli.api.image import GenerateImageRequest
+from gflow_cli.api.video import GenerateVideoRequest, VideoResult
+from gflow_cli.config import Settings
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+)
+from gflow_cli.data.redaction import PromptMode, prompt_fields, redact_metadata
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _file_sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _file_bytes(path: Path) -> int | None:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+class OperationRecorder:
+    repository: DataRepository
+    prompt_mode: PromptMode
+
+    def __init__(self, repository: DataRepository, *, prompt_mode: PromptMode) -> None:
+        self.repository = repository
+        self.prompt_mode = prompt_mode
+
+    @classmethod
+    def open(cls, settings: Settings) -> OperationRecorder:
+        store = DataStore.open(settings.resolved_db_path())
+        return cls(DataRepository(store), prompt_mode=settings.history_prompts)
+
+    def close(self) -> None:
+        self.repository.store.close()
+
+    # ------------------------------------------------------------------
+    # Image upload
+    # ------------------------------------------------------------------
+
+    def record_upload_image(
+        self,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        project: ProjectInfo,
+        asset: AssetInfo,
+        image_path: Path,
+    ) -> None:
+        repo = self.repository
+
+        repo.upsert_profile(profile_name, profile_dir)
+        repo.upsert_project(
+            ProjectRecord(
+                id=_new_id(),
+                profile_name=profile_name,
+                flow_project_id=project.project_id,
+                title=project.title,
+                source="uploaded",
+            )
+        )
+
+        asset_id = _new_id()
+        media_type = mimetypes.guess_type(image_path.name)[0]
+        repo.upsert_asset(
+            AssetRecord(
+                id=asset_id,
+                profile_name=profile_name,
+                flow_project_id=asset.project_id,
+                flow_media_id=asset.name,
+                flow_workflow_id=asset.workflow_id,
+                flow_media_generation_id=None,
+                kind=AssetKind.IMAGE,
+                status="ready",
+                model=None,
+                aspect_ratio=None,
+                width=asset.width or None,
+                height=asset.height or None,
+                duration_seconds=None,
+                seed=None,
+                metadata_json=redact_metadata({"display_name": asset.display_name}),
+            )
+        )
+
+        op_id = _new_id()
+        repo.insert_operation(
+            OperationRecord(
+                id=op_id,
+                profile_name=profile_name,
+                flow_project_id=asset.project_id,
+                command="image upload",
+                mode=OperationKind.UPLOAD_IMAGE,
+                status=OperationStatus.SUCCEEDED,
+                flow_operation_id=None,
+                flow_batch_id=None,
+                prompt=None,
+                prompt_hash=None,
+                prompt_redacted=False,
+                model=None,
+                aspect_ratio=None,
+                error_type=None,
+                error_detail=None,
+            )
+        )
+        repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, 0)
+
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id=_new_id(),
+                profile_name=profile_name,
+                asset_id=asset_id,
+                path=image_path.resolve(),
+                media_type=media_type,
+                bytes=_file_bytes(image_path),
+                sha256=_file_sha256(image_path),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Generated images (T2I / I2I)
+    # ------------------------------------------------------------------
+
+    def record_generated_images(
+        self,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        project: ProjectInfo,
+        request: GenerateImageRequest,
+        images: list[GeneratedImage],
+        saved_paths: list[Path],
+        input_media_ids: list[str],
+        operation_kind: str,
+    ) -> None:
+        repo = self.repository
+
+        repo.upsert_profile(profile_name, profile_dir)
+        repo.upsert_project(
+            ProjectRecord(
+                id=_new_id(),
+                profile_name=profile_name,
+                flow_project_id=project.project_id,
+                title=project.title,
+                source="generated",
+            )
+        )
+
+        pf = prompt_fields(request.prompt, mode=self.prompt_mode)
+        op_id = _new_id()
+        repo.insert_operation(
+            OperationRecord(
+                id=op_id,
+                profile_name=profile_name,
+                flow_project_id=project.project_id,
+                command=f"image {operation_kind}",
+                mode=OperationKind(operation_kind),
+                status=OperationStatus.SUCCEEDED,
+                flow_operation_id=None,
+                flow_batch_id=None,
+                prompt=pf.prompt,
+                prompt_hash=pf.prompt_hash,
+                prompt_redacted=pf.prompt_redacted,
+                model=request.model.value,
+                aspect_ratio=request.aspect.value,
+                error_type=None,
+                error_detail=None,
+            )
+        )
+
+        # Link input assets (I2I seed images)
+        for i, media_id in enumerate(input_media_ids):
+            input_asset = repo.get_asset_by_flow_media_id(profile_name, media_id)
+            if input_asset is not None:
+                repo.link_operation_asset(op_id, input_asset.id, OperationAssetRole.INPUT, i)
+
+        # Persist each output image
+        for i, (image, saved_path) in enumerate(zip(images, saved_paths, strict=False)):
+            media_type = mimetypes.guess_type(saved_path.name)[0]
+            asset_id = _new_id()
+            width, height = image.dimensions
+            repo.upsert_asset(
+                AssetRecord(
+                    id=asset_id,
+                    profile_name=profile_name,
+                    flow_project_id=project.project_id,
+                    flow_media_id=image.media_name,
+                    flow_workflow_id=image.workflow_id,
+                    flow_media_generation_id=image.media_generation_id,
+                    kind=AssetKind.IMAGE,
+                    status="ready",
+                    model=image.model_name_type,
+                    aspect_ratio=image.aspect_ratio,
+                    width=width,
+                    height=height,
+                    duration_seconds=None,
+                    seed=image.seed,
+                    metadata_json=redact_metadata({"fife_url": image.fife_url}),
+                )
+            )
+            repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, i)
+            repo.upsert_local_file(
+                LocalFileRecord(
+                    id=_new_id(),
+                    profile_name=profile_name,
+                    asset_id=asset_id,
+                    path=saved_path.resolve(),
+                    media_type=media_type,
+                    bytes=_file_bytes(saved_path),
+                    sha256=_file_sha256(saved_path),
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Video — started / completed
+    # Note: Task 7 will introduce a proper "started video" DTO; for now
+    # we accept primitive kwargs. Task 8 will wire this through callers.
+    # ------------------------------------------------------------------
+
+    def record_started_video(
+        self,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        request: GenerateVideoRequest,
+        flow_media_id: str,
+        flow_project_id: str,
+        flow_operation_id: str | None,
+    ) -> None:
+        repo = self.repository
+
+        repo.upsert_profile(profile_name, profile_dir)
+        repo.upsert_project(
+            ProjectRecord(
+                id=_new_id(),
+                profile_name=profile_name,
+                flow_project_id=flow_project_id,
+                title="gflow-cli video",
+                source="generated",
+            )
+        )
+
+        asset_id = _new_id()
+        repo.upsert_asset(
+            AssetRecord(
+                id=asset_id,
+                profile_name=profile_name,
+                flow_project_id=flow_project_id,
+                flow_media_id=flow_media_id,
+                flow_workflow_id=None,
+                flow_media_generation_id=None,
+                kind=AssetKind.VIDEO,
+                status="pending",
+                model=request.model.value if request.model is not None else None,
+                aspect_ratio=request.aspect.value,
+                width=None,
+                height=None,
+                duration_seconds=float(request.duration) if request.duration is not None else None,
+                seed=request.seed,
+                metadata_json={},
+            )
+        )
+
+        pf = prompt_fields(request.prompt, mode=self.prompt_mode)
+        op_id = _new_id()
+        repo.insert_operation(
+            OperationRecord(
+                id=op_id,
+                profile_name=profile_name,
+                flow_project_id=flow_project_id,
+                command=f"video {request.mode.value}",
+                mode=OperationKind(request.mode.value),
+                status=OperationStatus.STARTED,
+                flow_operation_id=flow_operation_id,
+                flow_batch_id=None,
+                prompt=pf.prompt,
+                prompt_hash=pf.prompt_hash,
+                prompt_redacted=pf.prompt_redacted,
+                model=request.model.value if request.model is not None else None,
+                aspect_ratio=request.aspect.value,
+                error_type=None,
+                error_detail=None,
+            )
+        )
+        repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, 0)
+
+    def record_completed_video(
+        self,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        request: GenerateVideoRequest,
+        result: VideoResult,
+    ) -> None:
+        # VideoResult carries status.media_id (the flow_media_id) and local_path
+        repo = self.repository
+        flow_media_id = result.status.media_id
+
+        repo.update_asset_status(profile_name, flow_media_id, "ready")
+
+        # Update the STARTED operation for this asset to SUCCEEDED
+        from datetime import UTC, datetime
+
+        completed_at = datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        op = repo.get_operation_for_output_asset(
+            profile_name, flow_media_id, OperationKind(request.mode.value)
+        )
+        if op is not None:
+            repo.update_operation_status(op.id, OperationStatus.SUCCEEDED, completed_at, None, None)
+
+        if result.local_path is not None:
+            asset_lookup = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)
+            if asset_lookup is not None:
+                media_type = mimetypes.guess_type(result.local_path.name)[0]
+                repo.upsert_local_file(
+                    LocalFileRecord(
+                        id=_new_id(),
+                        profile_name=profile_name,
+                        asset_id=asset_lookup.id,
+                        path=result.local_path.resolve(),
+                        media_type=media_type,
+                        bytes=_file_bytes(result.local_path),
+                        sha256=_file_sha256(result.local_path),
+                    )
+                )

--- a/src/gflow_cli/data/redaction.py
+++ b/src/gflow_cli/data/redaction.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+PromptMode = Literal["store", "redacted"]
+SENSITIVE_URL_KEYS = {"fifeurl", "signedurl", "downloadurl", "mediaurl"}
+SENSITIVE_QUERY_KEYS = ("signature=", "x-goog-signature=", "x-goog-credential=", "expires=")
+
+
+@dataclass(frozen=True)
+class PromptFields:
+    prompt: str | None
+    prompt_hash: str | None
+    prompt_redacted: bool
+
+
+def prompt_fields(prompt: str | None, *, mode: PromptMode) -> PromptFields:
+    if prompt is None:
+        return PromptFields(prompt=None, prompt_hash=None, prompt_redacted=False)
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    if mode == "redacted":
+        return PromptFields(prompt=None, prompt_hash=digest, prompt_redacted=True)
+    return PromptFields(prompt=prompt, prompt_hash=digest, prompt_redacted=False)
+
+
+def redact_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        d = cast(dict[str, Any], value)
+        for key, item in d.items():
+            lowered: str = key.lower()
+            if lowered in {"token", "recaptchatoken"}:
+                out[key] = "<redacted:token>"
+            elif lowered in {"authorization", "cookie", "set-cookie"}:
+                out[key] = "<redacted:secret>"
+            elif lowered in SENSITIVE_URL_KEYS and isinstance(item, str):
+                out[key] = "<redacted:url>"
+            else:
+                out[key] = redact_metadata(item)
+        return out
+    if isinstance(value, list):
+        items = cast(list[Any], value)
+        return [redact_metadata(item) for item in items]
+    if isinstance(value, str) and any(marker in value.lower() for marker in SENSITIVE_QUERY_KEYS):
+        return "<redacted:url>"
+    return value

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetLookup,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+    SeedImage,
+)
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataIntegrityError
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class DataRepository:
+    def __init__(self, store: DataStore) -> None:
+        self._store = store
+
+    # ------------------------------------------------------------------
+    # Profiles
+    # ------------------------------------------------------------------
+
+    def upsert_profile(self, name: str, profile_dir: Path) -> None:
+        now = _utc_now()
+        with self._store.transaction(immediate=True):
+            self._store.conn.execute(
+                """
+                INSERT INTO profiles(name, profile_dir, first_seen_at, last_used_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    profile_dir = excluded.profile_dir,
+                    last_used_at = excluded.last_used_at
+                """,
+                (name, str(profile_dir), now, now),
+            )
+
+    # ------------------------------------------------------------------
+    # Projects
+    # ------------------------------------------------------------------
+
+    def upsert_project(self, record: ProjectRecord) -> ProjectRecord:
+        now = _utc_now()
+        created_at = record.created_at or now
+        with self._store.transaction(immediate=True):
+            self._store.conn.execute(
+                """
+                INSERT INTO projects(id, profile_name, flow_project_id, title, source, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    profile_name = excluded.profile_name,
+                    flow_project_id = excluded.flow_project_id,
+                    title = excluded.title,
+                    source = excluded.source
+                """,
+                (
+                    record.id,
+                    record.profile_name,
+                    record.flow_project_id,
+                    record.title,
+                    record.source,
+                    created_at,
+                ),
+            )
+        return dataclasses.replace(record, created_at=created_at)
+
+    # ------------------------------------------------------------------
+    # Assets
+    # ------------------------------------------------------------------
+
+    def upsert_asset(self, record: AssetRecord) -> AssetRecord:
+        now = _utc_now()
+        created_at = record.created_at or now
+        metadata = json.dumps(record.metadata_json, sort_keys=True)
+        with self._store.transaction(immediate=True):
+            self._store.conn.execute(
+                """
+                INSERT INTO assets(
+                    id, profile_name, flow_project_id, flow_media_id,
+                    flow_workflow_id, flow_media_generation_id,
+                    kind, status, model, aspect_ratio,
+                    width, height, duration_seconds, seed,
+                    created_at, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    profile_name = excluded.profile_name,
+                    flow_project_id = excluded.flow_project_id,
+                    flow_media_id = excluded.flow_media_id,
+                    flow_workflow_id = excluded.flow_workflow_id,
+                    flow_media_generation_id = excluded.flow_media_generation_id,
+                    kind = excluded.kind,
+                    status = excluded.status,
+                    model = excluded.model,
+                    aspect_ratio = excluded.aspect_ratio,
+                    width = excluded.width,
+                    height = excluded.height,
+                    duration_seconds = excluded.duration_seconds,
+                    seed = excluded.seed,
+                    metadata_json = excluded.metadata_json
+                """,
+                (
+                    record.id,
+                    record.profile_name,
+                    record.flow_project_id,
+                    record.flow_media_id,
+                    record.flow_workflow_id,
+                    record.flow_media_generation_id,
+                    record.kind.value,
+                    record.status,
+                    record.model,
+                    record.aspect_ratio,
+                    record.width,
+                    record.height,
+                    record.duration_seconds,
+                    record.seed,
+                    created_at,
+                    metadata,
+                ),
+            )
+        return dataclasses.replace(record, created_at=created_at)
+
+    def update_asset_status(self, profile_name: str, flow_media_id: str, status: str) -> None:
+        with self._store.transaction(immediate=True):
+            self._store.conn.execute(
+                "UPDATE assets SET status = ? WHERE profile_name = ? AND flow_media_id = ?",
+                (status, profile_name, flow_media_id),
+            )
+
+    def get_asset_by_flow_media_id(
+        self, profile_name: str, flow_media_id: str
+    ) -> AssetLookup | None:
+        row = self._store.conn.execute(
+            """
+            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            FROM assets
+            WHERE profile_name = ? AND flow_media_id = ?
+            """,
+            (profile_name, flow_media_id),
+        ).fetchone()
+        if row is None:
+            return None
+        file_rows = self._store.conn.execute(
+            """
+            SELECT id, profile_name, asset_id, path, media_type, bytes, sha256, created_at
+            FROM local_files
+            WHERE profile_name = ? AND asset_id = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            (profile_name, row["id"]),
+        ).fetchall()
+        local_files = [_row_to_local_file(r) for r in file_rows]
+        return AssetLookup(
+            id=str(row["id"]),
+            profile_name=str(row["profile_name"]),
+            flow_project_id=row["flow_project_id"],
+            flow_media_id=str(row["flow_media_id"]),
+            kind=AssetKind(row["kind"]),
+            local_files=local_files,
+        )
+
+    def candidate_image_exists(self, profile_name: str, flow_media_id: str) -> bool:
+        row = self._store.conn.execute(
+            """
+            SELECT 1 FROM assets
+            WHERE profile_name = ? AND flow_media_id = ?
+              AND kind = 'image' AND flow_project_id IS NOT NULL
+            """,
+            (profile_name, flow_media_id),
+        ).fetchone()
+        return row is not None
+
+    # ------------------------------------------------------------------
+    # Operations
+    # ------------------------------------------------------------------
+
+    def insert_operation(self, record: OperationRecord) -> OperationRecord:
+        now = _utc_now()
+        started_at = record.started_at or now
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO operations(
+                        id, profile_name, flow_project_id, command, mode,
+                        prompt, prompt_hash, prompt_redacted, model, aspect_ratio,
+                        status, started_at, completed_at,
+                        error_type, error_detail,
+                        flow_operation_id, flow_batch_id
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.id,
+                        record.profile_name,
+                        record.flow_project_id,
+                        record.command,
+                        record.mode.value,
+                        record.prompt,
+                        record.prompt_hash,
+                        int(bool(record.prompt_redacted)),
+                        record.model,
+                        record.aspect_ratio,
+                        record.status.value,
+                        started_at,
+                        record.completed_at,
+                        record.error_type,
+                        record.error_detail,
+                        record.flow_operation_id,
+                        record.flow_batch_id,
+                    ),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.insert_operation") from exc
+        return dataclasses.replace(record, started_at=started_at)
+
+    def update_operation_status(
+        self,
+        operation_id: str,
+        status: OperationStatus,
+        completed_at: str | None,
+        error_type: str | None,
+        error_detail: str | None,
+    ) -> None:
+        with self._store.transaction(immediate=True):
+            self._store.conn.execute(
+                """
+                UPDATE operations
+                SET status = ?, completed_at = ?, error_type = ?, error_detail = ?
+                WHERE id = ?
+                """,
+                (status.value, completed_at, error_type, error_detail, operation_id),
+            )
+
+    def get_operation_for_output_asset(
+        self, profile_name: str, flow_media_id: str, mode: OperationKind
+    ) -> OperationRecord | None:
+        row = self._store.conn.execute(
+            """
+            SELECT o.id, o.profile_name, o.flow_project_id, o.command, o.mode,
+                   o.prompt, o.prompt_hash, o.prompt_redacted, o.model, o.aspect_ratio,
+                   o.status, o.started_at, o.completed_at,
+                   o.error_type, o.error_detail,
+                   o.flow_operation_id, o.flow_batch_id
+            FROM operations o
+            JOIN operation_assets oa ON oa.operation_id = o.id
+            JOIN assets a ON a.id = oa.asset_id
+            WHERE o.profile_name = ?
+              AND a.flow_media_id = ?
+              AND o.mode = ?
+              AND oa.role = ?
+            ORDER BY o.started_at DESC
+            LIMIT 1
+            """,
+            (profile_name, flow_media_id, mode.value, OperationAssetRole.OUTPUT.value),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_operation(row)
+
+    # ------------------------------------------------------------------
+    # Operation-asset links
+    # ------------------------------------------------------------------
+
+    def link_operation_asset(
+        self,
+        operation_id: str,
+        asset_id: str,
+        role: OperationAssetRole,
+        position: int,
+    ) -> None:
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO operation_assets(operation_id, asset_id, role, position)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (operation_id, asset_id, role.value, position),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.link_operation_asset") from exc
+
+    # ------------------------------------------------------------------
+    # Local files
+    # ------------------------------------------------------------------
+
+    def upsert_local_file(self, record: LocalFileRecord) -> LocalFileRecord:
+        now = _utc_now()
+        created_at = record.created_at or now
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO local_files(
+                        id, profile_name, asset_id, path,
+                        sha256, bytes, media_type, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(asset_id, path) DO UPDATE SET
+                        id = excluded.id,
+                        profile_name = excluded.profile_name,
+                        sha256 = excluded.sha256,
+                        bytes = excluded.bytes,
+                        media_type = excluded.media_type
+                    """,
+                    (
+                        record.id,
+                        record.profile_name,
+                        record.asset_id,
+                        str(record.path),
+                        record.sha256,
+                        record.bytes,
+                        record.media_type,
+                        created_at,
+                    ),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.upsert_local_file") from exc
+        return dataclasses.replace(record, created_at=created_at)
+
+    # ------------------------------------------------------------------
+    # Seed image resolvers
+    # ------------------------------------------------------------------
+
+    def resolve_seed_image(self, profile_name: str, flow_media_id: str) -> SeedImage | None:
+        row = self._store.conn.execute(
+            """
+            SELECT a.id, a.profile_name, a.flow_project_id, a.flow_media_id,
+                   a.flow_workflow_id, a.kind, a.width, a.height,
+                   a.model, a.aspect_ratio, a.created_at,
+                   o.prompt
+            FROM assets a
+            LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = ?
+            LEFT JOIN operations o ON o.id = oa.operation_id
+            WHERE a.profile_name = ?
+              AND a.flow_media_id = ?
+              AND a.kind = 'image'
+            LIMIT 1
+            """,
+            (OperationAssetRole.OUTPUT.value, profile_name, flow_media_id),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["flow_project_id"] is None:
+            return None
+        local_path = self._latest_local_path(str(row["id"]))
+        return SeedImage(
+            profile_name=str(row["profile_name"]),
+            flow_project_id=str(row["flow_project_id"]),
+            flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
+            local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=str(row["created_at"]),
+        )
+
+    def resolve_seed_image_by_path(self, profile_name: str, path: Path) -> SeedImage | None:
+        row = self._store.conn.execute(
+            """
+            SELECT a.id, a.profile_name, a.flow_project_id, a.flow_media_id,
+                   a.flow_workflow_id, a.kind, a.width, a.height,
+                   a.model, a.aspect_ratio, a.created_at,
+                   o.prompt
+            FROM assets a
+            JOIN local_files lf ON lf.asset_id = a.id
+            LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = ?
+            LEFT JOIN operations o ON o.id = oa.operation_id
+            WHERE a.profile_name = ?
+              AND a.kind = 'image'
+              AND lf.path = ?
+            LIMIT 1
+            """,
+            (OperationAssetRole.OUTPUT.value, profile_name, str(path)),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["flow_project_id"] is None:
+            return None
+        local_path = self._latest_local_path(str(row["id"]))
+        return SeedImage(
+            profile_name=str(row["profile_name"]),
+            flow_project_id=str(row["flow_project_id"]),
+            flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
+            local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=str(row["created_at"]),
+        )
+
+    def resolve_latest_image(
+        self,
+        profile_name: str,
+        flow_project_id: str | None,
+        model: str | None,
+        aspect_ratio: str | None,
+    ) -> SeedImage | None:
+        clauses: list[str] = [
+            "a.profile_name = ?",
+            "a.kind = 'image'",
+            "a.flow_project_id IS NOT NULL",
+        ]
+        params: list[object] = [profile_name]
+        if flow_project_id is not None:
+            clauses.append("a.flow_project_id = ?")
+            params.append(flow_project_id)
+        if model is not None:
+            clauses.append("a.model = ?")
+            params.append(model)
+        if aspect_ratio is not None:
+            clauses.append("a.aspect_ratio = ?")
+            params.append(aspect_ratio)
+        where = " AND ".join(clauses)
+        sql = f"""
+            SELECT a.id, a.profile_name, a.flow_project_id, a.flow_media_id,
+                   a.flow_workflow_id, a.kind, a.width, a.height,
+                   a.model, a.aspect_ratio, a.created_at,
+                   o.prompt
+            FROM assets a
+            LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = ?
+            LEFT JOIN operations o ON o.id = oa.operation_id
+            WHERE {where}
+            ORDER BY a.created_at DESC, a.id DESC
+            LIMIT 1
+        """
+        row = self._store.conn.execute(
+            sql,
+            [OperationAssetRole.OUTPUT.value, *params],
+        ).fetchone()
+        if row is None:
+            return None
+        if row["flow_project_id"] is None:
+            return None
+        local_path = self._latest_local_path(str(row["id"]))
+        return SeedImage(
+            profile_name=str(row["profile_name"]),
+            flow_project_id=str(row["flow_project_id"]),
+            flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
+            local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=str(row["created_at"]),
+        )
+
+    def list_project_images(self, profile_name: str, flow_project_id: str) -> list[SeedImage]:
+        rows = self._store.conn.execute(
+            """
+            SELECT a.id, a.profile_name, a.flow_project_id, a.flow_media_id,
+                   a.flow_workflow_id, a.kind, a.width, a.height,
+                   a.model, a.aspect_ratio, a.created_at,
+                   o.prompt
+            FROM assets a
+            LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = ?
+            LEFT JOIN operations o ON o.id = oa.operation_id
+            WHERE a.profile_name = ?
+              AND a.flow_project_id = ?
+              AND a.kind = 'image'
+            ORDER BY a.created_at DESC, a.id DESC
+            """,
+            (OperationAssetRole.OUTPUT.value, profile_name, flow_project_id),
+        ).fetchall()
+        result: list[SeedImage] = []
+        for row in rows:
+            if row["flow_project_id"] is None:
+                continue
+            local_path = self._latest_local_path(str(row["id"]))
+            result.append(
+                SeedImage(
+                    profile_name=str(row["profile_name"]),
+                    flow_project_id=str(row["flow_project_id"]),
+                    flow_media_id=str(row["flow_media_id"]),
+                    flow_workflow_id=row["flow_workflow_id"],
+                    kind=AssetKind(row["kind"]),
+                    width=row["width"],
+                    height=row["height"],
+                    local_path=local_path,
+                    prompt=row["prompt"],
+                    model=row["model"],
+                    aspect_ratio=row["aspect_ratio"],
+                    created_at=str(row["created_at"]),
+                )
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _latest_local_path(self, asset_id: str) -> Path | None:
+        row = self._store.conn.execute(
+            """
+            SELECT path FROM local_files
+            WHERE asset_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (asset_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return Path(str(row["path"]))
+
+
+# ------------------------------------------------------------------
+# Row-to-dataclass helpers
+# ------------------------------------------------------------------
+
+
+def _row_to_local_file(row: sqlite3.Row) -> LocalFileRecord:
+    return LocalFileRecord(
+        id=str(row["id"]),
+        profile_name=str(row["profile_name"]),
+        asset_id=str(row["asset_id"]),
+        path=Path(str(row["path"])),
+        media_type=row["media_type"],
+        bytes=row["bytes"],
+        sha256=row["sha256"],
+        created_at=row["created_at"],
+    )
+
+
+def _row_to_operation(row: sqlite3.Row) -> OperationRecord:
+    return OperationRecord(
+        id=str(row["id"]),
+        profile_name=str(row["profile_name"]),
+        flow_project_id=row["flow_project_id"],
+        command=row["command"],
+        mode=OperationKind(row["mode"]),
+        status=OperationStatus(row["status"]),
+        flow_operation_id=row["flow_operation_id"],
+        flow_batch_id=row["flow_batch_id"],
+        prompt=row["prompt"],
+        prompt_hash=row["prompt_hash"],
+        prompt_redacted=bool(int(row["prompt_redacted"])),
+        model=row["model"],
+        aspect_ratio=row["aspect_ratio"],
+        error_type=row["error_type"],
+        error_detail=row["error_detail"],
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+    )

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -5,6 +5,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from gflow_cli.data.models import (
     AssetKind,
@@ -87,7 +88,7 @@ class DataRepository:
                 )
         except sqlite3.IntegrityError as exc:
             raise DataIntegrityError(detail=str(exc), route="data.upsert_project") from exc
-        return dataclasses.replace(record, created_at=created_at)
+        return cast(ProjectRecord, dataclasses.replace(record, created_at=created_at))  # pyright: ignore[reportUnnecessaryCast]
 
     # ------------------------------------------------------------------
     # Assets
@@ -146,7 +147,7 @@ class DataRepository:
                 )
         except sqlite3.IntegrityError as exc:
             raise DataIntegrityError(detail=str(exc), route="data.upsert_asset") from exc
-        return dataclasses.replace(record, created_at=created_at)
+        return cast(AssetRecord, dataclasses.replace(record, created_at=created_at))  # pyright: ignore[reportUnnecessaryCast]
 
     def update_asset_status(self, profile_name: str, flow_media_id: str, status: str) -> None:
         with self._store.transaction(immediate=True):
@@ -240,7 +241,7 @@ class DataRepository:
                 )
         except sqlite3.IntegrityError as exc:
             raise DataIntegrityError(detail=str(exc), route="data.insert_operation") from exc
-        return dataclasses.replace(record, started_at=started_at)
+        return cast(OperationRecord, dataclasses.replace(record, started_at=started_at))  # pyright: ignore[reportUnnecessaryCast]
 
     def update_operation_status(
         self,
@@ -345,7 +346,7 @@ class DataRepository:
                 )
         except sqlite3.IntegrityError as exc:
             raise DataIntegrityError(detail=str(exc), route="data.upsert_local_file") from exc
-        return dataclasses.replace(record, created_at=created_at)
+        return cast(LocalFileRecord, dataclasses.replace(record, created_at=created_at))  # pyright: ignore[reportUnnecessaryCast]
 
     # ------------------------------------------------------------------
     # Seed image resolvers

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -36,17 +36,20 @@ class DataRepository:
 
     def upsert_profile(self, name: str, profile_dir: Path) -> None:
         now = _utc_now()
-        with self._store.transaction(immediate=True):
-            self._store.conn.execute(
-                """
-                INSERT INTO profiles(name, profile_dir, first_seen_at, last_used_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(name) DO UPDATE SET
-                    profile_dir = excluded.profile_dir,
-                    last_used_at = excluded.last_used_at
-                """,
-                (name, str(profile_dir), now, now),
-            )
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO profiles(name, profile_dir, first_seen_at, last_used_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(name) DO UPDATE SET
+                        profile_dir = excluded.profile_dir,
+                        last_used_at = excluded.last_used_at
+                    """,
+                    (name, str(profile_dir), now, now),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.upsert_profile") from exc
 
     # ------------------------------------------------------------------
     # Projects
@@ -55,26 +58,31 @@ class DataRepository:
     def upsert_project(self, record: ProjectRecord) -> ProjectRecord:
         now = _utc_now()
         created_at = record.created_at or now
-        with self._store.transaction(immediate=True):
-            self._store.conn.execute(
-                """
-                INSERT INTO projects(id, profile_name, flow_project_id, title, source, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    profile_name = excluded.profile_name,
-                    flow_project_id = excluded.flow_project_id,
-                    title = excluded.title,
-                    source = excluded.source
-                """,
-                (
-                    record.id,
-                    record.profile_name,
-                    record.flow_project_id,
-                    record.title,
-                    record.source,
-                    created_at,
-                ),
-            )
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO projects(
+                        id, profile_name, flow_project_id, title, source, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        profile_name = excluded.profile_name,
+                        flow_project_id = excluded.flow_project_id,
+                        title = excluded.title,
+                        source = excluded.source
+                    """,
+                    (
+                        record.id,
+                        record.profile_name,
+                        record.flow_project_id,
+                        record.title,
+                        record.source,
+                        created_at,
+                    ),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.upsert_project") from exc
         return dataclasses.replace(record, created_at=created_at)
 
     # ------------------------------------------------------------------
@@ -85,52 +93,55 @@ class DataRepository:
         now = _utc_now()
         created_at = record.created_at or now
         metadata = json.dumps(record.metadata_json, sort_keys=True)
-        with self._store.transaction(immediate=True):
-            self._store.conn.execute(
-                """
-                INSERT INTO assets(
-                    id, profile_name, flow_project_id, flow_media_id,
-                    flow_workflow_id, flow_media_generation_id,
-                    kind, status, model, aspect_ratio,
-                    width, height, duration_seconds, seed,
-                    created_at, metadata_json
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO assets(
+                        id, profile_name, flow_project_id, flow_media_id,
+                        flow_workflow_id, flow_media_generation_id,
+                        kind, status, model, aspect_ratio,
+                        width, height, duration_seconds, seed,
+                        created_at, metadata_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        profile_name = excluded.profile_name,
+                        flow_project_id = excluded.flow_project_id,
+                        flow_media_id = excluded.flow_media_id,
+                        flow_workflow_id = excluded.flow_workflow_id,
+                        flow_media_generation_id = excluded.flow_media_generation_id,
+                        kind = excluded.kind,
+                        status = excluded.status,
+                        model = excluded.model,
+                        aspect_ratio = excluded.aspect_ratio,
+                        width = excluded.width,
+                        height = excluded.height,
+                        duration_seconds = excluded.duration_seconds,
+                        seed = excluded.seed,
+                        metadata_json = excluded.metadata_json
+                    """,
+                    (
+                        record.id,
+                        record.profile_name,
+                        record.flow_project_id,
+                        record.flow_media_id,
+                        record.flow_workflow_id,
+                        record.flow_media_generation_id,
+                        record.kind.value,
+                        record.status,
+                        record.model,
+                        record.aspect_ratio,
+                        record.width,
+                        record.height,
+                        record.duration_seconds,
+                        record.seed,
+                        created_at,
+                        metadata,
+                    ),
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    profile_name = excluded.profile_name,
-                    flow_project_id = excluded.flow_project_id,
-                    flow_media_id = excluded.flow_media_id,
-                    flow_workflow_id = excluded.flow_workflow_id,
-                    flow_media_generation_id = excluded.flow_media_generation_id,
-                    kind = excluded.kind,
-                    status = excluded.status,
-                    model = excluded.model,
-                    aspect_ratio = excluded.aspect_ratio,
-                    width = excluded.width,
-                    height = excluded.height,
-                    duration_seconds = excluded.duration_seconds,
-                    seed = excluded.seed,
-                    metadata_json = excluded.metadata_json
-                """,
-                (
-                    record.id,
-                    record.profile_name,
-                    record.flow_project_id,
-                    record.flow_media_id,
-                    record.flow_workflow_id,
-                    record.flow_media_generation_id,
-                    record.kind.value,
-                    record.status,
-                    record.model,
-                    record.aspect_ratio,
-                    record.width,
-                    record.height,
-                    record.duration_seconds,
-                    record.seed,
-                    created_at,
-                    metadata,
-                ),
-            )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.upsert_asset") from exc
         return dataclasses.replace(record, created_at=created_at)
 
     def update_asset_status(self, profile_name: str, flow_media_id: str, status: str) -> None:

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -30,6 +30,10 @@ class DataRepository:
     def __init__(self, store: DataStore) -> None:
         self._store = store
 
+    @property
+    def store(self) -> DataStore:
+        return self._store
+
     # ------------------------------------------------------------------
     # Profiles
     # ------------------------------------------------------------------

--- a/src/gflow_cli/data/store.py
+++ b/src/gflow_cli/data/store.py
@@ -90,42 +90,58 @@ def _sql_update_quote_state(
     return in_single, in_double, 0
 
 
+@dataclass
+class _SqlTokenizerState:
+    in_single: bool = False
+    in_double: bool = False
+    in_line_comment: bool = False
+
+
+def _sql_advance_one_char(
+    state: _SqlTokenizerState, buf: list[str], char: str, nxt: str
+) -> tuple[int, str | None]:
+    """Process one char of SQL; return ``(chars_consumed, yielded_statement)``.
+
+    ``yielded_statement`` is non-None only when the char terminated a statement
+    (a `;` outside any string/comment). Pure function over the mutable ``state``
+    + ``buf``; the caller owns the index advancement.
+    """
+    if state.in_line_comment:
+        if char == "\n":
+            state.in_line_comment = False
+        buf.append(char)
+        return 1, None
+    if not state.in_single and not state.in_double and char == "-" and nxt == "-":
+        state.in_line_comment = True
+        buf.extend([char, nxt])
+        return 2, None
+    state.in_single, state.in_double, extra = _sql_update_quote_state(
+        char, nxt, state.in_single, state.in_double
+    )
+    if extra:
+        buf.extend([char, nxt])
+        return 2, None
+    if char == ";" and not state.in_single and not state.in_double:
+        statement = "".join(buf).strip()
+        buf.clear()
+        return 1, statement or None
+    buf.append(char)
+    return 1, None
+
+
 def _iter_sql_statements(sql: str) -> Iterator[str]:
     buf: list[str] = []
-    in_single = False
-    in_double = False
-    in_line_comment = False
+    state = _SqlTokenizerState()
     i = 0
     while i < len(sql):
-        char = sql[i]
         nxt = sql[i + 1] if i + 1 < len(sql) else ""
-        if in_line_comment:
-            if char == "\n":
-                in_line_comment = False
-            buf.append(char)
-            i += 1
-            continue
-        if not in_single and not in_double and char == "-" and nxt == "-":
-            in_line_comment = True
-            buf.extend([char, nxt])
-            i += 2
-            continue
-        in_single, in_double, extra = _sql_update_quote_state(char, nxt, in_single, in_double)
-        if extra:
-            buf.extend([char, nxt])
-            i += 2
-            continue
-        if char == ";" and not in_single and not in_double:
-            statement = "".join(buf).strip()
-            if statement:
-                yield statement
-            buf.clear()
-        else:
-            buf.append(char)
-        i += 1
-    statement = "".join(buf).strip()
-    if statement:
-        yield statement
+        consumed, statement = _sql_advance_one_char(state, buf, sql[i], nxt)
+        if statement is not None:
+            yield statement
+        i += consumed
+    tail = "".join(buf).strip()
+    if tail:
+        yield tail
 
 
 class DataStore:

--- a/src/gflow_cli/data/store.py
+++ b/src/gflow_cli/data/store.py
@@ -127,7 +127,7 @@ class DataStore:
             return store
         except DataMigrationError:
             raise
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, OSError) as exc:
             raise DataStoreError(detail=str(exc), route="data.open") from exc
 
     def close(self) -> None:
@@ -146,7 +146,10 @@ class DataStore:
             yield
             self.conn.execute("COMMIT")
         except Exception:
-            self.conn.execute("ROLLBACK")
+            try:
+                self.conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
             raise
 
     def apply_migrations(self) -> None:

--- a/src/gflow_cli/data/store.py
+++ b/src/gflow_cli/data/store.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib import resources
+from importlib.resources.abc import Traversable
+from pathlib import Path
+
+from gflow_cli.errors import DataMigrationError, DataStoreError
+
+MIGRATION_PACKAGE = "gflow_cli.data.migrations"
+BUSY_TIMEOUT_MS = 5000
+MIGRATION_RE = re.compile(r"^(?P<version>\d{4,})_.+\.sql$")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _normalize_sql_for_checksum(sql: str) -> str:
+    normalized = sql.replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.rstrip() for line in normalized.split("\n")).rstrip()
+
+
+def _checksum_sql(sql: str) -> str:
+    return hashlib.sha256(_normalize_sql_for_checksum(sql).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: str
+    version_number: int
+    filename: str
+    sql: str
+    checksum: str
+
+
+def _load_migrations() -> list[Migration]:
+    files: list[Traversable] = []
+    for item in resources.files(MIGRATION_PACKAGE).iterdir():
+        if item.name.endswith(".sql"):
+            files.append(item)
+    migrations: list[Migration] = []
+    for file_ref in sorted(files, key=lambda p: p.name):
+        match = MIGRATION_RE.match(file_ref.name)
+        if match is None:
+            raise DataMigrationError(
+                detail=f"invalid migration filename {file_ref.name!r}",
+                route="data.migrate",
+            )
+        version = match.group("version")
+        sql = file_ref.read_text(encoding="utf-8")
+        migrations.append(
+            Migration(
+                version=version,
+                version_number=int(version),
+                filename=file_ref.name,
+                sql=sql,
+                checksum=_checksum_sql(sql),
+            )
+        )
+    return migrations
+
+
+def _iter_sql_statements(sql: str) -> Iterator[str]:
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    in_line_comment = False
+    i = 0
+    while i < len(sql):
+        char = sql[i]
+        nxt = sql[i + 1] if i + 1 < len(sql) else ""
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            buf.append(char)
+            i += 1
+            continue
+        if not in_single and not in_double and char == "-" and nxt == "-":
+            in_line_comment = True
+            buf.extend([char, nxt])
+            i += 2
+            continue
+        if in_single and char == "'" and nxt == "'":
+            buf.extend([char, nxt])
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        if char == ";" and not in_single and not in_double:
+            statement = "".join(buf).strip()
+            if statement:
+                yield statement
+            buf.clear()
+        else:
+            buf.append(char)
+        i += 1
+    statement = "".join(buf).strip()
+    if statement:
+        yield statement
+
+
+class DataStore:
+    def __init__(self, conn: sqlite3.Connection, path: Path) -> None:
+        self.conn = conn
+        self.path = path
+
+    @classmethod
+    def open(cls, path: Path) -> DataStore:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(path, isolation_level=None)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+            store = cls(conn=conn, path=path)
+            store.apply_migrations()
+            return store
+        except DataMigrationError:
+            raise
+        except sqlite3.Error as exc:
+            raise DataStoreError(detail=str(exc), route="data.open") from exc
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> DataStore:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    @contextmanager
+    def transaction(self, *, immediate: bool = False) -> Generator[None, None, None]:
+        try:
+            self.conn.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
+            yield
+            self.conn.execute("COMMIT")
+        except Exception:
+            self.conn.execute("ROLLBACK")
+            raise
+
+    def apply_migrations(self) -> None:
+        migrations = _load_migrations()
+        if not migrations:
+            raise DataMigrationError(detail="no SQL migrations packaged", route="data.migrate")
+
+        table_exists = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+        ).fetchone()
+        latest_known = migrations[-1].version_number
+        if table_exists is not None:
+            rows = self.conn.execute("SELECT version FROM schema_migrations").fetchall()
+            current = max((int(str(row["version"])) for row in rows), default=0)
+            if current > latest_known:
+                raise DataMigrationError(
+                    detail=(
+                        f"database schema {current} is newer than installed schema {latest_known}"
+                    ),
+                    route="data.migrate",
+                )
+
+        applied = (
+            {
+                str(row["version"]): str(row["checksum"])
+                for row in self.conn.execute(
+                    "SELECT version, checksum FROM schema_migrations"
+                ).fetchall()
+            }
+            if table_exists is not None
+            else {}
+        )
+
+        for migration in migrations:
+            existing = applied.get(migration.version)
+            if existing is not None:
+                if existing != migration.checksum:
+                    raise DataMigrationError(
+                        detail=f"migration {migration.version} checksum drift",
+                        route="data.migrate",
+                    )
+                continue
+            with self.transaction(immediate=True):
+                for statement in _iter_sql_statements(migration.sql):
+                    self.conn.execute(statement)
+                self.conn.execute(
+                    "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (migration.version, migration.filename, migration.checksum, _utc_now()),
+                )
+                self.conn.execute(f"PRAGMA user_version = {migration.version_number}")

--- a/src/gflow_cli/data/store.py
+++ b/src/gflow_cli/data/store.py
@@ -16,6 +16,7 @@ from gflow_cli.errors import DataMigrationError, DataStoreError
 MIGRATION_PACKAGE = "gflow_cli.data.migrations"
 BUSY_TIMEOUT_MS = 5000
 MIGRATION_RE = re.compile(r"^(?P<version>\d{4,})_.+\.sql$")
+_ROUTE_MIGRATE = "data.migrate"
 
 
 def _utc_now() -> str:
@@ -51,7 +52,7 @@ def _load_migrations() -> list[Migration]:
         if match is None:
             raise DataMigrationError(
                 detail=f"invalid migration filename {file_ref.name!r}",
-                route="data.migrate",
+                route=_ROUTE_MIGRATE,
             )
         version = match.group("version")
         sql = file_ref.read_text(encoding="utf-8")
@@ -65,6 +66,28 @@ def _load_migrations() -> list[Migration]:
             )
         )
     return migrations
+
+
+def _sql_update_quote_state(
+    char: str,
+    nxt: str,
+    in_single: bool,
+    in_double: bool,
+) -> tuple[bool, bool, int]:
+    """Update single/double-quote state for one character.
+
+    Returns (in_single, in_double, extra_advance) where extra_advance is 1
+    when an escaped single-quote (``''``) was consumed so the caller skips
+    the second ``'``.
+    """
+    if in_single and char == "'" and nxt == "'":
+        # Escaped single-quote inside a string literal — consume both chars.
+        return in_single, in_double, 1
+    if char == "'" and not in_double:
+        return not in_single, in_double, 0
+    if char == '"' and not in_single:
+        return in_single, not in_double, 0
+    return in_single, in_double, 0
 
 
 def _iter_sql_statements(sql: str) -> Iterator[str]:
@@ -87,14 +110,11 @@ def _iter_sql_statements(sql: str) -> Iterator[str]:
             buf.extend([char, nxt])
             i += 2
             continue
-        if in_single and char == "'" and nxt == "'":
+        in_single, in_double, extra = _sql_update_quote_state(char, nxt, in_single, in_double)
+        if extra:
             buf.extend([char, nxt])
             i += 2
             continue
-        if char == "'" and not in_double:
-            in_single = not in_single
-        elif char == '"' and not in_single:
-            in_double = not in_double
         if char == ";" and not in_single and not in_double:
             statement = "".join(buf).strip()
             if statement:
@@ -155,7 +175,7 @@ class DataStore:
     def apply_migrations(self) -> None:
         migrations = _load_migrations()
         if not migrations:
-            raise DataMigrationError(detail="no SQL migrations packaged", route="data.migrate")
+            raise DataMigrationError(detail="no SQL migrations packaged", route=_ROUTE_MIGRATE)
 
         table_exists = self.conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
@@ -169,7 +189,7 @@ class DataStore:
                     detail=(
                         f"database schema {current} is newer than installed schema {latest_known}"
                     ),
-                    route="data.migrate",
+                    route=_ROUTE_MIGRATE,
                 )
 
         applied = (
@@ -189,7 +209,7 @@ class DataStore:
                 if existing != migration.checksum:
                     raise DataMigrationError(
                         detail=f"migration {migration.version} checksum drift",
-                        route="data.migrate",
+                        route=_ROUTE_MIGRATE,
                     )
                 continue
             with self.transaction(immediate=True):

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -19,6 +19,9 @@ __all__ = [
     "AuthLoginTimeoutError",
     "BatchPartialError",
     "BatchIntegrityError",
+    "DataStoreError",
+    "DataMigrationError",
+    "DataIntegrityError",
     "EXIT_CODE_MAP",
 ]
 
@@ -391,10 +394,39 @@ class BatchIntegrityError(GFlowError):
         self.prompt_indices = prompt_indices
 
 
+class DataStoreError(GFlowError):
+    """Raised when the local data layer cannot open, read, or write SQLite."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-store"
+    title = "Data store error"
+    _default_remediation = (
+        "Check GFLOW_CLI_DB_PATH and filesystem permissions. "
+        "If the DB was created by a newer gflow-cli, upgrade gflow-cli or "
+        "point GFLOW_CLI_DB_PATH at a compatible database."
+    )
+
+
+class DataMigrationError(DataStoreError):
+    """Raised when local SQLite schema migration cannot proceed safely."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-migration"
+    title = "Data migration error"
+
+
+class DataIntegrityError(DataStoreError):
+    """Raised when repository writes violate expected local DB constraints."""
+
+    problem_type = "https://gflow-cli.dev/errors/data-integrity"
+    title = "Data integrity error"
+
+
 # EXIT_CODE_MAP — most-specific class FIRST per isinstance walk semantics.
 # Subclasses inherit their parent's exit code if they don't have their own
 # entry. New entries MUST go BEFORE their parent class in this dict.
 EXIT_CODE_MAP: dict[type[GFlowError], int] = {
+    DataMigrationError: 16,
+    DataIntegrityError: 16,
+    DataStoreError: 16,
     BrowserSessionClosedError: 15,
     AuthBrowserRejectedError: 14,
     AuthLoginTimeoutError: 12,

--- a/src/gflow_cli/exceptions.py
+++ b/src/gflow_cli/exceptions.py
@@ -14,6 +14,9 @@ from gflow_cli.errors import AuthMissingError as AuthMissingError
 from gflow_cli.errors import BrowserSessionClosedError as BrowserSessionClosedError
 from gflow_cli.errors import ConfigurationError as ConfigurationError
 from gflow_cli.errors import ContentPolicyError as ContentPolicyError
+from gflow_cli.errors import DataIntegrityError as DataIntegrityError
+from gflow_cli.errors import DataMigrationError as DataMigrationError
+from gflow_cli.errors import DataStoreError as DataStoreError
 from gflow_cli.errors import FlowApiError as FlowApiError
 from gflow_cli.errors import GFlowError as GFlowError
 from gflow_cli.errors import NetworkError as NetworkError

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -390,8 +390,8 @@ async def run_image_batch(
     continue_on_error: bool,
     project_title: str,
     client_factory: Callable[..., Any] | None = None,
-    profile_name: str | None = None,
-    recorder: OperationRecorder | None = None,
+    _profile_name: str | None = None,
+    _recorder: OperationRecorder | None = None,
 ) -> list[BatchOutcome]:
     """Run prompts sequentially through one FlowApiClient session."""
 
@@ -662,6 +662,67 @@ def _to_request(item: BatchPromptItem) -> GenerateImageRequest:
     )
 
 
+async def _download_item_images(
+    *,
+    client: Any,
+    item: BatchPromptItem,
+    result: BatchSubmissionResult,
+    output_dir: Path,
+) -> list[Path]:
+    """Download all images for one ok BatchSubmissionResult; return saved paths."""
+    stem = item.output_filename or f"prompt_{item.index}"
+    saved: list[Path] = []
+    for img_idx, img in enumerate(result.images):
+        target = output_dir / f"{stem}_{img_idx}.png"
+        path = await client.download_image(img, target)
+        saved.append(path)
+        try:
+            sha = hashlib.sha256(Path(path).read_bytes()).hexdigest()[:16]
+        except (OSError, TypeError):
+            sha = "unreadable"
+        logger.info(
+            "image_batch.row_completed",
+            row_idx=item.index,
+            output_idx=img_idx,
+            prompt_hash=result.prompt_hash,
+            project_id=result.project_id,
+            sha256_prefix=sha,
+            outcome="ok",
+        )
+    return saved
+
+
+def _try_record_images(
+    *,
+    recorder: OperationRecorder,
+    profile_name: str,
+    profile_dir: Path,
+    item: BatchPromptItem,
+    result: BatchSubmissionResult,
+    saved: list[Path],
+) -> None:
+    """Persist generated-image metadata; warn on DataStoreError (non-fatal)."""
+    try:
+        recorder.record_generated_images(
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            project=ProjectInfo(project_id=result.project_id, title="gflow-cli image batch"),
+            request=_to_request(item),
+            images=list(result.images),
+            saved_paths=saved,
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+    except DataStoreError as exc:
+        first_image = result.images[0] if result.images else None
+        first_path = saved[0] if saved else None
+        _warn_persistence_failed_after_success(
+            exc=exc,
+            flow_media_id=first_image.media_name if first_image else None,
+            local_path=first_path,
+        )
+
+
 async def _download_results(
     *,
     client: Any,
@@ -697,25 +758,9 @@ async def _download_results(
             )
             continue
 
-        stem = item.output_filename or f"prompt_{item.index}"
-        saved: list[Path] = []
-        for img_idx, img in enumerate(result.images):
-            target = output_dir / f"{stem}_{img_idx}.png"
-            path = await client.download_image(img, target)
-            saved.append(path)
-            try:
-                sha = hashlib.sha256(Path(path).read_bytes()).hexdigest()[:16]
-            except (OSError, TypeError):
-                sha = "unreadable"
-            logger.info(
-                "image_batch.row_completed",
-                row_idx=item.index,
-                output_idx=img_idx,
-                prompt_hash=result.prompt_hash,
-                project_id=result.project_id,
-                sha256_prefix=sha,
-                outcome="ok",
-            )
+        saved = await _download_item_images(
+            client=client, item=item, result=result, output_dir=output_dir
+        )
         outcomes.append(
             BatchOutcome(
                 index=item.index,
@@ -724,29 +769,15 @@ async def _download_results(
                 saved_paths=saved,
             )
         )
-
         if recorder is not None and profile_name is not None and profile_dir is not None:
-            try:
-                recorder.record_generated_images(
-                    profile_name=profile_name,
-                    profile_dir=profile_dir,
-                    project=ProjectInfo(
-                        project_id=result.project_id, title="gflow-cli image batch"
-                    ),
-                    request=_to_request(item),
-                    images=list(result.images),
-                    saved_paths=saved,
-                    input_media_ids=[],
-                    operation_kind="t2i",
-                )
-            except DataStoreError as exc:
-                first_image = result.images[0] if result.images else None
-                first_path = saved[0] if saved else None
-                _warn_persistence_failed_after_success(
-                    exc=exc,
-                    flow_media_id=first_image.media_name if first_image else None,
-                    local_path=first_path,
-                )
+            _try_record_images(
+                recorder=recorder,
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                item=item,
+                result=result,
+                saved=saved,
+            )
 
     return outcomes
 

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -20,14 +20,16 @@ from gflow_cli._cli_helpers import (
     safe_path_text,
 )
 from gflow_cli.api.client import FlowApiClient
-from gflow_cli.api.dto import BatchSubmissionResult
+from gflow_cli.api.dto import BatchSubmissionResult, ProjectInfo
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
     BatchIntegrityError,
     BatchPartialError,
     ConfigurationError,
+    DataStoreError,
     GFlowError,
 )
 
@@ -36,6 +38,21 @@ if TYPE_CHECKING:
 
 console = Console()
 logger = structlog.get_logger(__name__)
+
+
+def _warn_persistence_failed_after_success(
+    *,
+    exc: Exception,
+    flow_media_id: str | None,
+    local_path: Path | None,
+) -> None:
+    logger.warning(
+        "data.persistence_failed_after_success",
+        error_class=type(exc).__name__,
+        flow_media_id=flow_media_id,
+        local_path=str(local_path) if local_path is not None else None,
+    )
+    console.print("[yellow]Generated media was saved, but local history was not updated.[/yellow]")
 
 
 def _prompt_hash(text: str) -> str:
@@ -373,6 +390,8 @@ async def run_image_batch(
     continue_on_error: bool,
     project_title: str,
     client_factory: Callable[..., Any] | None = None,
+    profile_name: str | None = None,
+    recorder: OperationRecorder | None = None,
 ) -> list[BatchOutcome]:
     """Run prompts sequentially through one FlowApiClient session."""
 
@@ -649,6 +668,9 @@ async def _download_results(
     prompts: tuple[BatchPromptItem, ...],
     results: list[BatchSubmissionResult],
     output_dir: Path,
+    profile_name: str | None = None,
+    profile_dir: Path | None = None,
+    recorder: OperationRecorder | None = None,
 ) -> list[BatchOutcome]:
     """Download images from ok BatchSubmissionResults and build BatchOutcome list."""
     outcomes: list[BatchOutcome] = []
@@ -702,6 +724,30 @@ async def _download_results(
                 saved_paths=saved,
             )
         )
+
+        if recorder is not None and profile_name is not None and profile_dir is not None:
+            try:
+                recorder.record_generated_images(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    project=ProjectInfo(
+                        project_id=result.project_id, title="gflow-cli image batch"
+                    ),
+                    request=_to_request(item),
+                    images=list(result.images),
+                    saved_paths=saved,
+                    input_media_ids=[],
+                    operation_kind="t2i",
+                )
+            except DataStoreError as exc:
+                first_image = result.images[0] if result.images else None
+                first_path = saved[0] if saved else None
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=first_image.media_name if first_image else None,
+                    local_path=first_path,
+                )
+
     return outcomes
 
 
@@ -715,6 +761,8 @@ async def run_manifest_image_batch(
     continue_on_error: bool,
     jitter_range: tuple[float, float] = (JITTER_MIN_SECONDS, JITTER_MAX_SECONDS),
     client_factory: Callable[..., Any] | None = None,
+    profile_name: str | None = None,
+    recorder: OperationRecorder | None = None,
 ) -> list[BatchOutcome]:
     """Run a manifest batch via the transport's stay-mounted batch method.
 
@@ -774,6 +822,9 @@ async def run_manifest_image_batch(
                 prompts=prompts,
                 results=list(exc.partial_results),
                 output_dir=output_dir,
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                recorder=recorder,
             )
             raise BatchPartialError(
                 detail=exc.detail,
@@ -819,6 +870,9 @@ async def run_manifest_image_batch(
             prompts=prompts,
             results=results,
             output_dir=output_dir,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            recorder=recorder,
         )
 
         # Post-download integrity check.

--- a/src/gflow_cli/paths.py
+++ b/src/gflow_cli/paths.py
@@ -53,6 +53,11 @@ def config_file(home: Path) -> Path:
     return home / "config.toml"
 
 
+def database_path(home: Path) -> Path:
+    """SQLite DB path under GFLOW_CLI_HOME."""
+    return home / "gflow.db"
+
+
 def _validate_job_id(job_id: str) -> str:
     if not _SAFE_ID_RE.match(job_id):
         raise ValueError(f"Unsafe job_id returned by API: {job_id!r}")

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -397,6 +397,66 @@ async def test_generate_image_translates_target_closed_to_browser_session_closed
             )
 
 
+# ---------------------------------------------------------------------------
+# generate_video client-boundary tests (Task 7)
+# ---------------------------------------------------------------------------
+
+
+class _VideoCapableFakeTransport(_FakeTransport):
+    """FakeTransport that also implements generate_video."""
+
+    async def generate_video(
+        self,
+        *,
+        request: object,
+        out_dir: object,
+        poll_timeout_s: float,
+        download: bool,
+        on_started: object = None,
+    ) -> object:
+        from gflow_cli.api.video import VideoResult, VideoStatus
+
+        status = VideoStatus(media_id="media-1", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+        return VideoResult(status=status, local_path=None)
+
+
+@pytest.mark.asyncio
+async def test_generate_video_delegates_to_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FlowApiClient.generate_video must delegate to the transport's generate_video."""
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    _patch_playwright(monkeypatch)
+    fake = _VideoCapableFakeTransport()
+
+    from gflow_cli.api.video import GenerateVideoRequest, Mode
+
+    request = GenerateVideoRequest(prompt="sunset over mountains", mode=Mode.T2V)
+
+    async with FlowApiClient(profile_dir=tmp_path, transport=fake) as client:
+        result = await client.generate_video(req=request, out_dir=tmp_path, download=True)
+
+    assert result.status.media_id == "media-1"
+
+
+@pytest.mark.asyncio
+async def test_generate_video_raises_for_non_video_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """generate_video must raise RuntimeError if the transport lacks generate_video."""
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    _patch_playwright(monkeypatch)
+    fake = _FakeTransport()  # does NOT implement generate_video
+
+    from gflow_cli.api.video import GenerateVideoRequest, Mode
+
+    request = GenerateVideoRequest(prompt="x", mode=Mode.T2V)
+
+    async with FlowApiClient(profile_dir=tmp_path, transport=fake) as client:
+        with pytest.raises(RuntimeError, match="does not support video"):
+            await client.generate_video(req=request, out_dir=tmp_path, download=True)
+
+
 @pytest.mark.asyncio
 async def test_download_video_delegates_to_download(tmp_path: Path) -> None:
     """download_video(media_id, out_path) delegates to self.download()."""

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -17,6 +17,7 @@ from gflow_cli.api.video import (
     VideoResult,
     VideoStatus,
     media_name_from_generate_response,
+    operation_name_from_generate_response,
     parse_video_status,
 )
 
@@ -269,6 +270,28 @@ class TestParseVideoStatus:
     def test_malformed_status_raises(self) -> None:
         with pytest.raises(ValueError, match="mediaGenerationStatus"):
             parse_video_status({"media": [{"name": "m", "mediaMetadata": {}}]}, media_id="m")
+
+
+class TestOperationNameFromGenerateResponse:
+    def test_reads_operation_name(self) -> None:
+        body = {
+            "media": [{"name": "media-1"}],
+            "operations": [{"operation": {"name": "media-1"}}],
+        }
+        assert operation_name_from_generate_response(body) == "media-1"
+
+    def test_matches_current_media_id_in_fixture(self) -> None:
+        body = {
+            "media": [{"name": "media-1"}],
+            "operations": [{"operation": {"name": "media-1"}}],
+        }
+        assert operation_name_from_generate_response(body) == body["media"][0]["name"]
+
+    def test_returns_none_when_operations_absent(self) -> None:
+        assert operation_name_from_generate_response({"media": [{"name": "m"}]}) is None
+
+    def test_returns_none_when_operations_empty(self) -> None:
+        assert operation_name_from_generate_response({"operations": []}) is None
 
 
 class TestVideoResult:

--- a/tests/api/transports/test_common.py
+++ b/tests/api/transports/test_common.py
@@ -204,3 +204,19 @@ def test_interpret_response_non_json_body_chained_from_json_decode_error() -> No
     import json as _json
 
     assert isinstance(exc_info.value.__cause__, _json.JSONDecodeError)
+
+
+# ---------------------------------------------------------------------------
+# extract_project_id
+# ---------------------------------------------------------------------------
+
+
+from gflow_cli.api.transports._common import extract_project_id  # noqa: E402
+
+
+def test_extract_project_id_from_flow_url() -> None:
+    assert extract_project_id("https://labs.google/fx/tools/flow/project/abc-123?x=1") == "abc-123"
+
+
+def test_extract_project_id_returns_none_for_gallery_url() -> None:
+    assert extract_project_id("https://labs.google/fx/tools/flow") is None

--- a/tests/cli/test_cli_data.py
+++ b/tests/cli/test_cli_data.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from gflow_cli.data.models import AssetRecord, LocalFileRecord, ProjectRecord
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def _seed_db(db_path: Path, *, media_id: str, profile: str = "default") -> None:
+    with DataStore.open(db_path) as store:
+        repo = DataRepository(store)
+        repo.upsert_profile(profile, db_path.parent / "profile_default")
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name=profile,
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        asset = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-local",
+                profile_name=profile,
+                flow_project_id="flow-project-1",
+                flow_media_id=media_id,
+            )
+        )
+        local_path = db_path.parent / "image.png"
+        local_path.write_bytes(b"x")
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-local",
+                profile_name=profile,
+                asset_id=asset.id,
+                path=local_path,
+                media_type="image/png",
+                bytes=1,
+                sha256=None,
+            )
+        )
+
+
+def test_data_media_prints_media_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    monkeypatch.setenv("GFLOW_CLI_HOME", str(tmp_path))
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    monkeypatch.setenv("GFLOW_CLI_PROFILE", "default")
+    _seed_db(db, media_id="media-image-1")
+
+    from gflow_cli.config import reset_settings
+
+    reset_settings()
+    runner = CliRunner()
+    result = runner.invoke(main, ["data", "media", "media-image-1", "--profile", "default"])
+    assert result.exit_code == 0, result.output
+    assert "media-image-1" in result.output
+    assert "flow-project-1" in result.output
+    assert "image" in result.output  # asset kind
+
+
+def test_data_media_missing_exits_non_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    monkeypatch.setenv("GFLOW_CLI_HOME", str(tmp_path))
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    monkeypatch.setenv("GFLOW_CLI_PROFILE", "default")
+    _seed_db(db, media_id="media-image-1")  # seed one record so the DB exists
+
+    from gflow_cli.config import reset_settings
+
+    reset_settings()
+    runner = CliRunner()
+    result = runner.invoke(main, ["data", "media", "media-missing", "--profile", "default"])
+    assert result.exit_code != 0
+    assert "media-missing" in result.output or "not" in result.output.lower()

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -6,9 +6,26 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import structlog
 from click.testing import CliRunner
 
 from gflow_cli.api.dto import AssetInfo, GeneratedImage
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.uploads: list[dict] = []
+        self.generated: list[dict] = []
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def record_upload_image(self, **kwargs: object) -> None:
+        self.uploads.append(kwargs)
+
+    def record_generated_images(self, **kwargs: object) -> None:
+        self.generated.append(kwargs)
 
 
 @pytest.fixture
@@ -620,3 +637,158 @@ class TestTransportFlag:
         assert result.exit_code == 0, result.output
         _, kwargs = mock_cls.call_args
         assert kwargs.get("transport") == "bearer"
+
+
+# ---------------------------------------------------------------------------
+# OperationRecorder integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderIntegration:
+    def test_upload_records_upload_image(self, runner: CliRunner, tmp_path: Path) -> None:
+        png = tmp_path / "hero.png"
+        png.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = _make_mock_client(asset_name="asset-uuid-123")
+        recorder = FakeRecorder()
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch("gflow_cli.cli_image.OperationRecorder.open", return_value=recorder),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "upload", str(png)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(recorder.uploads) == 1
+        rec = recorder.uploads[0]
+        assert rec["profile_name"] == "default"
+        assert rec["profile_dir"] == tmp_path / "prof"
+        assert rec["image_path"] == png
+        assert rec["asset"].name == "asset-uuid-123"
+        assert rec["project"].project_id == "proj-1"
+        assert recorder.closed
+
+    def test_t2i_records_generated_images_after_download(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        images = [_make_generated_image(media_name="m1")]
+        client = _make_t2i_client(images=images)
+        recorder = FakeRecorder()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch("gflow_cli.cli_image.OperationRecorder.open", return_value=recorder),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(recorder.generated) == 1
+        rec = recorder.generated[0]
+        assert rec["operation_kind"] == "t2i"
+        assert rec["input_media_ids"] == []
+        assert rec["profile_name"] == "default"
+        assert rec["profile_dir"] == tmp_path / "prof"
+        assert rec["images"] == images
+        assert len(rec["saved_paths"]) == 1
+        assert recorder.closed
+
+    def test_i2i_records_inputs_and_outputs(self, runner: CliRunner, tmp_path: Path) -> None:
+        png = tmp_path / "hero.png"
+        png.write_bytes(b"\x89PNG\r\n\x1a\n")
+        upload_uuid = "ddb6ef97-262d-49f4-8269-4a28c0fae6a2"
+        images = [_make_generated_image(media_name="out-img-1")]
+        client = _make_i2i_client(images=images, upload_uuid=upload_uuid)
+        recorder = FakeRecorder()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch("gflow_cli.cli_image.OperationRecorder.open", return_value=recorder),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "i2i", "make cinematic", "--ref", str(png), "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(recorder.generated) == 1
+        rec = recorder.generated[0]
+        assert rec["operation_kind"] == "i2i"
+        assert rec["input_media_ids"] == [upload_uuid]
+        assert recorder.closed
+
+    def test_t2i_persistence_failure_after_success_warns_and_succeeds(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        install_log_capture: structlog.testing.LogCapture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gflow_cli.errors import DataStoreError
+
+        images = [_make_generated_image(media_name="m1")]
+        client = _make_t2i_client(images=images)
+        out_dir = tmp_path / "out"
+
+        class FailingRecorder(FakeRecorder):
+            def record_generated_images(self, **kwargs: object) -> None:
+                raise DataStoreError("simulated write failure")
+
+        recorder = FailingRecorder()
+
+        # Reset structlog so the install_log_capture fixture's configure() takes effect.
+        structlog.reset_defaults()
+        # Re-install capture after reset (install_log_capture ran before reset).
+        cap = structlog.testing.LogCapture()
+        structlog.configure(
+            processors=[structlog.contextvars.merge_contextvars, cap],
+        )
+
+        # Prevent CLI bootstrap from overwriting the test's LogCapture chain.
+        import gflow_cli.cli as _cli_mod
+
+        monkeypatch.setattr(_cli_mod, "configure_logging", lambda *a, **kw: None)
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch("gflow_cli.cli_image.OperationRecorder.open", return_value=recorder),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        # Command must succeed despite recorder failure
+        assert result.exit_code == 0, result.output
+        # Saved file must be preserved
+        written = list(out_dir.rglob("*.png"))
+        assert len(written) == 1, f"Expected 1 file, got {written}"
+        # structlog warning must be emitted
+        events = [e["event"] for e in cap.entries]
+        assert "data.persistence_failed_after_success" in events

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -126,3 +126,77 @@ def test_t2v_does_not_instantiate_ui_automation_transport_directly(tmp_path: Pat
     # Exit code may be non-zero for other reasons (profile resolution, etc.) but
     # the sentinel assertion must not appear.
     assert result.exception is None or not isinstance(result.exception, AssertionError)
+
+
+class FakeVideoRecorder:
+    def __init__(self) -> None:
+        self.started: list[dict] = []
+        self.completed: list[dict] = []
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def record_started_video(self, **kwargs):
+        self.started.append(kwargs)
+
+    def record_completed_video(self, **kwargs):
+        self.completed.append(kwargs)
+
+
+def test_t2v_records_started_then_completed(tmp_path: Path) -> None:
+    """Recorder.record_started_video is called via on_started callback, then
+    record_completed_video is called after generate_video returns."""
+    from gflow_cli.api.video import VideoResult, VideoStarted, VideoStatus
+
+    saved = tmp_path / "test-uuid.mp4"
+    saved.touch()
+
+    stub_result = VideoResult(
+        status=VideoStatus(
+            media_id="m1",
+            status="MEDIA_GENERATION_STATUS_SUCCESSFUL",
+        ),
+        local_path=saved,
+        project_id="p1",
+        flow_operation_id="o1",
+    )
+
+    fake_recorder = FakeVideoRecorder()
+
+    async def fake_generate_video(*, req, out_dir, poll_timeout_s=None, download, on_started):
+        if on_started is not None:
+            await on_started(VideoStarted(media_id="m1", project_id="p1", flow_operation_id="o1"))
+        return stub_result
+
+    runner = CliRunner()
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.data.recorder.OperationRecorder.open", return_value=fake_recorder),
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aenter__",
+            new_callable=AsyncMock,
+        ) as mock_enter,
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aexit__",
+            new_callable=AsyncMock,
+        ),
+    ):
+        from gflow_cli.api.client import FlowApiClient
+
+        fake_client = MagicMock(spec=FlowApiClient)
+        fake_client.generate_video = fake_generate_video
+        mock_enter.return_value = fake_client
+
+        result = runner.invoke(video, ["t2v", "x"])
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_recorder.started) == 1
+    started_kwargs = fake_recorder.started[0]
+    assert started_kwargs["profile_name"] == "default"
+    assert started_kwargs["started"].media_id == "m1"
+    assert len(fake_recorder.completed) == 1
+    completed_kwargs = fake_recorder.completed[0]
+    assert completed_kwargs["result"] is stub_result
+    assert fake_recorder.closed is True

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -66,3 +66,63 @@ def test_t2v_rejects_invalid_aspect(tmp_path: Path) -> None:
     ):
         result = runner.invoke(video, ["t2v", "prompt", "--aspect", "4:3"])
     assert result.exit_code != 0
+
+
+def test_t2v_does_not_instantiate_ui_automation_transport_directly(tmp_path: Path) -> None:
+    """After Task 7, _run_t2v must go through FlowApiClient, not UiAutomationTransport directly.
+
+    We verify this by monkeypatching UiAutomationTransport.__init__ to blow up,
+    and patching FlowApiClient.generate_video to return a stub result. If the CLI
+    path still instantiates UiAutomationTransport directly, the test will fail.
+    """
+    from gflow_cli.api.video import VideoResult, VideoStatus
+
+    stub_result = VideoResult(
+        status=VideoStatus(media_id="test-uuid", status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+        local_path=tmp_path / "test-uuid.mp4",
+    )
+    (tmp_path / "test-uuid.mp4").touch()
+
+    runner = CliRunner()
+
+    def _sentinel_init(self: object, *args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "UiAutomationTransport.__init__ was called directly — "
+            "_run_t2v must route through FlowApiClient"
+        )
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch(
+            "gflow_cli.api.transports.ui_automation.UiAutomationTransport.__init__",
+            _sentinel_init,
+        ),
+        patch(
+            "gflow_cli.api.client.FlowApiClient.generate_video",
+            new_callable=AsyncMock,
+            return_value=stub_result,
+        ),
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aenter__",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_enter,
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aexit__",
+            new_callable=AsyncMock,
+        ),
+    ):
+        # Patch __aenter__ to return the client itself
+        from gflow_cli.api.client import FlowApiClient
+
+        mock_enter.return_value = FlowApiClient.__new__(FlowApiClient)
+        mock_enter.return_value.generate_video = AsyncMock(return_value=stub_result)
+        result = runner.invoke(video, ["t2v", "a golden sunset"])
+
+    # The sentinel must NOT have fired — exit_code 0 proves it (or at least no
+    # AssertionError from the sentinel).
+    assert "UiAutomationTransport.__init__ was called directly" not in (result.output or "")
+    # Exit code may be non-zero for other reasons (profile resolution, etc.) but
+    # the sentinel assertion must not appear.
+    assert result.exception is None or not isinstance(result.exception, AssertionError)

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -166,7 +166,13 @@ def test_t2v_records_started_then_completed(tmp_path: Path) -> None:
 
     async def fake_generate_video(*, req, out_dir, poll_timeout_s=None, download, on_started):
         if on_started is not None:
-            await on_started(VideoStarted(media_id="m1", project_id="p1", flow_operation_id="o1"))
+            import inspect
+
+            result_or_coro = on_started(
+                VideoStarted(media_id="m1", project_id="p1", flow_operation_id="o1")
+            )
+            if inspect.isawaitable(result_or_coro):
+                await result_or_coro
         return stub_result
 
     runner = CliRunner()

--- a/tests/data/test_packaging.py
+++ b/tests/data/test_packaging.py
@@ -1,0 +1,30 @@
+import subprocess
+import tarfile
+import zipfile
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+
+def test_migration_resource_is_discoverable() -> None:
+    migration = resources.files("gflow_cli.data.migrations").joinpath("0001_initial.sql")
+    assert migration.is_file()
+
+
+@pytest.mark.integration
+def test_built_distributions_contain_sql_migrations(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--sdist", "--out-dir", str(dist_dir)],
+        check=True,
+    )
+    wheel = next(dist_dir.glob("gflow_cli-*.whl"))
+    with zipfile.ZipFile(wheel) as archive:
+        assert "gflow_cli/data/migrations/0001_initial.sql" in archive.namelist()
+    sdist = next(dist_dir.glob("gflow_cli-*.tar.gz"))
+    with tarfile.open(sdist) as archive:
+        assert any(
+            name.endswith("src/gflow_cli/data/migrations/0001_initial.sql")
+            for name in archive.getnames()
+        )

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
+from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def test_record_upload_persists_project_asset_and_file(tmp_path: Path) -> None:
+    image_path = tmp_path / "seed.png"
+    image_path.write_bytes(b"png-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        project = ProjectInfo(project_id="flow-project-1", title="gflow-cli upload")
+        asset = AssetInfo(
+            name="media-upload-1",
+            project_id="flow-project-1",
+            workflow_id="workflow-upload-1",
+            display_name="seed.png",
+            width=640,
+            height=480,
+        )
+        recorder.record_upload_image(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=project,
+            asset=asset,
+            image_path=image_path,
+        )
+        found = recorder.repository.get_asset_by_flow_media_id("default", "media-upload-1")
+        assert found is not None
+        assert found.flow_project_id == "flow-project-1"
+        assert found.local_files[0].path == image_path.resolve()
+
+
+def test_record_generated_images_persists_generation_metadata(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="redacted")
+        project = ProjectInfo(project_id="flow-project-1", title="gflow-cli t2i")
+        image = GeneratedImage(
+            media_name="media-generated-1",
+            workflow_id="workflow-generated-1",
+            seed=123,
+            prompt="prompt text",
+            model_name_type="NARWHAL",
+            aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+            fife_url="https://flow-content.google/path?Signature=abc",
+            dimensions=(1024, 1792),
+            media_generation_id="generation-1",
+        )
+        req = GenerateImageRequest(
+            prompt="prompt text",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=project,
+            request=req,
+            images=[image],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        asset_row = store.conn.execute(
+            "SELECT flow_media_generation_id, metadata_json "
+            "FROM assets WHERE flow_media_id='media-generated-1'"
+        ).fetchone()
+        operation_row = store.conn.execute(
+            "SELECT prompt, prompt_hash, prompt_redacted FROM operations WHERE mode='t2i'"
+        ).fetchone()
+        assert operation_row["prompt"] is None
+        assert operation_row["prompt_hash"]
+        assert operation_row["prompt_redacted"] == 1
+        assert asset_row["flow_media_generation_id"] == "generation-1"
+        assert "Signature=abc" not in asset_row["metadata_json"]

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.api.video import Aspect as VideoAspect
+from gflow_cli.api.video import GenerateVideoRequest, Mode, VideoResult, VideoStarted, VideoStatus
 from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
@@ -78,3 +80,76 @@ def test_record_generated_images_persists_generation_metadata(tmp_path: Path) ->
         assert operation_row["prompt_redacted"] == 1
         assert asset_row["flow_media_generation_id"] == "generation-1"
         assert "Signature=abc" not in asset_row["metadata_json"]
+
+
+def test_record_started_video_persists_pending_media_and_operation(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="video prompt",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="operation-video-1",
+            ),
+        )
+        asset = recorder.repository.get_asset_by_flow_media_id("default", "media-video-1")
+        assert asset is not None
+        row = store.conn.execute(
+            "SELECT status, flow_operation_id FROM operations WHERE mode='t2v'"
+        ).fetchone()
+        assert row["status"] == "started"
+        assert row["flow_operation_id"] == "operation-video-1"
+
+
+def test_record_completed_video_updates_media_operation_and_file(tmp_path: Path) -> None:
+    saved = tmp_path / "video.mp4"
+    saved.write_bytes(b"video-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="video prompt",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="media-video-1",
+            ),
+        )
+        result = VideoResult(
+            status=VideoStatus(
+                media_id="media-video-1",
+                status="MEDIA_GENERATION_STATUS_SUCCESSFUL",
+            ),
+            local_path=saved,
+            project_id="flow-project-video-1",
+            flow_operation_id="media-video-1",
+        )
+        recorder.record_completed_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            result=result,
+        )
+        asset = recorder.repository.get_asset_by_flow_media_id("default", "media-video-1")
+        assert asset is not None
+        assert asset.flow_project_id == "flow-project-video-1"
+        assert asset.local_files[0].path == saved.resolve()
+        row = store.conn.execute(
+            "SELECT status, completed_at FROM operations WHERE mode='t2v'"
+        ).fetchone()
+        assert row["status"] == "succeeded"
+        assert row["completed_at"] is not None

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -140,7 +140,7 @@ def test_record_completed_video_updates_media_operation_and_file(tmp_path: Path)
         )
         recorder.record_completed_video(
             profile_name="default",
-            profile_dir=tmp_path / "profile_default",
+            _profile_dir=tmp_path / "profile_default",
             request=request,
             result=result,
         )

--- a/tests/data/test_redaction.py
+++ b/tests/data/test_redaction.py
@@ -1,0 +1,31 @@
+from gflow_cli.data.redaction import prompt_fields, redact_metadata
+
+
+def test_prompt_fields_store_mode_stores_text_and_hash() -> None:
+    fields = prompt_fields("hello", mode="store")
+    assert fields.prompt == "hello"
+    assert fields.prompt_hash is not None
+    assert fields.prompt_redacted is False
+
+
+def test_prompt_fields_redacted_mode_stores_hash_only() -> None:
+    fields = prompt_fields("hello", mode="redacted")
+    assert fields.prompt is None
+    assert fields.prompt_hash is not None
+    assert fields.prompt_redacted is True
+
+
+def test_redact_metadata_removes_signed_urls_and_tokens() -> None:
+    raw = {
+        "fifeUrl": "https://flow-content.google/path?Signature=abc",
+        "publicUrl": "https://example.com/public.png",
+        "clientContext": {"recaptchaContext": {"token": "secret"}},
+        "nested": [{"authorization": "Bearer abc"}],
+        "safe": "kept",
+    }
+    redacted = redact_metadata(raw)
+    assert redacted["fifeUrl"] == "<redacted:url>"
+    assert redacted["publicUrl"] == "https://example.com/public.png"
+    assert redacted["clientContext"]["recaptchaContext"]["token"] == "<redacted:token>"
+    assert redacted["nested"][0]["authorization"] == "<redacted:secret>"
+    assert redacted["safe"] == "kept"

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -184,3 +184,89 @@ def test_upsert_asset_natural_key_conflict_raises_data_integrity_error(tmp_path:
                     flow_media_id="media-1",
                 )
             )
+
+
+def test_resolve_seed_image_returns_project_media_and_path(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", tmp_path / "profile_default")
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        asset = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-local",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                flow_media_id="media-image-1",
+            )
+        )
+        image_path = tmp_path / "image.png"
+        image_path.write_bytes(b"image-bytes")
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-local",
+                profile_name="default",
+                asset_id=asset.id,
+                path=image_path,
+                media_type="image/png",
+                bytes=11,
+                sha256="b" * 64,
+            )
+        )
+        seed = repo.resolve_seed_image("default", "media-image-1")
+        assert seed is not None
+        assert seed.flow_project_id == "flow-project-1"
+        assert seed.flow_media_id == "media-image-1"
+        assert seed.local_path == image_path.resolve()
+
+
+def test_seed_read_api_resolves_by_path_latest_project_and_candidate(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", tmp_path / "profile_default")
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        image_path = tmp_path / "latest.png"
+        image_path.write_bytes(b"image-bytes")
+        asset = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-latest",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                flow_media_id="media-latest",
+            )
+        )
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-latest",
+                profile_name="default",
+                asset_id=asset.id,
+                path=image_path,
+                media_type="image/png",
+                bytes=11,
+                sha256=None,
+            )
+        )
+        by_path = repo.resolve_seed_image_by_path("default", image_path)
+        latest = repo.resolve_latest_image("default", None, None, None)
+        assert by_path is not None
+        assert latest is not None
+        assert by_path.flow_media_id == "media-latest"
+        assert latest.flow_media_id == "media-latest"
+        project_images = repo.list_project_images("default", "flow-project-1")
+        assert [item.flow_media_id for item in project_images] == ["media-latest"]
+        assert repo.candidate_image_exists("default", "media-latest") is True

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+)
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataIntegrityError
+
+
+def test_upserts_project_asset_operation_and_file(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="gflow-cli t2i",
+                source="generated",
+            )
+        )
+        asset = repo.upsert_asset(
+            AssetRecord(
+                id="asset-local",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                flow_media_id="media-1",
+                flow_workflow_id="workflow-1",
+                flow_media_generation_id="generation-1",
+                kind=AssetKind.IMAGE,
+                status="ready",
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                width=1024,
+                height=1792,
+                duration_seconds=None,
+                seed=123,
+                metadata_json={},
+            )
+        )
+        operation = repo.insert_operation(
+            OperationRecord(
+                id="operation-local",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                command="gflow image t2i",
+                mode=OperationKind.T2I,
+                status=OperationStatus.SUCCEEDED,
+                flow_operation_id=None,
+                flow_batch_id=None,
+                prompt="a prompt",
+                prompt_hash=None,
+                prompt_redacted=False,
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                error_type=None,
+                error_detail=None,
+            )
+        )
+        repo.link_operation_asset(operation.id, asset.id, OperationAssetRole.OUTPUT, 0)
+        repo.upsert_local_file(
+            LocalFileRecord(
+                id="file-local",
+                profile_name="default",
+                asset_id=asset.id,
+                path=tmp_path / "media-1.png",
+                media_type="image/png",
+                bytes=10,
+                sha256="a" * 64,
+            )
+        )
+
+        found = repo.get_asset_by_flow_media_id("default", "media-1")
+        assert found is not None
+        assert found.flow_project_id == "flow-project-1"
+        assert found.local_files[0].path == tmp_path / "media-1.png"
+
+
+def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        project = repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        asset_one = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-1",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                flow_media_id="media-1",
+            )
+        )
+        asset_two = repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-2",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                flow_media_id="media-2",
+            )
+        )
+        operation = repo.insert_operation(
+            OperationRecord.minimal(
+                id="operation-1",
+                profile_name="default",
+                flow_project_id=project.flow_project_id,
+                mode=OperationKind.I2I,
+            )
+        )
+        repo.link_operation_asset(operation.id, asset_one.id, OperationAssetRole.INPUT, 0)
+        with pytest.raises(DataIntegrityError):
+            repo.link_operation_asset(operation.id, asset_two.id, OperationAssetRole.INPUT, 0)

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -127,3 +127,60 @@ def test_operation_asset_position_is_unique(tmp_path: Path) -> None:
         repo.link_operation_asset(operation.id, asset_one.id, OperationAssetRole.INPUT, 0)
         with pytest.raises(DataIntegrityError):
             repo.link_operation_asset(operation.id, asset_two.id, OperationAssetRole.INPUT, 0)
+
+
+def test_upsert_project_natural_key_conflict_raises_data_integrity_error(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/default"))
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-a",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="A",
+                source="generated",
+            )
+        )
+        with pytest.raises(DataIntegrityError):
+            repo.upsert_project(
+                ProjectRecord(
+                    id="project-b",
+                    profile_name="default",
+                    flow_project_id="flow-project-1",
+                    title="B",
+                    source="generated",
+                )
+            )
+
+
+def test_upsert_asset_natural_key_conflict_raises_data_integrity_error(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/default"))
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-local",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                title="title",
+                source="generated",
+            )
+        )
+        repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-a",
+                profile_name="default",
+                flow_project_id="flow-project-1",
+                flow_media_id="media-1",
+            )
+        )
+        with pytest.raises(DataIntegrityError):
+            repo.upsert_asset(
+                AssetRecord.minimal_image(
+                    id="asset-b",
+                    profile_name="default",
+                    flow_project_id="flow-project-1",
+                    flow_media_id="media-1",
+                )
+            )

--- a/tests/data/test_settings_and_errors.py
+++ b/tests/data/test_settings_and_errors.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.config import Settings
+from gflow_cli.errors import (
+    EXIT_CODE_MAP,
+    DataIntegrityError,
+    DataMigrationError,
+    DataStoreError,
+    GFlowError,
+)
+from gflow_cli.paths import database_path
+
+
+def test_database_path_defaults_under_home(tmp_path: Path) -> None:
+    assert database_path(tmp_path) == tmp_path / "gflow.db"
+
+
+def test_settings_resolves_default_db_path(tmp_path: Path) -> None:
+    settings = Settings(home=tmp_path)
+    assert settings.resolved_db_path() == tmp_path / "gflow.db"
+
+
+def test_settings_respects_db_path_override(tmp_path: Path) -> None:
+    override = tmp_path / "custom.db"
+    settings = Settings(home=tmp_path, db_path=override)
+    assert settings.resolved_db_path() == override
+
+
+def test_settings_accepts_prompt_redaction_modes(tmp_path: Path) -> None:
+    assert Settings(home=tmp_path, history_prompts="store").history_prompts == "store"
+    assert Settings(home=tmp_path, history_prompts="redacted").history_prompts == "redacted"
+
+
+def test_data_errors_extend_gflow_error() -> None:
+    assert issubclass(DataStoreError, GFlowError)
+    assert issubclass(DataMigrationError, DataStoreError)
+    assert issubclass(DataIntegrityError, DataStoreError)
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [DataStoreError, DataMigrationError, DataIntegrityError],
+)
+def test_data_errors_use_exit_code_16(exc_type: type[DataStoreError]) -> None:
+    assert next(code for cls, code in EXIT_CODE_MAP.items() if issubclass(exc_type, cls)) == 16

--- a/tests/data/test_store_migrations.py
+++ b/tests/data/test_store_migrations.py
@@ -1,0 +1,101 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.store import (
+    DataStore,
+    _checksum_sql,
+    _iter_sql_statements,
+    _normalize_sql_for_checksum,
+)
+from gflow_cli.errors import DataMigrationError
+
+
+def test_normalize_sql_for_checksum_trims_line_endings() -> None:
+    assert _normalize_sql_for_checksum("CREATE TABLE x(id);\r\n  \r\n") == "CREATE TABLE x(id);"
+
+
+def test_checksum_sql_uses_sha256() -> None:
+    checksum = _checksum_sql("CREATE TABLE x(id);\n")
+    assert len(checksum) == 64
+    assert checksum == _checksum_sql("CREATE TABLE x(id);\r\n")
+
+
+def test_open_creates_schema_and_migration_row(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with DataStore.open(db) as store:
+        rows = store.conn.execute("SELECT version FROM schema_migrations").fetchall()
+        assert [row["version"] for row in rows] == ["0001"]
+        assert store.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert store.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+        assert store.conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+
+def test_newer_schema_raises(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE schema_migrations(version TEXT PRIMARY KEY, filename TEXT, "
+            "checksum TEXT, applied_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, filename, checksum, applied_at) "
+            "VALUES ('9999', '9999_future.sql', 'abc', '2026-05-24T00:00:00Z')"
+        )
+    with pytest.raises(DataMigrationError, match="newer"):
+        DataStore.open(db)
+
+
+def test_checksum_drift_raises(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with DataStore.open(db):
+        pass
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE schema_migrations SET checksum='bad' WHERE version='0001'")
+    with pytest.raises(DataMigrationError, match="checksum"):
+        DataStore.open(db)
+
+
+def test_foreign_keys_reject_orphan_rows(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with pytest.raises(sqlite3.IntegrityError):
+            store.conn.execute(
+                "INSERT INTO local_files(id, profile_name, asset_id, path, media_type, created_at) "
+                "VALUES ('file-1', 'default', 'missing', 'C:/missing.png', "
+                "'image/png', '2026-05-24T00:00:00Z')"
+            )
+
+
+def test_transaction_uses_begin_immediate_for_writes(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with store.transaction(immediate=True):
+            store.conn.execute(
+                "INSERT INTO profiles(name, profile_dir, first_seen_at, last_used_at) "
+                "VALUES ('default', 'C:/profiles/default', '2026-05-24T00:00:00Z', "
+                "'2026-05-24T00:00:00Z')"
+            )
+        row = store.conn.execute("SELECT name FROM profiles").fetchone()
+        assert row["name"] == "default"
+
+
+def test_migration_statement_batch_rolls_back_on_failure(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        with pytest.raises(sqlite3.Error):
+            with store.transaction(immediate=True):
+                for statement in _iter_sql_statements(
+                    "CREATE TABLE rollback_probe(id INTEGER); "
+                    "INSERT INTO missing_table(id) VALUES (1);"
+                ):
+                    store.conn.execute(statement)
+        row = store.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_probe'"
+        ).fetchone()
+        assert row is None
+
+
+def test_iter_sql_statements_preserves_semicolon_inside_string_literal() -> None:
+    statements = list(
+        _iter_sql_statements("CREATE TABLE x(v TEXT); INSERT INTO x(v) VALUES ('a;b');")
+    )
+    assert statements == ["CREATE TABLE x(v TEXT)", "INSERT INTO x(v) VALUES ('a;b')"]

--- a/tests/data/test_store_migrations.py
+++ b/tests/data/test_store_migrations.py
@@ -99,3 +99,16 @@ def test_iter_sql_statements_preserves_semicolon_inside_string_literal() -> None
         _iter_sql_statements("CREATE TABLE x(v TEXT); INSERT INTO x(v) VALUES ('a;b');")
     )
     assert statements == ["CREATE TABLE x(v TEXT)", "INSERT INTO x(v) VALUES ('a;b')"]
+
+
+def test_open_wraps_oserror_into_datastoreerror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gflow_cli.errors import DataStoreError
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    with pytest.raises(DataStoreError):
+        DataStore.open(tmp_path / "gflow.db")

--- a/tests/e2e/test_data_layer_e2e.py
+++ b/tests/e2e/test_data_layer_e2e.py
@@ -1,0 +1,439 @@
+"""Live E2E for the SQLite data layer.
+
+Drives `gflow image t2i` and `gflow video t2v` end-to-end via subprocess
+against a real Pro/Ultra Google Flow account, then asserts the
+``OperationRecorder`` actually persisted:
+
+  - the active ``profile`` row
+  - the Flow ``project`` row (source=generated)
+  - the Flow ``asset`` row (image / video, kind + dimensions + media IDs)
+  - the ``operation`` row (t2i / t2v, status=succeeded, prompt fields)
+  - the ``operation_assets`` link (output, position 0)
+  - the ``local_files`` row (resolved absolute path, sha256, bytes)
+
+Also drives ``gflow data media <media_id>`` and asserts the persisted row
+round-trips through the read CLI.
+
+Spec: ``docs/superpowers/specs/2026-05-24-data-layer-design.md``
+Plan: ``docs/superpowers/plans/2026-05-24-data-layer.md``
+Doc:  ``docs/DATA_LAYER.md``
+
+# Opt-in gates
+
+  - ``GFLOW_CLI_E2E_PROFILE``    master gate; Chrome-strategy profile name
+  - ``GFLOW_CLI_E2E_RUN_VIDEO``  default "1"; set to "0" to skip the Veo step
+                                  (only spends an Imagen credit then)
+
+# Spending
+
+  - t2i: ~1 Imagen credit
+  - t2v: 1 Veo credit (omni-flash, 4s, count=1 — cheapest configuration)
+
+Per the project's 5-layer verification ledger ([[verification-ledger-5-layer]])
+plus a 6th layer: data-layer row presence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+_E2E_RUN_VIDEO_ENV = "GFLOW_CLI_E2E_RUN_VIDEO"
+
+_IMAGE_PROMPT = "a single red apple on a wooden table, soft daylight"
+_VIDEO_PROMPT = "a single red apple on a wooden table, soft daylight"
+
+# Generous because real Flow latency: image ~30-60s; video ~60-180s.
+_IMAGE_TIMEOUT_S = 240
+_VIDEO_TIMEOUT_S = 600
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _profile_name() -> str:
+    name = os.environ.get(_E2E_PROFILE_ENV, "").strip()
+    if not name:
+        pytest.skip(
+            f"E2E data-layer test requires {_E2E_PROFILE_ENV} — "
+            "set it to a logged-in Chromium profile name and re-run with -m e2e"
+        )
+    return name
+
+
+def _run_video_enabled() -> bool:
+    return os.environ.get(_E2E_RUN_VIDEO_ENV, "1").strip() != "0"
+
+
+def _run_gflow(
+    args: list[str], env: dict[str, str], timeout: float
+) -> subprocess.CompletedProcess[str]:
+    """Run ``gflow`` in a subprocess and capture stdout/stderr/exit-code."""
+    cmd = [sys.executable, "-m", "gflow_cli", *args]
+    return subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+@pytest.fixture
+def e2e_env(tmp_path: Path) -> Iterator[dict[str, str]]:
+    """Build an isolated subprocess env: tmp DB + tmp output dir + active profile."""
+    profile = _profile_name()
+    db = tmp_path / "gflow.db"
+    out = tmp_path / "out"
+    out.mkdir()
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    env["GFLOW_CLI_DB_PATH"] = str(db)
+    env["GFLOW_CLI_OUTPUT_DIR"] = str(out)
+    env["GFLOW_CLI_PROFILE"] = profile
+    env["GFLOW_CLI_HISTORY_PROMPTS"] = "store"  # keep full prompt for assertion
+    yield env
+
+
+def _open_db(env: dict[str, str]) -> sqlite3.Connection:
+    db_path = Path(env["GFLOW_CLI_DB_PATH"])
+    assert db_path.exists(), f"data layer never wrote to {db_path}"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _image_magic(path: Path) -> str | None:
+    head = path.read_bytes()[:12]
+    if head.startswith(b"\x89PNG"):
+        return "png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "jpeg"
+    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def _is_mp4(path: Path) -> bool:
+    # ISO BMFF container; bytes 4..8 are 'ftyp' for valid mp4/mov.
+    return path.read_bytes()[4:8] == b"ftyp"
+
+
+# ---------------------------------------------------------------------------
+# t2i: image generation records every layer
+# ---------------------------------------------------------------------------
+
+
+def test_t2i_records_full_provenance(e2e_env: dict[str, str]) -> None:
+    """Live t2i: ~1 Imagen credit. Asserts file lands AND DB carries the full
+    profile→project→asset→operation→operation_assets→local_files chain."""
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    out_dir = Path(e2e_env["GFLOW_CLI_OUTPUT_DIR"])
+
+    result = _run_gflow(
+        ["image", "t2i", _IMAGE_PROMPT, "--aspect", "1:1", "--profile", profile],
+        env=e2e_env,
+        timeout=_IMAGE_TIMEOUT_S,
+    )
+
+    assert result.returncode == 0, (
+        f"gflow image t2i exited {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    # ---- 5-layer file ledger ----
+    images = [
+        p
+        for p in sorted(out_dir.rglob("*"))
+        if p.is_file() and p.suffix.lower() in (".png", ".jpg", ".jpeg", ".webp")
+    ]
+    assert len(images) >= 1, f"no image files landed in {out_dir}"
+    image = images[0]
+    assert image.stat().st_size > 1024, f"suspiciously small image: {image.stat().st_size} bytes"
+    assert _image_magic(image) is not None, f"bad magic bytes: {image.read_bytes()[:12]!r}"
+
+    # Pillow check (dimensions are a strong "real image" signal).
+    from PIL import Image
+
+    with Image.open(image) as im:
+        width, height = im.size
+        assert width > 0 and height > 0, f"zero-dimension image: {im.size}"
+        # 1:1 aspect — allow ±2% slack for H.264-style alignment.
+        ratio = width / height
+        assert abs(ratio - 1.0) <= 0.02, f"aspect mismatch on 1:1: {im.size}"
+
+    # ---- data-layer row ledger ----
+    conn = _open_db(e2e_env)
+    try:
+        # profile
+        profile_rows = conn.execute("SELECT name FROM profiles").fetchall()
+        assert profile in [r["name"] for r in profile_rows], (
+            f"profile {profile!r} not persisted; rows: {[dict(r) for r in profile_rows]}"
+        )
+
+        # operation: exactly one t2i operation, succeeded, prompt persisted
+        op_rows = conn.execute(
+            "SELECT mode, status, prompt, prompt_hash, prompt_redacted, model, aspect_ratio, "
+            "started_at, completed_at FROM operations WHERE mode='t2i'"
+        ).fetchall()
+        assert len(op_rows) == 1, f"expected 1 t2i operation, got {len(op_rows)}"
+        op = op_rows[0]
+        assert op["status"] == "succeeded", f"expected status=succeeded, got {op['status']!r}"
+        assert op["prompt"] == _IMAGE_PROMPT, (
+            f"prompt round-trip failed: persisted={op['prompt']!r} expected={_IMAGE_PROMPT!r}"
+        )
+        assert op["prompt_hash"] and len(op["prompt_hash"]) == 64, (
+            f"prompt_hash should be SHA-256 hex (64 chars), got {op['prompt_hash']!r}"
+        )
+        assert op["prompt_redacted"] == 0, "store mode must keep prompt_redacted=0"
+        assert op["started_at"] is not None and op["completed_at"] is not None
+
+        # asset: at least one image asset with a Flow media ID
+        asset_rows = conn.execute(
+            "SELECT id, flow_media_id, flow_project_id, kind, status, width, height "
+            "FROM assets WHERE kind='image'"
+        ).fetchall()
+        assert len(asset_rows) >= 1, "no image asset row persisted"
+        asset = asset_rows[0]
+        assert asset["flow_media_id"], f"asset has empty flow_media_id: {dict(asset)}"
+        assert asset["flow_project_id"], (
+            f"asset has empty flow_project_id (would break I2V seed resolution): {dict(asset)}"
+        )
+
+        # project: source='generated' for t2i
+        project_rows = conn.execute("SELECT flow_project_id, source FROM projects").fetchall()
+        assert any(p["source"] == "generated" for p in project_rows), (
+            f"no generated project persisted: {[dict(p) for p in project_rows]}"
+        )
+
+        # operation_assets: link as output position 0
+        link_rows = conn.execute("SELECT role, position FROM operation_assets").fetchall()
+        assert any(r["role"] == "output" and r["position"] == 0 for r in link_rows), (
+            f"no output position-0 link persisted: {[dict(r) for r in link_rows]}"
+        )
+
+        # local_files: resolved absolute path, sha256, bytes
+        file_rows = conn.execute(
+            "SELECT path, sha256, bytes, media_type FROM local_files"
+        ).fetchall()
+        assert len(file_rows) >= 1, "no local_files row persisted"
+        file_row = file_rows[0]
+        assert Path(file_row["path"]).is_absolute(), (
+            f"local_files.path must be absolute: {file_row['path']}"
+        )
+        assert file_row["sha256"] and len(file_row["sha256"]) == 64, (
+            f"sha256 should be hex (64 chars): {file_row['sha256']!r}"
+        )
+        assert file_row["bytes"] and file_row["bytes"] > 1024, (
+            f"local_files.bytes too small: {file_row['bytes']}"
+        )
+
+        flow_media_id = asset["flow_media_id"]
+    finally:
+        conn.close()
+
+    # ---- read CLI round-trip ----
+    lookup = _run_gflow(
+        ["data", "media", flow_media_id, "--profile", profile],
+        env=e2e_env,
+        timeout=30,
+    )
+    assert lookup.returncode == 0, (
+        f"gflow data media exited {lookup.returncode}\n"
+        f"STDOUT:\n{lookup.stdout}\nSTDERR:\n{lookup.stderr}"
+    )
+    assert flow_media_id in lookup.stdout, (
+        f"flow_media_id {flow_media_id!r} not in CLI output:\n{lookup.stdout}"
+    )
+    assert "image" in lookup.stdout, f"kind 'image' not in CLI output:\n{lookup.stdout}"
+
+
+# ---------------------------------------------------------------------------
+# t2v: video generation records started + completed lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_t2v_records_started_and_completed_lifecycle(e2e_env: dict[str, str]) -> None:
+    """Live t2v: 1 Veo credit (omni-flash, 4s, count=1). Asserts video lands
+    AND DB shows the operation went through started → succeeded plus a
+    video-kind asset and a local_files row.
+
+    Skipped when ``GFLOW_CLI_E2E_RUN_VIDEO=0`` (cost-control)."""
+    if not _run_video_enabled():
+        pytest.skip(f"{_E2E_RUN_VIDEO_ENV}=0 — skipping live Veo run")
+
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    out_dir = Path(e2e_env["GFLOW_CLI_OUTPUT_DIR"])
+
+    # gflow video t2v does NOT honor GFLOW_CLI_OUTPUT_DIR (defaults to ./tmp);
+    # pass --out-dir explicitly so the test's tmp_path captures the mp4.
+    result = _run_gflow(
+        [
+            "video",
+            "t2v",
+            _VIDEO_PROMPT,
+            "--aspect",
+            "16:9",
+            "--model",
+            "omni-flash",
+            "--duration",
+            "4",
+            "--count",
+            "1",
+            "--profile",
+            profile,
+            "--out-dir",
+            str(out_dir),
+        ],
+        env=e2e_env,
+        timeout=_VIDEO_TIMEOUT_S,
+    )
+
+    assert result.returncode == 0, (
+        f"gflow video t2v exited {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    # ---- file ledger ----
+    videos = [p for p in sorted(out_dir.rglob("*")) if p.is_file() and p.suffix.lower() == ".mp4"]
+    assert len(videos) >= 1, f"no .mp4 files landed in {out_dir}"
+    video = videos[0]
+    assert video.stat().st_size > 100 * 1024, (
+        f"suspiciously small video: {video.stat().st_size} bytes"
+    )
+    assert _is_mp4(video), f"bad mp4 magic bytes: {video.read_bytes()[:12]!r}"
+
+    # ---- data-layer row ledger ----
+    conn = _open_db(e2e_env)
+    try:
+        # asset FIRST so we can cross-check flow_operation_id below.
+        asset_rows = conn.execute(
+            "SELECT flow_media_id, flow_project_id, kind, status FROM assets WHERE kind='video'"
+        ).fetchall()
+        assert len(asset_rows) == 1, (
+            f"expected exactly 1 video asset, got {[dict(r) for r in asset_rows]}"
+        )
+        asset = asset_rows[0]
+
+        # operation: t2v, terminal status, prompt + completed_at populated
+        op_rows = conn.execute(
+            "SELECT id, status, completed_at, prompt, prompt_hash, "
+            "flow_operation_id FROM operations WHERE mode='t2v'"
+        ).fetchall()
+        assert len(op_rows) >= 1, "no t2v operation persisted"
+        # We expect exactly one row in v1 — record_completed_video updates the
+        # pending row via update_operation_status, it does not insert a second.
+        terminal = [r for r in op_rows if r["status"] == "succeeded"]
+        assert len(terminal) == 1, (
+            f"expected exactly 1 succeeded t2v operation, got {[dict(r) for r in op_rows]}"
+        )
+        op = terminal[0]
+        assert op["prompt"] == _VIDEO_PROMPT
+        assert op["prompt_hash"] and len(op["prompt_hash"]) == 64
+        assert op["completed_at"] is not None
+        # flow_operation_id is opportunistic — Flow's omni-flash response does
+        # not always carry operations[0].operation.name. Spec: store SEPARATELY
+        # from flow_media_id when present. If present, it currently equals
+        # flow_media_id (observation; subject to Flow API drift).
+        if op["flow_operation_id"]:
+            assert op["flow_operation_id"] == asset["flow_media_id"], (
+                "When flow_operation_id is present, current Flow API surfaces "
+                f"it as the media id; got op={op['flow_operation_id']!r}, "
+                f"media={asset['flow_media_id']!r}"
+            )
+        assert asset["flow_media_id"], "video asset has empty flow_media_id"
+        assert asset["flow_project_id"], "video asset has empty flow_project_id"
+        assert "SUCCESSFUL" in (asset["status"] or "").upper(), (
+            f"video asset status not terminal SUCCESSFUL: {asset['status']!r}"
+        )
+
+        # local_files: at least one row for the video
+        file_rows = conn.execute(
+            "SELECT path, bytes FROM local_files WHERE path LIKE '%.mp4'"
+        ).fetchall()
+        assert len(file_rows) >= 1, "no video local_files row persisted"
+
+        flow_media_id = asset["flow_media_id"]
+    finally:
+        conn.close()
+
+    # ---- read CLI round-trip ----
+    lookup = _run_gflow(
+        ["data", "media", flow_media_id, "--profile", profile],
+        env=e2e_env,
+        timeout=30,
+    )
+    assert lookup.returncode == 0, (
+        f"gflow data media exited {lookup.returncode}\n"
+        f"STDOUT:\n{lookup.stdout}\nSTDERR:\n{lookup.stderr}"
+    )
+    assert flow_media_id in lookup.stdout
+    assert "video" in lookup.stdout
+
+
+# ---------------------------------------------------------------------------
+# data CLI: not-found path
+# ---------------------------------------------------------------------------
+
+
+def test_data_media_unknown_id_exits_non_zero(e2e_env: dict[str, str]) -> None:
+    """Sanity: an unknown media ID against a freshly-created DB exits non-zero
+    via DataStoreError (exit 16). This does NOT spend credits."""
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    # Touch the DB so it exists (open + migrate happens on first command).
+    _run_gflow(["data", "media", "ignored", "--profile", profile], env=e2e_env, timeout=30)
+    # Now query for a media ID we KNOW isn't there.
+    result = _run_gflow(
+        ["data", "media", "does-not-exist", "--profile", profile],
+        env=e2e_env,
+        timeout=30,
+    )
+    assert result.returncode != 0, (
+        f"expected non-zero for unknown media ID, got 0\nSTDOUT:\n{result.stdout}"
+    )
+    assert result.returncode == 16, f"expected exit 16 (DataStoreError), got {result.returncode}"
+
+
+# ---------------------------------------------------------------------------
+# Evidence dump — call from a single test to write a JSON snapshot for the
+# LIVE_VERIFICATION_data_layer.md doc.
+# ---------------------------------------------------------------------------
+
+
+def dump_db_evidence(db_path: Path, dest: Path) -> None:
+    """Snapshot every data-layer table from ``db_path`` to ``dest`` (JSON).
+
+    Helper used to capture verification evidence after a live run — call from
+    the shell with the post-run DB path produced by pytest --basetemp.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        snapshot: dict[str, object] = {}
+        for tbl in (
+            "profiles",
+            "projects",
+            "assets",
+            "operations",
+            "operation_assets",
+            "local_files",
+            "schema_migrations",
+        ):
+            rows = [dict(r) for r in conn.execute(f"SELECT * FROM {tbl}").fetchall()]
+            snapshot[tbl] = rows
+        dest.write_text(json.dumps(snapshot, indent=2, default=str), encoding="utf-8")
+    finally:
+        conn.close()

--- a/tests/features/test_image_steps.py
+++ b/tests/features/test_image_steps.py
@@ -75,6 +75,7 @@ def _make_fake_t2i(file_count: int):
 
     async def _fake_t2i(
         *,
+        profile_name: str,
         profile_dir: Path,
         headless: bool,
         req: Any,

--- a/tests/image_batch/test_image_manifest.py
+++ b/tests/image_batch/test_image_manifest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from gflow_cli.errors import ConfigurationError
+from gflow_cli.errors import BatchPartialError, ConfigurationError
 from gflow_cli.image_batch import (
     MAX_BATCH_PROMPTS,
     BatchPromptItem,
@@ -16,6 +16,33 @@ from gflow_cli.image_batch import (
     parse_tsv_manifest,
     run_manifest_image_batch,
 )
+
+# ---------------------------------------------------------------------------
+# FakeRecorder shared by recorder-integration tests
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.generated: list[dict] = []
+        self.uploads: list[dict] = []
+        self.closed = False
+        self.fail_index: int | None = None  # if set, raise DataStoreError on that 0-based call
+
+    def close(self) -> None:
+        self.closed = True
+
+    def record_upload_image(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.uploads.append(kwargs)
+
+    def record_generated_images(self, **kwargs):  # type: ignore[no-untyped-def]
+        idx = len(self.generated)
+        self.generated.append(kwargs)
+        if self.fail_index is not None and idx == self.fail_index:
+            from gflow_cli.errors import DataStoreError
+
+            raise DataStoreError(detail="boom", route="test")
+
 
 # ---------------------------------------------------------------------------
 # TSV parsing
@@ -382,3 +409,197 @@ def test_manifest_dispatcher_raises_on_invalid_fixture() -> None:
     assert fixture.is_file(), "fixture must be committed"
     with pytest.raises(ConfigurationError):
         parse_manifest_file(fixture)
+
+
+# ---------------------------------------------------------------------------
+# OperationRecorder integration tests for run_manifest_image_batch
+# ---------------------------------------------------------------------------
+
+
+def _make_recorder_batch_factory(
+    *,
+    project_id: str = "flow-project-batch",
+    n_rows: int = 2,
+    fail_download_on_idx: int | None = None,
+) -> type:
+    """Build a client factory for recorder-integration tests.
+
+    ``fail_download_on_idx``: if set, ``download_image`` raises on that row index
+    to exercise the partial-results + recorder path.
+    """
+    from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
+    from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+
+    fake_image = GeneratedImage(
+        media_name="m1",
+        workflow_id="wf1",
+        seed=1,
+        prompt="p",
+        model_name_type="NARWHAL",
+        aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+        fife_url="https://example.com/img.png",
+        dimensions=(64, 64),
+    )
+
+    class _FakeTransport(UiAutomationTransport):
+        def __init__(self) -> None:
+            pass
+
+    class _FakeClient:
+        def __init__(self, **_: object) -> None:
+            transport_instance = _FakeTransport()
+            _n = n_rows
+
+            async def _batch_impl(prompts, jitter_range, continue_on_error=False):  # type: ignore[no-untyped-def]
+                results = []
+                for idx, req in enumerate(prompts):
+                    results.append(
+                        BatchSubmissionResult(
+                            status="ok",
+                            project_id=project_id,
+                            prompt_idx=idx,
+                            prompt_hash="aabbccdd",
+                            images=(fake_image,) * req.count,
+                        )
+                    )
+                return results
+
+            transport_instance.generate_images_batch = _batch_impl  # type: ignore[method-assign]
+            self.transport = transport_instance
+            self._download_call_idx = 0
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            pass
+
+        async def download_image(self, img: object, target: Path) -> Path:
+            idx = self._download_call_idx
+            self._download_call_idx += 1
+            if fail_download_on_idx is not None and idx == fail_download_on_idx:
+                raise RuntimeError(f"simulated download failure at idx {idx}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"PNG")
+            return target
+
+    return _FakeClient
+
+
+class TestRunManifestImageBatchRecorder:
+    @pytest.mark.asyncio
+    async def test_run_manifest_image_batch_records_each_row(self, tmp_path: Path) -> None:
+        """Recorder receives one entry per ok row with correct fields."""
+        recorder = FakeRecorder()
+        factory = _make_recorder_batch_factory(project_id="flow-project-batch", n_rows=2)
+        items = _make_items(2)
+
+        await run_manifest_image_batch(
+            profile_dir=tmp_path,
+            headless=True,
+            transport=None,
+            prompts=items,
+            output_dir=tmp_path / "out",
+            continue_on_error=True,
+            jitter_range=(0.0, 0.0),
+            client_factory=factory,
+            profile_name="default",
+            recorder=recorder,
+        )
+
+        assert len(recorder.generated) == 2
+        for rec in recorder.generated:
+            assert rec["profile_name"] == "default"
+            assert rec["operation_kind"] == "t2i"
+            assert rec["input_media_ids"] == []
+            assert rec["project"].project_id == "flow-project-batch"
+            assert rec["project"].title == "gflow-cli image batch"
+
+    @pytest.mark.asyncio
+    async def test_run_manifest_image_batch_records_partial_results_before_re_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """Row 0 is recorded before BatchPartialError is re-raised on row 1 download failure."""
+
+        # Make transport return 2 ok results, but download fails on idx 1 (row 1's image)
+        recorder = FakeRecorder()
+        items = _make_items(2)
+
+        # The batch raises BatchPartialError because download fails mid-way.
+        # We need to make the transport itself raise BatchPartialError with partial results.
+        # Since our factory raises RuntimeError on download, we need a different approach:
+        # patch _download_results to simulate the BatchPartialError path.
+
+        # Actually: the fail_download_on_idx raises RuntimeError inside _download_results,
+        # which is NOT caught as BatchPartialError — that path is only for transport failures.
+        # For this test, we simulate a transport-level BatchPartialError.
+
+        from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
+        from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+
+        fake_image = GeneratedImage(
+            media_name="m1",
+            workflow_id="wf1",
+            seed=1,
+            prompt="p",
+            model_name_type="NARWHAL",
+            aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+            fife_url="https://example.com/img.png",
+            dimensions=(64, 64),
+        )
+
+        ok_result = BatchSubmissionResult(
+            status="ok",
+            project_id="flow-project-batch",
+            prompt_idx=0,
+            prompt_hash="aabbccdd",
+            images=(fake_image,),
+        )
+
+        class _FakeTransport(UiAutomationTransport):
+            def __init__(self) -> None:
+                pass
+
+        class _PartialClient:
+            def __init__(self, **_: object) -> None:
+                transport_instance = _FakeTransport()
+
+                async def _batch_impl(prompts, jitter_range, continue_on_error=False):  # type: ignore[no-untyped-def]
+                    raise BatchPartialError(
+                        detail="fail-fast",
+                        route="test",
+                        partial_results=(ok_result,),
+                    )
+
+                transport_instance.generate_images_batch = _batch_impl  # type: ignore[method-assign]
+                self.transport = transport_instance
+
+            async def __aenter__(self) -> _PartialClient:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            async def download_image(self, img: object, target: Path) -> Path:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(b"PNG")
+                return target
+
+        with pytest.raises(BatchPartialError):
+            await run_manifest_image_batch(
+                profile_dir=tmp_path,
+                headless=True,
+                transport=None,
+                prompts=items,
+                output_dir=tmp_path / "out",
+                continue_on_error=False,
+                jitter_range=(0.0, 0.0),
+                client_factory=_PartialClient,
+                profile_name="default",
+                recorder=recorder,
+            )
+
+        # Recorder must have captured the salvaged row before re-raise
+        assert len(recorder.generated) == 1
+        assert recorder.generated[0]["profile_name"] == "default"
+        assert recorder.generated[0]["project"].project_id == "flow-project-batch"

--- a/tests/image_batch/test_observability_events.py
+++ b/tests/image_batch/test_observability_events.py
@@ -16,6 +16,32 @@ from structlog.testing import LogCapture
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.image_batch import BatchPromptItem, run_manifest_image_batch
 
+# ---------------------------------------------------------------------------
+# FakeRecorder for recorder-observability tests
+# ---------------------------------------------------------------------------
+
+
+class FakeRecorder:
+    def __init__(self) -> None:
+        self.generated: list[dict] = []
+        self.uploads: list[dict] = []
+        self.closed = False
+        self.fail_index: int | None = None  # if set, raise DataStoreError on that 0-based call
+
+    def close(self) -> None:
+        self.closed = True
+
+    def record_upload_image(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.uploads.append(kwargs)
+
+    def record_generated_images(self, **kwargs):  # type: ignore[no-untyped-def]
+        idx = len(self.generated)
+        self.generated.append(kwargs)
+        if self.fail_index is not None and idx == self.fail_index:
+            from gflow_cli.errors import DataStoreError
+
+            raise DataStoreError(detail="boom", route="test")
+
 
 def _make_fake_image() -> object:
     from gflow_cli.api.dto import GeneratedImage
@@ -183,3 +209,55 @@ async def test_emits_row_completed_per_row(
     assert "sha256_prefix" in completed[0]
     assert "prompt_hash" in completed[0]
     assert "project_id" in completed[0]
+
+
+@pytest.mark.asyncio
+async def test_recorder_persistence_failure_emits_event_and_continues(
+    tmp_path: Path,
+    install_log_capture: LogCapture,
+) -> None:
+    """DataStoreError on row 0 record emits data.persistence_failed_after_success,
+    does NOT stop row 1 from being recorded, and both files are saved on disk."""
+    recorder = FakeRecorder()
+    recorder.fail_index = 0  # row 0 recorder call raises DataStoreError
+
+    prompts = (
+        BatchPromptItem(
+            text="cat", count=1, aspect_ratio="1:1", model="nano2", output_filename="p0", index=0
+        ),
+        BatchPromptItem(
+            text="dog", count=1, aspect_ratio="1:1", model="nano2", output_filename="p1", index=1
+        ),
+    )
+    out_dir = tmp_path / "out"
+
+    await run_manifest_image_batch(
+        profile_dir=tmp_path,
+        headless=True,
+        transport=None,
+        prompts=prompts,
+        output_dir=out_dir,
+        continue_on_error=True,
+        jitter_range=(0.0, 0.0),
+        client_factory=_make_client_factory(project_id="flow-project-batch"),
+        profile_name="default",
+        recorder=recorder,
+    )
+
+    # structlog stream must contain a persistence_failed_after_success event for row 0
+    warn_events = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "data.persistence_failed_after_success"
+    ]
+    assert len(warn_events) >= 1, f"Expected warning event, got: {install_log_capture.entries}"
+
+    # Row 1 must still be recorded despite row 0 failure
+    assert len(recorder.generated) == 2, (
+        f"Expected 2 recorder entries (row 0 fails but is still appended, row 1 succeeds), "
+        f"got {len(recorder.generated)}"
+    )
+
+    # Both files must exist on disk
+    saved_files = list(out_dir.rglob("*.png"))
+    assert len(saved_files) == 2, f"Expected 2 saved files, got {saved_files}"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -163,8 +163,8 @@ def test_exit_code_map_ordering_invariant():
     seen: list[type] = []
     for cls in EXIT_CODE_MAP:
         for prior in seen:
-            assert not issubclass(prior, cls), (
-                f"{prior.__name__} is a subclass of {cls.__name__} but appears AFTER it; "
+            assert not issubclass(cls, prior), (
+                f"{cls.__name__} is a subclass of {prior.__name__} but appears AFTER it; "
                 f"swap their order in EXIT_CODE_MAP."
             )
         seen.append(cls)


### PR DESCRIPTION
## Summary

Implements the SQLite-backed local data layer from the spec in PR #52. Records every new image, batch, and T2V operation with full provenance, exposes a read-only `gflow data media <id>` lookup, and normalizes T2V behind `FlowApiClient.generate_video` so image and video share one client boundary.

**Stacked on #52** (docs/spec-data-layer). Retarget to `develop` after #52 merges.

## What changed

- **`gflow_cli.data` module** — `DataStore` (SQLite + migrations + WAL/FK/busy_timeout PRAGMAs), `DataRepository` (typed upserts + seed queries), `OperationRecorder` (high-level facade), `redaction.py` (prompt hashing + signed-URL/token stripping).
- **Schema v1** in `migrations/0001_initial.sql` — `profiles`, `projects`, `assets`, `operations`, `operation_assets`, `local_files`, plus 9 indexes. Migration runner uses SHA-256 checksums via `importlib.resources`.
- **Error taxonomy** — `DataStoreError` / `DataMigrationError` / `DataIntegrityError`, exit code 16. Re-exported through `gflow_cli.exceptions`.
- **CLI recording wired into** `cli_image.py` (upload, t2i, i2i), `image_batch.py` (per-row + salvage path), `cli_video.py` (started + completed via `on_started` callback).
- **T2V client-boundary refactor** — `FlowApiClient.generate_video` + `VideoCapableTransport` Protocol. `cli_video.py` no longer constructs `UiAutomationTransport` directly. `VideoResult` now carries `project_id` + `flow_operation_id`.
- **Read-only CLI** — `gflow data media <media_id> [--profile <name>]`.
- **Packaging** — `pyproject.toml` `force-include` for SQL migrations in wheel + sdist; packaging test verifies via `importlib.resources` (with `@pytest.mark.integration` build-inspection test).
- **Docs** — CONFIGURATION (new env vars), USAGE (new command + exit 16 + recovery), SECURITY (storage + redaction), ARCHITECTURE (new module + T2V boundary), PLAN (Phase 6 → implemented).

## Persistence-failure handling

- **Pre-Flow failures** (DB open, migration, checksum drift, newer schema) → fail fast with exit code 16.
- **Post-success failures** (generation completed, file downloaded, but `INSERT` failed) → emit `data.persistence_failed_after_success` structlog event with `flow_media_id` and local path; command still exits 0.
- One row's persistence failure in a batch does NOT stop later rows from being recorded.

## Test plan

- [x] 197 focused tests pass (`tests/data tests/cli/test_cli_data.py tests/cli/test_cli_image.py tests/cli/test_cli_video.py tests/api/test_client.py tests/api/test_video.py tests/api/transports/test_common.py tests/api/transports/test_ui_automation_video.py`)
- [x] `ruff check src tests` clean
- [x] `ruff format --check src tests` clean (119 files)
- [x] `pyright src` clean (0 errors)
- [x] `scripts/ci/check_repo_hygiene.py` passes (274 files)
- [ ] CI full sweep with coverage
- [ ] SonarCloud quality gate
- [ ] Live `gflow image t2i` against a real profile creates a row in `~/.gflow/gflow.db`
- [ ] Live `gflow video t2v` records started + completed
- [ ] `gflow data media <id>` returns the persisted record

## Process notes

- Plan was executed via the `superpowers:subagent-driven-development` skill: one implementer subagent per task, followed by parallel spec-compliance + code-quality reviewer subagents. Three reviewer-flagged correctness gaps were fixed in-band (rollback masking BEGIN failure, OSError not wrapped to typed error, natural-key conflicts leaking bare `sqlite3.IntegrityError`).
- Self-Review Checklist from the plan: all 11 items confirmed.