### PR TITLE
fix(image): re-introduce i2i ref-attach (#50) with locale-agnostic media-dialog selectors (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run could not acquire it and spiralled into rapid `about:blank` tabs +
   `TargetClosedError`. Context close + driver stop are now shared by
   `__aenter__`'s guard and `__aexit__` via `_close_browser_resources`.
+- `gflow image i2i --ref <local-file>` now binds the reference through the
+  editor's media dialog instead of the REST `uploadImage` endpoint (which 401s —
+  same root as #15/#39). Local-path refs ride a new `GenerateImageRequest.ref_paths`
+  field and are attached via the inherited R2V `_attach_references` (the image-mode
+  add-media dialog is the same `add_2` surface). Bare-UUID `--ref` still flows
+  through `refs` unchanged. Re-introduces #50 (reverted in #57 for the account/
+  locale variant tracked in #56); the media-dialog selectors are now
+  locale-agnostic (see the next entry).
 - `gflow image t2i/i2i --model` now actually selects the requested model. It was
   a no-op under `ui_automation` (the wire field was set but the model picker was
   never clicked, so Flow used its UI default). Adds `_select_image_model`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through `refs` unchanged. Re-introduces #50 (reverted in #57 for the account/
   locale variant tracked in #56); the media-dialog selectors are now
   locale-agnostic (see the next entry).
+- The media-dialog upload selectors are now **locale-agnostic** (issue #56/#24).
+  `UPLOAD_MEDIA_BUTTON` matched localized text (`has-text('Upload media')`), so on
+  a non-English Chrome profile (Flow follows the *Chrome profile* language, which
+  the `--lang=en-US` arg cannot override) the click missed and the file chooser
+  never opened — a silent ~34s hang. It now anchors on the locale-free `upload`
+  icon ligature (`:text-is('upload')`, exact, so it doesn't grab the `Uploads`
+  tab), with the original English-text selector kept as a graceful **fallback
+  tier** (matches if Google ever changes the icon but keeps the English label);
+  'Add to Prompt' (which has no icon) is selected structurally as the only
+  iconless button in the open dialog. If neither tier opens a chooser,
+  `_upload_via_open_dialog` raises a clear error + writes a screenshot (no silent
+  hang) and points the operator at the Chrome-profile-language workaround. Fixes
+  I2I/I2V/R2V upload alike.
 - `gflow image t2i/i2i --model` now actually selects the requested model. It was
   a no-op under `ui_automation` (the wire field was set but the model picker was
   never clicked, so Flow used its UI default). Adds `_select_image_model`.

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -181,6 +182,10 @@ class GenerateImageRequest:
     aspect: Aspect = Aspect.PORTRAIT
     model: Model = Model.NARWHAL
     refs: tuple[ImageRef, ...] = ()
+    # Local reference-image files for I2I — attached through the editor's media
+    # dialog by the ui_automation transport (the REST uploadImage path 401s).
+    # The common i2i case; `refs` (pre-uploaded UUIDs) would need library-select.
+    ref_paths: tuple[Path, ...] = ()
     recaptcha_token: str = ""  # populated by caller right before send; "" means unminted
     # number of images to generate (1–4); UI transport uses this to set Flow's count tab
     count: int = 1

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1502,6 +1502,13 @@ class UiAutomationTransport(VideoGenerationMixin):
             page, aspect_cli, request.count, model=request.model
         )
 
+        # I2I: bind local reference images through the editor's media dialog —
+        # the same add_2 dialog as video R2V, via the inherited _attach_references.
+        # The REST uploadImage path 401s, and passive capture needs the refs IN
+        # the UI (not just a wire body), so we attach + let Flow's JS include them.
+        if request.ref_paths:
+            await self._attach_references(page, list(request.ref_paths), out_dir=out_dir)
+
         # Attach the response listener SYNCHRONOUSLY before any prompt
         # action. asyncio.create_task is unsafe here: it defers the listener
         # registration until the new task gets event-loop scheduling, which

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -138,8 +138,34 @@ UPLOAD_IMAGE_ROUTE = "uploadImage"
 FRAME_SLOT_BY_LABEL = "div[aria-haspopup='dialog']:has-text('{label}')"
 SWAP_CONTAINER = "div:has(> button:has(i.google-symbols:text-is('swap_horiz')))"
 FRAME_SLOTS_STRUCT = SWAP_CONTAINER + " > div[aria-haspopup='dialog']"
-UPLOAD_MEDIA_BUTTON = "button:has-text('Upload media')"
-ADD_TO_PROMPT_BUTTON = "button:has-text('Add to Prompt')"
+# Media-dialog action buttons. These MUST be locale-agnostic: Flow renders the
+# dialog in the CHROME PROFILE's language (NOT the Google account language, and
+# the `--lang=en-US` launch arg does NOT override an existing profile's stored
+# language), so a text match like has-text('Upload media') silently misses on a
+# pt-BR / th / ... profile -> the file chooser never opens -> 34s hang (#56).
+# Anchor on the Material Symbols icon ligature (locale-free) instead:
+#   - 'Upload media' carries the `upload` icon. Use :text-is('upload') (EXACT) so
+#     it doesn't also grab the 'Uploads' tab (icon `drive_folder_upload`).
+#   - 'Add to Prompt' has NO icon, so it can't be matched by ligature; it's the
+#     only iconless button in the open dialog -> selected structurally at the
+#     call site via .filter(has_not=<icon>).
+# Both are scoped to the open Radix popover ([role='dialog'][data-state='open']).
+# FALLBACK / OPERATOR NOTE: if Google ever restructures this dialog so even these
+# anchors break, `_upload_via_open_dialog` raises a clear error + screenshot
+# instead of hanging. The operator workaround is to set the CHROME PROFILE
+# language to English -- the Google ACCOUNT language alone is NOT enough.
+UPLOAD_MEDIA_BUTTON = (
+    "[role='dialog'][data-state='open'] button:has(i.google-symbols:text-is('upload'))"
+)
+# Tier-2 fallback: the original localized-text selector (#50). Only matches an
+# ENGLISH-rendering profile — kept as a graceful fallback for the narrow case
+# where Google changes the `upload` icon ligature but the English label survives.
+# This is exactly why the failure message tells the operator to set the Chrome
+# profile to English: it makes this fallback tier viable.
+UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
+# 'Add to Prompt' has no stable string anchor; selected structurally (the lone
+# iconless button) at the call site. This scope is the open media dialog.
+ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
 # the 'add_2' icon (its visible text 'Create' / 'Add Media' is unreliable — a
@@ -625,13 +651,18 @@ class VideoGenerationMixin:
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
         await VideoGenerationMixin._upload_via_open_dialog(
-            page, image, log_label=label, timeout_s=timeout_s
+            page, image, log_label=label, out_dir=out_dir, timeout_s=timeout_s
         )
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
     async def _upload_via_open_dialog(
-        page: Page, image: Path, *, log_label: str, timeout_s: float = 120.0
+        page: Page,
+        image: Path,
+        *,
+        log_label: str,
+        out_dir: Path | None = None,
+        timeout_s: float = 120.0,
     ) -> None:
         """With a media dialog ALREADY open, upload `image` and commit it into
         the active slot/carousel: 'Upload media' (file chooser) -> wait the
@@ -649,9 +680,35 @@ class VideoGenerationMixin:
 
         page.on("response", on_response)
         try:
-            async with page.expect_file_chooser(timeout=8000) as fc_info:
-                await page.locator(UPLOAD_MEDIA_BUTTON).first.click()
-            chooser = await fc_info.value
+            # Tier 1 = locale-agnostic icon selector (primary, every locale).
+            # Tier 2 = the original English-text selector (#50) — catches an
+            # icon-ligature change on an English profile. If BOTH miss, fail loud
+            # with a screenshot. Short per-tier timeouts so two misses can't add
+            # up to the silent ~34s hang that #56 was about.
+            chooser = None
+            last_err: Exception | None = None
+            for sel in (UPLOAD_MEDIA_BUTTON, UPLOAD_MEDIA_BUTTON_TEXT):
+                try:
+                    async with page.expect_file_chooser(timeout=8000) as fc_info:
+                        await page.locator(sel).first.click(timeout=4000)
+                    chooser = await fc_info.value
+                    break
+                except Exception as e:  # noqa: BLE001 — fall through to the next tier
+                    last_err = e
+            if chooser is None:
+                shot = await _capture_debug_screenshot(
+                    page, out_dir, f"debug_upload_no_chooser_{log_label}.png"
+                )
+                raise RuntimeError(
+                    f"Neither the icon nor the text 'Upload media' selector opened a file "
+                    f"chooser for {log_label!r} — Google likely changed the media dialog "
+                    f"(issue #56). Screenshot: {shot}. Workaround: set the CHROME BROWSER "
+                    f"PROFILE's language to English (chrome://settings/languages). NOTE: "
+                    f"this is the Chrome PROFILE language, NOT the Google ACCOUNT language "
+                    f"— changing only the Google account language does NOT work, because "
+                    f"Flow follows the Chrome profile locale (and the --lang=en-US launch "
+                    f"arg cannot override an already-configured profile)."
+                ) from last_err
             await chooser.set_files(str(image))
             deadline = time.monotonic() + timeout_s
             while not uploaded and time.monotonic() < deadline:
@@ -661,7 +718,14 @@ class VideoGenerationMixin:
         finally:
             page.remove_listener("response", on_response)
 
-        add_btn = page.locator(ADD_TO_PROMPT_BUTTON).first
+        # 'Add to Prompt' = the only iconless button in the open dialog (its text
+        # is localized; see the UPLOAD_MEDIA_BUTTON note). Select it structurally.
+        add_btn = (
+            page.locator(ADD_TO_PROMPT_DIALOG)
+            .last.locator("button")
+            .filter(has_not=page.locator("i.google-symbols"))
+            .last
+        )
         if await add_btn.count():
             await add_btn.click()
         try:
@@ -705,7 +769,7 @@ class VideoGenerationMixin:
             await add_media.click()
             await page.wait_for_timeout(1000)
             await VideoGenerationMixin._upload_via_open_dialog(
-                page, img, log_label=f"ref{i}", timeout_s=timeout_s
+                page, img, log_label=f"ref{i}", out_dir=out_dir, timeout_s=timeout_s
             )
             attached += 1
             log.info("ui_automation_video.reference_attached", index=i)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -102,9 +102,9 @@ def _classify_ref(ref: str) -> ImageRef | Path:
       (raised by ``strict=True``) which we re-raise as :class:`click.UsageError`
       for an exit-2 + friendly message.
 
-    Centralized here so the ``i2i`` Click callback (upfront validation) and
-    the ``_resolve_refs`` async helper (dispatch) share one implementation
-    instead of duplicating the UUID regex check.
+    Centralized here so the ``i2i`` Click callback validates upfront and
+    ``_run_i2i`` can split UUID refs (wire) from local paths (UI-attached)
+    without duplicating the UUID regex check.
 
     Raises:
         click.UsageError: if *ref* is neither a UUID nor an existing path.
@@ -761,38 +761,6 @@ def i2i(
     )
 
 
-async def _resolve_refs(
-    client: FlowApiClient,
-    project_id: str,
-    classified_refs: list[ImageRef | Path],
-) -> tuple[ImageRef, ...]:
-    """Resolve a pre-classified ref list into a tuple of :class:`ImageRef`.
-
-    The input list is produced by :func:`_classify_ref` at the CLI boundary,
-    so this helper only has to dispatch on type:
-
-    * :class:`ImageRef` — append verbatim (already-uploaded asset).
-    * :class:`Path` — upload and wrap the returned UUID.
-
-    Uploads are sequential — parallel uploads are tempting but Flow's web UI
-    uploads serially and we don't want to surprise the rate limiter. Order is
-    preserved so the resulting ``imageInputs[]`` matches the order the user
-    specified on the command line.
-    """
-    resolved: list[ImageRef] = []
-    for item in classified_refs:
-        if isinstance(item, ImageRef):
-            resolved.append(item)
-            continue
-        # Per-file progress feedback. Acceptable Rich `console.print` inside
-        # this async helper because cli_image.py *is* the CLI layer; structlog
-        # will replace this when it lands in Phase 1.
-        console.print(f"  Uploading {item.name}...")
-        asset = await client.upload_image(project_id, item)
-        resolved.append(ImageRef(name=asset.name))
-    return tuple(resolved)
-
-
 async def _run_i2i(
     *,
     profile_dir: Path,
@@ -815,16 +783,23 @@ async def _run_i2i(
         project = await client.create_project(title="gflow-cli i2i")
         console.print(f"  Project: [dim]{project.project_id}[/dim]")
 
-        resolved_refs = await _resolve_refs(client, project.project_id, classified_refs)
+        # Local-file refs are attached through the editor's media dialog by the
+        # ui_automation transport (the REST uploadImage path 401s — see #15/#39).
+        # Already-uploaded UUID refs go on `refs` (best-effort; binding a library
+        # asset by UUID via the UI is not wired yet — local files are the path).
+        uuid_refs = tuple(r for r in classified_refs if isinstance(r, ImageRef))
+        local_ref_paths = tuple(r for r in classified_refs if isinstance(r, Path))
         req = GenerateImageRequest(
             prompt=prompt,
             aspect=aspect,
             model=model,
-            refs=resolved_refs,
+            refs=uuid_refs,
+            ref_paths=local_ref_paths,
         )
 
+        n_refs = len(uuid_refs) + len(local_ref_paths)
         console.print(
-            f"  Generating {count} image(s) with {len(resolved_refs)} ref(s) "
+            f"  Generating {count} image(s) with {n_refs} ref(s) "
             f"({req.model.value}, {req.aspect.value})..."
         )
         if count == 1:

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1049,6 +1049,49 @@ class TestGenerateImages:
         ):
             await t.generate_images(project_id="x", request=_req())
 
+    @pytest.mark.asyncio
+    async def test_i2i_ref_paths_bound_via_attach_references(self) -> None:
+        """I2I local refs (request.ref_paths) bind through the editor media
+        dialog — _generate_images_locked awaits the inherited _attach_references
+        with the local paths. Without this, the i2i bind is only covered at the
+        CLI layer (mirrors the R2V transport-attach coverage)."""
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+        ref = Path("hero.png")
+        req = GenerateImageRequest(prompt="stylize", model=Model.NARWHAL, ref_paths=(ref,))
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_references", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=req)
+
+        attach.assert_awaited_once()
+        call = attach.await_args
+        assert call is not None
+        # The local path is forwarded to the attach helper (positional arg 1).
+        assert list(call.args[1]) == [ref]
+
+    @pytest.mark.asyncio
+    async def test_t2i_without_ref_paths_skips_attach(self) -> None:
+        """T2I (no ref_paths) must NOT touch _attach_references."""
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_references", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=_req())
+
+        attach.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Unit 3.10 — refresh_auth (no-op)

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -312,13 +312,12 @@ def _make_i2i_client(
 
 
 class TestImageI2I:
-    def test_i2i_uploads_local_ref_paths(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Local --ref path triggers upload_image; the returned UUID lands in
-        the GenerateImageRequest.refs and downstream imageInputs[]."""
+    def test_i2i_attaches_local_ref_paths(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Local --ref path lands on req.ref_paths for UI media-dialog attach —
+        it must NOT hit the REST uploadImage endpoint (which 401s, see #15/#39)."""
         png = tmp_path / "hero.png"
         png.write_bytes(b"\x89PNG\r\n\x1a\n")
-        upload_uuid = "ddb6ef97-262d-49f4-8269-4a28c0fae6a2"
-        client = _make_i2i_client(upload_uuid=upload_uuid)
+        client = _make_i2i_client(upload_uuid="should-not-be-used")
         out_dir = tmp_path / "out"
 
         with (
@@ -335,14 +334,14 @@ class TestImageI2I:
             )
 
         assert result.exit_code == 0, result.output
-        client.upload_image.assert_awaited_once()
-        # Inspect the GenerateImageRequest passed to generate_image — UUID
-        # from upload_image should appear in req.refs.
+        client.upload_image.assert_not_called()
+        # Local file goes to req.ref_paths (UI-attached); refs (wire UUIDs) stays empty.
         call = client.generate_image.await_args
         assert call is not None
         req = call.kwargs["req"]
-        assert len(req.refs) == 1
-        assert req.refs[0].name == upload_uuid
+        assert req.refs == ()
+        assert len(req.ref_paths) == 1
+        assert req.ref_paths[0] == png.resolve()
 
     def test_i2i_passes_through_uuid_refs(self, runner: CliRunner, tmp_path: Path) -> None:
         """Bare-UUID --ref must NOT trigger upload_image and must be used verbatim."""
@@ -371,13 +370,13 @@ class TestImageI2I:
         assert len(req.refs) == 1
         assert req.refs[0].name == uuid_str
 
-    def test_i2i_mixes_paths_and_uuids(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Mixed `--ref path --ref uuid` → one upload, two ordered entries."""
+    def test_i2i_splits_paths_and_uuids(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Mixed `--ref path --ref uuid` → local path on ref_paths (UI-attached),
+        bare UUID on refs (wire). No REST upload for either."""
         png = tmp_path / "hero.png"
         png.write_bytes(b"\x89PNG\r\n\x1a\n")
-        uploaded_uuid = "11111111-1111-1111-1111-111111111111"
         passthrough_uuid = "22222222-2222-2222-2222-222222222222"
-        client = _make_i2i_client(upload_uuid=uploaded_uuid)
+        client = _make_i2i_client(upload_uuid="should-not-be-used")
         out_dir = tmp_path / "out"
 
         with (
@@ -404,13 +403,13 @@ class TestImageI2I:
             )
 
         assert result.exit_code == 0, result.output
-        # Exactly one upload (for the path) — the bare UUID must be passed through.
-        assert client.upload_image.await_count == 1
+        client.upload_image.assert_not_called()
         call = client.generate_image.await_args
         assert call is not None
         req = call.kwargs["req"]
-        # Order matters: path → uploaded_uuid first, then passthrough_uuid.
-        assert [r.name for r in req.refs] == [uploaded_uuid, passthrough_uuid]
+        # Local path → ref_paths; bare UUID → refs.
+        assert [p for p in req.ref_paths] == [png.resolve()]
+        assert [r.name for r in req.refs] == [passthrough_uuid]
 
     def test_i2i_errors_on_no_refs(self, runner: CliRunner) -> None:
         """`image i2i` without any --ref must exit 2 with a clear message."""

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -126,6 +126,56 @@ async def test_e2e_single_image_gen(strategy: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Criterion C2 (i2i variant) — local-file reference attach via media dialog (#56)
+# ---------------------------------------------------------------------------
+
+
+def _tiny_png(path: Path) -> Path:
+    """Write a valid 8x8 red RGBA PNG (no external asset / Pillow dependency)."""
+    import struct
+    import zlib
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        crc = zlib.crc32(body) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", crc)
+
+    w = h = 8
+    raw = b"".join(b"\x00" + b"\xff\x00\x00\xff" * w for _ in range(h))
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_e2e_i2i_local_ref_attach(tmp_path: Path) -> None:
+    """C2/i2i (#56): generate_image with a LOCAL-FILE ``ref_paths`` binds the
+    reference through the editor's media dialog and returns >= 1 image.
+
+    UI-automation transport ONLY — the REST transports (bearer/sapisidhash)
+    cannot drive the add-media dialog, so they never invoke ``_attach_references``.
+
+    This exercises the locale-agnostic media-dialog selectors (icon ``upload`` +
+    iconless 'Add to Prompt') that replaced the text-based selectors which hung
+    on non-English Chrome profiles. Costs 1 credit when it runs.
+    """
+    profile = _profile_dir()
+    ref = _tiny_png(tmp_path / "ref.png")
+    req = GenerateImageRequest(prompt=_PROMPT, model=Model.NARWHAL, ref_paths=(ref,))
+
+    async with _make_client("evaluate_fetch", profile) as client:
+        image = await client.generate_image(req=req)
+
+    assert image.media_name, "i2i ref-attach returned no image"
+    assert image.fife_url.startswith("https://"), (
+        f"fife_url must be an https:// URL, got: {image.fife_url!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Criterion C3 — 5 sequential batches × 4 images = 20 images
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Re-introduces the i2i local-file ref-attach from #50 (reverted in #57) and fixes the #56 root cause by making the media-dialog upload selectors **locale-agnostic**. Branched off `develop` @ `5345c1b` as you suggested.

## Root cause (#56)

It turned out to be a **locale leak**, not an intermediate-menu / nesting difference. Your `ffroliva` dump ([#issuecomment-4528075496](https://github.com/ffroliva/gflow-cli/issues/56#issuecomment-4528075496)) shows the **same** popover with the **same** "Upload media" button at the **same** level as mine — just rendered in pt-BR (`Enviar mídia`). The old `UPLOAD_MEDIA_BUTTON = button:has-text('Upload media')` didn't match the pt-BR label, so the click missed → `expect_file_chooser` never fired → the ~34s silent timeout.

Flow renders the dialog in the **Chrome _profile_ language**, which `--lang=en-US` cannot override on an already-configured profile (matches your "server-side locale overrides the launch arg" observation; same class as #51 / #24).

## Changes

`src/gflow_cli/api/transports/ui_automation_video.py`:

- **`UPLOAD_MEDIA_BUTTON`** → the locale-free `upload` icon ligature, `:text-is('upload')` (exact — so it doesn't also grab the `Uploads` tab whose icon is `drive_folder_upload`), scoped to `[role='dialog'][data-state='open']`. This is the selector you recommended, with the exact-match refinement.
- **Fallback tier** — the original English-text selector (`has-text('Upload media')`), tried only if the icon misses. Covers the narrow case where Google changes the icon ligature but keeps the English label. Short per-tier timeouts so two misses can't recreate a long silent hang.
- **'Add to Prompt'** has **no icon** (confirmed via DOM), so it's selected structurally as the lone iconless button in the open dialog (`.filter(has_not=<i.google-symbols>)`) instead of by localized text.
- **Fail-loud guard** — if neither tier opens a chooser, screenshot + a clear `RuntimeError`. The message explicitly tells the operator to set the **Chrome _profile_ language** to English (`chrome://settings/languages`) and that the **Google _account_ language is not enough** — that distinction is genuinely easy to get wrong.

`tests/e2e/test_transports_e2e.py`:
- Adds the C2-style **i2i e2e variant** (`test_e2e_i2i_local_ref_attach`), `GFLOW_CLI_E2E_PROFILE`-gated, ui-automation transport only (the REST transports can't drive the add-media dialog). Generates a tiny PNG inline — no asset dependency.

The shared `_upload_via_open_dialog` is also used by I2V/R2V, so this hardens those upload paths too.

## Verification

Real CLI, English-rendering profile, this branch:

```
11:22:55.614  image_mode_entered
11:23:00.372  count_setter_completed
11:23:13.986  image_uploaded  status=200   <- upload fired (~13.6s, not the 34s hang)
11:23:15.670  reference_attached
11:23:16.318  prompt_submitted
11:23:50.935  batch_response_captured status=200  -> image returned
```

**Honest caveat:** I can only verify on an English-rendering profile, where *both* the icon and text selectors would match — so this proves the end-to-end path works, but not the pt-BR path specifically. The icon selector is locale-independent by construction and your `ffroliva` dump confirms the same `upload` ligature there. Could you run the gated e2e (or your `capture_image_add_media_dom.py` from #59) on `ffroliva` to confirm before closing #56? I deliberately wrote "Refs", not "Closes".

## Not fixed here (focused PR — flagging per your preference)

`FRAME_SLOT_BY_LABEL` (I2V Start/End slots, `div[aria-haspopup='dialog']:has-text('{label}')`) is still **text-based** and will hit the same locale issue on a non-English profile. It's the I2V frame-slot path, separate from this upload fix, and belongs with #24 — happy to follow up separately rather than widen this PR.

## Test plan

- [x] `check_repo_hygiene.py` — clean (255 files)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean (103 files)
- [x] `pyright src` — 0 errors
- [x] `pytest -q -m "not e2e and not live"` — 806 passed, 6 skipped (single local interpreter)
- [x] Real CLI `gflow image i2i --ref <png>` on an EN profile — image returned (timeline above)
- [ ] CI matrix 3.11 / 3.12 / 3.13 (fork PR → `action_required`; needs your approve-and-run)
- [ ] e2e i2i variant on a logged-in profile (`GFLOW_CLI_E2E_PROFILE=...`)

DCO-signed (both commits). Refs #56, #24.