### PR TITLE
docs: v0.9.0 release design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-24-v0.9.0-release-implementation.md
+++ b/docs/superpowers/plans/2026-05-24-v0.9.0-release-implementation.md
@@ -1,0 +1,2123 @@
+# v0.9.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `gflow-cli` v0.9.0 — adds `gflow data list` read CLI over the existing SQLite catalog, publishes `ROADMAP.md`, wires sponsorship (`.github/FUNDING.yml` + README badges), refreshes docs to reflect the data layer maturity, then closes the release (version bump, signed tag, PyPI, back-merge).
+
+**Architecture:** Five sequential phases, each its own feature branch off `develop`, each merged via PR before the next begins. Phase 5 cuts `release/v0.9.0` from `develop` for the tag + PyPI. The spec lives in commit `bf66f2b` on branch `docs/v0.9.0-release-spec`; this plan ships alongside it on the same branch.
+
+**Tech Stack:** Python 3.11+ · Click 8 · Rich · structlog · pytest · pytest-bdd · pytest-cov · sqlite3 (stdlib) · `uv` · `hatchling` · `pyright` strict · `ruff` · GitHub Actions + Trusted Publishing.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md`
+
+**Phase order is load-bearing.** Phase 1 produces the schema reconciliation that Phase 2's column lists depend on. Phases 3 and 4 can be developed in parallel after Phase 2 lands but must merge sequentially to avoid INDEX.md conflicts. Phase 5 requires all prior phases on `develop`.
+
+---
+
+## Phase 1 — Audit + Schema Reconciliation
+
+**Branch:** `chore/v0.9.0-audit` off `develop`
+**Goal:** Confirm the spec's `gflow data list` column lists match the real `gflow_cli.data` schema; if not, produce a one-page reconciliation note that downstream phases consume. Also verify the in-flight `CHANGELOG.md` data-layer draft (already in your working tree) covers PR #58 fully.
+**Output PR:** A reconciliation note + (if needed) CHANGELOG.md `[Unreleased]` adjustments. No code changes.
+
+### Task 1.1: Capture actual data-layer schema
+
+**Files:**
+- Read: `src/gflow_cli/data/` (entire package — every `.py` file)
+- Read: `src/gflow_cli/data/migrations/` if it exists
+- Create: `docs/superpowers/notes/v0.9.0-schema-reconciliation.md`
+
+- [ ] **Step 1: List the data package contents**
+
+```bash
+ls src/gflow_cli/data/
+```
+
+Expected: at least `__init__.py`, plus repository/dao/schema modules. Note the file names.
+
+- [ ] **Step 2: Read every file in the data package**
+
+For each `.py` file under `src/gflow_cli/data/`, open and read it. Extract:
+- Table names (look for `CREATE TABLE` in migration SQL or model classes)
+- Column names + types per table
+- Index names
+- Public functions / classes that already perform reads (these are the seeds for the new query layer)
+
+- [ ] **Step 3: Write the reconciliation note**
+
+Create `docs/superpowers/notes/v0.9.0-schema-reconciliation.md` with this exact structure:
+
+```markdown
+# v0.9.0 — gflow data list schema reconciliation
+
+> Source of truth for Phase 2 column mapping. Compares spec §3.1 columns against the live `gflow_cli.data` schema as of <commit hash>.
+
+## Tables found
+
+| Table | Purpose | Columns |
+|---|---|---|
+| <table_1> | <purpose> | <comma-separated list> |
+| ... | ... | ... |
+
+## Spec → schema mapping per noun
+
+### projects
+| Spec column | Real column(s) | Notes |
+|---|---|---|
+| project_id | <real_name> | |
+| profile | <real_name> | |
+| created_at | <real_name> | |
+| image_count | <derived from JOIN/COUNT> | aggregate |
+| video_count | <derived from JOIN/COUNT> | aggregate |
+
+### images
+<same shape>
+
+### videos
+<same shape>
+
+### profiles
+<same shape — aggregate across all tables>
+
+## Drift identified
+
+- <bullet per mismatch>
+
+## Recommendations for Phase 2
+
+- <bullet — e.g. "rename spec `local_path` to schema `output_path` in plan tasks before execution">
+```
+
+Fill in every `<placeholder>` from the actual schema. If a spec column has no schema equivalent (e.g. `image_count` is aggregate-only), explicitly note that the query function computes it via `COUNT()` joined on the project_id.
+
+- [ ] **Step 4: Verify Phase 2 plan tasks still apply**
+
+Re-read Phase 2 tasks below in this plan. For each column reference (e.g. `created_at`, `media_id`, `local_path`), confirm it matches your reconciliation note or list the patch needed. If patches are needed, list them at the bottom of the reconciliation note under "## Phase 2 patches required".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -b chore/v0.9.0-audit
+git add docs/superpowers/notes/v0.9.0-schema-reconciliation.md
+git commit -m "chore(audit): reconcile gflow data list column plan vs real data schema"
+```
+
+### Task 1.2: Audit CHANGELOG.md [Unreleased] for completeness
+
+**Files:**
+- Modify (if needed): `CHANGELOG.md`
+
+- [ ] **Step 1: Read the current Unreleased section**
+
+```bash
+git diff develop -- CHANGELOG.md
+```
+
+Note: as of 2026-05-24 your working tree already has a draft `Local data layer` entry referencing PR #58 stacked on #52. This task validates it, not rewrites it.
+
+- [ ] **Step 2: Cross-check against PR #58 + #52 actual scope**
+
+```bash
+gh pr view 58 --json title,body,files
+gh pr view 52 --json title,body,files
+```
+
+For each notable feature in those PRs, confirm the draft CHANGELOG line covers it. Specifically verify:
+- `gflow data media <id>` command mentioned
+- `DataRepository` seed-image resolvers mentioned
+- Exit code 16 + the three error subclasses mentioned
+- Post-success failures behavior (warn + exit 0) mentioned
+- Reference to `docs/DATA_LAYER.md` present
+
+- [ ] **Step 3: If gaps found, extend the draft entry**
+
+If anything from Step 2 is missing, edit `CHANGELOG.md` to extend the draft entry. Keep the bullet under `### Added` in the existing `## [Unreleased]` block.
+
+- [ ] **Step 4: Verify no other Unreleased gaps**
+
+Run:
+```bash
+git log v0.8.1..develop --oneline
+```
+
+Every PR title that ships user-visible behavior must appear somewhere in `[Unreleased]`. If something is missing, add it under the appropriate subsection (`### Added`, `### Changed`, `### Fixed`).
+
+- [ ] **Step 5: Commit (only if changes made in Steps 3 or 4)**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): extend Unreleased data-layer entry to cover PR #58 scope"
+```
+
+If no changes, skip — the working-tree draft from before this phase is fine and will be committed as part of Phase 5 instead.
+
+### Task 1.3: Open and merge Phase 1 PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin chore/v0.9.0-audit
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+gh pr create --base develop --title "chore(audit): v0.9.0 schema reconciliation + CHANGELOG audit" --body "$(cat <<'EOF'
+## Summary
+- Captures the live `gflow_cli.data` schema as the source of truth for Phase 2's `gflow data list` column mapping.
+- Validates the in-flight CHANGELOG `[Unreleased]` draft covers PR #58 + #52 scope.
+
+## Refs
+Refs #58, #52. Part of v0.9.0 release sequence — Phase 1 of 5.
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI, then merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout develop && git pull
+```
+
+---
+
+## Phase 2 — `gflow data list` CLI
+
+**Branch:** `feature/data-list-cli` off `develop` (after Phase 1 merges)
+**Goal:** Ship the four read-only `gflow data list <noun>` commands with `--limit`, `--offset`, `--profile`, `--json` flags, rich-table TTY output, JSONL non-TTY output, newest-first sort, exit 16 on data-store errors.
+**Output PR:** Working CLI + ~20 tests + registered Click group + INDEX.md mention.
+
+### File structure for Phase 2
+
+- Create: `src/gflow_cli/cli_data.py` — Click group, output formatting, flag parsing
+- Create: `src/gflow_cli/data/queries.py` — pure query functions, no Click awareness
+- Create: `tests/test_cli_data.py` — Click-runner integration tests
+- Create: `tests/test_data_queries.py` — query-function unit tests
+- Create: `tests/fixtures/seeded_catalog.py` — helper to build a fixture SQLite catalog
+- Modify: `src/gflow_cli/cli.py` — register the `data` subgroup
+
+### Task 2.1: Fixture catalog helper
+
+**Files:**
+- Create: `tests/fixtures/seeded_catalog.py`
+
+- [ ] **Step 1: Read the existing test-fixture conventions**
+
+```bash
+ls tests/fixtures/
+```
+
+Open one or two existing fixture files to match style (imports, docstring shape, type hints).
+
+- [ ] **Step 2: Write the seeded_catalog helper**
+
+Create `tests/fixtures/seeded_catalog.py`. Use the table/column names from the reconciliation note (Phase 1, Task 1.1). Example skeleton — adapt to real schema:
+
+```python
+"""Build a fixture SQLite catalog seeded with known projects/images/videos.
+
+Used by tests/test_cli_data.py and tests/test_data_queries.py.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from gflow_cli.data import DataRepository  # adjust import per reconciliation note
+
+
+def build_seeded_catalog(db_path: Path) -> DataRepository:
+    """Create a fresh DB at db_path with 3 profiles, 5 projects, 12 images, 4 videos.
+
+    Timestamps span the last 7 days so default newest-first sort has predictable order.
+    """
+    repo = DataRepository(db_path)
+    repo.run_migrations()
+
+    now = datetime.utcnow()
+    profiles = ["alice", "bob", "carol"]
+
+    # Seed projects (adapt method names from reconciliation note)
+    for i, profile in enumerate(profiles):
+        for j in range(2 if profile == "alice" else 1):
+            project_id = f"proj-{profile}-{j:03d}"
+            repo.record_project(
+                project_id=project_id,
+                profile=profile,
+                created_at=now - timedelta(days=i, hours=j),
+            )
+            # Seed images
+            for k in range(2):
+                repo.record_image(
+                    media_id=f"img-{profile}-{j}-{k}",
+                    project_id=project_id,
+                    profile=profile,
+                    prompt=f"prompt for {profile} image {k}",
+                    aspect="16:9",
+                    model="nano2",
+                    created_at=now - timedelta(days=i, hours=j, minutes=k * 5),
+                    local_path=f"/tmp/{profile}/{j}/{k}.png",
+                )
+            # Seed videos for alice only
+            if profile == "alice":
+                repo.record_video(
+                    media_id=f"vid-{profile}-{j}",
+                    project_id=project_id,
+                    profile=profile,
+                    prompt=f"video prompt {j}",
+                    aspect="9:16",
+                    model="veo-fast",
+                    duration=6,
+                    created_at=now - timedelta(days=i, hours=j),
+                    local_path=f"/tmp/{profile}/{j}/video.mp4",
+                )
+    return repo
+```
+
+If the real `DataRepository` uses different method names (e.g. `add_project` vs `record_project`), use the real names from the reconciliation note.
+
+- [ ] **Step 3: Smoke-run the helper**
+
+```python
+# Inline check — run in a Python REPL
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from tests.fixtures.seeded_catalog import build_seeded_catalog
+
+with TemporaryDirectory() as td:
+    repo = build_seeded_catalog(Path(td) / "test.db")
+    print(repo.count_projects(), repo.count_images(), repo.count_videos())
+```
+
+Expected: `4 8 2` (3 profiles, alice has 2 projects, others 1 each, total 4 projects; 8 images = 4 projects × 2 images; 2 videos = alice's 2 projects × 1 video each).
+
+If counts differ, adjust the seed logic to match the spec's expected shape: 4 projects total, 8 images, 2 videos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git checkout -b feature/data-list-cli
+git add tests/fixtures/seeded_catalog.py
+git commit -m "test(data): add seeded_catalog fixture helper for data-list tests"
+```
+
+### Task 2.2: Query function — list_projects
+
+**Files:**
+- Create: `src/gflow_cli/data/queries.py`
+- Create: `tests/test_data_queries.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_data_queries.py`:
+
+```python
+"""Tests for gflow_cli.data.queries — pure read-only query functions."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.queries import list_projects
+from tests.fixtures.seeded_catalog import build_seeded_catalog
+
+
+@pytest.fixture
+def seeded(tmp_path: Path):
+    db = tmp_path / "test.db"
+    build_seeded_catalog(db)
+    return db
+
+
+def test_list_projects_returns_all_by_default(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 4
+    assert {r.profile for r in rows} == {"alice", "bob", "carol"}
+
+
+def test_list_projects_filters_by_profile(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile="alice", limit=20, offset=0)
+    assert len(rows) == 2
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_projects_respects_limit(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=2, offset=0)
+    assert len(rows) == 2
+
+
+def test_list_projects_respects_offset(seeded: Path) -> None:
+    page1 = list_projects(db_path=seeded, profile=None, limit=2, offset=0)
+    page2 = list_projects(db_path=seeded, profile=None, limit=2, offset=2)
+    assert {r.project_id for r in page1} & {r.project_id for r in page2} == set()
+
+
+def test_list_projects_newest_first(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=20, offset=0)
+    timestamps = [r.created_at for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_list_projects_empty_catalog_returns_empty_list(tmp_path: Path) -> None:
+    from gflow_cli.data import DataRepository
+    db = tmp_path / "empty.db"
+    DataRepository(db).run_migrations()
+    rows = list_projects(db_path=db, profile=None, limit=20, offset=0)
+    assert rows == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+(On Windows if `uv run` is flaky, use `.venv\Scripts\python.exe -m pytest tests/test_data_queries.py -v`.)
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'gflow_cli.data.queries'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/gflow_cli/data/queries.py`:
+
+```python
+"""Read-only query functions over the gflow-cli SQLite catalog.
+
+These are pure functions: they accept a db path, return dataclass rows, do not
+mutate state, and do not depend on Click or Rich. The CLI adapter (cli_data.py)
+formats their output.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProjectRow:
+    project_id: str
+    profile: str
+    created_at: datetime
+    image_count: int
+    video_count: int
+
+
+def list_projects(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[ProjectRow]:
+    """Return projects newest-first, filtered by profile if given.
+
+    image_count / video_count are aggregated via subqueries.
+    """
+    sql = """
+        SELECT
+            p.project_id,
+            p.profile,
+            p.created_at,
+            (SELECT COUNT(*) FROM images i WHERE i.project_id = p.project_id) AS image_count,
+            (SELECT COUNT(*) FROM videos v WHERE v.project_id = p.project_id) AS video_count
+        FROM projects p
+        WHERE (:profile IS NULL OR p.profile = :profile)
+        ORDER BY p.created_at DESC
+        LIMIT :limit OFFSET :offset
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [
+        ProjectRow(
+            project_id=r["project_id"],
+            profile=r["profile"],
+            created_at=datetime.fromisoformat(r["created_at"]),
+            image_count=r["image_count"],
+            video_count=r["video_count"],
+        )
+        for r in rows
+    ]
+```
+
+**Important:** if the reconciliation note (Phase 1) says the real columns are named differently (e.g. `created_ts` not `created_at`, or `prompts` not `images`), adjust the SQL and the dataclass field accordingly. The Python field names in `ProjectRow` MUST stay as `created_at`, `image_count`, `video_count` because Phase 2 tests assert on them.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py::test_list_projects_returns_all_by_default -v
+```
+
+Expected: PASS.
+
+Then run the full file:
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/data/queries.py tests/test_data_queries.py
+git commit -m "feat(data): add list_projects query function"
+```
+
+### Task 2.3: Query function — list_images
+
+**Files:**
+- Modify: `src/gflow_cli/data/queries.py`
+- Modify: `tests/test_data_queries.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_data_queries.py`:
+
+```python
+from gflow_cli.data.queries import list_images
+
+
+def test_list_images_returns_all_by_default(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 8
+
+
+def test_list_images_filters_by_profile(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile="alice", limit=20, offset=0)
+    assert len(rows) == 4
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_images_newest_first(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile=None, limit=20, offset=0)
+    assert [r.created_at for r in rows] == sorted(
+        [r.created_at for r in rows], reverse=True
+    )
+
+
+def test_list_images_carries_prompt_aspect_model_local_path(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile="alice", limit=1, offset=0)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.prompt is not None
+    assert r.aspect == "16:9"
+    assert r.model == "nano2"
+    assert r.local_path.endswith(".png")
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 4 new tests FAIL with `ImportError`.
+
+- [ ] **Step 3: Add ImageRow + list_images to queries.py**
+
+Append to `src/gflow_cli/data/queries.py`:
+
+```python
+@dataclass(frozen=True)
+class ImageRow:
+    media_id: str
+    profile: str
+    project_id: str
+    prompt: str
+    aspect: str
+    model: str
+    created_at: datetime
+    local_path: str
+
+
+def list_images(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[ImageRow]:
+    sql = """
+        SELECT
+            media_id, profile, project_id, prompt, aspect, model,
+            created_at, local_path
+        FROM images
+        WHERE (:profile IS NULL OR profile = :profile)
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [
+        ImageRow(
+            media_id=r["media_id"],
+            profile=r["profile"],
+            project_id=r["project_id"],
+            prompt=r["prompt"],
+            aspect=r["aspect"],
+            model=r["model"],
+            created_at=datetime.fromisoformat(r["created_at"]),
+            local_path=r["local_path"],
+        )
+        for r in rows
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 10 tests PASS (6 projects + 4 images).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/data/queries.py tests/test_data_queries.py
+git commit -m "feat(data): add list_images query function"
+```
+
+### Task 2.4: Query function — list_videos
+
+**Files:**
+- Modify: `src/gflow_cli/data/queries.py`
+- Modify: `tests/test_data_queries.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_data_queries.py`:
+
+```python
+from gflow_cli.data.queries import list_videos
+
+
+def test_list_videos_returns_all_by_default(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 2
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_videos_filter_no_match(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile="bob", limit=20, offset=0)
+    assert rows == []
+
+
+def test_list_videos_carries_duration(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile="alice", limit=1, offset=0)
+    assert rows[0].duration == 6
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 3 new tests FAIL with ImportError.
+
+- [ ] **Step 3: Add VideoRow + list_videos**
+
+Append to `src/gflow_cli/data/queries.py`:
+
+```python
+@dataclass(frozen=True)
+class VideoRow:
+    media_id: str
+    profile: str
+    project_id: str
+    prompt: str
+    aspect: str
+    model: str
+    duration: int
+    created_at: datetime
+    local_path: str
+
+
+def list_videos(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[VideoRow]:
+    sql = """
+        SELECT
+            media_id, profile, project_id, prompt, aspect, model, duration,
+            created_at, local_path
+        FROM videos
+        WHERE (:profile IS NULL OR profile = :profile)
+        ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [
+        VideoRow(
+            media_id=r["media_id"],
+            profile=r["profile"],
+            project_id=r["project_id"],
+            prompt=r["prompt"],
+            aspect=r["aspect"],
+            model=r["model"],
+            duration=r["duration"],
+            created_at=datetime.fromisoformat(r["created_at"]),
+            local_path=r["local_path"],
+        )
+        for r in rows
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 13 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/data/queries.py tests/test_data_queries.py
+git commit -m "feat(data): add list_videos query function"
+```
+
+### Task 2.5: Query function — list_profiles
+
+**Files:**
+- Modify: `src/gflow_cli/data/queries.py`
+- Modify: `tests/test_data_queries.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_data_queries.py`:
+
+```python
+from gflow_cli.data.queries import list_profiles
+
+
+def test_list_profiles_returns_catalog_known_profiles(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    assert {r.profile_name for r in rows} == {"alice", "bob", "carol"}
+
+
+def test_list_profiles_carries_aggregate_counts(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    by_name = {r.profile_name: r for r in rows}
+    assert by_name["alice"].project_count == 2
+    assert by_name["alice"].image_count == 4
+    assert by_name["alice"].video_count == 2
+    assert by_name["bob"].video_count == 0
+
+
+def test_list_profiles_sorted_by_last_used_desc(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    timestamps = [r.last_used_at for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 3 new tests FAIL.
+
+- [ ] **Step 3: Add ProfileRow + list_profiles**
+
+Append to `src/gflow_cli/data/queries.py`:
+
+```python
+@dataclass(frozen=True)
+class ProfileRow:
+    profile_name: str
+    last_used_at: datetime
+    project_count: int
+    image_count: int
+    video_count: int
+
+
+def list_profiles(
+    *,
+    db_path: Path,
+    limit: int,
+    offset: int,
+) -> list[ProfileRow]:
+    """Profiles that have at least one recorded project/image/video.
+
+    Distinct from `gflow auth list` which lists login-known profiles; this lists
+    catalog-known profiles. A profile that has logged in but never generated
+    anything does not appear here.
+    """
+    sql = """
+        WITH profile_activity AS (
+            SELECT profile, MAX(created_at) AS last_used_at FROM projects GROUP BY profile
+            UNION ALL
+            SELECT profile, MAX(created_at) FROM images GROUP BY profile
+            UNION ALL
+            SELECT profile, MAX(created_at) FROM videos GROUP BY profile
+        )
+        SELECT
+            profile AS profile_name,
+            MAX(last_used_at) AS last_used_at,
+            (SELECT COUNT(*) FROM projects WHERE profile = pa.profile) AS project_count,
+            (SELECT COUNT(*) FROM images WHERE profile = pa.profile) AS image_count,
+            (SELECT COUNT(*) FROM videos WHERE profile = pa.profile) AS video_count
+        FROM profile_activity pa
+        GROUP BY profile
+        ORDER BY last_used_at DESC
+        LIMIT :limit OFFSET :offset
+    """
+    params = {"limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [
+        ProfileRow(
+            profile_name=r["profile_name"],
+            last_used_at=datetime.fromisoformat(r["last_used_at"]),
+            project_count=r["project_count"],
+            image_count=r["image_count"],
+            video_count=r["video_count"],
+        )
+        for r in rows
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+uv run python -m pytest tests/test_data_queries.py -v
+```
+
+Expected: 16 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/data/queries.py tests/test_data_queries.py
+git commit -m "feat(data): add list_profiles query function"
+```
+
+### Task 2.6: CLI adapter — Click group + project listing
+
+**Files:**
+- Create: `src/gflow_cli/cli_data.py`
+- Modify: `src/gflow_cli/cli.py`
+- Create: `tests/test_cli_data.py`
+
+- [ ] **Step 1: Read the existing CLI registration pattern**
+
+Open `src/gflow_cli/cli.py` and `src/gflow_cli/cli_image.py`. Note:
+- How Click groups are created and added to the root.
+- How `--profile` is resolved (likely via `_cli_helpers._resolve_profile`).
+- How exceptions are caught and mapped to exit codes.
+- How TTY detection happens for table-vs-JSON output.
+
+- [ ] **Step 2: Write the failing CLI test**
+
+Create `tests/test_cli_data.py`:
+
+```python
+"""CLI integration tests for gflow data list ..."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from tests.fixtures.seeded_catalog import build_seeded_catalog
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "catalog.db"
+    build_seeded_catalog(db)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    return db
+
+
+def test_data_list_projects_default_limit(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert "bob" in result.output
+    assert "PROJECT_ID" in result.output  # rich-table header
+
+
+def test_data_list_projects_json(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--json"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 4
+    first = json.loads(lines[0])
+    assert "project_id" in first
+    assert "profile" in first
+    assert "image_count" in first
+
+
+def test_data_list_projects_filter_profile(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--profile", "alice", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 2
+    assert all(r["profile"] == "alice" for r in rows)
+
+
+def test_data_list_projects_pagination(seeded_db: Path) -> None:
+    page1 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "0", "--json"])
+    page2 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "2", "--json"])
+    p1_ids = {json.loads(ln)["project_id"] for ln in page1.output.splitlines() if ln.strip()}
+    p2_ids = {json.loads(ln)["project_id"] for ln in page2.output.splitlines() if ln.strip()}
+    assert p1_ids & p2_ids == set()
+
+
+def test_data_list_projects_empty_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from gflow_cli.data import DataRepository
+    db = tmp_path / "empty.db"
+    DataRepository(db).run_migrations()
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    assert result.exit_code == 0
+    assert "No projects recorded." in result.output
+
+
+def test_data_list_projects_invalid_limit(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "0"])
+    assert result.exit_code == 2  # Click usage error
+```
+
+- [ ] **Step 3: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py -v
+```
+
+Expected: 6 tests FAIL because `data` is not a registered group.
+
+- [ ] **Step 4: Implement cli_data.py with the projects subcommand**
+
+Create `src/gflow_cli/cli_data.py`:
+
+```python
+"""`gflow data list ...` — read-only catalog query CLI.
+
+Layer: thin Click adapter. Query logic lives in gflow_cli.data.queries.
+Output: rich-table on TTY, JSONL on pipe or with --json.
+Exit codes: 0 success, 2 Click usage error, 16 DataStoreError family.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gflow_cli.data.queries import (
+    ProjectRow,
+    list_projects,
+)
+
+
+def _db_path() -> Path:
+    """Resolve the catalog DB path from env or platformdirs default."""
+    if env := os.environ.get("GFLOW_CLI_DB_PATH"):
+        return Path(env)
+    # Match data layer's default — adapt per Phase 1 reconciliation if needed.
+    from platformdirs import user_data_dir
+    return Path(user_data_dir("gflow-cli")) / "data.db"
+
+
+def _emit_json(rows: list) -> None:
+    """Print one JSON object per line (JSONL)."""
+    for row in rows:
+        d = dataclasses.asdict(row)
+        # Serialize datetimes as ISO strings
+        for k, v in d.items():
+            if isinstance(v, datetime):
+                d[k] = v.isoformat()
+        click.echo(json.dumps(d))
+
+
+def _emit_projects_table(rows: list[ProjectRow]) -> None:
+    console = Console()
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("PROJECT_ID")
+    table.add_column("PROFILE")
+    table.add_column("CREATED")
+    table.add_column("IMG", justify="right")
+    table.add_column("VID", justify="right")
+    for r in rows:
+        table.add_row(
+            r.project_id,
+            r.profile,
+            r.created_at.strftime("%Y-%m-%d %H:%M"),
+            str(r.image_count),
+            str(r.video_count),
+        )
+    console.print(table)
+
+
+@click.group(name="data")
+def data_group() -> None:
+    """Query the local gflow-cli SQLite catalog."""
+
+
+@data_group.group(name="list")
+def list_group() -> None:
+    """List entries from the catalog."""
+
+
+@list_group.command(name="projects")
+@click.option("--profile", default=None, help="Filter by profile name.")
+@click.option("--limit", type=click.IntRange(1, 1000), default=20, show_default=True)
+@click.option("--offset", type=click.IntRange(0), default=0, show_default=True)
+@click.option("--json", "as_json", is_flag=True, help="Emit JSONL instead of a rich table.")
+def list_projects_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List projects newest-first."""
+    rows = list_projects(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    if not rows:
+        if not as_json and sys.stdout.isatty():
+            click.echo("No projects recorded.")
+        return
+    if as_json or not sys.stdout.isatty():
+        _emit_json(rows)
+    else:
+        _emit_projects_table(rows)
+```
+
+- [ ] **Step 5: Register the group in cli.py**
+
+Open `src/gflow_cli/cli.py`. Locate where other groups (image, video, auth) are added. Add:
+
+```python
+from gflow_cli.cli_data import data_group
+
+main.add_command(data_group)
+```
+
+(Use the same idiom the existing groups use — `add_command` vs `add_group` vs decorator depends on the project's pattern. Match it.)
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py -v
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gflow_cli/cli_data.py src/gflow_cli/cli.py tests/test_cli_data.py
+git commit -m "feat(cli): add gflow data list projects"
+```
+
+### Task 2.7: CLI adapter — images / videos / profiles subcommands
+
+**Files:**
+- Modify: `src/gflow_cli/cli_data.py`
+- Modify: `tests/test_cli_data.py`
+
+- [ ] **Step 1: Write the failing tests for images / videos / profiles**
+
+Append to `tests/test_cli_data.py` — add 3 mirror tests per noun (default, --json, --profile filter, pagination — total 12 new tests). Mirror the projects pattern. Example for images:
+
+```python
+def test_data_list_images_default(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "images"])
+    assert result.exit_code == 0
+    assert "MEDIA_ID" in result.output
+
+
+def test_data_list_images_json(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "images", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 8
+
+
+def test_data_list_images_profile_filter(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "images", "--profile", "alice", "--json"])
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 4
+
+
+def test_data_list_videos_default(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "videos", "--json"])
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 2
+
+
+def test_data_list_videos_filter_no_match(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "videos", "--profile", "bob", "--json"])
+    assert result.exit_code == 0
+    assert [ln for ln in result.output.splitlines() if ln.strip()] == []
+
+
+def test_data_list_profiles_default(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "profiles", "--json"])
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 3
+    assert {r["profile_name"] for r in rows} == {"alice", "bob", "carol"}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py -v
+```
+
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Implement the three remaining subcommands**
+
+Extend `src/gflow_cli/cli_data.py`. Add three more commands using the same pattern as `list_projects_cmd`. Add three table emitters mirroring `_emit_projects_table` with the columns specified in the spec §3.1. Truncate `prompt` to 40 chars in the table emitters with an ellipsis if longer.
+
+Example for images:
+
+```python
+from gflow_cli.data.queries import ImageRow, VideoRow, ProfileRow, list_images, list_videos, list_profiles
+
+
+def _truncate(s: str, n: int = 40) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _emit_images_table(rows: list[ImageRow]) -> None:
+    console = Console()
+    table = Table(show_header=True, header_style="bold")
+    for col in ("MEDIA_ID", "PROFILE", "PROJECT_ID", "PROMPT", "ASPECT", "MODEL", "CREATED", "LOCAL_PATH"):
+        table.add_column(col)
+    for r in rows:
+        table.add_row(
+            r.media_id, r.profile, r.project_id,
+            _truncate(r.prompt), r.aspect, r.model,
+            r.created_at.strftime("%Y-%m-%d %H:%M"),
+            r.local_path,
+        )
+    console.print(table)
+
+
+@list_group.command(name="images")
+@click.option("--profile", default=None)
+@click.option("--limit", type=click.IntRange(1, 1000), default=20, show_default=True)
+@click.option("--offset", type=click.IntRange(0), default=0, show_default=True)
+@click.option("--json", "as_json", is_flag=True)
+def list_images_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List images newest-first."""
+    rows = list_images(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    if not rows:
+        if not as_json and sys.stdout.isatty():
+            click.echo("No images recorded.")
+        return
+    if as_json or not sys.stdout.isatty():
+        _emit_json(rows)
+    else:
+        _emit_images_table(rows)
+```
+
+Repeat for `videos` (with `DURATION` column) and `profiles` (no `--profile` flag — it would be redundant; columns: `PROFILE_NAME`, `LAST_USED`, `PROJECTS`, `IMAGES`, `VIDEOS`).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run full data-related test suite**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py tests/test_data_queries.py -v --cov=gflow_cli.cli_data --cov=gflow_cli.data.queries --cov-report=term-missing
+```
+
+Expected: coverage ≥ 80% on both new modules.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/cli_data.py tests/test_cli_data.py
+git commit -m "feat(cli): add gflow data list images / videos / profiles"
+```
+
+### Task 2.8: DataStoreError handling
+
+**Files:**
+- Modify: `src/gflow_cli/cli_data.py`
+- Modify: `tests/test_cli_data.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_cli_data.py`:
+
+```python
+def test_data_list_projects_db_missing_exits_16(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(tmp_path / "does-not-exist.db"))
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    assert result.exit_code == 16
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py::test_data_list_projects_db_missing_exits_16 -v
+```
+
+Expected: FAIL — current code probably crashes with an `sqlite3.OperationalError` and exits with 1 or a different code.
+
+- [ ] **Step 3: Wrap each command in DataStoreError handling**
+
+Refactor the four `list_*_cmd` functions to share a try/except. Use the project's existing exit-code helper if there is one (look in `src/gflow_cli/_cli_helpers.py` or `src/gflow_cli/errors.py`). Pattern:
+
+```python
+from gflow_cli.errors import DataStoreError  # adjust import per actual module
+from gflow_cli._cli_helpers import handle_gflow_error  # if exists
+
+
+def _run_list(query_fn, /, **kwargs) -> int:
+    try:
+        return query_fn(**kwargs)
+    except DataStoreError as e:
+        # Use project's standard exit-code mapping
+        click.echo(f"Data store error: {e}", err=True)
+        raise click.exceptions.Exit(16)
+```
+
+Wrap each subcommand body. (If the project already has a decorator like `@gflow_command` that does this, use it.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run python -m pytest tests/test_cli_data.py -v
+```
+
+Expected: all tests PASS, including the new exit-16 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/cli_data.py tests/test_cli_data.py
+git commit -m "feat(cli): wire DataStoreError → exit 16 for gflow data list"
+```
+
+### Task 2.9: Run the Impeccable Routine
+
+- [ ] **Step 1: Run the full quality routine**
+
+```powershell
+$env:PYTHONUTF8=1
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run python -m pytest -q --cov=gflow_cli tests/test_cli_data.py tests/test_data_queries.py
+```
+
+(Per memory `full-test-suite-ooms`, do NOT run the unscoped full sweep locally on Windows — trust CI for that.)
+
+Expected: all green. If ruff format fails, run `uv run ruff format src tests` then re-check.
+
+- [ ] **Step 2: Fix any pyright errors**
+
+If pyright flags strict-mode issues in `cli_data.py` or `queries.py`, fix them. Common ones:
+- Missing return type annotations.
+- Implicit `Optional` from `str = None` defaults.
+- `dataclasses.asdict()` returning `dict[str, Any]` — may need a `cast`.
+
+- [ ] **Step 3: Commit fixes**
+
+```bash
+git add -u
+git commit -m "chore(types): tighten gflow data list for pyright strict"
+```
+
+### Task 2.10: Open and merge Phase 2 PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feature/data-list-cli
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base develop --title "feat(cli): add gflow data list (read-only catalog query)" --body "$(cat <<'EOF'
+## Summary
+- New `gflow data list {projects,images,videos,profiles}` subcommand.
+- Flags: `--limit` (1..1000, default 20) / `--offset` (≥0, default 0) / `--profile NAME` / `--json`.
+- TTY → rich table; pipe or `--json` → JSONL.
+- Default sort: newest first.
+- Exit code: 0 success / 2 Click usage / 16 DataStoreError.
+- 22 new unit + integration tests; coverage ≥ 80% on new modules.
+
+## Test plan
+- [ ] Local: `uv run python -m pytest tests/test_cli_data.py tests/test_data_queries.py -v` — all green.
+- [ ] Locally exercise `gflow data list projects --limit 3` against a real catalog on a Pro/Ultra profile.
+
+Refs the v0.9.0 release spec (`docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` §3.1).
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI + merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout develop && git pull
+```
+
+---
+
+## Phase 3 — ROADMAP + Sponsorship
+
+**Branch:** `docs/roadmap-and-sponsorship` off `develop` (after Phase 2 merges)
+**Goal:** Publish `ROADMAP.md`, wire `.github/FUNDING.yml`, add GH Sponsors + BMC badges to README, add `## Support` section.
+**Output PR:** Docs + config only — no code.
+
+### Task 3.1: Create FUNDING.yml
+
+**Files:**
+- Create: `.github/FUNDING.yml`
+
+- [ ] **Step 1: Verify the directory exists**
+
+```bash
+ls .github/
+```
+
+If it doesn't exist, GitHub Actions wouldn't be running — the directory exists; just check.
+
+- [ ] **Step 2: Write the file**
+
+Create `.github/FUNDING.yml` with this exact content (replace `ffroliva` with the actual BMC username once the account is set up; GH Sponsors uses the GitHub username which is already `ffroliva`):
+
+```yaml
+# Sponsorship channels for gflow-cli.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [ffroliva]
+buy_me_a_coffee: ffroliva
+```
+
+If the BMC account isn't ready yet, leave the `buy_me_a_coffee` placeholder — GitHub silently skips entries with no live page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git checkout -b docs/roadmap-and-sponsorship
+git add .github/FUNDING.yml
+git commit -m "chore(funding): add GitHub Sponsors + Buy Me a Coffee config"
+```
+
+### Task 3.2: Author ROADMAP.md
+
+**Files:**
+- Create: `ROADMAP.md`
+
+- [ ] **Step 1: Write the file**
+
+Create `ROADMAP.md` at the repo root with this exact content:
+
+```markdown
+# Roadmap
+
+> Themes, not deadlines. `gflow-cli` is an unofficial CLI tracking a private Google Flow API — a single upstream UI change can rearrange a sprint, so we publish themed milestones with deliverables and let velocity emerge.
+
+## v0.9.0 — Maturity & Visibility (current)
+
+The release that makes the underlying data layer visible to the user. Adds `gflow data list` for read-only catalog browsing, publishes this roadmap, wires sponsorship, and refreshes the documentation surface to reflect everything that shipped through v0.8.x.
+
+- Local SQLite catalog (shipped in PR #58, surfaced here)
+- `gflow video t2v` model picker (`omni-flash` / `veo-lite` / `veo-fast` / `veo-quality` / `veo-lite-lp`)
+- `gflow video i2v` — image-to-video with optional end frame
+- `gflow video r2v` — reference-to-video (Flow ingredients)
+- `gflow data list {projects,images,videos,profiles}` — read-only catalog query
+- Locale-agnostic media-dialog selectors (fixes non-English Chrome profiles)
+- `ROADMAP.md`, `.github/FUNDING.yml`, sponsor badges
+
+## v0.10.0 — Data Query Surface
+
+Extends the data layer surface from read-only listing to inspection and selective export. Same local SQLite catalog, richer ways to interrogate it.
+
+- `gflow data show <media_id>` — full record for one image / video / project
+- `gflow data search` — filter by prompt substring, model, aspect, date range
+- `gflow data export` — JSON / CSV / TSV
+- `gflow data prune` — retention controls (`--older-than`, `--keep-last-n`)
+
+## v0.11.0 — Local HTTP API + Web UI
+
+The API and the UI ship together as one deliverable — neither is useful alone. `gflow ui` boots a local HTTP server on 127.0.0.1 that hosts both the API and the UI; everything stays loopback-only.
+
+- `gflow ui` — single command, single port
+- Local REST API over the SQLite catalog with read endpoints for projects / images / videos / profiles
+- Web UI consumes the API; browses generations with thumbnails
+- Aggregated view across local profiles (read-only)
+
+## v1.0.0 — Stable API
+
+The point at which `FlowApiClient` carries a SemVer commitment and the documentation reaches "production-ready" standard.
+
+- `FlowApiClient` SemVer commitment
+- HTTP transport revival path (community-contrib; if feasible)
+- Production-ready documentation
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ROADMAP.md
+git commit -m "docs(roadmap): publish v0.9 → v1.0 themed roadmap"
+```
+
+### Task 3.3: Add sponsor badges + Support section to README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read current README**
+
+Open `README.md`. Identify:
+- The badge row near the top.
+- The docs TOC location.
+- A natural spot near the bottom for a `## Support` section (above LICENSE / Disclaimer).
+
+- [ ] **Step 2: Add two badges to the existing badge row**
+
+After the existing badges (PyPI / CI / Sonar / etc.), add:
+
+```markdown
+[![Sponsor on GitHub](https://img.shields.io/static/v1?label=Sponsor&message=GitHub&color=ea4aaa&logo=github)](https://github.com/sponsors/ffroliva)
+[![Buy Me A Coffee](https://img.shields.io/static/v1?label=Buy%20Me%20a&message=Coffee&color=ffdd00&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/ffroliva)
+```
+
+- [ ] **Step 3: Add Support section near the bottom**
+
+Insert above the `## License` section (or wherever the project's "last sections" live):
+
+```markdown
+## Support
+
+If `gflow-cli` saves you time, a coffee or sponsorship goes a long way to keeping it maintained.
+
+- [GitHub Sponsors](https://github.com/sponsors/ffroliva)
+- [Buy Me a Coffee](https://www.buymeacoffee.com/ffroliva)
+
+Thanks to everyone who has supported the project so far.
+```
+
+- [ ] **Step 4: Add ROADMAP link to docs TOC**
+
+Find the docs TOC table in README (the one that lists CHANGELOG, KNOWN_ISSUES, etc.). Add a row:
+
+```markdown
+| [ROADMAP](ROADMAP.md) | Themed milestones through v1.0 | You want to see where the project is heading |
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add sponsor badges, Support section, and ROADMAP link"
+```
+
+### Task 3.4: Add ROADMAP row to docs/INDEX.md
+
+**Files:**
+- Modify: `docs/INDEX.md`
+
+- [ ] **Step 1: Insert ROADMAP row**
+
+In the docs table near the top of `docs/INDEX.md`, add (after the README/AGENTS/llms.txt rows, before PLAN.md):
+
+```markdown
+| [ROADMAP](../ROADMAP.md) | Themed milestones from v0.9 through v1.0 | You want a multi-release view of where the project is heading |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/INDEX.md
+git commit -m "docs(index): add ROADMAP row"
+```
+
+### Task 3.5: Open and merge Phase 3 PR
+
+- [ ] **Step 1: Push and PR**
+
+```bash
+git push -u origin docs/roadmap-and-sponsorship
+gh pr create --base develop --title "docs: publish ROADMAP.md + wire sponsorship (GH Sponsors + BMC)" --body "$(cat <<'EOF'
+## Summary
+- New `ROADMAP.md` with themed milestones through v1.0.
+- `.github/FUNDING.yml` for GitHub Sponsors + Buy Me a Coffee.
+- README: two sponsor badges and a `## Support` section.
+- `docs/INDEX.md`: ROADMAP row added.
+
+Refs the v0.9.0 release spec §3.2 + §3.3. Part of v0.9.0 release sequence — Phase 3 of 5.
+EOF
+)"
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout develop && git pull
+```
+
+---
+
+## Phase 4 — Documentation Maturity Refresh
+
+**Branch:** `docs/v0.9.0-maturity-refresh` off `develop` (after Phase 3 merges)
+**Goal:** Update AGENTS.md, INDEX.md, DATA_LAYER.md, PROJECT_STATUS.md, llms.txt to reflect data-layer + new video commands + ROADMAP existence. Validate the KNOWN_ISSUES.md omni-flash draft from the working tree.
+
+### Task 4.1: Update AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Add `data/` to the module list**
+
+In the "Project at a glance" section, find the list of top-level modules under `src/gflow_cli/`. Add `data/` to that list (alphabetical position).
+
+- [ ] **Step 2: Note exit code 16 in code-style section**
+
+Find the line about `EXIT_CODE_MAP` and exit codes 3-15. Update the range to 3-16 and add an inline note: `(16 = data-store failures, see [memory: exit-code-16-data-store])` — actually since AGENTS.md is for external agents, drop the memory ref and write: `(16 = data-store failures from gflow_cli.data)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git checkout -b docs/v0.9.0-maturity-refresh
+git add AGENTS.md
+git commit -m "docs(agents): add data/ module and exit-code 16 to AGENTS.md"
+```
+
+### Task 4.2: Update docs/INDEX.md
+
+**Files:**
+- Modify: `docs/INDEX.md`
+
+- [ ] **Step 1: Add DATA_LAYER row if missing**
+
+Check whether `docs/INDEX.md` already has a row for `docs/DATA_LAYER.md`. If not, add one:
+
+```markdown
+| **[docs/DATA_LAYER.md](DATA_LAYER.md)** | SQLite catalog schema, where the DB lives, how to query it with `gflow data list` | Curious what gflow records, or building tooling against the catalog |
+```
+
+- [ ] **Step 2: Add topic shortcut**
+
+In the "Topic shortcuts" section, add:
+
+```markdown
+**"How do I see what's in my gflow catalog?"** → [USAGE § gflow data list](USAGE.md#gflow-data-list) (or run `gflow data list projects --limit 5`)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/INDEX.md
+git commit -m "docs(index): add DATA_LAYER row and data-list topic shortcut"
+```
+
+### Task 4.3: Update docs/DATA_LAYER.md
+
+**Files:**
+- Modify: `docs/DATA_LAYER.md`
+
+- [ ] **Step 1: Read current content**
+
+Open `docs/DATA_LAYER.md`. Find a natural place to add a new section — likely after the schema description, before any "Future work" / "Caveats" section.
+
+- [ ] **Step 2: Add "Querying the catalog" section**
+
+```markdown
+## Querying the catalog
+
+As of v0.9.0, `gflow data list` is the supported way to read the catalog from the CLI:
+
+```bash
+# Newest 20 projects across all profiles
+gflow data list projects
+
+# All images for one profile, pagable
+gflow data list images --profile ffroliva --limit 50 --offset 0
+
+# Videos, as JSONL for piping into jq
+gflow data list videos --json | jq '.media_id'
+
+# Profiles that have ever generated anything via gflow
+gflow data list profiles
+```
+
+Flags shared by all four subcommands:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--limit N` | 20 | 1..1000 |
+| `--offset N` | 0 | for pagination |
+| `--profile NAME` | unset | filter to one profile (not available on `profiles`) |
+| `--json` | off | JSONL output, one object per line |
+
+TTY stdout → rich table; pipe or `--json` → JSONL. Default sort: newest first. Exit code 16 on data-store errors.
+
+For one-record lookup, see `gflow data media <id>` (the existing provenance command).
+
+> **`data list profiles` vs `gflow auth list`:** `data list profiles` shows profiles that have recorded generations in the catalog; `gflow auth list` shows profiles that have ever logged in via `gflow auth login`. A profile that logged in but never generated anything will appear in `auth list` but not in `data list profiles`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/DATA_LAYER.md
+git commit -m "docs(data-layer): document gflow data list query surface"
+```
+
+### Task 4.4: Update docs/PROJECT_STATUS.md
+
+**Files:**
+- Modify: `docs/PROJECT_STATUS.md`
+
+- [ ] **Step 1: Add v0.9.0 milestone row**
+
+Open `docs/PROJECT_STATUS.md`. Find the milestone table. Add a new row at the top (most recent first) for v0.9.0:
+
+```markdown
+| v0.9.0 | 2026-05-XX | `gflow data list` read CLI · ROADMAP.md · sponsorship wired · doc maturity refresh | Maturity & Visibility |
+```
+
+(The date `2026-05-XX` is replaced with the actual release date in Phase 5 when the tag is cut.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/PROJECT_STATUS.md
+git commit -m "docs(status): add v0.9.0 row to milestone table"
+```
+
+### Task 4.5: Update llms.txt
+
+**Files:**
+- Modify: `llms.txt`
+
+- [ ] **Step 1: Read current content**
+
+```bash
+cat llms.txt | head -50
+```
+
+Note the version reference (`v0.8.1`) and the capability list section.
+
+- [ ] **Step 2: Bump version + add data-list capability**
+
+In-place edits:
+- Change `v0.8.1` → `v0.9.0` in any "current version" / "as of" text.
+- In the capability list, add a line about `gflow data list` (one line, similar tone to existing entries).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add llms.txt
+git commit -m "docs(llms): bump to v0.9.0 and document gflow data list"
+```
+
+### Task 4.6: Carry over working-tree KNOWN_ISSUES.md draft
+
+**Files:**
+- Modify: `KNOWN_ISSUES.md`
+
+You may have an in-flight draft of an omni-flash known-issue entry in your working tree from before the v0.9.0 brainstorm. If so, validate and commit it here.
+
+- [ ] **Step 1: Check status**
+
+```bash
+git status --porcelain KNOWN_ISSUES.md
+```
+
+If the file shows ` M` (modified), the draft is present. If clean, skip this task.
+
+- [ ] **Step 2: Review the diff**
+
+```bash
+git diff KNOWN_ISSUES.md
+```
+
+Confirm the omni-flash `flow_operation_id` NULL entry is accurate, actionable, and lists status / severity / workaround / roadmap.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add KNOWN_ISSUES.md
+git commit -m "docs(known-issues): add omni-flash flow_operation_id NULL entry"
+```
+
+### Task 4.7: Run /gflow:doc-review LLM council
+
+- [ ] **Step 1: Invoke the slash command**
+
+Per the project's custom command (see CLAUDE.md), run:
+
+```
+/gflow:doc-review
+```
+
+This dispatches 3 parallel review subagents (completeness / cross-reference / drift) per memory `llm-council-audit-protocol`.
+
+Expected outcome: GREEN or YELLOW verdict. RED blocks the phase.
+
+- [ ] **Step 2: Address any findings**
+
+If YELLOW (advisory): file follow-ups but proceed.
+If RED (blocking): apply fixes inline, re-run the review, repeat until at least YELLOW.
+
+- [ ] **Step 3: Commit any fix-up changes**
+
+```bash
+git add -u
+git commit -m "docs: address doc-review council findings for v0.9.0"
+```
+
+### Task 4.8: Open and merge Phase 4 PR
+
+- [ ] **Step 1: Push and PR**
+
+```bash
+git push -u origin docs/v0.9.0-maturity-refresh
+gh pr create --base develop --title "docs: v0.9.0 maturity refresh (AGENTS / INDEX / DATA_LAYER / STATUS / llms / KNOWN_ISSUES)" --body "$(cat <<'EOF'
+## Summary
+- AGENTS.md: `data/` module added, exit-code 16 noted.
+- docs/INDEX.md: DATA_LAYER row + topic shortcut for `gflow data list`.
+- docs/DATA_LAYER.md: new "Querying the catalog" section.
+- docs/PROJECT_STATUS.md: v0.9.0 row added.
+- llms.txt: version bump + data-list capability.
+- KNOWN_ISSUES.md: omni-flash `flow_operation_id` NULL entry.
+
+Doc-review council verdict: GREEN/YELLOW (see PR comments).
+
+Refs v0.9.0 release spec §3.4. Part of v0.9.0 release sequence — Phase 4 of 5.
+EOF
+)"
+gh pr checks --watch
+gh pr merge --merge --delete-branch
+git checkout develop && git pull
+```
+
+---
+
+## Phase 5 — Release Closure
+
+**Branch:** `release/v0.9.0` off `develop` (after Phases 1–4 merge)
+**Goal:** Bump version, rename Unreleased to 0.9.0, capture LIVE_VERIFICATION_v0.9.0.md evidence, signed tag, PyPI publish, back-merge to develop.
+
+### Task 5.1: Cut the release branch
+
+- [ ] **Step 1: Confirm develop is clean and current**
+
+```bash
+git checkout develop
+git pull
+git status --porcelain
+```
+
+Expected: clean working tree.
+
+- [ ] **Step 2: Cut the branch**
+
+```bash
+git checkout -b release/v0.9.0
+```
+
+### Task 5.2: Version bump
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/gflow_cli/__init__.py` (if `__version__` lives there)
+
+- [ ] **Step 1: Bump pyproject.toml**
+
+Edit `pyproject.toml` line 3 from:
+
+```toml
+version = "0.8.1"
+```
+
+to:
+
+```toml
+version = "0.9.0"
+```
+
+- [ ] **Step 2: Check for __version__ in __init__.py**
+
+```bash
+grep -n "__version__" src/gflow_cli/__init__.py
+```
+
+If present, bump it to `"0.9.0"` to match.
+
+- [ ] **Step 3: Verify version metadata loads correctly**
+
+```bash
+uv run python -c "from importlib.metadata import version; print(version('gflow-cli'))"
+```
+
+Expected: `0.9.0`. If you get `0.8.1`, run `uv sync` first to refresh the editable install.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml src/gflow_cli/__init__.py
+git commit -m "chore(release): bump version to 0.9.0"
+```
+
+### Task 5.3: CHANGELOG rename
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Rename Unreleased to 0.9.0**
+
+In `CHANGELOG.md`:
+1. Change `## [Unreleased]` to `## [0.9.0] — 2026-05-XX` (use today's date).
+2. Insert a new empty `## [Unreleased]` block above the 0.9.0 block:
+
+```markdown
+## [Unreleased]
+```
+
+3. At the bottom compare-links section, update the existing line:
+
+```
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.8.0...HEAD
+```
+
+to:
+
+```
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/ffroliva/gflow-cli/compare/v0.8.1...v0.9.0
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): finalize 0.9.0 release notes"
+```
+
+### Task 5.4: Live verification — `gflow data list` against a real catalog
+
+**Files:**
+- Create: `docs/LIVE_VERIFICATION_v0.9.0.md`
+
+- [ ] **Step 1: Set up the verification scratchpad**
+
+```bash
+mkdir -p tmp/v0.9.0-verification
+```
+
+- [ ] **Step 2: Run each subcommand against a real catalog**
+
+Against your real Pro/Ultra profile catalog (NOT a tmp DB), run:
+
+```bash
+gflow data list projects --limit 5 > tmp/v0.9.0-verification/projects.txt
+gflow data list images --limit 5 > tmp/v0.9.0-verification/images.txt
+gflow data list videos --limit 5 > tmp/v0.9.0-verification/videos.txt
+gflow data list profiles > tmp/v0.9.0-verification/profiles.txt
+gflow data list images --profile <your-profile> --json | head -3 > tmp/v0.9.0-verification/images.jsonl
+```
+
+Verify each output:
+- Rich table rendering on TTY.
+- JSONL format valid (`jq . tmp/v0.9.0-verification/images.jsonl` should parse cleanly).
+- Newest-first ordering matches your last few generations.
+- Counts on `profiles` aggregate row match what you remember generating.
+
+- [ ] **Step 3: Run one regression generation per surface**
+
+To make sure the release didn't break the existing surfaces:
+
+```bash
+gflow image t2i "smoke test for v0.9.0" --aspect 1:1 --profile <your-profile>
+gflow video t2v "smoke test for v0.9.0" --aspect 9:16 --model omni-flash --duration 4 --profile <your-profile>
+```
+
+Verify both produce a file and a fresh catalog entry. Cross-check with `gflow data list images --limit 1` + `gflow data list videos --limit 1`.
+
+- [ ] **Step 4: Write the LIVE_VERIFICATION_v0.9.0.md file**
+
+Create `docs/LIVE_VERIFICATION_v0.9.0.md` mirroring the structure of `docs/LIVE_VERIFICATION_v0.8.1.md`:
+
+```markdown
+# Live verification — v0.9.0
+
+> Evidence for the v0.9.0 release. Per memory `verification-ledger-5-layer`, this file captures the artifacts that justify claiming the release works end-to-end against the real Flow API and a real catalog.
+
+## Environment
+
+- Date: 2026-05-XX
+- Profile: <profile name>
+- gflow-cli: v0.9.0 (commit <short hash>)
+- Python: 3.X.Y
+- Chrome: <version>
+
+## Surface 1 — `gflow data list projects`
+
+```
+<paste tmp/v0.9.0-verification/projects.txt>
+```
+
+Verified:
+- ✅ Rich table renders with all 5 columns (PROJECT_ID, PROFILE, CREATED, IMG, VID).
+- ✅ Newest-first sort.
+- ✅ image_count + video_count aggregates match catalog count.
+
+## Surface 2 — `gflow data list images --json`
+
+```
+<paste first 3 JSONL lines>
+```
+
+Verified:
+- ✅ JSONL parses with jq.
+- ✅ All 8 spec columns present.
+
+## Surface 3 — `gflow data list videos`
+
+(same shape)
+
+## Surface 4 — `gflow data list profiles`
+
+(same shape)
+
+## Surface 5 — Regression: `gflow image t2i`
+
+(file count + magic bytes + Pillow dims + structlog event excerpts per the 5-layer ledger)
+
+## Surface 6 — Regression: `gflow video t2v`
+
+(same shape)
+
+## Conclusion
+
+All six surfaces pass live verification. Release is safe to tag.
+```
+
+Fill every `<placeholder>` with real data.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/LIVE_VERIFICATION_v0.9.0.md
+git commit -m "docs(release): live-verification evidence for v0.9.0"
+```
+
+### Task 5.5: Run the Impeccable Routine
+
+- [ ] **Step 1: Run the full check**
+
+```powershell
+$env:PYTHONUTF8=1
+uv run python scripts/ci/check_repo_hygiene.py
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run pyright src
+uv run python -m pytest -q tests/test_cli_data.py tests/test_data_queries.py
+```
+
+Expected: green. (Per memory `full-test-suite-ooms`, do NOT run unscoped full suite locally.)
+
+- [ ] **Step 2: Confirm CI on develop is green**
+
+```bash
+gh run list --branch develop --limit 5
+```
+
+Expected: latest run on `develop` (the merge of Phase 4) is success.
+
+### Task 5.6: Verify sponsor accounts are live (acceptance criterion)
+
+- [ ] **Step 1: GitHub Sponsors**
+
+Open https://github.com/sponsors/ffroliva. Expected: a live page with at least one tier visible (even $1 is fine). If the page 404s or shows "this user is not accepting sponsorships," you must complete the Stripe Connect setup BEFORE tagging.
+
+- [ ] **Step 2: Buy Me a Coffee**
+
+Open https://www.buymeacoffee.com/ffroliva. Expected: a live page.
+
+- [ ] **Step 3: If either is not live, BLOCK tagging**
+
+Stop and complete account setup. The acceptance criterion is explicit. Tagging now ships a broken link to PyPI.
+
+### Task 5.7: Open release PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin release/v0.9.0
+```
+
+- [ ] **Step 2: PR base = main**
+
+```bash
+gh pr create --base main --title "release: v0.9.0 — Maturity & Visibility" --body "$(cat <<'EOF'
+## Summary
+
+Adds the read-only `gflow data list` surface over the existing SQLite catalog (PR #58), publishes ROADMAP.md and FUNDING.yml, refreshes documentation to reflect the new maturity baseline, and bumps to 0.9.0.
+
+See [`CHANGELOG.md`](../CHANGELOG.md#090--2026-05-XX) for the full notes and [`docs/LIVE_VERIFICATION_v0.9.0.md`](../docs/LIVE_VERIFICATION_v0.9.0.md) for end-to-end evidence on a real account.
+
+## Pre-tag checklist
+
+- [x] Phases 1-4 merged to develop
+- [x] Version bumped (pyproject + __init__)
+- [x] CHANGELOG renamed to [0.9.0]
+- [x] LIVE_VERIFICATION_v0.9.0.md committed
+- [x] GH Sponsors account live
+- [x] BMC account live
+- [x] Impeccable Routine passes locally
+- [x] CI green on develop
+
+After merge: signed annotated tag `v0.9.0`, PyPI auto-publish, back-merge to develop.
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI, merge to main**
+
+```bash
+gh pr checks --watch
+gh pr merge --merge   # NOT squash — preserves the distinct release-branch commits per memory pr-hygiene-revert-and-multi-commit
+git checkout main && git pull
+```
+
+### Task 5.8: Signed annotated tag
+
+- [ ] **Step 1: Create the tag on main**
+
+```bash
+git tag -s v0.9.0 -m "v0.9.0 — Maturity & Visibility"
+```
+
+(SSH signing must already be configured per memory `release-signing`.)
+
+- [ ] **Step 2: Verify signature**
+
+```bash
+git tag -v v0.9.0
+```
+
+Expected: `Good "ssh-..." signature for ffroliva@...`. CI rejects unsigned tags.
+
+- [ ] **Step 3: Push the tag**
+
+```bash
+git push origin v0.9.0
+```
+
+- [ ] **Step 4: Watch the release workflow**
+
+```bash
+gh run watch
+```
+
+The release workflow uses PyPI Trusted Publishing and creates a GitHub release. Expected: green.
+
+- [ ] **Step 5: Verify PyPI**
+
+```bash
+pip index versions gflow-cli
+```
+
+Expected: `0.9.0` appears in the list. The PyPI page https://pypi.org/project/gflow-cli/0.9.0/ should render the current README.
+
+### Task 5.9: Back-merge main → develop
+
+Per memory `release-back-merge-gap-recovery`, this step is non-optional.
+
+- [ ] **Step 1: Back-merge**
+
+```bash
+git checkout develop
+git pull
+git merge --no-ff main -m "chore: back-merge v0.9.0 from main into develop"
+git push
+```
+
+- [ ] **Step 2: Confirm develop's tip is now ahead of main only on Unreleased**
+
+```bash
+git log main..develop --oneline
+```
+
+Expected: empty (develop has everything main has, and main has the merge commit) — OR just merge-commits if any unrelated work happened. No phase 1-4 commits should be missing from develop.
+
+- [ ] **Step 3: Confirm CI green on develop after back-merge**
+
+```bash
+gh run list --branch develop --limit 1
+```
+
+Expected: green.
+
+### Task 5.10: Post-release housekeeping
+
+- [ ] **Step 1: Delete the spec/plan branch**
+
+The spec lives only in the repo for the duration of the release. Per memory `release-spec-plan-memory-consolidation`, extract any durable patterns into memory and remove the working artifacts.
+
+```bash
+git branch -d docs/v0.9.0-release-spec
+git push origin --delete docs/v0.9.0-release-spec
+```
+
+(Or open a separate PR removing `docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` and `docs/superpowers/plans/2026-05-24-v0.9.0-release-implementation.md` from develop if those branches were merged in.)
+
+- [ ] **Step 2: Update memory entries that v0.9.0 changes**
+
+If any auto-memory entry referenced "v0.8.1 is current," update it.
+
+- [ ] **Step 3: Announce release**
+
+Drop a note in your usual channel (Discord, etc.) pointing to the GitHub release page.
+
+---
+
+## Self-Review Notes
+
+This plan covers spec sections:
+- §1 Goal — covered by all 5 phases.
+- §2 Non-goals — none of the deferred items are scheduled here.
+- §3.1 `gflow data list` — Phase 2 (Tasks 2.1–2.9).
+- §3.2 `ROADMAP.md` — Phase 3 (Task 3.2).
+- §3.3 Sponsorship — Phase 3 (Tasks 3.1, 3.3, 3.4).
+- §3.4 Documentation refresh — Phase 4 (Tasks 4.1–4.6).
+- §3.5 Release closure — Phase 5 (Tasks 5.1–5.10).
+- §4 Architecture / file layout — Phase 2 file structure section.
+- §5 Acceptance criteria — explicitly cross-referenced in Phase 5 (Task 5.6 for sponsor accounts, Task 5.4 for verification evidence, Task 5.9 for back-merge).
+- §6 Risks — addressed inline: Phase 1 Task 1.1 (schema drift), Phase 1 Task 1.2 (CHANGELOG drift), Phase 5 Task 5.6 (sponsor accounts), Phase 5 Task 5.9 (back-merge skip).

--- a/docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md
+++ b/docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md
@@ -1,0 +1,204 @@
+# v0.9.0 — Maturity & Visibility Release
+
+> Status: **draft for review** · Author: Flavio Oliva · Date: 2026-05-24
+> Brainstorm transcript: this conversation
+> Supersedes: nothing; this is the v0.9.0 release design
+
+## 1. Goal
+
+Cut `gflow-cli` v0.9.0 with three deliveries that together close the maturity gap:
+
+1. **Visibility** — give users a first read-only window into the SQLite catalog that landed in PR #58 via a new `gflow data list` command. Today the data layer is write-only from the user's perspective.
+2. **Direction** — publish `ROADMAP.md` as a first-class doc so the community sees a credible trajectory through v1.0.
+3. **Sustainability** — wire `.github/FUNDING.yml` + README badges for **GitHub Sponsors + Buy Me a Coffee** so contributors who want to support the work have a clear path.
+
+Plus the standard release closure: bump 0.8.1 → 0.9.0, audit `[Unreleased]` (currently **missing the data layer**), update docs to reflect the maturity gain, tag, publish to PyPI, write a `LIVE_VERIFICATION_v0.9.0.md` evidence file.
+
+## 2. Non-goals (explicit deferrals)
+
+- **No `gflow data show / search / export / prune`** — those are v0.10 (Data Query Surface).
+- **No local web UI / local HTTP API** — v0.11.
+- **No HTTP transport revival** — community-contrib track; v1.0 stretch.
+- **No date commitments on the roadmap.** Themed milestones only — Flow's UI can break a sprint and dated promises erode trust faster than thematic ones.
+
+## 3. Scope
+
+### 3.1 `gflow data list` — read-only data layer query CLI
+
+**Command shape:**
+
+```
+gflow data list projects   [OPTIONS]
+gflow data list images     [OPTIONS]
+gflow data list videos     [OPTIONS]
+gflow data list profiles   [OPTIONS]
+```
+
+The `list` namespace leaves room for `show` / `search` / `export` / `prune` in v0.10 without rearranging the surface.
+
+**Flags (apply to all four nouns):**
+
+| Flag | Default | Range | Behaviour |
+|---|---|---|---|
+| `--limit N` | `20` | `1..1000` | Max rows returned |
+| `--offset N` | `0` | `≥0` | Rows to skip (paginate) |
+| `--profile NAME` | unset | — | Filter by profile; defaults to no filter (all profiles) |
+| `--json` | off | flag | Force JSONL output even on a TTY |
+
+**Output format:**
+- TTY stdout → rich table (already a project dep)
+- non-TTY OR `--json` → newline-delimited JSON, one row per line
+- This mirrors the existing structlog TTY/JSON pattern.
+
+**Default sort:** newest first (`ORDER BY created_at DESC` or per-noun equivalent). No flag in v0.9.0.
+
+**Columns per noun** (subject to reconciliation against the actual `gflow_cli.data` schema during implementation; the implementation plan resolves any mismatch):
+
+| Noun | Columns |
+|---|---|
+| `projects` | project_id, profile, created_at, image_count, video_count |
+| `images` | media_id, profile, project_id, prompt (truncated 40 chars), aspect, model, created_at, local_path |
+| `videos` | media_id, profile, project_id, prompt (truncated 40 chars), aspect, model, duration, created_at, local_path |
+| `profiles` | profile_name, last_used_at, project_count, image_count, video_count |
+
+> Semantic note for `profiles`: the source is the **catalog** (profiles that have at least one recorded project/image/video), NOT `profile_store`. A profile that has logged in via `gflow auth login` but never generated anything does not appear in `gflow data list profiles`. Use `gflow auth list` for the full login-known profile inventory.
+
+**Error contract:**
+- Empty catalog → exit 0, prints `No <noun> recorded.` to TTY or empty output on `--json`.
+- DB error (file missing, migration mismatch) → existing `DataStoreError` family, exit code **16** per memory `exit-code-16-data-store`.
+- Bad `--limit` / `--offset` → Click validation error, exit 2.
+
+**Tests:**
+- Unit tests over a fixture catalog (small SQLite seeded via `tests/conftest.py` helper) — 1 happy-path + 1 pagination + 1 `--profile` filter + 1 empty-catalog + 1 JSONL output per noun (4 nouns × 5 cases = 20 tests minimum).
+- No integration tests against live Flow — this is pure local DB read.
+- Coverage floor: 80% on the new `gflow_cli/cli_data.py` module (matches project standard).
+
+### 3.2 `ROADMAP.md` — first-class roadmap doc
+
+New file at repo root, linked from README + `docs/INDEX.md`. Structure:
+
+```
+## v0.9.0 — Maturity & Visibility (current)
+- Data layer (PR #58)
+- t2v model picker / i2v / r2v video commands
+- gflow data list (read-only)
+- Locale-agnostic media-dialog selectors
+- Sponsorship + ROADMAP
+
+## v0.10.0 — Data Query Surface
+- gflow data show <media_id>
+- gflow data search --prompt / --model / --aspect
+- gflow data export (JSON / CSV)
+- gflow data prune (retention controls)
+
+## v0.11.0 — Local HTTP API + Web UI
+- gflow ui — boots a local HTTP server on 127.0.0.1 hosting both the API and the UI together
+- Local REST API over the SQLite catalog with read endpoints for projects / images / videos / profiles
+- Web UI consumes the API; browses generations with thumbnails and aggregated views across local profiles
+- Single command, single port, bound to loopback only
+- The API and the UI ship together as one deliverable — neither is useful alone
+
+## v1.0.0 — Stable API
+- FlowApiClient SemVer commitment
+- HTTP transport revival path (community-contrib; if feasible)
+- Documentation reaches "production-ready" standard
+```
+
+Each milestone gets a one-paragraph "what this means" framing, not just a bullet list. No dates. Add a footer note: *"Themes, not deadlines. An unofficial CLI tracking a private API can have its sprint broken by a single UI change upstream."*
+
+### 3.3 Sponsorship wiring
+
+**`.github/FUNDING.yml`:**
+
+```yaml
+github: [ffroliva]
+buy_me_a_coffee: ffroliva   # placeholder — user creates the account
+```
+
+**README placement:**
+- Above-the-fold badge row near the existing trust-signal warnings. Two small badges (GH Sponsors button + BMC button), no big banner.
+- New `## Support` section near the bottom (above the existing docs TOC) with one short paragraph thanking sponsors + the same two links.
+
+**No mention of sponsorship in CLI output, error messages, or `--help`.** Keep the surface clean. Sponsorship lives in README and `FUNDING.yml`, full stop.
+
+### 3.4 Documentation maturity refresh
+
+The 0.8.1 → 0.9.0 docs are mostly fine but a few touch-points need updating to reflect the data layer + new video commands + ROADMAP existence.
+
+| File | Edit |
+|---|---|
+| `README.md` | Add ROADMAP link to the docs TOC; add sponsor badges + Support section; bump `v0.8.1` → `v0.9.0` references; add one line to the AI-agents block pointing at `gflow data list` |
+| `AGENTS.md` | Add `data/` to the module list in "Project at a glance"; note exit code 16 in code-style section |
+| `docs/INDEX.md` | Add ROADMAP.md row; add DATA_LAYER.md row if not yet present; add a topic shortcut: *"How do I see what's in the catalog?"* → `gflow data list` |
+| `docs/DATA_LAYER.md` | Add a "Querying the catalog" section pointing at `gflow data list` |
+| `docs/PROJECT_STATUS.md` | Add v0.9.0 row to milestone table |
+| `CHANGELOG.md` | **AUDIT FIRST** — currently missing the data layer (PR #52, #58). Add an `Added` entry for the catalog; verify the Unreleased section covers everything since v0.8.1 (i2v, r2v, t2v model picker, locale fixes, i2i media-dialog fix, model-select fix, the `__aenter__` cleanup). Then rename `[Unreleased]` → `[0.9.0] — 2026-05-XX` |
+| `llms.txt` | Bump version reference; add `gflow data list` to capability list |
+| `CLAUDE.md` | No edits expected — file is intentionally minimal |
+| `pyproject.toml` | `version = "0.9.0"` |
+| `src/gflow_cli/__init__.py` | `__version__ = "0.9.0"` if it exists there |
+
+A `/gflow:doc-review` LLM council pass (per memory `llm-council-audit-protocol`) runs before tagging — the council catches what single-pass checklists miss.
+
+### 3.5 Release closure flow
+
+Standard `/gflow:release` flow per `RELEASE.md`. Notable for this release:
+
+1. `develop` → `release/v0.9.0` branch
+2. Version bumps + CHANGELOG rename + ROADMAP.md + FUNDING.yml + README updates land on the release branch
+3. `/gflow:doc-review` council audit
+4. Live verification: at least one `gflow data list <each-noun>` against the real catalog, plus a re-run of one `image t2i` + one `video t2v` to confirm no regression. Evidence in `docs/LIVE_VERIFICATION_v0.9.0.md`.
+5. PR `release/v0.9.0` → `main`, signed annotated tag `v0.9.0`, push, PyPI auto-publish via existing trusted-publishing workflow.
+6. **Back-merge `main` → `develop` immediately** per memory `release-back-merge-gap-recovery` — don't skip this.
+
+## 4. Architecture / file layout for the new code
+
+```
+src/gflow_cli/
+  cli_data.py          # NEW — Click group `gflow data list ...`
+  data/
+    __init__.py        # existing
+    queries.py         # NEW or extended — read-only list functions per noun
+                       # signatures: list_projects(profile, limit, offset) -> list[ProjectRow]
+                       # ... images, videos, profiles
+src/gflow_cli/cli.py   # register the new `data` subgroup
+tests/
+  test_cli_data.py     # NEW — covers all 20+ cases described above
+  fixtures/
+    seeded_catalog.py  # NEW — helper to build a fixture catalog in tests
+```
+
+`cli_data.py` is a thin Click adapter: parses flags, calls the query functions in `data/queries.py`, formats output. Query logic is its own module so v0.10's `show`/`search`/`export` can reuse it.
+
+## 5. Acceptance criteria
+
+A v0.9.0 release is "done" when ALL of:
+
+- [ ] `gflow data list {projects,images,videos,profiles}` works with `--limit`, `--offset`, `--profile`, `--json` on a real catalog from a Pro/Ultra profile.
+- [ ] `ROADMAP.md` exists with the v0.9 → v1.0 themed structure and is linked from README + INDEX.
+- [ ] `.github/FUNDING.yml` present; README has GH Sponsors + BMC badges and a `## Support` section linking both.
+- [ ] CHANGELOG `[Unreleased]` has been audited; data layer added; section renamed to `[0.9.0] — YYYY-MM-DD` with compare links updated.
+- [ ] All docs in §3.4 updated; LLM council pass GREEN or YELLOW (RED blocks the release).
+- [ ] `pyproject.toml` at `0.9.0`; `__init__.py` matching.
+- [ ] `docs/LIVE_VERIFICATION_v0.9.0.md` has evidence of `data list` against a real catalog + one image + one video regression check.
+- [ ] Signed annotated tag `v0.9.0` on `main`; PyPI release published; `main` → `develop` back-merged.
+- [ ] CI green on `develop` after back-merge.
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Data layer schema mismatch — the column list in §4.1 may not match `gflow_cli.data` reality | First step of the implementation plan: read the actual schema, reconcile the column list inline, update this spec if necessary before coding |
+| CHANGELOG drift — the data-layer entries from PR #52/#58 were never added to Unreleased | Explicit audit step in §4.5; LLM council will also catch it |
+| Sponsor accounts not yet created on user's side | FUNDING.yml supports placeholder usernames; user creates GH Sponsors + BMC accounts before tagging; release blocks on this (acceptance criterion above) |
+| Back-merge skipped (recurrence of release `0.8.0` gap) | Explicit acceptance criterion + memory `release-back-merge-gap-recovery` is already wired into `/gflow:release` |
+
+## 7. Out of scope of this spec (handled elsewhere)
+
+- The implementation plan (created by `writing-plans` skill after this spec is approved).
+- The actual prose for ROADMAP.md, README updates, CHANGELOG entries — drafted during execution against this spec.
+- Live verification artifact contents — written during the release.
+
+---
+
+**Next step after approval**: invoke `writing-plans` skill to produce an executable implementation plan from this spec.


### PR DESCRIPTION
## Summary

Adds the design spec and implementation plan that drive the v0.9.0 release work. These are project-management artifacts (not public docs) and will be deleted post-release per the release-spec-plan-memory-consolidation convention.

- `docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` — release scope: `gflow data list` read CLI, ROADMAP.md, sponsorship wiring, doc maturity refresh, release closure flow.
- `docs/superpowers/plans/2026-05-24-v0.9.0-release-implementation.md` — 5-phase implementation plan with ~36 atomic tasks.

## Test plan
- [x] Spec self-reviewed for placeholders / consistency / scope / ambiguity
- [x] Plan self-reviewed for spec coverage / placeholders / type consistency
- [ ] CI green on the docs-only diff

Refs the upcoming v0.9.0 release (Phase 0 of the plan).