### PR TITLE
chore(audit): v0.9.0 schema reconciliation + CHANGELOG audit

### DIFF
--- a/docs/superpowers/notes/v0.9.0-schema-reconciliation.md
+++ b/docs/superpowers/notes/v0.9.0-schema-reconciliation.md
@@ -1,0 +1,108 @@
+# v0.9.0 — gflow data list schema reconciliation
+
+> Source of truth for Phase 2 column mapping. Compares spec §3.1 columns against the live `gflow_cli.data` schema as of commit 03bc5db.
+
+## Tables found
+
+| Table | Purpose | Columns |
+|---|---|---|
+| schema_migrations | Migration version tracking | version, filename, checksum, applied_at |
+| profiles | Known Chrome profiles | name, profile_dir, first_seen_at, last_used_at |
+| projects | Flow projects created by the CLI | id, profile_name, flow_project_id, title, source, created_at |
+| assets | Generated images and videos (both kinds in one table, distinguished by `kind`) | id, profile_name, flow_project_id, flow_media_id, flow_workflow_id, flow_media_generation_id, kind, status, model, aspect_ratio, width, height, duration_seconds, seed, created_at, metadata_json |
+| operations | CLI invocations (t2i, i2i, t2v, i2v, r2v, upload_image) | id, profile_name, flow_project_id, command, mode, prompt, prompt_hash, prompt_redacted, model, aspect_ratio, status, started_at, completed_at, error_type, error_detail, flow_operation_id, flow_batch_id |
+| operation_assets | Many-to-many join between operations and assets | operation_id, asset_id, role, position |
+| local_files | On-disk file paths for downloaded assets | id, profile_name, asset_id, path, sha256, bytes, media_type, created_at |
+
+## Spec → schema mapping per noun
+
+### projects
+
+The spec treats projects as a flat table with `project_id` and `profile` columns. The real schema uses the internal surrogate `id` as the primary key and stores the Flow-side identifier separately in `flow_project_id`. Profile is stored as `profile_name`, not `profile`. Image and video counts require JOINs into `assets` — there are no dedicated image or video tables.
+
+| Spec column | Real column(s) | Notes |
+|---|---|---|
+| project_id | `projects.flow_project_id` | The spec's `project_id` is the Flow-side identifier. The internal surrogate is `projects.id` (UUID). |
+| profile | `projects.profile_name` | Renamed: spec says `profile`, schema says `profile_name`. |
+| created_at | `projects.created_at` | Same name; stored as ISO-8601 TEXT (UTC). |
+| image_count | COUNT derived via `assets` WHERE `kind = 'image'` AND `flow_project_id = p.flow_project_id` | No dedicated images table; aggregate from `assets` with `kind` filter. |
+| video_count | COUNT derived via `assets` WHERE `kind = 'video'` AND `flow_project_id = p.flow_project_id` | Same pattern as image_count. |
+
+### images
+
+The spec treats images as a flat table. The real schema merges images and videos into the `assets` table (discriminated by `kind = 'image'`). Prompt is not on `assets`; it lives on the associated `operations` row (joined via `operation_assets`). `local_path` is not on `assets`; it is on `local_files.path`. `aspect` in the spec maps to `aspect_ratio` in the schema. The spec's `media_id` maps to `assets.flow_media_id`.
+
+| Spec column | Real column(s) | Notes |
+|---|---|---|
+| media_id | `assets.flow_media_id` | Renamed: spec says `media_id`, schema says `flow_media_id`. |
+| profile | `assets.profile_name` | Renamed: spec says `profile`, schema says `profile_name`. |
+| project_id | `assets.flow_project_id` | Same semantic as projects mapping above; column is `flow_project_id`. |
+| prompt | `operations.prompt` via JOIN `operation_assets` (role = 'output') | Not on `assets`. Must LEFT JOIN `operation_assets oa ON oa.asset_id = a.id AND oa.role = 'output'` then JOIN `operations o ON o.id = oa.operation_id`. May be NULL if the asset was uploaded rather than generated. |
+| aspect | `assets.aspect_ratio` | Renamed: spec says `aspect`, schema says `aspect_ratio`. |
+| model | `assets.model` | Same name. |
+| created_at | `assets.created_at` | Same name; ISO-8601 TEXT. |
+| local_path | `local_files.path` via JOIN on `asset_id` | Not on `assets`. Must JOIN `local_files lf ON lf.asset_id = a.id`. Use latest file (ORDER BY `lf.created_at DESC, lf.id DESC LIMIT 1`). May be NULL if file was never downloaded. |
+
+### videos
+
+Same structure as images, with the addition of `duration`. The schema stores duration as `duration_seconds` (REAL, seconds as a float) rather than an integer `duration` (spec).
+
+| Spec column | Real column(s) | Notes |
+|---|---|---|
+| media_id | `assets.flow_media_id` | Renamed: spec says `media_id`, schema says `flow_media_id`. |
+| profile | `assets.profile_name` | Renamed: spec says `profile`, schema says `profile_name`. |
+| project_id | `assets.flow_project_id` | Spec `project_id` → schema `flow_project_id`. |
+| prompt | `operations.prompt` via JOIN (same as images) | Not on `assets`; joined from `operations`. |
+| aspect | `assets.aspect_ratio` | Renamed: spec says `aspect`, schema says `aspect_ratio`. |
+| model | `assets.model` | Same name. |
+| duration | `assets.duration_seconds` | Renamed and typed: spec says `duration` (implied integer), schema says `duration_seconds` (REAL/float). Phase 2 should round or cast to int if the spec contract demands an integer. |
+| created_at | `assets.created_at` | Same name; ISO-8601 TEXT. |
+| local_path | `local_files.path` via JOIN | Same as images. |
+
+### profiles
+
+The spec derives profiles from catalog activity. The schema has a `profiles` table, but its `name` column records all profiles that have ever called `upsert_profile`, not just those with catalog entries. The spec's intent ("profiles that have at least one recorded project/image/video") requires aggregating from `projects` and `assets` rather than reading `profiles` directly. The `last_used_at` column does exist on `profiles`, but it may lag if `upsert_profile` was not called after every operation. The safest approach is to derive `last_used_at` from `MAX(created_at)` across `projects` and `assets` for each `profile_name`.
+
+| Spec column | Real column(s) | Notes |
+|---|---|---|
+| profile_name | `projects.profile_name` / `assets.profile_name` (UNION / GROUP BY) | The `profiles` table has `name`, but the aggregate should be built from `projects` and `assets` to match the spec's "catalog-known" definition. |
+| last_used_at | MAX(`projects.created_at`, `assets.created_at`) per profile | The `profiles.last_used_at` column exists but may be stale. Deriving from catalog rows is more accurate. |
+| project_count | COUNT DISTINCT `projects.flow_project_id` WHERE `profile_name = p` | Aggregate. |
+| image_count | COUNT `assets` WHERE `kind = 'image'` AND `profile_name = p` | Aggregate. |
+| video_count | COUNT `assets` WHERE `kind = 'video'` AND `profile_name = p` | Aggregate. |
+
+## Drift identified
+
+- **No `images` or `videos` tables exist.** Both kinds are stored in a single `assets` table with a `kind` discriminator column (`'image'` or `'video'`). The plan's Phase 2 SQL in Tasks 2.2–2.4 queries `FROM images` and `FROM videos` — these tables do not exist. Every query must target `assets WHERE kind = 'image'` or `assets WHERE kind = 'video'`.
+- **`project_id` → `flow_project_id`.** The spec uses bare `project_id`; the schema calls it `flow_project_id` on both `projects` and `assets`. The internal surrogate is `id` (a UUID, not the Flow ID).
+- **`profile` → `profile_name`.** Every table uses `profile_name`, not `profile`. The plan's dataclass fields (`r.profile`) and SQL (`p.profile`) are incorrect throughout Phase 2.
+- **`aspect` → `aspect_ratio`.** The `assets` table column is `aspect_ratio`, not `aspect`.
+- **`duration` → `duration_seconds`.** The `assets` column is `duration_seconds` (REAL), not `duration` (integer). The `VideoRow` dataclass in the plan declares `duration: int` — Phase 2 should cast with `int(r["duration_seconds"])` or change the type to `float`.
+- **`prompt` is not on `assets`.** Prompt lives on `operations.prompt` and must be reached via `LEFT JOIN operation_assets ON role = 'output' LEFT JOIN operations`. For uploaded assets (no associated operation), prompt will be NULL.
+- **`local_path` is not on `assets`.** It lives on `local_files.path` and must be reached via `LEFT JOIN local_files ON asset_id = a.id`. For assets that were never downloaded, it will be NULL.
+- **The plan's `list_profiles` SQL references `FROM projects` and `FROM images` and `FROM videos` tables.** The `FROM images` and `FROM videos` references are invalid. The CTE must use `FROM assets WHERE kind = 'image'` and `FROM assets WHERE kind = 'video'`.
+- **The plan's `list_projects` subquery uses `FROM images` and `FROM videos`.** Must be replaced with `FROM assets WHERE kind = 'image' AND flow_project_id = p.flow_project_id` etc.
+
+## Recommendations for Phase 2
+
+- In every Phase 2 query, replace `FROM images` with `FROM assets WHERE kind = 'image'` and `FROM videos` with `FROM assets WHERE kind = 'video'`.
+- Rename all `profile` column references in SQL to `profile_name`; rename all `aspect` references to `aspect_ratio`; rename all `project_id` references (that mean the Flow ID) to `flow_project_id`; rename `duration` to `duration_seconds`.
+- Rename all Python dataclass fields that map to the above (`r.profile` → `r["profile_name"]`, etc.) in the query functions. The *output* dataclass field names (`ProjectRow.profile`, `ImageRow.aspect`, etc.) may remain using the short spec names since those are the public API surface.
+- For `prompt` and `local_path`, use LEFT JOINs; both can be NULL.
+- In `VideoRow`, change `duration: int` to `duration: float` (or cast with `int(...)` if integer seconds is required and all known Flow videos have whole-second durations).
+- The `build_seeded_catalog` fixture in Task 2.1 cannot call `repo.record_project(...)` / `repo.record_image(...)` / `repo.record_video(...)` — those methods do not exist. Use `DataRepository.upsert_project(ProjectRecord(...))`, `DataRepository.upsert_asset(AssetRecord(..., kind=AssetKind.IMAGE, ...))`, `DataRepository.upsert_local_file(LocalFileRecord(...))`, and `DataRepository.insert_operation(OperationRecord(...))` + `DataRepository.link_operation_asset(...)` to attach a prompt. The `DataRepository` constructor takes a `DataStore` instance, not a `Path` directly; see `gflow_cli.data.store.DataStore` for the correct constructor.
+- For `list_profiles`, source `profile_name` from `projects.profile_name UNION assets.profile_name` (GROUP BY) rather than the `profiles` table to match the "catalog-known" definition from the spec.
+
+## Phase 2 patches required
+
+- **Task 2.1 (seeded_catalog fixture):** The `DataRepository` constructor signature is `DataRepository(store: DataStore)`, not `DataRepository(db_path: Path)`. The fixture must construct a `DataStore` first. Methods `record_project`, `record_image`, `record_video` do not exist — use `upsert_project(ProjectRecord(...))`, `upsert_asset(AssetRecord(...))`, `upsert_local_file(LocalFileRecord(...))`, and `insert_operation` + `link_operation_asset` to seed prompts. Also `run_migrations()` does not exist as an instance method on `DataRepository`; migration running is on `DataStore`.
+
+- **Task 2.2 SQL (`list_projects`):** Replace `FROM projects p` subqueries `FROM images i WHERE i.project_id` and `FROM videos v WHERE v.project_id` with `FROM assets i WHERE i.kind = 'image' AND i.flow_project_id = p.flow_project_id` and `FROM assets v WHERE v.kind = 'video' AND v.flow_project_id = p.flow_project_id`. Replace `p.project_id` → `p.flow_project_id`, `p.profile` → `p.profile_name`.
+
+- **Task 2.3 SQL (`list_images`):** Replace `FROM images` with `FROM assets WHERE kind = 'image'`. Replace column refs: `media_id` → `flow_media_id`, `profile` → `profile_name`, `project_id` → `flow_project_id`, `aspect` → `aspect_ratio`. Add LEFT JOINs for `prompt` (from `operations`) and `local_path` (from `local_files`).
+
+- **Task 2.4 SQL (`list_videos`):** Same column renames as images, plus `duration` → `duration_seconds`. `VideoRow.duration` type should be `float` (or cast to `int` explicitly).
+
+- **Task 2.5 SQL (`list_profiles`):** In the CTE, replace `FROM images GROUP BY profile` and `FROM videos GROUP BY profile` with `FROM assets WHERE kind = 'image' GROUP BY profile_name` and `FROM assets WHERE kind = 'video' GROUP BY profile_name`. Replace `FROM projects GROUP BY profile` with `FROM projects GROUP BY profile_name`. The outer SELECT `profile AS profile_name` becomes `profile_name`. All inner subquery `WHERE profile = pa.profile` become `WHERE profile_name = pa.profile_name`.
+
+- **Task 2.2 test assertions:** `r.profile` → `r.profile` is fine (the Python dataclass field can keep the short name); the SQL parameter binding key changes, not the dataclass field name.


### PR DESCRIPTION
## Summary

Phase 1 of the v0.9.0 release sequence — audit only, no code changes.

- Captures the live `gflow_cli.data` schema as the source of truth for Phase 2's `gflow data list` column mapping. Documents drift: no `images`/`videos` tables (single `assets` table discriminated by `kind`), several column renames (`profile` → `profile_name`, `project_id` → `flow_project_id`, `aspect` → `aspect_ratio`, etc.), JOIN requirements for `prompt` and `local_path`. Includes per-task Phase 2 patches.
- Audited the CHANGELOG `[Unreleased]` draft against PR #58 + #52 scope — found to be complete; no edits needed.

Refs the v0.9.0 release spec (`docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md`). Part of v0.9.0 release sequence — Phase 1 of 5.