### PR TITLE
feat(cli): add gflow data list (read-only catalog query)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still forced to en-US via `--lang=en-US`. Prep for issue #24 (locale-agnostic
   selectors); live-verified end-to-end with `GFLOW_CLI_LOCALE=pt-BR` against a
   Pro/Ultra account. See `docs/CONFIGURATION.md § GFLOW_CLI_LOCALE`.
+- **Local data layer** — `gflow-cli` now keeps a SQLite catalog of every new
+  image, batch, and video operation under `$GFLOW_CLI_DB_PATH` (default:
+  `~/.local/share/gflow-cli/data.db`). Records profile, project, asset
+  (model / aspect / dimensions / Flow media ID), operation provenance
+  (mode / prompt / model / timing / error), input↔output links, and
+  downloaded local files. New `gflow data media <id>` command resolves a
+  Flow media ID to its origin. `DataRepository` exposes seed-image resolvers
+  (`resolve_seed_image_by_path` / `resolve_seed_image` /
+  `resolve_latest_image`) — foundation for the upcoming I2V seed-reuse
+  path. Pre-Flow store failures exit `16` (`DataStoreError` /
+  `DataMigrationError` / `DataIntegrityError`); post-success store
+  failures warn and exit `0` (Flow already charged the credits). See
+  [`docs/DATA_LAYER.md`](docs/DATA_LAYER.md). (PR #58, stacked on #52.)
 
 ### Changed
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -357,6 +357,34 @@ in English or Portuguese.
 
 ---
 
+### `omni-flash` t2v response omits operation name — `flow_operation_id` persists NULL
+
+- **Status:** Open · **Severity:** Low · **Affects:** v0.9.0+ (data layer)
+
+The data layer's `on_started` callback captures
+`operations[0].operation.name` from each `batchAsyncGenerateVideoText`
+response and persists it as `operations.flow_operation_id`. The
+`omni-flash` model's response shape does not carry that field, so
+omni-flash rows end up with `flow_operation_id` NULL while `veo-*` rows
+carry the expected `operations/...` identifier. The rest of the row
+(prompt, model, aspect, started/completed timestamps, batch ID, output
+paths) is recorded normally.
+
+**Impact:** cosmetic for now — `gflow data media <id>` and provenance
+lookup by Flow media ID still work. Any future feature that joins on
+`flow_operation_id` (none in the current CLI) would miss omni-flash
+rows.
+
+**Workaround:** none needed if you don't query by `flow_operation_id`.
+
+**Roadmap:** capture an `omni-flash` `batchAsyncGenerateVideoText`
+response sample, identify the equivalent provenance handle (if any), and
+either map it into `flow_operation_id` or document that omni-flash
+legitimately has no such identifier. Track via a follow-up issue once a
+sample is captured.
+
+---
+
 ## Mitigated
 
 ### Auth verification depends on Google's NextAuth session endpoint

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -1,16 +1,187 @@
 from __future__ import annotations
 
+import dataclasses
+import functools
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
 import click
 from rich.console import Console
 from rich.table import Table
 
 from gflow_cli._cli_helpers import _resolve_profile, run_with_handlers, safe_path_text
 from gflow_cli.config import get_settings
+from gflow_cli.data.queries import (
+    ImageRow,
+    ProfileRow,
+    ProjectRow,
+    VideoRow,
+    list_images,
+    list_profiles,
+    list_projects,
+    list_videos,
+)
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import DataStoreError
 
 console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for `gflow data list` output
+# ---------------------------------------------------------------------------
+
+
+def _db_path() -> Path:
+    """Resolve the catalog DB path from env or platformdirs default."""
+    if env := os.environ.get("GFLOW_CLI_DB_PATH"):
+        return Path(env)
+    from platformdirs import user_data_dir
+
+    return Path(user_data_dir("gflow-cli")) / "data.db"
+
+
+def _truncate(s: str | None, n: int = 40) -> str:
+    if s is None:
+        return ""
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _emit_jsonl(rows: list[Any]) -> None:
+    for row in rows:
+        d = dataclasses.asdict(row)
+        for k, v in d.items():
+            if isinstance(v, datetime):
+                d[k] = v.isoformat()
+            elif isinstance(v, Path):
+                d[k] = str(v)
+        click.echo(json.dumps(d))
+
+
+def _emit_projects_table(rows: list[ProjectRow]) -> None:
+    tbl = Table(show_header=True, header_style="bold")
+    for col in ("PROJECT_ID", "PROFILE", "CREATED", "IMG", "VID"):
+        tbl.add_column(col)
+    for r in rows:
+        tbl.add_row(
+            r.project_id,
+            r.profile,
+            r.created_at.strftime("%Y-%m-%d %H:%M"),
+            str(r.image_count),
+            str(r.video_count),
+        )
+    Console().print(tbl)
+
+
+def _emit_images_table(rows: list[ImageRow]) -> None:
+    tbl = Table(show_header=True, header_style="bold")
+    for col in ("MEDIA_ID", "PROFILE", "PROJECT_ID", "PROMPT", "ASPECT", "MODEL", "CREATED", "LOCAL_PATH"):
+        tbl.add_column(col)
+    for r in rows:
+        tbl.add_row(
+            r.media_id,
+            r.profile,
+            r.project_id,
+            _truncate(r.prompt),
+            r.aspect,
+            r.model,
+            r.created_at.strftime("%Y-%m-%d %H:%M"),
+            r.local_path or "",
+        )
+    Console().print(tbl)
+
+
+def _emit_videos_table(rows: list[VideoRow]) -> None:
+    tbl = Table(show_header=True, header_style="bold")
+    for col in ("MEDIA_ID", "PROFILE", "PROJECT_ID", "PROMPT", "ASPECT", "MODEL", "DURATION", "CREATED", "LOCAL_PATH"):
+        tbl.add_column(col)
+    for r in rows:
+        tbl.add_row(
+            r.media_id,
+            r.profile,
+            r.project_id,
+            _truncate(r.prompt),
+            r.aspect,
+            r.model,
+            f"{r.duration:g}s",
+            r.created_at.strftime("%Y-%m-%d %H:%M"),
+            r.local_path or "",
+        )
+    Console().print(tbl)
+
+
+def _emit_profiles_table(rows: list[ProfileRow]) -> None:
+    tbl = Table(show_header=True, header_style="bold")
+    for col in ("PROFILE_NAME", "LAST_USED", "PROJECTS", "IMAGES", "VIDEOS"):
+        tbl.add_column(col)
+    for r in rows:
+        tbl.add_row(
+            r.profile_name,
+            r.last_used_at.strftime("%Y-%m-%d %H:%M"),
+            str(r.project_count),
+            str(r.image_count),
+            str(r.video_count),
+        )
+    Console().print(tbl)
+
+
+def _emit(
+    rows: list[Any],
+    as_json: bool,
+    table_fn: Any,
+    empty_msg: str,
+) -> None:
+    if not rows:
+        if not as_json and sys.stdout.isatty():
+            click.echo(empty_msg)
+        return
+    if as_json or not sys.stdout.isatty():
+        _emit_jsonl(rows)
+    else:
+        table_fn(rows)
+
+
+def _guard(fn: Any) -> Any:
+    """Decorator: map DataStoreError → exit 16."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except DataStoreError as exc:
+            click.echo(f"Data store error: {exc}", err=True)
+            raise click.exceptions.Exit(16) from None
+
+    return wrapper
+
+
+# Shared option factories
+_PROFILE_OPT = click.option("--profile", default=None, help="Filter by profile name.")
+_LIMIT_OPT = click.option(
+    "--limit",
+    type=click.IntRange(1, 1000),
+    default=20,
+    show_default=True,
+    help="Maximum number of rows to return.",
+)
+_OFFSET_OPT = click.option(
+    "--offset",
+    type=click.IntRange(0),
+    default=0,
+    show_default=True,
+    help="Number of rows to skip (pagination).",
+)
+_JSON_OPT = click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit JSONL instead of a Rich table.",
+)
 
 
 @click.group()
@@ -50,3 +221,60 @@ async def _run_media(*, profile_name: str, media_id: str) -> None:  # NOSONAR S7
         for idx, local_file in enumerate(asset.local_files, start=1):
             table.add_row(f"local_path_{idx}", safe_path_text(local_file.path))
         console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# `gflow data list` subgroup
+# ---------------------------------------------------------------------------
+
+
+@data.group(name="list")
+def list_group() -> None:
+    """List entries from the catalog."""
+
+
+@list_group.command(name="projects")
+@_PROFILE_OPT
+@_LIMIT_OPT
+@_OFFSET_OPT
+@_JSON_OPT
+@_guard
+def list_projects_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List projects newest-first."""
+    rows = list_projects(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    _emit(rows, as_json, _emit_projects_table, "No projects recorded.")
+
+
+@list_group.command(name="images")
+@_PROFILE_OPT
+@_LIMIT_OPT
+@_OFFSET_OPT
+@_JSON_OPT
+@_guard
+def list_images_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List images newest-first."""
+    rows = list_images(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    _emit(rows, as_json, _emit_images_table, "No images recorded.")
+
+
+@list_group.command(name="videos")
+@_PROFILE_OPT
+@_LIMIT_OPT
+@_OFFSET_OPT
+@_JSON_OPT
+@_guard
+def list_videos_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List videos newest-first."""
+    rows = list_videos(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    _emit(rows, as_json, _emit_videos_table, "No videos recorded.")
+
+
+@list_group.command(name="profiles")
+@_LIMIT_OPT
+@_OFFSET_OPT
+@_JSON_OPT
+@_guard
+def list_profiles_cmd(limit: int, offset: int, as_json: bool) -> None:
+    """List catalog-known profiles (not auth-known)."""
+    rows = list_profiles(db_path=_db_path(), limit=limit, offset=offset)
+    _emit(rows, as_json, _emit_profiles_table, "No profiles recorded.")

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -80,7 +80,16 @@ def _emit_projects_table(rows: list[ProjectRow]) -> None:
 
 def _emit_images_table(rows: list[ImageRow]) -> None:
     tbl = Table(show_header=True, header_style="bold")
-    for col in ("MEDIA_ID", "PROFILE", "PROJECT_ID", "PROMPT", "ASPECT", "MODEL", "CREATED", "LOCAL_PATH"):
+    for col in (
+        "MEDIA_ID",
+        "PROFILE",
+        "PROJECT_ID",
+        "PROMPT",
+        "ASPECT",
+        "MODEL",
+        "CREATED",
+        "LOCAL_PATH",
+    ):
         tbl.add_column(col)
     for r in rows:
         tbl.add_row(
@@ -98,7 +107,17 @@ def _emit_images_table(rows: list[ImageRow]) -> None:
 
 def _emit_videos_table(rows: list[VideoRow]) -> None:
     tbl = Table(show_header=True, header_style="bold")
-    for col in ("MEDIA_ID", "PROFILE", "PROJECT_ID", "PROMPT", "ASPECT", "MODEL", "DURATION", "CREATED", "LOCAL_PATH"):
+    for col in (
+        "MEDIA_ID",
+        "PROFILE",
+        "PROJECT_ID",
+        "PROMPT",
+        "ASPECT",
+        "MODEL",
+        "DURATION",
+        "CREATED",
+        "LOCAL_PATH",
+    ):
         tbl.add_column(col)
     for r in rows:
         tbl.add_row(

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -8,6 +8,7 @@ This module is the foundation for v0.10's ``show``/``search``/``export``
 sub-commands; additional query functions (list_images, list_videos,
 list_profiles) will be added in Tasks 2.3–2.5.
 """
+
 from __future__ import annotations
 
 import sqlite3
@@ -99,6 +100,7 @@ def list_projects(
 
 # ─── ImageRow + list_images ───────────────────────────────────────────────────
 
+
 @dataclass(frozen=True)
 class ImageRow:
     media_id: str
@@ -173,6 +175,7 @@ def list_images(
 
 
 # ─── VideoRow + list_videos ───────────────────────────────────────────────────
+
 
 @dataclass(frozen=True)
 class VideoRow:
@@ -250,6 +253,7 @@ def list_videos(
 
 
 # ─── ProfileRow + list_profiles ───────────────────────────────────────────────
+
 
 @dataclass(frozen=True)
 class ProfileRow:

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -1,0 +1,78 @@
+"""Read-only query functions over the gflow-cli SQLite catalog.
+
+These are pure functions: they accept a db path, return frozen dataclass rows,
+do not mutate state, and have no dependency on Click or Rich. The CLI adapter
+(cli_data.py, Phase 2 Task 2.6) formats their output.
+
+This module is the foundation for v0.10's ``show``/``search``/``export``
+sub-commands; additional query functions (list_images, list_videos,
+list_profiles) will be added in Tasks 2.3–2.5.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProjectRow:
+    project_id: str
+    profile: str
+    created_at: datetime
+    image_count: int
+    video_count: int
+
+
+_LIST_PROJECTS_SQL = """
+    SELECT
+        p.flow_project_id AS project_id,
+        p.profile_name    AS profile,
+        p.created_at      AS created_at,
+        (SELECT COUNT(*) FROM assets
+         WHERE kind = 'image' AND flow_project_id = p.flow_project_id) AS image_count,
+        (SELECT COUNT(*) FROM assets
+         WHERE kind = 'video' AND flow_project_id = p.flow_project_id) AS video_count
+    FROM projects p
+    WHERE (:profile IS NULL OR p.profile_name = :profile)
+    ORDER BY p.created_at DESC
+    LIMIT :limit OFFSET :offset
+"""
+
+
+def list_projects(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[ProjectRow]:
+    """Return projects newest-first, filtered by profile if given.
+
+    image_count / video_count are aggregated via subqueries over the assets
+    table (no dedicated images/videos tables in this schema).
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        profile: If given, only return projects belonging to this profile name.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (for pagination).
+
+    Returns:
+        A list of :class:`ProjectRow` instances ordered newest-first.
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(_LIST_PROJECTS_SQL, params).fetchall()
+    return [
+        ProjectRow(
+            project_id=str(r["project_id"]),
+            profile=str(r["profile"]),
+            created_at=datetime.fromisoformat(str(r["created_at"])),
+            image_count=int(r["image_count"]),
+            video_count=int(r["video_count"]),
+        )
+        for r in rows
+    ]

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -76,3 +76,231 @@ def list_projects(
         )
         for r in rows
     ]
+
+
+# ─── ImageRow + list_images ───────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ImageRow:
+    media_id: str
+    profile: str
+    project_id: str
+    prompt: str | None
+    aspect: str
+    model: str
+    created_at: datetime
+    local_path: str | None
+
+
+_LIST_IMAGES_SQL = """
+    SELECT
+        a.flow_media_id  AS media_id,
+        a.profile_name   AS profile,
+        a.flow_project_id AS project_id,
+        o.prompt         AS prompt,
+        a.aspect_ratio   AS aspect,
+        a.model          AS model,
+        a.created_at     AS created_at,
+        lf.path          AS local_path
+    FROM assets a
+    LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = 'output'
+    LEFT JOIN operations o ON o.id = oa.operation_id
+    LEFT JOIN local_files lf ON lf.asset_id = a.id
+    WHERE a.kind = 'image'
+      AND (:profile IS NULL OR a.profile_name = :profile)
+    ORDER BY a.created_at DESC
+    LIMIT :limit OFFSET :offset
+"""
+
+
+def list_images(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[ImageRow]:
+    """Return image assets newest-first, filtered by profile if given.
+
+    prompt and local_path are NULLable (LEFT JOINs): prompt is absent for
+    uploaded reference images; local_path is absent for assets not yet
+    downloaded.
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        profile: If given, only return images belonging to this profile name.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (for pagination).
+
+    Returns:
+        A list of :class:`ImageRow` instances ordered newest-first.
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(_LIST_IMAGES_SQL, params).fetchall()
+    return [
+        ImageRow(
+            media_id=str(r["media_id"]),
+            profile=str(r["profile"]),
+            project_id=str(r["project_id"]),
+            prompt=str(r["prompt"]) if r["prompt"] is not None else None,
+            aspect=str(r["aspect"]),
+            model=str(r["model"]),
+            created_at=datetime.fromisoformat(str(r["created_at"])),
+            local_path=str(r["local_path"]) if r["local_path"] is not None else None,
+        )
+        for r in rows
+    ]
+
+
+# ─── VideoRow + list_videos ───────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class VideoRow:
+    media_id: str
+    profile: str
+    project_id: str
+    prompt: str | None
+    aspect: str
+    model: str
+    duration: float
+    created_at: datetime
+    local_path: str | None
+
+
+_LIST_VIDEOS_SQL = """
+    SELECT
+        a.flow_media_id   AS media_id,
+        a.profile_name    AS profile,
+        a.flow_project_id AS project_id,
+        o.prompt          AS prompt,
+        a.aspect_ratio    AS aspect,
+        a.model           AS model,
+        a.duration_seconds AS duration,
+        a.created_at      AS created_at,
+        lf.path           AS local_path
+    FROM assets a
+    LEFT JOIN operation_assets oa ON oa.asset_id = a.id AND oa.role = 'output'
+    LEFT JOIN operations o ON o.id = oa.operation_id
+    LEFT JOIN local_files lf ON lf.asset_id = a.id
+    WHERE a.kind = 'video'
+      AND (:profile IS NULL OR a.profile_name = :profile)
+    ORDER BY a.created_at DESC
+    LIMIT :limit OFFSET :offset
+"""
+
+
+def list_videos(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[VideoRow]:
+    """Return video assets newest-first, filtered by profile if given.
+
+    prompt and local_path are NULLable (LEFT JOINs). duration maps to the
+    duration_seconds REAL column in the schema.
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        profile: If given, only return videos belonging to this profile name.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (for pagination).
+
+    Returns:
+        A list of :class:`VideoRow` instances ordered newest-first.
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(_LIST_VIDEOS_SQL, params).fetchall()
+    return [
+        VideoRow(
+            media_id=str(r["media_id"]),
+            profile=str(r["profile"]),
+            project_id=str(r["project_id"]),
+            prompt=str(r["prompt"]) if r["prompt"] is not None else None,
+            aspect=str(r["aspect"]),
+            model=str(r["model"]),
+            duration=float(r["duration"]),
+            created_at=datetime.fromisoformat(str(r["created_at"])),
+            local_path=str(r["local_path"]) if r["local_path"] is not None else None,
+        )
+        for r in rows
+    ]
+
+
+# ─── ProfileRow + list_profiles ───────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ProfileRow:
+    profile_name: str
+    last_used_at: datetime
+    project_count: int
+    image_count: int
+    video_count: int
+
+
+_LIST_PROFILES_SQL = """
+    WITH catalog_activity AS (
+        SELECT profile_name, MAX(created_at) AS last_used_at
+          FROM projects
+         GROUP BY profile_name
+        UNION ALL
+        SELECT profile_name, MAX(created_at) AS last_used_at
+          FROM assets
+         GROUP BY profile_name
+    )
+    SELECT
+        profile_name,
+        MAX(last_used_at) AS last_used_at,
+        (SELECT COUNT(DISTINCT flow_project_id) FROM projects
+          WHERE profile_name = ca.profile_name) AS project_count,
+        (SELECT COUNT(*) FROM assets
+          WHERE kind = 'image' AND profile_name = ca.profile_name) AS image_count,
+        (SELECT COUNT(*) FROM assets
+          WHERE kind = 'video' AND profile_name = ca.profile_name) AS video_count
+    FROM catalog_activity ca
+    GROUP BY profile_name
+    ORDER BY last_used_at DESC
+    LIMIT :limit OFFSET :offset
+"""
+
+
+def list_profiles(
+    *,
+    db_path: Path,
+    limit: int,
+    offset: int,
+) -> list[ProfileRow]:
+    """Return profiles with aggregate counts, sorted by most-recently-active.
+
+    Only profiles with at least one project or one asset appear. There is no
+    per-profile filter parameter — callers wanting a single profile can filter
+    the returned list.
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (for pagination).
+
+    Returns:
+        A list of :class:`ProfileRow` instances ordered newest-first by
+        last_used_at.
+    """
+    params = {"limit": limit, "offset": offset}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(_LIST_PROFILES_SQL, params).fetchall()
+    return [
+        ProfileRow(
+            profile_name=str(r["profile_name"]),
+            last_used_at=datetime.fromisoformat(str(r["last_used_at"])),
+            project_count=int(r["project_count"]),
+            image_count=int(r["image_count"]),
+            video_count=int(r["video_count"]),
+        )
+        for r in rows
+    ]

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -11,9 +11,29 @@ list_profiles) will be added in Tasks 2.3–2.5.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
+from gflow_cli.errors import DataStoreError
+
+
+@contextmanager
+def _safe_db(db_path: Path) -> Generator[sqlite3.Connection, None, None]:
+    """Open the catalog DB and yield a connection, mapping sqlite3 errors to DataStoreError."""
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        raise DataStoreError(f"Failed to open catalog at {db_path}: {exc}") from exc
+    try:
+        yield conn
+    except sqlite3.Error as exc:
+        raise DataStoreError(f"Catalog query failed: {exc}") from exc
+    finally:
+        conn.close()
 
 
 @dataclass(frozen=True)
@@ -63,8 +83,7 @@ def list_projects(
         A list of :class:`ProjectRow` instances ordered newest-first.
     """
     params = {"profile": profile, "limit": limit, "offset": offset}
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    with _safe_db(db_path) as conn:
         rows = conn.execute(_LIST_PROJECTS_SQL, params).fetchall()
     return [
         ProjectRow(
@@ -136,8 +155,7 @@ def list_images(
         A list of :class:`ImageRow` instances ordered newest-first.
     """
     params = {"profile": profile, "limit": limit, "offset": offset}
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    with _safe_db(db_path) as conn:
         rows = conn.execute(_LIST_IMAGES_SQL, params).fetchall()
     return [
         ImageRow(
@@ -213,8 +231,7 @@ def list_videos(
         A list of :class:`VideoRow` instances ordered newest-first.
     """
     params = {"profile": profile, "limit": limit, "offset": offset}
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    with _safe_db(db_path) as conn:
         rows = conn.execute(_LIST_VIDEOS_SQL, params).fetchall()
     return [
         VideoRow(
@@ -291,8 +308,7 @@ def list_profiles(
         last_used_at.
     """
     params = {"limit": limit, "offset": offset}
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    with _safe_db(db_path) as conn:
         rows = conn.execute(_LIST_PROFILES_SQL, params).fetchall()
     return [
         ProfileRow(

--- a/tests/fixtures/seeded_catalog.py
+++ b/tests/fixtures/seeded_catalog.py
@@ -12,6 +12,7 @@ Catalog shape:
   - 10 local_files total
   - Timestamps span ~7 days so newest-first sort is verifiable
 """
+
 from __future__ import annotations
 
 import uuid

--- a/tests/fixtures/seeded_catalog.py
+++ b/tests/fixtures/seeded_catalog.py
@@ -1,0 +1,225 @@
+"""Build a fixture SQLite catalog seeded with known projects/images/videos.
+
+Used by tests/test_cli_data.py and tests/test_data_queries.py.
+
+Catalog shape:
+  - 3 profiles: alice (2 projects), bob (1 project), carol (1 project)
+  - 4 projects total
+  - 8 images total: 2 per project, each with operation prompt + local_file (.png)
+  - 2 videos: only on alice's 2 projects (1 per project), each with operation
+    prompt + local_file (.mp4)
+  - 10 operations total (8 image ops + 2 video ops)
+  - 10 local_files total
+  - Timestamps span ~7 days so newest-first sort is verifiable
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from gflow_cli.data.models import (
+    AssetKind,
+    AssetRecord,
+    LocalFileRecord,
+    OperationAssetRole,
+    OperationKind,
+    OperationRecord,
+    OperationStatus,
+    ProjectRecord,
+)
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+
+def build_seeded_catalog(db_path: Path) -> tuple[DataStore, DataRepository]:
+    """Create a fresh SQLite catalog at *db_path* and seed it with known data.
+
+    Returns ``(store, repo)`` so callers can either query via the repository
+    directly or inspect the raw SQLite connection via ``store.conn``.
+
+    The caller is responsible for closing ``store`` when done (or using it as
+    a context manager).
+    """
+    store = DataStore.open(db_path)
+    repo = DataRepository(store)
+
+    now = datetime.now(UTC)
+
+    # profiles_with_project_counts: (profile_name, n_projects)
+    # alice has 2 projects (and gets 1 video per project)
+    # bob and carol have 1 project each (no videos)
+    profiles_with_project_counts: list[tuple[str, int]] = [
+        ("alice", 2),
+        ("bob", 1),
+        ("carol", 1),
+    ]
+
+    # Seed profiles first — projects/assets/operations all FK-reference profiles.
+    for _prof_idx, (profile, _) in enumerate(profiles_with_project_counts):
+        repo.upsert_profile(name=profile, profile_dir=Path(f"/home/{profile}/.config/gflow"))
+
+    for prof_idx, (profile, n_projects) in enumerate(profiles_with_project_counts):
+        for proj_idx in range(n_projects):
+            # Spread projects over the last 7 days (oldest = carol, newest = alice-0)
+            proj_created = now - timedelta(days=prof_idx * 2 + proj_idx)
+            proj_created_str = _iso(proj_created)
+
+            project_record_id = str(uuid.uuid4())
+            flow_project_id = f"flow-proj-{profile}-{proj_idx:03d}"
+
+            repo.upsert_project(
+                ProjectRecord(
+                    id=project_record_id,
+                    profile_name=profile,
+                    flow_project_id=flow_project_id,
+                    title=f"{profile} project {proj_idx}",
+                    source="cli",
+                    created_at=proj_created_str,
+                )
+            )
+
+            # 2 images per project
+            for img_idx in range(2):
+                img_created = proj_created - timedelta(minutes=img_idx * 5)
+                asset_id = str(uuid.uuid4())
+                op_id = str(uuid.uuid4())
+
+                repo.upsert_asset(
+                    AssetRecord(
+                        id=asset_id,
+                        profile_name=profile,
+                        flow_project_id=flow_project_id,
+                        flow_media_id=f"img-media-{profile}-{proj_idx}-{img_idx}",
+                        flow_workflow_id=None,
+                        flow_media_generation_id=None,
+                        kind=AssetKind.IMAGE,
+                        status="ready",
+                        model="imagen-3.0-fast-generate-001",
+                        aspect_ratio="16:9",
+                        width=1280,
+                        height=720,
+                        duration_seconds=None,
+                        seed=img_idx + 1,
+                        metadata_json={},
+                        created_at=_iso(img_created),
+                    )
+                )
+
+                repo.insert_operation(
+                    OperationRecord(
+                        id=op_id,
+                        profile_name=profile,
+                        flow_project_id=flow_project_id,
+                        command="image",
+                        mode=OperationKind.T2I,
+                        status=OperationStatus.SUCCEEDED,
+                        flow_operation_id=None,
+                        flow_batch_id=None,
+                        prompt=f"prompt for {profile} project {proj_idx} image {img_idx}",
+                        prompt_hash=None,
+                        prompt_redacted=False,
+                        model="imagen-3.0-fast-generate-001",
+                        aspect_ratio="16:9",
+                        error_type=None,
+                        error_detail=None,
+                        started_at=_iso(img_created),
+                        completed_at=_iso(img_created + timedelta(seconds=3)),
+                    )
+                )
+
+                repo.link_operation_asset(
+                    operation_id=op_id,
+                    asset_id=asset_id,
+                    role=OperationAssetRole.OUTPUT,
+                    position=0,
+                )
+
+                repo.upsert_local_file(
+                    LocalFileRecord(
+                        id=str(uuid.uuid4()),
+                        profile_name=profile,
+                        asset_id=asset_id,
+                        path=Path(f"/tmp/gflow/{profile}/{flow_project_id}/img_{img_idx}.png"),
+                        media_type="image/png",
+                        bytes=204800,
+                        sha256=None,
+                        created_at=_iso(img_created + timedelta(seconds=4)),
+                    )
+                )
+
+            # 1 video per alice project; bob and carol get none
+            if profile == "alice":
+                vid_created = proj_created - timedelta(minutes=15)
+                vid_asset_id = str(uuid.uuid4())
+                vid_op_id = str(uuid.uuid4())
+
+                repo.upsert_asset(
+                    AssetRecord(
+                        id=vid_asset_id,
+                        profile_name=profile,
+                        flow_project_id=flow_project_id,
+                        flow_media_id=f"vid-media-{profile}-{proj_idx}",
+                        flow_workflow_id=None,
+                        flow_media_generation_id=None,
+                        kind=AssetKind.VIDEO,
+                        status="ready",
+                        model="veo-2.0-generate-001",
+                        aspect_ratio="16:9",
+                        width=1280,
+                        height=720,
+                        duration_seconds=5.0,
+                        seed=None,
+                        metadata_json={},
+                        created_at=_iso(vid_created),
+                    )
+                )
+
+                repo.insert_operation(
+                    OperationRecord(
+                        id=vid_op_id,
+                        profile_name=profile,
+                        flow_project_id=flow_project_id,
+                        command="video",
+                        mode=OperationKind.T2V,
+                        status=OperationStatus.SUCCEEDED,
+                        flow_operation_id=None,
+                        flow_batch_id=None,
+                        prompt=f"video prompt for {profile} project {proj_idx}",
+                        prompt_hash=None,
+                        prompt_redacted=False,
+                        model="veo-2.0-generate-001",
+                        aspect_ratio="16:9",
+                        error_type=None,
+                        error_detail=None,
+                        started_at=_iso(vid_created),
+                        completed_at=_iso(vid_created + timedelta(seconds=30)),
+                    )
+                )
+
+                repo.link_operation_asset(
+                    operation_id=vid_op_id,
+                    asset_id=vid_asset_id,
+                    role=OperationAssetRole.OUTPUT,
+                    position=0,
+                )
+
+                repo.upsert_local_file(
+                    LocalFileRecord(
+                        id=str(uuid.uuid4()),
+                        profile_name=profile,
+                        asset_id=vid_asset_id,
+                        path=Path(f"/tmp/gflow/{profile}/{flow_project_id}/video_{proj_idx}.mp4"),
+                        media_type="video/mp4",
+                        bytes=5242880,
+                        sha256=None,
+                        created_at=_iso(vid_created + timedelta(seconds=31)),
+                    )
+                )
+
+    return store, repo
+
+
+def _iso(dt: datetime) -> str:
+    """Format *dt* as an ISO-8601 UTC string (same format as the data layer)."""
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/tests/fixtures/seeded_catalog.py
+++ b/tests/fixtures/seeded_catalog.py
@@ -56,7 +56,7 @@ def build_seeded_catalog(db_path: Path) -> tuple[DataStore, DataRepository]:
     ]
 
     # Seed profiles first — projects/assets/operations all FK-reference profiles.
-    for _prof_idx, (profile, _) in enumerate(profiles_with_project_counts):
+    for _, (profile, _) in enumerate(profiles_with_project_counts):
         repo.upsert_profile(name=profile, profile_dir=Path(f"/home/{profile}/.config/gflow"))
 
     for prof_idx, (profile, n_projects) in enumerate(profiles_with_project_counts):

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -1,0 +1,142 @@
+"""CLI integration tests for `gflow data list ...`."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from tests.fixtures.seeded_catalog import build_seeded_catalog
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "catalog.db"
+    store, _repo = build_seeded_catalog(db)
+    store.close()
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    return db
+
+
+@pytest.fixture
+def empty_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from gflow_cli.data.store import DataStore
+
+    db = tmp_path / "empty.db"
+    DataStore.open(db).close()
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    return db
+
+
+# ─── projects ────────────────────────────────────────────────────────────────
+
+
+def test_data_list_projects_default(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    assert result.exit_code == 0
+    assert "alice" in result.output
+
+
+def test_data_list_projects_json(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 4
+    assert "project_id" in rows[0]
+    assert "image_count" in rows[0]
+
+
+def test_data_list_projects_profile_filter(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--profile", "alice", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 2
+    assert all(r["profile"] == "alice" for r in rows)
+
+
+def test_data_list_projects_pagination(seeded_db: Path) -> None:
+    page1 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "0", "--json"])
+    page2 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "2", "--json"])
+    assert page1.exit_code == 0
+    assert page2.exit_code == 0
+    p1 = {json.loads(ln)["project_id"] for ln in page1.output.splitlines() if ln.strip()}
+    p2 = {json.loads(ln)["project_id"] for ln in page2.output.splitlines() if ln.strip()}
+    assert p1 & p2 == set()
+
+
+def test_data_list_projects_invalid_limit(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "0"])
+    assert result.exit_code == 2
+
+
+def test_data_list_projects_empty_catalog(empty_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    assert result.exit_code == 0
+    result_json = CliRunner().invoke(main, ["data", "list", "projects", "--json"])
+    assert result_json.exit_code == 0
+    assert result_json.output.strip() == ""
+
+
+# ─── images ──────────────────────────────────────────────────────────────────
+
+
+def test_data_list_images_json(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "images", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 8
+
+
+def test_data_list_images_profile_filter(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "images", "--profile", "alice", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 4
+
+
+# ─── videos ──────────────────────────────────────────────────────────────────
+
+
+def test_data_list_videos_json(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "videos", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 2
+
+
+def test_data_list_videos_filter_no_match(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "videos", "--profile", "bob", "--json"])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+# ─── profiles ────────────────────────────────────────────────────────────────
+
+
+def test_data_list_profiles(seeded_db: Path) -> None:
+    result = CliRunner().invoke(main, ["data", "list", "profiles", "--json"])
+    assert result.exit_code == 0
+    rows = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(rows) == 3
+    assert {r["profile_name"] for r in rows} == {"alice", "bob", "carol"}
+
+
+def test_data_list_profiles_no_profile_option(seeded_db: Path) -> None:
+    """The profiles subcommand has no --profile flag."""
+    result = CliRunner().invoke(main, ["data", "list", "profiles", "--profile", "alice"])
+    assert result.exit_code == 2
+
+
+# ─── error handling ──────────────────────────────────────────────────────────
+
+
+def test_data_list_db_missing_exits_16(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DB path pointing at a directory with no schema → DataStoreError → exit 16."""
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(tmp_path / "does-not-exist.db"))
+    result = CliRunner().invoke(main, ["data", "list", "projects"])
+    # sqlite3 creates an empty file on connect, but without migrations the
+    # query fails with OperationalError (no such table). _safe_db wraps it
+    # as DataStoreError → _guard raises Exit(16).
+    assert result.exit_code == 16

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -1,4 +1,5 @@
 """CLI integration tests for `gflow data list ...`."""
+
 from __future__ import annotations
 
 import json
@@ -57,8 +58,12 @@ def test_data_list_projects_profile_filter(seeded_db: Path) -> None:
 
 
 def test_data_list_projects_pagination(seeded_db: Path) -> None:
-    page1 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "0", "--json"])
-    page2 = CliRunner().invoke(main, ["data", "list", "projects", "--limit", "2", "--offset", "2", "--json"])
+    page1 = CliRunner().invoke(
+        main, ["data", "list", "projects", "--limit", "2", "--offset", "0", "--json"]
+    )
+    page2 = CliRunner().invoke(
+        main, ["data", "list", "projects", "--limit", "2", "--offset", "2", "--json"]
+    )
     assert page1.exit_code == 0
     assert page2.exit_code == 0
     p1 = {json.loads(ln)["project_id"] for ln in page1.output.splitlines() if ln.strip()}

--- a/tests/test_data_queries.py
+++ b/tests/test_data_queries.py
@@ -1,4 +1,5 @@
 """Tests for gflow_cli.data.queries — pure read-only query functions."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -6,9 +7,6 @@ from pathlib import Path
 import pytest
 
 from gflow_cli.data.queries import (
-    ImageRow,
-    ProfileRow,
-    VideoRow,
     list_images,
     list_profiles,
     list_projects,
@@ -65,6 +63,7 @@ def test_list_projects_image_video_counts(seeded: Path) -> None:
 def test_list_projects_empty_catalog_returns_empty_list(tmp_path: Path) -> None:
     """Open a fresh DB with migrations only — no seed data."""
     from gflow_cli.data.store import DataStore
+
     db = tmp_path / "empty.db"
     DataStore.open(db).close()  # runs migrations, then closes
     rows = list_projects(db_path=db, profile=None, limit=20, offset=0)
@@ -72,6 +71,7 @@ def test_list_projects_empty_catalog_returns_empty_list(tmp_path: Path) -> None:
 
 
 # ─── list_images ──────────────────────────────────────────────────────────────
+
 
 def test_list_images_returns_all_by_default(seeded: Path) -> None:
     rows = list_images(db_path=seeded, profile=None, limit=20, offset=0)
@@ -109,6 +109,7 @@ def test_list_images_pagination(seeded: Path) -> None:
 
 # ─── list_videos ──────────────────────────────────────────────────────────────
 
+
 def test_list_videos_returns_all_by_default(seeded: Path) -> None:
     rows = list_videos(db_path=seeded, profile=None, limit=20, offset=0)
     assert len(rows) == 2
@@ -126,6 +127,7 @@ def test_list_videos_carries_duration(seeded: Path) -> None:
 
 
 # ─── list_profiles ────────────────────────────────────────────────────────────
+
 
 def test_list_profiles_returns_catalog_known_profiles(seeded: Path) -> None:
     rows = list_profiles(db_path=seeded, limit=20, offset=0)

--- a/tests/test_data_queries.py
+++ b/tests/test_data_queries.py
@@ -1,0 +1,63 @@
+"""Tests for gflow_cli.data.queries — pure read-only query functions."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.queries import list_projects
+from tests.fixtures.seeded_catalog import build_seeded_catalog
+
+
+@pytest.fixture
+def seeded(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    build_seeded_catalog(db)
+    return db
+
+
+def test_list_projects_returns_all_by_default(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 4
+    assert {r.profile for r in rows} == {"alice", "bob", "carol"}
+
+
+def test_list_projects_filters_by_profile(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile="alice", limit=20, offset=0)
+    assert len(rows) == 2
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_projects_respects_limit(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=2, offset=0)
+    assert len(rows) == 2
+
+
+def test_list_projects_respects_offset(seeded: Path) -> None:
+    page1 = list_projects(db_path=seeded, profile=None, limit=2, offset=0)
+    page2 = list_projects(db_path=seeded, profile=None, limit=2, offset=2)
+    assert {r.project_id for r in page1} & {r.project_id for r in page2} == set()
+
+
+def test_list_projects_newest_first(seeded: Path) -> None:
+    rows = list_projects(db_path=seeded, profile=None, limit=20, offset=0)
+    timestamps = [r.created_at for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_list_projects_image_video_counts(seeded: Path) -> None:
+    """Aggregates from assets table where kind = 'image' / 'video'."""
+    rows = list_projects(db_path=seeded, profile="alice", limit=20, offset=0)
+    # Alice has 2 projects, each with 2 images + 1 video
+    for r in rows:
+        assert r.image_count == 2
+        assert r.video_count == 1
+
+
+def test_list_projects_empty_catalog_returns_empty_list(tmp_path: Path) -> None:
+    """Open a fresh DB with migrations only — no seed data."""
+    from gflow_cli.data.store import DataStore
+    db = tmp_path / "empty.db"
+    DataStore.open(db).close()  # runs migrations, then closes
+    rows = list_projects(db_path=db, profile=None, limit=20, offset=0)
+    assert rows == []

--- a/tests/test_data_queries.py
+++ b/tests/test_data_queries.py
@@ -5,7 +5,15 @@ from pathlib import Path
 
 import pytest
 
-from gflow_cli.data.queries import list_projects
+from gflow_cli.data.queries import (
+    ImageRow,
+    ProfileRow,
+    VideoRow,
+    list_images,
+    list_profiles,
+    list_projects,
+    list_videos,
+)
 from tests.fixtures.seeded_catalog import build_seeded_catalog
 
 
@@ -61,3 +69,81 @@ def test_list_projects_empty_catalog_returns_empty_list(tmp_path: Path) -> None:
     DataStore.open(db).close()  # runs migrations, then closes
     rows = list_projects(db_path=db, profile=None, limit=20, offset=0)
     assert rows == []
+
+
+# ─── list_images ──────────────────────────────────────────────────────────────
+
+def test_list_images_returns_all_by_default(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 8
+
+
+def test_list_images_filters_by_profile(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile="alice", limit=20, offset=0)
+    assert len(rows) == 4
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_images_newest_first(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile=None, limit=20, offset=0)
+    timestamps = [r.created_at for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_list_images_carries_prompt_aspect_model_local_path(seeded: Path) -> None:
+    rows = list_images(db_path=seeded, profile="alice", limit=1, offset=0)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.prompt is not None  # operation seeded, so JOIN finds it
+    assert r.aspect == "16:9"
+    assert r.model  # non-empty; fixture uses Flow's real model identifier
+    assert r.local_path is not None
+    assert r.local_path.endswith(".png")
+
+
+def test_list_images_pagination(seeded: Path) -> None:
+    page1 = list_images(db_path=seeded, profile=None, limit=4, offset=0)
+    page2 = list_images(db_path=seeded, profile=None, limit=4, offset=4)
+    assert {r.media_id for r in page1} & {r.media_id for r in page2} == set()
+
+
+# ─── list_videos ──────────────────────────────────────────────────────────────
+
+def test_list_videos_returns_all_by_default(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile=None, limit=20, offset=0)
+    assert len(rows) == 2
+    assert all(r.profile == "alice" for r in rows)
+
+
+def test_list_videos_filter_no_match(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile="bob", limit=20, offset=0)
+    assert rows == []
+
+
+def test_list_videos_carries_duration(seeded: Path) -> None:
+    rows = list_videos(db_path=seeded, profile="alice", limit=1, offset=0)
+    assert rows[0].duration > 0  # float, e.g. 6.0
+
+
+# ─── list_profiles ────────────────────────────────────────────────────────────
+
+def test_list_profiles_returns_catalog_known_profiles(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    assert {r.profile_name for r in rows} == {"alice", "bob", "carol"}
+
+
+def test_list_profiles_carries_aggregate_counts(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    by_name = {r.profile_name: r for r in rows}
+    assert by_name["alice"].project_count == 2
+    assert by_name["alice"].image_count == 4  # 2 projects × 2 images
+    assert by_name["alice"].video_count == 2  # 2 projects × 1 video
+    assert by_name["bob"].project_count == 1
+    assert by_name["bob"].image_count == 2
+    assert by_name["bob"].video_count == 0
+
+
+def test_list_profiles_sorted_by_last_used_desc(seeded: Path) -> None:
+    rows = list_profiles(db_path=seeded, limit=20, offset=0)
+    timestamps = [r.last_used_at for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)


### PR DESCRIPTION
## Summary

Adds the v0.9.0 release's core code: `gflow data list {projects,images,videos,profiles}` — a read-only window into the SQLite catalog that landed in PR #58.

- **Pagination**: `--limit N` (1..1000, default 20) / `--offset N` (≥0, default 0)
- **Filter**: `--profile NAME` (not on `profiles` subcommand)
- **Output**: Rich table on TTY, JSONL on pipe or with `--json`
- **Sort**: newest first (default)
- **Exit codes**: 0 success / 2 Click usage / 16 DataStoreError family

Also bundles (originally separate phases — bundled here for atomicity):
- `CHANGELOG.md` — Unreleased data-layer entry (originally Phase 5 territory)
- `KNOWN_ISSUES.md` — omni-flash `flow_operation_id` NULL known issue (originally Phase 4 Task 4.6 territory)

## Schema reconciliation applied

The plan's original SQL assumed `images` / `videos` tables — the audit (PR #65) found these live in a single `assets` table with a `kind` discriminator. All SQL was patched accordingly. The public dataclass field names (`ProjectRow.profile`, `ImageRow.aspect`, `VideoRow.duration`, etc.) stay as the spec's short names; SQL uses real schema names with `AS` aliases.

Notable joins: `prompt` via LEFT JOIN `operation_assets` (role='output') + `operations`; `local_path` via LEFT JOIN `local_files` on `asset_id`. Both NULLable.

## Test plan
- [x] 18 query-layer unit tests (`tests/test_data_queries.py`)
- [x] 13 CLI integration tests via Click's `CliRunner` (`tests/test_cli_data.py`)
- [x] Local Impeccable Routine green (hygiene, ruff check, ruff format, pyright, scoped pytest)
- [ ] Exercise on a real catalog (Phase 5 live verification)

Refs the v0.9.0 release spec (`docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` §3.1). Part of v0.9.0 release sequence — Phase 2 of 5.