### PR TITLE
docs: publish ROADMAP.md + wire sponsorship (GH Sponsors + BMC)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Sponsorship channels for gflow-cli.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [ffroliva]
+buy_me_a_coffee: ffroliva

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Type checked: pyright](https://img.shields.io/badge/type%20checked-pyright-blue.svg)](https://github.com/microsoft/pyright)
 [![Tests: TDD](https://img.shields.io/badge/tests-TDD-brightgreen.svg)](CONTRIBUTING.md)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli)
+[![Sponsor on GitHub](https://img.shields.io/static/v1?label=Sponsor&message=GitHub&color=ea4aaa&logo=github)](https://github.com/sponsors/ffroliva)
+[![Buy Me A Coffee](https://img.shields.io/static/v1?label=Buy%20Me%20a&message=Coffee&color=ffdd00&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/ffroliva)
 
 > ⚠️ **Unofficial. Reverse-engineered. Not affiliated with Google.** Endpoints can change at any time. Full [DISCLAIMER](DISCLAIMER.md).
 >
@@ -68,7 +70,7 @@ Reproduce the recording: [`scripts/record_demo.ps1`](scripts/record_demo.ps1) (W
 | 🎯 **Getting started** | [User Guide](docs/USER_GUIDE.md) · [Usage](docs/USAGE.md) · [Configuration](docs/CONFIGURATION.md) |
 | 🔐 **Auth & sessions** | [Authentication](docs/AUTHENTICATION.md) · [Known issues](KNOWN_ISSUES.md) |
 | 🏗️ **Internals** | [Architecture](docs/ARCHITECTURE.md) · [Security](docs/SECURITY.md) · [Debugging](docs/DEBUGGING.md) |
-| 📦 **Releases** | [Changelog](CHANGELOG.md) · [Release protocol](RELEASE.md) · [Project status](docs/PROJECT_STATUS.md) |
+| 📦 **Releases** | [Changelog](CHANGELOG.md) · [Roadmap](ROADMAP.md) · [Release protocol](RELEASE.md) · [Project status](docs/PROJECT_STATUS.md) |
 | 🤝 **Contributing** | [Contributing](CONTRIBUTING.md) · [Development](docs/DEVELOPMENT.md) · [GitHub workflow](docs/GITHUB.md) |
 
 ## For AI agents & LLMs
@@ -104,7 +106,16 @@ gflow CLI  →  Provider (interchangeable)  →  Flow (ui_automation) / Mock (te
 
 ## Project status
 
-**v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](docs/USAGE.md#gflow-video-batch)). The next release will pick up everything in `[Unreleased]` (i2v/r2v wiring, t2v model picker, `GFLOW_CLI_LOCALE` env override). Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md).
+**v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](docs/USAGE.md#gflow-video-batch)). The next release will pick up everything in `[Unreleased]` (i2v/r2v wiring, t2v model picker, `GFLOW_CLI_LOCALE` env override). Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md). Where the project is heading → [ROADMAP.md](ROADMAP.md).
+
+## Support
+
+If `gflow-cli` saves you time, a coffee or sponsorship goes a long way to keeping it maintained.
+
+- [GitHub Sponsors](https://github.com/sponsors/ffroliva)
+- [Buy Me a Coffee](https://www.buymeacoffee.com/ffroliva)
+
+Thanks to everyone who has supported the project so far.
 
 ## License & legal
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+> Themes, not deadlines. `gflow-cli` is an unofficial CLI tracking a private Google Flow API — a single upstream UI change can rearrange a sprint, so we publish themed milestones with deliverables and let velocity emerge.
+
+## v0.9.0 — Maturity & Visibility (current)
+
+The release that makes the underlying data layer visible to the user. Adds `gflow data list` for read-only catalog browsing, publishes this roadmap, wires sponsorship, and refreshes the documentation surface to reflect everything that shipped through v0.8.x.
+
+- Local SQLite catalog (shipped in PR #58, surfaced here)
+- `gflow video t2v` model picker (`omni-flash` / `veo-lite` / `veo-fast` / `veo-quality` / `veo-lite-lp`)
+- `gflow video i2v` — image-to-video with optional end frame
+- `gflow video r2v` — reference-to-video (Flow ingredients)
+- `gflow data list {projects,images,videos,profiles}` — read-only catalog query
+- Locale-agnostic media-dialog selectors (fixes non-English Chrome profiles)
+- `ROADMAP.md`, `.github/FUNDING.yml`, sponsor badges
+
+## v0.10.0 — Data Query Surface
+
+Extends the data layer surface from read-only listing to inspection and selective export. Same local SQLite catalog, richer ways to interrogate it.
+
+- `gflow data show <media_id>` — full record for one image / video / project
+- `gflow data search` — filter by prompt substring, model, aspect, date range
+- `gflow data export` — JSON / CSV / TSV
+- `gflow data prune` — retention controls (`--older-than`, `--keep-last-n`)
+
+## v0.11.0 — Local HTTP API + Web UI
+
+The API and the UI ship together as one deliverable — neither is useful alone. `gflow ui` boots a local HTTP server on `127.0.0.1` that hosts both the API and the UI; everything stays loopback-only.
+
+- `gflow ui` — single command, single port
+- Local REST API over the SQLite catalog with read endpoints for projects / images / videos / profiles
+- Web UI consumes the API; browses generations with thumbnails
+- Aggregated view across local profiles (read-only)
+
+## v1.0.0 — Stable API
+
+The point at which `FlowApiClient` carries a SemVer commitment and the documentation reaches "production-ready" standard.
+
+- `FlowApiClient` SemVer commitment
+- HTTP transport revival path (community-contrib; if feasible)
+- Production-ready documentation
+
+---
+
+*Themes, not deadlines. An unofficial CLI tracking a private API can have its sprint broken by a single UI change upstream — fixed dates would be dishonest.*

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [CLAUDE.md](../CLAUDE.md) | Claude Code's session memory hub (Claude-Code-specific protocol; delegates universal rules to AGENTS.md) | First time Claude Code opens the repo |
 | [PLAN.md](../PLAN.md) | Implementation plan (DDD / CQRS / phases / ADRs) | You want the architectural intent and roadmap |
 | [RELEASE.md](../RELEASE.md) | Release checklist, prerelease policy, PyPI/GitHub publishing protocol | Cutting or auditing a release |
+| [ROADMAP.md](../ROADMAP.md) | Themed milestones from v0.9 through v1.0 | You want a multi-release view of where the project is heading |
 | [CHANGELOG](../CHANGELOG.md) | Version-by-version user-visible changes | Upgrading or auditing what shipped |
 | [KNOWN_ISSUES](../KNOWN_ISSUES.md) | Open / mitigated / resolved issues with workarounds | Before opening a bug report; when something feels off |
 | [DISCLAIMER](../DISCLAIMER.md) | Legal scope, takedown policy, prohibited uses | Before deploying anywhere non-trivial |


### PR DESCRIPTION
## Summary

Phase 3 of the v0.9.0 release — docs + config only.

- **New `ROADMAP.md`** with themed milestones through v1.0 (no dates): v0.9 Maturity & Visibility (current) · v0.10 Data Query Surface · v0.11 Local HTTP API + Web UI (one deliverable, both 127.0.0.1 loopback) · v1.0 Stable API.
- **`.github/FUNDING.yml`** wiring GitHub Sponsors + Buy Me a Coffee.
- **README**: two sponsor badges added to the badge row; new `## Support` section after Project status; `Roadmap` link added to the docs TOC's Releases row.
- **`docs/INDEX.md`**: `ROADMAP.md` row added between RELEASE and CHANGELOG.

Refs the v0.9.0 release spec (`docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` §3.2 + §3.3). Part of v0.9.0 release sequence — Phase 3 of 5.