### PR TITLE
docs: v0.9.0 maturity refresh (AGENTS / INDEX / DATA_LAYER / STATUS / llms)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Supported tools that auto-discover this file: Cursor, Codex, Aider, Gemini CLI, 
 
 - Unofficial Python CLI for [Google Flow](https://labs.google/fx/tools/flow) — drives Veo (image-to-video, text-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at `aisandbox-pa.googleapis.com`.
 - Python 3.11+ · `uv`-managed · `hatchling` builds · Playwright Chromium transport · `pyright` strict · `ruff` · `pytest`.
-- Single-package modular monolith. Top-level modules under `src/gflow_cli/`: `api/`, `auth/`, `browser_manager.py`, `cli.py`, `_cli_helpers.py`, `cli_image.py`, `cli_run.py`, `cli_video.py`, `config.py`, `errors.py`, `exceptions.py`, `image_batch.py`, `manifest.py`, `observability.py`, `paths.py`, `profile_store.py`.
+- Single-package modular monolith. Top-level modules under `src/gflow_cli/`: `api/`, `auth/`, `browser_manager.py`, `cli.py`, `_cli_helpers.py`, `cli_data.py`, `cli_image.py`, `cli_run.py`, `cli_video.py`, `config.py`, `data/`, `errors.py`, `exceptions.py`, `image_batch.py`, `manifest.py`, `observability.py`, `paths.py`, `profile_store.py`.
 - Requires a Google AI Ultra or Pro subscription with Flow access. All generations bill against the user's own Google account.
 
 ## Headed-browser dependency (architectural reality)
@@ -53,7 +53,7 @@ Or invoke the wrapper: `/gflow:check`.
 
 - Type hints everywhere; `pyright` strict on `src/gflow_cli`.
 - Structured logging only (`structlog`) — **never** raw `print()` or `import logging` in `src/`.
-- Errors as RFC 9457 Problem Details with stable per-class exit codes (3–15). See `src/gflow_cli/errors.py::EXIT_CODE_MAP` for the complete mapping.
+- Errors as RFC 9457 Problem Details with stable per-class exit codes (3–16, where 16 is the `DataStoreError` family from `gflow_cli.data`). See `src/gflow_cli/errors.py::EXIT_CODE_MAP` for the complete mapping.
 - 100-char line length, `ruff` configured. Imports sorted by `ruff` (isort rules).
 
 ## PR instructions

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -172,6 +172,35 @@ See [`SECURITY.md`](SECURITY.md) for the broader threat model.
 
 ## Querying the data layer
 
+### `gflow data list {projects,images,videos,profiles}` — browse the catalog (v0.9.0+)
+
+```bash
+# Newest 20 projects across all profiles
+gflow data list projects
+
+# All images for one profile, paginated
+gflow data list images --profile ffroliva --limit 50 --offset 0
+
+# Videos as JSONL for piping into jq
+gflow data list videos --json | jq '.media_id'
+
+# Profiles with at least one recorded generation
+gflow data list profiles
+```
+
+Flags shared by all four subcommands:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--limit N` | 20 | 1..1000 |
+| `--offset N` | 0 | for pagination |
+| `--profile NAME` | unset | filter to one profile (not available on `profiles`) |
+| `--json` | off | JSONL output, one object per line |
+
+TTY stdout → Rich table; pipe or `--json` → JSONL. Default sort: newest first. Exit code 16 on data-store errors (same `DataStoreError` family as `gflow data media`).
+
+> **`data list profiles` vs `gflow auth list`:** `data list profiles` shows profiles that have **recorded generations** in the catalog; `gflow auth list` shows profiles that have ever **logged in** via `gflow auth login`. A profile that logged in but never generated anything will appear in `auth list` but not in `data list profiles`.
+
 ### `gflow data media <media_id>` — read a single asset
 
 ```

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -61,6 +61,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"How does the layered structure work?"** → [ARCHITECTURE § Layers](ARCHITECTURE.md#layers)
 **"What env var should I set for X?"** → [CONFIGURATION § Reference](CONFIGURATION.md#reference)
 **"What does gflow remember after a generation finishes?"** → [DATA_LAYER § What is recorded](DATA_LAYER.md#what-is-recorded)
+**"How do I see what's in my gflow catalog?"** → run `gflow data list projects` (or `images` / `videos` / `profiles`) — see [DATA_LAYER § Querying the data layer](DATA_LAYER.md#querying-the-data-layer)
 **"Where can I look up a media ID I generated yesterday?"** → [DATA_LAYER § Querying the data layer](DATA_LAYER.md#querying-the-data-layer)
 **"How do I stop gflow from storing my prompts?"** → [DATA_LAYER § Privacy and redaction](DATA_LAYER.md#privacy-and-redaction)
 **"What does exit code 16 mean and how do I recover?"** → [DATA_LAYER § Persistence-failure handling](DATA_LAYER.md#persistence-failure-handling)

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -6,7 +6,7 @@
 
 **v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](USAGE.md#gflow-video-batch)). Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
 
-**Develop (unreleased, post-v0.8.1):** PR #37 (Sonar refactor), PR #46 (README badges), PR #48 (i2v/r2v + t2v `--model`/`--duration`/`--count` + image `--model` no-op fix), PR #51 (`GFLOW_CLI_LOCALE` env override, prep for issue #24). Targets v0.9.0.
+**Develop (unreleased, post-v0.8.1):** PR #37 (Sonar refactor), PR #46 (README badges), PR #48 (i2v/r2v + t2v `--model`/`--duration`/`--count` + image `--model` no-op fix), PR #51 (`GFLOW_CLI_LOCALE` env override, prep for issue #24), PR #52 + #58 (local SQLite catalog / data layer + `gflow data media`), PR #60 (locale-agnostic media-dialog selectors), PR #66 (`gflow data list` read CLI over the catalog), PR #67 (`ROADMAP.md` + sponsorship). Targets **v0.9.0 — Maturity & Visibility**.
 
 ## Milestone history
 
@@ -35,6 +35,10 @@
 | `gflow video i2v` (start + optional end frame) on `ui_automation` | ✅ done (Unreleased) |
 | `gflow video r2v` (reference-to-video, model-aware ref cap omni≤7 / veo≤3) | ✅ done (Unreleased) |
 | `gflow image t2i/i2i --model` actually selects the model (was a no-op) | ✅ done (Unreleased) |
+| Local SQLite catalog (data layer) recording every project / image / video / operation | ✅ done (Unreleased) |
+| `gflow data list {projects,images,videos,profiles}` read CLI over the catalog | ✅ done (Unreleased) |
+| `ROADMAP.md` published + sponsorship wired (GitHub Sponsors + Buy Me a Coffee) | ✅ done (Unreleased) |
+| Locale-agnostic media-dialog upload selectors (fixes non-English Chrome profiles) | ✅ done (Unreleased) |
 | `gflow video batch` (TSV manifest) on `ui_automation` | ⏳ Phase B |
 | Persistence layer (stay-mounted batch sessions across project boundaries) | ⏳ Phase B |
 | Provider abstraction for official Veo 3.1 API | ⏳ planned |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # gflow-cli
 
-> Unofficial Python CLI for Google Flow — drives Veo (image-to-video, text-to-video, reference-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at aisandbox-pa.googleapis.com. Requires a Google AI Ultra or Pro subscription with Flow access. Uses Playwright Chromium under the hood (one-time real-Chrome auth, then a persistent Chrome session driven via ui_automation). Production-stable for image generation and video T2V/I2V/R2V with a `--model`/`--duration`/`--count` picker; only `gflow video batch` (manifest runner) is still queued for Phase B — use a shell for-loop in the meantime. MIT licensed, not affiliated with Google.
+> Unofficial Python CLI for Google Flow — drives Veo (image-to-video, text-to-video, reference-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at aisandbox-pa.googleapis.com. Requires a Google AI Ultra or Pro subscription with Flow access. Uses Playwright Chromium under the hood (one-time real-Chrome auth, then a persistent Chrome session driven via ui_automation). Production-stable for image generation and video T2V/I2V/R2V with a `--model`/`--duration`/`--count` picker; only `gflow video batch` (manifest runner) is still queued for Phase B — use a shell for-loop in the meantime. Keeps a local SQLite catalog of every generation, queryable via `gflow data list {projects,images,videos,profiles}`. MIT licensed, not affiliated with Google.
 
 This file is forward-staged for a future docs site at https://ffroliva.github.io/gflow-cli/llms.txt and is also usable today by LLM agents that read the repo directly.
 
@@ -13,6 +13,8 @@ This file is forward-staged for a future docs site at https://ffroliva.github.io
 - [Authentication](https://github.com/ffroliva/gflow-cli/blob/main/docs/AUTHENTICATION.md): One-time Chrome login, session storage, multi-account.
 - [Configuration](https://github.com/ffroliva/gflow-cli/blob/main/docs/CONFIGURATION.md): All env vars, output paths, precedence.
 - [Known Issues](https://github.com/ffroliva/gflow-cli/blob/main/KNOWN_ISSUES.md): Open + mitigated issues with workarounds.
+- [Data Layer](https://github.com/ffroliva/gflow-cli/blob/main/docs/DATA_LAYER.md): Local SQLite catalog schema and the `gflow data list` query CLI.
+- [Roadmap](https://github.com/ffroliva/gflow-cli/blob/main/ROADMAP.md): Themed milestones through v1.0.
 
 ## For AI coding agents
 


### PR DESCRIPTION
## Summary

Phase 4 of the v0.9.0 release — docs only.

- **AGENTS.md**: added `cli_data.py` + `data/` to the module list; exit-code range updated from 3–15 to 3–16 with note that 16 is the `DataStoreError` family.
- **docs/INDEX.md**: added topic shortcut *"How do I see what's in my gflow catalog?"* → `gflow data list ...`.
- **docs/DATA_LAYER.md**: added new `### gflow data list {projects,images,videos,profiles}` subsection at the top of the existing "Querying the data layer" section — documents flags, output, sort, exit codes, and the `data list profiles` vs `gflow auth list` semantic distinction.
- **docs/PROJECT_STATUS.md**: Develop line refreshed with PRs #52/#58/#60/#66/#67; milestone table gains rows for data layer, `gflow data list`, ROADMAP+sponsorship, locale-agnostic selectors.
- **llms.txt**: description gains the catalog + `gflow data list` capability; Docs section gains Data Layer + Roadmap links.

KNOWN_ISSUES.md (omni-flash entry) already landed via PR #66's bundling, so Phase 4 Task 4.6 is a no-op.

Refs the v0.9.0 release spec (`docs/superpowers/specs/2026-05-24-v0.9.0-release-design.md` §3.4). Part of v0.9.0 release sequence — Phase 4 of 5.