### PR TITLE
release: v0.9.1 — wheel-build fix (PyPI rescue for v0.9.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-05-25
+
+### Fixed
+
+- **Wheel build no longer emits duplicate ZIP entries.** PyPI rejected the
+  `v0.9.0` upload with HTTP 400 *"Duplicate filename in local headers"*
+  because `pyproject.toml` had `[tool.hatch.build.targets.wheel.force-include]`
+  AND `[tool.hatch.build.targets.sdist.force-include]` blocks pointing at
+  `src/gflow_cli/data/migrations`, on top of the already-comprehensive
+  `packages = ["src/gflow_cli"]` directive — hatchling included the
+  migrations directory twice (both the `__init__.py` and the
+  `0001_initial.sql`). The force-include blocks have been removed;
+  hatchling's default package inclusion already covers `.sql` files inside
+  the package tree. Tag `v0.9.0` exists on GitHub but never reached PyPI;
+  **`v0.9.1` is the first PyPI release of the v0.9.x line and carries the
+  same content as `v0.9.0`** plus this build fix.
+
 ## [0.9.0] — 2026-05-25
 
 > **Maturity & Visibility release.** Surfaces the SQLite catalog (PR #52/#58)
@@ -932,7 +949,8 @@ shell-script template that branches on these codes.
 
 First skeleton. Not functional end-to-end yet.
 
-[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/ffroliva/gflow-cli/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/ffroliva/gflow-cli/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/ffroliva/gflow-cli/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/ffroliva/gflow-cli/compare/v0.7.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.9.0"
+version = "0.9.1"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -51,12 +51,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gflow_cli"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/gflow_cli/data/migrations" = "gflow_cli/data/migrations"
-
-[tool.hatch.build.targets.sdist.force-include]
-"src/gflow_cli/data/migrations" = "src/gflow_cli/data/migrations"
 
 [tool.ruff]
 line-length = 100

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
## Why

The v0.9.0 release workflow [run #26415129126](https://github.com/ffroliva/gflow-cli/actions/runs/26415129126) failed at the PyPI publish step:

> 400 Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.

Root cause: `pyproject.toml` had both `[tool.hatch.build.targets.wheel.force-include]` and `[tool.hatch.build.targets.sdist.force-include]` blocks pointing at `src/gflow_cli/data/migrations`, on top of the already-comprehensive `packages = ["src/gflow_cli"]` directive — hatchling included the migrations directory twice (both `__init__.py` and `0001_initial.sql`).

## Fix

Remove the redundant force-include blocks. Hatchling's default package inclusion already covers `.sql` files when they live inside `packages`.

## Verification

Local rebuild after the fix:
- Wheel total entries: 56, unique: 56, duplicates: `[]`
- `gflow_cli/data/migrations/0001_initial.sql` still included
- Impeccable Routine: hygiene · ruff · pyright src · 31/31 scoped tests — all green

## Release notes

`v0.9.1` carries the same product content as `v0.9.0` plus this single build fix. The v0.9.0 tag stays on GitHub for historical accuracy but never reached PyPI; v0.9.1 is the first PyPI release of the v0.9.x line.

Refs the v0.9.0 release sequence — recovery patch.