### PR TITLE
fix(build): wheel-build duplicate-include (PyPI rescue for v0.9.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/gflow_cli"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/gflow_cli/data/migrations" = "gflow_cli/data/migrations"
-
-[tool.hatch.build.targets.sdist.force-include]
-"src/gflow_cli/data/migrations" = "src/gflow_cli/data/migrations"
-
 [tool.ruff]
 line-length = 100
 target-version = "py311"


### PR DESCRIPTION
## Why

The v0.9.0 release workflow (run [#26415129126](https://github.com/ffroliva/gflow-cli/actions/runs/26415129126)) failed at the PyPI publish step:

> 400 Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.

`pyproject.toml` had `[tool.hatch.build.targets.wheel.force-include]` and `[tool.hatch.build.targets.sdist.force-include]` blocks pointing at `src/gflow_cli/data/migrations`, on top of `packages = ["src/gflow_cli"]`. Hatchling included the migrations directory twice — both `__init__.py` and `0001_initial.sql` appeared as duplicate ZIP entries.

## Fix

Remove both force-include blocks. Hatchling's default package inclusion already covers `.sql` files when they live inside the `packages` tree.

## Local verification

```
$ uv build
Successfully built dist/gflow_cli-0.9.0.tar.gz
Successfully built dist/gflow_cli-0.9.0-py3-none-any.whl

$ python -c "import zipfile; ..."
Wheel: gflow_cli-0.9.0-py3-none-any.whl
Entries: 56  Unique: 56  Dupes: []
SQL: ['gflow_cli/data/migrations/0001_initial.sql']
```

## What happens after merge

The existing `v0.9.0` git tag (currently on a commit with the broken wheel config) will be **deleted from local + origin** and **re-created at the new merge commit**. PyPI will be retried at v0.9.0.

Risk acknowledged: if PyPI marked v0.9.0 filename as "consumed" on the failed upload, the retry will fail and we'll fall back to v0.9.1.

Refs the v0.9.0 release sequence — recovery patch.