### PR TITLE
docs(v0.9.0): pre-tag doc-review council fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-existent `aria-controls*=9_16`; the video-mode tab match was ambiguous.
   All now use exact `[id$=-trigger-X]` suffixes + aria-label text.
 
+### Build
+
+- **Wheel build no longer emits duplicate ZIP entries.** An earlier attempt at
+  tagging v0.9.0 was rejected by PyPI with HTTP 400 ("Duplicate filename in
+  local headers") because `pyproject.toml` had
+  `[tool.hatch.build.targets.wheel.force-include]` and
+  `[tool.hatch.build.targets.sdist.force-include]` blocks pointing at
+  `src/gflow_cli/data/migrations`, on top of the already-comprehensive
+  `packages = ["src/gflow_cli"]` directive — hatchling included the
+  migrations directory twice (both `__init__.py` and `0001_initial.sql`). The
+  force-include blocks have been removed; hatchling's default package
+  inclusion already covers `.sql` files inside the package tree. (PR #74.)
+
 ### Notes
 
 - I2V/R2V image inputs bind through the editor's media dialog (frame slot /

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ gflow CLI  →  Provider (interchangeable)  →  Flow (ui_automation) / Mock (te
 
 **Current transport:** `ui_automation` — drives Flow via a persistent Playwright Chromium profile. Production-stable, end-to-end verified per release (see [LIVE_VERIFICATION_*](docs/) per-release evidence files).
 
-**What's blocked:** A pure HTTP transport for video generation. The video upload endpoint returns HTTP 401 under non-Chrome browsers + a reCAPTCHA mint we cannot reproduce headlessly. Three earlier HTTP strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual transport modules have not yet been extracted into a subpackage.
+**What's blocked:** A pure HTTP transport for video generation. The video upload endpoint returns HTTP 401 under non-Chrome browsers + a reCAPTCHA mint we cannot reproduce headlessly. Three earlier HTTP strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) live under `src/gflow_cli/api/transports/experimental/` — they are importable for research but not on the production critical path.
 
 **How you can help:** If you have successfully driven `aisandbox-pa.googleapis.com` from outside a real Chrome session — or have insight into Google's anti-bot stack here — please open an issue. A working REST transport would unlock serverless deployments, true horizontal concurrency, and roughly 10× the project's reach. Details: [docs/ARCHITECTURE.md § Headed-browser dependency](docs/ARCHITECTURE.md#headed-browser-dependency--current-limitation).
 
 ## Project status
 
-**v0.9.0 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. New in v0.9.0: `gflow data list {projects,images,videos,profiles}` read CLI over the local SQLite catalog, `ROADMAP.md`, sponsorship wiring, and locale-agnostic media-dialog selectors. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](docs/USAGE.md#gflow-video-batch)). Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md). Where the project is heading → [ROADMAP.md](ROADMAP.md).
+**v0.9.0 — alpha.** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on `ui_automation`, with a video `--model` picker (5 Veo models) + `--duration` / `--count`. New in v0.9.0: `gflow data list {projects,images,videos,profiles}` read CLI over the local SQLite catalog, `ROADMAP.md`, and locale-agnostic media-dialog selectors that fix non-English Chrome profiles. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](docs/USAGE.md#gflow-video-batch)). Full milestone history → [docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md). Changelog → [CHANGELOG.md](CHANGELOG.md). Where the project is heading → [ROADMAP.md](ROADMAP.md).
 
 ## License & legal
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,9 +50,9 @@ The hexagonal target above is the steady state. The **current** package — and 
 - `gflow_cli.errors` — exception taxonomy aligned with [RFC 9457 Problem Details](https://datatracker.ietf.org/doc/html/rfc9457). Each `GFlowError` subclass carries `type` (URI), `title`, `status`, `detail`, `instance`, `remediation_hint`. The `to_problem_details()` method serializes to the RFC 9457 JSON shape and is the stable contract for telemetry consumers.
 - `gflow_cli.observability` — structlog configuration + the `error_raised` event emitter. This is the future home for metrics + tracing (Phase 5+) too.
 
-**Data layer module (feature/data-layer, targeting v0.9.0):**
+**Data layer module (shipped in v0.9.0):**
 
-- `gflow_cli/data/` — local SQLite persistence layer (`DataStore` + repository + `OperationRecorder` + redaction). Records all new image/video operations, asset provenance, and local file metadata. Default path `<GFLOW_CLI_HOME>/gflow.db`. Migrations versioned via SHA-256 checksums; safe forward-only semantics with newer-schema detection. T2V now flows through `FlowApiClient.generate_video`, sharing the client boundary with image commands.
+- `gflow_cli/data/` — local SQLite persistence layer (`DataStore` + `DataRepository` + `OperationRecorder` + redaction + read-only `queries` for `gflow data list`). Records all new image/video operations, asset provenance, and local file metadata. Default DB path is resolved from `$GFLOW_CLI_DB_PATH` (default: `~/.local/share/gflow-cli/data.db` on POSIX, the equivalent platformdirs user-data dir on Windows). Migrations versioned via SHA-256 checksums; safe forward-only semantics with newer-schema detection. T2V now flows through `FlowApiClient.generate_video`, sharing the client boundary with image commands.
 
 **Why RFC 9457 for errors:** Problem Details is the IETF-standard shape for machine-readable HTTP error responses. Even though gflow-cli is a CLI (not an HTTP server), adopting the same vocabulary means: (a) the error log shape is greppable by stable `type` URI, (b) future cloud-edge integrations (e.g., a `gflow serve` HTTP front-end) can return our errors directly without translation, (c) downstream telemetry tools recognize the shape immediately.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -78,7 +78,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"A gflow command hangs / fails — where do I start?"** → [DEBUGGING § Quick reference](DEBUGGING.md#quick-reference)
 **"Flow's UI broke a selector — how do I diagnose it?"** → [DEBUGGING § Inspecting Flow's live UI](DEBUGGING.md#inspecting-flows-live-ui)
 **"What does each `ui_automation.*` log event mean?"** → [DEBUGGING § Listener & HTTP-layer debugging](DEBUGGING.md#listener--http-layer-debugging)
-**"What was actually live-verified for the latest release?"** → [LIVE_VERIFICATION_v0.8.1](LIVE_VERIFICATION_v0.8.1.md) · prior: [v0.7.0](LIVE_VERIFICATION_v0.7.0.md)
+**"What was actually live-verified for the latest release?"** → [LIVE_VERIFICATION_v0.9.0](LIVE_VERIFICATION_v0.9.0.md) · prior: [v0.8.1](LIVE_VERIFICATION_v0.8.1.md) · [v0.7.0](LIVE_VERIFICATION_v0.7.0.md)
 **"What was live-verified for the data layer (PR #58)?"** → [LIVE_VERIFICATION_data_layer](LIVE_VERIFICATION_data_layer.md) — 1 Imagen + 1 Veo credit on denon82, 6-layer ledger (file + magic + Pillow + DB rows + CLI round-trip + structlog)
 **"What was live-verified for the video-download feature (#29)?"** → [LIVE_VERIFICATION_video_download](LIVE_VERIFICATION_video_download.md)
 **"What is the jitter matrix evidence for `gflow image batch`?"** → [`LIVE_VERIFICATION_image_batch.md`](LIVE_VERIFICATION_image_batch.md) — jitter matrix evidence for `gflow image batch` (always-same-project mode)

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,9 +4,9 @@
 
 ## Current release
 
-**v0.8.1 — alpha (latest on PyPI).** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](USAGE.md#gflow-video-batch)). Three earlier HTTP transport strategies (`evaluate_fetch` / `bearer` / `sapisidhash`) are named in the codebase history; the actual modules have not been extracted into a subpackage. The production path is `ui_automation`.
+**v0.9.0 — alpha.** Image (T2I / I2I / upload) + Video T2V / I2V / R2V live end-to-end on the `ui_automation` transport against live Pro/Ultra accounts, with a video `--model` picker (5 Veo models) and `--duration` / `--count`. New surface in v0.9.0: `gflow data list {projects,images,videos,profiles}` — read-only browse over the local SQLite catalog. Only video `batch` (manifest runner) is still queued for Phase B — use a shell for-loop until then ([USAGE](USAGE.md#gflow-video-batch)). Three earlier HTTP transport strategies live under `src/gflow_cli/api/transports/experimental/` (`evaluate_fetch` / `bearer` / `sapisidhash`); the production path is `ui_automation`. Sponsorship wiring was prepared but deferred to a follow-up patch release pending account activation.
 
-**Develop (unreleased, post-v0.8.1):** PR #37 (Sonar refactor), PR #46 (README badges), PR #48 (i2v/r2v + t2v `--model`/`--duration`/`--count` + image `--model` no-op fix), PR #51 (`GFLOW_CLI_LOCALE` env override, prep for issue #24), PR #52 + #58 (local SQLite catalog / data layer + `gflow data media`), PR #60 (locale-agnostic media-dialog selectors), PR #66 (`gflow data list` read CLI over the catalog), PR #67 (`ROADMAP.md` + sponsorship). Targets **v0.9.0 — Maturity & Visibility**.
+**Develop (unreleased, post-v0.9.0):** *(empty — develop is the staging branch for v0.10 work).*
 
 ## Milestone history
 
@@ -34,11 +34,12 @@
 | `gflow video t2v` model picker (5 Veo models) + `--duration` / `--count` | ✅ done (Unreleased) |
 | `gflow video i2v` (start + optional end frame) on `ui_automation` | ✅ done (Unreleased) |
 | `gflow video r2v` (reference-to-video, model-aware ref cap omni≤7 / veo≤3) | ✅ done (Unreleased) |
-| `gflow image t2i/i2i --model` actually selects the model (was a no-op) | ✅ done (Unreleased) |
-| Local SQLite catalog (data layer) recording every project / image / video / operation | ✅ done (Unreleased) |
-| `gflow data list {projects,images,videos,profiles}` read CLI over the catalog | ✅ done (Unreleased) |
-| `ROADMAP.md` published (themed milestones through v1.0) | ✅ done (Unreleased) |
-| Locale-agnostic media-dialog upload selectors (fixes non-English Chrome profiles) | ✅ done (Unreleased) |
+| `gflow image t2i/i2i --model` actually selects the model (was a no-op) | ✅ done (v0.9.0) |
+| Local SQLite catalog (data layer) recording every project / image / video / operation | ✅ done (v0.9.0) |
+| `gflow data list {projects,images,videos,profiles}` read CLI over the catalog | ✅ done (v0.9.0) |
+| `ROADMAP.md` published (themed milestones through v1.0) | ✅ done (v0.9.0) |
+| Locale-agnostic media-dialog upload selectors (fixes non-English Chrome profiles) | ✅ done (v0.9.0) |
+| Wheel-build fix (removed redundant `force-include` causing duplicate ZIP entries) | ✅ done (v0.9.0 hotfix, PR #74) |
 | `gflow video batch` (TSV manifest) on `ui_automation` | ⏳ Phase B |
 | Persistence layer (stay-mounted batch sessions across project boundaries) | ⏳ Phase B |
 | Provider abstraction for official Veo 3.1 API | ⏳ planned |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -383,6 +383,49 @@ videos won't appear together in your Flow gallery. The files on disk are
 identical to what `batch` would produce. The same pattern works for
 `gflow video i2v <image> "<prompt>"` and `gflow video r2v "<prompt>" --ref <img>`.
 
+## `gflow data list`
+
+Read-only browse over the local SQLite catalog. Shipped in v0.9.0.
+
+```text
+gflow data list projects   [--profile NAME] [--limit N] [--offset N] [--json]
+gflow data list images     [--profile NAME] [--limit N] [--offset N] [--json]
+gflow data list videos     [--profile NAME] [--limit N] [--offset N] [--json]
+gflow data list profiles                    [--limit N] [--offset N] [--json]
+
+Options:
+  --profile NAME        Filter to one profile (not available on `profiles`).
+  --limit N             Max rows returned. Range 1..1000. Default 20.
+  --offset N            Rows to skip (pagination). Default 0.
+  --json                Force JSONL output (one record per line).
+```
+
+Output:
+- TTY stdout → Rich-formatted table.
+- Pipe / non-TTY / `--json` → JSONL.
+
+Default sort: newest first (by `created_at`). Exit codes: 0 success / 2 Click usage / **16** `DataStoreError` family (catalog missing, migration mismatch, etc.).
+
+**Examples:**
+
+```bash
+# Newest 20 projects across all profiles
+gflow data list projects
+
+# All images for one profile, paginated
+gflow data list images --profile ffroliva --limit 50 --offset 0
+
+# Videos as JSONL for piping into jq
+gflow data list videos --json | jq '.media_id'
+
+# Profiles with at least one recorded generation
+gflow data list profiles
+```
+
+> **`data list profiles` vs `gflow auth list`** — `data list profiles` shows profiles that have **recorded generations** in the catalog; `gflow auth list` shows profiles that have ever **logged in** via `gflow auth login`. A profile that logged in but never generated anything will appear in `auth list` but not in `data list profiles`.
+
+For full schema details and JOIN semantics, see [`docs/DATA_LAYER.md § Querying the data layer`](DATA_LAYER.md#querying-the-data-layer).
+
 ## `gflow data media`
 
 Look up a recorded operation by its Flow media ID. Prints a summary of the stored provenance record: profile, media ID, Flow project ID, kind (image/video), and the local file paths that were written for that operation.


### PR DESCRIPTION
## Summary

Pre-tag doc-review (per `.claude/commands/gflow/doc-review.md` section 8 — 3-agent LLM council) found 7 Tier 1 documentation gaps that should be in the v0.9.0 release artifact. Fixing them before the v0.9.0 tag is re-signed at this commit.

Council verdict: all 3 auditors YELLOW. No hard release blocker (RED), but real fixes needed:

| # | Finding | File |
|---|---|---|
| 1 | "latest on PyPI" false (becomes true after publish) + "sponsorship wiring" stripped | `README.md` |
| 2 | Claims experimental transports "not yet extracted into a subpackage" — but `api/transports/experimental/` exists | `README.md` |
| 3 | Data layer "targeting v0.9.0" with stale DB filename `gflow.db` (real default is `data.db` under `GFLOW_CLI_DB_PATH`) | `docs/ARCHITECTURE.md` |
| 4 | `gflow data list` was missing entirely (only `gflow data media` was documented) | `docs/USAGE.md` |
| 5 | "Latest live-verified release" shortcut still pointed at v0.8.1 | `docs/INDEX.md` |
| 6 | Current release line, Develop line, and milestone-history rows all stale for v0.9.0; PR #74 wheel-build hotfix row added | `docs/PROJECT_STATUS.md` |
| 7 | `[0.9.0]` entry didn't mention PR #74 wheel-build fix that the v0.9.0 tag will now point at | `CHANGELOG.md` |

Council reports kept locally at `tmp/council/0{1,2,3}-*.md`.

## Test plan
- [x] hygiene + doc-link checker green
- [ ] CI green on this PR

After merge: v0.9.0 git tag re-signed at the new merge commit, then re-pushed to trigger the PyPI workflow.

Refs the v0.9.0 release sequence — second pre-tag fix.