### PR TITLE
refactor: fix SonarCloud S107 + S3776 maintainability issues

### DIFF
--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -70,6 +70,13 @@ class GenerateVideoRequest:
     def __post_init__(self) -> None:
         if not self.prompt.strip():
             raise ValueError("prompt must not be empty")
+        if len(self.reference_images) > MAX_REFERENCE_IMAGES:
+            raise ValueError(f"at most {MAX_REFERENCE_IMAGES} reference images")
+        if self.seed is not None and not (0 <= self.seed <= 2**31 - 1):
+            raise ValueError("seed out of range")
+        self._validate_mode_inputs()
+
+    def _validate_mode_inputs(self) -> None:
         if self.mode is Mode.T2V and (self.start_image or self.end_image or self.reference_images):
             raise ValueError("T2V request must not carry image inputs")
         if self.mode is Mode.I2V:
@@ -82,10 +89,6 @@ class GenerateVideoRequest:
                 raise ValueError("R2V request requires at least one reference image")
             if self.start_image or self.end_image:
                 raise ValueError("R2V request must not carry start/end images")
-        if len(self.reference_images) > MAX_REFERENCE_IMAGES:
-            raise ValueError(f"at most {MAX_REFERENCE_IMAGES} reference images")
-        if self.seed is not None and not (0 <= self.seed <= 2**31 - 1):
-            raise ValueError("seed out of range")
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -15,6 +15,7 @@ in :mod:`gflow_cli._cli_helpers` since T4b — a negative AST-based test in
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import re
 import sys
 from pathlib import Path
@@ -58,6 +59,7 @@ from gflow_cli.image_batch import (
 )
 from gflow_cli.image_batch import (
     MAX_PROMPT_FILE_BYTES,
+    BatchClientConfig,
     parse_manifest_file,
     parse_prompt_lines,
     prompt_items_from_parsed,
@@ -404,9 +406,9 @@ def t2i(
 
     outcomes = asyncio.run(
         run_image_batch(
-            profile_dir=provider_dir,
-            headless=settings.headless,
-            transport=transport,
+            BatchClientConfig(
+                profile_dir=provider_dir, headless=settings.headless, transport=transport
+            ),
             prompts=batch_prompts,
             output_dir=output_dir,
             continue_on_error=continue_on_error,
@@ -621,9 +623,9 @@ def batch(
 
     outcomes = asyncio.run(
         run_manifest_image_batch(
-            profile_dir=provider_dir,
-            headless=settings.headless,
-            transport=transport,
+            BatchClientConfig(
+                profile_dir=provider_dir, headless=settings.headless, transport=transport
+            ),
             prompts=prompts,
             output_dir=output_dir,
             continue_on_error=continue_on_error,
@@ -737,11 +739,13 @@ def i2i(
         lambda: _run_i2i(
             profile_dir=provider_dir,
             headless=settings.headless,
-            prompt=prompt,
+            base_req=GenerateImageRequest(
+                prompt=prompt,
+                aspect=Aspect.from_cli(aspect),
+                model=Model.from_cli(model),
+                count=count,
+            ),
             classified_refs=classified_refs,
-            aspect=Aspect.from_cli(aspect),
-            model=Model.from_cli(model),
-            count=count,
             out=out,
             output_root=settings.output_dir,
             transport=transport,
@@ -786,11 +790,8 @@ async def _run_i2i(
     *,
     profile_dir: Path,
     headless: bool,
-    prompt: str,
+    base_req: GenerateImageRequest,
     classified_refs: list[ImageRef | Path],
-    aspect: Aspect,
-    model: Model,
-    count: int,
     out: Path | None,
     output_root: Path,
     transport: str | None = None,
@@ -805,23 +806,18 @@ async def _run_i2i(
         console.print(f"  Project: [dim]{project.project_id}[/dim]")
 
         resolved_refs = await _resolve_refs(client, project.project_id, classified_refs)
-        req = GenerateImageRequest(
-            prompt=prompt,
-            aspect=aspect,
-            model=model,
-            refs=resolved_refs,
-        )
+        req = dataclasses.replace(base_req, refs=resolved_refs)
 
         console.print(
-            f"  Generating {count} image(s) with {len(resolved_refs)} ref(s) "
+            f"  Generating {base_req.count} image(s) with {len(resolved_refs)} ref(s) "
             f"({req.model.value}, {req.aspect.value})..."
         )
-        if count == 1:
+        if base_req.count == 1:
             img = await client.generate_image(project_id=project.project_id, req=req)
             images: list[GeneratedImage] = [img]
         else:
             images = await client.generate_images_batch(
-                project_id=project.project_id, req=req, count=count
+                project_id=project.project_id, req=req, count=base_req.count
             )
 
         saved_paths: list[Path] = []

--- a/src/gflow_cli/cli_run.py
+++ b/src/gflow_cli/cli_run.py
@@ -30,6 +30,7 @@ from gflow_cli.errors import ConfigurationError
 from gflow_cli.image_batch import (
     MAX_PROMPTS,
     MIN_PROMPTS,
+    BatchClientConfig,
     BatchOutcome,
     BatchPromptItem,
     parse_batch_item_dict,
@@ -171,9 +172,7 @@ async def _run_batch(
     ``generate_image`` call.
     """
     outcomes = await run_image_batch(
-        profile_dir=profile_dir,
-        headless=headless,
-        transport=transport,
+        BatchClientConfig(profile_dir=profile_dir, headless=headless, transport=transport),
         prompts=prompts,
         output_dir=output_dir,
         continue_on_error=continue_on_error,

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -99,6 +99,15 @@ class BatchOutcome:
     exit_code: int = 0
 
 
+@dataclass(frozen=True)
+class BatchClientConfig:
+    """Session parameters for creating a FlowApiClient."""
+
+    profile_dir: Path
+    headless: bool
+    transport: str | None = None
+
+
 def resolve_exit_code(exc: GFlowError) -> int:
     for cls, code in EXIT_CODE_MAP.items():
         if isinstance(exc, cls):
@@ -364,10 +373,8 @@ async def run_one_image_prompt(
 
 
 async def run_image_batch(
+    config: BatchClientConfig,
     *,
-    profile_dir: Path,
-    headless: bool,
-    transport: str | None,
     prompts: tuple[BatchPromptItem, ...],
     output_dir: Path,
     continue_on_error: bool,
@@ -388,9 +395,7 @@ async def run_image_batch(
         )
 
     return await run_sequential_batch(
-        profile_dir=profile_dir,
-        headless=headless,
-        transport=transport,
+        config,
         items=prompts,
         continue_on_error=continue_on_error,
         project_title=project_title,
@@ -401,10 +406,8 @@ async def run_image_batch(
 
 
 async def run_sequential_batch(
+    config: BatchClientConfig,
     *,
-    profile_dir: Path,
-    headless: bool,
-    transport: str | None,
     items: tuple[Any, ...],
     continue_on_error: bool,
     project_title: str,
@@ -418,7 +421,9 @@ async def run_sequential_batch(
 
     outcomes: list[BatchOutcome] = []
     factory = client_factory or FlowApiClient
-    async with factory(profile_dir=profile_dir, headless=headless, transport=transport) as client:
+    async with factory(
+        profile_dir=config.profile_dir, headless=config.headless, transport=config.transport
+    ) as client:
         project = await client.create_project(title=project_title)
         for idx, item in enumerate(items):
             outcome = await worker(client, project.project_id, idx, item)
@@ -706,10 +711,8 @@ async def _download_results(
 
 
 async def run_manifest_image_batch(
+    config: BatchClientConfig,
     *,
-    profile_dir: Path,
-    headless: bool,
-    transport: str | None,
     prompts: tuple[BatchPromptItem, ...],
     output_dir: Path,
     continue_on_error: bool,
@@ -743,9 +746,9 @@ async def run_manifest_image_batch(
     output_dir.mkdir(parents=True, exist_ok=True)
     factory = client_factory or FlowApiClient
     async with factory(
-        profile_dir=profile_dir,
-        headless=headless,
-        transport=transport,
+        profile_dir=config.profile_dir,
+        headless=config.headless,
+        transport=config.transport,
         out_dir=output_dir,
     ) as client:
         # Capability check: only UiAutomationTransport implements generate_images_batch.

--- a/tests/cli/test_t2i_multi_prompt.py
+++ b/tests/cli/test_t2i_multi_prompt.py
@@ -287,7 +287,7 @@ def test_t2i_rejects_prompt_file_directory_before_profile_and_output_dir(
 def test_t2i_multi_positional_delegates_to_batch_runner(tmp_path: Path) -> None:
     from gflow_cli.cli import main
 
-    async def _fake_run_batch(**_kwargs: object) -> list[object]:
+    async def _fake_run_batch(*_args: object, **_kwargs: object) -> list[object]:
         return []
 
     out = tmp_path / "out"
@@ -328,7 +328,7 @@ def test_t2i_multi_positional_delegates_to_batch_runner(tmp_path: Path) -> None:
 def test_t2i_multi_prompt_prints_fanout_before_batch_runner(tmp_path: Path) -> None:
     from gflow_cli.cli import main
 
-    async def _fake_run_batch(**_kwargs: object) -> list[object]:
+    async def _fake_run_batch(*_args: object, **_kwargs: object) -> list[object]:
         return []
 
     with (

--- a/tests/e2e/test_image_batch_e2e.py
+++ b/tests/e2e/test_image_batch_e2e.py
@@ -25,6 +25,7 @@ from structlog.testing import LogCapture
 from gflow_cli.image_batch import (
     JITTER_MAX_SECONDS,
     JITTER_MIN_SECONDS,
+    BatchClientConfig,
     parse_manifest_file,
     run_manifest_image_batch,
 )
@@ -113,9 +114,7 @@ async def test_image_batch_e2e(
     # diagnosing matrix-run failures post-mortem (spec §11 risk register).
     try:
         outcomes = await run_manifest_image_batch(
-            profile_dir=e2e_profile_dir,
-            headless=False,
-            transport=None,
+            BatchClientConfig(profile_dir=e2e_profile_dir, headless=False),
             prompts=prompts,
             output_dir=out,
             continue_on_error=False,

--- a/tests/features/test_image_steps.py
+++ b/tests/features/test_image_steps.py
@@ -127,7 +127,7 @@ def _mock_wire_format(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @given("the mocked t2i batch runner writes one image per prompt")
 def _mock_t2i_batch_runner(monkeypatch: pytest.MonkeyPatch, batch_state: dict[str, Any]) -> None:
-    async def _fake_batch(**kwargs: Any) -> list[Any]:
+    async def _fake_batch(*_args: Any, **kwargs: Any) -> list[Any]:
         from gflow_cli.image_batch import BatchOutcome
 
         prompts = list(kwargs["prompts"])

--- a/tests/image_batch/test_image_manifest.py
+++ b/tests/image_batch/test_image_manifest.py
@@ -10,6 +10,7 @@ import pytest
 from gflow_cli.errors import ConfigurationError
 from gflow_cli.image_batch import (
     MAX_BATCH_PROMPTS,
+    BatchClientConfig,
     BatchPromptItem,
     parse_json_manifest,
     parse_manifest_file,
@@ -283,9 +284,7 @@ class TestRunManifestImageBatch:
         factory = _make_batch_factory(project_id="proj-abc")
 
         outcomes = await run_manifest_image_batch(
-            profile_dir=tmp_path,
-            headless=True,
-            transport=None,
+            BatchClientConfig(profile_dir=tmp_path, headless=True),
             prompts=_make_items(2),
             output_dir=tmp_path / "out",
             continue_on_error=False,
@@ -305,9 +304,7 @@ class TestRunManifestImageBatch:
         factory = _make_batch_factory(project_id="proj-abc", fail_on_idx=1)
 
         outcomes = await run_manifest_image_batch(
-            profile_dir=tmp_path,
-            headless=True,
-            transport=None,
+            BatchClientConfig(profile_dir=tmp_path, headless=True),
             prompts=_make_items(3),
             output_dir=tmp_path / "out",
             continue_on_error=True,
@@ -340,9 +337,7 @@ class TestRunManifestImageBatch:
 
         with pytest.raises(RuntimeError, match="ui_automation"):
             await run_manifest_image_batch(
-                profile_dir=tmp_path,
-                headless=True,
-                transport=None,
+                BatchClientConfig(profile_dir=tmp_path, headless=True),
                 prompts=_make_items(1),
                 output_dir=tmp_path / "out",
                 continue_on_error=False,

--- a/tests/image_batch/test_observability_events.py
+++ b/tests/image_batch/test_observability_events.py
@@ -14,7 +14,7 @@ import pytest
 from structlog.testing import LogCapture
 
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
-from gflow_cli.image_batch import BatchPromptItem, run_manifest_image_batch
+from gflow_cli.image_batch import BatchClientConfig, BatchPromptItem, run_manifest_image_batch
 
 
 def _make_fake_image() -> object:
@@ -91,9 +91,7 @@ async def test_emits_submission_attempt_per_row(
         BatchPromptItem(text="dog", count=1, aspect_ratio="1:1", model="nano2"),
     )
     await run_manifest_image_batch(
-        profile_dir=tmp_path,
-        headless=True,
-        transport=None,
+        BatchClientConfig(profile_dir=tmp_path, headless=True),
         prompts=prompts,
         output_dir=tmp_path / "out",
         continue_on_error=False,
@@ -166,9 +164,7 @@ async def test_emits_row_completed_per_row(
         ),
     )
     await run_manifest_image_batch(
-        profile_dir=tmp_path,
-        headless=True,
-        transport=None,
+        BatchClientConfig(profile_dir=tmp_path, headless=True),
         prompts=prompts,
         output_dir=tmp_path / "out",
         continue_on_error=False,


### PR DESCRIPTION
## Summary

- **S107 (too many parameters)**: Introduce `BatchClientConfig` dataclass to bundle `profile_dir/headless/transport`, reducing `run_sequential_batch`, `run_image_batch`, and `run_manifest_image_batch` from 8–9 params to ≤7. Also bundle `prompt/aspect/model/count` into the existing `GenerateImageRequest` for `_run_i2i` (10→7 params).
- **S3776 (cognitive complexity)**: Extract `_validate_mode_inputs` from `GenerateVideoRequest.__post_init__` to reduce its cognitive complexity from ~18 to ~4 (well below the 15 threshold).
- Update all callers (`cli_image.py`, `cli_run.py`) and test mocks accordingly.

## Test plan

- [x] `uv run ruff check src/ tests/` — no issues
- [x] `uv run ruff format --check src/ tests/` — all files formatted
- [x] `uv run pytest --ignore=tests/e2e` — 789 passed, 4 skipped, 1 xfailed

https://claude.ai/code/session_01Sei8fcnGdPnE7LhcDdf3QS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sei8fcnGdPnE7LhcDdf3QS)_