### PR TITLE
fix(data): align list/media DB path + NULL-guard video duration

### DIFF
--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -38,12 +38,22 @@ console = Console()
 
 
 def _db_path() -> Path:
-    """Resolve the catalog DB path from env or platformdirs default."""
+    """Resolve the catalog DB path: ``GFLOW_CLI_DB_PATH`` env first, then
+    the canonical resolver used by the rest of the codebase.
+
+    The env-var check is direct (not via ``Settings``) so test
+    ``monkeypatch.setenv`` calls take effect even when ``get_settings()`` is
+    already cached.  When the env var is absent, delegates to
+    ``paths.database_path(home)`` via ``Settings.resolved_db_path`` — the
+    SAME resolver as ``data media`` and the recorder, so all subcommands
+    agree on the path.  The prior platformdirs lookup here used the wrong
+    appauthor + filename and resolved to a non-existent path on Windows
+    (``AppData\\Local\\gflow-cli\\gflow-cli\\data.db`` vs the real
+    ``AppData\\Local\\ffroliva\\gflow-cli\\gflow.db``).
+    """
     if env := os.environ.get("GFLOW_CLI_DB_PATH"):
         return Path(env)
-    from platformdirs import user_data_dir
-
-    return Path(user_data_dir("gflow-cli")) / "data.db"
+    return get_settings().resolved_db_path()
 
 
 def _truncate(s: str | None, n: int = 40) -> str:
@@ -127,7 +137,7 @@ def _emit_videos_table(rows: list[VideoRow]) -> None:
             _truncate(r.prompt),
             r.aspect,
             r.model,
-            f"{r.duration:g}s",
+            f"{r.duration:g}s" if r.duration is not None else "",
             r.created_at.strftime("%Y-%m-%d %H:%M"),
             r.local_path or "",
         )

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -185,7 +185,7 @@ class VideoRow:
     prompt: str | None
     aspect: str
     model: str
-    duration: float
+    duration: float | None
     created_at: datetime
     local_path: str | None
 
@@ -222,7 +222,9 @@ def list_videos(
     """Return video assets newest-first, filtered by profile if given.
 
     prompt and local_path are NULLable (LEFT JOINs). duration maps to the
-    duration_seconds REAL column in the schema.
+    duration_seconds REAL column in the schema, which is also nullable
+    (e.g. omni-flash currently returns no duration in its t2v response, and
+    smoke-test fixtures may insert rows without it).
 
     Args:
         db_path: Absolute path to the SQLite catalog.
@@ -244,7 +246,7 @@ def list_videos(
             prompt=str(r["prompt"]) if r["prompt"] is not None else None,
             aspect=str(r["aspect"]),
             model=str(r["model"]),
-            duration=float(r["duration"]),
+            duration=float(r["duration"]) if r["duration"] is not None else None,
             created_at=datetime.fromisoformat(str(r["created_at"])),
             local_path=str(r["local_path"]) if r["local_path"] is not None else None,
         )

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -117,6 +117,69 @@ def test_data_list_videos_filter_no_match(seeded_db: Path) -> None:
     assert result.output.strip() == ""
 
 
+def test_data_list_videos_null_duration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: a video row with NULL duration_seconds (e.g. omni-flash t2v,
+    where the response shape omits duration) must not crash list_videos with
+    TypeError on float(None). Both JSON output and the Rich table renderer
+    must handle a None duration cleanly."""
+    import uuid
+    from datetime import UTC, datetime
+
+    from gflow_cli.data.models import AssetKind, AssetRecord, ProjectRecord
+    from gflow_cli.data.repository import DataRepository
+    from gflow_cli.data.store import DataStore
+
+    db = tmp_path / "null_duration.db"
+    store = DataStore.open(db)
+    try:
+        repo = DataRepository(store)
+        now_iso = datetime.now(UTC).isoformat()
+        repo.upsert_profile(name="someone", profile_dir=tmp_path / "profile_someone")
+        repo.upsert_project(
+            ProjectRecord(
+                id=str(uuid.uuid4()),
+                profile_name="someone",
+                flow_project_id="proj-x",
+                title="null-duration regression",
+                source="cli",
+                created_at=now_iso,
+            )
+        )
+        repo.upsert_asset(
+            AssetRecord(
+                id=str(uuid.uuid4()),
+                profile_name="someone",
+                flow_project_id="proj-x",
+                flow_media_id="vid-null-duration",
+                flow_workflow_id=None,
+                flow_media_generation_id=None,
+                kind=AssetKind.VIDEO,
+                status="ready",
+                model="omni-flash",
+                aspect_ratio="16:9",
+                width=1280,
+                height=720,
+                duration_seconds=None,
+                seed=None,
+                metadata_json={},
+                created_at=now_iso,
+            )
+        )
+    finally:
+        store.close()
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+
+    result_json = CliRunner().invoke(main, ["data", "list", "videos", "--json"])
+    assert result_json.exit_code == 0, result_json.output
+    rows = [json.loads(ln) for ln in result_json.output.splitlines() if ln.strip()]
+    assert len(rows) == 1
+    assert rows[0]["duration"] is None
+
+    result_tbl = CliRunner().invoke(main, ["data", "list", "videos"])
+    assert result_tbl.exit_code == 0, result_tbl.output
+    assert "vid-null-duration" in result_tbl.output
+
+
 # ─── profiles ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Two distinct bugs found while testing `gflow data list profile|videos|images` on Windows against the v0.9.0 install.

### 1. Default DB path drift (`cli_data._db_path`)

`cli_data._db_path()` resolved to `AppData\Local\gflow-cli\gflow-cli\data.db` (doubled appname, wrong filename), while the recorder + `data media` resolved to `AppData\Local\ffroliva\gflow-cli\gflow.db` via the canonical `settings.resolved_db_path()`. Net effect: every `data list` subcommand raised `DataStoreError` ("unable to open database file") on a fresh install — feature was unusable out-of-the-box on Windows.

Fix delegates to the canonical resolver after the env-var fast path (the env-var direct lookup is preserved so `monkeypatch.setenv` in tests still works against the cached `get_settings()` singleton).

### 2. `data list videos` TypeError on NULL duration (`queries.py:247`)

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

`duration_seconds` is nullable (omni-flash t2v responses omit it per [KNOWN_ISSUES](../KNOWN_ISSUES.md), and smoke fixtures insert rows without it). Every `data list videos` invocation crashed once such a row existed.

Fix: `VideoRow.duration` is now `float | None`, with the None threaded through both the Rich-table renderer (`f"{r.duration:g}s"` → `""`) and the `--json` output.

## Test plan

- [x] New regression test `test_data_list_videos_null_duration` inserts a profile/project/video chain with `duration_seconds=None` and asserts both output modes (`--json`, table) exit 0.
- [x] `tests/data/` + `tests/test_cli_data.py` — 47 passed.
- [x] Live smoke against the real Windows DB: `gflow data list profiles|projects|videos|images` all return rows now (was crashing on all four pre-fix).
- [x] `ruff check` + `ruff format` clean.

## Files changed

| File | Change |
|---|---|
| `src/gflow_cli/cli_data.py` | `_db_path()` delegates to `Settings.resolved_db_path()`; NULL-guard `r.duration` in Rich table. |
| `src/gflow_cli/data/queries.py` | `VideoRow.duration: float \| None`; NULL-guard the `float()` call. |
| `tests/test_cli_data.py` | New regression `test_data_list_videos_null_duration`. |

Closes #79, Closes #80
Refs #24 (loosely — also surfaced while validating PR #70 e2e)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>