### PR TITLE
chore(cleanup): keep test + example outputs out of the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ samples/captured/flow_outgoing_*.json
 
 worktrees/
 
+# E2E test logs (live Flow runs — may contain account/profile names)
+.planning/e2e-logs/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,25 @@
+"""Root-level pytest config.
+
+Only purpose right now: ensure the parent directory of the ``--basetemp``
+path exists before pytest's ``tmp_path_factory`` tries to create it. Without
+this, a clean CI checkout (no ``tmp/`` directory present) fails every test
+with ``FileNotFoundError: [Errno 2] No such file or directory:
+'.../tmp/pytest'`` because ``Path.mkdir(parents=False)`` won't auto-create
+the missing ``tmp`` parent.
+
+Why root-level: pytest loads root ``conftest.py`` before scanning ``testpaths``
+in ``pyproject.toml``, which is the window we need to create the parent dir.
+The ``addopts = "--basetemp=tmp/pytest"`` setting itself lives in
+``pyproject.toml`` so that ``pytest --help`` still surfaces the override.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+
+def pytest_configure(config) -> None:  # noqa: ANN001 — pytest config object
+    basetemp = config.getoption("basetemp", default=None)
+    if basetemp:
+        parent = pathlib.Path(basetemp).expanduser().resolve().parent
+        parent.mkdir(parents=True, exist_ok=True)

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,9 @@ cat examples/sample_prompts.txt | gflow image t2i --stdin
 GFLOW_EXAMPLE_PROFILE=<your-profile> python examples/batch_from_config.py
 ```
 
-Output PNGs land under `./gflow-output/<UTC-timestamp>/` by default.
+Output PNGs land under `~/gflow-output/<UTC-timestamp>/` by default (your home
+directory, not the current working directory — so running examples from inside
+the gflow-cli repo does not pollute the repo root).
 
 ## Notes
 

--- a/examples/sample_config.json
+++ b/examples/sample_config.json
@@ -1,5 +1,5 @@
 {
-  "output_dir": "gflow-output/example-batch",
+  "output_dir": "~/gflow-output/example-batch",
   "prompts": [
     {
       "text": "a quiet mountain lake at dawn, cinematic photography",

--- a/examples/single_image_t2i.py
+++ b/examples/single_image_t2i.py
@@ -43,8 +43,10 @@ Custom prompt + explicit profile::
         --profile <your-profile> \\
         --prompt "a quiet mountain lake at dawn, cinematic photography"
 
-Output is written to ``./gflow-output/<UTC-timestamp>/image_00.png`` by
-default. Override with ``--output-dir``.
+Output is written to ``~/gflow-output/<UTC-timestamp>/image_00.png`` by
+default (your home directory, not the current working directory — so running
+the example from inside the gflow-cli repo does not pollute the repo root).
+Override with ``--output-dir``.
 """
 
 from __future__ import annotations
@@ -103,7 +105,7 @@ def main() -> None:
         "--output-dir",
         type=Path,
         default=None,
-        help="Directory to write the PNG. Defaults to ./gflow-output/<UTC>/.",
+        help="Directory to write the PNG. Defaults to ~/gflow-output/<UTC>/.",
     )
     args = parser.parse_args()
 
@@ -125,7 +127,7 @@ def main() -> None:
         sys.exit(2)
 
     output_dir = args.output_dir or (
-        Path("gflow-output") / time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        Path.home() / "gflow-output" / time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     )
     saved = asyncio.run(_run(profile_dir, args.prompt, output_dir))
     print(f"\nImage saved: {saved} ({saved.stat().st_size} bytes)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ pythonVersion = "3.11"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Pin pytest's tmp_path basetemp under the repo's gitignored tmp/ dir so
+# tests never pollute the project root (or other CWDs) with pytest-of-<user>/
+# fixtures.  Without this, pytest falls back to `tempfile.gettempdir()` which
+# can be CWD on some Windows shells (e.g. msys2 sets TMPDIR=$PWD), leaving
+# stray pytest-of-*/ directories in the repo root.
+addopts = "--basetemp=tmp/pytest"
 markers = [
     "unit: pure logic, no I/O (the default category)",
     "integration: real Provider plumbing with mocked HTTP",

--- a/scripts/record_demo.ps1
+++ b/scripts/record_demo.ps1
@@ -30,8 +30,11 @@ param(
     [string]$BatchConfig = "examples/sample_config.json",
     [string]$MasterMp4 = "docs/assets/example-run.mp4",
     [string]$OutputGif = "docs/assets/example-run.gif",
-    [string]$BatchOutputDir = "gflow-output/example-batch",
-    [string]$SingleOutputDir = "gflow-output/example-single",
+    # Default under $HOME so running the script from the repo root does not
+    # leave gflow-output/ in the repo. Override with -BatchOutputDir to point
+    # somewhere else.
+    [string]$BatchOutputDir = (Join-Path $env:USERPROFILE "gflow-output\example-batch"),
+    [string]$SingleOutputDir = (Join-Path $env:USERPROFILE "gflow-output\example-single"),
     [int]$GifFps = 12,
     [int]$GifWidth = 960,
     [int]$GifQuality = 80,

--- a/src/gflow_cli/paths.py
+++ b/src/gflow_cli/paths.py
@@ -71,12 +71,17 @@ def resolve_batch_output_dir(
     output_root: Path,
     kind: str = "images",
 ) -> Path:
-    """CLI flag > config value > default (``<output_root>/<kind>/<YYYY-MM-DD>/``)."""
+    """CLI flag > config value > default (``<output_root>/<kind>/<YYYY-MM-DD>/``).
+
+    All path inputs are passed through ``.expanduser()`` so users can use
+    ``~/`` in their config files or CLI flags without it being interpreted
+    as a literal directory name.
+    """
     if cli_override is not None:
-        return cli_override
+        return cli_override.expanduser()
     if config_value is not None:
-        return Path(config_value)
-    return output_root / kind / date.today().isoformat()
+        return Path(config_value).expanduser()
+    return output_root.expanduser() / kind / date.today().isoformat()
 
 
 def video_output_path(

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -49,3 +49,48 @@ class TestImageOutputPath:
     def test_indexed_filename(self) -> None:
         p = paths.image_output_path(Path("/out"), job_id="x", index=3, on=date(2026, 1, 15))
         assert p == Path("/out/images/2026-01-15/x_3.png")
+
+
+class TestResolveBatchOutputDirExpanduser:
+    """resolve_batch_output_dir() must expand ``~`` so users can put
+    ``~/gflow-output`` in their config files / CLI flags without it being
+    interpreted as a literal directory name. Regression guard for the
+    examples/sample_config.json default that landed in the root-leak
+    cleanup PR."""
+
+    def test_config_value_expanduser(self) -> None:
+        home = Path.home()
+        out = paths.resolve_batch_output_dir(
+            cli_override=None,
+            config_value="~/gflow-output/example-batch",
+            output_root=Path("/unused"),
+        )
+        assert out == home / "gflow-output" / "example-batch"
+        assert "~" not in str(out)
+
+    def test_cli_override_expanduser(self) -> None:
+        home = Path.home()
+        out = paths.resolve_batch_output_dir(
+            cli_override=Path("~/some/where"),
+            output_root=Path("/unused"),
+        )
+        assert out == home / "some" / "where"
+
+    def test_output_root_expanduser(self) -> None:
+        home = Path.home()
+        out = paths.resolve_batch_output_dir(
+            cli_override=None,
+            config_value=None,
+            output_root=Path("~/data-root"),
+            kind="images",
+        )
+        expected_prefix = (home / "data-root" / "images").parts
+        assert out.parts[: len(expected_prefix)] == expected_prefix
+
+    def test_absolute_config_value_unchanged(self) -> None:
+        out = paths.resolve_batch_output_dir(
+            cli_override=None,
+            config_value="/abs/path",
+            output_root=Path("/unused"),
+        )
+        assert out == Path("/abs/path")


### PR DESCRIPTION
## Summary

The repo root kept accumulating gitignored-but-still-noisy output dirs (`gflow-output/`, `pytest-of-ffrol/`, profile leak dirs like `denon82/`) after every test run + example run + auth attempt. This PR fixes the root causes so a `rm -rf` is no longer needed periodically.

## Changes

### 1. Pytest `tmp_path` now lands under `tmp/pytest/`

`pyproject.toml`:
```toml
[tool.pytest.ini_options]
addopts = "--basetemp=tmp/pytest"
```

Without this, pytest falls back to `tempfile.gettempdir()` which can be CWD on Windows shells that set `TMPDIR=$PWD` (msys2-style). That's what was leaving `pytest-of-ffrol/` at the repo root after every test invocation. `tmp/` is already gitignored.

### 2. Example outputs default to `~/gflow-output/`

| File | Old default | New default |
|---|---|---|
| `examples/single_image_t2i.py` | `./gflow-output/<UTC>/` | `~/gflow-output/<UTC>/` |
| `examples/sample_config.json` | `gflow-output/example-batch` | `~/gflow-output/example-batch` |
| `scripts/record_demo.ps1` | `gflow-output/example-batch` | `$env:USERPROFILE\gflow-output\example-batch` |

Running an example from inside the repo no longer pollutes the repo root. README updated to match.

### 3. `resolve_batch_output_dir()` expands `~`

`Path.expanduser()` is now applied to all three input paths (cli_override / config_value / output_root) so users can put `~/...` in config files / CLI flags without it being interpreted as a literal directory.

New `TestResolveBatchOutputDirExpanduser` (4 tests):
- `test_config_value_expanduser`
- `test_cli_override_expanduser`
- `test_output_root_expanduser`
- `test_absolute_config_value_unchanged`

### 4. `.gitignore` gains `.planning/e2e-logs/`

Live Flow run logs may include account / profile names — should never be committed.

## Test plan

- [x] `tests/test_paths.py tests/cli/ tests/test_cli_data.py tests/data/` — 169 passed.
- [x] Smoke check: write a 1-line test, run it, confirm `tmp_path` lands under `<repo>/tmp/pytest/`. Verified.
- [x] `ruff check` + `ruff format` clean.
- [x] `pyright` on `paths.py` — 0 errors.

## What this does NOT solve

The `denon82/` leak at root (just `.gflow-cdp.lock` inside) came from an older code path or a chrome-subprocess bug; can't reproduce on current code, so no defensive change in this PR. If it recurs, file a follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>