### PR TITLE
docs(harness): reference repos analysis, improvement plan, memory init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 
 - Slash commands live under `.claude/commands/gflow/` (all prefixed `/gflow:`).
 - Skills under `skills/` are auto-discoverable; `gflow-cli` ships its own at [`skills/gflow-cli/SKILL.md`](skills/gflow-cli/SKILL.md).
-- Auto-memory at `~/.claude/projects/C--development-github-gflow-cli/memory/MEMORY.md` carries cross-session feedback and project state.
+- Agent memory lives at `~/.claude/projects/<project-slug>/memory/MEMORY.md`. The slug is derived from the local checkout path (e.g., `-home-user-gflow-cli` on Linux). Create the directory if it doesn't exist. The file carries cross-session state, harness decisions, and the session log. See `docs/REFERENCES.md` for the reference repositories that inform our harness decisions.
 
 ## Active phase
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [ROADMAP.md](../ROADMAP.md) | Themed milestones from v0.9 through v1.0 | You want a multi-release view of where the project is heading |
 | [CHANGELOG](../CHANGELOG.md) | Version-by-version user-visible changes | Upgrading or auditing what shipped |
 | [KNOWN_ISSUES](../KNOWN_ISSUES.md) | Open / mitigated / resolved issues with workarounds | Before opening a bug report; when something feels off |
+| **[docs/REFERENCES.md](REFERENCES.md)** | External repos studied for harness/agent patterns — what we adopted, rejected, and why | Evaluating a new agent engineering pattern; onboarding to the harness design decisions |
 | [DISCLAIMER](../DISCLAIMER.md) | Legal scope, takedown policy, prohibited uses | Before deploying anywhere non-trivial |
 | [LICENSE](../LICENSE) | MIT license text | Always |
 | [CONTRIBUTING](../CONTRIBUTING.md) | TDD workflow, test categories, coverage targets | Before opening a PR |

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -1,0 +1,247 @@
+# Reference Repositories
+
+> External repositories studied for harness engineering, agent workflow, and knowledge-base patterns. Kept as a citable record so future sessions know what we evaluated, what we adopted, and why we made each call.
+>
+> Last updated: 2026-05-26.
+
+---
+
+## How to use this file
+
+- Look here before reinventing a pattern — we may have already evaluated it.
+- Each entry records: what the repo does, what we extracted, adoption status, and the decision rationale.
+- "Adopted" means the pattern is live in this repo (cite the file). "Pending" means it's in the improvement plan. "Rejected" means we considered it and said no.
+
+---
+
+## 1. `walkinglabs/learn-harness-engineering`
+
+**URL:** <https://github.com/walkinglabs/learn-harness-engineering>
+**Stars:** ~6,500 | **Language:** TypeScript (course site + Electron app)
+**What it is:** Official harness engineering course — 6 progressive projects teaching how to build reliable environments for AI coding agents. Defines the canonical 5-subsystem model.
+
+### Key patterns extracted
+
+**The 5-Subsystem Harness Model:**
+1. **Instructions** — progressive disclosure across multiple files, not a monolith
+2. **State** — persistent tracking of progress, features, session context on disk
+3. **Verification** — gated task completion requiring runnable proof (tests, lint, type check)
+4. **Scope** — one feature per session, explicit "done" definition
+5. **Session Lifecycle** — structured `init → execute → wrap-up` phases with clean restart paths
+
+**Generated artifacts from their harness-creator skill:**
+- `AGENTS.md` / `CLAUDE.md` — agent operating manual
+- `feature_list.json` — machine-readable feature list with completion status
+- `progress.md` — session narrative + what's next
+- `init.sh` — environment health-check
+- `session-handoff.md` — wrap-up artifact each session writes
+
+**Core design philosophy:**
+> "The model decides what code to write. The harness governs when, where, and how it writes it. The harness doesn't make the model smarter; it makes the model's output reliable."
+
+**Anti-patterns they document:**
+- Monolithic instructions — agents skip sections
+- No state persistence — subsequent sessions lose continuity
+- Agent self-judgment on completion — no external verification gate
+- Unbounded scope — agent overreaches, under-finishes, hides unfinished work
+- Missing lifecycle phases — skipping init or cleanup leads to brittle state
+
+### What we adopted
+- Session lifecycle pattern (CLAUDE.md init sequence: AGENTS.md → INDEX.md → demand-load)
+- Verification-first completion (`/gflow:check` gates every commit)
+- Superpowers plan files as session narrative (our version of `progress.md`)
+- One handover doc per stopped investigation (organic from 2026-05-17-issue-15-handover.md)
+
+### What we decided against
+- `feature_list.json` — redundant with our `active_plan.py` + markdown checkboxes. Adding JSON would create dual state that can drift.
+- `init.sh` — covered by CI + documented `uv sync && playwright install chromium` in AGENTS.md.
+
+### What's pending
+- Formalized handover template (plan Task 3)
+- `/gflow:handover` command (plan Task 5)
+
+---
+
+## 2. `earendil-works/pi`
+
+**URL:** <https://github.com/earendil-works/pi>
+**Stars:** ~55,000 | **Language:** TypeScript (monorepo)
+**What it is:** The most-starred AI coding agent CLI on GitHub. Modular monorepo — unified LLM abstraction, agent runtime, TUI, Slack bot, vLLM pods. Their `AGENTS.md` is the most battle-tested agent instruction file we've seen in the wild.
+
+### Key patterns extracted
+
+**AGENTS.md production rules (full text):**
+```
+- Keep responses short and direct without emojis or filler
+- Answer questions first, then implement
+- Explicitly agree or disagree with feedback before making changes
+- Read full files before broad edits; never rely on search snippets
+- Avoid `any` types; check node_modules for external API types
+- No inline imports — top-level only
+- Upgrade outdated dependencies rather than downgrading code
+- Ask before removing intentional code
+- Never hardcode key checks; use configurable defaults instead
+- Run `npm run check` after code changes; fix all errors before committing
+- Don't run full test suite directly; use wrapper scripts
+- Create regression tests named `<issue-number>-<short-slug>.test.ts`
+- Write ad-hoc scripts to temp files; remove when done
+- Don't commit unless the user asks
+- Stage only your own changed files using explicit paths
+- Never use `git add -A`, `git reset --hard`, or force push
+- Resolve conflicts only in files you modified
+- Add `fixes #N` / `closes #N` in commit messages
+- Post GitHub comments via temp files with gh CLI
+```
+
+**Dependency management discipline:**
+> "Pin direct external deps to exact versions. Treat npm/pip changes as reviewed code. Use `--ignore-scripts` locally. Never downgrade code to match a dependency."
+
+**Changelog structure (enforced):**
+```
+## [Unreleased]
+### Breaking Changes
+### Added
+### Changed
+### Fixed
+### Removed
+```
+Never modify released sections. Link external contributions to PRs with author attribution.
+
+**Lockstep versioning:** All packages version together. Smoke-test isolated installs before release.
+
+**Supply chain hardening:**
+- Direct external deps pinned to exact versions
+- Lock files are the dependency ground truth; changes undergo review
+- Pre-commit hooks prevent accidental lock file modifications
+- Explicit allowlists for dependency lifecycle scripts (supply chain attack vector)
+
+### What we adopted
+- Changelog discipline with `[Unreleased]` sections (L25 in lessons.md) — already in place
+- `fixes #N` / `closes #N` in commit messages — already in AGENTS.md PR section implicitly
+- Don't commit unless user asks — already our practice
+
+### What's pending (plan Task 1)
+Six rules we're missing and should add to our `AGENTS.md`:
+1. "Read full files before broad edits; never rely on search snippets"
+2. "Explicitly agree or disagree with feedback before making changes"
+3. "Ask before removing intentional code"
+4. "Stage only your own changed files using explicit paths; never `git add -A`"
+5. "Resolve conflicts only in files you modified"
+6. Regression test naming: `tests/<issue-number>-<short-slug>.test.py`
+
+### What we decided against
+- Shrinkwrap files — Python uses `uv.lock`, which already serves this purpose.
+- `--ignore-scripts` on install — Python/uv doesn't have the same lifecycle-script attack surface as npm.
+
+---
+
+## 3. `yzddp/harnesscode`
+
+**URL:** <https://github.com/yzddp/harnesscode>
+**Stars:** ~92 | **Language:** Python
+**What it is:** Framework for long-running, unattended AI-driven development, based on the Anthropic Harness paper. External memory + small-step execution + auto-loop. Five specialized agents: Orchestrator, Initializer, Coder, Tester, Fixer, Reviewer.
+
+### Key patterns extracted
+
+**State-based coordination:**
+All agent coordination happens through files in `.harnesscode/` directory, not in memory. Agents read state, execute, write results back. Survives restarts.
+
+**8-priority orchestrator decision table:**
+```
+1. Missing init files          → INITIALIZER
+2. Pending human dependencies  → PAUSE_FOR_HUMAN
+3. Test failures               → FIXER (code_bug) or CODER (feature_not_implemented)
+4. Code review failures        → FIXER all
+5. Pending regular features    → CODER [module] [id]
+6. Feature 990 pending         → TESTER [module]
+7. Feature 991 pending         → REVIEWER
+8. All complete                → PROJECT COMPLETE
+```
+
+**`missing_info.json` blocker pattern:**
+When an agent hits a decision it cannot make alone, it writes a structured question to `missing_info.json` and pauses. Prevents autonomous drift. Human clears it to resume.
+
+**Tech spec severity markers:**
+```
+MUST: Mandatory requirement that cannot be violated
+FORBID: Explicitly disallowed behavior
+NORM: Recommended requirement
+```
+
+**Tech spec file format:** `tech-spec-{module-name}.md` with sections: Scope → Key Requirements → Full Specification → Correct Examples → Incorrect Examples.
+
+**Core principle:**
+> "AI executes, humans decide — encode reversibility at every meaningful state transition."
+
+### What we adopted
+- Lessons notebook (`tasks/lessons.md`) serves our "state coordination" need — lighter-weight
+- Open handover file (`docs/superpowers/2026-05-17-issue-15-handover.md`) is our `missing_info.json` equivalent
+
+### What's pending (plan Task 2)
+- MUST/FORBID/NORM markers on critical rules in AGENTS.md and key spec docs
+
+### What we decided against
+- `.harnesscode/` state directory — over-engineered for a single-developer CLI. Our superpowers plans + lessons.md cover this at appropriate weight.
+- Full orchestrator state machine — we handle this through human Coordinator judgment, not an automated 8-priority loop.
+
+---
+
+## 4. `atomicstrata/llm-wiki-compiler`
+
+**URL:** <https://github.com/atomicstrata/llm-wiki-compiler>
+**Stars:** ~1,300 | **Language:** TypeScript
+**What it is:** Compile-once, query-many knowledge architecture inspired by Karpathy's LLM Wiki pattern. Raw sources → structured interlinked wiki with provenance tracking. Outer loop handles decisions, inner loop handles knowledge compilation.
+
+### Key patterns extracted
+
+**Compile-once vs. RAG:**
+> "RAG retrieves chunks at query time. Every question re-discovers the same relationships from scratch. Nothing accumulates."
+
+The wiki builds a durable artifact — concepts become first-class pages with explicit cross-references. Knowledge compounds.
+
+**Two-phase inner loop:**
+1. Extract all concepts from all sources
+2. Generate pages
+
+Eliminates order-dependency. Catches failures before writing anything.
+
+**Page provenance frontmatter:**
+```yaml
+confidence: 0.87
+provenance: merged    # extracted | merged | inferred | ambiguous
+contradictedBy: [...]
+```
+With inline citations: `This claim is grounded here. ^[file.md:42-58]`
+
+**Staged approval workflow:**
+Candidate pages land in `.llmwiki/candidates/` before approval. Human inspects each before it enters the wiki. Lock file ensures concurrent safety.
+
+**Linting pass:**
+Detects broken wikilinks, orphaned pages, low-confidence content, contradictions, malformed citations.
+
+**Evidence packing (`get_context_pack`):**
+Builds structured evidence bundles for agents: primary pages + graph neighbors + semantic chunks + citations + warnings + suggested next actions. Separates evidence gathering from answer generation.
+
+**MCP server integration:**
+Exposes full pipeline to Claude Desktop / Cursor / Claude Code without CLI scraping.
+
+### What we adopted
+- `docs/INDEX.md` routing layer — our implementation of the compile-once navigation idea
+- `LIVE_VERIFICATION_*.md` files — dated verification evidence = our version of provenance
+
+### What's pending (plan Task 4)
+- Doc stability badges in volatile docs headers: e.g., `> ⚠ UNSTABLE — reverse-engineered API. May change without notice.`
+- Cross-reference lint: check that every link in `docs/INDEX.md` resolves
+
+### What we decided against
+- Full wiki compilation pipeline — too heavy for a CLI project's docs. Our structured `docs/` + INDEX.md is sufficient.
+- Confidence scores per page — over-engineered. A simple stability badge in the header conveys the same signal.
+- MCP server exposure — interesting for v1.0+, but out of scope now.
+
+---
+
+## See also
+
+- `tasks/lessons.md` — hard-won project rules (L1-L25), more implementation-specific than the patterns above
+- `~/.claude/projects/-home-user-gflow-cli/memory/MEMORY.md` — cross-session memory including adoption decisions
+- `docs/superpowers/plans/2026-05-26-harness-improvements.md` — the improvement plan derived from this analysis

--- a/docs/superpowers/plans/2026-05-26-harness-improvements.md
+++ b/docs/superpowers/plans/2026-05-26-harness-improvements.md
@@ -1,0 +1,282 @@
+# Harness Improvements Plan
+
+**Date:** 2026-05-26
+**Source:** Pattern analysis of 4 reference repositories (see `docs/REFERENCES.md`)
+**Goal:** Systematically close the gaps between gflow-cli's current harness and patterns proven in the wild — without over-engineering for a single-developer CLI project.
+
+---
+
+## Assessment summary
+
+After a multi-dimensional audit across 8 dimensions, gflow-cli's harness is **above average** compared to the studied repos. The 5-subsystem model (Instructions, State, Verification, Scope, Lifecycle) is essentially complete. The gaps are surgical, not structural.
+
+### What we already do well (do not touch)
+
+| Dimension | Our implementation | Verdict |
+|---|---|---|
+| Instructions layer | CLAUDE.md + AGENTS.md + AGENT_GUIDE.md + docs/INDEX.md | Strong |
+| Verification gate | `/gflow:check` (hygiene + ruff + pyright + pytest) | Strong |
+| Scope control | `/gflow:plan` + active_plan.py + superpowers plans | Strong |
+| Session routing | CLAUDE.md init sequence (AGENTS.md → INDEX.md → demand-load) | Strong |
+| Lessons notebook | tasks/lessons.md (L1-L25, dated, commit-traced) | Excellent |
+| Feature narrative | docs/superpowers/plans/ + orchestration plans | Good |
+| Knowledge routing | docs/INDEX.md with topic shortcuts | Excellent |
+| Release protocol | /gflow:release (signed tags, back-merge, doc-review gate) | Strong |
+
+### Confirmed gaps (what this plan addresses)
+
+| Gap | Source repo | Priority | Task |
+|---|---|---|---|
+| Missing pi behavioral rules in AGENTS.md | earendil-works/pi | HIGH | T1 |
+| No MUST/FORBID/NORM severity markers on critical rules | yzddp/harnesscode | MEDIUM | T2 |
+| No formalized handover template | walkinglabs | MEDIUM | T3 |
+| No doc stability badges on volatile/reverse-engineered docs | atomicstrata/llm-wiki | LOW | T4 |
+| No `/gflow:handover` command | walkinglabs + harnesscode | LOW | T5 |
+| Memory file missing / path wrong in CLAUDE.md | (internal) | CRITICAL | T0 |
+| Reference repos undocumented | (internal) | HIGH | T0 |
+
+---
+
+## Task 0 — Memory + References (immediate, no review needed)
+
+**Status: DONE (2026-05-26)**
+
+- [x] Create `~/.claude/projects/-home-user-gflow-cli/memory/MEMORY.md` with 7 drawers
+- [x] Create `docs/REFERENCES.md` — annotated record of all 4 reference repos
+- [x] Fix `CLAUDE.md` — remove hardcoded Windows memory path; add environment-agnostic note
+- [x] Add `docs/REFERENCES.md` to `docs/INDEX.md` routing table
+- [x] Create this plan file
+
+---
+
+## Task 1 — AGENTS.md: Add pi behavioral rules
+
+**Priority:** HIGH
+**Effort:** Small (add ~8 rules to existing AGENTS.md)
+**Source:** `earendil-works/pi` AGENTS.md (battle-tested, 55k-star project)
+
+### Rules to add
+
+These 6 rules are absent from our current AGENTS.md and directly address failure modes we've seen in practice (L10, L11, L17 in tasks/lessons.md):
+
+```
+Read full files before broad edits; never rely on search snippets alone.
+Explicitly agree or disagree with feedback before making changes.
+Ask before removing code that appears intentional.
+Stage only your own changed files using explicit git paths; never `git add -A`.
+Resolve merge conflicts only in files you modified.
+Name regression tests: tests/<issue-number>-<short-slug>.test.py
+```
+
+### Where to insert
+
+Add as a new subsection `## Agent behavioral rules` in AGENTS.md, between `## Code style` and `## PR instructions`. Keep each rule to one sentence.
+
+### Definition of done
+
+- `AGENTS.md` has the 6 new rules
+- No existing rule is changed or removed (additive only)
+- `/gflow:check` passes after the edit
+
+---
+
+## Task 2 — Add MUST/FORBID/NORM markers to critical rules
+
+**Priority:** MEDIUM
+**Effort:** Small (annotation pass over AGENTS.md + AGENT_GUIDE.md)
+**Source:** `yzddp/harnesscode` tech-spec writing guide
+
+### What this is
+
+Prefix the most critical non-negotiable rules with severity markers to make precedence unambiguous:
+
+- **MUST:** mandatory — cannot be violated under any circumstances
+- **FORBID:** explicitly disallowed behavior
+- **NORM:** recommended — default behavior that can be overridden with reason
+
+### Scope
+
+Only apply markers to the rules most likely to cause damage if violated:
+
+| Rule | Marker |
+|---|---|
+| TDD before code; write a failing test first | MUST |
+| No raw `print()` or `import logging` in `src/` | MUST |
+| No secrets in commits | MUST |
+| No AI attribution in commit messages | MUST |
+| Signed tags only (`git tag -s`) | MUST |
+| Never `git add -A` | FORBID |
+| Never `git reset --hard` without explicit user instruction | FORBID |
+| Never force push to `main` or `develop` | FORBID |
+| Never `--no-verify` past hooks | FORBID |
+| Run `/gflow:check` before every commit | MUST |
+
+**Do not marker** every rule — only the ~10 that cause irreversible damage if skipped. Over-marking creates noise.
+
+### Definition of done
+
+- AGENTS.md MUSTs and FORBIDs are clearly prefixed
+- AGENT_GUIDE.md Mandates section is consistent with AGENTS.md markers
+- No behavioral change — purely annotation
+
+---
+
+## Task 3 — Formalize the handover template
+
+**Priority:** MEDIUM
+**Effort:** Small (template + one slash command)
+**Source:** `walkinglabs/learn-harness-engineering` + organic `2026-05-17-issue-15-handover.md`
+
+### What we have
+
+`docs/superpowers/2026-05-17-issue-15-handover.md` was created organically. It has excellent structure:
+- Status (one line)
+- Root cause (one line)
+- What was superseded and why
+- Current branch state
+- Next step (explicit)
+- Workflow reminder
+
+### What we need
+
+1. A template file at `docs/superpowers/HANDOVER_TEMPLATE.md`
+2. A note in `docs/superpowers/README.md` (create if missing) explaining when to create a handover
+3. A `/gflow:handover` command that scaffolds a handover doc from the current git state
+
+### Template structure
+
+```markdown
+# Handover — [Feature/Issue description] — YYYY-MM-DD
+
+## Status: [one line]
+
+## Root cause / investigation finding (one line)
+[Or: "Investigation not complete — stopped at:"]
+
+## What was done this session
+- Committed: [list commits with SHAs]
+- Explored: [local-only work not committed]
+- Superseded plans (if any): [file paths + why they are wrong]
+
+## Current branch state
+Branch: [name]
+Clean working tree: [yes/no — if no, list files]
+Tests: [passing/failing/unknown]
+
+## Open questions / blockers (missing_info)
+[Write these when you hit a decision you cannot make alone — human clears them]
+
+## Next step
+[Exactly what to do next — specific enough that a fresh session can start without re-reading history]
+
+## Skills to use
+[Suggested /gflow: commands or skills for the next session]
+
+## Workflow note
+[Any branch-protection or PR flow reminders relevant to this feature]
+```
+
+### Definition of done
+
+- `docs/superpowers/HANDOVER_TEMPLATE.md` exists
+- `.claude/commands/gflow/handover.md` exists and scaffolds a handover from git state
+- `docs/INDEX.md` updated with new command
+- `docs/superpowers/` has a brief README explaining the structure
+
+---
+
+## Task 4 — Doc stability badges on volatile docs
+
+**Priority:** LOW
+**Effort:** Tiny (add a callout block to ~3 doc files)
+**Source:** `atomicstrata/llm-wiki-compiler` provenance/confidence pattern
+
+### Problem
+
+Several docs describe reverse-engineered behavior that can change without notice. Readers (especially agents reading docs to make decisions) don't know whether to trust these claims fully or hedge.
+
+### Solution
+
+Add a stability badge callout at the top of each volatile doc:
+
+```markdown
+> ⚠ **API Stability: UNSTABLE** — This document describes reverse-engineered behavior
+> of Google Flow's private REST API. Claims may become incorrect without notice.
+> Verified as of: v0.9.0 (2026-05-24). Check KNOWN_ISSUES.md before relying on specifics.
+```
+
+### Files to badge
+
+| File | Why |
+|---|---|
+| `docs/AUTHENTICATION.md` | Describes private auth flow — reCAPTCHA, cookie capture |
+| `docs/ARCHITECTURE.md` § API surface | `aisandbox-pa.googleapis.com` routes can rotate |
+| `samples/README.md` | Captured request/response samples from live traffic |
+
+Do NOT badge `docs/USAGE.md`, `docs/CONFIGURATION.md`, or `docs/USER_GUIDE.md` — those describe our CLI behavior, which we control.
+
+### Definition of done
+
+- 3 docs have stability callout in their header section
+- Callout is consistent (same wording, same "Verified as of: vX.Y.Z" format)
+
+---
+
+## Task 5 — `/gflow:handover` slash command
+
+**Priority:** LOW (depends on Task 3)
+**Effort:** Small
+**Source:** walkinglabs harness-creator skill pattern
+
+### What it does
+
+When invoked, the command:
+1. Reads current git status and recent commits
+2. Reads the active superpowers plan (via `active_plan.py`)
+3. Reads any open blockers from memory
+4. Scaffolds a populated `docs/superpowers/YYYY-MM-DD-<feature>-handover.md`
+5. Tells the agent to fill in the "Root cause" and "Next step" sections manually
+
+### Command file location
+
+`.claude/commands/gflow/handover.md`
+
+### Definition of done
+
+- Command exists and produces a scaffolded handover doc
+- `docs/INDEX.md` updated with the new command
+- Handover doc creation is referenced in the session wrap-up note in CLAUDE.md
+
+---
+
+## Sequencing
+
+Tasks are independent and can be done in any order. Recommended sequence:
+
+```
+T0 (done) → T1 → T2 → T3 → T4 → T5
+```
+
+T1 and T2 are the highest-value items: they improve every session immediately. T3-T5 are workflow improvements that compound over time.
+
+---
+
+## What this plan deliberately does NOT include
+
+To avoid over-engineering:
+
+- ❌ `feature_list.json` — redundant with `active_plan.py` + markdown
+- ❌ `.harnesscode/` state directory — over-engineered for single-developer scope
+- ❌ Full orchestrator state machine — human Coordinator is sufficient
+- ❌ MCP server exposure — v1.0+ consideration
+- ❌ Full wiki compilation pipeline — `docs/` + INDEX.md is sufficient
+- ❌ `init.sh` environment script — CI + AGENTS.md dev-env section covers this
+- ❌ Confidence scores per doc page — stability badge is sufficient signal
+
+---
+
+## See also
+
+- `docs/REFERENCES.md` — full analysis of the 4 source repositories
+- `~/.claude/projects/-home-user-gflow-cli/memory/MEMORY.md` — adoption decisions recorded
+- `tasks/lessons.md` — operational lessons that informed this plan


### PR DESCRIPTION
## Summary

- **`docs/REFERENCES.md`** — Annotated study of 4 harness engineering repos (`walkinglabs/learn-harness-engineering`, `earendil-works/pi`, `yzddp/harnesscode`, `atomicstrata/llm-wiki-compiler`). Records what we extracted from each, what we adopted, what we rejected, and the decision rationale. Citable going forward so future sessions don't re-evaluate the same repos blind.

- **`docs/superpowers/plans/2026-05-26-harness-improvements.md`** — 5-task improvement plan derived from the analysis. Covers: (T1) adding pi behavioral rules to AGENTS.md, (T2) MUST/FORBID/NORM severity markers, (T3) formalized handover template, (T4) doc stability badges on volatile/reverse-engineered docs, (T5) `/gflow:handover` command. Also documents what the plan explicitly does NOT include to avoid over-engineering.

- **`CLAUDE.md`** — Removed the hardcoded Windows memory path (`C--development-github-gflow-cli`). Replaced with an environment-agnostic description: path is `~/.claude/projects/<project-slug>/memory/MEMORY.md` where the slug is derived from the local checkout path.

- **`docs/INDEX.md`** — Added `REFERENCES.md` to the routing table.

**Out-of-repo:** Initialized `~/.claude/projects/-home-user-gflow-cli/memory/MEMORY.md` with 7 drawers (Project State, Open Handovers, Reference Repositories, Harness Decisions, Active Blockers, Cross-Session Rules Digest, Session Log). This is session-local; it won't appear in the diff.

## Assessment context

Before writing anything, a full 8-dimension audit was done comparing gflow-cli's harness against the 4 repos:

| Dimension | Verdict |
|---|---|
| Instructions layer (CLAUDE.md + AGENTS.md + INDEX.md) | Strong — no action needed |
| Verification gate (`/gflow:check`) | Strong |
| Scope control (`/gflow:plan` + superpowers) | Strong |
| Feature narrative (superpowers plans) | Good |
| Lessons notebook (`tasks/lessons.md`) | Excellent |
| Memory system | **Broken** — path wrong, file missing → fixed |
| AGENTS.md behavioral rules | **Gap** — 6 pi rules missing → plan T1 |
| Reference documentation | **Missing** → created |

## Test plan

- [ ] `docs/REFERENCES.md` renders correctly on GitHub (tables, links, code blocks)
- [ ] `docs/superpowers/plans/2026-05-26-harness-improvements.md` renders correctly
- [ ] `CLAUDE.md` no longer references the Windows-specific path
- [ ] `docs/INDEX.md` REFERENCES.md row links resolve
- [ ] `/gflow:check` passes (docs-only change, no code touched)

https://claude.ai/code/session_01BLRVU4GDMTLpzD3ShDXYER

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLRVU4GDMTLpzD3ShDXYER)_