### PR TITLE
fix(transports): I2V frame-slot selectors work on non-EN profiles (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `gflow video i2v` no longer silently breaks on non-English Chrome profiles.
+  PR #70's structural-first `_attach_frame` cascade matched **zero** real
+  slots — its anchor selector assumed the `swap_horiz` icon used class
+  `google-symbols` (it uses `material-icons`) and the slots were `<button>`
+  (they're `<div type="button">`). Production I2V therefore relied on the
+  English-text fallback, which silently misses on any non-EN profile (pt-BR
+  shows `Inicial`/`Final`, DE shows `Anfang`/`Ende`, etc.). Replaced
+  `FRAME_SLOTS_STRUCT` with the locale-free pattern
+  `div[type='button'][aria-haspopup='dialog']` and added a `.first`-of-remaining
+  fallback for the End-frame case (after Start is attached, only one slot
+  matches and the prior `.nth(slot_index)` went out-of-bounds). Live-verified
+  with `tests/e2e/test_transports_e2e.py::test_e2e_i2v_start_end_frame_attach`
+  on `ffroliva` + `GFLOW_CLI_LOCALE=de-DE` (Chrome rendered pt-BR; both
+  non-EN). Closes [#63](https://github.com/ffroliva/gflow-cli/issues/63).
+
 ### Changed
 
 - `gflow data media <id>` now searches across **all** profiles by default,

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -347,10 +347,22 @@ issue and not blocked by any code change in this repo.
 
 - **`_attach_frame` (I2V/R2V frame slots) flipped to structural-first** — was
   English text-label first (`FRAME_SLOT_BY_LABEL`) with structural fallback; now
-  tries `FRAME_SLOTS_STRUCT` (`div:has(> button:has(i.google-symbols:text-is('swap_horiz'))) > div[aria-haspopup='dialog']`)
-  first, falls back to `FRAME_SLOT_BY_LABEL` only when structural count is
-  insufficient. Slot selection unit tests live in `TestAttachFrameSlotSelection`
-  (`tests/api/transports/test_ui_automation_video.py`).
+  tries `FRAME_SLOTS_STRUCT` first, falls back to `FRAME_SLOT_BY_LABEL` only
+  when structural count is insufficient. Slot selection unit tests live in
+  `TestAttachFrameSlotSelection` (`tests/api/transports/test_ui_automation_video.py`).
+
+  **Correction (2026-05-26, issue #63):** PR #70's original
+  `FRAME_SLOTS_STRUCT = "div:has(> button:has(i.google-symbols:text-is('swap_horiz'))) > div[aria-haspopup='dialog']"`
+  matched **zero** elements on real Flow DOMs — the `swap_horiz` icon uses class
+  `material-icons` (NOT `google-symbols`) and the slots are `<div type="button">`,
+  not children of any `div > button` wrapper. Production I2V therefore relied on
+  the English-text fallback and silently broke on non-EN profiles. Discovered
+  via DOM probe + LIVE e2e on `ffroliva` (de-DE → pt-BR effective). Replaced
+  with `FRAME_SLOTS_STRUCT = "div[type='button'][aria-haspopup='dialog']"` (a
+  unique pattern in Flow's editor). Also added a `.first` fallback for the
+  End-frame case — after Start is attached, only one structural slot remains
+  and the prior `.nth(slot_index)` went out-of-bounds. Both fixes shipped
+  together via [#63](https://github.com/ffroliva/gflow-cli/issues/63).
 
 - **`GFLOW_CLI_LOCALE`** — Playwright `locale=` env override from PR #51 remains
   available (default `en-US`).
@@ -365,6 +377,18 @@ issue and not blocked by any code change in this repo.
   with a 3.1 MB 1280×720 H.264 mp4 (8 s clip). Confirms the structural-first
   selectors and `GFLOW_CLI_LOCALE` env override work end-to-end on a locale
   outside the original 9-entry English/PT-BR list.
+
+- **Live I2V e2e on `de-DE` (2026-05-26, issue #63 closure)** —
+  `GFLOW_CLI_LOCALE=de-DE` I2V (Start + End frames) on `ffroliva` via
+  `tests/e2e/test_transports_e2e.py::test_e2e_i2v_start_end_frame_attach`
+  completed in 124 s and returned a terminal `SUCCESSFUL` `VideoResult` with a
+  downloaded mp4 carrying valid `ftyp` magic bytes. The test asserts on the
+  `ui_automation_video.frame_attached` structlog event for both Start and End,
+  proving the structural cascade resolved both slots without falling through
+  to the EN-text tier. Note: Chrome's UI rendered in pt-BR despite
+  `GFLOW_CLI_LOCALE=de-DE` (env affects Playwright's `Accept-Language`, not
+  Chrome's profile language) — both are non-EN so the test still verifies the
+  locale-leak fix.
 
 **Earlier — Phase 7 multi-image-prompt work** addressed the count-tab selectors:
 - `_COUNT_TAB_TEXT_RE = ^(1x|x[2-4])$` only matches the digit+x format Flow

--- a/scripts/dev/capture_i2v_frame_slots_dom.py
+++ b/scripts/dev/capture_i2v_frame_slots_dom.py
@@ -1,0 +1,198 @@
+# ruff: noqa: E501
+"""Capture the I2V editor's frame-slot DOM and verify FRAME_SLOTS_STRUCT matches.
+
+For issue #63: validate (without burning credits) that the structural-first
+selector cascade in ``_attach_frame`` (PR #70) actually matches the I2V Start
+and End frame slots on a non-English Chrome profile. The structural Tier 1
+selector is ``swap_horiz`` icon-anchor + child ``div[aria-haspopup='dialog']``;
+the text-tier fallback (``has-text('Start'/'End')``) is English-only.
+
+Reuses production helpers via ``FlowApiClient`` /
+``VideoGenerationMixin._wait_video_editor_ready`` /
+``_switch_to_video_mode`` — no selector drift.
+
+Zero credits: enters the editor, switches to video mode, waits for the editor
+to mount, counts how many ``FRAME_SLOTS_STRUCT`` and ``FRAME_SLOT_BY_LABEL``
+matches Playwright resolves, and writes a JSON evidence file + a screenshot.
+
+Usage:
+    .venv/Scripts/python.exe scripts/dev/capture_i2v_frame_slots_dom.py \\
+        --profile ffroliva \\
+        --out-dir tmp/i2v_frame_dom
+
+Environment variables (override args):
+    GFLOW_CLI_LOCALE      — sets the Chrome locale; default unset (en-US).
+    GFLOW_CLI_PROFILE     — fallback profile name if ``--profile`` omitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add ``src/`` to ``sys.path`` so this script works without ``pip install -e``.
+sys.path.append(str(Path(__file__).parent.parent.parent / "src"))
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.ui_automation_video import (
+    FRAME_SLOT_BY_LABEL,
+    FRAME_SLOTS_STRUCT,
+    VideoGenerationMixin,
+)
+from gflow_cli.paths import default_home, profile_subdir
+
+# PR #70's original anchor — kept inline for forensic comparison. It was removed
+# from production code by #63 because it matched zero elements (the `swap_horiz`
+# icon uses class `material-icons`, not `google-symbols`).
+SWAP_CONTAINER_PR70 = "div:has(> button:has(i.google-symbols:text-is('swap_horiz')))"
+
+
+async def capture(profile_name: str, out_dir: Path) -> int:
+    profile_dir = profile_subdir(default_home(), profile_name)
+    if not profile_dir.exists():
+        sys.exit(f"Profile dir does not exist: {profile_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    locale = os.environ.get("GFLOW_CLI_LOCALE", "<unset>")
+    print(f"Profile: {profile_name}  ({profile_dir})")
+    print(f"GFLOW_CLI_LOCALE: {locale}")
+    print(f"Out dir: {out_dir}")
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=False) as client:
+        transport = client.transport
+        if transport is None:
+            sys.exit("FlowApiClient.transport is None — transport wiring broken")
+        page = await client._checkout_page()
+        print("FlowApiClient ready, page checked out.")
+
+        print("Entering editor...")
+        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+        print("Dismissing blocking overlays...")
+        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+        print("Switching to video mode...")
+        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+        print("Waiting for video editor SPA to mount...")
+        await VideoGenerationMixin._wait_video_editor_ready(page)
+
+        # Frame slots only appear AFTER the "frames" sub-mode is selected in the
+        # settings panel — that's what `generate_video` does for I2V.  We mirror
+        # the production sequence here to give the probe a real I2V editor.
+        print("Switching to I2V 'frames' sub-mode (settings panel)...")
+        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+        print("Closing settings panel (Escape) — slots live in the main editor...")
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(600)
+
+        # Probe the selector tiers. `SWAP_CONTAINER_PR70` is the broken PR #70
+        # anchor — kept for forensic comparison (must match 0 on real Flow DOMs).
+        # `FRAME_SLOTS_STRUCT` is the post-#63 production primary; the text
+        # fallback only fires on EN profiles.
+        swap_pr70_count = await page.locator(SWAP_CONTAINER_PR70).count()
+        struct_count = await page.locator(FRAME_SLOTS_STRUCT).count()
+        text_start = await page.locator(FRAME_SLOT_BY_LABEL.format(label="Start")).count()
+        text_end = await page.locator(FRAME_SLOT_BY_LABEL.format(label="End")).count()
+        print()
+        print("=== Selector cascade match counts ===")
+        print(f"  SWAP_CONTAINER_PR70 (historical, broken)     → {swap_pr70_count}")
+        print(f"  FRAME_SLOTS_STRUCT  (post-#63 primary)        → {struct_count}")
+        print(f"  FRAME_SLOT_BY_LABEL (Start text, EN-only)     → {text_start}")
+        print(f"  FRAME_SLOT_BY_LABEL (End text, EN-only)       → {text_end}")
+        print()
+
+        # If Tier 1 found at least 2 dialog-divs inside the swap_horiz
+        # container we have evidence #63 is closed on this locale.
+        verdict = "PASS" if struct_count >= 2 else "FAIL"
+        print(f"Tier 1 (structural) verdict for issue #63 on locale {locale!r}: {verdict}")
+
+        # Dump the matched element outerHTML for forensic value.
+        struct_html: list[str] = []
+        if struct_count > 0:
+            struct_html = await page.locator(FRAME_SLOTS_STRUCT).evaluate_all(
+                "els => els.map(el => el.outerHTML)"
+            )
+
+        # Forensic dump: when the cascade misses, the slots may still exist with
+        # a different anchor (different icon ligature or different DOM shape).
+        # Pull every aria-haspopup='dialog' div + every google-symbols ligature
+        # near the prompt-textbox area so we can discover the real anchor.
+        # Filter to elements inside the bottom prompt-bar region (last 500px of
+        # the viewport height) to avoid 100s of unrelated matches.
+        forensics = await page.evaluate(
+            """() => {
+                const vh = window.innerHeight;
+                const inPromptArea = (el) => {
+                    const r = el.getBoundingClientRect();
+                    return r.top > vh * 0.55 && r.top < vh && r.left < window.innerWidth;
+                };
+                const haspopups = [...document.querySelectorAll("div[aria-haspopup='dialog']")]
+                    .filter(inPromptArea)
+                    .map(el => ({
+                        outerHTML: el.outerHTML.slice(0, 600),
+                        text: (el.innerText || '').trim().slice(0, 100),
+                        rect: (() => { const r = el.getBoundingClientRect(); return {x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height)}; })(),
+                    }));
+                const ligatures = [...document.querySelectorAll('i.google-symbols, i.material-symbols-outlined, i.material-icons')]
+                    .filter(inPromptArea)
+                    .map(el => ({
+                        text: (el.innerText || '').trim(),
+                        outerHTML: el.outerHTML.slice(0, 300),
+                        parent: el.parentElement ? el.parentElement.tagName + (el.parentElement.id ? '#' + el.parentElement.id : '') : null,
+                    }));
+                return {haspopups, ligatures};
+            }"""
+        )
+
+        print("\n=== Forensic DOM dump (bottom 45% of viewport) ===")
+        print(f"  div[aria-haspopup='dialog'] near prompt: {len(forensics['haspopups'])}")
+        for h in forensics["haspopups"]:
+            print(f"    text={h['text']!r}  rect={h['rect']}")
+        print(
+            f"  google-symbols / material-symbols ligatures near prompt: {len(forensics['ligatures'])}"
+        )
+        for lig in forensics["ligatures"]:
+            print(f"    ligature={lig['text']!r}  parent={lig['parent']}")
+
+        evidence = {
+            "profile_name": profile_name,
+            "locale": locale,
+            "swap_container_pr70_count": swap_pr70_count,
+            "frame_slots_struct_count": struct_count,
+            "frame_slot_by_label_start_count": text_start,
+            "frame_slot_by_label_end_count": text_end,
+            "verdict": verdict,
+            "frame_slots_struct_outer_html": struct_html,
+            "forensics_haspopup_dialog": forensics["haspopups"],
+            "forensics_ligatures": forensics["ligatures"],
+        }
+        (out_dir / "frame_slots_evidence.json").write_text(
+            json.dumps(evidence, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        await page.screenshot(path=str(out_dir / "video_editor.png"), full_page=True)
+        print(f"Evidence: {out_dir / 'frame_slots_evidence.json'}")
+        print(f"Screenshot: {out_dir / 'video_editor.png'}")
+        return 0 if verdict == "PASS" else 2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("GFLOW_CLI_PROFILE", "ffroliva"),
+        help="Chromium profile name (default: env GFLOW_CLI_PROFILE or 'ffroliva')",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("tmp/i2v_frame_dom"),
+        help="Where to write the JSON evidence + screenshot",
+    )
+    args = parser.parse_args()
+    code = asyncio.run(capture(args.profile, args.out_dir))
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/cdp_drive_and_probe.py
+++ b/scripts/dev/cdp_drive_and_probe.py
@@ -1,0 +1,119 @@
+"""CDP-attach driver + frame-slot selector probe (issue #63 sanity check).
+
+Attaches to a Chrome already launched with ``--remote-debugging-port`` (the
+gflow-agent-browser-spike's ``launch-flow-chrome.ps1``), drives the I2V editor
+setup via the production ``VideoGenerationMixin`` static helpers, then counts
+candidate selectors against the live DOM.
+
+Differs from ``capture_i2v_frame_slots_dom.py`` in transport: that script
+launches its own Playwright persistent context; this one ATTACHES to the
+user's real Chrome via CDP. Same selectors, different runtime — verifies the
+fix survives both transports.
+
+Zero credits: we only READ + navigate, never click Generate.
+
+Usage:
+    .venv/Scripts/python.exe scripts/dev/cdp_drive_and_probe.py --port 9334
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from playwright.async_api import async_playwright
+
+sys.path.append("src")
+
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    FRAME_SLOT_BY_LABEL,
+    FRAME_SLOTS_STRUCT,
+    VideoGenerationMixin,
+)
+
+_FLOW_URL = "https://labs.google/fx/tools/flow"
+
+
+async def probe(port: int) -> int:
+    cdp_url = f"http://127.0.0.1:{port}"
+    print(f"Connecting via CDP to {cdp_url}...")
+    async with async_playwright() as pw:
+        browser = await pw.chromium.connect_over_cdp(cdp_url)
+        if not browser.contexts:
+            print("ERROR: no contexts on the attached browser", file=sys.stderr)
+            return 2
+        ctx = browser.contexts[0]
+        pages = ctx.pages
+        page = pages[0] if pages else await ctx.new_page()
+        print(f"Initial page URL: {page.url}")
+
+        if "labs.google" not in page.url or "flow" not in page.url:
+            print(f"Navigating to {_FLOW_URL} ...")
+            await page.goto(_FLOW_URL, wait_until="domcontentloaded")
+
+        # Reuse production helpers for the editor + video mode + sub-mode
+        # transition. `_enter_editor` is an instance method but its body only
+        # uses `self` for structlog labels; instantiating a bare transport
+        # is fine here.
+        transport = UiAutomationTransport()
+        print("Entering editor (clicks gallery '+')...")
+        await transport._enter_editor(page, None)
+        print("Dismissing blocking overlays...")
+        await transport._dismiss_blocking_overlays(page, None)
+        print("Switching to video mode...")
+        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+        print("Waiting for video editor SPA to mount...")
+        await VideoGenerationMixin._wait_video_editor_ready(page)
+        print("Switching to I2V 'frames' sub-mode...")
+        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+        print("Closing settings panel (Escape)...")
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(600)
+
+        candidates = {
+            "OLD PR #70 SWAP_CONTAINER (broken)": (
+                "div:has(> button:has(i.google-symbols:text-is('swap_horiz')))"
+            ),
+            "swap_horiz icon, any icon class": ("div:has(> button:has(i:text-is('swap_horiz')))"),
+            "FIXED Tier 1: FRAME_SLOTS_STRUCT (current code)": FRAME_SLOTS_STRUCT,
+            "Tier 2: FRAME_SLOT_BY_LABEL Start (EN-only)": (
+                FRAME_SLOT_BY_LABEL.format(label="Start")
+            ),
+            "Tier 2: FRAME_SLOT_BY_LABEL End (EN-only)": (FRAME_SLOT_BY_LABEL.format(label="End")),
+            "pt-BR variant: Inicial": (FRAME_SLOT_BY_LABEL.format(label="Inicial")),
+            "pt-BR variant: Final": (FRAME_SLOT_BY_LABEL.format(label="Final")),
+        }
+
+        print()
+        print("=== Selector match counts (CDP-attached, live DOM) ===")
+        results: dict[str, int] = {}
+        for name, sel in candidates.items():
+            n = await page.locator(sel).count()
+            results[name] = n
+            print(f"  {n:3}  {name}")
+        print()
+
+        primary = results["FIXED Tier 1: FRAME_SLOTS_STRUCT (current code)"]
+        verdict = "PASS" if primary == 2 else f"FAIL (primary count={primary}, expected 2)"
+        print(f"Tier 1 verdict (CDP attach): {verdict}")
+        print(f"Page URL at probe time: {page.url}")
+        return 0 if primary == 2 else 2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9334,
+        help="CDP port (must match the spike launch script's -Port)",
+    )
+    args = parser.parse_args()
+    code = asyncio.run(probe(args.port))
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -133,16 +133,35 @@ VIDEO_MODEL_OPTION_SELECTORS: dict[VideoModel, str] = {
 # file chooser) -> wait uploadImage -> 'Add to Prompt' to commit it into the
 # slot. Only then does the DOM Generate click fire StartImage/StartAndEndImage.
 UPLOAD_IMAGE_ROUTE = "uploadImage"
-# Frame slots are `div[aria-haspopup='dialog']`. Their label text is localized
-# (EN 'Start'/'End', TH 'เริ่ม'/'สิ้นสุด'). `_attach_frame` uses FRAME_SLOTS_STRUCT
-# first (structural / locale-free: the dialog-divs inside the swap_horiz container,
-# by index 0=first, 1=last; the swap_horiz BUTTON is excluded by
-# `> div[aria-haspopup='dialog']`). FRAME_SLOT_BY_LABEL is the English text-label
-# fallback, only consulted when the structural count is insufficient. Caller labels
-# are always the hardcoded constants 'Start' / 'End', so no CSS-escaping is needed.
+# Frame slots are `<div type="button" aria-haspopup="dialog">` — Flow uses a
+# div-with-button-semantics custom component for the Start/End slots in I2V mode.
+# Their label text is localized (EN 'Start'/'End', PT-BR 'Inicial'/'Final',
+# DE 'Anfang'/'Ende', JA '開始'/'終了', etc.).
+#
+# Tier 1 (PRIMARY, locale-free): `FRAME_SLOTS_STRUCT` matches the exact pair via
+# the `type='button'` + `aria-haspopup='dialog'` composite — a unique pattern in
+# Flow's editor (regular elements don't carry a `type` attr on divs). Order is
+# DOM order: `.nth(0)` = Start, `.nth(1)` = End.
+#
+# Tier 2 (FALLBACK, EN-only): `FRAME_SLOT_BY_LABEL` matches by visible English
+# text. Kept for defense-in-depth in case Flow drops the `type` attribute on
+# the slots; the fail-loud `RuntimeError` in `_attach_frame` covers the case
+# where both tiers miss on a non-EN profile.
+#
+# Caller labels are always the hardcoded constants 'Start' / 'End', so no
+# CSS-escaping is needed.
+#
+# Earlier PR #70 used a structural anchor
+#   `div:has(> button:has(i.google-symbols:text-is('swap_horiz')))`
+# as the parent of the dialog slots. That anchor was broken on real Flow DOMs because
+# (1) the slots are `<div type="button">` not children of any `div > button`
+# wrapper, and (2) the `swap_horiz` icon uses class `material-icons` (NOT
+# `google-symbols`). PR #70's structural tier therefore matched ZERO elements
+# on every profile, silently falling through to the text-tier which only
+# matched on EN. This was discovered 2026-05-26 via DOM probe on pt-BR — see
+# scripts/dev/capture_i2v_frame_slots_dom.py.
+FRAME_SLOTS_STRUCT = "div[type='button'][aria-haspopup='dialog']"
 FRAME_SLOT_BY_LABEL = "div[aria-haspopup='dialog']:has-text('{label}')"
-SWAP_CONTAINER = "div:has(> button:has(i.google-symbols:text-is('swap_horiz')))"
-FRAME_SLOTS_STRUCT = SWAP_CONTAINER + " > div[aria-haspopup='dialog']"
 # Media-dialog action buttons. These MUST be locale-agnostic: Flow renders the
 # dialog in the CHROME PROFILE's language (NOT the Google account language, and
 # the `--lang=en-US` launch arg does NOT override an existing profile's stored
@@ -656,7 +675,17 @@ class VideoGenerationMixin:
 
         struct_count = await structs.count()
         if struct_count > slot_index:
+            # Both slots unfilled — pick by DOM order.
             slot = structs.nth(slot_index)
+        elif struct_count > 0:
+            # Some slots already attached (typical: Start filled, End remaining).
+            # The DOM only keeps `div[type='button'][aria-haspopup='dialog']` on
+            # the unfilled slot(s) — once an image binds, the slot transitions
+            # away from that pattern. The next unfilled slot is therefore
+            # `.first` of the remaining matches, regardless of its original
+            # positional index. This case is hit on the End-frame call after
+            # Start was just attached.
+            slot = structs.first
         else:
             # Structural count was insufficient; fall back to text-label match.
             slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -36,6 +36,14 @@ from gflow_cli.api.image import GenerateImageRequest, Model
 from gflow_cli.api.transports import make_transport
 from gflow_cli.api.transports.experimental.bearer import BearerTransport
 from gflow_cli.api.transports.experimental.sapisidhash import SapisidhashTransport
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+)
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
     AuthExpiredError,
@@ -188,6 +196,126 @@ async def test_e2e_i2i_local_ref_attach(
     assert "ui_automation_video.reference_attached" in events, (
         "expected a 'reference_attached' event proving the local ref bound through "
         f"the media dialog; captured events: {events}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion C2/i2v (#63) — I2V Start + End frame attach via media dialog
+# ---------------------------------------------------------------------------
+
+
+# Defaults are tuned for minimum credit spend: omni-flash, 4 s duration, count=1,
+# landscape. Override via env for variation (per [[e2e-tests-parameterize]]).
+_E2E_VIDEO_ASPECT_ENV = "GFLOW_CLI_E2E_VIDEO_ASPECT"
+_E2E_VIDEO_MODEL_ENV = "GFLOW_CLI_E2E_VIDEO_MODEL"
+_E2E_VIDEO_DURATION_ENV = "GFLOW_CLI_E2E_VIDEO_DURATION"
+_I2V_POLL_TIMEOUT_S = 600.0
+_I2V_PROMPT = "the subject moves gently in a calm scene, cinematic"
+
+
+def _i2v_aspect() -> Aspect:
+    raw = os.environ.get(_E2E_VIDEO_ASPECT_ENV, "landscape").strip().lower()
+    if raw == "landscape":
+        return Aspect.LANDSCAPE
+    if raw == "portrait":
+        return Aspect.PORTRAIT
+    pytest.skip(f"Unsupported {_E2E_VIDEO_ASPECT_ENV}={raw!r}")
+
+
+def _i2v_model() -> VideoModel | None:
+    raw = os.environ.get(_E2E_VIDEO_MODEL_ENV, "omni-flash").strip().lower()
+    return VideoModel.from_cli(raw)
+
+
+def _i2v_duration() -> int:
+    raw = os.environ.get(_E2E_VIDEO_DURATION_ENV, "4").strip()
+    return int(raw)
+
+
+@pytest.mark.asyncio
+async def test_e2e_i2v_start_end_frame_attach(
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """I2V (#63): generate_video with ``mode=I2V`` + ``start_image`` + ``end_image``
+    binds BOTH frames through the editor's media dialog and returns a successful
+    ``VideoResult`` with a downloaded mp4 on disk.
+
+    UI-automation transport ONLY — the REST transports drop UI-only DTO fields
+    silently (see [[rest-transports-drop-ui-fields]]).
+
+    This exercises the locale-free structural cascade in ``_attach_frame``
+    (``FRAME_SLOTS_STRUCT = "div[type='button'][aria-haspopup='dialog']"``).
+    PR #70's earlier anchor (``swap_horiz`` icon container) was broken on real
+    Flow DOMs and matched ZERO elements; production I2V silently relied on the
+    English-text fallback, which fails on non-English Chrome profiles. The
+    ``ui_automation_video.frame_attached`` event MUST fire twice (one per slot)
+    — its absence indicates the structural tier still misses.
+
+    Costs 1 credit per run (omni-flash, 4 s, count=1 by default). Override:
+        GFLOW_CLI_E2E_VIDEO_MODEL=veo-fast
+        GFLOW_CLI_E2E_VIDEO_DURATION=6
+        GFLOW_CLI_E2E_VIDEO_ASPECT=portrait
+    """
+    profile = _profile_dir()
+    start = _tiny_png(tmp_path / "start.png")
+    end = _tiny_png(tmp_path / "end.png")
+
+    req = GenerateVideoRequest(
+        prompt=_I2V_PROMPT,
+        mode=Mode.I2V,
+        aspect=_i2v_aspect(),
+        model=_i2v_model(),
+        duration=_i2v_duration(),
+        count=1,
+        start_image=start,
+        end_image=end,
+    )
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(profile)
+        result: VideoResult = await transport.generate_video(
+            request=req,
+            out_dir=tmp_path,
+            poll_timeout_s=_I2V_POLL_TIMEOUT_S,
+        )
+    finally:
+        await transport.teardown()
+
+    # 1. Terminal-success contract (mirrors test_video_t2v_e2e).
+    assert isinstance(result, VideoResult), (
+        f"generate_video() must return a VideoResult, got {type(result)!r}"
+    )
+    assert result.status.is_terminal and result.status.succeeded, (
+        f"Expected SUCCESSFUL terminal status, got {result.status.status!r}; "
+        f"failure_reasons={result.status.failure_reasons!r}"
+    )
+    assert result.status.media_id, "VideoStatus.media_id must be non-empty"
+
+    # 2. File-on-disk contract (per [[verification-ledger-5-layer]]).
+    assert result.local_path is not None and result.local_path.exists(), (
+        f"VideoResult.local_path must point to a downloaded mp4; got {result.local_path!r}"
+    )
+    head = result.local_path.read_bytes()[:32]
+    assert b"ftyp" in head, (
+        f"mp4 magic bytes not found in first 32 bytes of {result.local_path}: {head!r}"
+    )
+
+    # 3. Locale-free selector contract (the #63 closure):
+    #    _attach_frame must fire `frame_attached` exactly twice — once with
+    #    slot=Start and once with slot=End. Its presence proves the structural
+    #    cascade resolved both slots without falling through to the text-tier
+    #    (which only works on EN profiles). The text-tier would still allow a
+    #    successful run on EN but the EVENT would not fire if the cascade had
+    #    silently mismatched.
+    frame_events = [
+        e for e in install_log_capture.entries if e["event"] == "ui_automation_video.frame_attached"
+    ]
+    slots = {e.get("slot") for e in frame_events}
+    assert slots == {"Start", "End"}, (
+        f"expected frame_attached for {{Start, End}}, got {slots!r}; "
+        f"all events: {[e['event'] for e in install_log_capture.entries]}"
     )
 
 


### PR DESCRIPTION
## Summary

Closes #63. PR #70 shipped a structural-first \`_attach_frame\` cascade that was supposed to be locale-agnostic but matched **zero** elements on real Flow DOMs — the \`swap_horiz\` icon uses class \`material-icons\` (not \`google-symbols\`), and the slots are \`<div type=\"button\">\` (not children of any \`div > button\` wrapper). Production I2V therefore relied on the English-text fallback and silently broke on every non-English Chrome profile.

This PR fixes the structural selector and the after-Start End-frame OOB index.

## Root-cause evidence

DOM probe on \`ffroliva\` (effective pt-BR UI):
\`\`\`
SWAP_CONTAINER  (PR #70, broken)               → 0
swap_horiz icon, any icon class                → 1  (it's the swap-arrow button itself)
div[type='button'][aria-haspopup='dialog']     → 2  ← new primary
FRAME_SLOT_BY_LABEL  ('Start' / 'End', EN)     → 0  (Flow renders 'Inicial' / 'Final')
\`\`\`

Forensic outerHTML of the actual slots:
\`\`\`
<div type=\"button\" aria-haspopup=\"dialog\" aria-expanded=\"false\" aria-controls=\"radix-:r2i:\" data-state=\"closed\" ...>Inicial</div>
<div type=\"button\" aria-haspopup=\"dialog\" aria-expanded=\"false\" aria-controls=\"radix-:r2j:\" data-state=\"closed\" ...>Final</div>
\`\`\`

## Two fixes in this PR

1. **Tier-1 selector:** \`div[type='button'][aria-haspopup='dialog']\` (locale-free, unique-pattern; \`type='button'\` on a \`div\` is unusual outside Flow's custom components).
2. **End-frame OOB:** after Start is attached, only one structural slot remains in the DOM. The old \`structs.nth(slot_index)\` went OOB for slot_index=1 with count=1. The cascade now uses \`structs.first\` of remaining when \`struct_count > 0 and slot_index >= struct_count\`.

## Test plan

- [x] 41 unit tests in \`tests/api/transports/test_ui_automation_video.py\` — all green
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] **Live e2e (1 credit):** \`tests/e2e/test_transports_e2e.py::test_e2e_i2v_start_end_frame_attach\` on \`ffroliva\` + \`GFLOW_CLI_LOCALE=de-DE\` — **PASSED in 124 s**
  - Terminal \`SUCCESSFUL\` VideoStatus, non-empty media_id
  - mp4 downloaded to disk, \`ftyp\` magic bytes present
  - Both \`ui_automation_video.frame_attached\` events fired (Start + End)

## New artifacts

- \`tests/e2e/test_transports_e2e.py::test_e2e_i2v_start_end_frame_attach\` — env-driven I2V e2e (\`GFLOW_CLI_E2E_VIDEO_ASPECT\`/\`MODEL\`/\`DURATION\`); pins \`ui_automation\` transport per [[rest-transports-drop-ui-fields]]
- \`scripts/dev/capture_i2v_frame_slots_dom.py\` — Playwright DOM probe + forensic dump (produced the smoking gun for this fix)
- \`scripts/dev/cdp_drive_and_probe.py\` — CDP-attach selector probe for use with \`gflow-agent-browser-spike\`

## Memory updates

Two new project memories on develop:
- \`pr-70-issue-63-correction\` (implicit via this PR's commit message)
- Pattern reinforced: PR-only verification (no live e2e on the affected surface) misses class-of-bug like this. PR #70 was T2V-verified on de-DE but T2V doesn't touch \`_attach_frame\`.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)