### PR TITLE
feat(commands): extract pr-council-review to portable skill (v2)

### DIFF
--- a/.claude/commands/gflow/pr-council-review.md
+++ b/.claude/commands/gflow/pr-council-review.md
@@ -1,265 +1,36 @@
 ---
-description: Multi-dimensional LLM council review of an open PR. Adaptive dimensions per PR surface (data / transports / CLI / docs / auth). Baseline always includes correctness, code quality, security, and tests. With no argument, lists open PRs ranked by review priority.
+description: Multi-dimensional LLM council review of an open PR. Five baseline dimensions (correctness, quality, security, tests, memory-hygiene) plus adaptive per-surface dimensions. Sub-agents invoke specialized skills (security-review, code-review, verify). With no argument, lists open PRs ranked by priority. Wrapper around skills/pr-council-review/SKILL.md (canonical body).
 ---
 
 # `/gflow:pr-council-review [PR#]` — PR Council Review Gate
 
-Council-driven PR review. Dispatches **4 baseline + N adaptive** parallel reviewers, each scoped to one dimension, then synthesizes a single consensus verdict. Validated on PR #93 (2026-05-26) — see memory `llm-council-code-review-pr93`.
+This command is a **thin wrapper** around the canonical skill at `skills/pr-council-review/SKILL.md`. The skill contains all logic (preflight, phase-by-phase execution, per-dimension prompts, synthesis rules, report format). Keeping the body in a single source-of-truth means other tools (Gemini CLI / Codex / Cursor / Aider) can consume the same logic by loading the SKILL.md directly, and the Claude Code slash command stays a one-line invocation.
 
-**Two modes:**
-1. **No argument** → list open PRs ranked by review priority; user picks.
-2. **`PR#` argument** → run the full council on that PR.
+## How to invoke
 
-Treat **YELLOW as soft block** (per memory `llm-council-data-layer-fixes`).
+1. Load the skill with the `Skill` tool: `Skill(skill="pr-council-review")`.
+2. Pass the `PR#` argument (or leave empty for the prioritize-mode list).
+3. Follow the skill's phases exactly.
 
----
+Two modes:
+- **No argument** → list open PRs ranked by review priority; user picks.
+- **`PR#` argument** → run the full council (5 baseline + N adaptive parallel reviewers).
 
-## 0 · Pre-flight
+## Why a wrapper instead of inlining
 
-**All four checks are mandatory. Any failure halts before Phase 1/2.**
+- **Single source of truth:** the body lives in `skills/pr-council-review/SKILL.md`. Edits land in one place.
+- **Cross-tool portability:** the canonical SKILL.md is consumable by Gemini CLI's `activate_skill`, Cursor's `.cursor/rules`, Aider's `--prompt`, Codex's prompt-template flow, etc. See memory `[[pr-council-review-portability-backlog]]`.
+- **Token efficiency:** the Claude Code harness loads the skill on demand; the slash command itself is a few lines instead of ~330.
 
-1. **`gh` authenticated** — run `gh auth status`. Non-zero exit → stop with: *"`gh` is not authenticated. Run `gh auth login` and re-invoke."* Do NOT proceed to dispatch agents that would all fail opaquely.
-2. **Inside the repo** — assert `AGENTS.md` AND `CLAUDE.md` exist in the working directory.
-3. **Resolve the argument:**
-   - **Empty** → jump to **Phase 1 (Prioritize)**.
-   - **PR number** → validate it with `gh pr view <N> --json number`. If error → stop with the error verbatim. Do NOT silently fall back to Phase 1.
-4. **Draft check** (PR# mode only) — if `gh pr view <N> --json isDraft` returns `true`, surface a banner citing memory `draft-pr-merge-trap`: *"PR #N is DRAFT. Reviewing is fine, but do NOT merge a draft (the merge API can close it + delete the head ref). Run `gh pr ready N` first if you intend to merge. Continue review? (yes/no)"*. Ask the user before dispatching.
+## Sibling commands
 
----
+- `/review` — single-agent Claude Code built-in. Quick one-pass review. Use for spot-checks, draft iteration, or when council is overkill.
+- `/gflow:pr-council-review` — multi-agent council. Use before merge, on high-risk surfaces (auth, transports, data, release-gate), or when a single-agent pass would miss cross-dimension defects.
 
-## 1 · Prioritize (no-argument mode)
+## Provenance
 
-Run once, list open PRs in recommended order, then stop and ask the user which to review.
+- v1 (PR #97, 2026-05-26) — initial slash command, validated on PR #93 (locale selectors).
+- v2 (this PR) — extracted body into `skills/pr-council-review/SKILL.md`; added 5th baseline dimension (D5 Memory hygiene); fixed stale-working-tree-reads bug (sub-agents now use `git show origin/<head>:<path>` not `Read`); added per-dimension specialized-skill invocation (`security-review`, `code-review`, `verify`).
+- Provenance memory: `[[llm-council-code-review-pr93]]`, `[[pr-council-review-stale-tree-reads]]`, `[[pr-council-review-portability-backlog]]`.
 
-```bash
-gh pr list --state open --json number,title,author,isDraft,headRefName,updatedAt,additions,deletions,labels,reviewDecision,statusCheckRollup
-```
-
-**Empty-list short-circuit:** if the result is `[]`, print *"No open PRs to review."* and exit. Do NOT render an empty table or fall through to Phase 2.
-
-Rank with these heuristics (highest priority first):
-
-| Signal | Weight | Why |
-|---|---|---|
-| `isDraft == false` AND CI all-green | +3 | Ready to merge once approved — highest ROI |
-| Touched path includes `src/gflow_cli/api/transports/` | +2 | UI-automation is the highest-risk surface (memory `pr-must-verify-on-affected-surface`) |
-| Touched path includes `src/gflow_cli/auth/` or `recaptcha` | +2 | Auth changes need security-deep-dive |
-| Touched path includes `src/gflow_cli/data/` | +2 | Migration safety + #86 hygiene history |
-| Older than 7 days (stale risk) | +1 | Conflict risk grows with age |
-| `additions + deletions <= 300` | +1 | Small PRs ship faster |
-| Label contains `release-blocker`, `security`, `hotfix` | +5 | Anything labelled urgent jumps the queue |
-| `isDraft == true` AND CI red | −2 | Author still iterating; review wastes their time |
-
-Present a numbered table:
-
-```
-| Rank | PR# | Title | Ready? | CI | Surface | Why prioritized |
-|------|-----|-------|--------|----|---------| ---------------|
-| 1 | #71 | feat(image): native count selector …  | ✅ | green | transports | Ready + transports surface + small (220 LOC) |
-| 2 | …
-```
-
-Then **stop and ask** the user to pick a PR number. Do NOT auto-start a review on Rank 1 — *recommend*, do not *pre-select*. The user MUST type the PR number they want reviewed.
-
----
-
-## 2 · Gather context (PR# mode)
-
-Pull in parallel. Use `ctx_batch_execute` to avoid context-window flood.
-
-**Commands** (label → cmd):
-- `PR_META` → `gh pr view <N> --json title,body,author,baseRefName,headRefName,state,isDraft,additions,deletions,changedFiles,labels,files,statusCheckRollup`
-- `PR_DIFF` → `gh pr diff <N>`
-- `PR_CHECKS` → `gh pr checks <N>`
-- `TOUCHED_PATHS` → `gh pr view <N> --json files --jq '.files[].path' | sort -u`
-- `RECENT_COMMITS` → `gh pr view <N> --json commits --jq '.commits[-5:] | .[] | "\(.oid[:7]) \(.messageHeadline)"'`
-
-**Reference files** (Read inline; small enough to load):
-- `CLAUDE.md` — Claude-Code-specific protocol
-- `AGENTS.md` — universal agent rules
-- `docs/INDEX.md` — docs routing
-- `~/.claude/projects/C--development-github-gflow-cli/memory/MEMORY.md` — memory index
-
-**Memory traversal:** For each `TOUCHED_PATH`, glob memory for related entries:
-- `transports/` (image OR video) → `[[pr-must-verify-on-affected-surface]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[video-generation-spec]]`, `[[image-generation-401-next]]`
-- `data/` → `[[data-layer-overview]]`, `[[data-layer-test-pollution-trap]]`, `[[data-layer-v0.9.0-bugs]]`, `[[exit-code-16-data-store]]`, `[[on-started-callback-recorder-safety]]`
-- `auth/` → `[[real-browser-auth-mandatory]]`, `[[release-signing]]`
-- `cli` → `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`
-- `tests/` (any) → `[[bdd-stubs-mirror-runtime-signatures]]`, `[[background-e2e-pytest-pattern]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]`
-- `tests/features/` (BDD) → also `[[bdd-stubs-mirror-runtime-signatures]]` (silent TypeError trap)
-- `scripts/` (dev / CI / release helpers) → `[[wheel-build-sanity-gate]]`, `[[release-back-merge-gap-recovery]]`
-- `.planning/`, `docs/superpowers/` (process artifacts) → `[[release-spec-plan-memory-consolidation]]`
-- `docs/`, `*.md` → `[[readme-hybrid-router-pattern]]`, `[[llm-council-doc-review-v0.9.0]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]`
-- `pyproject.toml`, `.github/` → `[[release-spec-plan-memory-consolidation]]`, `[[pr-hygiene-revert-and-multi-commit]]`, `[[draft-pr-merge-trap]]`, `[[pypi-rejected-filename-reusable]]`
-
----
-
-## 3 · Detect adaptive dimensions
-
-The **baseline** 4 dimensions run for every PR. **Adaptive** dimensions activate only when the touched paths or labels match. Build the council roster before dispatching.
-
-| Dimension | Always? | Activates when… |
-|---|---|---|
-| **D1 — Correctness & completeness** | ✅ baseline | always |
-| **D2 — Code quality & best practices** | ✅ baseline | always |
-| **D3 — Security** | ✅ baseline | always |
-| **D4 — Tests & coverage** | ✅ baseline | always |
-| **D5 — UI / live-verification** | adaptive | any path under `src/gflow_cli/api/transports/` or `tests/e2e/` |
-| **D6 — Data-migration safety** | adaptive | any path under `src/gflow_cli/data/` or `*.sql` |
-| **D7 — CLI UX & help-text consistency** | adaptive | any path matching `src/gflow_cli/cli*.py` or `src/gflow_cli/commands/` |
-| **D8 — Docs cross-reference & drift** | adaptive | ≥2 of these touched: `README.md`, `docs/**`, `CHANGELOG.md`, `AGENTS.md`, `CLAUDE.md`, `PLAN.md` |
-| **D9 — Auth / reCAPTCHA / Chrome-profile** | adaptive | any path under `src/gflow_cli/auth/` or label `security` |
-| **D10 — Release-gate compliance** | adaptive | `pyproject.toml`, `src/gflow_cli/__init__.py`, `.github/workflows/`, or `release/*` branch |
-| **D11 — BDD step-stub signatures** | adaptive | any path under `tests/features/` (silent TypeError trap, memory `bdd-stubs-mirror-runtime-signatures`) |
-| **D12 — Dev / release scripts** | adaptive | any path under `scripts/` |
-
-**Baseline floor is non-negotiable.** D1–D4 ALWAYS run, even on docs-only PRs. The user spec explicitly required quality / security / best-practices / tests as a floor — do not skip.
-
-**Docs-only PRs** (defined as: 100% of touched paths match `*.md`, `docs/**`, `CHANGELOG.md`, `README.md`, `LICENSE`, `AUTHORS`) → D4 reframes from "test code coverage" to "docs-verification" (broken cross-references, dead links, code examples that don't run). The dimension still runs; only its lens shifts.
-
----
-
-## 4 · Dispatch the council
-
-Use `superpowers:dispatching-parallel-agents`. Send **all** agents in one message — they must run concurrently. Each agent must:
-
-- Get the PR number, base branch, and head branch.
-- Be told its dimension AND told what NOT to duplicate (the other dimensions' scope).
-- Use `ctx_execute` for large outputs (diff, file reads) — never flood the context.
-- Output a structured report: **Verdict (GREEN / YELLOW / RED)**, **Must-fix** (numbered, file:line refs), **Nice-to-have** (numbered), **Confirmed-good/safe/correct** (1-line bullets).
-- Be word-limited to **under 500 words** so the synthesizer doesn't drown.
-
-**Per-dimension prompt skeleton** (fill in `<…>`):
-
-```
-You are one of <N> parallel reviewers on a council reviewing PR #<N> of `gflow-cli` at C:\development\github\gflow-cli.
-
-Your dimension is **<DIMENSION NAME>**. Other agents handle <other dimensions> — do NOT duplicate their work.
-
-Get the diff with `gh pr diff <N>` via ctx_execute. If `additions + deletions > 5000`, do NOT pull the full diff at once — instead enumerate touched files with `gh pr view <N> --json files --jq '.files[].path'`, then read per-directory with `gh pr diff <N> -- <path>` to keep each call under 2k lines. Read the unchanged surrounding code with Read for any file you flag.
-
-Assess specifically:
-1. <dimension-specific question 1, with code citation hooks>
-2. <…>
-3. <…>
-
-**Mandatory memory you MUST consult and cite if relevant** (from the Dimension → Slugs table below): <fixed slug list for this dimension>.
-
-Output a structured report under 500 words:
-- Verdict: GREEN / YELLOW / RED
-- Must-fix (numbered, file:line refs)
-- Nice-to-have (numbered)
-- Confirmed-<good/safe/correct> (1-line bullets)
-
-Be skeptical. Cite file paths and line numbers. **If you have nothing to flag in your dimension, say so explicitly and state GREEN with a one-line justification — do NOT manufacture findings to look thorough.**
-```
-
-**Dimension → mandatory slugs table** (always pass these in the prompt, regardless of which paths the PR touches — they encode the recurring traps for that dimension):
-
-| Dim | Mandatory memory slugs |
-|---|---|
-| D1 | `[[pr-must-verify-on-affected-surface]]` |
-| D2 | (none mandatory; consult surrounding code style) |
-| D3 | `[[real-browser-auth-mandatory]]`, `[[release-signing]]` |
-| D4 | `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]` |
-| D5 | `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]` |
-| D6 | `[[on-started-callback-recorder-safety]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]`, `[[data-layer-v0.9.0-bugs]]` |
-| D7 | (none mandatory) |
-| D8 | `[[readme-hybrid-router-pattern]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]`, `[[llm-council-doc-review-v0.9.0]]` |
-| D9 | `[[real-browser-auth-mandatory]]` |
-| D10 | `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`, `[[pypi-rejected-filename-reusable]]`, `[[draft-pr-merge-trap]]` |
-| D11 | `[[bdd-stubs-mirror-runtime-signatures]]` |
-| D12 | `[[wheel-build-sanity-gate]]` |
-
-**Per-dimension specifics** (concrete checks each agent must perform):
-
-- **D1 Correctness & completeness:**
-  - Does the fix address the *root cause* or only the symptom? Cite the function being changed.
-  - Are edge cases handled? Spot-check 2 boundary conditions.
-  - Does the CHANGELOG entry match what shipped? Quote both.
-  - **PR-body compliance:** does the PR body's description match the diff? Are the PR body's test-plan checkboxes (the `- [ ]` / `- [x]` markers) accurate? If any unchecked box represents work the PR claims to deliver, flag it. If the PR claims `Closes #N` for an issue whose acceptance criteria are not met by the diff, flag it.
-- **D2 Code quality:** Style consistency with surrounding code? Comments explain WHY not WHAT (per `CLAUDE.md`)? Any abstraction that doesn't earn its keep? SRP intact? Type annotations on every new signature?
-- **D3 Security:** Injection vectors? Env-var trust boundary? Shell interpolation (`subprocess`, `shell=True`)? Path traversal? Secret-shaped literals? `--no-verify` or signature-bypass in commits?
-- **D4 Tests:**
-  - **Mandatory affected-surface check** (cardinal rule, memory `pr-must-verify-on-affected-surface`): identify the runtime surface the fix touches (T2V / I2V / R2V / data / CLI / auth / etc.). If the test suite does not exercise that exact surface (e.g. a fix for `_attach_frame` with only T2V tests), this is **automatically YELLOW**. Cite the test `file:line` that proves coverage of the affected surface — or state explicitly that no such test exists.
-  - Test pyramid placement (unit vs integration vs e2e)?
-  - Do tests verify *behavior* or just shape (static strings, mocked returns)?
-  - Coverage delta meaningful, or dead-coverage (counts new constants without exercising them)?
-- **D5 UI/live-verify:** Will this selector match real Flow DOM on non-EN locales? Is there runtime evidence beyond static-string invariants? Has the PR author pasted live-verify evidence (file count + magic bytes + Pillow dims + structlog events such as `new_project_clicked` / `submit_clicked` / `frame_attached` / `image_mode_entered` / `count_setter_completed` / `reference_attached`) in the PR body or a comment? **Absent live-verify on a UI-automation PR is YELLOW per memory `pr-must-verify-on-affected-surface`.**
-- **D6 Data-migration & on_started safety:**
-  - **Mandatory on_started callback check** (memory `on-started-callback-recorder-safety`): grep the diff for `VideoStartedCallback` / `on_started` / any new callback invoked inside a transport during a paid Flow generation. Verify each callsite is wrapped in `try/except DataStoreError` (and ideally a broad guard). **A bare callback in a paid-generation path is automatically RED** — uncaught exceptions abort paid generation.
-  - Schema-compat with existing rows? Migration script idempotent?
-  - `DataStoreError` vs `DataMigrationError` vs `DataIntegrityError` semantics correct? Pre-Flow failures vs post-success-warn-and-return-0 per memory `exit-code-16-data-store`?
-- **D7 CLI UX:** Help text matches behavior? Flag names follow `--kebab-case`? Does the new flag appear in `--help` golden-snapshot tests? Examples in docstring runnable?
-- **D8 Docs drift:** Cross-references mutually consistent (CLAUDE.md / AGENTS.md / docs/INDEX.md / README.md / PLAN.md)? Code examples actually run? Version strings consistent across files?
-- **D9 Auth:** Chrome-strategy profile required (memory `real-browser-auth-mandatory`)? Profile-dir SecurityError boundary intact (`outside of GFLOW_CLI_HOME`)? No new secret-shaped strings?
-- **D10 Release-gate:**
-  - **Quote the version string** from `pyproject.toml` AND from `src/gflow_cli/__init__.py` and confirm they match exactly. If only one was bumped → RED.
-  - Verify `CHANGELOG.md` `[Unreleased]` was emptied and a new version section added — cite the line range.
-  - Wheel build clean (`uv build` + ZIP-dupe check per memory `wheel-build-sanity-gate`)?
-  - Back-merge gap from prior releases addressed (memory `release-back-merge-gap-recovery`)?
-- **D11 BDD step-stub signatures:** any new `_run_*` kwarg or runtime signature change requires mirroring in `tests/features/_fake_*` stubs — silent `TypeError` trap. Cite each fake stub touched (or assert no signature change occurred).
-- **D12 Dev/release scripts:** any new script must run cleanly on Windows (memory `windows-dev-quirks`); release scripts must include the wheel-build sanity gate.
-
----
-
-## 5 · Synthesize the verdict
-
-After all agents return:
-
-1. **Tally verdicts:** count GREEN / YELLOW / RED per dimension.
-2. **Handle missing agents:** if any dimension failed to return (timeout, dispatch error), mark it `UNKNOWN` and downgrade the consensus by one step (GREEN → YELLOW, YELLOW → YELLOW, RED stays RED). Never wait indefinitely. Surface which dimension is missing so the user can re-dispatch if they want.
-3. **Consensus rule:**
-   - Any RED → **RED** (block merge).
-   - Any YELLOW → **YELLOW** (soft block — must address before merge, per memory `llm-council-data-layer-fixes`).
-   - All GREEN → **GREEN** (mergeable).
-4. **Deduplicate must-fix AND confirmed-good items:** if two dimensions flag the same issue (or confirm the same positive), list it once and credit both.
-5. **Live-verify gate** (D5 fired + PR body has unchecked live-verify boxes): emit an explicit `AskUserQuestion` with three options — (a) *Run now (estimate: ~1 Flow image credit per locale)*, (b) *Block merge — add to PR body as required reviewer action*, (c) *Skip and accept the risk*. Cite memory `verification-ledger-5-layer` in the question body so the user is reminded that file count alone is not proof. Do NOT spend credits without an explicit affirmative click.
-6. **YELLOW escape valve:** when reporting in Phase 6, the `AskUserQuestion` MUST include a *"Dismiss YELLOW with justification (logged)"* option so the user is never trapped without a path forward. Dismissal requires a one-line reason that gets appended to the PR body or comment, so the override is auditable.
-
----
-
-## 6 · Report
-
-Output to the user, in this exact shape:
-
-```
-# PR #<N> — Council Review Verdict
-
-## Consensus: <emoji> <GREEN | YELLOW | RED>
-
-| Dimension | Verdict | Headline |
-|---|---|---|
-| <D1> | … | <one-line summary> |
-| <D2> | … | … |
-…
-
-## Must-fix (<N>)
-1. **<short title>** — `<file>:<line>`. <description>. <which dimension flagged>.
-2. …
-
-## Nice-to-have (<N>)
-1. …
-
-## Confirmed-good (high-confidence positives)
-- …
-
-## How to proceed
-<AskUserQuestion: which must-fixes to apply now, whether to run live-verify, etc.>
-```
-
-Always end with an `AskUserQuestion` so the user can drive next steps (apply fixes, post evidence, dismiss findings).
-
----
-
-## 7 · Provenance & extensions
-
-> **Provenance:** the council protocol below was validated on PR #93 (locale selectors + DB isolation, merged 2026-05-26). The audit found an unanchored regex + a silent-test-pyramid gap that 152 passing unit tests missed. Then a meta-council audited *this* command itself, surfacing 13 must-fix items now applied. See memory `[[llm-council-code-review-pr93]]`.
-
-- Council baseline = 4 dimensions (D1–D4) always run. Adaptive ceiling = D5–D12 (currently). Going beyond ~12 dimensions adds noise faster than signal — split into two reviews instead.
-- Each agent currently uses `general-purpose`. If a future dedicated `code-reviewer` subagent ships, swap it in.
-- If a PR touches paths that don't match any adaptive dimension, document the gap and add a new dimension here (D13+).
-- The command is **stateless** — concurrent invocations on different PR numbers don't share data, so two instances can run in parallel without interference.
-- **Idempotence:** running the same council on the same PR SHA should produce comparable verdicts on different days. If verdicts drift, the cause is usually (a) memory grew new precedents, or (b) the mandatory-slug table here needs an update. Drift is informational, not a defect.
-- No destructive git/gh actions are taken by this command. Reviews are read-only. The user always drives apply-fix / push / merge through subsequent commands.
-- **Sibling commands.** `/review` is the single-agent Claude-Code built-in (one-pass code review, fast and cheap) — use it for spot-checks, draft iteration, or when the council is overkill. `/gflow:pr-council-review` is the multi-agent council version — use it before merge, on high-risk surfaces (auth, transports, data, release-gate), or whenever a single-agent pass would miss the cross-dimension defects the council is designed to catch.
+For all execution details — phases, dimension table, per-dimension prompt skeletons, mandatory memory slug table, synthesis rules, report format — see `skills/pr-council-review/SKILL.md`. This wrapper exists only so Claude Code users can type `/gflow:pr-council-review` instead of `Skill(skill="pr-council-review")`.

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: pr-council-review
+description: Multi-dimensional LLM council review of an open PR. Five baseline dimensions (correctness, quality, security, tests, memory-hygiene) plus adaptive dimensions per PR surface (transports / data / CLI / docs / auth / BDD / scripts / release-gate). Each agent invokes specialized skills (security-review, code-review, verify) for its dimension. Reads files via `git show origin/<head>:<path>` to avoid stale-working-tree false positives. Cross-tool portable.
+---
+
+# `pr-council-review` — PR Council Review skill
+
+Council-driven PR review. Dispatches **5 baseline + N adaptive** parallel reviewers, each scoped to one dimension, each invoking the relevant Claude Code specialized skill (e.g. `security-review`, `code-review`, `verify`), then synthesizes a single consensus verdict.
+
+This skill is the canonical body. The Claude Code slash command at `.claude/commands/gflow/pr-council-review.md` is a thin wrapper that invokes this skill. Non-Claude tools (Gemini CLI / Codex / Cursor / Aider) can consume this SKILL.md directly via their own skill loaders.
+
+**Two modes:**
+1. **No argument** → list open PRs ranked by review priority; user picks.
+2. **`PR#` argument** → run the full council on that PR.
+
+Treat **YELLOW as soft block** (per memory `[[llm-council-data-layer-fixes]]`).
+
+---
+
+## 0 · Pre-flight
+
+**All five checks are mandatory. Any failure halts before Phase 1/2.**
+
+1. **`gh` authenticated** — run `gh auth status`. Non-zero exit → stop with: *"`gh` is not authenticated. Run `gh auth login` and re-invoke."*
+2. **Inside the repo** — assert `AGENTS.md` AND `CLAUDE.md` exist in the working directory.
+3. **Resolve the argument:**
+   - **Empty** → jump to **Phase 1 (Prioritize)**.
+   - **PR number** → validate with `gh pr view <N> --json number`. If error → stop with the error verbatim.
+4. **Draft check** (PR# mode only) — if `gh pr view <N> --json isDraft` returns `true`, surface a banner citing memory `[[draft-pr-merge-trap]]`: *"PR #N is DRAFT. Reviewing is fine, but do NOT merge a draft (the merge API can close it + delete the head ref). Run `gh pr ready N` first if you intend to merge. Continue review? (yes/no)"*. Ask the user before dispatching.
+5. **Capture PR head ref + SHA** — `head_branch=$(gh pr view <N> --json headRefName --jq '.headRefName')` and `head_sha=$(gh pr view <N> --json headRefOid --jq '.headRefOid')`. Pass both to every dispatched agent. The local working tree is NOT on the PR head; all file reads must go through `git show origin/$head_branch:<path>`.
+
+---
+
+## 1 · Prioritize (no-argument mode)
+
+```bash
+gh pr list --state open --json number,title,author,isDraft,headRefName,updatedAt,additions,deletions,labels,reviewDecision,statusCheckRollup
+```
+
+**Empty-list short-circuit:** if the result is `[]`, print *"No open PRs to review."* and exit.
+
+Rank with these heuristics (highest priority first):
+
+| Signal | Weight | Why |
+|---|---|---|
+| `isDraft == false` AND CI all-green | +3 | Ready to merge once approved — highest ROI |
+| Touched path includes `src/gflow_cli/api/transports/` | +2 | UI-automation is the highest-risk surface (memory `[[pr-must-verify-on-affected-surface]]`) |
+| Touched path includes `src/gflow_cli/auth/` or `recaptcha` | +2 | Auth changes need security-deep-dive |
+| Touched path includes `src/gflow_cli/data/` | +2 | Migration safety + #86 hygiene history |
+| Older than 7 days (stale risk) | +1 | Conflict risk grows with age |
+| `additions + deletions <= 300` | +1 | Small PRs ship faster |
+| Label contains `release-blocker`, `security`, `hotfix` | +5 | Anything labelled urgent jumps the queue |
+| `isDraft == true` AND CI red | −2 | Author still iterating; review wastes their time |
+
+Present a numbered table, then **stop and ask** the user to pick a PR number. Do NOT auto-start on Rank 1 — *recommend*, do not *pre-select*.
+
+---
+
+## 2 · Gather context (PR# mode)
+
+Pull in parallel via `ctx_batch_execute`:
+- `PR_META` → `gh pr view <N> --json title,body,author,baseRefName,headRefName,headRefOid,state,isDraft,additions,deletions,changedFiles,labels,files,statusCheckRollup`
+- `PR_DIFF` → `gh pr diff <N>`
+- `PR_CHECKS` → `gh pr checks <N>`
+- `TOUCHED_PATHS` → `gh pr view <N> --json files --jq '.files[].path' | sort -u`
+- `RECENT_COMMITS` → `gh pr view <N> --json commits --jq '.commits[-5:] | .[] | "\(.oid[:7]) \(.messageHeadline)"'`
+
+**Reference files** (read via `git show origin/$head_branch:<path>` — NOT local `Read`, because the working tree is on `develop`):
+- `CLAUDE.md`, `AGENTS.md`, `docs/INDEX.md`
+
+**Memory traversal:** for each `TOUCHED_PATH`, look up relevant slugs:
+- `transports/` → `[[pr-must-verify-on-affected-surface]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[video-generation-spec]]`, `[[image-generation-401-next]]`
+- `data/` → `[[data-layer-overview]]`, `[[data-layer-test-pollution-trap]]`, `[[data-layer-v0.9.0-bugs]]`, `[[exit-code-16-data-store]]`, `[[on-started-callback-recorder-safety]]`
+- `auth/` → `[[real-browser-auth-mandatory]]`, `[[release-signing]]`
+- `cli` → `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`
+- `tests/` (any) → `[[bdd-stubs-mirror-runtime-signatures]]`, `[[background-e2e-pytest-pattern]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]`
+- `tests/features/` (BDD) → also `[[bdd-stubs-mirror-runtime-signatures]]`
+- `scripts/` → `[[wheel-build-sanity-gate]]`, `[[release-back-merge-gap-recovery]]`
+- `.planning/`, `docs/superpowers/` → `[[release-spec-plan-memory-consolidation]]`
+- `docs/`, `*.md` → `[[readme-hybrid-router-pattern]]`, `[[llm-council-doc-review-v0.9.0]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]`
+- `pyproject.toml`, `.github/` → `[[release-spec-plan-memory-consolidation]]`, `[[pr-hygiene-revert-and-multi-commit]]`, `[[draft-pr-merge-trap]]`, `[[pypi-rejected-filename-reusable]]`
+
+---
+
+## 3 · Detect adaptive dimensions
+
+| Dimension | Always? | Activates when… |
+|---|---|---|
+| **D1 — Correctness & completeness** | ✅ baseline | always |
+| **D2 — Code quality & best practices** | ✅ baseline | always |
+| **D3 — Security** | ✅ baseline | always |
+| **D4 — Tests & coverage** | ✅ baseline | always |
+| **D5 — Memory hygiene & consolidation** | ✅ baseline (NEW v2) | always |
+| **D6 — UI / live-verification** | adaptive | any path under `src/gflow_cli/api/transports/` or `tests/e2e/` |
+| **D7 — Data-migration safety** | adaptive | any path under `src/gflow_cli/data/` or `*.sql` |
+| **D8 — CLI UX & help-text consistency** | adaptive | any path matching `src/gflow_cli/cli*.py` or `src/gflow_cli/commands/` |
+| **D9 — Docs cross-reference & drift** | adaptive | ≥2 of: `README.md`, `docs/**`, `CHANGELOG.md`, `AGENTS.md`, `CLAUDE.md`, `PLAN.md` |
+| **D10 — Auth / reCAPTCHA / Chrome-profile** | adaptive | any path under `src/gflow_cli/auth/` or label `security` |
+| **D11 — Release-gate compliance** | adaptive | `pyproject.toml`, `src/gflow_cli/__init__.py`, `.github/workflows/`, `release/*` branch |
+| **D12 — BDD step-stub signatures** | adaptive | any path under `tests/features/` |
+| **D13 — Dev / release scripts** | adaptive | any path under `scripts/` |
+
+**Baseline floor is non-negotiable.** D1–D5 ALWAYS run. **Docs-only PRs** (100% paths under `*.md`, `docs/**`, `CHANGELOG.md`, `README.md`, `LICENSE`, `AUTHORS`) → D4 reframes from "test code coverage" to "docs-verification"; D5 still runs unchanged.
+
+---
+
+## 4 · Dispatch the council
+
+Use the `superpowers:dispatching-parallel-agents` skill. Send **all** agents in one message — they must run concurrently.
+
+### Per-dimension specialized-skill mapping (NEW v2)
+
+Each agent is a `general-purpose` agent (only subagent type that supports arbitrary parallel dispatch), but the prompt instructs it to invoke the relevant Claude Code skill **inside** the agent for specialized capability. Mapping:
+
+| Dim | Agent invokes skill (via Skill tool) | Rationale |
+|---|---|---|
+| D1 Correctness | `review` (single-agent PR review built-in) | Provides PR-review framing for free |
+| D2 Code quality | `code-review` | Reuse-and-quality lens |
+| D3 Security | **`security-review`** | Built-in security-review skill — the most important specialization |
+| D4 Tests | `superpowers:test-driven-development` (informed) | TDD principles + verification mindset |
+| D5 Memory hygiene | (none — direct memory inspection) | Inspect memory files via `git show` + filesystem |
+| D6 UI/live-verify | `verify` (if live-verify approved) | Runs the app to confirm behavior |
+| D7 Data-migration | (none — direct code inspection) | |
+| D8 CLI UX | (none — direct help-text inspection) | |
+| D9 Docs drift | (none — direct doc-cross-ref) | |
+| D10 Auth | `security-review` (subset of D3 with auth-specific lens) | |
+| D11 Release-gate | (none — direct config inspection) | |
+| D12 BDD | (none — direct stub-signature inspection) | |
+| D13 Scripts | (none — direct script inspection) | |
+
+### Per-agent prompt skeleton (mandatory v2 changes in bold)
+
+```
+You are one of <N> parallel reviewers on a council reviewing PR #<N> of `gflow-cli` at C:\development\github\gflow-cli.
+
+Your dimension is **<DIMENSION NAME>**. Other agents handle <other dimensions> — do NOT duplicate their work.
+
+**PR head branch:** `<head_branch>` (head SHA: `<head_sha>`).
+**Base branch:** `<base_branch>`.
+
+**🚨 CRITICAL — file reading rule (v2 stale-tree-reads fix):**
+The orchestrator's working tree is on `<base_branch>` (typically `develop`), NOT the PR head. If you `Read` a file in `C:\development\github\gflow-cli\`, you get the PRE-PR copy and will produce FALSE POSITIVES like "file X doesn't exist" or "claim Y not applied" when in fact X and Y are present on the PR head. To inspect a file as it WILL look post-merge, ALWAYS use:
+
+  ctx_execute(language="shell", code="git show origin/<head_branch>:<path>")
+
+For the diff itself, use `gh pr diff <N>` via ctx_execute. For PR metadata, use `gh pr view <N> --json ...`. Only use `Read` if you have explicitly verified you are on the PR head branch via `git branch --show-current`.
+
+**Specialized skill (if listed for your dimension):** before deep analysis, invoke the Skill tool for `<skill_name>` to load specialized review guidance. Apply that skill's checklists in addition to the dimension-specific questions below.
+
+Assess specifically:
+1. <dimension-specific question 1, with code citation hooks>
+2. <…>
+
+**Mandatory memory you MUST consult and cite if relevant:** <fixed slug list from the Dimension → Slugs table>.
+
+Output a structured report under 500 words:
+- Verdict: GREEN / YELLOW / RED
+- Must-fix (numbered, file:line refs)
+- Nice-to-have (numbered)
+- Confirmed-<good/safe/correct> (1-line bullets)
+
+If you have nothing to flag, say so explicitly and state GREEN with a one-line justification — do NOT manufacture findings.
+
+If you are NOT sure a finding is real because it depends on file content, VERIFY via `git show origin/<head_branch>:<path>` before reporting it. Stale-tree false positives are a documented v1 council bug.
+```
+
+### Dimension → mandatory memory slugs table
+
+| Dim | Mandatory memory slugs |
+|---|---|
+| D1 | `[[pr-must-verify-on-affected-surface]]` |
+| D2 | (none mandatory; consult surrounding code style) |
+| D3 | `[[real-browser-auth-mandatory]]`, `[[release-signing]]` |
+| D4 | `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]` |
+| D5 | `[[release-spec-plan-memory-consolidation]]`, `[[pr-council-review-stale-tree-reads]]` (this very bug, as the council should self-improve) |
+| D6 | `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]` |
+| D7 | `[[on-started-callback-recorder-safety]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]`, `[[data-layer-v0.9.0-bugs]]` |
+| D8 | (none mandatory) |
+| D9 | `[[readme-hybrid-router-pattern]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]`, `[[llm-council-doc-review-v0.9.0]]` |
+| D10 | `[[real-browser-auth-mandatory]]` |
+| D11 | `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`, `[[pypi-rejected-filename-reusable]]`, `[[draft-pr-merge-trap]]` |
+| D12 | `[[bdd-stubs-mirror-runtime-signatures]]` |
+| D13 | `[[wheel-build-sanity-gate]]` |
+
+### Per-dimension specifics
+
+- **D1 Correctness & completeness:** root cause vs symptom? Edge cases? CHANGELOG matches diff? PR-body compliance (test-plan checkboxes + `Closes #N` acceptance criteria met)?
+- **D2 Code quality:** style consistency? Comments WHY-not-WHAT (per CLAUDE.md)? SRP intact? Type annotations on every new signature?
+- **D3 Security:** injection vectors? Env-var trust boundary? Shell interpolation? Path traversal? Secret-shaped literals? `--no-verify` / signature-bypass?
+- **D4 Tests:**
+  - **Mandatory affected-surface check:** identify the runtime surface (T2V / I2V / data / CLI / auth / etc.). If the suite doesn't exercise that exact surface → **automatically YELLOW**. Cite the test file:line proving coverage, or state explicitly no such test exists.
+  - Test pyramid placement? Behavior vs shape? Coverage delta meaningful vs dead?
+- **D5 Memory hygiene & consolidation (NEW v2):**
+  - Inspect `~/.claude/projects/C--development-github-gflow-cli/memory/` (or the per-user equivalent if mempalace / mem0 / other MCP memory servers are available — probe with the relevant tool to enumerate).
+  - For each memory entry potentially relevant to the PR's surface: does the PR's content CONTRADICT or SUPERSEDE it? If so, the PR must include a memory edit/delete in the same change. Flag missing edits.
+  - Does the PR introduce a new durable pattern / failure mode / decision that should be captured as a NEW memory entry? Flag missing additions.
+  - Is `MEMORY.md` index still in sync (entries listed correspond to existing files)? Flag drift.
+  - Per `[[release-spec-plan-memory-consolidation]]`: any spec/plan in `docs/superpowers/` or `.planning/` that's now post-ship should be deleted on merge, with durable bits extracted to memory.
+- **D6 UI/live-verify:** selector matches real DOM on non-EN? Runtime evidence beyond static-string invariants? Live-verify evidence (file count + magic bytes + Pillow dims + structlog events: `new_project_clicked`/`submit_clicked`/`frame_attached`/`image_mode_entered`/`count_setter_completed`/`reference_attached`) in PR body? Absent → YELLOW per `[[pr-must-verify-on-affected-surface]]`.
+- **D7 Data-migration:** on_started callback safety (every callsite wrapped in `try/except DataStoreError` — bare callback in paid-generation path = RED). Schema compat. Migration idempotent. `DataStoreError` vs `DataMigrationError` vs `DataIntegrityError` semantics.
+- **D8 CLI UX:** help text matches? Flag names `--kebab-case`? `--help` golden-snapshot tests updated? Docstring examples runnable?
+- **D9 Docs drift:** cross-references mutually consistent? Code examples run? Version strings consistent?
+- **D10 Auth:** Chrome-strategy profile required (memory `[[real-browser-auth-mandatory]]`)? Profile-dir SecurityError boundary intact? No new secret-shaped strings?
+- **D11 Release-gate:** version match `pyproject.toml` ↔ `src/gflow_cli/__init__.py` (RED if drift). `[Unreleased]` emptied + new version added. Wheel build clean. Back-merge gap addressed.
+- **D12 BDD:** new `_run_*` kwarg → mirror in `tests/features/_fake_*` stubs (silent TypeError trap).
+- **D13 Scripts:** Windows-clean (memory `[[windows-dev-quirks]]`); release scripts include wheel-build sanity gate.
+
+---
+
+## 5 · Synthesize the verdict
+
+1. **Tally verdicts** per dimension.
+2. **Handle missing agents:** any dimension that failed → mark `UNKNOWN`, downgrade consensus by one step (GREEN→YELLOW, YELLOW→YELLOW, RED→RED). Never wait indefinitely.
+3. **Consensus rule:**
+   - Any RED → **RED** (block merge).
+   - Any YELLOW → **YELLOW** (soft block per `[[llm-council-data-layer-fixes]]`).
+   - All GREEN → **GREEN** (mergeable).
+4. **Deduplicate must-fix AND confirmed-good** — same finding from two dimensions = list once + credit both.
+5. **False-positive filter (NEW v2):** before reporting, spot-check 2-3 file-state claims via `git show origin/<head>:<path>`. If any agent claim contradicts the PR head, mark it FALSE POSITIVE in the report — do not silently drop, so the council's accuracy is auditable.
+6. **Live-verify gate** (D6 fired + PR body has unchecked live-verify boxes): explicit `AskUserQuestion` with three options — *Run now (~1 Flow credit per locale)*, *Block merge — add to PR body as required reviewer action*, *Skip and accept risk*. Cite `[[verification-ledger-5-layer]]`. Do NOT spend credits without affirmative click.
+7. **Memory-action gate** (D5 fired with must-fix items): explicit `AskUserQuestion` offering to APPLY the memory edits/additions/deletions in the same PR or as a follow-up.
+8. **YELLOW escape valve:** the Phase 6 `AskUserQuestion` MUST include a *"Dismiss YELLOW with justification (logged)"* option. Dismissal requires a one-line reason appended to the PR body or comment, so the override is auditable.
+
+---
+
+## 6 · Report
+
+```
+# PR #<N> — Council Review Verdict
+
+## Consensus: <emoji> <GREEN | YELLOW | RED>
+
+| Dimension | Verdict | Headline |
+|---|---|---|
+| <D1> | … | <one-line summary> |
+| <D2> | … | … |
+
+## Must-fix (<N>)
+1. **<short title>** — `<file>:<line>`. <description>. <which dimension flagged>.
+2. …
+
+## Nice-to-have (<N>)
+1. …
+
+## False positives (filtered out — agents misread stale tree)
+- D<n> claim about <…>: verified absent on PR HEAD via `git show origin/<head>:<path>` — dropping.
+
+## Confirmed-good (high-confidence positives)
+- …
+
+## Memory actions (D5)
+- ADD: <slug> capturing <pattern>
+- UPDATE: <slug> — claim X is now stale because <…>
+- DELETE: <slug> — superseded by <…>
+
+## How to proceed
+<AskUserQuestion>
+```
+
+Always end with an `AskUserQuestion`.
+
+---
+
+## 7 · Provenance & extensions
+
+> **Provenance:** v1 protocol validated on PR #93 (locale selectors, 2026-05-26). v2 evolved 2026-05-27 after running on PR #95 surfaced two real defects: (a) sub-agents read stale working-tree files producing 5+ false positives (memory `[[pr-council-review-stale-tree-reads]]`), (b) baseline missed memory-hygiene as a dimension. Both fixed in v2.
+
+- Council baseline = 5 dimensions (D1–D5). Adaptive ceiling = D6–D13. Going beyond ~13 adds noise faster than signal — split into two reviews instead.
+- Sub-agents are `general-purpose` agents that invoke specialized skills (`security-review`, `code-review`, `verify`, `review`) inside their prompt for dimension-specific capability.
+- The command is **stateless** and **read-only** — concurrent invocations on different PRs don't share data. No `gh pr merge`, no `git push`, no `gh pr close`.
+- **Idempotence:** same PR SHA → comparable verdicts on different days. Drift usually means memory grew new precedents or the mandatory-slug table needs an update.
+- **Sibling commands.** `/review` is the single-agent Claude-Code built-in (one-pass, cheap) — use for spot-checks or draft iteration. `/gflow:pr-council-review` is the council version for pre-merge audits and high-risk surfaces.
+- **Cross-tool portability.** This SKILL.md is the canonical body. The Claude Code slash command at `.claude/commands/gflow/pr-council-review.md` is a thin wrapper. Other tools (Gemini CLI / Codex / Cursor / Aider) consume this file directly via their own skill-loading mechanism. See `[[pr-council-review-portability-backlog]]` for the cross-tool playbook.


### PR DESCRIPTION
## Summary

Ships **4 improvements** to `/gflow:pr-council-review`, driven by running the v1 council on PR #95 (which surfaced concrete defects in the v1 design):

1. **Skill extraction (Phase A of portability backlog).** Canonical body moved to `skills/pr-council-review/SKILL.md` so Gemini CLI / Codex / Cursor / Aider can consume the same logic via their own skill loaders. `.claude/commands/gflow/pr-council-review.md` is now a thin wrapper that loads the skill via the `Skill` tool.
2. **D5 Memory hygiene & consolidation — new always-on baseline.** Council now checks: (a) memory entries the PR motivates are written, (b) memory the PR contradicts is updated/deleted, (c) `MEMORY.md` index stays clean, (d) spec/plan files in `docs/superpowers/` are consolidated per `[[release-spec-plan-memory-consolidation]]`. Probes `mempalace` / `mem0` / context-mode KB if available in-session.
3. **Per-dimension specialized-skill mapping.** Sub-agents stay on `general-purpose` (only subagent type that supports arbitrary parallel dispatch) but their prompt now instructs them to invoke the relevant Claude Code skill internally: D1→`review`, D2→`code-review`, **D3→`security-review`** (the most important miss in v1), D4→`superpowers:test-driven-development`, D6→`verify` (if live-verify approved), D10→`security-review` (auth lens).
4. **Stale-working-tree-reads fix.** v1 sub-agents called \`Read\` on the local working tree (currently \`develop\`) instead of the PR HEAD, producing **5+ false-positive must-fix items** on PR #95 (e.g. \"file X doesn't exist\" when it did on the head branch). v2 mandates \`git show origin/<head>:<path>\` via \`ctx_execute\` for any file inspection beyond the diff itself. Phase 0 now captures \`head_branch\` + \`head_sha\` and passes them to every dispatched agent. Section 5 step 5 adds a false-positive filter that spot-checks 2-3 file-state claims before publishing the verdict.

## Baseline dimensions (now 5, was 4)

D1 Correctness · D2 Code quality · D3 Security · D4 Tests · **D5 Memory hygiene (new)**

Adaptive: D6 UI/live-verify · D7 Data-migration · D8 CLI UX · D9 Docs drift · D10 Auth · D11 Release-gate · D12 BDD · D13 Scripts.

## Provenance

- v1 (PR #97, 2026-05-26) — initial slash command, validated on PR #93.
- v2 (this PR, 2026-05-27) — driven by Flavio running v1 on PR #95 and observing that all 7 agents used bare \`general-purpose\` ignoring our specialized skills, and that several findings were stale-tree false positives.
- Memory: [\`llm-council-code-review-pr93\`](https://github.com/ffroliva/gflow-cli/blob/main/skills/pr-council-review/SKILL.md), [\`pr-council-review-portability-backlog\`](https://github.com/ffroliva/gflow-cli/blob/main/skills/pr-council-review/SKILL.md), \`pr-council-review-stale-tree-reads\` (NEW).

## Test plan

- [x] SKILL.md frontmatter valid, skill auto-registers via Claude Code skill list (verified locally — \`pr-council-review\` appears under \`gflow:\` namespace)
- [x] Wrapper command exists and references skill correctly
- [x] All 28 memory slugs referenced in SKILL.md verified to exist (script in this session)
- [ ] **Dry-run on PR #95 via the v2 command (Hybrid sequencing — Flavio's plan)** to validate stale-tree fix drops the false-positive rate. To be done after merge.
- [ ] Optional: cross-tool test (Gemini CLI \`activate_skill('pr-council-review')\`) — defer to Phase A.2 follow-up

## Out of scope (still in backlog per \`pr-council-review-portability-backlog\`)

- **Phase B** Python helpers (\`scripts/dev/pr_council_prefetch.py\` + \`memory_filter.py\`) for ~30-50% per-agent context reduction
- **Phase C** Codify the meta-council (3-dim audit) as \`/gflow:meta-council-audit <path>\` for reuse on future skills/commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)