### PR TITLE
fix(image): correct file extension when Flow returns JPEG bytes (#96)

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -606,7 +606,14 @@ class FlowApiClient:
         if resp.status >= 400:
             _raise_for_non_retryable(resp, await resp.text(), route=route)
         out_path.write_bytes(await resp.body())
-        return out_path
+        # Flow's fife CDN may return JPEG bytes for an image whose target
+        # path is ``.png`` (issue #96). Rename in-place to match the actual
+        # format so downstream tools (and `gflow data list`) see the right
+        # extension. Returns the original path unchanged when format is
+        # already correct or unrecognised.
+        from gflow_cli.paths import correct_image_extension
+
+        return correct_image_extension(out_path)
 
     async def download_video(self, media_id: str, out_path: Path) -> Path:
         """Download a generated video by media ID to disk.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -44,6 +44,7 @@ from gflow_cli.errors import (
     RateLimitError,
     WireFormatError,
 )
+from gflow_cli.paths import correct_image_extension
 
 # Marker substring used by Playwright when a Page/Context/Browser is closed.
 # Stable across recent Playwright versions; we match on message text to avoid
@@ -606,13 +607,7 @@ class FlowApiClient:
         if resp.status >= 400:
             _raise_for_non_retryable(resp, await resp.text(), route=route)
         out_path.write_bytes(await resp.body())
-        # Flow's fife CDN may return JPEG bytes for an image whose target
-        # path is ``.png`` (issue #96). Rename in-place to match the actual
-        # format so downstream tools (and `gflow data list`) see the right
-        # extension. Returns the original path unchanged when format is
-        # already correct or unrecognised.
-        from gflow_cli.paths import correct_image_extension
-
+        # Issue #96: fife CDN may serve JPEG for a .png target — rename in-place.
         return correct_image_extension(out_path)
 
     async def download_video(self, media_id: str, out_path: Path) -> Path:

--- a/src/gflow_cli/paths.py
+++ b/src/gflow_cli/paths.py
@@ -102,6 +102,88 @@ def image_output_path(
     index: int = 1,
     on: date | None = None,
 ) -> Path:
-    """`<output_dir>/images/<YYYY-MM-DD>/<job_id>_<index>.png`."""
+    """`<output_dir>/images/<YYYY-MM-DD>/<job_id>_<index>.png`.
+
+    The ``.png`` suffix is an initial guess — Flow's fife CDN may return
+    JPEG or WebP bytes for the same content type. Callers should write
+    bytes to this path, then pass the result through
+    :func:`correct_image_extension` to rename when the actual format
+    differs. See issue #96.
+    """
     on = on or date.today()
     return output_dir / "images" / on.isoformat() / f"{_validate_job_id(job_id)}_{index}.png"
+
+
+# Magic-byte signatures for the image formats Flow's fife CDN is known to
+# return. Order matters only insofar as it lets the simpler signatures
+# short-circuit; checks are independent. ``RIFF/WEBP`` is special-cased
+# below because RIFF is also used by .wav/.avi.
+_MAGIC_SIGNATURES: tuple[tuple[bytes, str], ...] = (
+    (b"\xff\xd8\xff", ".jpg"),  # JPEG: FF D8 FF (E0/E1/DB/E2/...)
+    (b"\x89PNG\r\n\x1a\n", ".png"),  # PNG: 89 50 4E 47 0D 0A 1A 0A
+    (b"GIF87a", ".gif"),
+    (b"GIF89a", ".gif"),
+)
+
+# Suffixes treated as equivalent to ``.jpg`` for the no-op decision —
+# ``.jpeg`` is a documented alias and ``.jpe`` shows up on some Windows
+# media tooling. Lowercase comparison.
+_JPEG_ALIASES: frozenset[str] = frozenset({".jpg", ".jpeg", ".jpe"})
+
+
+def extension_from_magic(head: bytes) -> str | None:
+    """Return the canonical extension for ``head``'s magic bytes.
+
+    Returns ``".jpg"`` / ``".png"`` / ``".webp"`` / ``".gif"`` for recognised
+    formats, or ``None`` when the buffer is empty, too short, or doesn't
+    match any known signature.
+
+    Only inspects the first ~12 bytes — pass a longer buffer if you have
+    it (no harm), or just the first 12 if you've already sliced.
+    """
+    if len(head) < 3:
+        return None
+    for sig, ext in _MAGIC_SIGNATURES:
+        if head.startswith(sig):
+            return ext
+    # WebP needs both halves: RIFF<4-byte size>WEBP.
+    if len(head) >= 12 and head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return ".webp"
+    return None
+
+
+def correct_image_extension(path: Path) -> Path:
+    """Rename ``path`` to match the format detected in its first bytes.
+
+    The fix for issue #96 — Flow's fife CDN sometimes serves JPEG bytes
+    for a t2i / i2i request whose downstream filename is ``.png``. After
+    writing the bytes to disk, call this to rename the file in-place to
+    the correct extension.
+
+    No-ops in any of these cases:
+
+    * The first 12 bytes don't match any known image signature.
+    * The current extension already matches the detected format
+      (case-insensitive).
+    * The current extension is a ``.jpg`` alias (``.jpeg`` / ``.jpe``)
+      and the detected format is ``.jpg``.
+    * The target name already exists — avoids clobbering data on a
+      retry race; caller keeps the misnamed original.
+
+    Returns the (possibly renamed) :class:`Path`.
+    """
+    head = path.read_bytes()[:12]
+    actual = extension_from_magic(head)
+    if actual is None:
+        return path
+    current = path.suffix.lower()
+    if current == actual:
+        return path
+    if actual == ".jpg" and current in _JPEG_ALIASES:
+        return path
+    target = path.with_suffix(actual)
+    if target.exists():
+        # Collision: keep the original name rather than silently overwrite.
+        return path
+    path.rename(target)
+    return target

--- a/tests/api/test_client_image.py
+++ b/tests/api/test_client_image.py
@@ -515,6 +515,31 @@ class TestDownloadImage:
         out = await client.download_image(_make_image(fife_url=good_url), tmp_path / "out.png")
         assert out.read_bytes() == b"png"
 
+    async def test_download_image_corrects_jpeg_with_png_suffix(
+        self, client: FlowApiClient, tmp_path: Path
+    ) -> None:
+        """Issue #96: when Flow's fife_url returns JPEG bytes but the caller
+        requested ``.png``, the returned path must be ``.jpg`` and the bytes
+        must be intact on disk under the new name."""
+        jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 100
+
+        async def fake_request_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status = 200
+            resp.body = AsyncMock(return_value=jpeg_bytes)
+            return resp
+
+        client._page.request.get = AsyncMock(side_effect=fake_request_get)
+
+        out_path = tmp_path / "abc_1.png"
+        result = await client.download_image(_make_image(), out_path)
+
+        assert result.suffix == ".jpg"
+        assert result.name == "abc_1.jpg"
+        assert result.read_bytes() == jpeg_bytes
+        # Original .png path no longer exists — file was renamed in-place.
+        assert not out_path.exists()
+
 
 class TestSpecC2TokenReMint:
     """Spec C2: reCAPTCHA token is minted INSIDE the retry loop, EVERY attempt.

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -150,8 +150,17 @@ def _make_generated_image(
 def _make_t2i_client(
     *,
     images: list[GeneratedImage] | None = None,
+    payload: bytes = b"\x89PNG\r\n\x1a\n",
 ) -> MagicMock:
-    """Stub FlowApiClient: create_project + generate_image[s_batch] + download_image."""
+    """Stub FlowApiClient: create_project + generate_image[s_batch] + download_image.
+
+    ``payload`` is the bytes written by the fake ``download_image``. The fake
+    mirrors the real client (``api/client.py``): write bytes, then pass through
+    ``correct_image_extension`` so the CLI sees the post-rename path. Pass a
+    JPEG header to exercise the issue-#96 codepath end-to-end.
+    """
+    from gflow_cli.paths import correct_image_extension
+
     images = images or [_make_generated_image()]
     client = MagicMock()
     client.__aenter__ = AsyncMock(return_value=client)
@@ -164,8 +173,8 @@ def _make_t2i_client(
 
     async def _fake_download(image: GeneratedImage, out_path: Path) -> Path:
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_bytes(b"\x89PNG\r\n\x1a\n")
-        return out_path
+        out_path.write_bytes(payload)
+        return correct_image_extension(out_path)
 
     client.download_image = AsyncMock(side_effect=_fake_download)
     return client
@@ -706,6 +715,45 @@ class TestRecorderIntegration:
         assert rec["images"] == images
         assert len(rec["saved_paths"]) == 1
         assert recorder.closed
+
+    def test_t2i_records_corrected_extension_when_bytes_are_jpeg(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Issue #96 end-to-end: when Flow's CDN serves JPEG bytes for a
+        `.png` target, the recorder must receive the corrected `.jpg` path
+        — not the original `.png`. This is the surface that broke in PR #93;
+        unit + transport tests would have passed there too."""
+        images = [_make_generated_image(media_name="m1")]
+        # JFIF header followed by padding — sniffer detects this as .jpg.
+        jpeg_payload = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 64
+        client = _make_t2i_client(images=images, payload=jpeg_payload)
+        recorder = FakeRecorder()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch("gflow_cli.cli_image.OperationRecorder.open", return_value=recorder),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        rec = recorder.generated[0]
+        # Recorder receives the post-rename path — historical trap surface.
+        assert len(rec["saved_paths"]) == 1
+        saved = rec["saved_paths"][0]
+        assert saved.suffix == ".jpg", f"recorder got {saved!r}, expected .jpg"
+        assert saved.exists()
+        assert saved.read_bytes() == jpeg_payload
+        # No stale `.png` left in the output directory.
+        assert list(out_dir.rglob("*.png")) == []
 
     def test_i2i_records_inputs_and_outputs(self, runner: CliRunner, tmp_path: Path) -> None:
         # Post-PR-#50 i2i flow distinguishes two ref shapes:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -94,3 +94,118 @@ class TestResolveBatchOutputDirExpanduser:
             output_root=Path("/unused"),
         )
         assert out == Path("/abs/path")
+
+
+# Realistic magic-byte fixtures used by the extension-sniff tests. The
+# remaining body bytes are zero-padding; only the first ~12 bytes matter.
+_JPEG_JFIF_HEAD = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 100
+_JPEG_EXIF_HEAD = b"\xff\xd8\xff\xe1\x00\x10Exif" + b"\x00" * 100
+_PNG_HEAD = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+_WEBP_HEAD = b"RIFF\x00\x00\x00\x00WEBPVP8 " + b"\x00" * 100
+
+
+class TestExtensionFromMagic:
+    """`extension_from_magic` maps file-magic bytes to a canonical extension."""
+
+    def test_jpeg_jfif(self) -> None:
+        assert paths.extension_from_magic(_JPEG_JFIF_HEAD) == ".jpg"
+
+    def test_jpeg_exif(self) -> None:
+        assert paths.extension_from_magic(_JPEG_EXIF_HEAD) == ".jpg"
+
+    def test_png(self) -> None:
+        assert paths.extension_from_magic(_PNG_HEAD) == ".png"
+
+    def test_webp(self) -> None:
+        # RIFF + 4 size bytes + 'WEBP' — must verify both halves.
+        assert paths.extension_from_magic(_WEBP_HEAD) == ".webp"
+
+    def test_gif87a(self) -> None:
+        assert paths.extension_from_magic(b"GIF87a\x00\x00\x00\x00") == ".gif"
+
+    def test_gif89a(self) -> None:
+        assert paths.extension_from_magic(b"GIF89a\x00\x00\x00\x00") == ".gif"
+
+    def test_unknown_returns_none(self) -> None:
+        assert paths.extension_from_magic(b"NOT_AN_IMAGE_AT_ALL") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert paths.extension_from_magic(b"") is None
+
+    def test_two_bytes_returns_none(self) -> None:
+        # JPEG signature is 3 bytes; 2 bytes is insufficient.
+        assert paths.extension_from_magic(b"\xff\xd8") is None
+
+    def test_riff_without_webp_returns_none(self) -> None:
+        # RIFF is also used by .wav / .avi — only return .webp when bytes 8-11 == 'WEBP'.
+        assert paths.extension_from_magic(b"RIFF\x00\x00\x00\x00WAVE") is None
+
+
+class TestCorrectImageExtension:
+    """`correct_image_extension` renames a downloaded file to match its actual
+    format. Core fix for issue #96 (JPEG bytes written with .png suffix)."""
+
+    def test_jpeg_with_png_suffix_renamed(self, tmp_path: Path) -> None:
+        # The exact bug from issue #96: JPEG bytes saved as .png.
+        wrong = tmp_path / "abc-123_1.png"
+        wrong.write_bytes(_JPEG_JFIF_HEAD)
+        corrected = paths.correct_image_extension(wrong)
+        assert corrected.name == "abc-123_1.jpg"
+        assert corrected.exists()
+        assert not wrong.exists()
+        assert corrected.read_bytes() == _JPEG_JFIF_HEAD
+
+    def test_matching_png_no_op(self, tmp_path: Path) -> None:
+        right = tmp_path / "foo.png"
+        right.write_bytes(_PNG_HEAD)
+        corrected = paths.correct_image_extension(right)
+        assert corrected == right
+        assert right.exists()
+
+    def test_matching_jpg_no_op(self, tmp_path: Path) -> None:
+        right = tmp_path / "foo.jpg"
+        right.write_bytes(_JPEG_JFIF_HEAD)
+        corrected = paths.correct_image_extension(right)
+        assert corrected == right
+
+    def test_jpeg_extension_alias_not_renamed(self, tmp_path: Path) -> None:
+        # ``.jpeg`` is a valid alias of ``.jpg``; treat as a match.
+        right = tmp_path / "foo.jpeg"
+        right.write_bytes(_JPEG_JFIF_HEAD)
+        corrected = paths.correct_image_extension(right)
+        assert corrected == right
+
+    def test_unknown_format_no_op(self, tmp_path: Path) -> None:
+        f = tmp_path / "foo.png"
+        f.write_bytes(b"NOT_AN_IMAGE_DATA_AT_ALL")
+        corrected = paths.correct_image_extension(f)
+        assert corrected == f
+        assert f.exists()
+
+    def test_target_already_exists_no_op(self, tmp_path: Path) -> None:
+        # If the corrected target already exists, leave the original alone
+        # rather than clobbering. Avoids data loss on retry races.
+        wrong = tmp_path / "foo.png"
+        wrong.write_bytes(_JPEG_JFIF_HEAD)
+        existing = tmp_path / "foo.jpg"
+        existing.write_bytes(b"some other content")
+        corrected = paths.correct_image_extension(wrong)
+        assert corrected == wrong
+        assert wrong.exists()
+        # Pre-existing target is untouched.
+        assert existing.read_bytes() == b"some other content"
+
+    def test_case_insensitive_extension(self, tmp_path: Path) -> None:
+        # ``.PNG`` matches ``.png`` for the no-op decision (Windows-friendly).
+        right = tmp_path / "foo.PNG"
+        right.write_bytes(_PNG_HEAD)
+        corrected = paths.correct_image_extension(right)
+        assert corrected == right
+
+    def test_webp_with_png_suffix_renamed(self, tmp_path: Path) -> None:
+        # Future-proofing: Flow has historically served WebP for some surfaces.
+        wrong = tmp_path / "foo.png"
+        wrong.write_bytes(_WEBP_HEAD)
+        corrected = paths.correct_image_extension(wrong)
+        assert corrected.name == "foo.webp"
+        assert corrected.exists()


### PR DESCRIPTION
Closes #96.

## Summary

Flow's `fife` CDN may return JPEG bytes for an image whose downstream filename was constructed as `.png`. The file was readable by tools that magic-sniff (Pillow) but mishandled by anything that trusts the extension (ffmpeg, ImageMagick without `-f`, Windows Photo Viewer, downstream consumers reading kind from path).

**Fix:** post-write magic-byte sniff + rename, applied at the single seam (`client.download_image`) where bytes are first on disk. All four production call sites (t2i / i2i / image-batch ×2) flow through this method and get the fix transparently.

## Changes

Two helpers in `src/gflow_cli/paths.py`:

- `extension_from_magic(head: bytes) -> str | None` — maps JPEG / PNG / WebP / GIF magic bytes to canonical extensions; `None` for unknown or short buffers.
- `correct_image_extension(path: Path) -> Path` — read first 12 bytes; rename in-place to match. No-ops on unknown format, matching extension, `.jpeg`/`.jpe` aliases, and target-name collisions (no clobber on retry).

One call-site change in `src/gflow_cli/api/client.py:download_image()`: invoke `correct_image_extension(out_path)` after `write_bytes(...)` and return the possibly-renamed path.

`image_output_path()` keeps its `.png` default — it's now an initial guess; the post-write correction is the source of truth. Docstring updated.

## Tests (`tests/test_paths.py` + `tests/api/test_client_image.py` + `tests/cli/test_cli_image.py`)

| Layer | Tests | What's verified |
|---|---|---|
| Unit (paths.py helpers) | 18 cases | All formats, edge cases (empty, short, alias, case, collision, unknown, RIFF-without-WEBP) |
| Integration (client.download_image) | 1 case | JPEG bytes via mocked `page.request.get` → returned path is `.jpg`, original `.png` is gone |
| CLI-layer (t2i → recorder) | 1 case | The recorder receives the post-rename `.jpg` saved_path (the PR #93 trap surface) |

Scoped run: `pytest tests/test_paths.py tests/api/test_client_image.py tests/cli/test_cli_image.py` → 95 passed.

## Live verification (2026-05-27, de-DE / nano2 / ffroliva profile)

Run: `GFLOW_CLI_LOCALE=de-DE gflow image t2i "a calm forest at dawn" --profile ffroliva --model nano2 --out C:/tmp/gflow-verify-96`

| Ledger layer | Result |
|---|---|
| 1 — file count | 1 file written |
| 2 — magic bytes | `ffd8ffe0` → JPEG; file suffix `.jpg` → ✅ match |
| 3 — Pillow open | `format=JPEG size=(768, 1376) mode=RGB` (same dims as original bug report) |
| 4 — structlog events | `clicking_new_project` / `entered_editor` / `image_mode_entered` / `count_setter_completed` / `prompt_submitted` / `batch_response_captured (200)` all present |
| 5 — gallery (manual) | File is a valid JPEG; user can spot-check |

Output file: `C:\tmp\gflow-verify-96\088df4f1-0256-42d6-8a80-885250d52291_1.jpg` (the `_1.jpg` extension is the fix in action — pre-fix this would have been `_1.png` containing JPEG bytes).

## Council audit

Branch reviewed pre-PR via `/gflow:branch-review` (5 parallel reviewers, REVIEWED_SHA `2174ccb`). Verdict went 🟡 YELLOW → 🟢 after must-fixes applied:

- **D2 (Code quality)** — moved `correct_image_extension` import from inside `download_image()` to module-top (no circular-import excuse).
- **D4 (Tests)** — added the CLI-layer regression test (the PR #93 trap surface).
- **D5 (Memory hygiene)** — updated `[[image-t2i-jpeg-with-png-extension]]` memory entry to RESOLVED + MEMORY.md tagline (out-of-repo).

D1 Correctness and D3 Security were GREEN throughout.

## Out of scope (per issue acceptance)

- No retroactive migration of existing `.png`-containing-JPEG files in the data catalog.
- `_is_supported_image_header` (upload MIME validation, `api/client.py:82`) and the inline sniff in `ui_automation._download` are out of scope for this PR — three magic-byte sites now exist in the repo and a future consolidation pass is warranted.

## Test plan

- [x] Unit tests pass
- [x] Integration test pass
- [x] CLI-layer regression test pass
- [x] Live t2i verify on de-DE / nano2 confirms `.jpg` extension when bytes are JPEG
- [ ] Reviewer opens `C:\tmp\gflow-verify-96\088df4f1-...291_1.jpg` to confirm it renders as a valid image