### PR TITLE
feat(image): enforce per-model i2i reference cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-model i2i reference-image cap.** Flow silently keeps only the first N
+  reference images when an i2i request attaches more than the model accepts,
+  so a caller could believe every ref was used. `gflow_cli.api.image.reference_cap_for(model)`
+  exposes the live-observed per-model cap: NARWHAL (Nano Banana 2) and GEM_PIX_2
+  (Nano Pro) accept 10, IMAGEN_3_5 (Imagen 4) accepts 3. Enforced as a domain
+  invariant in `GenerateImageRequest.__post_init__` and at the CLI boundary in
+  `gflow image i2i` (clean `click.UsageError` / exit 2 before any
+  profile/network work). Mirrors the existing video r2v cap pattern. E2e
+  tripwire at `tests/e2e/test_image_i2i_ref_cap_e2e.py` asserts Flow actually
+  consumes all `cap` refs (one `reference_attached` event per ref) so a future
+  silent truncation on the Flow side fails the test.
 - **Layered e2e test strategy with cost sub-markers.** The single `e2e` marker is
   now augmented by cost sub-markers (`e2e_auth`, `e2e_image`, `e2e_video`,
   `e2e_batch`, `e2e_data`, `smoke`) so callers can run only the tier they can

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -137,6 +137,30 @@ _MODEL_FROM_CLI: Mapping[str, Model] = MappingProxyType(
     }
 )
 
+# Per-model I2I reference-image cap (live-observed). Flow silently keeps only
+# the first N references when more are attached, so the request is rejected up
+# front rather than letting the caller believe every ref was used. NARWHAL
+# (Nano Banana 2) and GEM_PIX_2 (Nano Pro) accept 10; IMAGEN_3_5 (Imagen 4)
+# accepts 3. MAX_IMAGE_REFERENCES is the ceiling for any (incl. future) model.
+MAX_IMAGE_REFERENCES = 10
+_IMAGE_REFERENCE_CAP: Mapping[Model, int] = MappingProxyType(
+    {
+        Model.NARWHAL: 10,
+        Model.GEM_PIX_2: 10,
+        Model.IMAGEN_3_5: 3,
+    }
+)
+
+
+def reference_cap_for(model: Model) -> int:
+    """Maximum number of I2I reference images *model* accepts.
+
+    Unknown/future models fall back to :data:`MAX_IMAGE_REFERENCES` rather than
+    raising, so adding a `Model` member without a cap entry degrades to the
+    ceiling instead of a `KeyError` at request-build time.
+    """
+    return _IMAGE_REFERENCE_CAP.get(model, MAX_IMAGE_REFERENCES)
+
 
 @dataclass(frozen=True)
 class ImageRef:
@@ -195,6 +219,12 @@ class GenerateImageRequest:
             raise ValueError("GenerateImageRequest.prompt must be non-empty")
         if not 1 <= self.count <= 4:
             raise ValueError(f"GenerateImageRequest.count must be 1–4, got {self.count}")
+        n_refs = len(self.refs) + len(self.ref_paths)
+        cap = reference_cap_for(self.model)
+        if n_refs > cap:
+            raise ValueError(
+                f"{self.model.value} allows at most {cap} reference image(s); got {n_refs}"
+            )
 
 
 def _client_context(*, project_id: str, recaptcha_token: str, session_id: str) -> dict[str, Any]:

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -32,7 +32,7 @@ from gflow_cli._cli_helpers import (
 )
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.dto import GeneratedImage
-from gflow_cli.api.image import Aspect, GenerateImageRequest, ImageRef, Model
+from gflow_cli.api.image import Aspect, GenerateImageRequest, ImageRef, Model, reference_cap_for
 from gflow_cli.api.transports import transport_choices
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
@@ -821,6 +821,16 @@ def i2i(
     # "no --ref" case with exit 2 before we get here.
     classified_refs: list[ImageRef | Path] = [_classify_ref(ref) for ref in refs]
 
+    # Reject over-cap ref counts at the CLI boundary with a clear message (exit
+    # 2) rather than letting the domain ValueError surface as a generic error.
+    # GenerateImageRequest.__post_init__ enforces the same cap as an invariant.
+    model_enum = Model.from_cli(model)
+    cap = reference_cap_for(model_enum)
+    if len(classified_refs) > cap:
+        raise click.UsageError(
+            f"{model} allows at most {cap} reference image(s); got {len(classified_refs)}."
+        )
+
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     settings = get_settings()
@@ -832,7 +842,7 @@ def i2i(
             prompt=prompt,
             classified_refs=classified_refs,
             aspect=Aspect.from_cli(aspect),
-            model=Model.from_cli(model),
+            model=model_enum,
             count=count,
             out=out,
             output_root=settings.output_dir,

--- a/tests/api/test_image.py
+++ b/tests/api/test_image.py
@@ -16,11 +16,13 @@ from typing import Any
 import pytest
 
 from gflow_cli.api.image import (
+    MAX_IMAGE_REFERENCES,
     Aspect,
     GenerateImageRequest,
     ImageRef,
     Model,
     _build_batch_generate_images_body,
+    reference_cap_for,
 )
 
 SAMPLES_DIR = Path(__file__).resolve().parents[2] / "samples" / "captured"
@@ -163,6 +165,48 @@ class TestGenerateImageRequest:
     def test_recaptcha_token_defaults_to_empty(self) -> None:
         req = GenerateImageRequest(prompt="test", model=Model.NARWHAL, aspect=Aspect.PORTRAIT)
         assert req.recaptcha_token == ""
+
+
+class TestReferenceCap:
+    def test_cap_values(self) -> None:
+        assert reference_cap_for(Model.NARWHAL) == 10
+        assert reference_cap_for(Model.GEM_PIX_2) == 10
+        assert reference_cap_for(Model.IMAGEN_3_5) == 3
+
+    def test_at_cap_is_allowed(self) -> None:
+        # Imagen 4 at exactly its 3-ref cap must build cleanly.
+        req = GenerateImageRequest(
+            prompt="ok",
+            model=Model.IMAGEN_3_5,
+            refs=tuple(ImageRef(f"ref-{i}") for i in range(3)),
+        )
+        assert len(req.refs) == 3
+
+    def test_over_cap_raises(self) -> None:
+        with pytest.raises(ValueError, match="at most 3"):
+            GenerateImageRequest(
+                prompt="too many",
+                model=Model.IMAGEN_3_5,
+                refs=tuple(ImageRef(f"ref-{i}") for i in range(4)),
+            )
+
+    def test_cap_counts_refs_and_ref_paths_together(self) -> None:
+        # The cap is on TOTAL refs (uploaded UUIDs + local files combined).
+        with pytest.raises(ValueError, match="at most 3"):
+            GenerateImageRequest(
+                prompt="mix",
+                model=Model.IMAGEN_3_5,
+                refs=(ImageRef("a"), ImageRef("b")),
+                ref_paths=(Path("c.png"), Path("d.png")),
+            )
+
+    def test_nano_allows_ten(self) -> None:
+        req = GenerateImageRequest(
+            prompt="ten refs",
+            model=Model.NARWHAL,
+            refs=tuple(ImageRef(f"ref-{i}") for i in range(MAX_IMAGE_REFERENCES)),
+        )
+        assert len(req.refs) == MAX_IMAGE_REFERENCES
 
 
 class TestBuildBatchGenerateImagesBody:

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -122,6 +122,28 @@ class TestImageUpload:
         assert str(missing) in result.output or "does not exist" in result.output.lower()
 
 
+class TestI2iRefCap:
+    def test_i2i_rejects_over_cap_refs(self, runner: CliRunner) -> None:
+        # imagen4 caps at 3 refs; 4 UUID refs must be rejected at the CLI
+        # boundary (exit 2) before any profile/network work. UUIDs are used so
+        # _classify_ref treats them as assets and doesn't stat a local file.
+        uuids = [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+            "33333333-3333-3333-3333-333333333333",
+            "44444444-4444-4444-4444-444444444444",
+        ]
+        from gflow_cli.cli import main
+
+        args = ["image", "i2i", "stylize", "--model", "imagen4"]
+        for u in uuids:
+            args += ["--ref", u]
+        result = runner.invoke(main, args, catch_exceptions=False)
+
+        assert result.exit_code == 2, result.output
+        assert "at most 3" in result.output
+
+
 # ---------------------------------------------------------------------------
 # t2i subcommand
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_image_i2i_ref_cap_e2e.py
+++ b/tests/e2e/test_image_i2i_ref_cap_e2e.py
@@ -1,0 +1,117 @@
+"""E2E test for per-model i2i reference-image cap.
+
+Verifies that ``Model.NARWHAL`` (nano-banana-2) accepts the full 10-ref
+boundary against the real Flow API — Flow silently keeps only the first
+N refs when more are attached, so a "wrong cap" bug shows up as: the
+generate call succeeds but ``ui_automation_video.reference_attached``
+fires fewer than the requested N times. Asserting on the structured
+event closes that false-positive class. Costs 1 Imagen credit.
+
+Skipped by default; opt in with::
+
+    GFLOW_CLI_E2E_PROFILE=<profile-name> uv run pytest -m e2e_image -v \\
+        tests/e2e/test_image_i2i_ref_cap_e2e.py
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+import structlog
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.image import GenerateImageRequest, Model, reference_cap_for
+
+pytestmark = pytest.mark.e2e
+
+_PROMPT = "place all references in a single colorful collage"
+
+
+def _tiny_png(path: Path, color: tuple[int, int, int]) -> Path:
+    """Write a valid 8x8 RGBA PNG of the given color. Lifted from
+    ``test_transports_e2e._tiny_png`` so this file is self-contained."""
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        crc = zlib.crc32(body) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", crc)
+
+    w = h = 8
+    r, g, b = color
+    raw = b"".join(b"\x00" + bytes((r, g, b, 0xFF)) * w for _ in range(h))
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_image
+async def test_e2e_i2i_at_cap_nano2_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """`nano2` at its 10-ref cap returns a valid image AND Flow actually
+    consumes all 10 refs (one `reference_attached` event per ref).
+
+    If Flow's actual cap is lower than ``reference_cap_for(NARWHAL)`` (10),
+    fewer events fire and the test FAILS — a tripwire for cap drift on the
+    Flow side. The cap-reject path (11 refs) is covered by unit + CLI tests
+    (`tests/api/test_image.py`, `tests/cli/test_cli_image.py`) and does not
+    spend a credit.
+    """
+    # Undo the autouse `_isolate_settings` fixture (tests/conftest.py) so
+    # profile lookup resolves to the user's real platformdirs path (where the
+    # live Chrome session was planted by `gflow auth login`). Isolation is the
+    # right default for non-e2e but breaks e2e session-dependent tests.
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile name")
+    e2e_profile_dir = _resolve_profile_dir(name)
+    if not e2e_profile_dir.exists():
+        pytest.skip(f"profile dir not found: {e2e_profile_dir}")
+
+    cap = reference_cap_for(Model.NARWHAL)
+    refs = tuple(
+        _tiny_png(tmp_path / f"r{i}.png", color=(40 + 20 * i, 80, 160 - 10 * i)) for i in range(cap)
+    )
+    req = GenerateImageRequest(prompt=_PROMPT, model=Model.NARWHAL, ref_paths=refs)
+
+    async with FlowApiClient(profile_dir=e2e_profile_dir) as client:
+        project = await client.create_project(title=f"e2e-i2i-cap-{cap}")
+        image = await client.generate_image(project_id=project.project_id, req=req)
+
+    assert image.media_name, "i2i at-cap returned no image"
+    assert image.fife_url.startswith("https://"), (
+        f"fife_url must be an https:// URL, got: {image.fife_url!r}"
+    )
+
+    # The cap-drift tripwire: Flow must report `reference_attached` for ALL
+    # `cap` refs. If only N < cap fire, Flow silently truncated and our cap
+    # value is too generous — bumping `reference_cap_for(NARWHAL)` would
+    # invite re-introduction of the bug this PR closes.
+    attached = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.reference_attached"
+    ]
+    assert len(attached) == cap, (
+        f"expected {cap} reference_attached events at the at-cap boundary; "
+        f"got {len(attached)}. Flow likely truncated silently — verify the "
+        f"`reference_cap_for(NARWHAL)` value matches Flow's actual cap."
+    )


### PR DESCRIPTION
## Summary

Flow silently keeps only the first N reference images when an `image i2i` request attaches more than the model accepts, so a caller could believe every ref was used. This PR adds the per-model cap as a data table and rejects over-cap requests up front, mirroring the existing video r2v cap pattern (PR #48):

| Model | Alias | Cap |
|---|---|---|
| `NARWHAL` | `nano2` (Nano Banana 2) | 10 |
| `GEM_PIX_2` | `nano-pro` (Nano Pro) | 10 |
| `IMAGEN_3_5` | `imagen4` / `image4` (Imagen 4) | 3 |

Enforced in two places (same as r2v):

- `GenerateImageRequest.__post_init__` — raises `ValueError` (domain invariant)
- `gflow image i2i` CLI — raises `click.UsageError` (clean exit 2 before any profile/network work)

`reference_cap_for(model)` exposes the cap publicly. Unknown/future models fall back to `MAX_IMAGE_REFERENCES = 10` rather than `KeyError`, so adding a new `Model` member without a cap entry degrades gracefully to the ceiling.

The cap values are live-observed (2026-05-24/28, Pro tier) on the live Flow UI: the editor's Add Media button disappears at N+1 (10 for nano2/nano-pro, 3 for imagen4).

## Validation

- [x] **Unit tests** — `tests/api/test_image.py` (domain `ValueError` per model, boundary `cap` vs `cap+1`) and `tests/cli/test_cli_image.py` (CLI `UsageError` exit 2, error-message contains model name + cap)
- [x] **E2e tripwire** — `tests/e2e/test_image_i2i_ref_cap_e2e.py::test_e2e_i2i_at_cap_nano2_succeeds` (1 Imagen credit, gated by `GFLOW_CLI_E2E_PROFILE`, `pytest -m e2e_image`). Sends 10 refs at the at-cap boundary and asserts ALL ten `ui_automation_video.reference_attached` events fire — if Flow silently truncates to a lower count in the future, this test fails as a cap-drift tripwire.
- [x] `uv run python scripts/ci/check_repo_hygiene.py` → 299 files clean
- [x] `uv run ruff check src tests` → clean
- [x] `uv run ruff format --check src tests` → 131 files already formatted
- [x] `uv run pyright src` → 1314 errors, ALL pre-existing baseline (`origin/develop` reports 1352 on the same checkout)
- [x] `uv run pytest -q --cov=gflow_cli --cov-fail-under=80` → **972 passed**, coverage **86.45%**
- [x] **Live verification** on a Pro profile (2026-05-28):
  - `gflow image i2i "test" --model nano2 --ref ... (11 refs)` → `exit 2`, message `nano2 allows at most 10 reference image(s); got 11.` (CLI guard fires before network — no credit spent)
  - `gflow image i2i "test" --model nano2 --ref ... (10 refs) --json` → real Flow gen succeeded, image saved 0.34 MB, all 10 `reference_attached` events fired, `images[0].seed = 201803`

## Notes

- The matching cap-on-r2v change (replace `OMNI_REFERENCE_CAP=7` / `VEO_REFERENCE_CAP=3` constants with a `VideoModel -> int` mapping that also covers `VEO_3_1_LITE_LOWER_PRIORITY` and the `VEO_3_1_QUALITY=0` "R2V unsupported" case per the [Flow models support page](https://support.google.com/flow/answer/16352836?hl=en)) is in a sibling PR — happy to keep them as separate reviews or bundle them, whichever you prefer.
- One small upstream gotcha I hit running the new e2e locally: the autouse `_isolate_settings` fixture in `tests/conftest.py` (the one that pins `GFLOW_CLI_HOME` to `tmp_path/gflow_home`) makes the `tests/e2e/conftest.py::e2e_profile_dir` fixture skip every e2e test, because the user's real Chrome session lives under platformdirs, not tmp. The new e2e test calls `monkeypatch.delenv("GFLOW_CLI_HOME"); reset_settings()` at the top to undo the isolation — same pattern your `CONTRIBUTING.md` already documents for default-resolution tests. Happy to also push a tiny `tests/e2e/conftest.py` patch that does this once for all e2e tests if you'd find that useful.
