### PR TITLE
feat(video): enforce per-model r2v reference cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-model r2v reference-image cap rebuilt as a data table.** Replaces the
+  prior pair of constants (`OMNI_REFERENCE_CAP=7`, `VEO_REFERENCE_CAP=3`) with
+  a `VideoModel -> int` mapping consulted by
+  `gflow_cli.api.video.reference_cap_for(model)`. New entries:
+  `veo_3_1_lite_lower_priority=3` (was implicitly covered by the veo branch),
+  and `veo_3_1_quality=0` — Veo 3.1 Quality does NOT support
+  Ingredients/References to Video at all per Google Flow's official support
+  page; passing it to r2v raises a clear `does not support R2V
+  (reference-to-video)` error rather than letting the request fail at the
+  wire. CLI guard added on `gflow video r2v` (`click.UsageError`, exit 2)
+  mirroring the i2i pattern so over-cap and quality+r2v fail before any
+  profile/network work. E2e tripwire at
+  `tests/e2e/test_video_r2v_ref_cap_e2e.py` asserts Flow actually consumes
+  all `cap` refs at the at-cap boundary.
 - **Per-model i2i reference-image cap.** Flow silently keeps only the first N
   reference images when an i2i request attaches more than the model accepts,
   so a caller could believe every ref was used. `gflow_cli.api.image.reference_cap_for(model)`
@@ -36,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `gflow_cli.api.video` no longer exposes the standalone `OMNI_REFERENCE_CAP` /
+  `VEO_REFERENCE_CAP` constants. Callers that need a per-model R2V cap should
+  use `reference_cap_for(model)` (which returns `0` for `VEO_3_1_QUALITY` —
+  R2V is unsupported there). `MAX_REFERENCE_IMAGES` (= 7) is unchanged and
+  still the absolute ceiling used when the model is unknown.
 - `GFLOW_CLI_E2E_RUN_VIDEO` default flipped from `"1"` to `"0"`. The Veo step in
   `test_data_layer_e2e.py` is now **opt-in**: set `GFLOW_CLI_E2E_RUN_VIDEO=1` to
   include it. This prevents accidental Veo credit burns on unattended CI runs.

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -8,10 +8,11 @@ retired — see the Phase A plan).
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 
@@ -90,14 +91,37 @@ class Aspect(StrEnum):
         return mapping[value]
 
 
-# Flow's R2V reference cap is MODEL-DEPENDENT (live-verified): omni_flash allows
-# 7 ("Maximum image ingredients reached (7 allowed)"), the veo_3_1_* models allow
-# 3. A veo request with >3 refs uploads all but the generate request silently
-# keeps only 3. MAX_REFERENCE_IMAGES is the absolute ceiling (omni); the
-# model-aware check below enforces the per-model limit when the model is known.
-OMNI_REFERENCE_CAP = 7
-VEO_REFERENCE_CAP = 3
-MAX_REFERENCE_IMAGES = OMNI_REFERENCE_CAP
+# Flow's R2V reference cap is MODEL-DEPENDENT (live-verified + Google's
+# official support page): omni_flash allows 7 ("Maximum image ingredients
+# reached (7 allowed)"); veo_3_1_lite / veo_3_1_fast / veo_3_1_lite_lower_priority
+# allow 3; veo_3_1_quality does NOT support R2V at all (Google Flow help page
+# "Ingredients/References to Video" row = "No"). A request that exceeds the cap
+# uploads all refs but the generate call silently keeps only N — so we reject
+# up front. MAX_REFERENCE_IMAGES is the absolute ceiling (omni) used when the
+# model is unknown; the model-aware check below enforces the exact per-model
+# limit (incl. the special cap=0 for QUALITY) when the model is known.
+MAX_REFERENCE_IMAGES = 7
+_VIDEO_REFERENCE_CAP: Mapping[VideoModel, int] = MappingProxyType(
+    {
+        VideoModel.OMNI_FLASH: 7,
+        VideoModel.VEO_3_1_LITE: 3,
+        VideoModel.VEO_3_1_FAST: 3,
+        VideoModel.VEO_3_1_LITE_LOWER_PRIORITY: 3,
+        VideoModel.VEO_3_1_QUALITY: 0,  # R2V unsupported per Google Flow docs
+    }
+)
+
+
+def reference_cap_for(model: VideoModel) -> int:
+    """Maximum number of R2V reference images *model* accepts.
+
+    Returns 0 for models that do not support R2V at all
+    (``VEO_3_1_QUALITY`` — per Google Flow's official support page).
+    Unknown/future models fall back to :data:`MAX_REFERENCE_IMAGES` rather than
+    raising, so adding a new ``VideoModel`` member without a cap entry degrades
+    to the ceiling instead of a ``KeyError`` at request-build time.
+    """
+    return _VIDEO_REFERENCE_CAP.get(model, MAX_REFERENCE_IMAGES)
 
 
 @dataclass(frozen=True)
@@ -152,14 +176,17 @@ class GenerateVideoRequest:
                 raise ValueError("R2V request must not carry start/end images")
         if len(self.reference_images) > MAX_REFERENCE_IMAGES:
             raise ValueError(f"at most {MAX_REFERENCE_IMAGES} reference images")
-        # Per-model reference cap: omni_flash=7, veo_3_1_*=3 (live-verified). When
-        # the model is None (Flow UI default) we can't know it — leave the ceiling.
+        # Per-model reference cap (live-verified): omni_flash=7, veo lite/fast/lite_lp=3,
+        # veo_quality=0 (R2V unsupported per Google docs). When the model is None
+        # (Flow UI default) we can't know it — leave the absolute ceiling above.
         if self.mode is Mode.R2V and self.model is not None:
-            cap = OMNI_REFERENCE_CAP if self.model is VideoModel.OMNI_FLASH else VEO_REFERENCE_CAP
+            cap = reference_cap_for(self.model)
+            if cap == 0:
+                raise ValueError(f"{self.model.value} does not support R2V (reference-to-video)")
             if len(self.reference_images) > cap:
                 raise ValueError(
-                    f"{self.model.value} allows at most {cap} reference images; "
-                    f"got {len(self.reference_images)} (omni_flash allows {OMNI_REFERENCE_CAP})"
+                    f"{self.model.value} allows at most {cap} reference image(s); "
+                    f"got {len(self.reference_images)}"
                 )
         if self.seed is not None and not (0 <= self.seed <= 2**31 - 1):
             raise ValueError("seed out of range")

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -18,6 +18,7 @@ from gflow_cli._cli_helpers import (
     _resolve_profile,
     run_with_handlers,
 )
+from gflow_cli.api.video import VideoModel, reference_cap_for
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import DataStoreError
@@ -372,12 +373,14 @@ def i2v(
     "r2v",
     short_help="Generate a video from reference images + prompt (ingredients).",
     help=(
-        "Reference-to-video: condition a generation on 1-3 reference images "
-        "(Flow's 'ingredients' / Elementos).\n\n"
+        "Reference-to-video: condition a generation on reference images "
+        "(Flow's 'ingredients' / Elementos). Per-model cap: omni-flash accepts "
+        "up to 7, veo-lite/veo-fast/veo-lite-lp accept up to 3, veo-quality "
+        "does not support R2V at all.\n\n"
         "\b\n"
         "Examples:\n"
-        '  gflow video r2v "a knight in this armor walks forward" --ref armor.png\n'
-        '  gflow video r2v "they meet" --ref a.png --ref b.png --aspect 16:9\n'
+        '  gflow video r2v "knight walks forward" --ref armor.png --model omni-flash\n'
+        '  gflow video r2v "they meet" --ref a.png --ref b.png --model veo-fast\n'
     ),
 )
 @click.argument("prompt")
@@ -387,7 +390,10 @@ def i2v(
     multiple=True,
     required=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
-    help="Reference image (repeat for up to 3).",
+    help=(
+        "Reference image (repeat per ref). Per-model cap enforced by --model: "
+        "omni-flash=7, veo-lite/veo-fast/veo-lite-lp=3, veo-quality rejects R2V."
+    ),
 )
 @click.option(
     "--aspect",
@@ -434,6 +440,22 @@ def r2v(
     out_dir: Path | None,
 ) -> None:
     """Generate a video from reference images (--ref) + PROMPT."""
+    # Reject over-cap ref counts (and the unsupported model+R2V combo) at the
+    # CLI boundary with a clear message (exit 2) rather than letting the domain
+    # ValueError surface as a generic error. GenerateVideoRequest.__post_init__
+    # enforces the same caps as an invariant. Mirrors the i2i pattern.
+    if model is not None:
+        model_enum = VideoModel.from_cli(model)
+        assert model_enum is not None  # narrows for type-checkers; from_cli only
+        # returns None for input None — we just guarded against that.
+        cap = reference_cap_for(model_enum)
+        if cap == 0:
+            raise click.UsageError(f"{model} does not support R2V (reference-to-video).")
+        if len(refs) > cap:
+            raise click.UsageError(
+                f"{model} allows at most {cap} reference image(s); got {len(refs)}."
+            )
+
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -19,6 +19,7 @@ from gflow_cli.api.video import (
     media_name_from_generate_response,
     operation_name_from_generate_response,
     parse_video_status,
+    reference_cap_for,
 )
 
 
@@ -147,19 +148,54 @@ class TestGenerateVideoRequest:
             GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=too_many)
 
     def test_per_model_reference_cap(self) -> None:
+        refs1 = (Path("r0.png"),)
+        refs3 = tuple(Path(f"r{i}.png") for i in range(3))
+        refs4 = tuple(Path(f"r{i}.png") for i in range(4))
         refs5 = tuple(Path(f"r{i}.png") for i in range(5))
         refs7 = tuple(Path(f"r{i}.png") for i in range(7))
-        # veo caps at 3 -> 5 refs rejected
-        with pytest.raises(ValueError, match="at most 3 reference"):
+        refs8 = tuple(Path(f"r{i}.png") for i in range(8))
+
+        # Veo lite/fast/lite_lp cap at 3 -> 4 refs rejected, 3 refs accepted.
+        for veo3 in (
+            VideoModel.VEO_3_1_LITE,
+            VideoModel.VEO_3_1_FAST,
+            VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+        ):
+            with pytest.raises(ValueError, match="at most 3 reference image"):
+                GenerateVideoRequest(prompt="x", mode=Mode.R2V, model=veo3, reference_images=refs4)
+            # exactly at cap is fine
+            GenerateVideoRequest(prompt="x", mode=Mode.R2V, model=veo3, reference_images=refs3)
+
+        # Veo 3.1 Quality does NOT support R2V at all (cap=0) — any ref count rejected.
+        with pytest.raises(ValueError, match="does not support R2V"):
             GenerateVideoRequest(
-                prompt="x", mode=Mode.R2V, model=VideoModel.VEO_3_1_FAST, reference_images=refs5
+                prompt="x",
+                mode=Mode.R2V,
+                model=VideoModel.VEO_3_1_QUALITY,
+                reference_images=refs1,
             )
-        # omni_flash allows 7
+
+        # omni_flash allows 7; 8 rejected (via the absolute ceiling), 7 accepted.
+        with pytest.raises(ValueError, match="at most 7 reference images"):
+            GenerateVideoRequest(
+                prompt="x",
+                mode=Mode.R2V,
+                model=VideoModel.OMNI_FLASH,
+                reference_images=refs8,
+            )
         GenerateVideoRequest(
             prompt="x", mode=Mode.R2V, model=VideoModel.OMNI_FLASH, reference_images=refs7
         )
-        # model None -> only the absolute ceiling (7) applies; 5 is fine
+
+        # model None -> only the absolute ceiling (7) applies; 5 is fine.
         GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=refs5)
+
+    def test_reference_cap_for_helper(self) -> None:
+        assert reference_cap_for(VideoModel.OMNI_FLASH) == 7
+        assert reference_cap_for(VideoModel.VEO_3_1_LITE) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_FAST) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_LITE_LOWER_PRIORITY) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_QUALITY) == 0
 
     def test_seed_range_enforced(self) -> None:
         with pytest.raises(ValueError, match="seed out of range"):

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -206,3 +206,67 @@ def test_t2v_records_started_then_completed(tmp_path: Path) -> None:
     completed_kwargs = fake_recorder.completed[0]
     assert completed_kwargs["result"] is stub_result
     assert fake_recorder.closed is True
+
+
+# ---------------------------------------------------------------------------
+# r2v reference-cap CLI guard (mirrors the i2i ref-cap tests).
+# ---------------------------------------------------------------------------
+
+
+def test_r2v_rejects_over_cap_for_veo_fast(tmp_path: Path) -> None:
+    """4 --ref against veo-fast (cap 3) -> exit 2 + UsageError message."""
+    runner = CliRunner()
+    refs: list[Path] = []
+    for i in range(4):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        refs.append(p)
+    args = ["r2v", "a prompt", "--model", "veo-fast"]
+    for r in refs:
+        args.extend(["--ref", str(r)])
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(video, args)
+    assert result.exit_code == 2, result.output
+    assert "at most 3 reference image" in result.output
+    assert "got 4" in result.output
+
+
+def test_r2v_rejects_quality_model(tmp_path: Path) -> None:
+    """veo-quality does not support R2V (cap 0) -> exit 2 even with 1 --ref."""
+    runner = CliRunner()
+    ref = tmp_path / "r.png"
+    ref.write_bytes(b"\x89PNG\r\n\x1a\n")
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(
+            video, ["r2v", "a prompt", "--model", "veo-quality", "--ref", str(ref)]
+        )
+    assert result.exit_code == 2, result.output
+    assert "does not support R2V" in result.output
+
+
+def test_r2v_accepts_seven_refs_for_omni_flash(tmp_path: Path) -> None:
+    """omni-flash accepts up to 7 refs; the cap guard must pass them through."""
+    runner = CliRunner()
+    refs: list[Path] = []
+    for i in range(7):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        refs.append(p)
+    args = ["r2v", "a prompt", "--model", "omni-flash"]
+    for r in refs:
+        args.extend(["--ref", str(r)])
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.cli_video._run_r2v", new_callable=AsyncMock) as mock_run,
+    ):
+        mock_run.return_value = None
+        result = runner.invoke(video, args)
+    assert result.exit_code == 0, result.output
+    mock_run.assert_awaited_once()

--- a/tests/e2e/test_video_r2v_ref_cap_e2e.py
+++ b/tests/e2e/test_video_r2v_ref_cap_e2e.py
@@ -1,0 +1,161 @@
+"""E2E test for per-model r2v reference-image cap.
+
+Verifies that ``VideoModel.VEO_3_1_LITE`` accepts the full 3-ref boundary
+against the real Flow API — Flow silently keeps only the first N refs when
+more are attached, so a "wrong cap" bug shows up as: the generate call
+succeeds but ``ui_automation_video.reference_attached`` fires fewer than
+the requested N times. Asserting on the structured event closes that
+false-positive class. Costs 1 Veo credit.
+
+Skipped by default; opt in with::
+
+    GFLOW_CLI_E2E_PROFILE=<profile-name> uv run pytest -m e2e_video -v \\
+        tests/e2e/test_video_r2v_ref_cap_e2e.py
+
+The cap-reject paths (4 refs against veo-lite, 1 ref against veo-quality
+where cap=0 means R2V is unsupported) are covered by unit + CLI tests
+(`tests/api/test_video.py`, `tests/cli/test_cli_video.py`) and spend
+zero credits.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+import structlog
+
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+    reference_cap_for,
+)
+
+pytestmark = pytest.mark.e2e
+
+_PROMPT = "a colorful scene with the references combined, cinematic"
+_R2V_POLL_TIMEOUT_S = 600.0
+
+
+def _tiny_png(path: Path, color: tuple[int, int, int]) -> Path:
+    """Write a valid 8x8 RGBA PNG of the given color."""
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        crc = zlib.crc32(body) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", crc)
+
+    w = h = 8
+    r, g, b = color
+    raw = b"".join(b"\x00" + bytes((r, g, b, 0xFF)) * w for _ in range(h))
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_video
+async def test_e2e_r2v_at_cap_veo_lite_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """`veo-lite` at its 3-ref cap returns a SUCCESSFUL VideoResult AND Flow
+    actually consumes all 3 refs (one `reference_attached` event per ref).
+
+    If Flow's actual cap is lower than ``reference_cap_for(VEO_3_1_LITE)``
+    (3), fewer events fire and the test FAILS — a tripwire for cap drift on
+    the Flow side. Picking `veo-lite` over `veo-fast` to keep the credit
+    burn on the cheaper tier; the cap (3) is identical across
+    lite/fast/lite_lp on the Flow wire.
+    """
+    # Undo the autouse `_isolate_settings` fixture (tests/conftest.py) so
+    # profile lookup resolves to the user's real platformdirs path (where the
+    # live Chrome session was planted by `gflow auth login`). Isolation is the
+    # right default for non-e2e but breaks e2e session-dependent tests.
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile name")
+    e2e_profile_dir = _resolve_profile_dir(name)
+    if not e2e_profile_dir.exists():
+        pytest.skip(f"profile dir not found: {e2e_profile_dir}")
+
+    cap = reference_cap_for(VideoModel.VEO_3_1_LITE)
+    assert cap == 3, f"unexpected veo-lite cap {cap}; e2e wired for 3"
+    refs = tuple(
+        _tiny_png(tmp_path / f"r{i}.png", color=(40 + 60 * i, 80 + 40 * i, 160 - 30 * i))
+        for i in range(cap)
+    )
+
+    req = GenerateVideoRequest(
+        prompt=_PROMPT,
+        mode=Mode.R2V,
+        aspect=Aspect.PORTRAIT,
+        model=VideoModel.VEO_3_1_LITE,
+        duration=8,  # veo_3_1_lite only supports 8s
+        count=1,
+        reference_images=refs,
+    )
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(e2e_profile_dir)
+        result: VideoResult = await transport.generate_video(
+            request=req,
+            out_dir=tmp_path,
+            poll_timeout_s=_R2V_POLL_TIMEOUT_S,
+        )
+    finally:
+        await transport.teardown()
+
+    # 1. Terminal-success contract.
+    assert isinstance(result, VideoResult), (
+        f"generate_video() must return a VideoResult, got {type(result)!r}"
+    )
+    assert result.status.is_terminal and result.status.succeeded, (
+        f"Expected SUCCESSFUL terminal status, got {result.status.status!r}; "
+        f"failure_reasons={result.status.failure_reasons!r}"
+    )
+    assert result.status.media_id, "VideoStatus.media_id must be non-empty"
+
+    # 2. File-on-disk contract (per [[verification-ledger-5-layer]]).
+    assert result.local_path is not None and result.local_path.exists(), (
+        f"VideoResult.local_path must point to a downloaded mp4; got {result.local_path!r}"
+    )
+    head = result.local_path.read_bytes()[:32]
+    assert b"ftyp" in head, (
+        f"mp4 magic bytes not found in first 32 bytes of {result.local_path}: {head!r}"
+    )
+
+    # 3. Cap-drift tripwire: Flow must report `reference_attached` for ALL
+    # `cap` refs. If only N < cap fire, Flow silently truncated and our cap
+    # value is too generous — bumping `reference_cap_for(VEO_3_1_LITE)` would
+    # invite re-introduction of the bug this PR closes.
+    attached = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.reference_attached"
+    ]
+    assert len(attached) == cap, (
+        f"expected {cap} reference_attached events at the at-cap boundary; "
+        f"got {len(attached)}. Flow likely truncated silently — verify the "
+        f"`reference_cap_for(VEO_3_1_LITE)` value matches Flow's actual cap."
+    )


### PR DESCRIPTION
## Summary

Flow's R2V reference cap is model-dependent (PR #48 already split `OMNI_REFERENCE_CAP=7` from `VEO_REFERENCE_CAP=3`), but the two-constant shape misses the newer `veo_3_1_lite_lower_priority` alias and the `veo_3_1_quality` "no R2V" case. Per Google Flow's [official support page](https://support.google.com/flow/answer/16352836?hl=en) (Ingredients/References to Video row):

| Model | Alias | Cap |
|---|---|---|
| `OMNI_FLASH` | `omni-flash` | 7 |
| `VEO_3_1_LITE` | `veo-lite` | 3 |
| `VEO_3_1_FAST` | `veo-fast` | 3 |
| `VEO_3_1_LITE_LOWER_PRIORITY` | `veo-lite-lp` | 3 |
| `VEO_3_1_QUALITY` | `veo-quality` | **0** (R2V unsupported) |

Replaces the two scalar constants with `_VIDEO_REFERENCE_CAP: Mapping[VideoModel, int]` (mirrors the i2i shape from the sibling i2i-ref-cap PR). `reference_cap_for` now does a dict lookup; `cap == 0` gets a dedicated `does not support R2V (reference-to-video)` message in `GenerateVideoRequest.__post_init__` instead of letting it fail at the wire.

Adds a `click.UsageError` (exit 2) guard on `gflow video r2v` mirroring the i2i pattern, so over-cap **and** quality+r2v fail before any profile/network work. The domain check backstops it for programmatic callers.

## Validation

- [x] **Unit tests** — `tests/api/test_video.py` (per-model cap + cap=0 quality reject + `reference_cap_for` table assertion) and `tests/cli/test_cli_video.py` (CLI `UsageError` over-cap on `veo-fast` + CLI reject on `veo-quality` + omni-flash accepts 7 refs)
- [x] **E2e tripwire** — `tests/e2e/test_video_r2v_ref_cap_e2e.py::test_e2e_r2v_at_cap_veo_lite_succeeds` (1 Veo credit, gated by `GFLOW_CLI_E2E_PROFILE`, `pytest -m e2e_video`). Sends 3 refs at the at-cap boundary and asserts ALL 3 `ui_automation_video.reference_attached` events fire — cap-drift tripwire.
- [x] `uv run python scripts/ci/check_repo_hygiene.py` → 299 files clean
- [x] `uv run ruff check src tests` → clean
- [x] `uv run ruff format --check src tests` → 131 files already formatted
- [x] `uv run pyright src` → 1315 errors, ALL pre-existing baseline (`origin/develop` reports 1352)
- [x] `uv run pytest -q --cov=gflow_cli --cov-fail-under=80` → **970 passed**, coverage **86.51%**
- [x] **Live verification** on a Pro profile (2026-05-28):
  - `gflow video r2v "test" --model veo-lite --ref ... (4 refs)` → `exit 2`, `veo-lite allows at most 3 reference image(s); got 4.` (CLI guard, no credit spent)
  - `gflow video r2v "test" --model veo-quality --ref one.png` → `exit 2`, `veo-quality does not support R2V (reference-to-video).` (no credit spent)
  - `gflow video r2v "test" --model veo-lite --ref ... (3 refs) --json` → real Flow gen succeeded, mp4 saved 1.53 MB, `MEDIA_GENERATION_STATUS_SUCCESSFUL`, all 3 `reference_attached` events fired

## Heads-up — semantic constant changes (no action needed)

Following the same convention you flagged in PR #48 for `MAX_REFERENCE_IMAGES`:

- `OMNI_REFERENCE_CAP` and `VEO_REFERENCE_CAP` are **removed** from `gflow_cli.api.video`. Callers that imported them should switch to `reference_cap_for(model)` — it returns `0` for `VEO_3_1_QUALITY` (R2V unsupported), so old `OMNI_REFERENCE_CAP if model is OMNI_FLASH else VEO_REFERENCE_CAP` call sites would have produced the wrong cap for QUALITY anyway.
- `MAX_REFERENCE_IMAGES` (= 7) is unchanged — still the absolute ceiling used when the model is unknown / `None`.
- A `### Changed` entry under `[Unreleased]` in `CHANGELOG.md` covers this so anyone pinning to the old constants has a paper trail.

## Notes

- **`veo-lite-lp = 3` is inferred, not live-tested.** I'm on a Pro tier; `veo-lite-lp` is Ultra-only. The Flow changelog (4/10/2026) and the public support docs treat it as a billing/scheduling tier of the Lite engine (lower priority, lower price, same wire model) so I've set the cap to match Lite. If you have an Ultra account, a one-line confirmation on this would be great — and if Flow ever exposes a different cap for it, the mapping is a one-line fix.
- Companion PR: the i2i-ref-cap change (image side, same pattern). Each PR stands alone but they're conceptually a pair.
