### PR TITLE
feat: machine-readable --json output across CLI + new gflow models catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--json` flag on `gflow video t2v`, `gflow video i2v`, and `gflow video r2v`.**
+  Emits the `VideoResult` (status / command / media_id / generation_status /
+  succeeded / local_path / failure_reasons / error_message) plus the request
+  echo (model / mode / aspect / duration / count / seed) as a single JSON
+  object on stdout. A failed generation still emits its JSON payload and
+  then exits 1. The data-layer recorder
+  (`record_started_video` / `record_completed_video`) fires regardless of
+  `--json` so audit history is independent of the output channel. E2e
+  coverage for `--json` shape across image / video / auth / models lives at
+  `tests/e2e/test_json_output_e2e.py`.
 - **`--json` flag on `gflow image t2i` and `gflow image i2i`.** Emits the
   complete `GeneratedImage` result (every field — `media_name`,
   `workflow_id`, `seed`, `prompt`, `model_name_type`, `aspect_ratio`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-model r2v reference-image cap rebuilt as a data table.** Replaces the
+  prior pair of constants (`OMNI_REFERENCE_CAP=7`, `VEO_REFERENCE_CAP=3`) with
+  a `VideoModel -> int` mapping consulted by
+  `gflow_cli.api.video.reference_cap_for(model)`. New entries:
+  `veo_3_1_lite_lower_priority=3` (was implicitly covered by the veo branch),
+  and `veo_3_1_quality=0` — Veo 3.1 Quality does NOT support
+  Ingredients/References to Video at all per Google Flow's official support
+  page; passing it to r2v raises a clear `does not support R2V
+  (reference-to-video)` error rather than letting the request fail at the
+  wire. CLI guard added on `gflow video r2v` (`click.UsageError`, exit 2)
+  mirroring the i2i pattern so over-cap and quality+r2v fail before any
+  profile/network work. E2e tripwire at
+  `tests/e2e/test_video_r2v_ref_cap_e2e.py` asserts Flow actually consumes
+  all `cap` refs at the at-cap boundary.
 - **Per-model i2i reference-image cap.** Flow silently keeps only the first N
   reference images when an i2i request attaches more than the model accepts,
   so a caller could believe every ref was used. `gflow_cli.api.image.reference_cap_for(model)`
@@ -36,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `gflow_cli.api.video` no longer exposes the standalone `OMNI_REFERENCE_CAP` /
+  `VEO_REFERENCE_CAP` constants. Callers that need a per-model R2V cap should
+  use `reference_cap_for(model)` (which returns `0` for `VEO_3_1_QUALITY` —
+  R2V is unsupported there). `MAX_REFERENCE_IMAGES` (= 7) is unchanged and
+  still the absolute ceiling used when the model is unknown.
 - `GFLOW_CLI_E2E_RUN_VIDEO` default flipped from `"1"` to `"0"`. The Veo step in
   `test_data_layer_e2e.py` is now **opt-in**: set `GFLOW_CLI_E2E_RUN_VIDEO=1` to
   include it. This prevents accidental Veo credit burns on unattended CI runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--json` flag on `gflow auth list`.** Emits the profile inventory as a JSON
+  array (`name` / `is_default` / `cookies_present` / `profile_dir` /
+  `last_used_at`) on stdout so a programmatic caller (e.g. a worker discovering
+  authenticated profiles) can `json.loads(stdout)` instead of scraping the
+  Rich table.
 - **Per-model r2v reference-image cap rebuilt as a data table.** Replaces the
   prior pair of constants (`OMNI_REFERENCE_CAP=7`, `VEO_REFERENCE_CAP=3`) with
   a `VideoModel -> int` mapping consulted by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--json` flag on `gflow image t2i` and `gflow image i2i`.** Emits the
+  complete `GeneratedImage` result (every field — `media_name`,
+  `workflow_id`, `seed`, `prompt`, `model_name_type`, `aspect_ratio`,
+  `dimensions`, `fife_url`, `is_signed_url`) plus the on-disk `local_path`
+  as a single JSON object on stdout. A worker keys `images[0].seed` for
+  refine-regen seed continuity. Single-prompt only (`--json` rejects
+  multi-prompt batch with a Click usage error); progress chatter is
+  suppressed so stdout is pure JSON. `ref_count` surfaces only on i2i.
 - **`gflow models` catalog command.** New top-level command that enumerates
   the image and video model catalog as a Rich table (default) or as a single
   JSON object (`--json`). Per-model: `name`, CLI aliases (filtered to what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gflow models` catalog command.** New top-level command that enumerates
+  the image and video model catalog as a Rich table (default) or as a single
+  JSON object (`--json`). Per-model: `name`, CLI aliases (filtered to what
+  the generation command's `--model` Choice actually accepts), `ref_cap`,
+  `default` (image), `max_duration` (video). Built from the
+  `Model` / `VideoModel` enums + their alias maps so the catalog can never
+  drift from what the generation commands accept. A UI populating its model
+  picker from `gflow models --json` is guaranteed to pass any selected alias
+  back to `--model`.
+- **`gflow_cli.json_output` module + `--json` error path on
+  `run_with_handlers`.** Pure builders for image/video result payloads and
+  RFC 9457 problem-details errors (plus a `retryable` flag worker schedulers
+  key their retry-vs-absorb decision off — WAF / rate-limit / network /
+  timeout). When `as_json=True`, errors emit a parseable JSON payload on
+  stdout with the same exit code as the Rich path; the observability event
+  still fires.
 - **`--json` flag on `gflow auth list`.** Emits the profile inventory as a JSON
   array (`name` / `is_default` / `cookies_present` / `profile_dir` /
   `last_used_at`) on stdout so a programmatic caller (e.g. a worker discovering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cost sub-marker, and self-tests for the auto-marker conftest hook.
 - `docs/E2E_TESTING.md` — comprehensive e2e strategy and layer reference document.
 
+### Fixed
+
+- Structlog logs are now routed to stderr (via
+  `PrintLoggerFactory(file=sys.stderr)`) instead of stdout. Previously every
+  CLI event leaked onto stdout, which broke the `--json` contract for
+  programmatic callers — `json.loads(stdout)` failed because the JSON
+  payload was preceded by event-log lines. Logs are diagnostics; stdout is
+  data. No-op for human users (terminals still show logs the same way).
+
 ### Changed
 
 - `gflow_cli.api.video` no longer exposes the standalone `OMNI_REFERENCE_CAP` /

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -45,7 +45,7 @@ import structlog
 from rich.console import Console
 
 from gflow_cli import auth as auth_mod
-from gflow_cli import profile_store
+from gflow_cli import json_output, profile_store
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
     GFlowError,
@@ -144,6 +144,7 @@ def run_with_handlers(
     coro_factory: Callable[[], Coroutine[Any, Any, Any]],
     *,
     cli_command: str,
+    as_json: bool = False,
 ) -> None:
     """Wrap an :func:`asyncio.run` call in the GFlowError + unhandled handlers.
 
@@ -158,16 +159,39 @@ def run_with_handlers(
             lambda: _run_t2i(prompt, ...),
             cli_command="image t2i",
         )
+
+    When ``as_json`` is set the error path emits a machine-readable JSON
+    payload on stdout instead of the Rich message (the observability event
+    still fires either way) so a programmatic caller gets a parseable failure
+    with the same exit code. The success payload is the coroutine's own
+    responsibility — it knows the result shape.
     """
     import asyncio
 
     try:
         asyncio.run(coro_factory())
     except GFlowError as e:
+        if as_json:
+            emit_error_event(_logger, e, cli_command=cli_command)
+            json_output.emit(json_output.error_payload(e))
+            sys.exit(_exit_code_for(e))
         sys.exit(_handle_gflow_error(e, cli_command=cli_command))
     except (KeyboardInterrupt, click.Abort):
         sys.exit(130)
+    except SystemExit:
+        # A coroutine that has already taken responsibility for its own exit
+        # (e.g. `video t2v --json` emits the failed `video_result` payload and
+        # then raises SystemExit(1) so we don't print a second "Saved:" / Rich
+        # error). Propagate the exit code without emitting a SECOND JSON
+        # `UnexpectedError` payload through the catch-all below — that would
+        # leave stdout with two concatenated documents that no `json.loads`
+        # call can parse, defeating the whole point of --json.
+        raise
     except BaseException as e:  # noqa: BLE001 — intentional catch-all at the CLI boundary
+        if as_json:
+            emit_unhandled_event(_logger, e, cli_command=cli_command)
+            json_output.emit(json_output.unexpected_payload())
+            sys.exit(1)
         sys.exit(_handle_unhandled_error(e, cli_command=cli_command))
 
 

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -162,6 +162,16 @@ def reference_cap_for(model: Model) -> int:
     return _IMAGE_REFERENCE_CAP.get(model, MAX_IMAGE_REFERENCES)
 
 
+def model_aliases(model: Model) -> list[str]:
+    """Sorted CLI aliases that resolve to *model* (for `gflow models`)."""
+    return sorted(alias for alias, m in _MODEL_FROM_CLI.items() if m is model)
+
+
+def aspect_choices() -> dict[str, str]:
+    """Map each accepted CLI aspect ratio to its wire value."""
+    return {ratio: aspect.value for ratio, aspect in _ASPECT_FROM_CLI.items()}
+
+
 @dataclass(frozen=True)
 class ImageRef:
     """A reference image for I2I, identified by the upload's media UUID.

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -49,30 +49,35 @@ class VideoModel(StrEnum):
         if value is None:
             return None
         key = value.strip().lower().replace("-", "_").replace(" ", "_")
-        mapping = {
-            "omni_flash": cls.OMNI_FLASH,
-            "omni": cls.OMNI_FLASH,
-            "flash": cls.OMNI_FLASH,
-            "veo_3_1_lite": cls.VEO_3_1_LITE,
-            "veo_lite": cls.VEO_3_1_LITE,
-            "lite": cls.VEO_3_1_LITE,
-            "veo_3_1_fast": cls.VEO_3_1_FAST,
-            "veo_fast": cls.VEO_3_1_FAST,
-            "fast": cls.VEO_3_1_FAST,
-            "veo_3_1_quality": cls.VEO_3_1_QUALITY,
-            "veo_quality": cls.VEO_3_1_QUALITY,
-            "quality": cls.VEO_3_1_QUALITY,
-            "veo_3_1_lite_lower_priority": cls.VEO_3_1_LITE_LOWER_PRIORITY,
-            "veo_lite_lp": cls.VEO_3_1_LITE_LOWER_PRIORITY,
-            "lite_lp": cls.VEO_3_1_LITE_LOWER_PRIORITY,
-            "lower_priority": cls.VEO_3_1_LITE_LOWER_PRIORITY,
-        }
-        if key not in mapping:
+        if key not in _VIDEO_MODEL_FROM_CLI:
             raise ValueError(
                 f"Unknown video model {value!r}; choose from "
-                f"{sorted({m.value for m in cls})} or aliases {sorted(mapping)}"
+                f"{sorted({m.value for m in cls})} or aliases {sorted(_VIDEO_MODEL_FROM_CLI)}"
             )
-        return mapping[key]
+        return _VIDEO_MODEL_FROM_CLI[key]
+
+
+# Module-level alias map — friendly CLI strings -> VideoModel. Hoisted out of
+# `VideoModel.from_cli` (defined after the class so the members resolve) so
+# `gflow models` can enumerate the aliases without duplicating them.
+_VIDEO_MODEL_FROM_CLI: dict[str, VideoModel] = {
+    "omni_flash": VideoModel.OMNI_FLASH,
+    "omni": VideoModel.OMNI_FLASH,
+    "flash": VideoModel.OMNI_FLASH,
+    "veo_3_1_lite": VideoModel.VEO_3_1_LITE,
+    "veo_lite": VideoModel.VEO_3_1_LITE,
+    "lite": VideoModel.VEO_3_1_LITE,
+    "veo_3_1_fast": VideoModel.VEO_3_1_FAST,
+    "veo_fast": VideoModel.VEO_3_1_FAST,
+    "fast": VideoModel.VEO_3_1_FAST,
+    "veo_3_1_quality": VideoModel.VEO_3_1_QUALITY,
+    "veo_quality": VideoModel.VEO_3_1_QUALITY,
+    "quality": VideoModel.VEO_3_1_QUALITY,
+    "veo_3_1_lite_lower_priority": VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+    "veo_lite_lp": VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+    "lite_lp": VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+    "lower_priority": VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+}
 
 
 class Aspect(StrEnum):
@@ -122,6 +127,25 @@ def reference_cap_for(model: VideoModel) -> int:
     to the ceiling instead of a ``KeyError`` at request-build time.
     """
     return _VIDEO_REFERENCE_CAP.get(model, MAX_REFERENCE_IMAGES)
+
+
+def model_aliases(model: VideoModel) -> list[str]:
+    """Sorted CLI aliases that resolve to *model* (for `gflow models`)."""
+    return sorted(alias for alias, m in _VIDEO_MODEL_FROM_CLI.items() if m is model)
+
+
+def max_duration_for(model: VideoModel) -> int:
+    """Maximum clip length in seconds: omni_flash=10, veo_3_1_*=8."""
+    return 10 if model is VideoModel.OMNI_FLASH else 8
+
+
+def aspect_choices() -> dict[str, str]:
+    """Map each accepted CLI aspect ratio to its wire value."""
+    return {
+        "9:16": Aspect.PORTRAIT.wire(),
+        "16:9": Aspect.LANDSCAPE.wire(),
+        "1:1": Aspect.SQUARE.wire(),
+    }
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -8,10 +8,11 @@ retired — see the Phase A plan).
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 
@@ -90,14 +91,37 @@ class Aspect(StrEnum):
         return mapping[value]
 
 
-# Flow's R2V reference cap is MODEL-DEPENDENT (live-verified): omni_flash allows
-# 7 ("Maximum image ingredients reached (7 allowed)"), the veo_3_1_* models allow
-# 3. A veo request with >3 refs uploads all but the generate request silently
-# keeps only 3. MAX_REFERENCE_IMAGES is the absolute ceiling (omni); the
-# model-aware check below enforces the per-model limit when the model is known.
-OMNI_REFERENCE_CAP = 7
-VEO_REFERENCE_CAP = 3
-MAX_REFERENCE_IMAGES = OMNI_REFERENCE_CAP
+# Flow's R2V reference cap is MODEL-DEPENDENT (live-verified + Google's
+# official support page): omni_flash allows 7 ("Maximum image ingredients
+# reached (7 allowed)"); veo_3_1_lite / veo_3_1_fast / veo_3_1_lite_lower_priority
+# allow 3; veo_3_1_quality does NOT support R2V at all (Google Flow help page
+# "Ingredients/References to Video" row = "No"). A request that exceeds the cap
+# uploads all refs but the generate call silently keeps only N — so we reject
+# up front. MAX_REFERENCE_IMAGES is the absolute ceiling (omni) used when the
+# model is unknown; the model-aware check below enforces the exact per-model
+# limit (incl. the special cap=0 for QUALITY) when the model is known.
+MAX_REFERENCE_IMAGES = 7
+_VIDEO_REFERENCE_CAP: Mapping[VideoModel, int] = MappingProxyType(
+    {
+        VideoModel.OMNI_FLASH: 7,
+        VideoModel.VEO_3_1_LITE: 3,
+        VideoModel.VEO_3_1_FAST: 3,
+        VideoModel.VEO_3_1_LITE_LOWER_PRIORITY: 3,
+        VideoModel.VEO_3_1_QUALITY: 0,  # R2V unsupported per Google Flow docs
+    }
+)
+
+
+def reference_cap_for(model: VideoModel) -> int:
+    """Maximum number of R2V reference images *model* accepts.
+
+    Returns 0 for models that do not support R2V at all
+    (``VEO_3_1_QUALITY`` — per Google Flow's official support page).
+    Unknown/future models fall back to :data:`MAX_REFERENCE_IMAGES` rather than
+    raising, so adding a new ``VideoModel`` member without a cap entry degrades
+    to the ceiling instead of a ``KeyError`` at request-build time.
+    """
+    return _VIDEO_REFERENCE_CAP.get(model, MAX_REFERENCE_IMAGES)
 
 
 @dataclass(frozen=True)
@@ -152,14 +176,17 @@ class GenerateVideoRequest:
                 raise ValueError("R2V request must not carry start/end images")
         if len(self.reference_images) > MAX_REFERENCE_IMAGES:
             raise ValueError(f"at most {MAX_REFERENCE_IMAGES} reference images")
-        # Per-model reference cap: omni_flash=7, veo_3_1_*=3 (live-verified). When
-        # the model is None (Flow UI default) we can't know it — leave the ceiling.
+        # Per-model reference cap (live-verified): omni_flash=7, veo lite/fast/lite_lp=3,
+        # veo_quality=0 (R2V unsupported per Google docs). When the model is None
+        # (Flow UI default) we can't know it — leave the absolute ceiling above.
         if self.mode is Mode.R2V and self.model is not None:
-            cap = OMNI_REFERENCE_CAP if self.model is VideoModel.OMNI_FLASH else VEO_REFERENCE_CAP
+            cap = reference_cap_for(self.model)
+            if cap == 0:
+                raise ValueError(f"{self.model.value} does not support R2V (reference-to-video)")
             if len(self.reference_images) > cap:
                 raise ValueError(
-                    f"{self.model.value} allows at most {cap} reference images; "
-                    f"got {len(self.reference_images)} (omni_flash allows {OMNI_REFERENCE_CAP})"
+                    f"{self.model.value} allows at most {cap} reference image(s); "
+                    f"got {len(self.reference_images)}"
                 )
         if self.seed is not None and not (0 <= self.seed <= 2**31 - 1):
             raise ValueError("seed out of range")

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -15,6 +15,7 @@ from gflow_cli import __version__, profile_store
 from gflow_cli import auth as auth_mod
 from gflow_cli.cli_data import data as _data_group
 from gflow_cli.cli_image import image as _image_group
+from gflow_cli.cli_models import models as _models_command
 from gflow_cli.cli_run import run as _run_command
 from gflow_cli.cli_video import video as _video_group
 from gflow_cli.config import get_settings
@@ -277,6 +278,7 @@ main.add_command(_data_group)
 main.add_command(_video_group)
 main.add_command(_image_group)
 main.add_command(_run_command)
+main.add_command(_models_command)
 
 
 if __name__ == "__main__":

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -190,9 +190,28 @@ def auth_status(profile: str | None) -> None:
 
 
 @auth.command("list")
-def auth_list() -> None:
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable JSON instead of a table.")
+def auth_list(as_json: bool) -> None:
     """List every profile and indicate the current default."""
     profiles = profile_store.list_profiles()
+    if as_json:
+        import json
+
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "name": p.name,
+                        "is_default": p.is_default,
+                        "cookies_present": p.cookies_present,
+                        "last_used_at": p.last_used_at.isoformat() if p.last_used_at else None,
+                        "profile_dir": str(p.profile_dir),
+                    }
+                    for p in profiles
+                ]
+            )
+        )
+        return
     _render_profiles_table(profiles)
 
 

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -24,6 +24,7 @@ import structlog
 from rich.console import Console
 from rich.table import Table
 
+from gflow_cli import json_output
 from gflow_cli._cli_helpers import (
     _make_provider_dir,
     _resolve_profile,
@@ -345,6 +346,12 @@ async def _run_upload(
         "GFLOW_CLI_EXPERIMENTAL_TRANSPORTS=1 to enable evaluate_fetch/bearer/sapisidhash."
     ),
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of a Rich table.",
+)
 def t2i(
     prompts: tuple[str, ...],
     prompts_file: Path | None,
@@ -356,10 +363,16 @@ def t2i(
     out: Path | None,
     profile: str | None,
     transport: str | None,
+    as_json: bool,
 ) -> None:
     """Generate image(s) from one or more text prompts."""
     is_multi_prompt = len(prompts) > 1 or prompts_file is not None or read_stdin
     _validate_t2i_input(prompts, prompts_file, read_stdin)
+
+    if is_multi_prompt and as_json:
+        # --json is single-prompt only — the batch summary shape is rich-table
+        # specific and a worker shells out one prompt at a time anyway.
+        raise click.UsageError("--json is single-prompt only; remove the extra prompts.")
 
     if not is_multi_prompt:
         if not prompts:
@@ -384,8 +397,10 @@ def t2i(
                 out=out,
                 output_root=settings.output_dir,
                 transport=transport,
+                as_json=as_json,
             ),
             cli_command="image t2i",
+            as_json=as_json,
         )
         return
 
@@ -515,6 +530,7 @@ async def _run_t2i(
     out: Path | None,
     output_root: Path,
     transport: str | None = None,
+    as_json: bool = False,
 ) -> None:
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
@@ -522,14 +538,16 @@ async def _run_t2i(
         async with FlowApiClient(
             profile_dir=profile_dir, headless=headless, transport=transport
         ) as client:
-            console.print(_CREATING_PROJECT_MSG)
+            if not as_json:
+                console.print(_CREATING_PROJECT_MSG)
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
             project = await client.create_project(title=_T2I_PROJECT_TITLE)
-            console.print(f"  Project: [dim]{project.project_id}[/dim]")
-            console.print(
-                f"  Generating {count} image(s) ({req.model.value}, {req.aspect.value})..."
-            )
+            if not as_json:
+                console.print(f"  Project: [dim]{project.project_id}[/dim]")
+                console.print(
+                    f"  Generating {count} image(s) ({req.model.value}, {req.aspect.value})..."
+                )
             if count == 1:
                 img = await client.generate_image(project_id=project.project_id, req=req)
                 images: list[GeneratedImage] = [img]
@@ -548,7 +566,18 @@ async def _run_t2i(
                 saved = await client.download_image(img, target)
                 saved_paths.append(saved)
 
-            _print_t2i_summary(images, saved_paths)
+            if as_json:
+                json_output.emit(
+                    json_output.image_result(
+                        command="image t2i",
+                        project_id=project.project_id,
+                        model=req.model.value,
+                        images=images,
+                        saved_paths=saved_paths,
+                    )
+                )
+            else:
+                _print_t2i_summary(images, saved_paths)
 
             try:
                 recorder.record_generated_images(
@@ -803,6 +832,12 @@ def batch(
         "GFLOW_CLI_EXPERIMENTAL_TRANSPORTS=1 to enable evaluate_fetch/bearer/sapisidhash."
     ),
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of a Rich table.",
+)
 def i2i(
     prompt: str,
     refs: tuple[str, ...],
@@ -812,6 +847,7 @@ def i2i(
     out: Path | None,
     profile: str | None,
     transport: str | None,
+    as_json: bool,
 ) -> None:
     """Generate image(s) from PROMPT + reference image(s) (image-to-image)."""
     # Classify each --ref upfront: UUIDs become ImageRef, path-likes become
@@ -847,8 +883,10 @@ def i2i(
             out=out,
             output_root=settings.output_dir,
             transport=transport,
+            as_json=as_json,
         ),
         cli_command="image i2i",
+        as_json=as_json,
     )
 
 
@@ -865,6 +903,7 @@ async def _run_i2i(
     out: Path | None,
     output_root: Path,
     transport: str | None = None,
+    as_json: bool = False,
 ) -> None:
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
@@ -872,11 +911,13 @@ async def _run_i2i(
         async with FlowApiClient(
             profile_dir=profile_dir, headless=headless, transport=transport
         ) as client:
-            console.print(_CREATING_PROJECT_MSG)
+            if not as_json:
+                console.print(_CREATING_PROJECT_MSG)
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
             project = await client.create_project(title="gflow-cli i2i")
-            console.print(f"  Project: [dim]{project.project_id}[/dim]")
+            if not as_json:
+                console.print(f"  Project: [dim]{project.project_id}[/dim]")
 
             # Local-file refs are attached through the editor's media dialog by the
             # ui_automation transport (the REST uploadImage path 401s — see #15/#39).
@@ -893,10 +934,11 @@ async def _run_i2i(
             )
 
             n_refs = len(uuid_refs) + len(local_ref_paths)
-            console.print(
-                f"  Generating {count} image(s) with {n_refs} ref(s) "
-                f"({req.model.value}, {req.aspect.value})..."
-            )
+            if not as_json:
+                console.print(
+                    f"  Generating {count} image(s) with {n_refs} ref(s) "
+                    f"({req.model.value}, {req.aspect.value})..."
+                )
             if count == 1:
                 img = await client.generate_image(project_id=project.project_id, req=req)
                 images: list[GeneratedImage] = [img]
@@ -915,7 +957,19 @@ async def _run_i2i(
                 saved = await client.download_image(img, target)
                 saved_paths.append(saved)
 
-            _print_i2i_summary(images, saved_paths)
+            if as_json:
+                json_output.emit(
+                    json_output.image_result(
+                        command="image i2i",
+                        project_id=project.project_id,
+                        model=req.model.value,
+                        images=images,
+                        saved_paths=saved_paths,
+                        ref_count=n_refs,
+                    )
+                )
+            else:
+                _print_i2i_summary(images, saved_paths)
 
             try:
                 recorder.record_generated_images(

--- a/src/gflow_cli/cli_models.py
+++ b/src/gflow_cli/cli_models.py
@@ -1,0 +1,121 @@
+"""`gflow models` — enumerate the image + video models the CLI accepts.
+
+The catalog is assembled from the `Model` / `VideoModel` enums, their alias
+maps, and the per-model reference caps, so it can never drift from what the
+generation commands actually accept. ``--json`` emits it machine-readably (the
+shape a UI populates model pickers + reference-slot counts from); otherwise a
+Rich table is printed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from gflow_cli import json_output
+from gflow_cli.api import image as image_api
+from gflow_cli.api import video as video_api
+from gflow_cli.image_batch import ALLOWED_MODELS as _IMAGE_CLI_MODELS
+
+console = Console()
+
+
+# The CLI aliases each generation command's `--model` actually accepts. The
+# catalog MUST advertise only these (a UI picks one and passes it straight to
+# `image t2i --model` / `video t2v --model`); listing the broader internal
+# alias set would offer values the gen commands reject (Click usage error).
+#   image  → image_batch.ALLOWED_MODELS (shared with cli_image's --model Choice)
+#   video  → mirror of cli_video's --model Choice (keep in sync if it changes)
+_VIDEO_CLI_MODELS: tuple[str, ...] = (
+    "omni-flash",
+    "veo-lite",
+    "veo-fast",
+    "veo-quality",
+    "veo-lite-lp",
+)
+
+# Aspects the video generation commands' `--aspect` Choice actually accepts.
+# `video_api.aspect_choices()` returns 9:16, 16:9, AND 1:1 because the underlying
+# `Aspect` enum has SQUARE — but `cli_video.py`'s `t2v` / `i2v` / `r2v` `--aspect`
+# options are `click.Choice(["9:16", "16:9"])` (no 1:1). Advertising 1:1 in the
+# catalog would mislead a UI into passing a value the gen command rejects.
+_VIDEO_CLI_ASPECTS: tuple[str, ...] = ("9:16", "16:9")
+
+
+def build_catalog() -> dict[str, Any]:
+    """Assemble the image + video model/aspect catalog (pure, no I/O)."""
+    image_models = [
+        {
+            "name": m.value,
+            # Only aliases the `--model` Choice accepts, mapped back to this model.
+            "aliases": [a for a in _IMAGE_CLI_MODELS if image_api.Model.from_cli(a) is m],
+            "ref_cap": image_api.reference_cap_for(m),
+            "default": m is image_api.Model.NARWHAL,
+        }
+        for m in image_api.Model
+    ]
+    image_aspects = [
+        {"ratio": ratio, "wire": wire} for ratio, wire in image_api.aspect_choices().items()
+    ]
+    video_models = [
+        {
+            "name": m.value,
+            # Only aliases the `--model` Choice accepts, mapped back to this model.
+            "aliases": [a for a in _VIDEO_CLI_MODELS if video_api.VideoModel.from_cli(a) is m],
+            "ref_cap": video_api.reference_cap_for(m),  # applies to r2v
+            "max_duration": video_api.max_duration_for(m),
+        }
+        for m in video_api.VideoModel
+    ]
+    # Only aspects the `--aspect` Choice accepts (see _VIDEO_CLI_ASPECTS).
+    video_aspects = [
+        {"ratio": ratio, "wire": wire}
+        for ratio, wire in video_api.aspect_choices().items()
+        if ratio in _VIDEO_CLI_ASPECTS
+    ]
+    return {
+        "image": {"models": image_models, "aspects": image_aspects},
+        "video": {
+            "models": video_models,
+            "aspects": video_aspects,
+            "tiers": [t.value for t in video_api.Tier],
+        },
+    }
+
+
+@click.command("models")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Machine-readable JSON catalog instead of a table.",
+)
+def models(as_json: bool) -> None:
+    """List the image + video models, their aliases, and reference caps."""
+    catalog = build_catalog()
+    if as_json:
+        json_output.emit(catalog)
+        return
+    _render_catalog(catalog)
+
+
+def _render_catalog(catalog: dict[str, Any]) -> None:
+    for kind in ("image", "video"):
+        section = catalog[kind]
+        table = Table(title=f"{kind} models")
+        table.add_column("model", style="bold")
+        table.add_column("aliases", overflow="fold")
+        table.add_column("ref cap", justify="right")
+        if kind == "video":
+            table.add_column("max dur (s)", justify="right")
+        for m in section["models"]:
+            row = [m["name"], ", ".join(m["aliases"]), str(m["ref_cap"])]
+            if kind == "video":
+                row.append(str(m["max_duration"]))
+            table.add_row(*row)
+        console.print(table)
+        ratios = ", ".join(a["ratio"] for a in section["aspects"])
+        console.print(f"  aspects: {ratios}\n")

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -13,6 +13,7 @@ import click
 import structlog
 from rich.console import Console
 
+from gflow_cli import json_output
 from gflow_cli._cli_helpers import (
     _make_provider_dir,
     _resolve_profile,
@@ -53,13 +54,21 @@ async def _generate_and_report(
     profile_name: str,
     profile_dir: Path,
     out_dir: Path | None,
+    command: str = "video",
+    as_json: bool = False,
 ) -> None:
     """Drive FlowApiClient for a single GenerateVideoRequest and print the
-    result (or fail with a non-zero exit). Shared by t2v, i2v, and r2v."""
+    result (or fail with a non-zero exit). Shared by t2v, i2v, and r2v.
+
+    With ``as_json`` the result is emitted as a JSON object (carrying the same
+    ok/fail status as the exit code) instead of the Rich lines; a failed
+    generation still emits its JSON payload and then exits 1.
+    """
     from gflow_cli.api.client import FlowApiClient
     from gflow_cli.api.video import VideoStarted
 
-    console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
+    if not as_json:
+        console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
     try:
@@ -103,6 +112,12 @@ async def _generate_and_report(
     finally:
         recorder.close()
 
+    if as_json:
+        json_output.emit(json_output.video_result(command=command, request=request, result=result))
+        if not result.status.succeeded:
+            raise SystemExit(1)
+        return
+
     if not result.status.succeeded:
         reasons = (
             ", ".join(result.status.failure_reasons)
@@ -125,6 +140,7 @@ async def _run_t2v(
     model: str | None = None,
     duration: int | None = None,
     count: int = 1,
+    as_json: bool = False,
 ) -> None:
     from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
 
@@ -137,7 +153,12 @@ async def _run_t2v(
         count=count,
     )
     await _generate_and_report(
-        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+        request,
+        profile_name=profile_name,
+        profile_dir=profile_dir,
+        out_dir=out_dir,
+        command="video t2v",
+        as_json=as_json,
     )
 
 
@@ -153,6 +174,7 @@ async def _run_i2v(
     model: str | None = None,
     duration: int | None = None,
     count: int = 1,
+    as_json: bool = False,
 ) -> None:
     from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
 
@@ -167,7 +189,12 @@ async def _run_i2v(
         end_image=Path(end_image) if end_image else None,
     )
     await _generate_and_report(
-        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+        request,
+        profile_name=profile_name,
+        profile_dir=profile_dir,
+        out_dir=out_dir,
+        command="video i2v",
+        as_json=as_json,
     )
 
 
@@ -182,6 +209,7 @@ async def _run_r2v(
     model: str | None = None,
     duration: int | None = None,
     count: int = 1,
+    as_json: bool = False,
 ) -> None:
     from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
 
@@ -195,7 +223,12 @@ async def _run_r2v(
         reference_images=tuple(Path(r) for r in refs),
     )
     await _generate_and_report(
-        request, profile_name=profile_name, profile_dir=profile_dir, out_dir=out_dir
+        request,
+        profile_name=profile_name,
+        profile_dir=profile_dir,
+        out_dir=out_dir,
+        command="video r2v",
+        as_json=as_json,
     )
 
 
@@ -256,6 +289,12 @@ def video() -> None:
     type=click.Path(file_okay=False, path_type=Path),
     help="Directory to save the generated mp4. Defaults to tmp/.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of Rich output.",
+)
 def t2v(
     prompt: str,
     aspect: str,
@@ -264,6 +303,7 @@ def t2v(
     count: int,
     profile: str | None,
     out_dir: Path | None,
+    as_json: bool,
 ) -> None:
     """Generate a video from PROMPT."""
     profile_name = _resolve_profile(profile)
@@ -278,8 +318,10 @@ def t2v(
             model=model,
             duration=int(duration) if duration is not None else None,
             count=count,
+            as_json=as_json,
         ),
         cli_command="video t2v",
+        as_json=as_json,
     )
 
 
@@ -338,6 +380,12 @@ def t2v(
     type=click.Path(file_okay=False, path_type=Path),
     help="Directory to save the generated mp4. Defaults to tmp/.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of Rich output.",
+)
 def i2v(
     image: str,
     prompt: str,
@@ -348,6 +396,7 @@ def i2v(
     count: int,
     profile: str | None,
     out_dir: Path | None,
+    as_json: bool,
 ) -> None:
     """Generate a video from a start IMAGE + motion PROMPT."""
     profile_name = _resolve_profile(profile)
@@ -364,8 +413,10 @@ def i2v(
             duration=int(duration) if duration is not None else None,
             count=count,
             out_dir=out_dir,
+            as_json=as_json,
         ),
         cli_command="video i2v",
+        as_json=as_json,
     )
 
 
@@ -424,6 +475,12 @@ def i2v(
     type=click.Path(file_okay=False, path_type=Path),
     help="Directory to save the generated mp4. Defaults to tmp/.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of Rich output.",
+)
 def r2v(
     prompt: str,
     refs: tuple[str, ...],
@@ -433,6 +490,7 @@ def r2v(
     count: int,
     profile: str | None,
     out_dir: Path | None,
+    as_json: bool,
 ) -> None:
     """Generate a video from reference images (--ref) + PROMPT."""
     # Reject over-cap ref counts (and the unsupported model+R2V combo) at the
@@ -464,8 +522,10 @@ def r2v(
             duration=int(duration) if duration is not None else None,
             count=count,
             out_dir=out_dir,
+            as_json=as_json,
         ),
         cli_command="video r2v",
+        as_json=as_json,
     )
 
 

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -18,6 +18,7 @@ from gflow_cli._cli_helpers import (
     _resolve_profile,
     run_with_handlers,
 )
+from gflow_cli.api.video import VideoModel, reference_cap_for
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import DataStoreError
@@ -434,6 +435,22 @@ def r2v(
     out_dir: Path | None,
 ) -> None:
     """Generate a video from reference images (--ref) + PROMPT."""
+    # Reject over-cap ref counts (and the unsupported model+R2V combo) at the
+    # CLI boundary with a clear message (exit 2) rather than letting the domain
+    # ValueError surface as a generic error. GenerateVideoRequest.__post_init__
+    # enforces the same caps as an invariant. Mirrors the i2i pattern.
+    if model is not None:
+        model_enum = VideoModel.from_cli(model)
+        assert model_enum is not None  # narrows for type-checkers; from_cli only
+        # returns None for input None — we just guarded against that.
+        cap = reference_cap_for(model_enum)
+        if cap == 0:
+            raise click.UsageError(f"{model} does not support R2V (reference-to-video).")
+        if len(refs) > cap:
+            raise click.UsageError(
+                f"{model} allows at most {cap} reference image(s); got {len(refs)}."
+            )
+
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     run_with_handlers(

--- a/src/gflow_cli/json_output.py
+++ b/src/gflow_cli/json_output.py
@@ -1,0 +1,176 @@
+"""Machine-readable ``--json`` payload builders + emitter.
+
+Pure module (no I/O beyond the single :func:`emit` ``click.echo``): every
+builder takes already-constructed domain objects and returns a JSON-native
+``dict``. Kept dependency-light (only :mod:`gflow_cli.errors` + typing) so it
+can be imported from both ``_cli_helpers`` (error path) and the command
+modules without an import cycle, and unit-tested without a browser/network.
+
+The shapes here are the stable contract a programmatic caller (e.g. a worker
+that shells out to ``gflow``) parses instead of scraping the Rich tables.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from gflow_cli.errors import (
+    EXIT_CODE_MAP,
+    BrowserSessionClosedError,
+    GFlowError,
+    NetworkError,
+    RateLimitError,
+    TransportTimeoutError,
+    WafRejectionError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from gflow_cli.api.dto import GeneratedImage
+    from gflow_cli.api.video import GenerateVideoRequest, VideoResult
+
+# Transient failures the caller can retry without operator intervention — WAF
+# bounce, rate-limit/quota, transport timeout, network blip, a dropped browser
+# session. Everything else (auth/content-policy/config/security) is terminal:
+# retrying the identical request will fail the same way. A worker keys its
+# "retry vs absorb-and-stop" decision off this flag.
+_RETRYABLE: tuple[type[GFlowError], ...] = (
+    WafRejectionError,
+    RateLimitError,
+    TransportTimeoutError,
+    NetworkError,
+    BrowserSessionClosedError,
+)
+
+
+def emit(payload: dict[str, Any]) -> None:
+    """Print *payload* as indented JSON on stdout (the only side effect here)."""
+    import click
+
+    click.echo(json.dumps(payload, indent=2))
+
+
+def _exit_code(exc: GFlowError) -> int:
+    """Mirror ``_cli_helpers._exit_code_for`` — most-specific class wins."""
+    for cls, code in EXIT_CODE_MAP.items():
+        if isinstance(exc, cls):
+            return code
+    return 1
+
+
+def error_payload(exc: GFlowError) -> dict[str, Any]:
+    """``{status: fail, error: {...RFC 9457..., class, exit_code, retryable}}``.
+
+    Reuses :meth:`GFlowError.to_problem_details` so the JSON error carries the
+    same fields (title/detail/remediation_hint/type) the Rich path prints,
+    plus the concrete class name, mapped process exit code, and the retryable
+    flag the caller branches on.
+    """
+    return {
+        "status": "fail",
+        "error": {
+            **exc.to_problem_details(),
+            "class": type(exc).__name__,
+            "exit_code": _exit_code(exc),
+            "retryable": isinstance(exc, _RETRYABLE),
+        },
+    }
+
+
+def unexpected_payload() -> dict[str, Any]:
+    """Privacy-safe payload for a non-:class:`GFlowError`.
+
+    Mirrors ``_handle_unhandled_error``: never leaks the raw message or stack —
+    only the fact that an unclassified error occurred. Always exit code 1.
+    """
+    return {
+        "status": "fail",
+        "error": {
+            "class": "UnexpectedError",
+            "title": "Unexpected error",
+            "exit_code": 1,
+            "retryable": False,
+        },
+    }
+
+
+def image_result(
+    *,
+    command: str,
+    project_id: str,
+    model: str,
+    images: list[GeneratedImage],
+    saved_paths: list[Path],
+    ref_count: int | None = None,
+) -> dict[str, Any]:
+    """Complete result for a single-prompt ``image t2i`` / ``image i2i`` run.
+
+    Every field captured by :class:`gflow_cli.api.dto.GeneratedImage` is
+    surfaced (nothing dropped); ``local_path`` is the on-disk PNG the CLI
+    downloaded. ``ref_count`` is set only by i2i (None ⇒ key omitted).
+    """
+    items: list[dict[str, Any]] = []
+    for img, path in zip(images, saved_paths, strict=True):
+        width, height = img.dimensions
+        items.append(
+            {
+                "media_name": img.media_name,
+                "workflow_id": img.workflow_id,
+                "seed": img.seed,
+                "prompt": img.prompt,
+                "model_name_type": img.model_name_type,
+                "aspect_ratio": img.aspect_ratio,
+                "dimensions": {"width": width, "height": height},
+                "fife_url": img.fife_url,
+                "is_signed_url": img.is_signed_url,
+                "local_path": str(path),
+            }
+        )
+    payload: dict[str, Any] = {
+        "status": "ok",
+        "command": command,
+        "project_id": project_id,
+        "model": model,
+        "count": len(items),
+        "images": items,
+    }
+    if ref_count is not None:
+        payload["ref_count"] = ref_count
+    return payload
+
+
+def video_result(
+    *,
+    command: str,
+    request: GenerateVideoRequest,
+    result: VideoResult,
+) -> dict[str, Any]:
+    """Complete result for a ``video t2v`` / ``i2v`` / ``r2v`` run.
+
+    Shape follows what Flow actually returns for video (``VideoResult`` +
+    ``VideoStatus``): no ``fife_url``/``dimensions``/per-output ``seed`` like
+    images — those simply do not exist on the video wire, so they are absent
+    rather than faked. ``status`` is "ok"/"fail" mirroring ``succeeded``;
+    ``generation_status`` is the raw ``MEDIA_GENERATION_STATUS_*`` wire value.
+    """
+    st = result.status
+    return {
+        "status": "ok" if st.succeeded else "fail",
+        "command": command,
+        "media_id": st.media_id,
+        "generation_status": st.status,
+        "succeeded": st.succeeded,
+        "local_path": str(result.local_path) if result.local_path is not None else None,
+        "failure_reasons": list(st.failure_reasons),
+        "error_message": st.error_message,
+        "request": {
+            "model": request.model.value if request.model is not None else None,
+            "mode": request.mode.value,
+            "aspect": request.aspect.value,
+            "duration": request.duration,
+            "count": request.count,
+            "seed": request.seed,
+        },
+    }

--- a/src/gflow_cli/observability.py
+++ b/src/gflow_cli/observability.py
@@ -55,7 +55,9 @@ __all__ = [
 def configure_logging(log_format: LogFormat = LogFormat.AUTO) -> None:
     """Bootstrap structlog.
 
-    Renders text on a TTY, JSON when stdout is piped (``LogFormat.AUTO``).
+    Logs are written to **stderr** (stdout is reserved for command output such
+    as ``--json`` payloads, so a consumer can ``json.loads(stdout)`` cleanly).
+    Renders text on a TTY, JSON when stderr is piped (``LogFormat.AUTO``).
     Sets ``show_locals=False`` on the exception renderer so frame locals
     (which can contain auth tokens or signed URLs) are NEVER serialized.
 
@@ -70,7 +72,8 @@ def configure_logging(log_format: LogFormat = LogFormat.AUTO) -> None:
     visible at the call site.
     """
     if log_format == LogFormat.AUTO:
-        is_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
+        # Detect the TTY on the LOG stream (stderr) — that's where logs go.
+        is_tty = bool(getattr(sys.stderr, "isatty", lambda: False)())
         log_format = LogFormat.TEXT if is_tty else LogFormat.JSON
 
     timestamper = structlog.processors.TimeStamper(fmt="iso", utc=True)
@@ -92,6 +95,9 @@ def configure_logging(log_format: LogFormat = LogFormat.AUTO) -> None:
     structlog.configure(
         processors=[*shared_processors, renderer],
         wrapper_class=structlog.make_filtering_bound_logger(INFO_LEVEL),
+        # Route to stderr: the default PrintLoggerFactory writes to stdout,
+        # which corrupts `--json` output (logs interleave with the payload).
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
         cache_logger_on_first_use=False,
     )
 

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -19,6 +19,7 @@ from gflow_cli.api.video import (
     media_name_from_generate_response,
     operation_name_from_generate_response,
     parse_video_status,
+    reference_cap_for,
 )
 
 
@@ -147,19 +148,54 @@ class TestGenerateVideoRequest:
             GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=too_many)
 
     def test_per_model_reference_cap(self) -> None:
+        refs1 = (Path("r0.png"),)
+        refs3 = tuple(Path(f"r{i}.png") for i in range(3))
+        refs4 = tuple(Path(f"r{i}.png") for i in range(4))
         refs5 = tuple(Path(f"r{i}.png") for i in range(5))
         refs7 = tuple(Path(f"r{i}.png") for i in range(7))
-        # veo caps at 3 -> 5 refs rejected
-        with pytest.raises(ValueError, match="at most 3 reference"):
+        refs8 = tuple(Path(f"r{i}.png") for i in range(8))
+
+        # Veo lite/fast/lite_lp cap at 3 -> 4 refs rejected, 3 refs accepted.
+        for veo3 in (
+            VideoModel.VEO_3_1_LITE,
+            VideoModel.VEO_3_1_FAST,
+            VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+        ):
+            with pytest.raises(ValueError, match="at most 3 reference image"):
+                GenerateVideoRequest(prompt="x", mode=Mode.R2V, model=veo3, reference_images=refs4)
+            # exactly at cap is fine
+            GenerateVideoRequest(prompt="x", mode=Mode.R2V, model=veo3, reference_images=refs3)
+
+        # Veo 3.1 Quality does NOT support R2V at all (cap=0) — any ref count rejected.
+        with pytest.raises(ValueError, match="does not support R2V"):
             GenerateVideoRequest(
-                prompt="x", mode=Mode.R2V, model=VideoModel.VEO_3_1_FAST, reference_images=refs5
+                prompt="x",
+                mode=Mode.R2V,
+                model=VideoModel.VEO_3_1_QUALITY,
+                reference_images=refs1,
             )
-        # omni_flash allows 7
+
+        # omni_flash allows 7; 8 rejected (via the absolute ceiling), 7 accepted.
+        with pytest.raises(ValueError, match="at most 7 reference images"):
+            GenerateVideoRequest(
+                prompt="x",
+                mode=Mode.R2V,
+                model=VideoModel.OMNI_FLASH,
+                reference_images=refs8,
+            )
         GenerateVideoRequest(
             prompt="x", mode=Mode.R2V, model=VideoModel.OMNI_FLASH, reference_images=refs7
         )
-        # model None -> only the absolute ceiling (7) applies; 5 is fine
+
+        # model None -> only the absolute ceiling (7) applies; 5 is fine.
         GenerateVideoRequest(prompt="x", mode=Mode.R2V, reference_images=refs5)
+
+    def test_reference_cap_for_helper(self) -> None:
+        assert reference_cap_for(VideoModel.OMNI_FLASH) == 7
+        assert reference_cap_for(VideoModel.VEO_3_1_LITE) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_FAST) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_LITE_LOWER_PRIORITY) == 3
+        assert reference_cap_for(VideoModel.VEO_3_1_QUALITY) == 0
 
     def test_seed_range_enforced(self) -> None:
         with pytest.raises(ValueError, match="seed out of range"):

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -359,6 +359,75 @@ def _make_i2i_client(
     return client
 
 
+class TestImageJsonOutput:
+    def test_t2i_json_emits_clean_machine_readable_result(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        import json as _json
+
+        client = _make_t2i_client(images=[_make_generated_image(media_name="m1")])
+        out_dir = tmp_path / "out"
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--json", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        # Output must be pure JSON — progress chatter is suppressed under --json,
+        # so json.loads succeeding is itself the assertion that nothing leaked.
+        data = _json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["command"] == "image t2i"
+        assert data["count"] == 1
+        assert data["images"][0]["media_name"] == "m1"
+        assert data["images"][0]["local_path"].endswith("m1_1.png")
+
+    def test_t2i_json_rejects_multi_prompt(self, runner: CliRunner) -> None:
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main,
+            ["image", "t2i", "first", "second", "--json"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 2, result.output
+        assert "single-prompt" in result.output
+
+    def test_i2i_json_includes_ref_count(self, runner: CliRunner, tmp_path: Path) -> None:
+        import json as _json
+
+        client = _make_t2i_client(images=[_make_generated_image(media_name="m1")])
+        out_dir = tmp_path / "out"
+        uuid = "11111111-1111-1111-1111-111111111111"
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "i2i", "stylize", "--ref", uuid, "--json", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        data = _json.loads(result.output)
+        assert data["command"] == "image i2i"
+        assert data["ref_count"] == 1
+        assert data["images"][0]["media_name"] == "m1"
+
+
 class TestImageI2I:
     def test_i2i_attaches_local_ref_paths(self, runner: CliRunner, tmp_path: Path) -> None:
         """Local --ref path lands on req.ref_paths for UI media-dialog attach —

--- a/tests/cli/test_cli_models.py
+++ b/tests/cli/test_cli_models.py
@@ -1,0 +1,92 @@
+"""Click-runner tests for `gflow models` (no network — pure catalog)."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from gflow_cli.cli_models import build_catalog
+
+
+def test_models_json_lists_image_and_video() -> None:
+    runner = CliRunner()
+    from gflow_cli.cli import main
+
+    result = runner.invoke(main, ["models", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert set(data) == {"image", "video"}
+
+    by_img = {m["name"]: m for m in data["image"]["models"]}
+    assert {"NARWHAL", "GEM_PIX_2", "IMAGEN_3_5"} <= set(by_img)
+    # Caps must agree with the i2i ref-cap feature.
+    assert by_img["IMAGEN_3_5"]["ref_cap"] == 3
+    assert by_img["NARWHAL"]["ref_cap"] == 10
+    assert by_img["NARWHAL"]["default"] is True
+
+    by_vid = {m["name"]: m for m in data["video"]["models"]}
+    assert by_vid["omni_flash"]["ref_cap"] == 7
+    assert by_vid["omni_flash"]["max_duration"] == 10
+    assert by_vid["veo_3_1_fast"]["ref_cap"] == 3
+    assert by_vid["veo_3_1_fast"]["max_duration"] == 8
+
+
+def test_models_table_renders_without_json() -> None:
+    runner = CliRunner()
+    from gflow_cli.cli import main
+
+    result = runner.invoke(main, ["models"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "NARWHAL" in result.output
+    assert "omni_flash" in result.output
+
+
+def test_catalog_aliases_are_all_gen_command_accepted() -> None:
+    """Every alias the catalog advertises MUST be accepted by the gen command's
+    `--model` Choice — else a UI picks an alias the gen command rejects with a
+    Click usage error (exit 2). Regression guard for that exact mismatch."""
+    from gflow_cli.cli_models import _VIDEO_CLI_MODELS
+    from gflow_cli.image_batch import ALLOWED_MODELS
+
+    catalog = build_catalog()
+    for m in catalog["image"]["models"]:
+        assert m["aliases"], f"{m['name']} has no CLI alias"
+        for a in m["aliases"]:
+            assert a in ALLOWED_MODELS, f"image alias {a!r} not in --model Choice"
+    for m in catalog["video"]["models"]:
+        assert m["aliases"], f"{m['name']} has no CLI alias"
+        for a in m["aliases"]:
+            assert a in _VIDEO_CLI_MODELS, f"video alias {a!r} not in --model Choice"
+
+    # The previously-broken defaults now resolve to accepted aliases.
+    by_img = {m["name"]: m for m in catalog["image"]["models"]}
+    assert by_img["NARWHAL"]["aliases"] == ["nano2"]
+    by_vid = {m["name"]: m for m in catalog["video"]["models"]}
+    assert by_vid["omni_flash"]["aliases"] == ["omni-flash"]
+
+
+def test_catalog_video_aspects_are_all_gen_command_accepted() -> None:
+    """Same regression guard as the alias check, applied to video aspects.
+
+    ``video_api.aspect_choices()`` returns 9:16, 16:9, AND 1:1 (the underlying
+    ``Aspect`` enum has SQUARE), but ``cli_video.py``'s ``--aspect`` Choice
+    only accepts ``9:16`` / ``16:9``. Advertising ``1:1`` in the catalog
+    would mislead a UI into passing a value the gen command rejects with a
+    Click usage error (exit 2).
+    """
+    from gflow_cli.cli_models import _VIDEO_CLI_ASPECTS
+
+    catalog = build_catalog()
+    video_ratios = {a["ratio"] for a in catalog["video"]["aspects"]}
+    assert video_ratios == set(_VIDEO_CLI_ASPECTS), (
+        f"catalog video aspects {sorted(video_ratios)} must match "
+        f"--aspect Choice {sorted(_VIDEO_CLI_ASPECTS)} exactly; "
+        "any drift leaks an unaccepted value to UI consumers."
+    )
+    assert "1:1" not in video_ratios, (
+        "video catalog must NOT advertise 1:1 — `gflow video t2v --aspect 1:1` "
+        "exits with Click invalid-choice (only 9:16 / 16:9 are accepted)."
+    )

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -209,6 +209,148 @@ def test_t2v_records_started_then_completed(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# --json output (mirrors the image json output tests).
+# ---------------------------------------------------------------------------
+
+
+def test_t2v_json_emits_clean_machine_readable_result(tmp_path: Path) -> None:
+    """`gflow video t2v --json` emits a pure-JSON document on stdout (no
+    progress chatter) when the generation succeeds."""
+    import json as _json
+
+    from gflow_cli.api.video import VideoResult, VideoStarted, VideoStatus
+
+    saved = tmp_path / "test-uuid.mp4"
+    saved.touch()
+    stub_result = VideoResult(
+        status=VideoStatus(media_id="m1", status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+        local_path=saved,
+        project_id="p1",
+        flow_operation_id="o1",
+    )
+
+    fake_recorder = FakeVideoRecorder()
+
+    async def fake_generate_video(*, req, out_dir, poll_timeout_s=None, download, on_started):
+        if on_started is not None:
+            import inspect
+
+            res = on_started(VideoStarted(media_id="m1", project_id="p1", flow_operation_id="o1"))
+            if inspect.isawaitable(res):
+                await res
+        return stub_result
+
+    runner = CliRunner()
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.data.recorder.OperationRecorder.open", return_value=fake_recorder),
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aenter__",
+            new_callable=AsyncMock,
+        ) as mock_enter,
+        patch("gflow_cli.api.client.FlowApiClient.__aexit__", new_callable=AsyncMock),
+    ):
+        from gflow_cli.api.client import FlowApiClient
+
+        fake_client = MagicMock(spec=FlowApiClient)
+        fake_client.generate_video = fake_generate_video
+        mock_enter.return_value = fake_client
+
+        result = runner.invoke(video, ["t2v", "a sunset", "--json"])
+
+    assert result.exit_code == 0, result.output
+    # Pure JSON: anything that doesn't parse cleanly means progress chatter leaked.
+    data = _json.loads(result.output)
+    assert data["status"] == "ok"
+    assert data["command"] == "video t2v"
+    assert data["succeeded"] is True
+    assert data["media_id"] == "m1"
+    assert data["request"]["mode"] == "t2v"
+
+
+def test_t2v_json_failed_gen_emits_exactly_one_payload(tmp_path: Path) -> None:
+    """A failed `video t2v --json` must emit EXACTLY ONE JSON document on
+    stdout and exit 1 — not two.
+
+    Regression guard for the bug where `_generate_and_report` emitted the
+    failed `video_result` payload + raised `SystemExit(1)`, and
+    `run_with_handlers(as_json=True)`'s `except BaseException` clause caught
+    the SystemExit and appended a SECOND `UnexpectedError` JSON document
+    behind the first — making `json.loads(stdout)` raise `Extra data` and
+    defeating the whole point of `--json` for a programmatic caller.
+    """
+    import json as _json
+
+    from gflow_cli.api.video import VideoResult, VideoStarted, VideoStatus
+
+    failed_result = VideoResult(
+        status=VideoStatus(
+            media_id="m_fail",
+            status="MEDIA_GENERATION_STATUS_FAILED",
+            failure_reasons=("safety_filter",),
+        ),
+        local_path=None,
+        project_id="p_fail",
+        flow_operation_id="o_fail",
+    )
+
+    fake_recorder = FakeVideoRecorder()
+
+    async def fake_generate_video(*, req, out_dir, poll_timeout_s=None, download, on_started):
+        if on_started is not None:
+            import inspect
+
+            res = on_started(
+                VideoStarted(media_id="m_fail", project_id="p_fail", flow_operation_id="o_fail")
+            )
+            if inspect.isawaitable(res):
+                await res
+        return failed_result
+
+    runner = CliRunner()
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.data.recorder.OperationRecorder.open", return_value=fake_recorder),
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aenter__",
+            new_callable=AsyncMock,
+        ) as mock_enter,
+        patch("gflow_cli.api.client.FlowApiClient.__aexit__", new_callable=AsyncMock),
+    ):
+        from gflow_cli.api.client import FlowApiClient
+
+        fake_client = MagicMock(spec=FlowApiClient)
+        fake_client.generate_video = fake_generate_video
+        mock_enter.return_value = fake_client
+
+        result = runner.invoke(video, ["t2v", "a sunset", "--json"])
+
+    # Exit code matches the failed-gen contract.
+    assert result.exit_code == 1, result.output
+    # `json.loads` succeeds iff stdout is exactly ONE JSON document.
+    # If a SECOND `UnexpectedError` payload leaks in (the old bug),
+    # `json.loads` raises ``json.JSONDecodeError: Extra data``.
+    data = _json.loads(result.output)
+    assert data["status"] == "fail"
+    assert data["command"] == "video t2v"
+    assert data["succeeded"] is False
+    assert data["media_id"] == "m_fail"
+    assert data["generation_status"] == "MEDIA_GENERATION_STATUS_FAILED"
+    assert data["failure_reasons"] == ["safety_filter"]
+    # Belt-and-braces: assert no second top-level JSON object follows.
+    # `{...}{...}` would parse only the first object with `raw_decode`, then
+    # leave non-whitespace trailing chars — the assertion below catches that.
+    decoder = _json.JSONDecoder()
+    _, end = decoder.raw_decode(result.output)
+    trailing = result.output[end:].strip()
+    assert trailing == "", (
+        f"stdout had a second JSON document after the failed-gen payload: {trailing[:200]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # r2v reference-cap CLI guard (mirrors the i2i ref-cap tests).
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -206,3 +206,67 @@ def test_t2v_records_started_then_completed(tmp_path: Path) -> None:
     completed_kwargs = fake_recorder.completed[0]
     assert completed_kwargs["result"] is stub_result
     assert fake_recorder.closed is True
+
+
+# ---------------------------------------------------------------------------
+# r2v reference-cap CLI guard (mirrors the i2i ref-cap tests).
+# ---------------------------------------------------------------------------
+
+
+def test_r2v_rejects_over_cap_for_veo_fast(tmp_path: Path) -> None:
+    """4 --ref against veo-fast (cap 3) -> exit 2 + UsageError message."""
+    runner = CliRunner()
+    refs: list[Path] = []
+    for i in range(4):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        refs.append(p)
+    args = ["r2v", "a prompt", "--model", "veo-fast"]
+    for r in refs:
+        args.extend(["--ref", str(r)])
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(video, args)
+    assert result.exit_code == 2, result.output
+    assert "at most 3 reference image" in result.output
+    assert "got 4" in result.output
+
+
+def test_r2v_rejects_quality_model(tmp_path: Path) -> None:
+    """veo-quality does not support R2V (cap 0) -> exit 2 even with 1 --ref."""
+    runner = CliRunner()
+    ref = tmp_path / "r.png"
+    ref.write_bytes(b"\x89PNG\r\n\x1a\n")
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(
+            video, ["r2v", "a prompt", "--model", "veo-quality", "--ref", str(ref)]
+        )
+    assert result.exit_code == 2, result.output
+    assert "does not support R2V" in result.output
+
+
+def test_r2v_accepts_seven_refs_for_omni_flash(tmp_path: Path) -> None:
+    """omni-flash accepts up to 7 refs; the cap guard must pass them through."""
+    runner = CliRunner()
+    refs: list[Path] = []
+    for i in range(7):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        refs.append(p)
+    args = ["r2v", "a prompt", "--model", "omni-flash"]
+    for r in refs:
+        args.extend(["--ref", str(r)])
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.cli_video._run_r2v", new_callable=AsyncMock) as mock_run,
+    ):
+        mock_run.return_value = None
+        result = runner.invoke(video, args)
+    assert result.exit_code == 0, result.output
+    mock_run.assert_awaited_once()

--- a/tests/e2e/test_json_output_e2e.py
+++ b/tests/e2e/test_json_output_e2e.py
@@ -1,0 +1,213 @@
+"""E2E test for ``--json`` machine-readable output.
+
+Verifies that ``--json`` produces stdout that ``json.loads`` parses cleanly
+(no Rich progress chatter, no structlog leakage on stdout — structlog is
+routed to stderr by the prior commit). A worker shelling out to gflow keys
+its retry / seed continuation off this exact shape, so any drift here is a
+contract break.
+
+Skipped by default; opt in with::
+
+    GFLOW_CLI_E2E_PROFILE=<profile-name> uv run pytest -m e2e -v \\
+        tests/e2e/test_json_output_e2e.py
+
+The non-network commands (``gflow models --json``, ``gflow auth list
+--json``) are also exercised by unit tests; this file adds the live
+subprocess pass to prove no Rich / log leak on the real binary path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.e2e_auth
+def test_e2e_auth_list_json_shape() -> None:
+    """`gflow auth list --json` emits a JSON array of profile records on
+    stdout — pure JSON, no Rich table leak. Worker discovery (``listProfiles``
+    on the aistudio side) keys off this shape."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "gflow_cli", "auth", "list", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"`gflow auth list --json` exited {proc.returncode}; stderr tail: {proc.stderr[-400:]!r}"
+    )
+    data = json.loads(proc.stdout)  # raises on any leak
+    assert isinstance(data, list), f"expected a list, got {type(data).__name__}"
+    if data:
+        keys = sorted(data[0].keys())
+        for required in ("name", "is_default", "cookies_present", "profile_dir"):
+            assert required in keys, f"profile record missing required key {required!r}; got {keys}"
+
+
+@pytest.mark.e2e_auth
+def test_e2e_models_catalog_json_shape() -> None:
+    """`gflow models --json` emits the image+video catalog as a single JSON
+    object on stdout. Catalog content is enum-derived (no I/O), but the
+    subprocess pass proves no Rich console leak."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "gflow_cli", "models", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"`gflow models --json` exited {proc.returncode}; stderr tail: {proc.stderr[-400:]!r}"
+    )
+    data = json.loads(proc.stdout)
+    assert set(data.keys()) >= {"image", "video"}, (
+        f"catalog must have 'image' and 'video' keys; got {sorted(data.keys())}"
+    )
+    # Every advertised alias must be one the gen command's --model Choice
+    # accepts — regression guard for the alias-filter fix folded into 0e318a9.
+    from gflow_cli.cli_models import _VIDEO_CLI_MODELS
+    from gflow_cli.image_batch import ALLOWED_MODELS
+
+    for m in data["image"]["models"]:
+        for alias in m["aliases"]:
+            assert alias in ALLOWED_MODELS, (
+                f"image alias {alias!r} ({m['name']}) is not in --model Choice"
+            )
+    for m in data["video"]["models"]:
+        for alias in m["aliases"]:
+            assert alias in _VIDEO_CLI_MODELS, (
+                f"video alias {alias!r} ({m['name']}) is not in --model Choice"
+            )
+
+
+@pytest.mark.e2e_image
+def test_e2e_image_t2i_json_shape(e2e_env: dict[str, str], tmp_path: Path) -> None:
+    """`gflow image t2i --json` produces a pure-JSON document with the
+    ``image_result`` schema (status / command / project_id / model / count /
+    images[]) when run against real Flow. Costs 1 Imagen credit.
+
+    A worker keys ``images[0].seed`` for refine-regen continuity; this test
+    asserts the field is present and an int, plus the on-disk file landed.
+    """
+    # ``e2e_env`` already creates ``tmp_path/out`` (see tests/e2e/conftest.py).
+    out_dir = tmp_path / "out"
+    # Drop the autouse-isolated GFLOW_CLI_HOME so the subprocess resolves to
+    # the user's real platformdirs path (where the live Chrome session lives).
+    env = dict(e2e_env)
+    env.pop("GFLOW_CLI_HOME", None)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gflow_cli",
+            "image",
+            "t2i",
+            "a calm forest at dawn",
+            "--model",
+            "nano2",
+            "--out",
+            str(out_dir),
+            "--json",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (
+        f"`image t2i --json` exited {proc.returncode}; stderr tail: {proc.stderr[-600:]!r}"
+    )
+
+    # Pure JSON on stdout — anything Rich on stdout breaks json.loads.
+    data = json.loads(proc.stdout)
+    assert data["status"] == "ok"
+    assert data["command"] == "image t2i"
+    assert data["count"] == 1
+    img = data["images"][0]
+    assert img["media_name"], "media_name must be non-empty"
+    assert isinstance(img["seed"], int), (
+        f"images[0].seed must be int for worker refine-regen seed continuity; "
+        f"got {type(img['seed']).__name__}"
+    )
+    saved = Path(img["local_path"])
+    assert saved.exists() and saved.stat().st_size > 0, (
+        f"local_path must point to a downloaded image of non-zero size; "
+        f"got {saved!r} (exists={saved.exists()})"
+    )
+    # JPEG extension fix (#96/#103 upstream) — Flow returns JPEG bytes; the
+    # CLI must save with the correct extension. The exact case differs by
+    # platform; the magic-byte check below is authoritative.
+    head = saved.read_bytes()[:12]
+    assert head.startswith(b"\xff\xd8\xff") or head.startswith(b"\x89PNG"), (
+        f"saved image is neither JPEG nor PNG (magic={head!r})"
+    )
+
+
+@pytest.mark.e2e_video
+def test_e2e_video_t2v_json_shape(e2e_env: dict[str, str], tmp_path: Path) -> None:
+    """`gflow video t2v --json` produces a pure-JSON document with the
+    ``video_result`` schema (status / command / media_id / generation_status /
+    succeeded / local_path / request) when run against real Flow. Costs 1
+    Veo credit (cheapest: veo-lite, 8s).
+    """
+    # ``e2e_env`` already creates ``tmp_path/out`` (see tests/e2e/conftest.py).
+    out_dir = tmp_path / "out"
+    # Use GFLOW_CLI_E2E_VIDEO_RUN guard so callers can opt out of the video
+    # spend even when they pass `-m e2e_video`. Default is OFF.
+    if os.environ.get("GFLOW_CLI_E2E_RUN_VIDEO", "") != "1":
+        pytest.skip(
+            "set GFLOW_CLI_E2E_RUN_VIDEO=1 to include the video --json e2e (spends 1 Veo credit)"
+        )
+
+    # Drop the autouse-isolated GFLOW_CLI_HOME so the subprocess resolves to
+    # the user's real platformdirs path (where the live Chrome session lives).
+    env = dict(e2e_env)
+    env.pop("GFLOW_CLI_HOME", None)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gflow_cli",
+            "video",
+            "t2v",
+            "a golden sunset over mountains",
+            "--model",
+            "veo-lite",
+            "--duration",
+            "8",
+            "--aspect",
+            "9:16",
+            "--out-dir",
+            str(out_dir),
+            "--json",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert proc.returncode == 0, (
+        f"`video t2v --json` exited {proc.returncode}; stderr tail: {proc.stderr[-600:]!r}"
+    )
+    data = json.loads(proc.stdout)
+    assert data["status"] == "ok"
+    assert data["command"] == "video t2v"
+    assert data["succeeded"] is True
+    assert data["media_id"], "media_id must be non-empty"
+    assert data["request"]["mode"] == "t2v"
+    saved = Path(data["local_path"])
+    assert saved.exists() and saved.stat().st_size > 0, (
+        f"local_path must point to a downloaded mp4 of non-zero size; "
+        f"got {saved!r} (exists={saved.exists()})"
+    )
+    head = saved.read_bytes()[:32]
+    assert b"ftyp" in head, f"mp4 magic bytes not in first 32 bytes of {saved}: {head!r}"

--- a/tests/e2e/test_video_r2v_ref_cap_e2e.py
+++ b/tests/e2e/test_video_r2v_ref_cap_e2e.py
@@ -1,0 +1,161 @@
+"""E2E test for per-model r2v reference-image cap.
+
+Verifies that ``VideoModel.VEO_3_1_LITE`` accepts the full 3-ref boundary
+against the real Flow API — Flow silently keeps only the first N refs when
+more are attached, so a "wrong cap" bug shows up as: the generate call
+succeeds but ``ui_automation_video.reference_attached`` fires fewer than
+the requested N times. Asserting on the structured event closes that
+false-positive class. Costs 1 Veo credit.
+
+Skipped by default; opt in with::
+
+    GFLOW_CLI_E2E_PROFILE=<profile-name> uv run pytest -m e2e_video -v \\
+        tests/e2e/test_video_r2v_ref_cap_e2e.py
+
+The cap-reject paths (4 refs against veo-lite, 1 ref against veo-quality
+where cap=0 means R2V is unsupported) are covered by unit + CLI tests
+(`tests/api/test_video.py`, `tests/cli/test_cli_video.py`) and spend
+zero credits.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+import structlog
+
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+    reference_cap_for,
+)
+
+pytestmark = pytest.mark.e2e
+
+_PROMPT = "a colorful scene with the references combined, cinematic"
+_R2V_POLL_TIMEOUT_S = 600.0
+
+
+def _tiny_png(path: Path, color: tuple[int, int, int]) -> Path:
+    """Write a valid 8x8 RGBA PNG of the given color."""
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        crc = zlib.crc32(body) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", crc)
+
+    w = h = 8
+    r, g, b = color
+    raw = b"".join(b"\x00" + bytes((r, g, b, 0xFF)) * w for _ in range(h))
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+    png += _chunk(b"IDAT", zlib.compress(raw))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_video
+async def test_e2e_r2v_at_cap_veo_lite_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """`veo-lite` at its 3-ref cap returns a SUCCESSFUL VideoResult AND Flow
+    actually consumes all 3 refs (one `reference_attached` event per ref).
+
+    If Flow's actual cap is lower than ``reference_cap_for(VEO_3_1_LITE)``
+    (3), fewer events fire and the test FAILS — a tripwire for cap drift on
+    the Flow side. Picking `veo-lite` over `veo-fast` to keep the credit
+    burn on the cheaper tier; the cap (3) is identical across
+    lite/fast/lite_lp on the Flow wire.
+    """
+    # Undo the autouse `_isolate_settings` fixture (tests/conftest.py) so
+    # profile lookup resolves to the user's real platformdirs path (where the
+    # live Chrome session was planted by `gflow auth login`). Isolation is the
+    # right default for non-e2e but breaks e2e session-dependent tests.
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile name")
+    e2e_profile_dir = _resolve_profile_dir(name)
+    if not e2e_profile_dir.exists():
+        pytest.skip(f"profile dir not found: {e2e_profile_dir}")
+
+    cap = reference_cap_for(VideoModel.VEO_3_1_LITE)
+    assert cap == 3, f"unexpected veo-lite cap {cap}; e2e wired for 3"
+    refs = tuple(
+        _tiny_png(tmp_path / f"r{i}.png", color=(40 + 60 * i, 80 + 40 * i, 160 - 30 * i))
+        for i in range(cap)
+    )
+
+    req = GenerateVideoRequest(
+        prompt=_PROMPT,
+        mode=Mode.R2V,
+        aspect=Aspect.PORTRAIT,
+        model=VideoModel.VEO_3_1_LITE,
+        duration=8,  # veo_3_1_lite only supports 8s
+        count=1,
+        reference_images=refs,
+    )
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(e2e_profile_dir)
+        result: VideoResult = await transport.generate_video(
+            request=req,
+            out_dir=tmp_path,
+            poll_timeout_s=_R2V_POLL_TIMEOUT_S,
+        )
+    finally:
+        await transport.teardown()
+
+    # 1. Terminal-success contract.
+    assert isinstance(result, VideoResult), (
+        f"generate_video() must return a VideoResult, got {type(result)!r}"
+    )
+    assert result.status.is_terminal and result.status.succeeded, (
+        f"Expected SUCCESSFUL terminal status, got {result.status.status!r}; "
+        f"failure_reasons={result.status.failure_reasons!r}"
+    )
+    assert result.status.media_id, "VideoStatus.media_id must be non-empty"
+
+    # 2. File-on-disk contract (per [[verification-ledger-5-layer]]).
+    assert result.local_path is not None and result.local_path.exists(), (
+        f"VideoResult.local_path must point to a downloaded mp4; got {result.local_path!r}"
+    )
+    head = result.local_path.read_bytes()[:32]
+    assert b"ftyp" in head, (
+        f"mp4 magic bytes not found in first 32 bytes of {result.local_path}: {head!r}"
+    )
+
+    # 3. Cap-drift tripwire: Flow must report `reference_attached` for ALL
+    # `cap` refs. If only N < cap fire, Flow silently truncated and our cap
+    # value is too generous — bumping `reference_cap_for(VEO_3_1_LITE)` would
+    # invite re-introduction of the bug this PR closes.
+    attached = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.reference_attached"
+    ]
+    assert len(attached) == cap, (
+        f"expected {cap} reference_attached events at the at-cap boundary; "
+        f"got {len(attached)}. Flow likely truncated silently — verify the "
+        f"`reference_cap_for(VEO_3_1_LITE)` value matches Flow's actual cap."
+    )

--- a/tests/features/test_image_steps.py
+++ b/tests/features/test_image_steps.py
@@ -83,6 +83,7 @@ def _make_fake_t2i(file_count: int):
         out: Path | None,
         output_root: Path,
         transport: str | None = None,
+        as_json: bool = False,
     ) -> None:
         # Honor ``count`` if the scenario set it; otherwise fall back to the
         # builder-bound ``file_count`` (lets us write exactly the right

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,148 @@
+"""Unit tests for the `--json` payload builders (pure, no I/O)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gflow_cli import json_output
+from gflow_cli.api.dto import GeneratedImage
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+    VideoStatus,
+)
+from gflow_cli.errors import ContentPolicyError, WafRejectionError
+
+
+def _img(media_name: str = "img-1") -> GeneratedImage:
+    return GeneratedImage(
+        media_name=media_name,
+        workflow_id="wf-1",
+        seed=42,
+        prompt="a cat",
+        model_name_type="NARWHAL",
+        aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+        fife_url="https://flow/x?Signature=abc",
+        dimensions=(768, 1344),
+    )
+
+
+class TestImageResult:
+    def test_complete_shape(self) -> None:
+        payload = json_output.image_result(
+            command="image t2i",
+            project_id="proj-1",
+            model="NARWHAL",
+            images=[_img("a"), _img("b")],
+            saved_paths=[Path("out/a.png"), Path("out/b.png")],
+        )
+        assert payload["status"] == "ok"
+        assert payload["command"] == "image t2i"
+        assert payload["project_id"] == "proj-1"
+        assert payload["count"] == 2
+        assert "ref_count" not in payload  # t2i omits it
+        # Every GeneratedImage field must be surfaced — nothing dropped.
+        assert payload["images"][0] == {
+            "media_name": "a",
+            "workflow_id": "wf-1",
+            "seed": 42,
+            "prompt": "a cat",
+            "model_name_type": "NARWHAL",
+            "aspect_ratio": "IMAGE_ASPECT_RATIO_PORTRAIT",
+            "dimensions": {"width": 768, "height": 1344},
+            "fife_url": "https://flow/x?Signature=abc",
+            "is_signed_url": True,
+            "local_path": str(Path("out/a.png")),
+        }
+
+    def test_i2i_includes_ref_count(self) -> None:
+        payload = json_output.image_result(
+            command="image i2i",
+            project_id="proj-1",
+            model="IMAGEN_3_5",
+            images=[_img()],
+            saved_paths=[Path("out/a.png")],
+            ref_count=3,
+        )
+        assert payload["ref_count"] == 3
+
+
+class TestVideoResult:
+    def _req(self) -> GenerateVideoRequest:
+        return GenerateVideoRequest(
+            prompt="move",
+            mode=Mode.I2V,
+            aspect=Aspect.PORTRAIT,
+            model=VideoModel.VEO_3_1_FAST,
+            duration=8,
+            count=1,
+            start_image=Path("hero.png"),
+        )
+
+    def test_success_shape(self, tmp_path: Path) -> None:
+        out = tmp_path / "v.mp4"
+        result = VideoResult(
+            status=VideoStatus(media_id="m-1", status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+            local_path=out,
+        )
+        payload = json_output.video_result(command="video i2v", request=self._req(), result=result)
+        assert payload["status"] == "ok"
+        assert payload["succeeded"] is True
+        assert payload["media_id"] == "m-1"
+        assert payload["local_path"] == str(out)
+        assert payload["request"]["model"] == "veo_3_1_fast"
+        assert payload["request"]["mode"] == "i2v"
+        assert payload["request"]["duration"] == 8
+
+    def test_failure_shape(self) -> None:
+        result = VideoResult(
+            status=VideoStatus(
+                media_id="m-2",
+                status="MEDIA_GENERATION_STATUS_FAILED",
+                failure_reasons=("policy",),
+                error_message="blocked",
+            ),
+            local_path=None,
+        )
+        payload = json_output.video_result(command="video t2v", request=self._req(), result=result)
+        assert payload["status"] == "fail"
+        assert payload["succeeded"] is False
+        assert payload["local_path"] is None
+        assert payload["failure_reasons"] == ["policy"]
+        assert payload["error_message"] == "blocked"
+
+    def test_model_none_serializes_as_null(self) -> None:
+        req = GenerateVideoRequest(prompt="x", mode=Mode.T2V)  # model None -> Flow UI default
+        result = VideoResult(
+            status=VideoStatus(media_id="m", status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+            local_path=Path("v.mp4"),
+        )
+        payload = json_output.video_result(command="video t2v", request=req, result=result)
+        assert payload["request"]["model"] is None
+
+
+class TestErrorPayload:
+    def test_retryable_waf(self) -> None:
+        payload = json_output.error_payload(WafRejectionError("blocked"))
+        assert payload["status"] == "fail"
+        assert payload["error"]["class"] == "WafRejectionError"
+        assert payload["error"]["retryable"] is True
+        assert payload["error"]["exit_code"] == 10
+        assert payload["error"]["title"]  # RFC 9457 fields carried through
+
+    def test_terminal_content_policy_not_retryable(self) -> None:
+        payload = json_output.error_payload(ContentPolicyError("nope"))
+        assert payload["error"]["class"] == "ContentPolicyError"
+        assert payload["error"]["retryable"] is False
+        assert payload["error"]["exit_code"] == 5
+
+    def test_unexpected_is_privacy_safe(self) -> None:
+        payload = json_output.unexpected_payload()
+        assert payload["error"]["class"] == "UnexpectedError"
+        assert payload["error"]["retryable"] is False
+        assert payload["error"]["exit_code"] == 1
+        # The raw exception message/stack must never leak into the payload.
+        assert "detail" not in payload["error"]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -31,10 +31,10 @@ def _reset_structlog():
 
 
 def test_auto_detects_tty_renders_text(monkeypatch):
-    """When stdout.isatty() == True, AUTO selects text format."""
+    """When stderr.isatty() == True, AUTO selects text format (logs go to stderr)."""
     fake_tty = StringIO()
     fake_tty.isatty = lambda: True  # type: ignore[method-assign]
-    monkeypatch.setattr("sys.stdout", fake_tty)
+    monkeypatch.setattr("sys.stderr", fake_tty)
     configure_logging(LogFormat.AUTO)
     log = structlog.get_logger("test")
     log.info("hello", extra="value")
@@ -48,7 +48,7 @@ def test_auto_detects_tty_renders_text(monkeypatch):
 def test_auto_detects_pipe_renders_json(monkeypatch):
     fake_pipe = StringIO()
     fake_pipe.isatty = lambda: False  # type: ignore[method-assign]
-    monkeypatch.setattr("sys.stdout", fake_pipe)
+    monkeypatch.setattr("sys.stderr", fake_pipe)
     configure_logging(LogFormat.AUTO)
     log = structlog.get_logger("test")
     log.info("hello", extra="value")
@@ -62,7 +62,7 @@ def test_show_locals_is_false_in_exception_renderer():
     """show_locals=False — secrets in local frames must NOT leak into output."""
     fake_pipe = StringIO()
     fake_pipe.isatty = lambda: False  # type: ignore[method-assign]
-    with patch("sys.stdout", fake_pipe):
+    with patch("sys.stderr", fake_pipe):
         configure_logging(LogFormat.JSON)
         log = structlog.get_logger("test")
         try:
@@ -72,6 +72,25 @@ def test_show_locals_is_false_in_exception_renderer():
             log.exception("oops")
         output = fake_pipe.getvalue()
     assert "DO_NOT_LEAK_xyz123" not in output
+
+
+def test_logs_go_to_stderr_not_stdout(monkeypatch):
+    """Logs must land on stderr, leaving stdout clean for command output.
+
+    Regression guard: structlog's default PrintLoggerFactory writes to stdout,
+    which interleaves log lines with a `--json` payload and breaks a
+    consumer's `json.loads(stdout)`. Logs belong on stderr.
+    """
+    fake_out = StringIO()
+    fake_out.isatty = lambda: False  # type: ignore[method-assign]
+    fake_err = StringIO()
+    fake_err.isatty = lambda: False  # type: ignore[method-assign]
+    monkeypatch.setattr("sys.stdout", fake_out)
+    monkeypatch.setattr("sys.stderr", fake_err)
+    configure_logging(LogFormat.JSON)
+    structlog.get_logger("test").info("diagnostic-event")
+    assert fake_out.getvalue() == ""  # stdout untouched
+    assert "diagnostic-event" in fake_err.getvalue()  # log on stderr
 
 
 def _install_log_capture() -> structlog.testing.LogCapture:


### PR DESCRIPTION
## Summary

Adds machine-readable JSON output across the credit-spending generation commands plus a new `gflow models` catalog command, so a programmatic caller (e.g. a worker shelling out to `gflow`) can parse output instead of scraping Rich tables.

**What lands:**

- **`gflow auth list --json`** → JSON array of `{name, is_default, cookies_present, profile_dir, last_used_at}` on stdout (programmatic profile discovery)
- **`gflow image t2i --json`** / **`gflow image i2i --json`** → complete `GeneratedImage` (every field — `media_name`, `workflow_id`, `seed`, `prompt`, `model_name_type`, `aspect_ratio`, `dimensions`, `fife_url`, `is_signed_url`) plus on-disk `local_path` and `ref_count` (i2i only). Single-prompt only — `--json` rejects multi-prompt batch with a Click usage error so stdout shape stays predictable.
- **`gflow video t2v --json`** / **`gflow video i2v --json`** / **`gflow video r2v --json`** → `VideoResult` + `VideoStatus` (`media_id`, `generation_status`, `succeeded`, `local_path`, `failure_reasons`) + request echo (`model` / `mode` / `aspect` / `duration` / `count` / `seed`). A failed gen still emits its JSON payload and then exits 1.
- **`gflow models [--json]`** → image + video catalog: model names, CLI aliases (filtered to what the gen command's `--model` Choice actually accepts), `ref_cap`, `default` (image), `max_duration` (video). Built from the `Model` / `VideoModel` enums + alias maps so it can't drift from what the generation commands accept.
- **Error path** — `_cli_helpers.run_with_handlers(as_json=True)` emits RFC 9457 problem details + a `retryable` flag (WAF / rate-limit / network / timeout) on stdout so a worker can key its retry-vs-absorb decision off a stable signal. Observability event still fires.

## Commits (7 focused, each with `Signed-off-by`)

1. `feat(image): enforce per-model i2i reference cap` (= the sibling i2i-ref-cap PR)
2. `feat(video): enforce per-model r2v reference cap` (= the sibling r2v-ref-cap PR)
3. `feat(auth): add --json to 'auth list'`
4. `fix: route structlog logs to stderr (keep stdout clean for --json)`
5. `feat(cli): json_output module + gflow models catalog`
6. `feat(image): --json output for image t2i/i2i`
7. `feat(video): --json output for video t2v/i2v/r2v`

Carrying the cap PRs as the first two commits because the catalog reads `reference_cap_for(model)` for both image and video. If you merge the cap PRs first I'll rebase this onto develop without the duplicates — just say the word.

## Design notes (would value your opinion)

- **Why structlog → stderr (separate fix commit).** Under `--json`, production code already avoids `console.print` on stdout, but the existing `PrintLoggerFactory()` default writes structlog events to stdout — first JSON gen run would have shipped the JSON payload preceded by ~25 lines of `ui_automation.*` event logs, breaking `json.loads(stdout)`. Logs are diagnostics; stdout is data. No-op for human users — terminals still show logs the same way.
- **Why filter catalog aliases to the gen-accepted set.** Without it, `gflow models --json` advertised every internal alias (e.g. `NARWHAL → nano-banana-2 / nano2 / narwhal / …`) while `gflow image t2i --model` accepts only `image_batch.ALLOWED_MODELS` (`nano2 / nano-pro / image4 / imagen4`). A UI picking the first advertised alias got a Click usage error (exit 2) — the catalog promised a value the gen command rejects. Regression test (`tests/cli/test_cli_models.py::test_catalog_aliases_are_all_gen_command_accepted`) asserts every catalog alias is in the matching `--model` Choice.
- **Single-prompt only on `image t2i --json`.** The batch summary shape is rich-table specific and a programmatic caller almost always wants one prompt + parseable JSON anyway; rejecting with a clean Click usage error keeps stdout shape unambiguous. Happy to add batch JSON later if you'd like — just keeping initial scope tight.
- **Bundled-or-split.** Happy to split into five smaller PRs (auth-list-json / stderr-fix / models-catalog / image-json / video-json) if you'd prefer focused review. Bundled here because each piece is small (the largest, `json_output` + `cli_models`, is ~470 LoC of mostly pure builders) and they were developed together; same diff either way.

## Validation

- [x] **Unit tests** — `tests/test_json_output.py` (148 lines pure tests for payload shapes), `tests/cli/test_cli_models.py` (`build_catalog` + alias-filter regression), `tests/cli/test_cli_image.py::TestImageJsonOutput` (t2i + i2i happy path + multi-prompt rejection), `tests/cli/test_cli_video.py::test_t2v_json_emits_clean_machine_readable_result`, `tests/test_observability.py` (stderr routing)
- [x] **E2e tests** — `tests/e2e/test_json_output_e2e.py` covers:
  - `test_e2e_auth_list_json_shape` (`e2e_auth`, 0 credits) — subprocess pass on the real binary, asserts pure-JSON stdout
  - `test_e2e_models_catalog_json_shape` (`e2e_auth`, 0 credits) — subprocess pass + alias-filter regression
  - `test_e2e_image_t2i_json_shape` (`e2e_image`, 1 Imagen credit) — subprocess pass with real Flow, asserts `images[0].seed` is `int`, file landed
  - `test_e2e_video_t2v_json_shape` (`e2e_video`, 1 Veo credit, opt-in via `GFLOW_CLI_E2E_RUN_VIDEO=1`) — subprocess pass with real Flow
- [x] `uv run python scripts/ci/check_repo_hygiene.py` → 305 files clean
- [x] `uv run ruff check src tests` → clean
- [x] `uv run ruff format --check src tests` → 137 files already formatted
- [x] `uv run pyright src` → 1348 errors, ALL pre-existing baseline (`origin/develop` reports 1352)
- [x] `uv run pytest -q --cov=gflow_cli --cov-fail-under=80` → **994 passed**, coverage **86.59%**
- [x] **Live verification** on a Pro profile (2026-05-28):
  - `gflow auth list --json` shape byte-for-byte stable; one profile record with all five expected keys
  - `gflow models --json` advertised `[nano2]` / `[omni-flash]` / `[veo-quality]` / etc. — every alias passes the gen command's `--model` Choice
  - `gflow image i2i "test" --model nano2 --ref ... (10 refs) --json` → real Flow gen, pure-JSON stdout, `images[0].seed = 201803`, `local_path` ends `.jpg` (the JPEG-extension fix from #103 working end-to-end)
  - `gflow video r2v "test" --model veo-lite --ref ... (3 refs) --json` → real Flow gen, pure-JSON stdout, `media_id` matches downloaded mp4 1.53 MB
  - Full e2e suite (6 tests including 2 cap PRs above) passed live in 469s end-to-end

## Notes

- **One small upstream gotcha I hit running the new e2e locally:** the autouse `_isolate_settings` fixture in `tests/conftest.py` (the one that pins `GFLOW_CLI_HOME` to `tmp_path/gflow_home`) makes the `tests/e2e/conftest.py::e2e_profile_dir` fixture skip every e2e test that needs a real Chrome session, because the session lives under platformdirs, not tmp. The new e2e tests call `monkeypatch.delenv("GFLOW_CLI_HOME"); reset_settings()` at the top to undo the isolation — same pattern your `CONTRIBUTING.md` already documents for default-resolution tests. Happy to send a tiny `tests/e2e/conftest.py` patch that does this once for all e2e tests if you'd find it useful.
- **`OMNI_REFERENCE_CAP` / `VEO_REFERENCE_CAP` removal** — see the heads-up section in the sibling r2v-ref-cap PR; `CHANGELOG.md` has the `### Changed` entry.
