### PR TITLE
feat(skills): add /gflow:predict and /gflow:scenario pre-implementation skills

### DIFF
--- a/.claude/commands/gflow/branch-review.md
+++ b/.claude/commands/gflow/branch-review.md
@@ -4,7 +4,9 @@ description: Multi-dimensional LLM council review on the current local feature b
 
 # `/gflow:branch-review [--base <ref>]`
 
-**Invoke `Skill(skill="pr-council-review")` now in BRANCH MODE**, passing `$ARGUMENTS` (optional `--base <ref>`; default `develop`).
+**Read `skills/pr-council-review/SKILL.md` and follow its protocol now in BRANCH MODE (§ 8)**, passing `$ARGUMENTS` (optional `--base <ref>`; default `develop`).
+
+> Do **not** call `Skill(skill="pr-council-review")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable (only `.claude/commands/gflow/*` are). Invoking it errors with `Unknown skill: pr-council-review`. Read the file directly instead.
 
 The canonical body is `skills/pr-council-review/SKILL.md`. § 8 documents branch-mode-specific behavior: pre-flight, the PR→branch translation table, `release/*` downgrade, SHA drift, and local-only output. All other phases (gather context, detect dimensions, dispatch, synthesize, report) are identical to PR mode.
 

--- a/.claude/commands/gflow/pr-council-review.md
+++ b/.claude/commands/gflow/pr-council-review.md
@@ -4,6 +4,8 @@ description: Multi-dimensional LLM council review of an open PR. Five baseline d
 
 # `/gflow:pr-council-review [PR#]`
 
-**Invoke `Skill(skill="pr-council-review")` now**, passing `$ARGUMENTS` (the PR number, or empty for prioritize-mode). The skill at `skills/pr-council-review/SKILL.md` contains the full protocol: preflight, dimension detection, parallel dispatch, synthesis, report.
+**Read `skills/pr-council-review/SKILL.md` and follow its protocol now**, treating `$ARGUMENTS` as the PR number (or empty for prioritize-mode). That file is the canonical body: preflight, dimension detection, parallel dispatch, synthesis, report.
+
+> Do **not** call `Skill(skill="pr-council-review")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable (only `.claude/commands/gflow/*` are). Invoking it errors with `Unknown skill: pr-council-review`. Read the file directly instead.
 
 Sibling: `/review` is the single-agent Claude-Code built-in (fast, one-pass). Use it for spot-checks; use this command for pre-merge multi-dim audits.

--- a/.claude/commands/gflow/predict.md
+++ b/.claude/commands/gflow/predict.md
@@ -1,0 +1,17 @@
+---
+description: >
+  Pre-implementation 5-persona adversarial analysis for high-stakes gflow-cli proposals.
+  Produces a GO / CAUTION / STOP verdict before any code is written.
+  Invoke before new transports, auth changes, selector redesigns, schema migrations,
+  or any PLAN.md backlog item gated on an investigation step.
+---
+
+# `/gflow:predict [proposal]`
+
+**Invoke `Skill(skill="predict")` now**, passing `$ARGUMENTS` as the proposal description.
+
+The skill at `skills/predict/SKILL.md` runs five independent expert personas
+(Architect · Security/reCAPTCHA · Performance/Playwright · CLI UX · Devil's Advocate),
+resolves conflicts, and returns a GO / CAUTION / STOP verdict with a confidence score.
+
+**Pair with `/gflow:scenario`** after a GO or CAUTION to enumerate edge cases before EXECUTE.

--- a/.claude/commands/gflow/predict.md
+++ b/.claude/commands/gflow/predict.md
@@ -8,7 +8,9 @@ description: >
 
 # `/gflow:predict [proposal]`
 
-**Invoke `Skill(skill="predict")` now**, passing `$ARGUMENTS` as the proposal description.
+**Read `skills/predict/SKILL.md` and follow its protocol now**, passing `$ARGUMENTS` as the proposal description.
+
+> Do **not** call `Skill(skill="predict")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable (only `.claude/commands/gflow/*` are). Invoking it errors with `Unknown skill: predict`. Read the file directly instead.
 
 The skill at `skills/predict/SKILL.md` runs five independent expert personas
 (Architect · Security/reCAPTCHA · Performance/Playwright · CLI UX · Devil's Advocate),

--- a/.claude/commands/gflow/scenario.md
+++ b/.claude/commands/gflow/scenario.md
@@ -1,0 +1,21 @@
+---
+description: >
+  Pre-implementation edge-case explorer for gflow-cli features.
+  Decomposes a proposed change across 12 gflow-cli-specific dimensions
+  (WAF/reCAPTCHA, selector drift, auth lifecycle, batch resume, data layer,
+  cross-platform paths, error propagation, observability) and produces a
+  severity-ranked scenario table and BDD skeleton.
+---
+
+# `/gflow:scenario [feature description]`
+
+**Invoke `Skill(skill="scenario")` now**, passing `$ARGUMENTS` as the feature or change description.
+
+The skill at `skills/scenario/SKILL.md` covers 12 dimensions tuned to gflow-cli's
+known failure surfaces and outputs:
+- A severity-ranked scenario table (Critical / High / Medium / Low)
+- Must-cover acceptance criteria for the PLAN.md task
+- Suggested BDD `Scenario:` blocks for `tests/features/`
+- Cross-references to open KNOWN_ISSUES entries
+
+**Typical order:** `/gflow:predict` → `/gflow:scenario` → PLAN.md task → `/gflow:check` → PR.

--- a/.claude/commands/gflow/scenario.md
+++ b/.claude/commands/gflow/scenario.md
@@ -9,7 +9,9 @@ description: >
 
 # `/gflow:scenario [feature description]`
 
-**Invoke `Skill(skill="scenario")` now**, passing `$ARGUMENTS` as the feature or change description.
+**Read `skills/scenario/SKILL.md` and follow its protocol now**, passing `$ARGUMENTS` as the feature or change description.
+
+> Do **not** call `Skill(skill="scenario")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable (only `.claude/commands/gflow/*` are). Invoking it errors with `Unknown skill: scenario`. Read the file directly instead.
 
 The skill at `skills/scenario/SKILL.md` covers 12 dimensions tuned to gflow-cli's
 known failure surfaces and outputs:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -43,6 +43,8 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 | `/gflow:known-issues` | Surface open and mitigated issues | Before touching auth, reCAPTCHA, or previously-flagged code |
 | `/gflow:changelog` | Show `[Unreleased]` entries + last tagged release | Need a quick picture of recent work |
 | `/gflow:release` | Full release flow (calls `/gflow:changelog` + `/gflow:check`) | Cutting a new version |
+| `/gflow:predict <proposal>` | 5-persona pre-implementation analysis → GO / CAUTION / STOP | Before any high-stakes design decision (new transport, auth change, selector redesign, schema migration) |
+| `/gflow:scenario <feature>` | 12-dimension edge-case explorer → severity-ranked scenario table + BDD skeleton | After predict GO/CAUTION; before writing the PLAN.md task spec |
 
 **Governance:** commands are executable docs — they decay like any doc. When a phase advances or a file path changes, update the relevant command in the same commit. `/gflow:release` includes a staleness review step.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,14 @@ This directory ships an installable Skill that lets agents (Claude Code, Cursor,
 
 [`gflow-cli/SKILL.md`](gflow-cli/SKILL.md) — describes when to invoke `gflow`, prerequisites, the command surface, recipes, and common errors. Plain Markdown with frontmatter, so it works as both a Claude Code skill and a generic agent reference doc.
 
+## predict skill
+
+[`predict/SKILL.md`](predict/SKILL.md) — pre-implementation 5-persona adversarial analysis (Architect · Security/reCAPTCHA · Performance/Playwright · CLI UX · Devil's Advocate). Returns a GO / CAUTION / STOP verdict before any code is written. Invoke via `/gflow:predict <proposal>` for high-stakes decisions: new transport, auth change, selector redesign, schema migration.
+
+## scenario skill
+
+[`scenario/SKILL.md`](scenario/SKILL.md) — 12-dimension edge-case explorer tuned to gflow-cli's known failure surfaces (WAF/reCAPTCHA scoring, Playwright selector drift, auth token lifecycle, batch resume idempotency, SQLite data layer, RFC 9457 error propagation, cross-platform paths, observability contract). Produces a severity-ranked scenario table and BDD `Scenario:` blocks. Invoke via `/gflow:scenario <feature>` after a predict GO/CAUTION, before writing the PLAN.md task spec.
+
 ### Install for Claude Code
 
 ```bash

--- a/skills/predict/SKILL.md
+++ b/skills/predict/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: predict
+description: >
+  Pre-implementation multi-persona adversarial analysis for gflow-cli proposals.
+  Five expert personas independently evaluate a proposed change before a single
+  line of code is written, then converge on a GO / CAUTION / STOP verdict.
+  Invoke before any high-stakes decision: new transport, auth change, selector
+  redesign, schema migration, API surface change, or backlog item requiring an
+  investigation gate.
+---
+
+# `predict` — Pre-Implementation Multi-Persona Analysis
+
+Structured pre-implementation review. Five expert personas assess the proposal
+**independently**, then debate, then converge on a verdict with a confidence
+score. Surfacing architectural, security, performance, and UX flaws before the
+first commit is the cheapest place to catch them.
+
+---
+
+## When to invoke
+
+Use before implementing any of:
+- A new transport strategy (`sapisidhash`, `cdp_attach`, `official_veo`)
+- Auth flow changes (new strategy, G12 bypass technique, cookie extraction)
+- Selector cascade redesigns affecting `ONBOARDING_SELECTORS`, `NEW_PROJECT_SELECTORS`, `FRAME_SLOTS_STRUCT`
+- Schema migrations in `gflow_cli/data/`
+- New CLI surface or exit-code changes
+- Any backlog item with an "investigation gate" in PLAN.md before coding
+
+Skip for: trivial bug fixes (< 10 lines, isolated, no boundary cross), already-approved PLAN.md tasks entering EXECUTE, pure doc changes.
+
+---
+
+## Invocation
+
+```
+/gflow:predict <proposal>
+```
+
+`<proposal>` is a short description of what you intend to build or change —
+one paragraph is enough. Examples:
+- "Wire SAPISIDHASH auth header into `_post_json` for all `aisandbox-pa` routes (Issue #15)"
+- "Add CDP-attach transport as opt-in `--transport cdp_attach` alongside `ui_automation`"
+- "Redesign `gflow video batch` to use a local manifest ledger for skip-already-done"
+- "Add `AuthBrowserBlockedError` to `internal_chromium.py` when Google rejects bundled Chromium"
+
+---
+
+## Protocol
+
+### Phase 1 — Persona briefings (parallel)
+
+Dispatch five personas simultaneously. Each reads `AGENTS.md`, `PLAN.md`, `KNOWN_ISSUES.md`, and the relevant source files for the proposal. Each assesses **independently** — no persona sees another's output during Phase 1.
+
+#### Persona 1 — Architect
+*Scope: hexagonal target, modular-monolith current shape, dependency direction, module boundary rules.*
+
+Asks:
+- Does this proposal respect the dependency rule (`interfaces → application → domain ← infrastructure`)?
+- Which module does this live in? Does it fit cleanly or does it need a new module, and if so, is that justified?
+- Will this make the eventual DDD graduation harder or easier?
+- Are there hidden coupling risks (e.g., a transport leaking into `cli.py`, a domain model importing from `infrastructure`)?
+- Does the proposed shape match the existing pattern (Protocol-based ports, frozen dataclasses for value objects, `structlog` for all logging)?
+
+Output: structured analysis, confidence `0–10`, architectural risks.
+
+#### Persona 2 — Security / reCAPTCHA
+*Scope: Google's anti-bot stack, SAPISIDHASH, G12 block, WAF scoring, profile isolation, secret storage.*
+
+Asks:
+- Does this touch auth headers, cookie extraction, or token minting? If yes, what's the trust boundary?
+- Could this trigger WAF score inflation on a per-profile basis?
+- Does the Chrome profile isolation guarantee (`SecurityError` if profile_dir outside `GFLOW_CLI_HOME`) remain intact?
+- Are any auth secrets (SAPISID, bearer tokens, reCAPTCHA tokens) at risk of leaking to logs? (`show_locals=False` is mandatory on exception renderers.)
+- Could this bypass the G12 stealth flag mechanism or reintroduce `navigator.webdriver=true`?
+- What's the attack surface against a third party who controls the Flow UI (XSS / selector injection)?
+
+Output: structured analysis, confidence `0–10`, security risks with severity.
+
+#### Persona 3 — Performance / Playwright
+*Scope: Page pool, `asyncio.gather`, reCAPTCHA mint latency, headless detection, BrowserContext lifecycle.*
+
+Asks:
+- Does this add latency to the hot path (per-generation or per-poll)?
+- Does it interact with the Page pool (`_checkout_page` / `_checkin_page`)? Is there a `QueueFull` risk?
+- Does it require additional `page.evaluate` calls? What's the latency budget vs the 200 ms/page threshold?
+- Does it affect `GFLOW_CLI_CONCURRENCY`? Could it reduce or increase the safe ceiling?
+- Could running this in a headless context trigger reCAPTCHA detection or WAF scoring?
+- Does it add any persistent state that's not cleaned up when `FlowApiClient.__aexit__` runs?
+
+Output: structured analysis, confidence `0–10`, performance bottlenecks.
+
+#### Persona 4 — CLI UX / Cross-platform
+*Scope: exit codes (RFC 9457), `structlog` events, Windows/macOS/Linux path handling, `--help` text, error recovery UX.*
+
+Asks:
+- What exit code does failure produce? Is it in `EXIT_CODE_MAP`? Is it distinct from existing codes?
+- What `structlog` events does this introduce? Are `error_raised` / `error_unhandled` paths handled?
+- Are new env vars or flags introduced? Do they follow `GFLOW_CLI_*` convention and have a `.env.template` entry?
+- Does the UX degrade gracefully if the new feature fails (remediation hint in error message)?
+- On Windows: are path separators, `platformdirs` paths, and `PYTHONUTF8=1` requirements respected?
+- If this is a new subcommand or flag: is the `--help` text self-contained and accurate?
+
+Output: structured analysis, confidence `0–10`, UX friction points.
+
+#### Persona 5 — Devil's Advocate
+*Scope: YAGNI, simpler paths, interaction with KNOWN_ISSUES, backlog sequencing.*
+
+Asks:
+- Is there a simpler way to achieve the same user outcome (fewer files, less Playwright surface, existing code reuse)?
+- Does PLAN.md already have an ADR that contradicts or defers this work?
+- Is there a known issue in `KNOWN_ISSUES.md` that makes this approach risky or likely to fail?
+- If this fails in production (WAF score spike, reCAPTCHA regression, selector drift), what's the rollback story?
+- Is the timing right? Does something else need to land first (e.g., Issue #14 before Issue #15)?
+- What's the simplest experiment (smoke test, `scripts/` script, isolated spike) that could prove/disprove the core assumption before committing to a full implementation?
+
+Output: structured analysis, confidence `0–10`, alternative paths, blocking concerns.
+
+---
+
+### Phase 2 — Conflict resolution
+
+After all five personas return:
+
+1. **Tally signals.** Identify any dimension where 2+ personas flag the same concern — those surface as high-confidence risks.
+2. **Resolve conflicts.** If Architect says "fits cleanly" but Devil's Advocate says "ADR #13 defers this" — surface the conflict explicitly. Do NOT silently suppress one view.
+3. **Score overall confidence** as the average of the five persona confidence scores, then apply modifiers:
+   - Any STOP condition from any persona → overall **STOP** regardless of average.
+   - Devil's Advocate identifies a simpler approach the others missed → downgrade confidence by 2.
+   - All five personas agree on the approach → upgrade confidence by 1.
+
+---
+
+### Phase 3 — Verdict
+
+**GO** (confidence ≥ 7, no STOP conditions): all personas aligned or concerns are mitigated within the proposal. Safe to proceed to PLAN mode.
+
+**CAUTION** (confidence 4–6, or one unresolved STOP candidate): proceed but explicitly address the flagged concerns in the PLAN before EXECUTE. Surface the specific mitigations needed.
+
+**STOP** (confidence < 4, or any hard STOP): one or more of:
+- A security bypass that cannot be fixed within the proposal scope
+- A fundamental architectural incompatibility with the hexagonal target
+- A performance regression that violates the 200 ms/page threshold at N=16
+- A PLAN.md ADR that explicitly defers this work
+- An existing KNOWN_ISSUES entry that makes the approach likely to fail
+- Devil's Advocate found a simpler approach that makes this one wasteful
+
+On STOP, output the specific blocking concern and the minimum change required to convert to CAUTION.
+
+---
+
+## Output format
+
+```
+# Predict: <proposal short title>
+
+## Verdict: <GO | CAUTION | STOP>
+**Confidence:** <N>/10
+
+## Summary
+<2-3 sentences. What the five personas collectively found.>
+
+## Persona findings
+
+### Architect — <signal> (<confidence>/10)
+<findings>
+
+### Security / reCAPTCHA — <signal> (<confidence>/10)
+<findings>
+
+### Performance / Playwright — <signal> (<confidence>/10)
+<findings>
+
+### CLI UX / Cross-platform — <signal> (<confidence>/10)
+<findings>
+
+### Devil's Advocate — <signal> (<confidence>/10)
+<findings>
+
+## High-confidence risks (flagged by 2+ personas)
+1. …
+
+## Conflicts resolved
+- <Persona A vs Persona B — resolution>
+
+## Required mitigations before EXECUTE (CAUTION only)
+1. …
+
+## Recommended next step
+<One sentence. E.g.: "Open a PLAN.md task for Issue #15 gated on SAPISIDHASH investigation steps 1–3." or "Run the smoke script in scripts/smoke_video_editor.py against the live API before committing to the full design.">
+```
+
+---
+
+## Integration with the gflow-cli workflow
+
+- **After GO:** proceed to PLAN.md and add a task under the relevant phase.
+- **After CAUTION:** address mitigations in the PLAN spec before invoking `/gflow:scenario` or entering EXECUTE.
+- **After STOP:** address the blocking concern first. Consider filing a PLAN.md investigation gate task.
+- **Before EXECUTE:** pair with `/gflow:scenario` for systematic edge-case coverage on the implementation.
+
+---
+
+## Provenance
+
+Adapted from `vc-predict` in [vibecode-pro-max-kit](https://github.com/withkynam/vibecode-pro-max-kit) (assessment 2026-05-28).
+Personas re-scoped to gflow-cli surfaces: Google anti-bot stack, Playwright Page pool, RFC 9457 exit codes, hexagonal architecture target.

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: scenario
+description: >
+  Pre-implementation edge-case and scenario explorer for gflow-cli.
+  Decomposes a proposed feature or change across 12 structured dimensions
+  specific to gflow-cli's failure surfaces (WAF/reCAPTCHA, Playwright selectors,
+  auth token lifecycle, batch resume, data layer safety, cross-platform paths).
+  Produces a severity-ranked scenario table to feed into the PLAN spec and
+  the test matrix before EXECUTE begins.
+---
+
+# `scenario` — Edge Case & Scenario Explorer
+
+Systematic pre-implementation scenario analysis. For a given feature or change,
+produces a severity-ranked table of test scenarios across 12 dimensions tuned
+to gflow-cli's known failure surfaces. Feed the output into PLAN.md tasks and
+`tests/features/` BDD scenarios before entering EXECUTE mode.
+
+---
+
+## When to invoke
+
+Use before implementing any of:
+- A new generation path (T2V, I2V, R2V, batch manifest runner)
+- Transport changes (any new HTTP call against `aisandbox-pa.googleapis.com`)
+- Auth or session changes (new strategy, cookie extraction, SAPISIDHASH wiring)
+- Selector cascade changes (`ONBOARDING_SELECTORS`, `NEW_PROJECT_SELECTORS`, `FRAME_SLOTS_STRUCT`, `IMAGE_MODEL_OPTION_SELECTORS`)
+- Data layer changes (schema migration, new `OperationRecorder` callsite, redaction change)
+- New CLI subcommand, flag, or exit code
+
+Skip for: pure doc changes, CHANGELOG/version bumps, `scripts/` tooling with no production callpath.
+
+---
+
+## Invocation
+
+```
+/gflow:scenario <feature or change description>
+```
+
+`<feature or change description>` is a brief summary of what you're about to implement. Examples:
+- "SAPISIDHASH auth header wired into `_post_json` for `aisandbox-pa` routes"
+- "gflow video batch manifest ledger (skip already-completed rows)"
+- "Image model picker converted from English has-text to structural anchor"
+- "CDP-attach transport as opt-in alongside ui_automation"
+
+---
+
+## The 12 dimensions
+
+For each dimension, enumerate scenarios that are **non-obvious** — do not list
+things that a basic happy-path test already covers. Focus on things that break
+in production but pass in unit tests.
+
+### D1 — Auth & session lifecycle
+The SAPISID cookie expires. The user re-runs `gflow auth login` mid-batch. A
+profile is created but the Flow session was never verified. The session is valid
+for `labs.google` tRPC but not for `aisandbox-pa`. Two profiles are in use
+simultaneously (Chromium profile-lock).
+
+### D2 — WAF / reCAPTCHA scoring
+A profile's WAF heat score is elevated from prior automation runs. reCAPTCHA
+Enterprise detects `navigator.webdriver=true` despite the `--disable-blink-features`
+stealth flag. The `grecaptcha.execute()` call times out or returns a challenge
+that requires human interaction. The same token is submitted twice (single-use
+token reuse). A batch run fires multiple rapid token mints within one session.
+
+### D3 — Selector cascade drift (Flow UI updates)
+Google Flow ships a UI update that renames or restructures a selector anchor.
+`FRAME_SLOTS_STRUCT` matches zero elements (the PR #70 regression). The
+structural-first tier matches but selects the wrong element (e.g., two elements
+matching `div[type='button'][aria-haspopup='dialog']` after Flow adds a new
+dialog button). A new locale is used whose CMP dialog is not in
+`_ONBOARDING_TEXT_SELECTORS`. The `--lang=en-US` Chromium arg is removed before
+`IMAGE_MODEL_OPTION_SELECTORS` is converted to structural anchors.
+
+### D4 — Batch manifest & resume
+A 50-row TSV manifest dies at row 23 (auth expiry). On resume, rows 1–22 are
+re-submitted and double-billed. A row has an empty `start_image` field (T2V)
+while the column parser expected a path. The output path already exists on disk
+from a prior run (overwrite vs skip decision). Two `gflow video batch` invocations
+against the same profile run concurrently (Chromium profile-lock).
+
+### D5 — Concurrency & Page pool
+`GFLOW_CLI_CONCURRENCY=16` fans out 16 simultaneous `page.evaluate()` reCAPTCHA
+token mints — do they share site key state safely? A Page is returned to the pool
+while still in a modal dialog (state contamination for the next checkout). A
+`QueueFull` double-checkin race where two coroutines both attempt to return the
+same Page object. `asyncio.gather` propagates one failure but leaves the other
+coroutines in a half-completed state with no cleanup path.
+
+### D6 — Data layer (SQLite / DataStore)
+`DataStore` migration runs on a schema that's one version ahead (newer-schema
+detection should raise `DataStoreError` exit 16, not silently corrupt). An
+`OperationRecorder.on_started` callback raises inside a generation loop — does
+the batch continue or crash? `GFLOW_CLI_HISTORY_PROMPTS=redacted` is set — does
+the new callsite respect the redaction gate? A Windows path with a drive letter
+is stored in the DB and retrieved on Linux (or vice versa). The DB is on a
+network filesystem and the write locks time out.
+
+### D7 — Error propagation & exit codes
+A new exception class is added but not registered in `EXIT_CODE_MAP`. A
+`FlowApiError` subclass is raised inside a retry loop — does `reraise=True`
+propagate the right typed exception or does tenacity eat it? `WireFormatError`
+discovery payload logs the route body prefix — does it redact reCAPTCHA tokens
+and auth headers? An unhandled exception escapes `run_with_handlers` — is it
+SHA-256-hashed before logging (never raw message)?
+
+### D8 — Cross-platform paths
+A Windows user has a Unicode character in their `%LOCALAPPDATA%` path. The
+output directory path contains spaces. `platformdirs` returns a different base
+path on macOS vs Linux vs Windows — does the feature hardcode any of these?
+`PYTHONUTF8=1` is not set — are there `cp1252` encoding traps on Windows for
+prompt text or file names?
+
+### D9 — Transport edge cases
+The HTTP response body is valid JSON but has an unexpected top-level key (should
+emit `WireFormatError` with discovery payload, not crash). A video generation
+response omits `operations[0].operation.name` (the `omni-flash` NULL
+`flow_operation_id` issue). A status-poll response arrives before the listener
+is attached (`_attach_status_response_listener` race). A video download URL has
+a `googleapis.com` host not in the SSRF allowlist.
+
+### D10 — Headless vs headed environment
+The feature is run in a CI environment with no display server (Linux, no Xvfb).
+The Playwright context is launched headed (user has `GFLOW_CLI_HEADLESS=false`)
+and the window is closed manually mid-batch. `gflow auth login --browser
+internal` is used on a machine where Playwright bundled Chromium is flagged by
+Google's G12 block.
+
+### D11 — Input validation & boundary values
+A prompt string is 4001 characters (Flow's apparent limit). A manifest TSV has
+zero rows (after the header). `--seed` receives a negative integer or a string.
+`-n 5` is passed to `gflow image t2i` (Flow's UI cap is `x4`). An aspect ratio
+of `3:2` is passed (valid-looking but not in the whitelist). A `--profile` name
+contains path-separator characters.
+
+### D12 — Observability & structured log contract
+A new `structlog` event is emitted — is its key name stable and documented in
+`docs/ARCHITECTURE.md`? A new `error_raised` path: does it carry the full RFC
+9457 Problem Details shape (`type`, `title`, `status`, `detail`, `instance`,
+`remediation_hint`)? `correlation_id` is bound at the process boundary — does
+it propagate into the new code path or is it missing from the event?
+
+---
+
+## Output format
+
+```
+# Scenario: <feature short title>
+
+## Coverage map
+<Which of the 12 dimensions are relevant for this feature? List active dimensions and why skipped dimensions are skipped.>
+
+## Scenario table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D2 WAF/reCAPTCHA | WAF score elevated on profile from prior run | Critical | WafRejectionError raised with remediation hint "let score decay or use a different profile"; exit code 403-mapped | E2E live (`@pytest.mark.live`) |
+| … | … | … | … | … | … |
+
+Severity: **Critical** (data loss / billed twice / unrecoverable) · **High** (feature broken, workaround exists) · **Medium** (degraded UX, explicit error) · **Low** (cosmetic or edge-only)
+
+Test category: **Unit** (no I/O) · **Integration** (mocked HTTP/Playwright) · **BDD** (Gherkin feature file) · **E2E smoke** (`@pytest.mark.smoke`) · **E2E live** (`@pytest.mark.live`, opt-in)
+
+## Must-cover before merge (Critical + High)
+1. …
+
+## Deferred (Medium + Low — log as issues, not blockers)
+1. …
+
+## Suggested BDD scenarios (for `tests/features/`)
+```gherkin
+Feature: <feature name>
+  Scenario: <scenario title>
+    Given …
+    When …
+    Then …
+```
+
+## Known-issues cross-reference
+<Any scenario that maps to an existing KNOWN_ISSUES entry — link and note whether the proposed implementation resolves, mitigates, or is blocked by it.>
+```
+
+---
+
+## Integration with the gflow-cli workflow
+
+1. Run `/gflow:predict` first to validate the approach (GO/CAUTION/STOP).
+2. Run `/gflow:scenario` to enumerate edge cases and build the test matrix.
+3. Use the "Must-cover before merge" list as the acceptance criteria for the PLAN.md task.
+4. Add BDD scenarios to `tests/features/` **before** coding (TDD is non-negotiable per AGENTS.md).
+5. After implementation, verify Critical + High scenarios are covered by tests before running `/gflow:check`.
+
+---
+
+## Provenance
+
+Adapted from `vc-scenario` in [vibecode-pro-max-kit](https://github.com/withkynam/vibecode-pro-max-kit) (assessment 2026-05-28).
+12 dimensions re-scoped to gflow-cli's specific failure surfaces: Google WAF/reCAPTCHA, Playwright selector drift, auth token lifecycle, batch resume idempotency, SQLite data layer, RFC 9457 error propagation, cross-platform Windows/macOS/Linux paths.


### PR DESCRIPTION
## Summary

Assessment of [vibecode-pro-max-kit](https://github.com/withkynam/vibecode-pro-max-kit) identified two high-value pre-implementation patterns we were missing. This PR adds them as gflow-cli-native skills, adapted to our specific failure surfaces.

- **`/gflow:predict <proposal>`** — 5-persona adversarial analysis (Architect · Security/reCAPTCHA · Performance/Playwright · CLI UX · Devil's Advocate) → GO / CAUTION / STOP verdict before any code is written
- **`/gflow:scenario <feature>`** — 12-dimension edge-case explorer → severity-ranked scenario table + BDD `Scenario:` skeletons + KNOWN_ISSUES cross-references

## Why these two

gflow-cli already has strong post-implementation review (`/gflow:pr-council-review`, `code-review`, `security-review`) and post-commit hygiene (`/gflow:check`). What was missing was a **pre-implementation gate** — something to stress-test a proposed approach before the first commit. The vibecode kit's `vc-predict` and `vc-scenario` fill exactly that gap.

The other 29 skills and 12 agents in the vibecode kit were assessed but not adopted:
- **Already covered by us:** `vc-code-reviewer` (our council is more sophisticated), `vc-scout` (we have the `Explore` agent), `vc-watzup` (we have `/gflow:plan`), `vc-git-manager`, `vc-tester`, `vc-update-process-agent`, `vc-publish`
- **Not relevant:** `vc-ui-ux-designer` (we're a CLI), `vc-chrome-devtools` (we use Playwright), `vc-tech-graph`, `vc-repomix`, `vc-team`
- **Medium value, deferred:** `vc-autoresearch` (automated coverage iteration), `vc-sequential-thinking` (structured debugging), RIPER-5 fast-mode

## Intended workflow

```
/gflow:predict "SAPISIDHASH wired into _post_json for Issue #15"
→ GO / CAUTION / STOP
/gflow:scenario "SAPISIDHASH auth header on aisandbox-pa routes"
→ scenario table + BDD skeletons
→ add to PLAN.md task spec
→ /gflow:check
→ PR
```

## Files changed

| File | Change |
|---|---|
| `skills/predict/SKILL.md` | New — 5-persona predict protocol |
| `skills/scenario/SKILL.md` | New — 12-dimension scenario explorer |
| `.claude/commands/gflow/predict.md` | New — thin `/gflow:predict` wrapper |
| `.claude/commands/gflow/scenario.md` | New — thin `/gflow:scenario` wrapper |
| `docs/INDEX.md` | Added both commands to Agent commands table |
| `skills/README.md` | Added entries for both new skills |

## Test plan

- [ ] `python scripts/ci/check_doc_links.py` — passes (all internal links resolve)
- [ ] `python scripts/ci/check_repo_hygiene.py` — passes (no hygiene violations)
- [ ] Both skills discoverable: `Skill(skill="predict")` and `Skill(skill="scenario")` route correctly
- [ ] `/gflow:predict "add SAPISIDHASH to Issue #15"` produces a structured 5-persona verdict
- [ ] `/gflow:scenario "SAPISIDHASH auth on aisandbox-pa"` produces a 12-dimension scenario table
- [ ] Cross-tool: `skills/predict/SKILL.md` and `skills/scenario/SKILL.md` are self-contained Markdown (usable by Gemini CLI / Codex / Cursor without Claude Code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4ZPhgXnPKrBqkbkHXVqF3)_