### PR TITLE
test(data): guard list-query plans against full scans of local_files (refs #112)

### DIFF
--- a/tests/test_data_queries.py
+++ b/tests/test_data_queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -10,6 +11,8 @@ import pytest
 
 from gflow_cli.data.models import AssetKind, AssetRecord, LocalFileRecord, ProjectRecord
 from gflow_cli.data.queries import (
+    _LIST_IMAGES_SQL,
+    _LIST_VIDEOS_SQL,
     list_images,
     list_profiles,
     list_projects,
@@ -295,3 +298,67 @@ def test_list_images_no_local_files_copy_count_is_zero(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0].copy_count == 0
     assert rows[0].local_path is None
+
+
+# ---------------------------------------------------------------------------
+# Query-plan regression — closes #112
+# ---------------------------------------------------------------------------
+
+
+def _local_files_scan_lines(plan_rows: list[sqlite3.Row]) -> list[str]:
+    """Return plan detail lines that scan the ``local_files`` table directly."""
+    details = [str(row[-1]) for row in plan_rows]
+    return [d for d in details if "local_files" in d and d.lstrip().startswith(("SCAN", "SEARCH"))]
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [_LIST_IMAGES_SQL, _LIST_VIDEOS_SQL],
+    ids=["images", "videos"],
+)
+def test_list_aggregation_uses_index_not_full_scan(tmp_path: Path, sql: str) -> None:
+    """#112: the ``GROUP BY asset_id`` aggregation must resolve via an index, never
+    a full table scan of ``local_files``.
+
+    The covering index is supplied for free by the ``UNIQUE(asset_id, path)``
+    constraint — SQLite's implicit ``sqlite_autoindex_local_files_2`` — so no extra
+    index or migration is warranted (this is why #112 needs no schema change). The
+    assertion matches on "uses an index" rather than the autoindex's name so it stays
+    valid if SQLite renames it or we later add an explicit index. It guards against a
+    schema change (e.g. dropping that UNIQUE constraint) silently regressing the list
+    queries to a full scan.
+    """
+    params = {"profile": None, "limit": 50, "offset": 0}
+    with DataStore.open(tmp_path / "plan.db") as store:
+        plan = store.conn.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+
+    scans = _local_files_scan_lines(plan)
+    assert scans, f"expected the plan to scan local_files; plan was {[r[-1] for r in plan]}"
+    for line in scans:
+        assert "USING" in line and "INDEX" in line, (
+            f"full-scan regression on local_files — expected an index scan, got {line!r}"
+        )
+
+
+def test_local_files_scan_guard_detects_full_scan() -> None:
+    """Proves the guard above is not vacuous: without the ``UNIQUE(asset_id, path)``
+    covering index the same aggregation falls back to a bare ``SCAN local_files``,
+    which :func:`_local_files_scan_lines` flags and the assertion above would reject."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE TABLE local_files (id TEXT PRIMARY KEY, asset_id TEXT NOT NULL, "
+            "path TEXT NOT NULL)"
+        )
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT asset_id, COUNT(*), MAX(path) FROM local_files GROUP BY asset_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    scans = _local_files_scan_lines(plan)
+    assert scans, "expected a scan over local_files"
+    assert any("USING" not in line or "INDEX" not in line for line in scans), (
+        f"expected a bare full scan without the covering index; got {scans}"
+    )

--- a/tests/test_data_queries.py
+++ b/tests/test_data_queries.py
@@ -11,7 +11,9 @@ import pytest
 
 from gflow_cli.data.models import AssetKind, AssetRecord, LocalFileRecord, ProjectRecord
 from gflow_cli.data.queries import (
+    _LIST_IMAGES_ALL_COPIES_SQL,
     _LIST_IMAGES_SQL,
+    _LIST_VIDEOS_ALL_COPIES_SQL,
     _LIST_VIDEOS_SQL,
     list_images,
     list_profiles,
@@ -301,7 +303,7 @@ def test_list_images_no_local_files_copy_count_is_zero(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Query-plan regression — closes #112
+# Query-plan regression — refs #112
 # ---------------------------------------------------------------------------
 
 
@@ -313,12 +315,18 @@ def _local_files_scan_lines(plan_rows: list[sqlite3.Row]) -> list[str]:
 
 @pytest.mark.parametrize(
     "sql",
-    [_LIST_IMAGES_SQL, _LIST_VIDEOS_SQL],
-    ids=["images", "videos"],
+    [
+        _LIST_IMAGES_SQL,
+        _LIST_VIDEOS_SQL,
+        _LIST_IMAGES_ALL_COPIES_SQL,
+        _LIST_VIDEOS_ALL_COPIES_SQL,
+    ],
+    ids=["images-agg", "videos-agg", "images-all-copies", "videos-all-copies"],
 )
-def test_list_aggregation_uses_index_not_full_scan(tmp_path: Path, sql: str) -> None:
-    """#112: the ``GROUP BY asset_id`` aggregation must resolve via an index, never
-    a full table scan of ``local_files``.
+def test_list_queries_use_index_not_full_scan(tmp_path: Path, sql: str) -> None:
+    """#112: every list-images/videos query must reach ``local_files`` through an
+    index, never a full table scan — both the default per-asset aggregation
+    (``GROUP BY asset_id``) and the ``--all-copies`` flat join.
 
     The covering index is supplied for free by the ``UNIQUE(asset_id, path)``
     constraint — SQLite's implicit ``sqlite_autoindex_local_files_2`` — so no extra
@@ -333,7 +341,9 @@ def test_list_aggregation_uses_index_not_full_scan(tmp_path: Path, sql: str) -> 
         plan = store.conn.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
 
     scans = _local_files_scan_lines(plan)
-    assert scans, f"expected the plan to scan local_files; plan was {[r[-1] for r in plan]}"
+    assert scans, (
+        f"expected local_files to be reached via an index; plan was {[r[-1] for r in plan]}"
+    )
     for line in scans:
         assert "USING" in line and "INDEX" in line, (
             f"full-scan regression on local_files — expected an index scan, got {line!r}"


### PR DESCRIPTION
## Summary

Issue #112 reported that the data-layer list-images/videos queries fall back to a **full table scan** of `local_files` for the `GROUP BY asset_id` aggregation, because the only explicitly-named asset_id index (`idx_local_files_asset(profile_name, asset_id)`) has the wrong leading column — and proposed adding `idx_local_files_by_asset(asset_id)`.

**Investigation showed the premise is false, so no migration was added.** `local_files` declares `UNIQUE(asset_id, path)`, which makes SQLite auto-create an implicit **covering** index (`sqlite_autoindex_local_files_2`, leading column `asset_id`). `EXPLAIN QUERY PLAN` against a freshly-migrated `DataStore` confirms both list queries already resolve the aggregation from that index with zero table access:

```
MATERIALIZE lfa
SCAN local_files USING COVERING INDEX sqlite_autoindex_local_files_2
```

The proposed `idx_local_files_by_asset(asset_id)` is **never selected** by the planner (the covering autoindex is strictly more useful), and a covering `(asset_id, path)` variant would merely **duplicate** the existing autoindex — extra write/disk cost, zero read benefit.

Instead of a redundant migration, this PR adds the genuinely useful kernel the ticket itself suggested as optional: an **`EXPLAIN QUERY PLAN` regression test** that locks in the "no full scan of `local_files`" invariant across **all four** list-query SQL statements (per-asset aggregation + `--all-copies` flat join), so a future schema change (e.g. dropping the `UNIQUE` constraint) can't silently regress it.

- `tests/test_data_queries.py` — `test_list_queries_use_index_not_full_scan` (parametrized over both queries × both modes) asserts the `local_files` access uses an index; matches on "uses an index" rather than the autoindex's name to stay robust to SQLite renames / a future explicit index.
- `test_local_files_scan_guard_detects_full_scan` — a meta-test proving the guard is not vacuous (a constraint-less `local_files` produces a bare `SCAN`, which the assertion rejects).

No production code or schema change. Uses `Refs #112` (not `Closes`) — the resolution is "no migration needed"; the ticket is closed manually with the evidence so the reasoning is preserved.

## Review

5-dimension LLM council (correctness / quality / security / tests / memory-hygiene) ran in branch mode: **consensus GREEN, zero must-fix**. Both nice-to-haves (extend to `--all-copies`; align comment to `refs`) applied in this PR.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on the changed file
- [x] `pyright` clean on the added code (one pre-existing unrelated warning at the existing `test_list_videos_carries_duration` left untouched)
- [x] `pytest tests/test_data_queries.py -q` → 28 passed
- [x] All four parametrized variants (`images-agg`, `videos-agg`, `images-all-copies`, `videos-all-copies`) + meta-test pass
- [ ] CI green on develop