### PR TITLE
ci(sonar): block CI on quality gate + coverage-exclude e2e transports

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -76,6 +76,13 @@ Local agents running inside an MCP/context sandbox may need to split the
 marker-filtered pytest suite by path and omit coverage locally; CI remains the
 authoritative coverage gate.
 
+A sixth gate runs after the scan: the **SonarCloud quality gate** (new-code
+coverage ≥ 80 %, rating A, duplication ≤ 3 %). It blocks merge via
+`sonar.qualitygate.wait=true`, so a failed gate turns the `SonarCloud analysis`
+check red rather than reporting silently on the dashboard. Browser-automation
+and live-auth transports are coverage-excluded (e2e-tested, not unit-tested).
+See [docs/GITHUB.md § SonarCloud Quality Gate](GITHUB.md#sonarcloud-quality-gate).
+
 ### Merging feature PRs into develop
 
 - Squash merge preferred — keeps `develop` history linear.

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -92,6 +92,44 @@ This is intentional. Do not switch the normal PR workflow to
 repository privileges and can expose secrets if it checks out or executes
 untrusted PR code.
 
+## SonarCloud Quality Gate
+
+The gate is evaluated on **new code** (changed lines vs `main`, per
+`sonar.newCode.referenceBranch`). Conditions: new-code coverage ≥ 80 %,
+reliability / security / maintainability rating A, duplicated lines ≤ 3 %, and
+all new security hotspots reviewed.
+
+**The gate blocks CI.** `sonar-project.properties` sets
+`sonar.qualitygate.wait=true`, so the scanner polls for the verdict and the
+`SonarCloud analysis` check goes **red** when the gate is ERROR. Without that
+flag the check only confirmed the scan was *submitted* — a failed gate showed a
+misleading green while the real verdict sat on the dashboard. If you see a green
+`SonarCloud analysis` check, the gate genuinely passed.
+
+### Coverage exclusions (why a refactor can still be green)
+
+Browser-automation and live-auth transports are exercised by the **e2e suite**
+(real Chrome / live Flow), not unit tests. They are listed under
+`sonar.coverage.exclusions` so unreachable Playwright/network glue does not drag
+new-code coverage below the gate:
+
+- `api/transports/ui_automation.py`, `ui_automation_video.py`
+- `api/transports/experimental/{bearer,evaluate_fetch,sapisidhash}.py`
+
+Excluded files are **still analysed** for bugs and code smells — only the
+coverage metric ignores them. Everything else (CLI, data layer, helpers, REST
+plumbing) must hit 80 % on changed lines: add unit tests, don't widen the
+exclusion list.
+
+### Reading a red gate
+
+Open the PR Summary at `sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli&pullRequest=<N>`.
+- **Coverage failed** → add tests for the changed non-excluded lines.
+- **New issues** (e.g. `S5655` "function expects a different type" after a
+  `cast(...)` removal) → fix them, or keep the
+  `cast(T, ...)  # pyright: ignore[reportUnnecessaryCast]` pattern that satisfies
+  S5655/S5890 (removing those casts reintroduces the finding).
+
 ## If Sonar Did Not Run
 
 For small PRs, merge to `develop` after review when tests and gitleaks are

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,8 +28,27 @@ sonar.exclusions=\
 
 sonar.test.exclusions=tests/**
 
+# Coverage exclusions — browser-automation and live-auth transports are exercised
+# by the e2e suite (real Chrome / live Flow), not unit tests. Excluding them from
+# the coverage metric keeps the new-code coverage gate honest: it blocks REAL
+# unit-coverage regressions instead of unreachable Playwright/network glue. These
+# files are STILL analysed for bugs and code smells — only coverage is excluded.
+sonar.coverage.exclusions=\
+  src/gflow_cli/api/transports/ui_automation.py,\
+  src/gflow_cli/api/transports/ui_automation_video.py,\
+  src/gflow_cli/api/transports/experimental/bearer.py,\
+  src/gflow_cli/api/transports/experimental/evaluate_fetch.py,\
+  src/gflow_cli/api/transports/experimental/sapisidhash.py
+
 # Encoding
 sonar.sourceEncoding=UTF-8
 
 # New Code definition — changes on main since the previous version
 sonar.newCode.referenceBranch=main
+
+# Quality gate — make the gate verdict BLOCK CI. Without this, the scanner job
+# only confirms the analysis was submitted (always green) while a failed gate
+# (e.g. new-code coverage below threshold) is reported asynchronously on the
+# dashboard — a misleading green. `wait=true` polls the gate and fails the CI
+# step when the verdict is ERROR, so a red gate is evident in CI.
+sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary

Follow-up to #117. The SonarCloud quality gate failed on #117 (new-code coverage 69.9% < 80%) **but CI showed green** — the `SonarCloud analysis` check only confirmed the scan was submitted, not that the gate passed. This makes the gate evident and fair:

- **`sonar.qualitygate.wait=true`** — the scanner now polls for the gate verdict and fails the CI step when it's ERROR. A red gate ⇒ red check (no more misleading green).
- **`sonar.coverage.exclusions`** for the browser-automation / live-auth transports (`ui_automation*.py`, `experimental/{bearer,evaluate_fetch,sapisidhash}.py`) — these are e2e-tested (real Chrome / live Flow), not unit-tested. Excluding them from the *coverage* metric (they're still analysed for bugs/smells) keeps the gate blocking **real** unit-coverage regressions rather than unreachable Playwright/network glue.
- Docs: new "SonarCloud Quality Gate" section in `docs/GITHUB.md`; pointer added to `docs/DEVELOPMENT.md`.

## Why this is safe

This PR changes no Python, so it has no new lines to cover — the now-blocking gate should pass on it. Going forward, testable surfaces (CLI, data layer, helpers) must still hit 80% on changed lines; only the genuinely-untestable transport glue is excluded.

## Test plan

- [ ] CI green, and the `SonarCloud analysis` check now reflects the gate verdict (waits for it)
- [ ] SonarCloud PR Summary shows the quality gate passing
- [ ] `sonar-project.properties` parses (scanner runs without config error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)