### PR TITLE
fix(transports): exit Agent composer mode before mode switch so the gen panel mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Create-project generation failing when Flow's "Agent" composer mode is active.**
+  Flow's newer editor adds an Agent toggle next to the prompt box; when it is on,
+  the media-generation panel (the `crop_*` settings trigger, Image/Video mode
+  tablist, and count/model controls) is removed from the DOM, so the UI-automation
+  transport raised "mode-switch dropdown trigger not found". `_switch_to_image_mode`
+  and `_switch_to_video_mode` now call `_exit_agent_mode()` first, which re-mounts
+  the panel by clicking the toggle off. Detection is locale-invariant and uses no
+  UI text and no `aria-` attribute (`button:has(span.content)` plus the absence of
+  the locale-stable `crop_*` trigger), so it works in every Flow UI language.
+
 ## [0.10.0] — 2026-05-29
 
 ### Fixed

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -832,6 +832,10 @@ class UiAutomationTransport(VideoGenerationMixin):
         The dropdown is closed afterwards (via :kbd:`Escape`) so the caller's
         :meth:`_configure_generation_settings` can open it fresh.
         """
+        # New Flow UI: if the composer is in Agent mode the generation panel is
+        # absent — switch back to media mode first so the trigger probe below
+        # can find the crop_* dropdown.
+        await VideoGenerationMixin._exit_agent_mode(page)
         trigger = await VideoGenerationMixin._probe_selector_cascade(
             page,
             "mode_switch_trigger",

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -80,6 +80,44 @@ VIDEO_TAB_IN_MENU_SELECTORS = (
     "[role='menu'] [role='tab']:has-text('Vídeo')",
     "[role='menu'] [role='tab']:has-text('Video')",
 )
+
+# Composer "Agent" mode toggle. Flow's newer editor puts a pill toggle next to
+# the prompt box: a ``<button>`` whose only label is a ``<span class="content">``.
+# When Agent mode is on, the whole media-generation panel is REMOVED from the
+# DOM — the aspect/settings button (the locale-stable ``crop_*`` icon trigger
+# keyed on by MODE_SWITCH_TRIGGER_SELECTORS / GEN_SETTINGS_BUTTON_SELECTORS), the
+# Image/Video tablist, and the count/model controls all disappear, so
+# ``_switch_to_image_mode`` / ``_switch_to_video_mode`` raise "mode-switch
+# dropdown trigger not found". Clicking the pill returns to media mode.
+#
+# This selector is deliberately STRUCTURAL — no localized text and no ARIA:
+#  * No localized text: the pill's "Agent" label is translated in some Flow
+#    locales, so matching it by visible text would regress non-English users
+#    (issue #24: locale-agnostic selectors — a recurring source of PR pushback in
+#    this module). The only ``:text(...)`` here is ``arrow_forward``, a Material
+#    Symbols icon ligature, which is locale-invariant — the same technique the
+#    module already uses for ``crop_*`` / SUBMIT_BUTTON_SELECTORS anchors.
+#  * No ARIA: aria-* anchors have also been pushed back on in past reviews, and
+#    one is not needed here — Agent mode is detected from the *absence* of the
+#    ``crop_*`` media trigger, so the toggle only has to be located, not have its
+#    state read.
+#
+# SCOPED to the generation composer (PR #124 review must-fix): the pill is
+# matched only inside the element that holds BOTH the Slate prompt box AND the
+# ``arrow_forward`` submit button. Page-wide there is exactly one
+# ``button:has(span.content)`` today (live-verified count == 1), but ``.first``
+# on the bare global selector would silently grab the wrong element if a future
+# Flow build added another ``span.content`` button (header/sidebar) ordered
+# before the pill. Scoping to the prompt+submit composer keeps the match correct
+# regardless of unrelated additions elsewhere. The composer's own ancestor chain
+# carries no stable id/role/data-* attribute (all styled-component hashes), so
+# the prompt box and submit icon ARE the stable structural anchors. Uniqueness is
+# pinned by a structural unit test (decoy outside the composer) and asserted live
+# (count == 1) in the e2e.
+COMPOSER_AGENT_TOGGLE_SELECTOR = (
+    "div:has(div[role='textbox'][data-slate-editor='true'])"
+    ":has(button:has(i:text('arrow_forward'))) button:has(span.content)"
+)
 # Output-count + duration tabs are selected by aria-label text in
 # `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
 # tab '-trigger-4' and the duration tab '-trigger-4' (4s) share a suffix, so an
@@ -516,9 +554,77 @@ class VideoGenerationMixin:
         return None
 
     @staticmethod
+    async def _media_panel_present(page: Page) -> bool:
+        """True if the media-generation panel is mounted.
+
+        Keyed on the locale-stable ``crop_*`` settings trigger
+        (:data:`MODE_SWITCH_TRIGGER_SELECTORS`) — the same anchor the mode
+        switches probe. Its presence is the signal that the composer is in media
+        (Image/Video) mode rather than Agent mode, which removes the panel.
+        """
+        for sel in MODE_SWITCH_TRIGGER_SELECTORS:
+            if await page.locator(sel).count() > 0:
+                return True
+        return False
+
+    @staticmethod
+    async def _exit_agent_mode(page: Page) -> bool:
+        """Ensure the composer is in media (Image/Video) mode, not Agent mode.
+
+        When Flow's composer is in "Agent" mode the media-generation panel is
+        absent (see :data:`COMPOSER_AGENT_TOGGLE_SELECTOR`), which makes
+        :meth:`_switch_to_image_mode`, :meth:`_switch_to_video_mode`, and
+        ``_configure_generation_settings`` fail to find their ``crop_*`` trigger.
+        This presses the Agent pill toggle off to re-mount the panel.
+
+        Returns ``True`` only when it actually brought the media panel back,
+        ``False`` otherwise (already in media mode, the toggle is absent on an
+        older UI, or the click did not re-mount the panel). Best-effort,
+        locale-invariant, and never raises — a DOM probe failure must not abort
+        generation.
+        """
+        try:
+            # Common case: the media panel is already mounted → media mode,
+            # nothing to do. This keeps the helper a cheap no-op on every normal
+            # generation and avoids touching the toggle unnecessarily.
+            if await VideoGenerationMixin._media_panel_present(page):
+                return False
+            # Panel absent → we are in Agent mode: click the pill (located by its
+            # structural span.content child) to turn Agent off and re-mount the
+            # panel. No ARIA state and no localized label is read — the panel
+            # absence above already established the mode, so the toggle only has
+            # to be found. Works in every Flow UI language.
+            toggle = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
+            if await toggle.count() == 0:
+                return False  # toggle not present (older UI) → leave as-is
+            await toggle.click()
+            await page.wait_for_timeout(700)
+            # Defensive: confirm the click actually re-mounted the panel instead
+            # of blindly trusting it. The pill is a binary toggle, so if the
+            # panel was absent for some other reason — or a future Flow change
+            # flips the click direction — the crop_* trigger stays missing. Don't
+            # claim a false "exited"; warn and let the caller's own trigger probe
+            # fail loudly (with a screenshot) so the real cause surfaces.
+            if await VideoGenerationMixin._media_panel_present(page):
+                log.info("ui_automation_video.exited_agent_mode")
+                return True
+            log.warning(
+                "ui_automation_video.exit_agent_mode_no_panel",
+                note="clicked the composer toggle but the media panel did not re-mount",
+            )
+            return False
+        except Exception as e:  # noqa: BLE001 — best-effort, never fatal
+            log.debug("ui_automation_video.agent_toggle_probe_failed", error=str(e)[:80])
+            return False
+
+    @staticmethod
     async def _switch_to_video_mode(page: Page, *, out_dir: Path | None) -> None:
         """Open the 2-step mode dropdown and switch to Video mode. The menu
         stays open afterward so the caller can also set aspect + count."""
+        # New Flow UI: if the composer is in Agent mode the generation panel is
+        # absent — return to media mode first so the trigger probe can find the
+        # crop_* dropdown.
+        await VideoGenerationMixin._exit_agent_mode(page)
         trigger = await VideoGenerationMixin._probe_selector_cascade(
             page,
             "mode_switch_trigger",

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -31,6 +31,10 @@ from gflow_cli.api.transports.ui_automation import (
     UiAutomationTransport,
     _count_tabs_locator,  # noqa: PLC2701
 )
+from gflow_cli.api.transports.ui_automation_video import (
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+    VideoGenerationMixin,
+)
 from gflow_cli.errors import ContentPolicyError, WafRejectionError
 
 # ---------------------------------------------------------------------------
@@ -2043,3 +2047,263 @@ class TestSelectorLocaleInvariance:
             assert "[aria-label*='Project'" not in sel, (
                 f"English-only aria-label in NEW_PROJECT_SELECTORS: {sel!r}"
             )
+
+
+def _agent_loc(count: int) -> MagicMock:
+    """A Playwright-locator mock with a fixed ``.count()`` and chainable ``.first``."""
+    loc = MagicMock()
+    loc.first = loc
+    loc.count = AsyncMock(return_value=count)
+    loc.click = AsyncMock()
+    return loc
+
+
+class TestExitAgentMode:
+    """``_exit_agent_mode`` restores the media panel when Flow's composer is in
+    "Agent" mode — without matching any localized UI string or aria attribute
+    (issue #24 locale discipline + the aria-selector pushback in past reviews)."""
+
+    def test_toggle_selector_is_locale_safe_aria_free_and_scoped(self) -> None:
+        """The toggle selector is locale-safe, aria-free, AND scoped to the composer.
+
+        Guards the three review concerns at once:
+
+        * **Locale (issue #24):** no visible-text match (``:has-text`` /
+          ``:text-is`` / ``text-matches``) and the literal label "Agent" never
+          appears — it is translated per Flow locale. The only ``:text(...)`` is
+          ``arrow_forward``, a Material Symbols icon ligature, which is
+          locale-invariant (same technique the module uses for ``crop_*``).
+        * **No ARIA:** aria-* anchors were rejected in past reviews; none here.
+        * **Scoped (PR #124 must-fix):** the pill is matched only inside the
+          composer holding the Slate prompt box, so ``.first`` cannot grab an
+          unrelated ``span.content`` button added elsewhere in a future build.
+        """
+        sel = COMPOSER_AGENT_TOGGLE_SELECTOR
+        # Structural pill marker.
+        assert "span.content" in sel
+        # Locale-safe: no aria, no visible-text engines, no literal label.
+        assert "aria-" not in sel
+        assert ":has-text(" not in sel
+        assert ":text-is(" not in sel
+        assert "text-matches" not in sel
+        assert "Agent" not in sel and "agent" not in sel
+        # The only :text() permitted is the locale-invariant icon ligature.
+        assert sel.count(":text(") == 1
+        assert ":text('arrow_forward')" in sel
+        # Scoped to the prompt-box composer — not the bare global selector.
+        assert "data-slate-editor" in sel
+        assert sel.strip() != "button:has(span.content)"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_media_panel_present(self) -> None:
+        """The crop_* media-settings trigger is mounted → media mode already, so
+        the helper returns False and never touches the toggle (common path)."""
+        page = AsyncMock()
+        page.locator = MagicMock(return_value=_agent_loc(1))  # crop trigger present
+        page.wait_for_timeout = AsyncMock()
+
+        switched = await UiAutomationTransport._exit_agent_mode(page)
+
+        assert switched is False
+        page.wait_for_timeout.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clicks_toggle_and_confirms_panel_remounts(self) -> None:
+        """Panel absent + pill present → click the pill; once the crop_* panel
+        comes back, return True (this is the Agent-mode bug being fixed)."""
+        page = AsyncMock()
+        state = {"clicked": False}
+
+        toggle = MagicMock()
+        toggle.first = toggle
+        toggle.count = AsyncMock(return_value=1)
+        toggle.click = AsyncMock(side_effect=lambda: state.__setitem__("clicked", True))
+
+        def _crop_loc() -> MagicMock:
+            loc = MagicMock()
+            loc.first = loc
+            # crop_* trigger is absent until the toggle is clicked (Agent off).
+            loc.count = AsyncMock(return_value=1 if state["clicked"] else 0)
+            return loc
+
+        def locator(sel: str) -> MagicMock:
+            return toggle if sel == COMPOSER_AGENT_TOGGLE_SELECTOR else _crop_loc()
+
+        page.locator = MagicMock(side_effect=locator)
+        page.wait_for_timeout = AsyncMock()
+
+        switched = await UiAutomationTransport._exit_agent_mode(page)
+
+        assert switched is True
+        toggle.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_panel_does_not_remount(self) -> None:
+        """Panel absent + pill present, but clicking does NOT bring the crop_*
+        trigger back → return False (no false "exited" claim) and warn, rather
+        than blindly reporting success."""
+        page = AsyncMock()
+        toggle = _agent_loc(1)
+
+        def locator(sel: str) -> MagicMock:
+            # Toggle present; crop_* trigger never appears (before OR after click).
+            return toggle if sel == COMPOSER_AGENT_TOGGLE_SELECTOR else _agent_loc(0)
+
+        page.locator = MagicMock(side_effect=locator)
+        page.wait_for_timeout = AsyncMock()
+
+        switched = await UiAutomationTransport._exit_agent_mode(page)
+
+        assert switched is False
+        toggle.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_toggle_present(self) -> None:
+        """Crop trigger absent AND no pill toggle (older UI) → clean no-op."""
+        page = AsyncMock()
+        page.locator = MagicMock(return_value=_agent_loc(0))  # nothing present
+        page.wait_for_timeout = AsyncMock()
+
+        switched = await UiAutomationTransport._exit_agent_mode(page)
+
+        assert switched is False
+        page.wait_for_timeout.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_probe_error(self) -> None:
+        """A DOM probe failure is swallowed (best-effort) and returns False —
+        a transient editor error must not abort generation."""
+        page = AsyncMock()
+        page.locator = MagicMock(side_effect=RuntimeError("execution context destroyed"))
+
+        switched = await UiAutomationTransport._exit_agent_mode(page)
+
+        assert switched is False
+
+    def test_scope_excludes_a_decoy_span_content_button_outside_composer(self) -> None:
+        """Structural guard for the PR #124 must-fix: the scoped selector must
+        match the Agent pill *inside the composer* and exclude a
+        ``button > span.content`` that lives elsewhere on the page (a future Flow
+        build could add one in the header/sidebar).
+
+        Playwright's ``:has()`` / ``:text()`` pseudo-classes can only be resolved
+        by a real browser (covered live by the e2e's ``count() == 1`` assert), so
+        this pins the same invariant the selector encodes against a hand-written
+        DOM using the stdlib parser — no browser, runs in CI. It confirms exactly
+        one ``span.content`` button sits within the element that holds BOTH the
+        Slate prompt box and the ``arrow_forward`` submit (the composer), while a
+        decoy in the page header is seen as outside.
+        """
+        from html.parser import HTMLParser
+
+        html = (
+            '<header><button><span class="content">Sidebar</span></button></header>'
+            '<div class="composer">'
+            '<div role="textbox" data-slate-editor="true"></div>'
+            '<button><span class="content">Agent</span></button>'
+            '<button><i class="google-symbols">arrow_forward</i></button>'
+            "</div>"
+        )
+
+        class _Counter(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.depth = 0
+                self.composer_depth: int | None = None
+                self.in_button = 0
+                self.cur_has_span_content = False
+                self.cur_in_composer = False
+                self.pill_in_composer = 0
+                self.pill_outside = 0
+
+            def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+                a = dict(attrs)
+                self.depth += 1
+                if tag == "div" and a.get("class") == "composer":
+                    self.composer_depth = self.depth
+                if tag == "button":
+                    self.in_button += 1
+                    self.cur_has_span_content = False
+                    self.cur_in_composer = (
+                        self.composer_depth is not None and self.depth > self.composer_depth
+                    )
+                if tag == "span" and self.in_button and "content" in (a.get("class") or "").split():
+                    self.cur_has_span_content = True
+
+            def handle_endtag(self, tag: str) -> None:
+                if tag == "button" and self.in_button:
+                    if self.cur_has_span_content:
+                        if self.cur_in_composer:
+                            self.pill_in_composer += 1
+                        else:
+                            self.pill_outside += 1
+                    self.in_button -= 1
+                if tag == "div" and self.depth == self.composer_depth:
+                    self.composer_depth = None
+                self.depth -= 1
+
+        counter = _Counter()
+        counter.feed(html)
+
+        assert counter.pill_in_composer == 1, "expected one span.content pill inside the composer"
+        assert counter.pill_outside == 1, "the header decoy must be seen as outside the composer"
+        # The production selector is the scoped form that achieves this.
+        assert "data-slate-editor" in COMPOSER_AGENT_TOGGLE_SELECTOR
+        assert "arrow_forward" in COMPOSER_AGENT_TOGGLE_SELECTOR
+
+
+class TestModeSwitchExitsAgentFirst:
+    """Both mode switches must call ``_exit_agent_mode`` BEFORE probing for the
+    ``crop_*`` trigger — otherwise an Agent-mode composer (panel removed) makes
+    the trigger probe fail. The image path is exercised live by the e2e; these
+    cheap mock tests pin the call-site ordering for BOTH paths in CI (PR #124)."""
+
+    @pytest.mark.asyncio
+    async def test_switch_to_image_mode_exits_agent_first(self) -> None:
+        page = AsyncMock()
+        page.keyboard = AsyncMock()
+        order: list[str] = []
+
+        async def _exit(_p: object) -> bool:
+            order.append("exit_agent")
+            return True
+
+        async def _probe(_p: object, _label: str, _sels: object) -> MagicMock:
+            order.append("probe")
+            trigger = MagicMock()
+            trigger.click = AsyncMock()
+            return trigger
+
+        # The mode switches reference the helpers on VideoGenerationMixin
+        # directly (the base class), so patch there — patching the subclass would
+        # not intercept the base-class lookup.
+        with (
+            patch.object(VideoGenerationMixin, "_exit_agent_mode", new=_exit),
+            patch.object(VideoGenerationMixin, "_probe_selector_cascade", new=_probe),
+        ):
+            await UiAutomationTransport._switch_to_image_mode(page)
+
+        assert order and order[0] == "exit_agent", f"expected exit_agent first, got {order}"
+
+    @pytest.mark.asyncio
+    async def test_switch_to_video_mode_exits_agent_first(self) -> None:
+        page = AsyncMock()
+        order: list[str] = []
+
+        async def _exit(_p: object) -> bool:
+            order.append("exit_agent")
+            return True
+
+        async def _probe(_p: object, _label: str, _sels: object) -> MagicMock:
+            order.append("probe")
+            loc = MagicMock()
+            loc.click = AsyncMock()
+            return loc
+
+        with (
+            patch.object(VideoGenerationMixin, "_exit_agent_mode", new=_exit),
+            patch.object(VideoGenerationMixin, "_probe_selector_cascade", new=_probe),
+        ):
+            await UiAutomationTransport._switch_to_video_mode(page, out_dir=None)
+
+        assert order and order[0] == "exit_agent", f"expected exit_agent first, got {order}"

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -38,6 +38,7 @@ from gflow_cli.api.transports import make_transport
 from gflow_cli.api.transports.experimental.bearer import BearerTransport
 from gflow_cli.api.transports.experimental.sapisidhash import SapisidhashTransport
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.api.transports.ui_automation_video import COMPOSER_AGENT_TOGGLE_SELECTOR
 from gflow_cli.api.video import (
     Aspect,
     GenerateVideoRequest,
@@ -479,3 +480,110 @@ async def test_e2e_health_check_false_after_close(e2e_profile_dir: Path) -> None
     assert await client.health_check() is False, (
         "health_check() must return False (not raise) on a closed client"
     )
+
+
+# ---------------------------------------------------------------------------
+# Agent composer mode recovery (create-project gen panel) — zero credits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_auth
+async def test_e2e_agent_mode_recovered_before_mode_switch(
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """Flow's "Agent" composer mode no longer breaks the generate path.
+
+    Flow's newer editor adds an Agent toggle next to the prompt box. When Agent
+    mode is active the whole media-generation panel — including the ``crop_*``
+    settings trigger that ``_switch_to_image_mode`` / ``_switch_to_video_mode``
+    probe — is removed from the DOM, so the mode switch used to raise
+    "mode-switch dropdown trigger not found" and create-project generation
+    failed. ``_exit_agent_mode`` (called at the top of the mode switch) must
+    re-mount the panel.
+
+    This reproduces the bug on the **real DOM** then proves the fix: enter a
+    fresh project, force Agent mode on (panel disappears), call
+    ``_switch_to_image_mode``, and assert the ``crop_*`` trigger is back. Costs
+    **zero credits** — no generation is submitted; it stops once the panel is
+    confirmed re-mounted (the exact precondition the generate path needs).
+
+    Skips on accounts whose Flow UI predates the Agent toggle (older editor).
+    """
+    # Undo the autouse `_isolate_settings` fixture (tests/conftest.py) so profile
+    # lookup resolves to the user's real platformdirs path where the live Chrome
+    # session lives — the `e2e_profile_dir` fixture is pinned to tmp by isolation.
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile name")
+    profile = _resolve_profile_dir(name)
+    if not profile.exists():
+        pytest.skip(f"profile dir not found: {profile}")
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(profile)
+        page = transport._page  # noqa: SLF001 — e2e drives the transport's live page
+        assert page is not None, "setup() must acquire a page"
+
+        # Fresh project so the composer is in its default editor state. Mirror
+        # the real generate path: enter the editor, dismiss any changelog overlay
+        # that can cover the composer (#26), and wait for the prompt box to mount.
+        # The editor SPA renders incrementally after the /project/ URL nav (the
+        # same reason _wait_video_editor_ready exists), and the Agent pill mounts
+        # a beat after the prompt box, so poll generously for it before deciding
+        # the account lacks the toggle — otherwise the test false-skips flakily.
+        await transport._enter_editor(page)  # noqa: SLF001
+        await transport._dismiss_blocking_overlays(page)  # noqa: SLF001
+        await transport._wait_video_editor_ready(page)  # noqa: SLF001
+
+        toggle = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR)
+        try:
+            await toggle.first.wait_for(state="attached", timeout=15000)
+        except Exception:
+            pytest.skip("Flow account has no Agent composer toggle (older editor UI)")
+
+        # Uniqueness on the real DOM (PR #124 must-fix): the scoped selector must
+        # resolve to exactly one element, so the ``.first`` the production helper
+        # uses can never pick the wrong button. Only a real browser can evaluate
+        # the Playwright :has()/:text() selector, so it is asserted here.
+        count = await toggle.count()
+        assert count == 1, (
+            f"COMPOSER_AGENT_TOGGLE_SELECTOR must match exactly one element; got {count}"
+        )
+
+        # Reproduce: force Agent mode ON so the media panel is removed. Clicking
+        # the pill from media mode enters Agent mode; if it is already on, the
+        # crop_* trigger is already gone.
+        if await transport._media_panel_present(page):  # noqa: SLF001
+            await toggle.first.click()
+            await page.wait_for_timeout(700)
+        assert not await transport._media_panel_present(page), (  # noqa: SLF001
+            "could not reproduce Agent mode — crop_* trigger still present after "
+            "toggling the Agent pill; the toggle semantics may have changed"
+        )
+
+        # The fix: switching to image mode must first exit Agent mode, which
+        # re-mounts the media panel and makes the crop_* trigger probe succeed.
+        await transport._switch_to_image_mode(page)  # noqa: SLF001
+
+        assert await transport._media_panel_present(page), (  # noqa: SLF001
+            "media panel did not re-mount after _switch_to_image_mode — "
+            "_exit_agent_mode failed to leave Agent mode"
+        )
+        events = [e["event"] for e in install_log_capture.entries]
+        assert "ui_automation_video.exited_agent_mode" in events, (
+            f"expected an 'exited_agent_mode' event proving the fix ran; captured events: {events}"
+        )
+    finally:
+        await transport.teardown()


### PR DESCRIPTION
## Problem

On accounts whose Flow editor shows the new **"Agent"** composer toggle next to the prompt box, create-project generation intermittently fails. When Agent mode is active, Flow removes the entire media-generation panel from the DOM — the `crop_*` settings trigger, the Image/Video mode tablist, and the count/model controls all disappear. `_switch_to_image_mode` / `_switch_to_video_mode` then can't find their trigger and raise:

```
RuntimeError: mode-switch dropdown trigger not found on the Flow editor.
```

This affects both image (`generate_images`, stay-mounted batch) and video paths.

## Fix

Add `VideoGenerationMixin._exit_agent_mode(page)`, called at the top of **both** `_switch_to_image_mode` and `_switch_to_video_mode`:

- If the locale-stable `crop_*` settings trigger is already present → media mode → **no-op** (the common path; the toggle is never touched).
- If the panel is absent → Agent mode → click the pill, then **confirm the panel actually re-mounted**. If it does not, log a warning and return `False` rather than claim a false "exited" — the caller's own trigger probe then fails loudly. Best-effort: never raises.

Panel presence is a small `_media_panel_present()` helper, reused by the e2e.

## Selector — scoped, locale-safe, no ARIA

```python
COMPOSER_AGENT_TOGGLE_SELECTOR = (
    "div:has(div[role='textbox'][data-slate-editor='true'])"
    ":has(button:has(i:text('arrow_forward'))) button:has(span.content)"
)
```

- **Scoped (must-fix #1):** the pill is matched only inside the composer that holds **both** the Slate prompt box **and** the `arrow_forward` submit — so `.first` can't grab an unrelated `span.content` button added elsewhere in a future Flow build. The composer's ancestor chain has no stable id/role/data-* (all styled-component hashes), so the prompt box + submit icon are the structural anchors.
- **Locale-safe (issue #24):** no visible-text match and the literal "Agent" never appears. The only `:text()` is `arrow_forward`, a Material Symbols icon ligature (locale-invariant — same technique as the existing `crop_*` anchors).
- **No ARIA:** mode is detected from the *absence* of the `crop_*` trigger, not an `aria-pressed` state.

## Tests

- **Unit** — `TestExitAgentMode` (7): no-op when panel present, click + confirm re-mount, **returns False when the click does not re-mount** (no false success), no-op when toggle absent, never-raises on probe error, a selector guard (locale-safe + aria-free + scoped), and a **stdlib-parser scope guard** proving a decoy `span.content` button *outside* the composer is excluded. `TestModeSwitchExitsAgentFirst` (2): both mode switches call `_exit_agent_mode` first.
- **E2E** — `test_e2e_agent_mode_recovered_before_mode_switch` (`e2e_auth`, **zero credits**): reproduces Agent mode on the real DOM, **asserts the scoped selector resolves to exactly one element** (`count() == 1` — the browser-only check the unit test can't do), then proves `_switch_to_image_mode` re-mounts the panel + emits `exited_agent_mode`. Verified locally on a live profile (1 passed, ~18 s).

## Review items

- **#1 selector uniqueness** — addressed both ways the review offered: scoped the selector to the composer **and** added a unit scope-guard + a live `count() == 1` assert.
- **#2 structlog prefix** — events now use `ui_automation_video.` to match the module.
- **#3 defense-in-depth** — composer-scoping hardens against stray clicks.
- **#4 video-path wiring** — `TestModeSwitchExitsAgentFirst` pins the call-site for both paths.
- **#5 non-EN evidence** — scoping the claim honestly: the selector is locale-safe **by construction** (zero localized text — pinned by unit test). A genuine non-EN *live* run isn't possible here: per the `flow-locale-driven-by-chrome-profile-lang` finding the UI follows the Chrome **profile** language, and `GFLOW_CLI_LOCALE=de-DE` on this EN profile still renders `htmlLang=en` / `?hl=en` — a true non-EN run needs a German-created profile I don't have.

## Validation

- [x] hygiene · doc-links · `ruff check` · `ruff format --check` · `pyright src` (0 errors) — all clean
- [x] `pytest --cov=gflow_cli --cov-fail-under=80` — **1056 passed, 85.9% coverage**
- [x] Live e2e verified on a real authenticated profile (scoped selector `count() == 1`)
- [x] CHANGELOG under `[Unreleased] → Fixed`
- [x] DCO `Signed-off-by` present

_Updated at head `e757e09`._