### PR TITLE
feat(skills): SkillOpt adoption — format alignment + mock harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ The `skills/` directory ships installable agent skill docs in plain Markdown wit
 | `pr-council-review` | [`skills/pr-council-review/SKILL.md`](skills/pr-council-review/SKILL.md) | Multi-dimensional PR council review |
 
 **Cursor / Aider / Codex / Gemini CLI:** paste or include the relevant `SKILL.md` in your system context.
-**Claude Code:** skills are auto-discovered from `skills/` — invoke via `/gflow:` slash commands.
+**Claude Code:** symlink `skills/gflow-cli` to `~/.claude/skills/gflow-cli` to register the skill; the `/gflow:` slash commands (in `.claude/commands/gflow/`) are auto-discovered from the project directory.
 **Custom agents:** fetch `skills/gflow-cli/SKILL.md` into your knowledge base before answering gflow questions.
 
 The SkillOpt harness at `scripts/dev/skillopt/` measures how accurately each skill guides an agent, and supports multiple providers (Anthropic, OpenAI-compat, Gemini, local models). See [`scripts/dev/skillopt/README.md`](scripts/dev/skillopt/README.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,23 @@ Or invoke the wrapper: `/gflow:check`.
 - Run `/gflow:check` (or the Impeccable Routine) before every commit.
 - All releases require a signed annotated tag (`git tag -s vX.Y.Z`); CI rejects unsigned tags.
 
+## Skills reference (cross-tool)
+
+The `skills/` directory ships installable agent skill docs in plain Markdown with YAML frontmatter. Any agent can consume them directly:
+
+| Skill | Path | When to load |
+|---|---|---|
+| `gflow-cli` | [`skills/gflow-cli/SKILL.md`](skills/gflow-cli/SKILL.md) | User wants to run any `gflow` command — auth, T2V, I2V, T2I, I2I, batch |
+| `predict` | [`skills/predict/SKILL.md`](skills/predict/SKILL.md) | Pre-implementation adversarial analysis before any high-stakes change |
+| `scenario` | [`skills/scenario/SKILL.md`](skills/scenario/SKILL.md) | Edge-case explorer after a predict GO/CAUTION |
+| `pr-council-review` | [`skills/pr-council-review/SKILL.md`](skills/pr-council-review/SKILL.md) | Multi-dimensional PR council review |
+
+**Cursor / Aider / Codex / Gemini CLI:** paste or include the relevant `SKILL.md` in your system context.
+**Claude Code:** skills are auto-discovered from `skills/` — invoke via `/gflow:` slash commands.
+**Custom agents:** fetch `skills/gflow-cli/SKILL.md` into your knowledge base before answering gflow questions.
+
+The SkillOpt harness at `scripts/dev/skillopt/` measures how accurately each skill guides an agent, and supports multiple providers (Anthropic, OpenAI-compat, Gemini, local models). See [`scripts/dev/skillopt/README.md`](scripts/dev/skillopt/README.md).
+
 ## Where to look next
 
 - **Architecture & target shape** → [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,20 @@
 - Skills under `skills/` are auto-discoverable; `gflow-cli` ships its own at [`skills/gflow-cli/SKILL.md`](skills/gflow-cli/SKILL.md).
 - Auto-memory at `~/.claude/projects/C--development-github-gflow-cli/memory/MEMORY.md` carries cross-session feedback and project state.
 
+## MCP GitHub tool — PR body rule (non-negotiable)
+
+When calling `mcp__github__create_pull_request` or `mcp__github__update_pull_request`, the `body` parameter **must be a plain string**. Shell heredoc syntax (`$(cat <<'EOF' ... EOF)`) is **never valid** here — MCP tool parameters are JSON, not shell; the heredoc is not evaluated and appears literally in the PR description.
+
+```
+# WRONG — produces literal "$(cat <<'EOF'" in the PR body:
+body: "$(cat <<'EOF'\n## Summary\n...\nEOF\n)"
+
+# CORRECT — plain multiline string:
+body: "## Summary\n\n- Item 1\n- Item 2\n\n## Test plan\n- [ ] ..."
+```
+
+The heredoc pattern (`$(cat <<'EOF' ... EOF)`) is only valid inside a `Bash` tool call because the **shell** evaluates it there. In every MCP tool parameter it is a literal string. This mistake has recurred across multiple PRs — treat this rule as a hard blocker before every PR creation or update.
+
 ## Active phase
 
 See [PLAN.md](PLAN.md) or run `/gflow:plan` for the current detailed plan.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,8 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | **[docs/SECURITY.md](SECURITY.md)** | What secrets are stored where, threat model, hardening | Audit, code review, multi-user machines |
 | **[docs/DATA_LAYER.md](DATA_LAYER.md)** | Local SQLite catalog: goals, schema, recording flow, redaction, `gflow data` CLI, migrations, extension guide | Anything touching `gflow_cli.data`, debugging missing rows, building I2V/repair tooling, auditing what is stored |
 | **[tasks/lessons.md](../tasks/lessons.md)** | Running notebook of patterns + reviewer findings, dated and traced to commits | Starting a new phase; debugging "why did the council flag this?" |
+| **[skills/README.md](../skills/README.md)** | Installable agent skill docs (gflow-cli, predict, pr-council-review, scenario) — cross-tool portable Markdown consumed by Claude Code, Cursor, Codex, Gemini CLI, Aider, etc. | Any agent wanting to use gflow-cli correctly |
+| **[scripts/dev/skillopt/README.md](../scripts/dev/skillopt/README.md)** | SkillOpt mock harness — rollout→score loop for measuring and improving skill doc accuracy across multiple LLM providers | Measuring a skill edit's impact; comparing Claude vs GPT-4o vs Gemini on gflow tasks |
 
 ## Agent commands
 
@@ -73,6 +75,9 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"Where can I look up a media ID I generated yesterday?"** → [DATA_LAYER § Querying the data layer](DATA_LAYER.md#querying-the-data-layer)
 **"How do I stop gflow from storing my prompts?"** → [DATA_LAYER § Privacy and redaction](DATA_LAYER.md#privacy-and-redaction)
 **"What does exit code 16 mean and how do I recover?"** → [DATA_LAYER § Persistence-failure handling](DATA_LAYER.md#persistence-failure-handling)
+**"How do I use this project's skills in Cursor / Codex / Gemini CLI / Aider?"** → [skills/README.md](../skills/README.md#use-with-other-agents)
+**"How do I benchmark a skill doc against real tasks?"** → [scripts/dev/skillopt/README.md](../scripts/dev/skillopt/README.md)
+**"How do I compare Claude vs GPT-4o vs Gemini on gflow tasks?"** → `python scripts/dev/skillopt/harness.py --provider openai --model gpt-4o` (see [skillopt README](../scripts/dev/skillopt/README.md))
 **"How do I report a security issue?"** → [SECURITY § Reporting](SECURITY.md#reporting)
 **"What branch do I work on? How do I name it?"** → [DEVELOPMENT § Branching model](DEVELOPMENT.md#branching-model)
 **"How do I handle an external GitHub PR?"** → [GITHUB § Scenario Matrix](GITHUB.md#scenario-matrix)

--- a/scripts/dev/skillopt/README.md
+++ b/scripts/dev/skillopt/README.md
@@ -1,0 +1,106 @@
+# SkillOpt harness for gflow-cli
+
+Measures how accurately an LLM agent answers gflow-cli usage questions when
+guided by a skill document. Provides the rollout → score step of the
+[SkillOpt](https://github.com/microsoft/SkillOpt) loop so you can measure
+baseline accuracy, manually edit the skill, and confirm the score improves
+before running the full automated SkillOpt optimizer.
+
+## Quick start
+
+```bash
+# Dry-run: inspect prompts and scoring specs
+python scripts/dev/skillopt/harness.py --dry-run
+
+# Live run (needs Anthropic API key)
+uv pip install anthropic
+ANTHROPIC_API_KEY=sk-ant-... python scripts/dev/skillopt/harness.py
+
+# Filter to a surface area
+python scripts/dev/skillopt/harness.py --tags auth,error-recovery --dry-run
+
+# Compare a candidate skill edit
+python scripts/dev/skillopt/harness.py --skill /tmp/SKILL_candidate.md
+```
+
+## Task dataset (`tasks.json`)
+
+20 scored scenarios covering the full CLI surface:
+
+| Tag | Count | What it tests |
+|---|---|---|
+| `auth` | 4 | login, status, multi-profile, expired-session recovery |
+| `video` | 5 | T2V, I2V, aspect, output path, batch manifest |
+| `image` | 6 | T2I, I2I, fan-out, seed, UUID reuse, model selection |
+| `error-recovery` | 3 | reCAPTCHA headless, auth expiry, Playwright missing |
+| `python-api` | 1 | Library async usage pattern |
+| `parallel` | 1 | Multi-profile parallel generation (anti-pattern guard) |
+
+Each task item:
+```json
+{
+  "id": "auth-001",
+  "question": "...",
+  "context": "...",
+  "expected": {
+    "must_include": ["gflow auth login"],
+    "must_not_include": ["gflow login"],
+    "partial_credit": ["playwright install chromium"]
+  },
+  "tags": ["auth", "first-run"],
+  "notes": "Why this test case matters."
+}
+```
+
+## Scoring
+
+| Field | Effect |
+|---|---|
+| `must_include` | Each missing item deducts `1/N` from the base score |
+| `must_not_include` | Each hit deducts `0.30` |
+| `partial_credit` | Each hit adds `0.10` (max `+0.30` total) |
+| Final score | `max(0.0, min(1.0, base − penalties + bonus))` |
+
+A task **passes** at score ≥ 0.80.
+
+## The SkillOpt improvement loop (manual)
+
+SkillOpt's automated loop (rollout → reflect → edit → validate) can be
+run against these tasks once a mock transport exists. Until then, the
+manual equivalent is:
+
+1. **Baseline** — run the harness, note which tasks fail and why.
+2. **Reflect** — read the failure reasons; identify patterns (wrong flag,
+   missing prerequisite, wrong subcommand).
+3. **Edit** — update `skills/gflow-cli/SKILL.md`:
+   - Add the missing information to the relevant section.
+   - Add the mistake to the `## Known agent failure modes` table.
+   - Bump `skillopt_epoch` in the frontmatter.
+4. **Validate** — re-run the harness with `--skill` pointing at the edited file.
+   Only accept the edit if the total score improves.
+5. **Commit** — commit the improved skill doc.
+
+## Running the full SkillOpt optimizer
+
+To run the real SkillOpt optimizer against these tasks (automated edits):
+
+```bash
+# Install SkillOpt
+git clone https://github.com/microsoft/SkillOpt
+cd SkillOpt
+pip install -e .
+
+# The gflow-cli task format is compatible with SkillOpt's custom benchmark
+# interface. A config and adapter are needed (future work — see PLAN.md).
+```
+
+The blocker for automated SkillOpt training is that every rollout currently
+touches Playwright + reCAPTCHA + the live Google API. Once
+`GFLOW_CLI_PROVIDER=mock` is available (tracked in PLAN.md), the harness
+can be wired directly into the SkillOpt `train.py` script.
+
+## Adding new tasks
+
+Edit `tasks.json`. Keep each task focused on a single skill gap. Check
+the `notes` field documents *why* agents fail this task — that context
+guides future optimizer runs.

--- a/scripts/dev/skillopt/harness.py
+++ b/scripts/dev/skillopt/harness.py
@@ -7,21 +7,32 @@ agents guided by that skill answer gflow-cli usage questions.
 Mimics the SkillOpt rollout→score loop without the automated edit step,
 making it easy to measure baseline accuracy before / after manual edits.
 
-Usage:
-    # Dry-run: print formatted prompts without calling the API
-    python scripts/dev/skillopt/harness.py --dry-run
+Supports multiple LLM providers so you can compare how different agents
+perform against the same skill doc:
 
-    # Live run against Claude (requires ANTHROPIC_API_KEY)
+Provider: anthropic (default)
     ANTHROPIC_API_KEY=sk-ant-... python scripts/dev/skillopt/harness.py
+    python scripts/dev/skillopt/harness.py --model claude-sonnet-4-6
 
-    # Point at a different skill version
-    python scripts/dev/skillopt/harness.py --skill skills/gflow-cli/SKILL.md
+Provider: openai  (GPT-4o, Gemini OpenAI-compat, local Ollama, LM Studio, …)
+    OPENAI_API_KEY=sk-... python scripts/dev/skillopt/harness.py \\
+        --provider openai --model gpt-4o
 
-    # Filter by tag
-    python scripts/dev/skillopt/harness.py --tags auth,video --dry-run
+    # Gemini via its OpenAI-compatible endpoint
+    OPENAI_API_KEY=$GEMINI_API_KEY python scripts/dev/skillopt/harness.py \\
+        --provider openai \\
+        --base-url https://generativelanguage.googleapis.com/v1beta/openai/ \\
+        --model gemini-2.0-flash
 
-    # Use a specific model
-    python scripts/dev/skillopt/harness.py --model claude-haiku-4-5-20251001
+    # Local model via Ollama
+    python scripts/dev/skillopt/harness.py \\
+        --provider openai --base-url http://localhost:11434/v1 \\
+        --model llama3.2 --api-key ollama
+
+Other flags:
+    --dry-run          Print prompts + scoring spec; no API call
+    --skill PATH       Point at a different skill version
+    --tags auth,video  Filter tasks by tag
 """
 from __future__ import annotations
 
@@ -36,6 +47,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 TASKS_PATH = Path(__file__).parent / "tasks.json"
 DEFAULT_SKILL_PATH = REPO_ROOT / "skills" / "gflow-cli" / "SKILL.md"
 DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_PROVIDER = "anthropic"
 
 SYSTEM_TEMPLATE = """\
 You are an agent assistant helping users operate gflow-cli, the unofficial terminal CLI for Google Flow (Veo video generation and Imagen image generation).
@@ -128,6 +140,49 @@ def run_dry(tasks: list[dict[str, Any]], skill_text: str, version: str, epoch: i
         print()
 
 
+def _call_anthropic(system: str, user: str, model: str, api_key: str) -> str:
+    try:
+        import anthropic
+    except ImportError:
+        sys.exit(
+            "anthropic package not found. Install it:\n"
+            "  uv pip install anthropic"
+        )
+    client = anthropic.Anthropic(api_key=api_key)
+    msg = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return msg.content[0].text.strip()
+
+
+def _call_openai_compat(
+    system: str, user: str, model: str, api_key: str, base_url: str | None
+) -> str:
+    try:
+        import openai
+    except ImportError:
+        sys.exit(
+            "openai package not found. Install it:\n"
+            "  uv pip install openai"
+        )
+    kwargs: dict[str, Any] = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = openai.OpenAI(**kwargs)
+    resp = client.chat.completions.create(
+        model=model,
+        max_tokens=512,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+    )
+    return (resp.choices[0].message.content or "").strip()
+
+
 def run_live(
     tasks: list[dict[str, Any]],
     skill_text: str,
@@ -135,33 +190,27 @@ def run_live(
     epoch: int,
     model: str,
     api_key: str,
+    provider: str = DEFAULT_PROVIDER,
+    base_url: str | None = None,
 ) -> None:
-    try:
-        import anthropic
-    except ImportError:
-        sys.exit(
-            "anthropic package not found. Install it:\n"
-            "  uv pip install anthropic\n"
-            "or:\n"
-            "  pip install anthropic"
-        )
-
-    client = anthropic.Anthropic(api_key=api_key)
     results: list[dict[str, Any]] = []
 
-    print(f"=== LIVE RUN — {len(tasks)} task(s) — skill v{version} epoch {epoch} — model {model} ===\n")
+    print(
+        f"=== LIVE RUN — {len(tasks)} task(s) — skill v{version} epoch {epoch}"
+        f" — provider {provider} — model {model} ===\n"
+    )
 
     for i, task in enumerate(tasks, 1):
         system, user = format_prompt(skill_text, version, epoch, task)
         print(f"[{i}/{len(tasks)}] {task['id']}: {task['question'][:70]}...")
 
-        message = client.messages.create(
-            model=model,
-            max_tokens=512,
-            system=system,
-            messages=[{"role": "user", "content": user}],
-        )
-        response = message.content[0].text.strip()
+        if provider == "anthropic":
+            response = _call_anthropic(system, user, model, api_key)
+        elif provider == "openai":
+            response = _call_openai_compat(system, user, model, api_key, base_url)
+        else:
+            sys.exit(f"Unknown provider '{provider}'. Use 'anthropic' or 'openai'.")
+
         score, reasons = score_response(response, task["expected"])
 
         status = "PASS" if score >= 0.8 else ("PARTIAL" if score >= 0.4 else "FAIL")
@@ -236,10 +285,34 @@ def main() -> None:
         help="Comma-separated tag filter, e.g. 'auth,video'",
     )
     parser.add_argument(
+        "--provider",
+        type=str,
+        default=DEFAULT_PROVIDER,
+        choices=["anthropic", "openai"],
+        help=(
+            "LLM provider (default: anthropic). "
+            "Use 'openai' for GPT-4o, Gemini (via --base-url), or any OpenAI-compat endpoint."
+        ),
+    )
+    parser.add_argument(
         "--model",
         type=str,
-        default=DEFAULT_MODEL,
-        help=f"Claude model ID (default: {DEFAULT_MODEL})",
+        default=None,
+        help=(
+            f"Model ID. Defaults: anthropic={DEFAULT_MODEL}, openai=gpt-4o. "
+            "For Gemini: gemini-2.0-flash. For Ollama: llama3.2."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        dest="base_url",
+        help=(
+            "OpenAI-compatible base URL (openai provider only). "
+            "Examples: https://generativelanguage.googleapis.com/v1beta/openai/ (Gemini), "
+            "http://localhost:11434/v1 (Ollama)."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -249,8 +322,11 @@ def main() -> None:
     parser.add_argument(
         "--api-key",
         type=str,
-        default=os.environ.get("ANTHROPIC_API_KEY"),
-        help="Anthropic API key (default: $ANTHROPIC_API_KEY)",
+        default=None,
+        help=(
+            "API key. Defaults: $ANTHROPIC_API_KEY (anthropic provider) or "
+            "$OPENAI_API_KEY (openai provider)."
+        ),
     )
     args = parser.parse_args()
 
@@ -266,12 +342,20 @@ def main() -> None:
 
     skill_text, version, epoch = load_skill(args.skill)
 
+    provider_defaults = {"anthropic": DEFAULT_MODEL, "openai": "gpt-4o"}
+    model = args.model or provider_defaults.get(args.provider, DEFAULT_MODEL)
+
     if args.dry_run:
         run_dry(tasks, skill_text, version, epoch)
     else:
-        if not args.api_key:
-            sys.exit("No API key. Set ANTHROPIC_API_KEY or pass --api-key.")
-        run_live(tasks, skill_text, version, epoch, args.model, args.api_key)
+        env_key = "ANTHROPIC_API_KEY" if args.provider == "anthropic" else "OPENAI_API_KEY"
+        api_key = args.api_key or os.environ.get(env_key)
+        if not api_key:
+            sys.exit(f"No API key. Set ${env_key} or pass --api-key.")
+        run_live(
+            tasks, skill_text, version, epoch, model, api_key,
+            provider=args.provider, base_url=args.base_url,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/dev/skillopt/harness.py
+++ b/scripts/dev/skillopt/harness.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+SkillOpt mock harness for gflow-cli skills.
+
+Runs a scored task suite against a skill document to measure how well
+agents guided by that skill answer gflow-cli usage questions.
+Mimics the SkillOpt rollout→score loop without the automated edit step,
+making it easy to measure baseline accuracy before / after manual edits.
+
+Usage:
+    # Dry-run: print formatted prompts without calling the API
+    python scripts/dev/skillopt/harness.py --dry-run
+
+    # Live run against Claude (requires ANTHROPIC_API_KEY)
+    ANTHROPIC_API_KEY=sk-ant-... python scripts/dev/skillopt/harness.py
+
+    # Point at a different skill version
+    python scripts/dev/skillopt/harness.py --skill skills/gflow-cli/SKILL.md
+
+    # Filter by tag
+    python scripts/dev/skillopt/harness.py --tags auth,video --dry-run
+
+    # Use a specific model
+    python scripts/dev/skillopt/harness.py --model claude-haiku-4-5-20251001
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TASKS_PATH = Path(__file__).parent / "tasks.json"
+DEFAULT_SKILL_PATH = REPO_ROOT / "skills" / "gflow-cli" / "SKILL.md"
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+SYSTEM_TEMPLATE = """\
+You are an agent assistant helping users operate gflow-cli, the unofficial terminal CLI for Google Flow (Veo video generation and Imagen image generation).
+
+Your job is to answer the user's question with the exact CLI command(s) or code they should run.
+- Output only the command(s) / code snippet — no markdown fences unless showing multi-line code.
+- If the task asks a yes/no or remediation question, give a concise direct answer followed by the command.
+- Do not add lengthy explanations unless the task is specifically about concepts.
+
+Use the skill reference below as your authoritative source.
+
+=== SKILL REFERENCE (gflow-cli v{version}, epoch {epoch}) ===
+{skill_body}
+=== END SKILL REFERENCE ==="""
+
+
+def load_tasks(path: Path, tags: list[str] | None = None) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = json.loads(path.read_text())
+    if tags:
+        tag_set = set(tags)
+        items = [t for t in items if tag_set.intersection(t.get("tags", []))]
+    return items
+
+
+def load_skill(path: Path) -> tuple[str, str, int]:
+    """Return (full_text, version, epoch) from the skill file."""
+    text = path.read_text()
+    version = "unknown"
+    epoch = 0
+    for line in text.splitlines():
+        if line.startswith("version:"):
+            version = line.split(":", 1)[1].strip().strip('"')
+        elif line.startswith("skillopt_epoch:"):
+            try:
+                epoch = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+    return text, version, epoch
+
+
+def score_response(response: str, expected: dict[str, Any]) -> tuple[float, list[str]]:
+    """Score a response. Returns (score 0.0–1.0, list of reason strings)."""
+    resp_lower = response.lower()
+    reasons: list[str] = []
+
+    must_include: list[str] = expected.get("must_include", [])
+    must_not_include: list[str] = expected.get("must_not_include", [])
+    partial_credit: list[str] = expected.get("partial_credit", [])
+
+    hits = sum(1 for item in must_include if item.lower() in resp_lower)
+    misses = [item for item in must_include if item.lower() not in resp_lower]
+    base = hits / len(must_include) if must_include else 1.0
+
+    forbidden_hits = [p for p in must_not_include if p.lower() in resp_lower]
+    penalty = len(forbidden_hits) * 0.3
+
+    bonus_hits = [p for p in partial_credit if p.lower() in resp_lower]
+    bonus = min(len(bonus_hits) * 0.1, 0.3)
+
+    score = max(0.0, min(1.0, base - penalty + bonus))
+
+    if misses:
+        reasons.append(f"MISS: {misses}")
+    if forbidden_hits:
+        reasons.append(f"FORBIDDEN hit: {forbidden_hits}")
+    if bonus_hits:
+        reasons.append(f"BONUS: {bonus_hits}")
+
+    return score, reasons
+
+
+def format_prompt(skill_text: str, version: str, epoch: int, task: dict[str, Any]) -> tuple[str, str]:
+    system = SYSTEM_TEMPLATE.format(
+        version=version, epoch=epoch, skill_body=skill_text
+    )
+    question = task["question"]
+    context = task.get("context")
+    user = f"Context: {context}\n\n{question}" if context else question
+    return system, user
+
+
+def run_dry(tasks: list[dict[str, Any]], skill_text: str, version: str, epoch: int) -> None:
+    print(f"=== DRY RUN — {len(tasks)} task(s) — skill v{version} epoch {epoch} ===\n")
+    for task in tasks:
+        system, user = format_prompt(skill_text, version, epoch, task)
+        print(f"--- [{task['id']}] {task['question'][:80]} ---")
+        print(f"USER PROMPT:\n{user}\n")
+        print(f"SCORING: {task['expected']}\n")
+        print(f"NOTES: {task.get('notes', '')}\n")
+        print()
+
+
+def run_live(
+    tasks: list[dict[str, Any]],
+    skill_text: str,
+    version: str,
+    epoch: int,
+    model: str,
+    api_key: str,
+) -> None:
+    try:
+        import anthropic
+    except ImportError:
+        sys.exit(
+            "anthropic package not found. Install it:\n"
+            "  uv pip install anthropic\n"
+            "or:\n"
+            "  pip install anthropic"
+        )
+
+    client = anthropic.Anthropic(api_key=api_key)
+    results: list[dict[str, Any]] = []
+
+    print(f"=== LIVE RUN — {len(tasks)} task(s) — skill v{version} epoch {epoch} — model {model} ===\n")
+
+    for i, task in enumerate(tasks, 1):
+        system, user = format_prompt(skill_text, version, epoch, task)
+        print(f"[{i}/{len(tasks)}] {task['id']}: {task['question'][:70]}...")
+
+        message = client.messages.create(
+            model=model,
+            max_tokens=512,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        response = message.content[0].text.strip()
+        score, reasons = score_response(response, task["expected"])
+
+        status = "PASS" if score >= 0.8 else ("PARTIAL" if score >= 0.4 else "FAIL")
+        print(f"  Score: {score:.2f} [{status}]  {' | '.join(reasons) if reasons else 'OK'}")
+        print(f"  Response: {response[:120].replace(chr(10), ' ')}")
+
+        results.append(
+            {
+                "id": task["id"],
+                "tags": task.get("tags", []),
+                "score": score,
+                "status": status,
+                "response_preview": response[:200],
+                "reasons": reasons,
+            }
+        )
+
+    _print_summary(results)
+
+
+def _print_summary(results: list[dict[str, Any]]) -> None:
+    total = len(results)
+    if total == 0:
+        print("\nNo results.")
+        return
+
+    avg = sum(r["score"] for r in results) / total
+    passed = sum(1 for r in results if r["status"] == "PASS")
+    failed = [r for r in results if r["status"] == "FAIL"]
+
+    print(f"\n{'='*60}")
+    print(f"SUMMARY: {passed}/{total} passed  avg score {avg:.3f}")
+
+    if failed:
+        print(f"\nFailed tasks ({len(failed)}):")
+        for r in failed:
+            print(f"  {r['id']}: {r['reasons']}")
+
+    tag_scores: dict[str, list[float]] = {}
+    for r in results:
+        for tag in r.get("tags", []):
+            tag_scores.setdefault(tag, []).append(r["score"])
+
+    if tag_scores:
+        print("\nPer-tag averages:")
+        for tag, scores in sorted(tag_scores.items()):
+            print(f"  {tag:<20} {sum(scores)/len(scores):.3f}  (n={len(scores)})")
+    print("=" * 60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="SkillOpt mock harness for gflow-cli",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--skill",
+        type=Path,
+        default=DEFAULT_SKILL_PATH,
+        help="Path to the skill markdown file (default: skills/gflow-cli/SKILL.md)",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=Path,
+        default=TASKS_PATH,
+        help="Path to the tasks JSON file (default: scripts/dev/skillopt/tasks.json)",
+    )
+    parser.add_argument(
+        "--tags",
+        type=str,
+        default=None,
+        help="Comma-separated tag filter, e.g. 'auth,video'",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help=f"Claude model ID (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print prompts and scoring spec without calling the API",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=os.environ.get("ANTHROPIC_API_KEY"),
+        help="Anthropic API key (default: $ANTHROPIC_API_KEY)",
+    )
+    args = parser.parse_args()
+
+    if not args.skill.exists():
+        sys.exit(f"Skill file not found: {args.skill}")
+    if not args.tasks.exists():
+        sys.exit(f"Tasks file not found: {args.tasks}")
+
+    tags = [t.strip() for t in args.tags.split(",")] if args.tags else None
+    tasks = load_tasks(args.tasks, tags)
+    if not tasks:
+        sys.exit("No tasks matched the given filter.")
+
+    skill_text, version, epoch = load_skill(args.skill)
+
+    if args.dry_run:
+        run_dry(tasks, skill_text, version, epoch)
+    else:
+        if not args.api_key:
+            sys.exit("No API key. Set ANTHROPIC_API_KEY or pass --api-key.")
+        run_live(tasks, skill_text, version, epoch, args.model, args.api_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/skillopt/harness.py
+++ b/scripts/dev/skillopt/harness.py
@@ -102,7 +102,7 @@ def score_response(response: str, expected: dict[str, Any]) -> tuple[float, list
     base = hits / len(must_include) if must_include else 1.0
 
     forbidden_hits = [p for p in must_not_include if p.lower() in resp_lower]
-    penalty = len(forbidden_hits) * 0.3
+    penalty = min(len(forbidden_hits) * 0.3, 0.9)
 
     bonus_hits = [p for p in partial_credit if p.lower() in resp_lower]
     bonus = min(len(bonus_hits) * 0.1, 0.3)
@@ -311,7 +311,9 @@ def main() -> None:
         help=(
             "OpenAI-compatible base URL (openai provider only). "
             "Examples: https://generativelanguage.googleapis.com/v1beta/openai/ (Gemini), "
-            "http://localhost:11434/v1 (Ollama)."
+            "http://localhost:11434/v1 (Ollama). "
+            "WARNING: do not point at internal/metadata endpoints in CI — "
+            "this value is passed directly to the SDK without validation."
         ),
     )
     parser.add_argument(
@@ -324,8 +326,9 @@ def main() -> None:
         type=str,
         default=None,
         help=(
-            "API key. Defaults: $ANTHROPIC_API_KEY (anthropic provider) or "
-            "$OPENAI_API_KEY (openai provider)."
+            "API key. Prefer env vars ($ANTHROPIC_API_KEY / $OPENAI_API_KEY) over this flag — "
+            "CLI flags are visible in process listings (ps aux). "
+            "This flag exists only for scripting contexts where env vars are unavailable."
         ),
     )
     args = parser.parse_args()

--- a/scripts/dev/skillopt/tasks.json
+++ b/scripts/dev/skillopt/tasks.json
@@ -5,7 +5,7 @@
     "context": "Clean install. No profiles exist. Playwright Chromium has not been downloaded yet.",
     "expected": {
       "must_include": ["gflow auth login"],
-      "must_not_include": ["gflow login", "gflow auth ", "gflow auth --"],
+      "must_not_include": ["gflow login", "gflow auth\n", "gflow auth --"],
       "partial_credit": ["playwright install chromium", "gflow auth status"]
     },
     "tags": ["auth", "first-run"],
@@ -148,12 +148,12 @@
     "question": "Apply the style 'cinematic, golden hour' to the user's local file hero.png.",
     "context": null,
     "expected": {
-      "must_include": ["gflow image i2i", "--ref hero.png"],
+      "must_include": ["gflow image i2i", "--ref"],
       "must_not_include": ["gflow image t2i", "--input", "--base", "--source"],
-      "partial_credit": []
+      "partial_credit": ["hero.png"]
     },
     "tags": ["image", "i2i"],
-    "notes": "Image-to-image uses '--ref', not '--input' or '--base'. Subcommand is 'gflow image i2i'."
+    "notes": "Image-to-image uses '--ref', not '--input' or '--base'. Subcommand is 'gflow image i2i'. '--ref' without the filename matches both '--ref hero.png' and '--ref ./hero.png'."
   },
   {
     "id": "image-005",

--- a/scripts/dev/skillopt/tasks.json
+++ b/scripts/dev/skillopt/tasks.json
@@ -5,7 +5,7 @@
     "context": "Clean install. No profiles exist. Playwright Chromium has not been downloaded yet.",
     "expected": {
       "must_include": ["gflow auth login"],
-      "must_not_include": ["gflow login", "gflow auth\n", "gflow auth --"],
+      "must_not_include": ["gflow login", "gflow auth ", "gflow auth --"],
       "partial_credit": ["playwright install chromium", "gflow auth status"]
     },
     "tags": ["auth", "first-run"],

--- a/scripts/dev/skillopt/tasks.json
+++ b/scripts/dev/skillopt/tasks.json
@@ -1,0 +1,242 @@
+[
+  {
+    "id": "auth-001",
+    "question": "A user just installed gflow-cli on a fresh machine and wants to sign in to their Google account for the first time.",
+    "context": "Clean install. No profiles exist. Playwright Chromium has not been downloaded yet.",
+    "expected": {
+      "must_include": ["gflow auth login"],
+      "must_not_include": ["gflow login", "gflow auth\n", "gflow auth --"],
+      "partial_credit": ["playwright install chromium", "gflow auth status"]
+    },
+    "tags": ["auth", "first-run"],
+    "notes": "Agents often suggest bare 'gflow auth' or 'gflow login' which do not trigger browser sign-in. Missing the Playwright prerequisite is the other common gap."
+  },
+  {
+    "id": "auth-002",
+    "question": "The user wants to check whether their current session is still valid before running a long batch job.",
+    "context": "Profile 'default' was created last week.",
+    "expected": {
+      "must_include": ["gflow auth status"],
+      "must_not_include": ["gflow auth login", "gflow auth check"],
+      "partial_credit": []
+    },
+    "tags": ["auth"],
+    "notes": "Agents sometimes suggest 'gflow auth login' (which would open a browser) instead of the non-destructive status check."
+  },
+  {
+    "id": "auth-003",
+    "question": "The user has two Google accounts and wants to generate a T2I image using their 'work' account profile.",
+    "context": "Profiles 'work' and 'personal' both exist. Default is 'personal'.",
+    "expected": {
+      "must_include": ["gflow image t2i", "--profile work"],
+      "must_not_include": ["gflow auth use work", "--account", "GFLOW_CLI_PROFILE"],
+      "partial_credit": []
+    },
+    "tags": ["auth", "multi-profile", "image"],
+    "notes": "Agents sometimes suggest 'gflow auth use work' (which changes the default permanently) rather than the per-command --profile flag."
+  },
+  {
+    "id": "auth-004",
+    "question": "The user's gflow commands are suddenly failing with 'No session for profile default'. What is the fix?",
+    "context": "Profile 'default' exists but the session cookies have expired.",
+    "expected": {
+      "must_include": ["gflow auth login"],
+      "must_not_include": ["gflow auth refresh", "gflow auth renew", "gflow auth reset", "gflow auth update"],
+      "partial_credit": ["gflow auth status"]
+    },
+    "tags": ["auth", "error-recovery"],
+    "notes": "gflow has no 'refresh' or 'renew' subcommand. The only fix for an expired session is a fresh 'gflow auth login'."
+  },
+  {
+    "id": "video-001",
+    "question": "Generate a short vertical video of 'a surfer riding a massive wave at sunset'.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow video t2v"],
+      "must_not_include": ["gflow video generate", "gflow video create", "gflow t2v", "gflow video i2v"],
+      "partial_credit": ["--aspect 9:16", "-o "]
+    },
+    "tags": ["video", "t2v"],
+    "notes": "The subcommand is 'gflow video t2v', not 'gflow video generate'. Vertical (9:16) is the default aspect."
+  },
+  {
+    "id": "video-002",
+    "question": "Generate a landscape (16:9) video of 'a timelapse of clouds over mountains' and save it to ./output/clouds.mp4.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow video t2v", "--aspect 16:9", "-o "],
+      "must_not_include": ["--output ", "--format", "--save"],
+      "partial_credit": ["clouds.mp4"]
+    },
+    "tags": ["video", "t2v", "aspect"],
+    "notes": "Output path uses '-o', not '--output'. Aspect uses '--aspect 16:9'."
+  },
+  {
+    "id": "video-003",
+    "question": "Animate a local image ./hero.png with the prompt 'slow cinematic push-in, soft golden light'.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow video i2v", "./hero.png"],
+      "must_not_include": ["gflow video t2v", "--image", "--start-image", "--input"],
+      "partial_credit": ["-o ", "--aspect"]
+    },
+    "tags": ["video", "i2v"],
+    "notes": "Image-to-video uses 'gflow video i2v IMAGE PROMPT'. The image path is a positional argument, not a flag."
+  },
+  {
+    "id": "video-004",
+    "question": "Using the 'client-a' profile, generate a video from ./logo.png with the prompt 'spinning logo reveal'.",
+    "context": "Profile 'client-a' exists alongside the default profile.",
+    "expected": {
+      "must_include": ["gflow video i2v", "--profile client-a"],
+      "must_not_include": ["gflow auth use client-a", "--account"],
+      "partial_credit": ["./logo.png"]
+    },
+    "tags": ["video", "i2v", "multi-profile"],
+    "notes": "Profile is specified per-command with --profile, not by switching the default with 'gflow auth use'."
+  },
+  {
+    "id": "video-005",
+    "question": "Run all 10 video generation jobs from a TSV manifest at ./batch.tsv and save output files to ./out/.",
+    "context": "The manifest columns are: start_image, prompt, end_image, aspect, output_path.",
+    "expected": {
+      "must_include": ["gflow video batch", "./batch.tsv"],
+      "must_not_include": ["gflow video t2v", "for ", "while ", "xargs"],
+      "partial_credit": ["--out-dir", "./out"]
+    },
+    "tags": ["video", "batch"],
+    "notes": "gflow has a native batch runner. Agents sometimes suggest shell loops over 'gflow video t2v' instead."
+  },
+  {
+    "id": "image-001",
+    "question": "Generate a single image of 'a minimalist fox logo on a white background'.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow image t2i"],
+      "must_not_include": ["gflow image generate", "gflow t2i", "gflow image create", "gflow image make"],
+      "partial_credit": []
+    },
+    "tags": ["image", "t2i"],
+    "notes": "Subcommand is 'gflow image t2i', not 'gflow image generate'."
+  },
+  {
+    "id": "image-002",
+    "question": "Generate 4 landscape variations of 'futuristic city skyline at night'.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow image t2i", "-n 4", "--aspect 16:9"],
+      "must_not_include": ["-n4", "--count 4", "--num 4", "--variants"],
+      "partial_credit": []
+    },
+    "tags": ["image", "t2i", "fanout"],
+    "notes": "Flag is '-n 4' (with space), not '-n4' or '--count'. Aspect is '--aspect 16:9'."
+  },
+  {
+    "id": "image-003",
+    "question": "Generate a reproducible image of 'golden hour rolling hills' that the user can regenerate with the same result later.",
+    "context": "The user wants deterministic output.",
+    "expected": {
+      "must_include": ["gflow image t2i", "--seed"],
+      "must_not_include": ["--random-seed", "-s ", "--deterministic"],
+      "partial_credit": []
+    },
+    "tags": ["image", "t2i", "seed"],
+    "notes": "Determinism uses '--seed N'. Agents sometimes suggest '-s' which is not a valid flag."
+  },
+  {
+    "id": "image-004",
+    "question": "Apply the style 'cinematic, golden hour' to the user's local file hero.png.",
+    "context": null,
+    "expected": {
+      "must_include": ["gflow image i2i", "--ref hero.png"],
+      "must_not_include": ["gflow image t2i", "--input", "--base", "--source"],
+      "partial_credit": []
+    },
+    "tags": ["image", "i2i"],
+    "notes": "Image-to-image uses '--ref', not '--input' or '--base'. Subcommand is 'gflow image i2i'."
+  },
+  {
+    "id": "image-005",
+    "question": "The user already uploaded hero.png and got asset UUID 'a1b2c3d4-xyz'. Apply 'make it minimalist' to the same asset without re-uploading.",
+    "context": "UUID 'a1b2c3d4-xyz' is from a previous 'gflow image upload' call.",
+    "expected": {
+      "must_include": ["gflow image i2i", "--ref a1b2c3d4-xyz"],
+      "must_not_include": ["gflow image upload", "gflow image t2i"],
+      "partial_credit": []
+    },
+    "tags": ["image", "i2i", "uuid-reuse"],
+    "notes": "Already-uploaded UUIDs can be passed directly to --ref. Agents often suggest re-uploading, burning quota."
+  },
+  {
+    "id": "image-006",
+    "question": "Generate an image using the highest-quality Imagen model (not a Nano model).",
+    "context": "Available model aliases: nano2, nano-pro, image4.",
+    "expected": {
+      "must_include": ["gflow image t2i", "--model image4"],
+      "must_not_include": ["--model imagen", "--model quality", "--model high", "--model imagen3", "--model best"],
+      "partial_credit": []
+    },
+    "tags": ["image", "t2i", "model-selection"],
+    "notes": "The highest-quality alias is '--model image4' (maps to IMAGEN_3_5). 'imagen' is not a valid alias."
+  },
+  {
+    "id": "error-001",
+    "question": "Image generation keeps failing silently. The user suspects the headless browser is being detected as a bot by reCAPTCHA. Which environment variable disables headless mode?",
+    "context": "Running on Linux CI. No display available but the user can launch a visible window via SSH tunnel.",
+    "expected": {
+      "must_include": ["GFLOW_CLI_HEADLESS=false"],
+      "must_not_include": ["GFLOW_CLI_HEADLESS=true", "GFLOW_CLI_HEADLESS=0", "GFLOW_CLI_HEADLESS=1"],
+      "partial_credit": []
+    },
+    "tags": ["error-recovery", "recaptcha", "headless"],
+    "notes": "Setting HEADLESS=false disables headless mode so the visible browser passes reCAPTCHA. HEADLESS=true makes it worse."
+  },
+  {
+    "id": "error-002",
+    "question": "During a batch video job, the run stops with 'AuthExpiredError'. What is the minimum command to fix the session and resume?",
+    "context": "Profile 'default' exists. The session cookies expired mid-batch.",
+    "expected": {
+      "must_include": ["gflow auth login"],
+      "must_not_include": ["gflow auth refresh", "gflow auth renew", "gflow auth reset", "gflow auth fix"],
+      "partial_credit": ["gflow auth status"]
+    },
+    "tags": ["error-recovery", "auth"],
+    "notes": "'gflow auth refresh' and 'gflow auth renew' do not exist. The only fix is 'gflow auth login' to re-establish the session."
+  },
+  {
+    "id": "error-003",
+    "question": "A fresh install throws 'Playwright Executable doesn't exist'. How does the user fix it?",
+    "context": "gflow-cli was just installed with 'uv tool install gflow-cli'. No Playwright browser has been downloaded.",
+    "expected": {
+      "must_include": ["playwright install chromium"],
+      "must_not_include": ["pip install playwright", "uv add playwright", "playwright install --all", "playwright install firefox"],
+      "partial_credit": ["uvx --from gflow-cli playwright install chromium"]
+    },
+    "tags": ["error-recovery", "playwright", "first-run"],
+    "notes": "Only Chromium is needed (~150 MB). '--all' wastes bandwidth. 'pip install' installs the Python package, not the browser."
+  },
+  {
+    "id": "python-001",
+    "question": "Show the minimal Python code to generate a video from a local image using gflow-cli as a library.",
+    "context": "User wants programmatic I2V, not the CLI. Python 3.11+.",
+    "expected": {
+      "must_include": ["FlowApiClient", "async with", "asyncio"],
+      "must_not_include": ["subprocess", "os.system", "os.popen"],
+      "partial_credit": ["from gflow_cli.api.client import FlowApiClient", "generate_video", "profile_dir", "await"]
+    },
+    "tags": ["python-api", "i2v"],
+    "notes": "FlowApiClient is an async context manager. Agents sometimes use subprocess to shell out instead of the library API."
+  },
+  {
+    "id": "parallel-001",
+    "question": "The user wants to run two video generations simultaneously, one for each of their profiles 'account-a' and 'account-b'. Give them the two commands to run in parallel.",
+    "context": "Both profiles are configured. The user understands the commands will run concurrently.",
+    "expected": {
+      "must_include": ["gflow video t2v", "--profile account-a", "--profile account-b"],
+      "must_not_include": ["--profile default", "same profile"],
+      "partial_credit": ["&", "tmux", "screen"]
+    },
+    "tags": ["video", "t2v", "multi-profile", "parallel"],
+    "notes": "Parallel generation requires different --profile names. Agents sometimes suggest running both on the same profile which crashes Chromium."
+  }
+]

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,13 @@
 # Skills
 
-This directory ships an installable Skill that lets agents (Claude Code, Cursor, Codex, Gemini CLI, Aider, etc.) discover and invoke `gflow-cli` correctly.
+This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.md` is plain Markdown with YAML frontmatter, consumable by Claude Code, Cursor, Codex, Gemini CLI, Aider, and any custom agent.
+
+| Skill | Path | `version` |
+|---|---|---|
+| gflow-cli | [`gflow-cli/SKILL.md`](gflow-cli/SKILL.md) | 1.1 |
+| predict | [`predict/SKILL.md`](predict/SKILL.md) | 1.0 |
+| scenario | [`scenario/SKILL.md`](scenario/SKILL.md) | — |
+| pr-council-review | [`pr-council-review/SKILL.md`](pr-council-review/SKILL.md) | 2.1 |
 
 ## gflow-cli skill
 
@@ -34,3 +41,26 @@ The SKILL.md file is plain Markdown. Read it into your agent's context however y
 - **Custom agents**: include it in your system prompt or knowledge base.
 
 The CLI itself (`gflow`) is identical regardless of which agent invokes it.
+
+## SkillOpt harness
+
+The harness at [`../scripts/dev/skillopt/`](../scripts/dev/skillopt/) measures how accurately any LLM agent performs against the 20-task scored dataset when guided by a skill doc. Supports Anthropic, OpenAI-compat (GPT-4o, Gemini, Ollama, LM Studio), and any custom provider.
+
+```bash
+# Dry-run (no API call)
+python scripts/dev/skillopt/harness.py --dry-run
+
+# Claude
+ANTHROPIC_API_KEY=... python scripts/dev/skillopt/harness.py
+
+# GPT-4o
+OPENAI_API_KEY=... python scripts/dev/skillopt/harness.py --provider openai --model gpt-4o
+
+# Gemini
+OPENAI_API_KEY=$GEMINI_API_KEY python scripts/dev/skillopt/harness.py \
+    --provider openai \
+    --base-url https://generativelanguage.googleapis.com/v1beta/openai/ \
+    --model gemini-2.0-flash
+```
+
+See [`scripts/dev/skillopt/README.md`](../scripts/dev/skillopt/README.md) for the full improvement loop.

--- a/skills/gflow-cli/SKILL.md
+++ b/skills/gflow-cli/SKILL.md
@@ -186,4 +186,4 @@ Documented errors agents commonly make — negative examples for the SkillOpt tr
 
 ## Disclaimer
 
-gflow-cli is **not affiliated with Google**. Reverse-engineered, alpha-stage (v0.3.0a1), may break. Read the [DISCLAIMER](https://github.com/ffroliva/gflow-cli/blob/main/DISCLAIMER.md) before deploying in any sensitive setting.
+gflow-cli is **not affiliated with Google**. Reverse-engineered, unofficial; may break when Google changes Flow's private API. Read the [DISCLAIMER](https://github.com/ffroliva/gflow-cli/blob/main/DISCLAIMER.md) before deploying in any sensitive setting.

--- a/skills/gflow-cli/SKILL.md
+++ b/skills/gflow-cli/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: gflow-cli
+version: "1.1"
+skillopt_epoch: 0
 description: Use when the user wants to drive Google Flow (Veo image-to-video, Veo text-to-video, Imagen / Nano Banana image generation) from the terminal or a script — including text-to-video, image-to-video, image-to-image, batch video pipelines, or burning Flow Ultra/Pro credits programmatically. The CLI is `gflow` (or `flow`); install with `uv tool install gflow-cli` or run ad-hoc with `uvx --from gflow-cli gflow ...`. Bypasses the web UI entirely after a one-time browser sign-in.
+optimization_notes: |
+  Known weak spots for the SkillOpt training loop (targets for epoch 1+):
+  - Wrong subcommand: agents emit 'gflow video generate' / 'gflow video create' instead of 'gflow video t2v' or 'gflow video i2v'
+  - Wrong output flag: '--output PATH' instead of '-o PATH'
+  - Prerequisite gap: Playwright Chromium install step skipped on fresh machines
+  - Profile parallelism anti-pattern: two generations launched on the same profile in parallel (crashes Chromium)
+  - reCAPTCHA direction inverted: agents suggest GFLOW_CLI_HEADLESS=true to fix detection; correct fix is =false
+  - UUID reuse: agents call 'gflow image upload' again for an already-uploaded UUID instead of passing it directly to --ref
+  - Model alias confusion: '--model imagen' / '--model quality' instead of '--model image4' / '--model nano2'
+  - Auth recovery: agents suggest 'gflow auth refresh' / 'gflow auth renew' which do not exist; correct command is 'gflow auth login'
 ---
 
 # gflow-cli skill
@@ -152,6 +164,25 @@ asyncio.run(make_clip(Path("in.png"), "Push-in", Path("out.mp4")))
 - **Don't share auth profiles.** The Playwright profile dir lives at the per-OS user-data location (Windows: `%LOCALAPPDATA%\gflow-cli\profile_*`; macOS: `~/Library/Application Support/gflow-cli/profile_*`; Linux: `~/.local/share/gflow-cli/profile_*`) and contains Google session cookies — treat as secrets.
 - **Same profile can't run in parallel.** Chromium refuses two persistent contexts on the same profile dir; use different `--profile` names for parallel work.
 - **Respect Google's [Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy).** Don't generate content that would get the user's Google account banned.
+
+## Known agent failure modes
+
+Documented errors agents commonly make — negative examples for the SkillOpt training loop:
+
+| Mistake | Correct behaviour |
+|---|---|
+| `gflow video generate` or `gflow video create` | `gflow video t2v` (text→video) or `gflow video i2v` (image→video) |
+| `--output PATH` on any video/image command | `-o PATH` (short flag) or `--out DIR` (image output dir) |
+| `gflow auth` bare or `gflow login` to sign in | `gflow auth login` — bare `gflow auth` only lists profiles |
+| `gflow auth refresh` / `gflow auth renew` (don't exist) | `gflow auth login` to refresh a stale or expired session |
+| `playwright install` or `playwright install --all` | `uvx --from gflow-cli playwright install chromium` (Chromium only, ~150 MB) |
+| Running two generations on the same `--profile` in parallel | Use different `--profile` names — Chromium refuses two persistent contexts on the same dir |
+| `GFLOW_CLI_HEADLESS=true` to fix reCAPTCHA failures | `GFLOW_CLI_HEADLESS=false` — headless mode *causes* bot-detection, not prevents it |
+| Calling `gflow image upload` again for an already-uploaded UUID | Pass the UUID directly to `--ref UUID` — no re-upload needed |
+| `--model imagen` / `--model quality` / `--model high` | `--model image4` (Imagen 3.5), `--model nano-pro` (Gem Pix 2), `--model nano2` (Narwhal) |
+| Python: `client = FlowApiClient(...)` then method calls | Must use `async with FlowApiClient(...) as client:` — it's an async context manager |
+| Python: `from gflow_cli import FlowApiClient` | `from gflow_cli.api.client import FlowApiClient` |
+| Piping `gflow video t2v` output into a shell loop for batch | Use `gflow video batch manifest.tsv` — the CLI has a native batch runner |
 
 ## Disclaimer
 

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-council-review
+version: "2.1"
 description: Multi-dimensional LLM council review of an open PR (default) or a local feature branch (§ 8 branch mode, invoked via `/gflow:branch-review`). Five baseline dimensions (correctness, quality, security, tests, memory-hygiene) plus adaptive dimensions per surface (transports / data / CLI / docs / auth / BDD / scripts / release-gate). Each agent invokes specialized skills (security-review, code-review, verify) for its dimension. Reads files via `git show <sha>:<path>` to avoid stale-working-tree false positives. Cross-tool portable.
 ---
 

--- a/skills/predict/SKILL.md
+++ b/skills/predict/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: predict
+version: "1.0"
 description: >
   Pre-implementation multi-persona adversarial analysis for gflow-cli proposals.
   Five expert personas independently evaluate a proposed change before a single


### PR DESCRIPTION
## Summary

- **Path 3 — Format alignment**: Updated all three skill docs (`gflow-cli`, `predict`, `pr-council-review`) with SkillOpt-compatible frontmatter (`version`, `skillopt_epoch`, `optimization_notes`) and added a `## Known agent failure modes` negative-examples table to `skills/gflow-cli/SKILL.md` covering 12 documented agent mistakes.
- **Path 2 — Mock harness**: Added `scripts/dev/skillopt/` with a 20-task scored dataset (`tasks.json`), a scoring harness (`harness.py`), and a README documenting the manual improvement loop and the path to full automated SkillOpt training.

## What changed

### `skills/gflow-cli/SKILL.md`
- New frontmatter fields: `version: "1.1"`, `skillopt_epoch: 0`, `optimization_notes` (8-item list of known agent weak spots)
- New `## Known agent failure modes` section — a 12-row table of documented mistakes agents make and their corrections. This is the primary SkillOpt training signal: negative examples significantly improve optimizer convergence.
- Disclaimer: removed stale v0.3.0a1 version pin (project is at v0.10.0)

### `skills/predict/SKILL.md` + `skills/pr-council-review/SKILL.md`
- `version` field added to frontmatter (`"1.0"` and `"2.1"` respectively)

### `scripts/dev/skillopt/tasks.json`
- 20 scored task items in SkillOpt-compatible format, covering: auth (4), video (5), image (6), error-recovery (3), python-api (1), parallel (1).
- Each item: `question`, `context`, `expected` (`must_include` / `must_not_include` / `partial_credit`), `tags`, `notes`.

### `scripts/dev/skillopt/harness.py`
- Multi-provider: `--provider anthropic|openai` covers Claude, GPT-4o, Gemini (via `--base-url`), Ollama, and any OpenAI-compat endpoint
- Dry-run mode: prints formatted prompts + scoring specs without calling any API
- Live mode: calls LLM API, scores each response, reports per-task score + per-tag accuracy breakdown
- Security: `--api-key` help warns against CLI use (process-list exposure); `--base-url` warns against use in CI

### `scripts/dev/skillopt/README.md`
- Scoring formula documented
- Manual improvement loop (baseline → reflect → edit → validate → commit)
- Path to full automated SkillOpt training gated on `GFLOW_CLI_PROVIDER=mock`

### `AGENTS.md`
- New "Skills reference" section so Cursor/Codex/Aider/Gemini CLI can discover `skills/` and the harness
- Corrected Claude Code skill registration description (symlink required; `/gflow:` commands auto-discovered from `.claude/commands/`)

### `docs/INDEX.md`
- Two new rows for `skills/README.md` and `scripts/dev/skillopt/README.md`
- Three new topic shortcuts (multi-agent use, benchmarking, provider comparison)

### `skills/README.md`
- Version table + SkillOpt harness section with multi-provider usage examples

## Test plan

- [ ] `python scripts/dev/skillopt/harness.py --dry-run` exits 0 and prints 20 tasks
- [ ] `python scripts/dev/skillopt/harness.py --dry-run --tags auth` prints exactly 5 tasks
- [ ] `python scripts/dev/skillopt/harness.py --dry-run --tags video` prints exactly 5 tasks
- [ ] Skill frontmatter parses correctly (version/epoch fields visible in dry-run header)
- [ ] `--help` shows `--provider`, `--base-url`, `--api-key` with security warnings