### PR TITLE
fix(video): i2v silently routed to T2V, dropping frames (#125)

### DIFF
--- a/.planning/issue-125-fix.md
+++ b/.planning/issue-125-fix.md
@@ -1,0 +1,207 @@
+# Issue #125 fix plan — `gflow video i2v` silently routes to T2V with `omni-flash`
+
+**Branch:** `bugfix/issue-125-i2v-t2v` (worktree at `.claude/worktrees/bugfix+issue-125-i2v-t2v/`)
+**Issue:** https://github.com/ffroliva/gflow-cli/issues/125
+**Status:** Plan — awaiting 5-persona council review before implementation.
+
+---
+
+## 1. Root cause (confirmed at zero credit)
+
+`omni-flash` does NOT support i2v interpolation (start+end frames). Flow's frontend silently drops the bound mediaIds at submit time and routes the request to `batchAsyncGenerateVideoText` with `image_inputs: null`. The user is charged 1 credit for a pure text-to-video generation that ignores the start/end frames entirely.
+
+This is **NOT** the originally hypothesised selector / UI-path bug. The "Add to Prompt" click in `_upload_via_open_dialog` IS correct on both EN and pt-BR locales (probe v1). The frame slots transition correctly (`FRAME_SLOTS_STRUCT.count()` drops 2 → 1 → 0, probe v3). The submit-button selector finds the right "Criar" button (probe v3). The bug is at Flow's model-vs-request-shape compatibility check, which is invisible from the DOM.
+
+## 2. Evidence
+
+### Zero-credit evidence
+
+| Probe | Sequence | Model | Captured URL | startImage | endImage |
+|---|---|---|---|---|---|
+| v4 prod-order | attaches → prompt → submit | (inherits Flow's last = omni-flash) | `batchAsyncGenerateVideoText` ❌ | `null` | `null` |
+| v4 reorder | prompt → attaches → submit | omni-flash | `batchAsyncGenerateVideoText` ❌ | `null` | `null` |
+| **v5 omni-flash + start+end** | attaches → prompt → submit | omni-flash (explicit) | `batchAsyncGenerateVideoText` ❌ | `null` | `null` |
+| **v5 omni-flash + start-only** | Start only → prompt → submit | omni-flash (explicit) | `batchAsyncGenerateVideoText` ❌ | `null` | `null` |
+| **v5 veo-lite + start+end** | attaches → prompt → submit | **veo-lite** | **`batchAsyncGenerateVideoStartAndEndImage` ✓** | **`4e551690...` ✓** | **`700c5522...` ✓** |
+
+**Conclusion: omni-flash does NOT support i2v in ANY form** — neither start-only nor start+end. The strict rejection in §3 is verified, not just conservative.
+
+Output dirs:
+- `C:\Users\ffrol\gflow-output\i2v-intercept-prodorder-20260530-160535\evidence.json` (omni-flash, broken)
+- `C:\Users\ffrol\gflow-output\i2v-intercept-veolite-20260530-165432\evidence.json` (veo-lite, correct)
+
+### Human-session HAR evidence
+
+`C:\Users\ffrol\Downloads\labs.google14.har` — manual i2v session on the same account, same UI flow as gflow. The captured generate body shows:
+
+```json
+{
+  "videoModelKey": "veo_3_1_interpolation_lite",  // ← Flow auto-promotes veo_3_1_lite → veo_3_1_interpolation_lite when start+end frames are present
+  "startImage": { "mediaId": "3c65f7ed-..." },
+  "endImage":   { "mediaId": "7e70fd03-..." }
+}
+```
+
+### Paid run evidence
+
+The original gflow paid retry (`C:\Users\ffrol\gflow-output\i2v-prompt-retry-20260530-133705\_err2.log`) used `--model omni-flash` (gflow's default), produced an 8s "wake-up in bedroom" stickman video that has zero visual continuity with `01-t2i.jpg` (stickman at desk) or `02-i2i.jpg` (arms-raised triumph at sunrise). Per the structured-log `generate_captured` event, the request URL was `batchAsyncGenerateVideoText` with all-null image_inputs — pure T2V from the prompt alone.
+
+**Retroactive impact:** every i2v paid run on `gflow v0.10.0` with the default model (or `--model omni-flash`) has been a silent T2V. The wf-004 promo "drift" was not Veo style-shift — it was a pure T2V.
+
+## 3. Scope
+
+### In scope (this PR) — council-revised
+
+- Add model-vs-mode compatibility helper `VideoModel.supports_i2v_interpolation()` returning False for `OMNI_FLASH`, True for the four `VEO_3_1_*` variants. Add `I2V_DEFAULT_MODEL = VideoModel.VEO_3_1_LITE` module constant in `api/video.py` (domain).
+- **Typed error class** `ModelModeIncompatibilityError` (new, in `gflow_cli.errors`) wired into `EXIT_CODE_MAP` with **exit code 17** (distinct from Click's exit 2 "usage error" and generic exit 1). Per CLI UX council finding: "semantic model/mode incompatibility known to the domain deserves a typed error."
+- `gflow video i2v` CLI: drop `omni-flash` from the i2v command's `--model` Click `Choice` tuple entirely (cleanest UX per CLI UX council). The `--help` output then lists only valid models; users see the constraint at help time. Note: t2v / r2v keep `omni-flash` in their Choice.
+- `gflow video i2v` CLI: when `--model` omitted → resolve to `I2V_DEFAULT_MODEL` (`veo-lite`). When a deserialized config still names `omni-flash` (e.g. from a stale `--config` JSON), the Click callback raises `ModelModeIncompatibilityError`.
+- **Defense-in-depth transport guard** in `_generate_video_locked`: place **immediately after `_select_video_model` (~L1170)** and BEFORE any `_attach_frame` call (Architect + Performance both flagged this as the right placement — fails before any DOM mutation, no cleanup needed, no `page.reload()`). Guard checks `mode is Mode.I2V and (start_image is not None or end_image is not None) and not model.supports_i2v_interpolation()` → raises `ModelModeIncompatibilityError`. Catches direct `FlowApiClient` callers (gflow-cli-remotion) who bypass Click.
+- **Structlog event** `ui_automation_video.model_mode_rejected` emitted by the transport guard before raising — fields `{model, mode, has_start_image, has_end_image, issue_ref: "#125"}`. Required for e2e assertion per CLI UX council + [[verification-ledger-5-layer]].
+- `--model` Click `help=` text on i2v + i2v command `examples=` corrected.
+- Unit tests for the typed error, Choice-drop, default resolution, transport guard, and structlog assertion — see §6.
+- CHANGELOG entries under both `### Fixed` and `### Changed` (the default-model shift is a Changed behaviour worth surfacing separately).
+- Update issue #125 with the actual root cause and link the PR.
+- Ship two diagnostic probes (`capture_i2v_post_bind_state.py`, `capture_i2v_intercept_submit.py`). **DROP probe v1 (`capture_i2v_upload_dialog_dom.py`)** — it proved a refuted hypothesis; ship-as-doc was post-hoc justification per Devil's Advocate.
+
+### Out of scope (deferred — with evidence-based plan)
+
+- **r2v + omni-flash compatibility** — Devil's Advocate flagged for in-scope inclusion. Probing r2v requires extending the probe with `--mode references` (different sub-mode, different attach helper `_attach_references`, different endpoint family `batchAsyncGenerateVideoReferenceImages`). Material rewrite. **Decision: file follow-up issue with a one-line probe extension as the first task. Defer scope expansion until evidence in hand.** The plan's transport guard is structured so adding r2v rejection later is a one-line change (`mode is Mode.R2V and not model.supports_r2v(...)`).
+- **omni-flash + start-only i2v** — RESOLVED by probe v5: also routes T2V. Already covered by the in-scope reject-omni-flash-for-any-i2v rule. No longer "unverified strictness."
+- **Full model+mode compatibility matrix** — broader spec; separate work.
+- **Selector-cascade hardening for `_upload_via_open_dialog`** (originally Stage A from the predict review) — no longer needed; probe v1 confirmed the selector works on pt-BR. Drop this scope. (Probe itself dropped from ship list per above.)
+
+## 4. Files touched — council-revised
+
+| File | Purpose | Change |
+|---|---|---|
+| `src/gflow_cli/api/video.py` | Domain | Add `VideoModel.supports_i2v_interpolation()` classmethod. Add `I2V_DEFAULT_MODEL = VideoModel.VEO_3_1_LITE`. Per Architect: "domain invariant, not adapter knowledge — analogous to `Aspect.wire()`." |
+| `src/gflow_cli/errors.py` | Typed error | Add `ModelModeIncompatibilityError(GFlowError)` with `exit_code=17`. Per CLI UX council. |
+| `src/gflow_cli/cli_video.py` | CLI surface | Drop `omni-flash` from i2v `--model` Click `Choice` (cleanest discoverability per CLI UX). Add a Click callback resolving omitted `--model` to `I2V_DEFAULT_MODEL`. Raise `ModelModeIncompatibilityError` if a deserialized config still names `omni-flash` for i2v. Update i2v `--model help=` and command examples. |
+| `src/gflow_cli/api/transports/ui_automation_video.py` | Transport guard | In `_generate_video_locked`, **immediately after `_select_video_model` (~L1170), BEFORE `_attach_frame`**: emit `ui_automation_video.model_mode_rejected` event and raise `ModelModeIncompatibilityError` if `mode is Mode.I2V and (start_image is not None or end_image is not None) and not model.supports_i2v_interpolation()`. Per Architect + Performance: earlier placement = no DOM mutation, no cleanup needed. **No `page.reload()`** — drop the R6 mitigation entirely. |
+| `tests/api/test_video.py` (or sibling) | Unit | `test_supports_i2v_interpolation_matrix` parametrized over all 5 VideoModel variants. `test_i2v_default_model_is_veo_lite`. |
+| `tests/errors/test_exit_codes.py` (or sibling) | Unit | `test_model_mode_incompatibility_error_exit_code_17` + ordering-invariant. |
+| `tests/cli/test_cli_video.py` (or sibling) | Unit | i2v --help no longer lists omni-flash; omitted --model resolves to veo-lite; explicit omni-flash via stale config raises exit 17. |
+| `tests/api/transports/test_ui_automation_video.py` (or sibling) | Unit | `test_transport_rejects_i2v_with_omni_flash` — stubbed request DTO, assert raise + `model_mode_rejected` event captured. |
+| `CHANGELOG.md` | Release note | New `### Fixed` entry (i2v silent T2V regression) + new `### Changed` entry (i2v default model shift to veo-lite). |
+| `scripts/dev/capture_i2v_post_bind_state.py` | Dev tooling | NEW — slot-state regression probe. |
+| `scripts/dev/capture_i2v_intercept_submit.py` | Dev tooling | NEW — definitive zero-credit reproducer (the smoking-gun probe). |
+| ~~`scripts/dev/capture_i2v_upload_dialog_dom.py`~~ | ~~Dev tooling~~ | **DROPPED from ship list** — proved a refuted hypothesis; not maintaining as documentation. |
+
+## 5. Implementation steps (in order — each a focused commit) — council-revised
+
+1. **Add `ModelModeIncompatibilityError`** to `gflow_cli.errors` + wire into `EXIT_CODE_MAP` with `exit_code=17`. Unit test for ordering-invariant + the new mapping.
+2. **Add `VideoModel.supports_i2v_interpolation()` + `I2V_DEFAULT_MODEL`** in `api/video.py` + unit tests.
+3. **Drop omni-flash from i2v's `--model` Click `Choice`; add resolution callback** in `cli_video.py`. Add `ModelModeIncompatibilityError` raise for the stale-config edge case. Unit tests for both paths.
+4. **Transport guard** at the correct placement (just after `_select_video_model`) in `_generate_video_locked` + structlog event + unit test stubbing the request DTO. Verify no `page.reload()` is added.
+5. **Update `--model help=` text + i2v command examples** in `cli_video.py`.
+6. **CHANGELOG**: `### Fixed` + `### Changed` entries.
+7. **Add the two dev probes** to `scripts/dev/`: `capture_i2v_post_bind_state.py` + `capture_i2v_intercept_submit.py`. Do NOT add `capture_i2v_upload_dialog_dom.py`.
+8. **Update issue #125** with the corrected root cause and link to the PR (in §7 verification, after merge).
+
+## 6. Test plan — council-revised
+
+### Unit tests
+
+- `test_omni_flash_does_not_support_i2v_interpolation`: `VideoModel.OMNI_FLASH.supports_i2v_interpolation() is False`
+- `test_veo_3_1_models_support_i2v_interpolation`: parametrize across the four VEO_3_1_* variants, all return True
+- `test_i2v_default_model_constant`: `I2V_DEFAULT_MODEL is VideoModel.VEO_3_1_LITE`
+- `test_model_mode_incompatibility_error_exit_code_is_17`: `ModelModeIncompatibilityError().exit_code == 17` and the class is registered in `EXIT_CODE_MAP`
+- `test_exit_code_map_ordering_invariant_still_holds` after the new entry (per [[exit-code-map-ordering-invariant-test-pitfall]])
+- `test_i2v_click_choice_excludes_omni_flash`: introspect the i2v command's `--model` Click `Choice` — `"omni-flash" not in choices`. (Compare to t2v Choice which DOES include it.)
+- `test_i2v_cli_resolves_default_to_veo_lite`: `gflow video i2v start.jpg "p" --end-image end.jpg` (no --model) → resolved model in the request DTO is `VideoModel.VEO_3_1_LITE`
+- `test_i2v_cli_rejects_stale_config_with_omni_flash`: a deserialized config JSON pointing at omni-flash for i2v → exits **17** (not 2) with stderr containing "#125" and "veo-lite"
+- `test_transport_raises_on_i2v_with_omni_flash_and_end_image`: invoke `_generate_video_locked` with a stubbed request `(model=OMNI_FLASH, mode=I2V, start_image=Path, end_image=Path)` → raises `ModelModeIncompatibilityError`, structlog captures `model_mode_rejected` event with fields `{model: "omni_flash", mode: "I2V", has_start_image: True, has_end_image: True, issue_ref: "#125"}`. **No DOM mutation must have occurred** — assert no `_attach_frame` call fired (via mock).
+- `test_transport_raises_on_i2v_with_omni_flash_and_start_only`: same shape but `end_image=None`, `start_image=Path` — still raises (omni-flash rejected for any i2v ref, per probe evidence).
+- `test_transport_does_NOT_raise_on_t2v_with_omni_flash`: pure t2v + omni-flash is a valid combination — guard must NOT fire.
+
+### Integration tests
+
+- BDD scenario: "user runs i2v with default model" → command resolves to veo-lite, no Flow interaction. Assert `structlog` shows `model_mode_rejected` is NOT emitted.
+- BDD scenario: "in-process API caller (e.g. flow_workflow.py shape) passes `model=OMNI_FLASH, mode=I2V, start_image=Path` to `FlowApiClient.generate_video`" → raises `ModelModeIncompatibilityError`, exit code 17. **This is the safety net for gflow-cli-remotion-style consumers.**
+- Audit existing i2v integration tests: any fixture using omni-flash for i2v must be updated to a Veo 3.1 model.
+
+### Live e2e (1 paid credit)
+
+- Re-run probe v5 (`capture_i2v_intercept_submit.py --model veo-lite ...`) zero-credit sanity check — captured URL must still be `StartAndEndImage` with bound mediaIds.
+- Then a live `gflow video i2v 01-t2i.jpg "<tightened stickman motion prompt>" --end-image 02-i2i.jpg --model veo-lite --aspect 9:16 --profile promo-denon82` → expect:
+  - structured log `ui_automation_video.generate_captured` event with `url=batchAsyncGenerateVideoStartAndEndImage` and `image_inputs.startImage` + `image_inputs.endImage` non-null
+  - **assert structured log does NOT contain `ui_automation_video.model_mode_rejected`** (positive verification that the new guard didn't false-fire on a valid combination)
+  - output mp4 visually: 2D ink line-art stickman starting at desk (matches 01-t2i.jpg), interpolating to arms-raised at sunrise (matches 02-i2i.jpg)
+  - 5-layer verification ledger per memory [[verification-ledger-5-layer]]: file count, magic bytes (mp4 signature), Pillow dims (720×1280), structlog invariants (above), user gallery confirmation.
+
+## 7. Verification ladder (definition of done) — council-revised
+
+- [ ] `ruff format --check` + `ruff check` clean on `src/gflow_cli/{cli_video,errors,api/video,api/transports/ui_automation_video}.py` and the two dev probe scripts shipping.
+- [ ] `pyright` clean on the same scoped paths.
+- [ ] All new unit tests pass (see §6).
+- [ ] Scoped pytest of `tests/cli/` + `tests/api/` + `tests/api/transports/` + `tests/errors/` passes (full sweep deferred to CI per [[full-test-suite-ooms]]).
+- [ ] BDD/integration tests pass.
+- [ ] **Exit-code-map ordering-invariant test passes** (per [[exit-code-map-ordering-invariant-test-pitfall]]) — adding code 17 must not invert any prior subclass-relation invariant.
+- [ ] Probe v5 re-run with `--model veo-lite` still produces `StartAndEndImage` URL with bound mediaIds (zero credit).
+- [ ] Probe v5 re-run with `--model omni-flash --start-only` still produces T2V (zero credit — proves the rejection is still warranted).
+- [ ] 1 paid live e2e i2v run completes; structured log shows `generate_captured.url=batchAsyncGenerateVideoStartAndEndImage` with non-null mediaIds AND `model_mode_rejected` event is NOT emitted.
+- [ ] User watches the output mp4 and verbally confirms it's a 2D ink line-art stickman desk → sunrise scene matching the refs.
+- [ ] Issue #125 comment thread updated with the actual root cause + closed by PR merge.
+- [ ] CHANGELOG entries present under `[Unreleased]` — both `### Fixed` and `### Changed`.
+
+## 8. Risks + mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| R1: Changing default model silently surprises users who already had a working incantation | LOW — prior incantation was broken (T2V output); making it work correctly is a strict improvement | None needed beyond clear CHANGELOG note |
+| R2: veo-lite has different cost/quality than omni-flash | LOW — both are tier-one lite models; veo-3.1-lite cost is documented in Flow's UI per `MEDIA_GENERATION_PAYGATE_TIER: PAYGATE_TIER_ONE` | Document in --model help text |
+| R3: omni-flash + start-only i2v might actually work (unverified) | MEDIUM — if it does work, our strict rejection blocks a valid combination | Conservative reject in this PR; reverse with probe evidence in a follow-up if proven |
+| R4: r2v + omni-flash has the same silent-drop pathology | MEDIUM — separate UI surface, separate ticket needed | Out of scope; file follow-up issue with link from #125 |
+| R5: Hidden in-process API callers (scripts using `FlowApiClient` directly like `gflow-cli-remotion/flow_workflow.py`) bypass the CLI validation | MEDIUM | The transport guard in `_generate_video_locked` is the safety net for these callers |
+| ~~R6: pre-submit guard raises but the page is left in a dirty state for the pool~~ | ~~LOW~~ | **DROPPED per Performance council review.** Guard now placed at L1170 (immediately after `_select_video_model`, BEFORE any `_attach_frame`) — fires before any DOM-state mutation, no Page cleanup needed, no `page.reload()`. Architect concurred ("earlier-fail is cleaner than dirty-state cleanup"). |
+
+## 9. Rollback
+
+- Revert the PR as a single commit-range. No DB migrations, no settings changes, no state mutations.
+- The transport guard fails-closed: if a user with cached venv hits the guard on a stale config, they get a clear error pointing at #125 with remediation. No silent regression.
+
+## 10. CHANGELOG entries — council-revised (two sections)
+
+```markdown
+### Fixed
+
+- `gflow video i2v` silently routed every call to the T2V endpoint with
+  `image_inputs: null` when the model was `omni-flash` (Flow's last-used
+  default in most sessions). Flow's frontend rejects omni-flash + frame
+  refs and falls back to text-only generation, but the rejection is
+  invisible to the client — every i2v paid run on v0.10.0 burned a
+  credit for a pure text-to-video generation that ignored the supplied
+  start/end frames. Issue #125. Fix: omni-flash dropped from the i2v
+  `--model` Click `Choice` entirely; a defense-in-depth transport guard
+  in `_generate_video_locked` raises `ModelModeIncompatibilityError`
+  (exit code 17) for direct `FlowApiClient` callers that bypass the CLI.
+
+### Changed
+
+- `gflow video i2v` default model is now `veo-lite` (was: inherit
+  Flow's last-used, which was typically `omni-flash` — see Fixed). The
+  veo-3.1 family is the only model line that supports i2v
+  interpolation; omni-flash is now correctly rejected for any i2v
+  invocation (start-only or start+end). Explicit `--model omni-flash`
+  for `gflow video t2v` and `gflow video r2v` remains valid.
+```
+
+## 11. Migration / backward compat
+
+- No breaking config or env-var changes.
+- v0.10.0 users running `gflow video i2v ... --end-image ...` without explicit `--model` previously got silent T2V output; they now get correct interpolation (silent improvement, no surprise).
+- v0.10.0 users running `gflow video i2v ... --end-image ... --model omni-flash` previously got silent T2V; they now get a clear error with `gflow video i2v ... --end-image ... --model veo-lite` as the remediation.
+- BREAKING for: nobody. The prior behavior was a silent bug.
+
+---
+
+## Appendix: probe scripts
+
+All zero-credit. Only two ship in this PR per Devil's Advocate review (probe v1 dropped — proved a refuted hypothesis, no future-locale-regression value).
+
+| Probe | What it proved | Ships? |
+|---|---|---|
+| `capture_i2v_upload_dialog_dom.py` | "Incluir no comando" pt-BR button matches the production `add_btn` selector — selector cascade is correct (REFUTED original hypothesis). | **NO** — proved a refuted hypothesis; not maintaining as documentation. |
+| `capture_i2v_post_bind_state.py` | `FRAME_SLOTS_STRUCT.count()` transitions 2 → 1 → 0 after binds; submit button is unambiguous (single arrow_forward "Criar" button); slots stay bound after prompt typing. | **YES** — useful future probe for slot-state regressions. |
+| `capture_i2v_intercept_submit.py` | Intercepts the submit XHR via `page.route(..., abort)` and inspects the request body. omni-flash → T2V with null images (both start+end and start-only); veo-lite → StartAndEndImage with populated mediaIds. **This is the definitive reproducer.** | **YES** — definitive regression probe for future model/mode work. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a defense-in-depth transport guard raises `ModelModeIncompatibilityError`
   (exit code 17) for direct `FlowApiClient` callers that bypass the CLI.
 
+- **`gflow video i2v` could still route to T2V even with a valid Veo model,
+  because the model-picker option `Veo 3.1 - Lite` was never selected (issue
+  #125, second path).** The picker selector was an exact-match
+  (`:text-is('volume_upVeo 3.1 - Lite')`) that hardcoded a Material Symbols
+  icon-ligature prefix; when it missed, `_select_video_model` warned and
+  continued, leaving Flow on `omni-flash` → the frames were dropped to T2V.
+  Fixes: (1) the selector is now a robust substring match
+  (`:has-text('Veo 3.1 - Lite'):not(:has-text('[Lower Priority]'))`); (2) for
+  i2v, a model-select miss is now FATAL — `_select_video_model(required=True)`
+  retries the picker then raises `VideoModelSelectionError` (exit code 18)
+  *before* any frame attach or submit, spending no credit; (3) a post-submit
+  backstop raises `WireFormatError` if an i2v request is still observed routing
+  to the T2V endpoint, so a "successful" T2V is never reported as i2v.
+
 - **Create-project generation failing when Flow's "Agent" composer mode is active.**
   Flow's newer editor adds an Agent toggle next to the prompt box; when it is on,
   the media-generation panel (the `crop_*` settings trigger, Image/Video mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`gflow video i2v` default model is now `veo-lite`** (was: inherit Flow's
+  last-used model, which was typically `omni-flash`). The Veo 3.1 family is
+  the only model line that supports i2v interpolation; `omni-flash` is now
+  rejected for any i2v invocation (start-only or start+end) and has been
+  removed from the i2v `--model` choices. `omni-flash` remains valid for
+  `gflow video t2v` and `gflow video r2v`. See issue #125.
+
 ### Fixed
+
+- **`gflow video i2v` silently produced text-to-video output, ignoring the
+  start/end frames (issue #125).** When the model was `omni-flash` (Flow's
+  last-used default in most sessions), Flow's frontend dropped the bound
+  start/end frame references at submit time and routed every call to
+  `batchAsyncGenerateVideoText` with `image_inputs: null` — charging a credit
+  for a pure text-to-video generation that had no visual relationship to the
+  supplied frames. **Every i2v paid run on v0.10.0 before this fix produced
+  T2V output regardless of the start/end frames.** Fix: `omni-flash` is
+  dropped from the i2v `--model` choices and the i2v default is now `veo-lite`;
+  a defense-in-depth transport guard raises `ModelModeIncompatibilityError`
+  (exit code 17) for direct `FlowApiClient` callers that bypass the CLI.
 
 - **Create-project generation failing when Flow's "Agent" composer mode is active.**
   Flow's newer editor adds an Agent toggle next to the prompt box; when it is on,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   last-used model, which was typically `omni-flash`). The Veo 3.1 family is
   the only model line that supports i2v interpolation; `omni-flash` is now
   rejected for any i2v invocation (start-only or start+end) and has been
-  removed from the i2v `--model` choices. `omni-flash` remains valid for
-  `gflow video t2v` and `gflow video r2v`. See issue #125.
+  removed from the i2v `--model` choices. Because `--duration 10` is
+  omni-flash-only, the i2v `--duration` choices are now `[4|6|8]`. `omni-flash`
+  (and `--duration 10`) remain valid for `gflow video t2v` and `gflow video r2v`.
+  See issue #125.
 
 ### Fixed
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -301,6 +301,13 @@ All prompts in a batch share one Flow project. The editor is opened once; each p
 > `--count INTEGER` (1–4; >1 multiplies credit cost), `--aspect [9:16|16:9]`,
 > `--profile NAME`, `--out-dir DIR` (default `tmp/`). The mp4 lands at
 > `<out-dir>/<media_id>.mp4`.
+>
+> **`i2v` is narrower (issue #125):** `omni-flash` does NOT support image-to-video
+> interpolation — Flow silently drops the start/end frames and produces a
+> text-only video — so it is **not** an accepted `--model` for `i2v`. The `i2v`
+> choices are `[veo-lite|veo-fast|veo-quality|veo-lite-lp]` and the **default is
+> `veo-lite`** (not Flow's UI default). `--duration` for `i2v` is `[4|6|8]` (10s
+> is omni-flash-only). `t2v` and `r2v` keep the full shared set above.
 
 ## `gflow video t2v`
 
@@ -679,6 +686,8 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `13` | `SecurityError`       | Unsafe local profile or secret handling blocked   | Follow the error's safety guidance                         |
 | `14` | `AuthBrowserRejectedError` | Google rejected the login browser             | `gflow auth login --browser chrome`                        |
 | `16` | `DataStoreError`      | Local database cannot be opened, a migration failed, or the DB schema is newer than the installed gflow-cli | See below                                  |
+| `17` | `ModelModeIncompatibilityError` | The chosen video model can't do the requested mode (e.g. `--model omni-flash` with an `i2v` start/end frame — issue #125) | Use `--model veo-lite` (or veo-fast / veo-quality / veo-lite-lp) for `i2v` |
+| `18` | `VideoModelSelectionError` | gflow could not select the requested video model in Flow's editor for an `i2v` run (model-picker option not found) | Usually transient — retry; if it persists, Flow's model-picker UI changed (report referencing #125) |
 | `130`| SIGINT                | User-interrupted (Ctrl-C)                        | —                                                          |
 
 **Exit code 16 — data store / migration error.** Fires when:

--- a/scripts/dev/capture_i2v_intercept_submit.py
+++ b/scripts/dev/capture_i2v_intercept_submit.py
@@ -1,0 +1,262 @@
+# ruff: noqa: E501
+"""Probe v4 for issue #125: intercept the submit XHR and inspect its body.
+
+Probes v1-v3 confirmed:
+- The "Add to Prompt" selector resolves correctly on pt-BR (idx 5 "Incluir
+  no comando", bbox_y=474). NOT a selector bug.
+- ``FRAME_SLOTS_STRUCT.count()`` transitions 2 -> 1 -> 0 as Start/End bind.
+  Slot DOM IS a reliable bind signal.
+- Only one ``arrow_forward`` submit button exists (text: "Criar"), correctly
+  disabled with no prompt, enabled after typing. NOT an ambiguous-submit bug.
+- Only one Slate textbox exists. NOT a wrong-textbox bug.
+- Slots stay bound (count 0) after typing the prompt. Typing does NOT
+  detach the bindings.
+
+But the original paid i2v run captured a T2V request body. So the bug must
+be at the actual submit-click moment — a race between React state
+propagation and the click, or Flow's JS reading stale state when the
+mediaId-binding hasn't propagated yet.
+
+This v4 probe nails it down at ZERO credits via a request route handler:
+
+1. Enter editor, switch to video + I2V frames, attach Start + End via
+   the production helpers.
+2. Type the prompt.
+3. Install ``page.route("**/v1/video:batchAsync**", abort)`` so the
+   submit XHR is BLOCKED at the browser before it leaves the network
+   layer. Also install ``page.on("request", capture)`` so we still see
+   the request the browser TRIED to send.
+4. Click the submit button. Wait briefly.
+5. Inspect the captured request: URL endpoint name + body's
+   startImage / endImage / referenceImages presence.
+
+If the captured URL is ``batchAsyncGenerateVideoText`` and image_inputs
+are null, we've reproduced issue #125 with zero credit consumed (the
+request never reached Veo because route.abort() killed it in-browser).
+
+Usage:
+    .venv/Scripts/python.exe scripts/dev/capture_i2v_intercept_submit.py \\
+        --profile promo-denon82 \\
+        --probe-image C:\\path\\to\\start.jpg \\
+        --out-dir tmp/i2v_intercept
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.append(str(Path(__file__).parent.parent.parent / "src"))
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.ui_automation import SUBMIT_BUTTON_SELECTORS
+from gflow_cli.api.transports.ui_automation_video import (
+    FRAME_SLOTS_STRUCT,
+    VideoGenerationMixin,
+    _summarize_request_image_inputs,
+)
+from gflow_cli.api.video import VideoModel
+from gflow_cli.paths import default_home, profile_subdir
+
+PROMPT_INPUT_SELECTOR = 'div[role="textbox"][data-slate-editor="true"]'
+ENDPOINT_GLOB = "**/v1/video:batchAsync**"
+
+
+async def capture(
+    profile_name: str,
+    probe_image: Path,
+    prompt_text: str,
+    reorder: bool,
+    model_alias: str | None,
+    start_only: bool,
+    out_dir: Path,
+) -> int:
+    profile_dir = profile_subdir(default_home(), profile_name)
+    if not profile_dir.exists():
+        sys.exit(f"Profile dir does not exist: {profile_dir}")
+    if not probe_image.exists():
+        sys.exit(f"Probe image not found: {probe_image}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Profile: {profile_name}  ({profile_dir})")
+    print(f"Probe image: {probe_image}")
+    print(
+        f"Sequence: {'PROMPT_FIRST then attaches' if reorder else 'ATTACHES first then prompt (production)'}"
+    )
+    print(f"Out dir: {out_dir}")
+
+    evidence: dict[str, Any] = {
+        "profile": profile_name,
+        "probe_image": str(probe_image),
+        "sequence": "prompt_first" if reorder else "attaches_first",
+        "prompt_text_len": len(prompt_text),
+    }
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=False) as client:
+        transport = client.transport
+        if transport is None:
+            sys.exit("FlowApiClient.transport is None")
+        page = await client._checkout_page()
+
+        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+        await VideoGenerationMixin._wait_video_editor_ready(page)
+        # Select model BEFORE attaching frames — mirrors _generate_video_locked
+        # order. Critical for the issue #125 model+i2v compatibility probe:
+        # omni-flash silently drops refs at submit, veo-3.1-* preserves them.
+        if model_alias:
+            chosen = VideoModel.from_cli(model_alias)
+            if chosen is None:
+                sys.exit(f"Unknown CLI model alias: {model_alias!r}")
+            evidence["selected_model"] = model_alias
+            print(f"Selecting model {model_alias!r} ({chosen.value})...")
+            await VideoGenerationMixin._select_video_model(page, chosen, out_dir=None)
+        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(600)
+
+        async def type_prompt() -> None:
+            print("Typing prompt...")
+            boxes = page.locator(PROMPT_INPUT_SELECTOR)
+            box = boxes.first
+            await box.click()
+            await page.keyboard.press("Control+A")
+            await page.keyboard.press("Delete")
+            await page.keyboard.insert_text(prompt_text)
+            await page.wait_for_timeout(500)
+
+        async def bind_frames() -> None:
+            print("Attaching Start...")
+            await VideoGenerationMixin._attach_frame(page, 0, "Start", probe_image, out_dir=out_dir)
+            if start_only:
+                print("Skipping End (start-only mode).")
+                return
+            print("Attaching End...")
+            await VideoGenerationMixin._attach_frame(page, 1, "End", probe_image, out_dir=out_dir)
+
+        # Sequence selection — this is what the probe is testing.
+        if reorder:
+            await type_prompt()
+            await bind_frames()
+        else:
+            await bind_frames()
+            await type_prompt()
+
+        evidence["slot_count_at_t_pre_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        await page.screenshot(path=str(out_dir / "01-pre-submit.png"))
+
+        # Install network-layer interceptor + request observer.
+        captured_requests: list[dict[str, Any]] = []
+
+        async def on_request(req: Any) -> None:
+            if "batchAsync" in req.url or "video:batch" in req.url:
+                summary = _summarize_request_image_inputs(req)
+                captured_requests.append(
+                    {
+                        "url": req.url,
+                        "method": req.method,
+                        "image_inputs": summary,
+                    }
+                )
+                print(f"  REQUEST observed: {req.url}")
+
+        async def on_route(route: Any) -> None:
+            # Block the request from reaching Veo so no credit consumed.
+            url = route.request.url
+            if "video:batchAsync" in url:
+                print(f"  ABORTING: {url}")
+                await route.abort()
+            else:
+                await route.continue_()
+
+        await page.route(ENDPOINT_GLOB, on_route)
+        page.on("request", on_request)
+
+        # Now click submit via the production selector cascade.
+        print("Clicking submit (XHR will be aborted before reaching Veo)...")
+        for sel in SUBMIT_BUTTON_SELECTORS:
+            try:
+                btn = page.locator(sel).first
+                await btn.wait_for(state="visible", timeout=2_000)
+                if await btn.is_disabled():
+                    print(f"  submit '{sel}' still disabled, skipping")
+                    continue
+                await btn.click()
+                print(f"  clicked via {sel}")
+                break
+            except Exception as e:
+                print(f"  miss {sel}: {e}")
+
+        # Give the browser ~3s to fire the request before we close.
+        await asyncio.sleep(3)
+        await page.screenshot(path=str(out_dir / "02-post-submit-attempt.png"))
+
+        evidence["slot_count_at_t_post_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        evidence["captured_requests"] = captured_requests
+
+        (out_dir / "evidence.json").write_text(
+            json.dumps(evidence, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        print("\n=== summary ===")
+        print(f"Pre-submit slot count:  {evidence['slot_count_at_t_pre_submit']}  (expect 0)")
+        print(f"Post-submit slot count: {evidence['slot_count_at_t_post_submit']}")
+        print(f"Captured generate requests: {len(captured_requests)}")
+        for r in captured_requests:
+            ep = r["url"].split("/")[-1].split("?")[0]
+            ii = r["image_inputs"]
+            print(
+                f"  {ep}  startImage={ii.get('startImage')!r}  endImage={ii.get('endImage')!r}  refs={ii.get('referenceCount')}"
+            )
+
+        print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
+        print("All requests to Veo were aborted at the browser — zero credits.")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--probe-image", type=Path, required=True)
+    parser.add_argument(
+        "--prompt",
+        default="probe test — do not submit, route blocked",
+        help="Prompt text typed into the editor.",
+    )
+    parser.add_argument(
+        "--reorder",
+        action="store_true",
+        help="Type prompt BEFORE binding frames (tests the ordering hypothesis).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="CLI model alias (omni-flash, veo-lite, etc.). Omit to inherit Flow's last-used.",
+    )
+    parser.add_argument(
+        "--start-only",
+        action="store_true",
+        help="Bind only the Start frame (skip End). Tests whether start-only i2v works on the chosen model.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=Path("tmp/i2v_intercept"))
+    args = parser.parse_args()
+    return asyncio.run(
+        capture(
+            args.profile,
+            args.probe_image,
+            args.prompt,
+            args.reorder,
+            args.model,
+            args.start_only,
+            args.out_dir,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/capture_i2v_model_select_repro.py
+++ b/scripts/dev/capture_i2v_model_select_repro.py
@@ -1,0 +1,104 @@
+# ruff: noqa: E501
+"""Zero-credit reproducer for the issue #125 model-select flakiness.
+
+The paid i2v run failed to select veo-lite (`model_option_not_found`) and fell
+back to omni-flash → T2V, yet `capture_i2v_intercept_submit.py --model veo-lite`
+selects it fine. The two differ in WHERE `_wait_video_editor_ready` (a ~1s
+settle) runs relative to `_select_video_model`:
+
+  intercept probe : enter → dismiss → switch_video_mode → wait_ready → select
+  production      : enter → wait_ready → dismiss → switch_video_mode → select
+
+Hypothesis: production probes the model menu too soon after opening the
+settings menu (no settle between switch and select), so the options haven't
+rendered. This probe runs the PRODUCTION order and reports whether
+`_select_video_model` logs `model_selected` or `model_option_not_found` — and
+with `--settle-ms N` inserts a settle between switch and select to test the fix.
+
+Zero credits: never clicks Generate. Reports the selected model + (on a miss)
+the menu items that WERE present, then quits.
+
+Usage:
+    .venv/Scripts/python.exe scripts/dev/capture_i2v_model_select_repro.py \\
+        --profile promo-denon82 --model veo-lite --settle-ms 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent.parent / "src"))
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.ui_automation_video import (
+    VideoGenerationMixin,
+)
+from gflow_cli.api.video import VideoModel
+from gflow_cli.paths import default_home, profile_subdir
+
+
+async def capture(profile_name: str, model_alias: str, settle_ms: int) -> int:
+    profile_dir = profile_subdir(default_home(), profile_name)
+    if not profile_dir.exists():
+        sys.exit(f"Profile dir does not exist: {profile_dir}")
+    model = VideoModel.from_cli(model_alias)
+    if model is None:
+        sys.exit(f"Unknown model alias: {model_alias!r}")
+    print(f"Profile: {profile_name}  model={model.value}  settle_ms={settle_ms}")
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=False) as client:
+        transport = client.transport
+        if transport is None:
+            sys.exit("FlowApiClient.transport is None")
+        page = await client._checkout_page()
+
+        # PRODUCTION order (mirrors _generate_video_locked exactly).
+        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+        await VideoGenerationMixin._wait_video_editor_ready(page)
+        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+
+        if settle_ms > 0:
+            print(f"Inserting {settle_ms}ms settle between switch and select...")
+            await page.wait_for_timeout(settle_ms)
+
+        # Enumerate menu items right before select (diagnostic).
+        try:
+            items = await page.locator("[role='menuitem']").all_inner_texts()
+            print(f"menuitems visible before select ({len(items)}): {[t[:30] for t in items][:12]}")
+        except Exception as e:
+            print(f"menuitem enumeration failed: {e}")
+
+        # Try selection. _select_video_model logs model_selected OR
+        # model_option_not_found — both visible on stderr.
+        try:
+            await VideoGenerationMixin._select_video_model(
+                page, model, out_dir=None, required=False
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"_select_video_model raised: {e}")
+
+        # Report what the model picker now shows (its label reflects the choice).
+        try:
+            items_after = await page.locator("[role='menuitem']").all_inner_texts()
+            print(f"menuitems after select attempt ({len(items_after)})")
+        except Exception:
+            pass
+        print("Done (no Generate — zero credits).")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--model", default="veo-lite")
+    parser.add_argument("--settle-ms", type=int, default=0)
+    args = parser.parse_args()
+    return asyncio.run(capture(args.profile, args.model, args.settle_ms))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/capture_i2v_post_bind_state.py
+++ b/scripts/dev/capture_i2v_post_bind_state.py
@@ -1,0 +1,288 @@
+# ruff: noqa: E501
+"""Probe v2 for issue #125: post-bind state + submit-button enumeration.
+
+Probe v1 (``capture_i2v_upload_dialog_dom.py``) refuted the selector hypothesis:
+``production add_btn`` resolves correctly to "Incluir no comando" (pt-BR
+equivalent of "Add to Prompt") at the bottom of the upload dialog. The
+selector cascade is fine.
+
+This v2 probe answers the next-layer questions, still zero credits:
+
+1. **Does ``FRAME_SLOTS_STRUCT.count()`` actually drop after a committed bind?**
+   The Stage A "post-attach DOM verification" guard depends on count dropping
+   2 -> 1 -> 0 as Start and End commit. If Flow keeps the slot's
+   ``div[type='button'][aria-haspopup='dialog']`` element in the DOM even after
+   the image binds (re-using the click target to swap), then ``count()`` is not
+   a reliable bind signal and the proposed guard would be a no-op.
+
+2. **Is the submit-button selector ambiguous?** The production submit ("via
+   ``button:has(i.google-symbols:text('arrow_forward'))``" — logged as
+   ``ui_automation.prompt_submitted``) may match more than one button in the
+   editor. With both frames bound, enumerate every ``arrow_forward`` candidate
+   on the page, with bounding box and parent classes, so we can see whether
+   a wrong-button click is the routing bug.
+
+Zero credits: enters the editor, switches to video + I2V frames, attaches
+the probe image to BOTH slots through the production ``_attach_frame`` /
+``_upload_via_open_dialog`` helpers, measures slot count after each commit,
+enumerates submit candidates, and quits BEFORE clicking Generate.
+
+Usage:
+    .venv/Scripts/python.exe scripts/dev/capture_i2v_post_bind_state.py \\
+        --profile promo-denon82 \\
+        --probe-image path/to/9_16.jpg \\
+        --out-dir tmp/i2v_post_bind_state
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent.parent / "src"))
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.ui_automation_video import (
+    FRAME_SLOTS_STRUCT,
+    VideoGenerationMixin,
+)
+from gflow_cli.paths import default_home, profile_subdir
+
+# The production `_send_prompt` clicks the FIRST button matching this selector
+# (logged in `ui_automation.prompt_submitted` as `via:`). Enumerating ALL matches
+# reveals whether the editor has multiple candidates (a top-level submit + an
+# in-panel submit + a Send-to-Agent submit, etc.).
+SUBMIT_CANDIDATE_SELECTOR = "button:has(i.google-symbols:text('arrow_forward'))"
+
+# `_send_prompt` types into `page.locator(PROMPT_INPUT_SELECTORS[0]).first`.
+# If Flow renders >1 textbox match, the first DOM hit may be the WRONG composer.
+PROMPT_INPUT_SELECTOR = 'div[role="textbox"][data-slate-editor="true"]'
+
+
+async def _enumerate_arrow_forward(page, out: dict) -> None:
+    """List every visible arrow_forward button in the editor, with bbox +
+    parent class prefix (helps disambiguate which panel each one lives in)."""
+    btns = page.locator(SUBMIT_CANDIDATE_SELECTOR)
+    n = await btns.count()
+    out["arrow_forward_count"] = n
+    out["arrow_forward_buttons"] = []
+    for i in range(n):
+        b = btns.nth(i)
+        try:
+            visible = await b.is_visible()
+        except Exception:
+            visible = False
+        text = (await b.inner_text()).strip()[:80]
+        aria_label = (await b.get_attribute("aria-label") or "")[:80]
+        cls = (await b.get_attribute("class") or "")[:80]
+        disabled = await b.is_disabled()
+        bbox = await b.bounding_box()
+        # Walk up 2 parents for context (class prefixes of the panel each lives in).
+        parent_classes: list[str] = []
+        try:
+            current = b
+            for _ in range(3):
+                parent = current.locator("xpath=..")
+                pc = (await parent.get_attribute("class") or "")[:80]
+                parent_classes.append(pc)
+                current = parent
+        except Exception:
+            pass
+        out["arrow_forward_buttons"].append(
+            {
+                "idx": i,
+                "visible": visible,
+                "disabled": disabled,
+                "text": text,
+                "aria_label": aria_label,
+                "class_prefix": cls,
+                "bbox_y": int(bbox["y"]) if bbox else None,
+                "bbox_x": int(bbox["x"]) if bbox else None,
+                "parent_classes": parent_classes,
+            }
+        )
+
+
+async def capture(profile_name: str, probe_image: Path, out_dir: Path) -> int:
+    profile_dir = profile_subdir(default_home(), profile_name)
+    if not profile_dir.exists():
+        sys.exit(f"Profile dir does not exist: {profile_dir}")
+    if not probe_image.exists():
+        sys.exit(f"Probe image not found: {probe_image}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Profile: {profile_name}  ({profile_dir})")
+    print(f"Probe image: {probe_image}")
+    print(f"Out dir: {out_dir}")
+
+    evidence: dict = {"profile": profile_name, "probe_image": str(probe_image)}
+
+    async with FlowApiClient(profile_dir=profile_dir, headless=False) as client:
+        transport = client.transport
+        if transport is None:
+            sys.exit("FlowApiClient.transport is None")
+        page = await client._checkout_page()
+        print("Editor ready.")
+
+        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+        await VideoGenerationMixin._wait_video_editor_ready(page)
+        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(600)
+
+        # T0 — empty editor, before any slot interaction.
+        evidence["t0_slot_count"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        await page.screenshot(path=str(out_dir / "01-t0-empty.png"))
+        print(f"t0 slot count (expect 2): {evidence['t0_slot_count']}")
+
+        # T1 — bind START via the PRODUCTION code path (full attach incl. commit).
+        print("Attaching Start frame via production _attach_frame...")
+        await VideoGenerationMixin._attach_frame(
+            page,
+            0,
+            "Start",
+            probe_image,
+            out_dir=out_dir,
+        )
+        await page.wait_for_timeout(500)
+        evidence["t1_slot_count_after_start_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        await page.screenshot(path=str(out_dir / "02-t1-after-start.png"))
+        print(
+            f"t1 slot count after Start bind (expect 1): {evidence['t1_slot_count_after_start_bind']}"
+        )
+
+        # T2 — bind END via the PRODUCTION code path.
+        print("Attaching End frame via production _attach_frame...")
+        await VideoGenerationMixin._attach_frame(
+            page,
+            1,
+            "End",
+            probe_image,
+            out_dir=out_dir,
+        )
+        await page.wait_for_timeout(500)
+        evidence["t2_slot_count_after_end_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        await page.screenshot(path=str(out_dir / "03-t2-after-end.png"))
+        print(
+            f"t2 slot count after End bind  (expect 0): {evidence['t2_slot_count_after_end_bind']}"
+        )
+
+        # T3 — both frames bound, prompt textbox in focus. Enumerate every
+        # arrow_forward submit candidate. Production picks .first.
+        print("Enumerating arrow_forward submit candidates...")
+        slot_state: dict = {}
+        await _enumerate_arrow_forward(page, slot_state)
+        evidence["t3_submit_candidates"] = slot_state
+        await page.screenshot(path=str(out_dir / "04-t3-submit-candidates.png"))
+        print(f"arrow_forward buttons found in editor: {slot_state['arrow_forward_count']}")
+        for b in slot_state["arrow_forward_buttons"]:
+            vis = "visible" if b["visible"] else "hidden"
+            dis = " disabled" if b["disabled"] else ""
+            print(
+                f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+            )
+
+        # T4 — enumerate all prompt textboxes (production picks .first).
+        print("Enumerating Slate textbox candidates...")
+        boxes = page.locator(PROMPT_INPUT_SELECTOR)
+        nbox = await boxes.count()
+        textboxes = []
+        for i in range(nbox):
+            b = boxes.nth(i)
+            try:
+                visible = await b.is_visible()
+            except Exception:
+                visible = False
+            cls = (await b.get_attribute("class") or "")[:80]
+            bbox = await b.bounding_box()
+            parent_classes: list[str] = []
+            try:
+                cur = b
+                for _ in range(3):
+                    parent = cur.locator("xpath=..")
+                    parent_classes.append((await parent.get_attribute("class") or "")[:80])
+                    cur = parent
+            except Exception:
+                pass
+            textboxes.append(
+                {
+                    "idx": i,
+                    "visible": visible,
+                    "class_prefix": cls,
+                    "bbox_y": int(bbox["y"]) if bbox else None,
+                    "bbox_x": int(bbox["x"]) if bbox else None,
+                    "parent_classes": parent_classes,
+                }
+            )
+        evidence["t4_textbox_count"] = nbox
+        evidence["t4_textboxes"] = textboxes
+        print(f"prompt textboxes: {nbox}")
+        for b in textboxes:
+            vis = "visible" if b["visible"] else "hidden"
+            print(
+                f"  idx={b['idx']} {vis} bbox=({b['bbox_x']},{b['bbox_y']}) class={b['class_prefix']!r}"
+            )
+
+        # T5 — type a non-paid prompt via production helper sequence, then
+        # measure slot state. Stop BEFORE the submit click — no Generate.
+        print("Typing test prompt into .first textbox (production sequence, no submit)...")
+        first_box = boxes.first
+        await first_box.click()
+        await page.keyboard.press("Control+A")
+        await page.keyboard.press("Delete")
+        await page.keyboard.insert_text("probe test prompt — do not submit")
+        await page.wait_for_timeout(500)
+        evidence["t5_slot_count_after_typing"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+        post_typing: dict = {}
+        await _enumerate_arrow_forward(page, post_typing)
+        evidence["t5_submit_candidates_after_typing"] = post_typing
+        await page.screenshot(path=str(out_dir / "05-t5-after-typing.png"))
+        print(f"t5 slot count after typing (expect 0): {evidence['t5_slot_count_after_typing']}")
+        print(f"t5 arrow_forward count: {post_typing['arrow_forward_count']}")
+        for b in post_typing["arrow_forward_buttons"]:
+            vis = "visible" if b["visible"] else "hidden"
+            dis = " DISABLED" if b["disabled"] else " enabled"
+            print(
+                f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+            )
+
+        # Write evidence + summary.
+        (out_dir / "evidence.json").write_text(
+            json.dumps(evidence, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        print("\n=== summary ===")
+        print(
+            f"FRAME_SLOTS_STRUCT count transition: "
+            f"{evidence['t0_slot_count']} -> {evidence['t1_slot_count_after_start_bind']} -> "
+            f"{evidence['t2_slot_count_after_end_bind']}"
+        )
+        print(
+            f"arrow_forward submit candidates: {evidence['t3_submit_candidates']['arrow_forward_count']}"
+        )
+        print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
+        print("Closing browser (no Generate clicked — zero credits).")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument(
+        "--probe-image",
+        type=Path,
+        required=True,
+        help="9:16 image attached to both Start and End slots via the production helpers.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=Path("tmp/i2v_post_bind_state"))
+    args = parser.parse_args()
+    return asyncio.run(capture(args.profile, args.probe_image, args.out_dir))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -725,9 +725,10 @@ class VideoGenerationMixin:
         On miss the default behaviour is non-fatal (Flow's default model
         applies) but logged at WARNING — picking the wrong model changes credit
         cost. When ``required=True`` (i2v: see issue #125), a miss is FATAL and
-        raises ``RuntimeError`` BEFORE any frame attach or submit, because Flow's
-        default model is ``omni-flash`` which silently drops i2v frame refs and
-        routes to T2V — a wasted credit. Failing here spends nothing.
+        raises ``VideoModelSelectionError`` BEFORE any frame attach or submit,
+        because Flow's default model is ``omni-flash`` which silently drops i2v
+        frame refs and routes to T2V — a wasted credit. Failing here spends
+        nothing.
 
         Reliability (issue #125): the trigger click occasionally does not open
         the menu (the option probe then times out and Flow keeps its default).
@@ -738,8 +739,11 @@ class VideoGenerationMixin:
         if option_sel is None:
             log.warning("ui_automation_video.model_unknown", model=model.value)
             if required:
+                # Consistent with the other required-misses below: a typed
+                # exit-18 error, not a bare RuntimeError (exit 1). Unreachable
+                # for the 5 registered models, but keeps the i2v contract intact.
                 msg = f"no model-picker selector registered for {model.value!r}"
-                raise RuntimeError(msg)
+                raise VideoModelSelectionError(detail=msg, route="model_option")
             return
         trigger = await VideoGenerationMixin._probe_selector_cascade(
             page,

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -36,7 +36,12 @@ from gflow_cli.api.video import (
     operation_name_from_generate_response,
     parse_video_status,
 )
-from gflow_cli.errors import AuthExpiredError, WafRejectionError, WireFormatError
+from gflow_cli.errors import (
+    AuthExpiredError,
+    ModelModeIncompatibilityError,
+    WafRejectionError,
+    WireFormatError,
+)
 from gflow_cli.storage import AnyPath, storage_path, write_asset_async
 
 if TYPE_CHECKING:
@@ -1151,6 +1156,35 @@ class VideoGenerationMixin:
     ) -> VideoResult:
         """Serialized body of `generate_video` — runs under `self._generate_lock`
         (shared with `generate_images`: one Page, one DOM)."""
+        # Defense-in-depth model/mode guard (issue #125). Pure DTO check — runs
+        # BEFORE any browser interaction so a bad combination fails instantly
+        # with no DOM state mutated and no credit risk. The CLI Click Choice
+        # already blocks omni-flash for i2v, but direct FlowApiClient callers
+        # (e.g. gflow-cli-remotion) bypass Click; this is their safety net.
+        # omni-flash silently drops i2v frame refs at submit and routes to the
+        # T2V endpoint — see VideoModel.supports_i2v_interpolation.
+        if (
+            request.mode is Mode.I2V
+            and (request.start_image is not None or request.end_image is not None)
+            and request.model is not None
+            and not request.model.supports_i2v_interpolation()
+        ):
+            log.error(
+                "ui_automation_video.model_mode_rejected",
+                model=request.model.value,
+                mode=request.mode.name,
+                has_start_image=request.start_image is not None,
+                has_end_image=request.end_image is not None,
+                issue_ref="#125",
+            )
+            raise ModelModeIncompatibilityError(
+                detail=(
+                    f"{request.model.value!r} does not support image-to-video "
+                    f"interpolation; Flow silently drops the start/end frames "
+                    f"and produces a text-only video (issue #125)."
+                ),
+            )
+
         page: Page = self._page  # type: ignore[assignment]  # guarded in generate_video
 
         await self._enter_editor(page, out_dir)

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -40,6 +40,7 @@ from gflow_cli.api.video import (
 from gflow_cli.errors import (
     AuthExpiredError,
     ModelModeIncompatibilityError,
+    VideoModelSelectionError,
     WafRejectionError,
     WireFormatError,
 )
@@ -168,7 +169,16 @@ VIDEO_MODEL_OPTION_SELECTORS: dict[VideoModel, str] = {
     VideoModel.OMNI_FLASH: "[role='menuitem']:has-text('Omni Flash')",
     VideoModel.VEO_3_1_FAST: "[role='menuitem']:has-text('Veo 3.1 - Fast')",
     VideoModel.VEO_3_1_QUALITY: "[role='menuitem']:has-text('Veo 3.1 - Quality')",
-    VideoModel.VEO_3_1_LITE: "[role='menuitem']:text-is('volume_upVeo 3.1 - Lite')",
+    # Substring `:has-text` (NOT `:text-is`) so it matches regardless of the
+    # leading Material Symbols icon ligature in the menu item's accessible text
+    # (e.g. "volume_upVeo 3.1 - Lite"). The exact-match `:text-is(...)` form that
+    # hardcoded the icon prefix was the issue #125 model-select reliability bug:
+    # it silently missed -> Flow kept omni-flash -> i2v routed to T2V. `:not`
+    # excludes the 'Veo 3.1 - Lite [Lower Priority]' sibling (has-text is a
+    # substring/prefix match).
+    VideoModel.VEO_3_1_LITE: (
+        "[role='menuitem']:has-text('Veo 3.1 - Lite'):not(:has-text('[Lower Priority]'))"
+    ),
     VideoModel.VEO_3_1_LITE_LOWER_PRIORITY: "[role='menuitem']:has-text('[Lower Priority]')",
 }
 
@@ -749,7 +759,7 @@ class VideoGenerationMixin:
                     f"for i2v. Refusing to proceed (Flow's default would drop the "
                     f"frames to T2V — issue #125). Screenshot: {shot}"
                 )
-                raise RuntimeError(msg)
+                raise VideoModelSelectionError(detail=msg, route="model_picker_trigger")
             return
 
         for attempt in (1, 2):
@@ -791,7 +801,7 @@ class VideoGenerationMixin:
                 f"({VideoModel.OMNI_FLASH.value}) silently drops the start/end "
                 f"frames and routes to T2V (issue #125). Screenshot: {shot}"
             )
-            raise RuntimeError(msg)
+            raise VideoModelSelectionError(detail=msg, route="model_option")
 
     @staticmethod
     async def _select_video_duration(page: Page, seconds: int) -> None:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -24,6 +24,7 @@ import structlog
 from gflow_cli.api import routes
 from gflow_cli.api.transports._common import extract_project_id
 from gflow_cli.api.video import (
+    I2V_DEFAULT_MODEL,
     Aspect,
     GenerateVideoRequest,
     Mode,
@@ -58,6 +59,9 @@ VIDEO_GENERATE_ROUTES = (
     "batchAsyncGenerateVideoStartAndEndImage",
     "batchAsyncGenerateVideoReferenceImages",
 )
+# The pure text-to-video route. An i2v request that lands here had its frame
+# refs silently dropped (issue #125) — used by the Layer-2 post-submit backstop.
+_T2V_GENERATE_ROUTE = "batchAsyncGenerateVideoText"
 # Status-poll route — Flow's SPA polls this itself while a generation runs.
 VIDEO_STATUS_ROUTE = "batchCheckAsyncVideoGenerationStatus"
 
@@ -699,13 +703,33 @@ class VideoGenerationMixin:
         await VideoGenerationMixin._set_output_count(page, 1)
 
     @staticmethod
-    async def _select_video_model(page: Page, model: VideoModel, *, out_dir: Path | None) -> None:
-        """Open the model picker and select `model`. Non-fatal on miss (Flow's
-        default model applies) but logged at WARNING — picking the wrong model
-        changes credit cost, so a miss is a real signal, not noise."""
+    async def _select_video_model(
+        page: Page,
+        model: VideoModel,
+        *,
+        out_dir: Path | None,
+        required: bool = False,
+    ) -> None:
+        """Open the model picker and select `model`.
+
+        On miss the default behaviour is non-fatal (Flow's default model
+        applies) but logged at WARNING — picking the wrong model changes credit
+        cost. When ``required=True`` (i2v: see issue #125), a miss is FATAL and
+        raises ``RuntimeError`` BEFORE any frame attach or submit, because Flow's
+        default model is ``omni-flash`` which silently drops i2v frame refs and
+        routes to T2V — a wasted credit. Failing here spends nothing.
+
+        Reliability (issue #125): the trigger click occasionally does not open
+        the menu (the option probe then times out and Flow keeps its default).
+        We click the trigger and probe the option up to two times, pressing
+        Escape between attempts to reset the dropdown state.
+        """
         option_sel = VIDEO_MODEL_OPTION_SELECTORS.get(model)
         if option_sel is None:
             log.warning("ui_automation_video.model_unknown", model=model.value)
+            if required:
+                msg = f"no model-picker selector registered for {model.value!r}"
+                raise RuntimeError(msg)
             return
         trigger = await VideoGenerationMixin._probe_selector_cascade(
             page,
@@ -718,29 +742,56 @@ class VideoGenerationMixin:
                 model=model.value,
                 note="Flow default model applies",
             )
+            if required:
+                shot = await _capture_debug_screenshot(page, out_dir, "debug_no_model_picker.png")
+                msg = (
+                    f"model picker trigger not found; cannot select {model.value!r} "
+                    f"for i2v. Refusing to proceed (Flow's default would drop the "
+                    f"frames to T2V — issue #125). Screenshot: {shot}"
+                )
+                raise RuntimeError(msg)
             return
-        await trigger.click()
-        await page.wait_for_timeout(600)
-        option = await VideoGenerationMixin._probe_selector_cascade(
-            page,
-            "model_option",
-            (option_sel,),
-        )
-        if option is None:
-            log.warning(
-                "ui_automation_video.model_option_not_found",
-                model=model.value,
-                note="Flow default model applies",
+
+        for attempt in (1, 2):
+            await trigger.click()
+            await page.wait_for_timeout(600)
+            option = await VideoGenerationMixin._probe_selector_cascade(
+                page,
+                "model_option",
+                (option_sel,),
             )
-            # The model dropdown is the TOP layer here — Escape closes only it,
-            # leaving the settings popover open (Escape on the popover itself
-            # would close everything). Safe to recover.
+            if option is not None:
+                await option.click()
+                await page.wait_for_timeout(800)
+                log.info("ui_automation_video.model_selected", model=model.value)
+                return
+            # The menu may not have opened (trigger click raced) or rendered the
+            # option late. Escape closes only the dropdown (the settings popover
+            # underneath stays open), then we retry the trigger click once.
+            log.debug(
+                "ui_automation_video.model_option_retry",
+                model=model.value,
+                attempt=attempt,
+            )
             await page.keyboard.press("Escape")
             await page.wait_for_timeout(200)
-            return
-        await option.click()
-        await page.wait_for_timeout(800)
-        log.info("ui_automation_video.model_selected", model=model.value)
+
+        log.warning(
+            "ui_automation_video.model_option_not_found",
+            model=model.value,
+            note="Flow default model applies" if not required else "i2v — refusing T2V fallback",
+        )
+        if required:
+            shot = await _capture_debug_screenshot(
+                page, out_dir, "debug_model_option_not_found.png"
+            )
+            msg = (
+                f"could not select video model {model.value!r} for i2v after 2 "
+                f"attempts. Refusing to proceed — Flow's default model "
+                f"({VideoModel.OMNI_FLASH.value}) silently drops the start/end "
+                f"frames and routes to T2V (issue #125). Screenshot: {shot}"
+            )
+            raise RuntimeError(msg)
 
     @staticmethod
     async def _select_video_duration(page: Page, seconds: int) -> None:
@@ -1163,9 +1214,11 @@ class VideoGenerationMixin:
         # (e.g. gflow-cli-remotion) bypass Click; this is their safety net.
         # omni-flash silently drops i2v frame refs at submit and routes to the
         # T2V endpoint — see VideoModel.supports_i2v_interpolation.
+        is_i2v_with_frames = request.mode is Mode.I2V and (
+            request.start_image is not None or request.end_image is not None
+        )
         if (
-            request.mode is Mode.I2V
-            and (request.start_image is not None or request.end_image is not None)
+            is_i2v_with_frames
             and request.model is not None
             and not request.model.supports_i2v_interpolation()
         ):
@@ -1185,6 +1238,20 @@ class VideoGenerationMixin:
                 ),
             )
 
+        # For i2v, never leave the model unset. An unset model means
+        # `_select_video_model` is skipped and Flow applies its last-used default
+        # (often omni-flash), which silently drops the frames to T2V (issue #125).
+        # Default to an interpolation-capable model — mirrors the CLI's resolution
+        # so direct FlowApiClient callers get the same safe behaviour.
+        effective_model: VideoModel | None = request.model
+        if is_i2v_with_frames and effective_model is None:
+            effective_model = I2V_DEFAULT_MODEL
+            log.info(
+                "ui_automation_video.i2v_model_defaulted",
+                model=effective_model.value,
+                issue_ref="#125",
+            )
+
         page: Page = self._page  # type: ignore[assignment]  # guarded in generate_video
 
         await self._enter_editor(page, out_dir)
@@ -1200,8 +1267,17 @@ class VideoGenerationMixin:
 
         # All settings-panel selections happen while the panel is open: model
         # (gates the 10s duration), sub-mode tab, aspect, count, duration.
-        if request.model is not None:
-            await VideoGenerationMixin._select_video_model(page, request.model, out_dir=out_dir)
+        # For i2v, model selection is REQUIRED (required=True): a silent miss
+        # would let Flow fall back to omni-flash and route to T2V (issue #125),
+        # so _select_video_model raises here — before any frame attach or submit,
+        # spending no credit.
+        if effective_model is not None:
+            await VideoGenerationMixin._select_video_model(
+                page,
+                effective_model,
+                out_dir=out_dir,
+                required=is_i2v_with_frames,
+            )
         if request.mode is Mode.I2V:
             await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=out_dir)
         elif request.mode is Mode.R2V:
@@ -1251,6 +1327,33 @@ class VideoGenerationMixin:
             await self._send_prompt(page, request.prompt, out_dir)
 
             generate_resp = await VideoGenerationMixin._await_generate_response(generate_captured)
+
+            # Layer-2 backstop (issue #125): for i2v, the request MUST have
+            # routed to a Start/StartAndEndImage endpoint. If it landed on the
+            # plain T2V route, Flow silently dropped the frames (e.g. an
+            # undiscovered fallback path) — the credit is already spent, but we
+            # MUST NOT return a "successful i2v" VideoResult that is actually a
+            # text-only video. Raise loudly instead of recording a fake success.
+            if is_i2v_with_frames:
+                captured_url = str(generate_resp.get("url") or "")
+                if _T2V_GENERATE_ROUTE in captured_url:
+                    log.error(
+                        "ui_automation_video.i2v_routed_to_t2v",
+                        url=captured_url,
+                        model=(effective_model.value if effective_model else None),
+                        issue_ref="#125",
+                    )
+                    raise WireFormatError(
+                        detail=(
+                            "i2v request routed to the T2V endpoint "
+                            f"({_T2V_GENERATE_ROUTE}); Flow dropped the start/end "
+                            "frames and produced a text-only video (issue #125). "
+                            "The credit was spent but the output is not an "
+                            "interpolation — refusing to report success."
+                        ),
+                        route=_T2V_GENERATE_ROUTE,
+                    )
+
             media_name, flow_operation_id = VideoGenerationMixin._parse_generate_response(
                 generate_resp,
             )

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -61,6 +61,29 @@ class VideoModel(StrEnum):
             )
         return _VIDEO_MODEL_FROM_CLI[key]
 
+    def supports_i2v_interpolation(self) -> bool:
+        """Whether this model supports image-to-video with start (and optional
+        end) frame references.
+
+        Verified empirically (issue #125, 2026-05-30) via the
+        ``scripts/dev/capture_i2v_intercept_submit.py`` probe with
+        ``page.route(..., abort)``: ``OMNI_FLASH`` causes Flow's frontend to
+        silently drop frame refs at submit and route to
+        ``batchAsyncGenerateVideoText`` with ``image_inputs: null``. The four
+        ``VEO_3_1_*`` variants preserve the refs and route to
+        ``batchAsyncGenerateVideoStartImage`` /
+        ``batchAsyncGenerateVideoStartAndEndImage``.
+        """
+        return self is not VideoModel.OMNI_FLASH
+
+
+# Default model for ``gflow video i2v`` and direct ``FlowApiClient.generate_video``
+# callers when ``model`` is omitted and the request carries a start/end frame.
+# ``omni_flash`` is excluded because it silently drops frame refs at submit
+# time (issue #125). ``veo_3_1_lite`` is the cheapest interpolation-capable
+# model, matching the price tier ``omni_flash`` previously occupied for t2v.
+I2V_DEFAULT_MODEL: VideoModel = VideoModel.VEO_3_1_LITE
+
 
 # Module-level alias map — friendly CLI strings -> VideoModel. Hoisted out of
 # `VideoModel.from_cli` (defined after the class so the members resolve) so

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -182,13 +182,36 @@ async def _run_i2v(
     count: int = 1,
     as_json: bool = False,
 ) -> None:
-    from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
+    from gflow_cli.api.video import (
+        I2V_DEFAULT_MODEL,
+        Aspect,
+        GenerateVideoRequest,
+        Mode,
+        VideoModel,
+    )
+    from gflow_cli.errors import ModelModeIncompatibilityError
+
+    # Resolve the model with i2v-specific defaulting + validation. The Click
+    # Choice already excludes omni-flash, but a stale `--config` JSON or a
+    # direct programmatic call can still smuggle it in. omni-flash silently
+    # drops the start/end frames at submit and routes to T2V (issue #125), so
+    # reject it here before any paid call.
+    resolved_model = VideoModel.from_cli(model)
+    if resolved_model is None:
+        resolved_model = I2V_DEFAULT_MODEL
+    elif not resolved_model.supports_i2v_interpolation():
+        msg = (
+            f"{resolved_model.value!r} does not support image-to-video "
+            f"interpolation; Flow silently drops the start/end frames and "
+            f"produces a text-only video (issue #125)."
+        )
+        raise ModelModeIncompatibilityError(detail=msg)
 
     request = GenerateVideoRequest(
         prompt=prompt,
         mode=Mode.I2V,
         aspect=Aspect.from_cli(aspect),
-        model=VideoModel.from_cli(model),
+        model=resolved_model,
         duration=duration,
         count=count,
         start_image=Path(image),
@@ -336,6 +359,10 @@ def t2v(
     short_help="Generate a video from a start image + motion prompt.",
     help=(
         "Image-to-video: animate a start image with a motion prompt (Veo).\n\n"
+        "Only the Veo 3.1 models support i2v interpolation; omni-flash is NOT "
+        "accepted here because Flow silently drops the start/end frames and "
+        "falls back to text-to-video (issue #125). Omit --model to use "
+        "veo-lite (the default i2v model).\n\n"
         "\b\n"
         "Examples:\n"
         '  gflow video i2v hero.png "slow cinematic push-in"\n'
@@ -362,14 +389,17 @@ def t2v(
 @click.option(
     "--model",
     default=None,
-    type=click.Choice(["omni-flash", "veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
-    help="Veo model. Omit to use Flow's current default.",
+    # omni-flash is intentionally absent: it does not support i2v
+    # interpolation and silently routes to T2V (issue #125). Use a Veo 3.1
+    # model. Omitting --model resolves to veo-lite (I2V_DEFAULT_MODEL).
+    type=click.Choice(["veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
+    help="Veo 3.1 model. Omit to use veo-lite (the default i2v model).",
 )
 @click.option(
     "--duration",
     default=None,
-    type=click.Choice(["4", "6", "8", "10"]),
-    help="Clip length in seconds. 10 requires --model omni-flash.",
+    type=click.Choice(["4", "6", "8"]),
+    help="Clip length in seconds (i2v supports 4/6/8; 10 is omni-flash-only).",
 )
 @click.option(
     "--count",

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -22,6 +22,7 @@ __all__ = [
     "RateLimitError",
     "SecurityError",
     "TransportTimeoutError",
+    "VideoModelSelectionError",
     "WafRejectionError",
     "WireFormatError",
 ]
@@ -287,6 +288,31 @@ class ModelModeIncompatibilityError(ConfigurationError):
     )
 
 
+class VideoModelSelectionError(ConfigurationError):
+    """Raised when the requested video model could not be selected in Flow's UI
+    for an i2v generation (issue #125).
+
+    The model picker option was not found (e.g. a selector drift / render race).
+    For i2v this is FATAL rather than a silent fallback: leaving Flow on its
+    default model (``omni-flash``) would drop the start/end frames and route to
+    T2V, charging a credit for a text-only video. Raised pre-submit by the
+    transport, so no credit is spent.
+
+    Distinct exit code 18 so scripted callers can branch on "the model UI failed"
+    (a retryable transport/selector issue) versus exit 17 "I picked an
+    incompatible model" (a request mistake).
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/video-model-selection"
+    title = "Could not select the requested video model"
+    _default_remediation = (
+        "gflow could not select the requested model in Flow's editor (the model "
+        "picker option was not found). This is usually transient — retry the "
+        "command. If it persists, Flow's model-picker UI may have changed; please "
+        "report it referencing issue #125."
+    )
+
+
 class SecurityError(GFlowError):
     """Raised when a security boundary is violated (e.g. profile_dir outside HOME)."""
 
@@ -462,9 +488,11 @@ EXIT_CODE_MAP: dict[type[GFlowError], int] = {
     AuthMissingError: 8,
     TransportTimeoutError: 9,
     WafRejectionError: 10,
-    # ModelModeIncompatibilityError BEFORE ConfigurationError (subclass) so the
-    # isinstance walk lands on 17, not 11. Per [[exit-code-map-ordering-invariant-test-pitfall]].
+    # ModelModeIncompatibilityError + VideoModelSelectionError BEFORE
+    # ConfigurationError (their parent) so the isinstance walk lands on 17/18,
+    # not 11. Per [[exit-code-map-ordering-invariant-test-pitfall]].
     ModelModeIncompatibilityError: 17,
+    VideoModelSelectionError: 18,
     ConfigurationError: 11,
     AuthExpiredError: 3,
     RateLimitError: 4,

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -16,6 +16,7 @@ __all__ = [
     "DataStoreError",
     "FlowApiError",
     "GFlowError",
+    "ModelModeIncompatibilityError",
     "NetworkError",
     "ProblemDetails",
     "RateLimitError",
@@ -259,6 +260,33 @@ class ConfigurationError(GFlowError):
     )
 
 
+class ModelModeIncompatibilityError(ConfigurationError):
+    """Raised when the chosen video model is incompatible with the requested
+    generation mode (issue #125).
+
+    The canonical case: ``omni-flash`` does NOT support i2v interpolation
+    (start or start+end frames). Flow's frontend silently drops the frame
+    refs at submit time and routes the request to the T2V endpoint,
+    charging a credit for a generation that ignores the supplied images
+    entirely. This error is raised pre-submit by both the CLI (Click
+    callback) and the transport (defense-in-depth for direct
+    ``FlowApiClient`` callers that bypass the CLI), preventing the
+    silent credit-burn.
+
+    Distinct exit code 17 (not Click's exit 2, not generic exit 1) so
+    scripted callers can branch on "I picked an incompatible
+    model/mode" without parsing stderr.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/model-mode-incompatibility"
+    title = "Model is incompatible with the requested generation mode"
+    _default_remediation = (
+        "The selected video model does not support this generation mode. "
+        "For i2v with a start or end frame, use --model veo-lite (or "
+        "veo-fast / veo-quality / veo-lite-lp). See issue #125."
+    )
+
+
 class SecurityError(GFlowError):
     """Raised when a security boundary is violated (e.g. profile_dir outside HOME)."""
 
@@ -434,6 +462,9 @@ EXIT_CODE_MAP: dict[type[GFlowError], int] = {
     AuthMissingError: 8,
     TransportTimeoutError: 9,
     WafRejectionError: 10,
+    # ModelModeIncompatibilityError BEFORE ConfigurationError (subclass) so the
+    # isinstance walk lands on 17, not 11. Per [[exit-code-map-ordering-invariant-test-pitfall]].
+    ModelModeIncompatibilityError: 17,
     ConfigurationError: 11,
     AuthExpiredError: 3,
     RateLimitError: 4,

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -38,6 +38,30 @@ class TestVideoModelEnum:
         with pytest.raises(ValueError, match="Unknown video model"):
             VideoModel.from_cli("sora")
 
+    def test_omni_flash_does_not_support_i2v_interpolation(self) -> None:
+        # Issue #125: omni-flash silently drops i2v frame refs at submit.
+        assert VideoModel.OMNI_FLASH.supports_i2v_interpolation() is False
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            VideoModel.VEO_3_1_LITE,
+            VideoModel.VEO_3_1_FAST,
+            VideoModel.VEO_3_1_QUALITY,
+            VideoModel.VEO_3_1_LITE_LOWER_PRIORITY,
+        ],
+    )
+    def test_veo_3_1_models_support_i2v_interpolation(self, model: VideoModel) -> None:
+        assert model.supports_i2v_interpolation() is True
+
+    def test_i2v_default_model_is_veo_lite(self) -> None:
+        from gflow_cli.api.video import I2V_DEFAULT_MODEL
+
+        assert I2V_DEFAULT_MODEL is VideoModel.VEO_3_1_LITE
+        # The default MUST itself support i2v — guards against a future edit
+        # that points the default at an incompatible model.
+        assert I2V_DEFAULT_MODEL.supports_i2v_interpolation() is True
+
 
 class TestVideoRequestNewFields:
     def test_defaults(self) -> None:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -876,8 +876,10 @@ class TestSelectVideoModelRequired:
     async def test_required_raises_when_option_never_found(self) -> None:
         """Issue #125 Layer 1: with required=True (i2v), a model-option miss is
         FATAL — raise rather than let Flow fall back to omni-flash -> T2V."""
+        from gflow_cli.errors import VideoModelSelectionError
+
         page = _select_model_page(option_visible_on_attempt=None)
-        with pytest.raises(RuntimeError, match="#125"):
+        with pytest.raises(VideoModelSelectionError, match="#125"):
             await VideoGenerationMixin._select_video_model(
                 page, VideoModel.VEO_3_1_LITE, out_dir=None, required=True
             )

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,7 +16,8 @@ from gflow_cli.api.transports.ui_automation_video import (
     FRAME_SLOTS_STRUCT,
     VideoGenerationMixin,
 )
-from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoStatus
+from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStatus
+from gflow_cli.errors import WireFormatError
 
 
 def _make_listener_page() -> tuple[MagicMock, list]:
@@ -36,6 +38,10 @@ def _make_response(*, url: str, status: int = 200, body: dict | None = None) -> 
 
 
 _T2V_URL = "https://aisandbox-pa.googleapis.com/v1/video:batchAsyncGenerateVideoText"
+_I2V_START_URL = "https://aisandbox-pa.googleapis.com/v1/video:batchAsyncGenerateVideoStartImage"
+_I2V_START_END_URL = (
+    "https://aisandbox-pa.googleapis.com/v1/video:batchAsyncGenerateVideoStartAndEndImage"
+)
 
 
 class TestAttachVideoResponseListener:
@@ -459,9 +465,15 @@ class TestGenerateVideoGuards:
         monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
         monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
         monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        # i2v with a single start frame must route to the StartImage endpoint;
+        # feeding the T2V url here would (correctly) trip the Layer-2 backstop.
         _stub_video_helpers(
             monkeypatch,
-            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+            generate_resp={
+                "status": 200,
+                "url": _I2V_START_URL,
+                "body": {"media": [{"name": "v"}]},
+            },
         )
         monkeypatch.setattr(
             VideoGenerationMixin,
@@ -475,6 +487,14 @@ class TestGenerateVideoGuards:
         await transport.generate_video(request=req, download=False)
         VideoGenerationMixin._switch_video_sub_mode.assert_awaited()  # type: ignore[attr-defined]
         VideoGenerationMixin._attach_frame.assert_awaited()  # type: ignore[attr-defined]
+        # model=None i2v must default to the interpolation-capable model and
+        # call _select_video_model with required=True (issue #125).
+        from gflow_cli.api.video import I2V_DEFAULT_MODEL
+
+        select_call = cast("Any", VideoGenerationMixin._select_video_model)
+        select_call.assert_awaited()
+        assert select_call.await_args.kwargs.get("required") is True
+        assert select_call.await_args.args[1] is I2V_DEFAULT_MODEL
 
     @pytest.mark.asyncio
     async def test_r2v_routes_to_references_and_attach(
@@ -804,3 +824,170 @@ class TestAttachFrameSlotSelection:
                 image=tmp_path / "nonexistent.png",
                 out_dir=None,
             )
+
+
+# ---------------------------------------------------------------------------
+# Issue #125 Layer 1 (model-select fatal for i2v) + Layer 2 (post-submit
+# T2V-routing backstop) + model-select reliability retry.
+# ---------------------------------------------------------------------------
+
+
+def _select_model_page(*, option_visible_on_attempt: int | None) -> MagicMock:
+    """A page for exercising _select_video_model. The model-picker trigger is
+    always visible; the model OPTION becomes visible only on
+    `option_visible_on_attempt` (1-based trigger click). None => never visible.
+    """
+    from gflow_cli.api.transports import ui_automation_video as mod
+
+    trigger_sel = mod.MODEL_PICKER_TRIGGER
+    option_sel = mod.VIDEO_MODEL_OPTION_SELECTORS[mod.VideoModel.VEO_3_1_LITE]
+    state = {"clicks": 0}
+    page = MagicMock()
+
+    def _locator(sel: str) -> MagicMock:
+        loc = MagicMock()
+        loc.first = loc
+
+        async def _wait_for(*_a: object, **_k: object) -> None:
+            if sel == trigger_sel:
+                return
+            if sel == option_sel and option_visible_on_attempt is not None:
+                if state["clicks"] >= option_visible_on_attempt:
+                    return
+            raise Exception("not visible")
+
+        async def _click(*_a: object, **_k: object) -> None:
+            if sel == trigger_sel:
+                state["clicks"] += 1
+
+        loc.wait_for = _wait_for
+        loc.click = _click
+        return loc
+
+    page.locator = MagicMock(side_effect=_locator)
+    page.wait_for_timeout = AsyncMock()
+    page.keyboard.press = AsyncMock()
+    page.screenshot = AsyncMock()
+    return page
+
+
+class TestSelectVideoModelRequired:
+    @pytest.mark.asyncio
+    async def test_required_raises_when_option_never_found(self) -> None:
+        """Issue #125 Layer 1: with required=True (i2v), a model-option miss is
+        FATAL — raise rather than let Flow fall back to omni-flash -> T2V."""
+        page = _select_model_page(option_visible_on_attempt=None)
+        with pytest.raises(RuntimeError, match="#125"):
+            await VideoGenerationMixin._select_video_model(
+                page, VideoModel.VEO_3_1_LITE, out_dir=None, required=True
+            )
+
+    @pytest.mark.asyncio
+    async def test_not_required_warns_and_returns_on_miss(self) -> None:
+        """required=False (t2v/r2v): a miss is non-fatal (Flow default applies)."""
+        page = _select_model_page(option_visible_on_attempt=None)
+        # Must NOT raise.
+        await VideoGenerationMixin._select_video_model(
+            page, VideoModel.VEO_3_1_LITE, out_dir=None, required=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_retries_trigger_click_and_succeeds_second_attempt(self) -> None:
+        """Reliability: the first trigger click may not open the menu; the
+        second attempt finds the option and selects it (no raise)."""
+        page = _select_model_page(option_visible_on_attempt=2)
+        await VideoGenerationMixin._select_video_model(
+            page, VideoModel.VEO_3_1_LITE, out_dir=None, required=True
+        )
+
+
+class TestI2vT2vRoutingBackstop:
+    @pytest.mark.asyncio
+    async def test_i2v_routed_to_t2v_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Issue #125 Layer 2: if an i2v request's captured generate URL is the
+        T2V endpoint, raise WireFormatError instead of returning a fake-success
+        VideoResult (the frames were silently dropped)."""
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        # veo-lite is a VALID i2v model — the DTO guard passes; only the
+        # post-submit URL backstop should fire.
+        req = GenerateVideoRequest(
+            prompt="x",
+            mode=Mode.I2V,
+            model=VideoModel.VEO_3_1_LITE,
+            start_image=Path("a.png"),
+            end_image=Path("b.png"),
+        )
+        with pytest.raises(WireFormatError, match="#125"):
+            await transport.generate_video(request=req, download=False)
+
+    @pytest.mark.asyncio
+    async def test_i2v_routed_to_start_end_image_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The backstop must NOT fire when the i2v request routes correctly."""
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={
+                "status": 200,
+                "url": _I2V_START_END_URL,
+                "body": {"media": [{"name": "v"}]},
+            },
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_poll_video_status",
+            AsyncMock(
+                return_value=VideoStatus(media_id="v", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+            ),
+        )
+        monkeypatch.setattr(transport, "_download_video", AsyncMock(return_value=Path("v.mp4")))
+        req = GenerateVideoRequest(
+            prompt="x",
+            mode=Mode.I2V,
+            model=VideoModel.VEO_3_1_LITE,
+            start_image=Path("a.png"),
+            end_image=Path("b.png"),
+        )
+        result = await transport.generate_video(request=req, download=False)
+        assert result.status.succeeded is True
+
+    @pytest.mark.asyncio
+    async def test_t2v_routed_to_t2v_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A genuine t2v request landing on the T2V route is correct — the
+        backstop is i2v-only."""
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_poll_video_status",
+            AsyncMock(
+                return_value=VideoStatus(media_id="v", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+            ),
+        )
+        monkeypatch.setattr(transport, "_download_video", AsyncMock(return_value=Path("v.mp4")))
+        req = GenerateVideoRequest(prompt="x", mode=Mode.T2V)
+        result = await transport.generate_video(request=req, download=False)
+        assert result.status.succeeded is True

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import structlog
 
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.api.transports.ui_automation_video import (
@@ -351,6 +352,104 @@ class TestGenerateVideoGuards:
         transport = UiAutomationTransport()
         with pytest.raises(RuntimeError, match="setup"):
             await transport.generate_video(request=GenerateVideoRequest(prompt="x"))
+
+    @pytest.mark.asyncio
+    async def test_i2v_with_omni_flash_raises_before_any_browser_call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        install_log_capture: structlog.testing.LogCapture,
+    ) -> None:
+        """Issue #125: omni-flash + i2v must raise ModelModeIncompatibilityError
+        BEFORE any DOM interaction, and emit `model_mode_rejected`."""
+        from gflow_cli.api.video import VideoModel
+        from gflow_cli.errors import ModelModeIncompatibilityError
+
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        # If the guard fails to fire first, _enter_editor would run — make it
+        # explode so a regression is caught loudly rather than silently passing.
+        monkeypatch.setattr(
+            transport,
+            "_enter_editor",
+            AsyncMock(side_effect=AssertionError("guard must fire before _enter_editor")),
+        )
+        req = GenerateVideoRequest(
+            prompt="rise up",
+            mode=Mode.I2V,
+            model=VideoModel.OMNI_FLASH,
+            start_image=Path("a.png"),
+            end_image=Path("b.png"),
+        )
+        with pytest.raises(ModelModeIncompatibilityError, match="#125"):
+            await transport.generate_video(request=req, download=False)
+
+        events = [
+            e
+            for e in install_log_capture.entries
+            if e["event"] == "ui_automation_video.model_mode_rejected"
+        ]
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["model"] == "omni_flash"
+        assert evt["mode"] == "I2V"
+        assert evt["has_start_image"] is True
+        assert evt["has_end_image"] is True
+        assert evt["issue_ref"] == "#125"
+
+    @pytest.mark.asyncio
+    async def test_i2v_start_only_with_omni_flash_also_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """omni-flash is rejected for start-only i2v too (probe v5 evidence)."""
+        from gflow_cli.api.video import VideoModel
+        from gflow_cli.errors import ModelModeIncompatibilityError
+
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(
+            transport,
+            "_enter_editor",
+            AsyncMock(side_effect=AssertionError("guard must fire first")),
+        )
+        req = GenerateVideoRequest(
+            prompt="rise up",
+            mode=Mode.I2V,
+            model=VideoModel.OMNI_FLASH,
+            start_image=Path("a.png"),
+        )
+        with pytest.raises(ModelModeIncompatibilityError):
+            await transport.generate_video(request=req, download=False)
+
+    @pytest.mark.asyncio
+    async def test_t2v_with_omni_flash_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard is i2v-only: t2v + omni-flash is a valid combination."""
+        from gflow_cli.api.video import VideoModel
+
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_poll_video_status",
+            AsyncMock(
+                return_value=VideoStatus(media_id="v", status="MEDIA_GENERATION_STATUS_SUCCESSFUL")
+            ),
+        )
+        monkeypatch.setattr(transport, "_download_video", AsyncMock(return_value=Path("v.mp4")))
+        req = GenerateVideoRequest(prompt="x", mode=Mode.T2V, model=VideoModel.OMNI_FLASH)
+        # Must NOT raise — the guard is scoped to i2v.
+        await transport.generate_video(request=req, download=False)
 
     @pytest.mark.asyncio
     async def test_i2v_routes_to_frames_and_attach(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -473,3 +473,110 @@ def test_r2v_accepts_seven_refs_for_omni_flash(tmp_path: Path) -> None:
         result = runner.invoke(video, args)
     assert result.exit_code == 0, result.output
     mock_run.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# i2v model/mode compatibility (issue #125).
+# ---------------------------------------------------------------------------
+
+
+def test_i2v_model_choice_excludes_omni_flash() -> None:
+    """omni-flash must not be a selectable --model choice for i2v (issue #125).
+
+    Introspect the Click Choice rather than scanning help prose — the help
+    text deliberately MENTIONS omni-flash to explain why it's rejected.
+    """
+    import click
+
+    i2v_cmd = video.commands["i2v"]
+    model_param = next(p for p in i2v_cmd.params if p.name == "model")
+    assert isinstance(model_param.type, click.Choice)
+    choices = list(model_param.type.choices)
+    assert "omni-flash" not in choices
+    assert "veo-lite" in choices
+
+    # Contrast: t2v keeps omni-flash as a valid choice.
+    t2v_cmd = video.commands["t2v"]
+    t2v_model = next(p for p in t2v_cmd.params if p.name == "model")
+    assert isinstance(t2v_model.type, click.Choice)
+    assert "omni-flash" in list(t2v_model.type.choices)
+
+
+def test_i2v_rejects_omni_flash_via_click_choice(tmp_path: Path) -> None:
+    """Passing --model omni-flash to i2v is a Click usage error (exit 2)."""
+    start = tmp_path / "start.png"
+    start.write_bytes(b"\x89PNG\r\n\x1a\n")
+    runner = CliRunner()
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(video, ["i2v", str(start), "rise up", "--model", "omni-flash"])
+    assert result.exit_code == 2, result.output
+    assert "omni-flash" in result.output  # Click lists it among invalid choices
+
+
+def test_i2v_run_defaults_to_veo_lite_when_model_omitted(tmp_path: Path) -> None:
+    """_run_i2v with model=None resolves the request model to veo-lite (#125)."""
+    import asyncio
+
+    from gflow_cli.api.video import VideoModel
+    from gflow_cli.cli_video import _run_i2v
+
+    captured: dict[str, object] = {}
+
+    async def _capture(request: object, **_kwargs: object) -> None:
+        captured["request"] = request
+
+    start = tmp_path / "start.png"
+    start.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    with patch("gflow_cli.cli_video._generate_and_report", new=_capture):
+        asyncio.run(
+            _run_i2v(
+                profile_name="default",
+                profile_dir=tmp_path,
+                image=str(start),
+                prompt="rise up",
+                aspect="9:16",
+                out_dir=None,
+                model=None,
+            )
+        )
+
+    request = captured["request"]
+    assert request.model is VideoModel.VEO_3_1_LITE  # type: ignore[attr-defined]
+
+
+def test_i2v_run_rejects_omni_flash_from_stale_config(tmp_path: Path) -> None:
+    """A direct/stale-config call that smuggles omni-flash past the Click Choice
+    must still be rejected with ModelModeIncompatibilityError (exit code 17)."""
+    import asyncio
+
+    from gflow_cli.cli_video import _run_i2v
+    from gflow_cli.errors import EXIT_CODE_MAP, ModelModeIncompatibilityError
+
+    start = tmp_path / "start.png"
+    start.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    async def _should_not_run(*_a: object, **_k: object) -> None:
+        raise AssertionError("_generate_and_report must not be reached")
+
+    with patch("gflow_cli.cli_video._generate_and_report", new=_should_not_run):
+        try:
+            asyncio.run(
+                _run_i2v(
+                    profile_name="default",
+                    profile_dir=tmp_path,
+                    image=str(start),
+                    prompt="rise up",
+                    aspect="9:16",
+                    out_dir=None,
+                    model="omni-flash",
+                )
+            )
+        except ModelModeIncompatibilityError as e:
+            assert EXIT_CODE_MAP[ModelModeIncompatibilityError] == 17
+            assert "#125" in (e.detail or "")
+        else:
+            raise AssertionError("expected ModelModeIncompatibilityError")

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -176,13 +176,20 @@ async def test_e2e_i2i_local_ref_attach(
 # ---------------------------------------------------------------------------
 
 
-# Defaults are tuned for minimum credit spend: omni-flash, 4 s duration, count=1,
+# Defaults are tuned for minimum credit spend: veo-lite, 4 s duration, count=1,
 # landscape. Override via env for variation (per [[e2e-tests-parameterize]]).
+# NOTE: the i2v default is veo-lite (NOT omni-flash) — omni-flash silently
+# drops the start/end frames and routes to T2V (issue #125). Using omni-flash
+# here previously made this test a false positive: frame_attached + terminal
+# success both held while the actual output was a text-only video.
 _E2E_VIDEO_ASPECT_ENV = "GFLOW_CLI_E2E_VIDEO_ASPECT"
 _E2E_VIDEO_MODEL_ENV = "GFLOW_CLI_E2E_VIDEO_MODEL"
 _E2E_VIDEO_DURATION_ENV = "GFLOW_CLI_E2E_VIDEO_DURATION"
 _I2V_POLL_TIMEOUT_S = 600.0
 _I2V_PROMPT = "the subject moves gently in a calm scene, cinematic"
+# The generate request MUST route here — the start+end frame endpoint. If it
+# lands on batchAsyncGenerateVideoText, the frames were dropped (issue #125).
+_I2V_EXPECTED_GENERATE_URL_SUBSTR = "batchAsyncGenerateVideoStartAndEndImage"
 
 
 def _i2v_aspect() -> Aspect:
@@ -195,7 +202,8 @@ def _i2v_aspect() -> Aspect:
 
 
 def _i2v_model() -> VideoModel | None:
-    raw = os.environ.get(_E2E_VIDEO_MODEL_ENV, "omni-flash").strip().lower()
+    # veo-lite default (issue #125): omni-flash does not support i2v.
+    raw = os.environ.get(_E2E_VIDEO_MODEL_ENV, "veo-lite").strip().lower()
     return VideoModel.from_cli(raw)
 
 
@@ -289,6 +297,32 @@ async def test_e2e_i2v_start_end_frame_attach(
     assert slots == {"Start", "End"}, (
         f"expected frame_attached for {{Start, End}}, got {slots!r}; "
         f"all events: {[e['event'] for e in install_log_capture.entries]}"
+    )
+
+    # 4. Frame-routing contract (issue #125 — the assertion this test was
+    #    missing). frame_attached fires even when Flow drops the refs and routes
+    #    to T2V, so it cannot prove the frames reached Veo. The captured generate
+    #    request URL is the only proof: it MUST be the StartAndEndImage endpoint,
+    #    NOT batchAsyncGenerateVideoText. And the model/mode guard must NOT have
+    #    fired (a valid veo-lite + i2v combination).
+    rejected = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.model_mode_rejected"
+    ]
+    assert not rejected, f"model_mode_rejected fired unexpectedly: {rejected!r}"
+    generate_events = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.generate_captured"
+    ]
+    assert generate_events, "no ui_automation_video.generate_captured event was emitted"
+    gen_url = str(generate_events[-1].get("url", ""))
+    assert _I2V_EXPECTED_GENERATE_URL_SUBSTR in gen_url, (
+        f"i2v generate request routed to {gen_url!r}; expected it to contain "
+        f"{_I2V_EXPECTED_GENERATE_URL_SUBSTR!r}. If it landed on "
+        f"batchAsyncGenerateVideoText, the start/end frames were dropped "
+        f"(issue #125 regression)."
     )
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,6 +15,7 @@ from gflow_cli.errors import (
     ContentPolicyError,
     FlowApiError,
     GFlowError,
+    ModelModeIncompatibilityError,
     NetworkError,
     ProblemDetails,
     RateLimitError,
@@ -148,10 +149,25 @@ def test_exit_code_map_synthetic_subclass_inherits_parent_code():
         (ContentPolicyError, 5),
         (NetworkError, 6),
         (WireFormatError, 7),
+        (ModelModeIncompatibilityError, 17),
     ],
 )
 def test_exit_code_map_per_class(exc_cls, expected_code):
     assert _exit_code_for(exc_cls(detail="x")) == expected_code
+
+
+def test_model_mode_incompatibility_error_exit_code_17():
+    """Issue #125: distinct exit code 17, NOT its parent ConfigurationError's 11.
+
+    The isinstance walk must hit ModelModeIncompatibilityError (registered
+    BEFORE ConfigurationError in EXIT_CODE_MAP) before falling through to the
+    parent — otherwise scripted callers can't branch on "incompatible
+    model/mode" vs a generic configuration error.
+    """
+    err = ModelModeIncompatibilityError(detail="omni-flash + i2v invalid")
+    assert isinstance(err, ConfigurationError)
+    assert _exit_code_for(err) == 17
+    assert EXIT_CODE_MAP[ModelModeIncompatibilityError] == 17
 
 
 def test_exit_code_map_ordering_invariant():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -20,6 +20,7 @@ from gflow_cli.errors import (
     ProblemDetails,
     RateLimitError,
     TransportTimeoutError,
+    VideoModelSelectionError,
     WafRejectionError,
     WireFormatError,
 )
@@ -168,6 +169,15 @@ def test_model_mode_incompatibility_error_exit_code_17():
     assert isinstance(err, ConfigurationError)
     assert _exit_code_for(err) == 17
     assert EXIT_CODE_MAP[ModelModeIncompatibilityError] == 17
+
+
+def test_video_model_selection_error_exit_code_18():
+    """Issue #125: model-select UI failure for i2v gets exit 18 (transport
+    reliability), distinct from 17 (incompatible model) and 11 (config)."""
+    err = VideoModelSelectionError(detail="could not select veo-lite (issue #125)")
+    assert isinstance(err, ConfigurationError)
+    assert _exit_code_for(err) == 18
+    assert EXIT_CODE_MAP[VideoModelSelectionError] == 18
 
 
 def test_exit_code_map_ordering_invariant():


### PR DESCRIPTION
## Summary

Fixes **#125** — `gflow video i2v` silently produced text-to-video output, ignoring the start/end frames and burning a credit on every call.

There were **two** independent silent-T2V paths; both are closed, plus three defense-in-depth layers so an i2v can never again silently degrade to T2V.

### Root causes

1. **`omni-flash` does not support i2v interpolation.** It was the i2v default. When an i2v request carried frame refs under omni-flash, Flow's frontend dropped the bound mediaIds at submit and routed to `batchAsyncGenerateVideoText` with `image_inputs: null`.
2. **The `Veo 3.1 - Lite` model-picker selector on `develop` was broken** — an exact match (`:text-is('volume_upVeo 3.1 - Lite')`) hardcoding a Material Symbols icon-ligature prefix. It never matched, so even when the user explicitly requested `--model veo-lite`, `_select_video_model` warned-and-continued and Flow stayed on omni-flash → T2V. (Introduced by PR #48 `aa047a3`; the `feature/avatar-generation` branch fixed it but it never reached develop.)

**Every i2v paid run on v0.10.0 before this fix produced T2V output regardless of the supplied frames.**

### How it was diagnosed (all zero-credit)

`page.route(..., abort)` request interception (`scripts/dev/capture_i2v_intercept_submit.py`) proved omni-flash → T2V/null and veo-lite → `StartAndEndImage` with bound mediaIds. A human-session HAR confirmed the manual UI uses `veo_3_1_interpolation_lite`. `capture_i2v_model_select_repro.py` reproduced the selector failure in the production call order and confirmed the robust selector fixes it. The fix plan (`.planning/issue-125-fix.md`) went through the 5-persona predict council.

## Changes

**Domain (`api/video.py`)**
- `VideoModel.supports_i2v_interpolation()` (False only for omni-flash) + `I2V_DEFAULT_MODEL = VEO_3_1_LITE`.

**Errors (`errors.py`)**
- `ModelModeIncompatibilityError` (exit 17) — incompatible model/mode.
- `VideoModelSelectionError` (exit 18) — model-picker UI failure for i2v.

**CLI (`cli_video.py`)**
- `omni-flash` removed from the i2v `--model` Choice; omitted `--model` → `veo-lite`; stale config with omni-flash → exit 17.

**Transport (`api/transports/ui_automation_video.py`)**
- DTO guard: omni-flash + i2v → `ModelModeIncompatibilityError` before any browser interaction.
- i2v defaults `model=None` → `veo-lite` so direct `FlowApiClient` callers can't inherit Flow's omni-flash default.
- **Robust veo-lite picker selector:** `[role='menuitem']:has-text('Veo 3.1 - Lite'):not(:has-text('[Lower Priority]'))`.
- **Layer 1:** `_select_video_model(required=True)` for i2v retries then raises `VideoModelSelectionError` (exit 18) **before submit** — spends no credit.
- **Layer 2:** post-submit, an i2v request observed routing to the T2V endpoint raises `WireFormatError` (fires `ui_automation_video.i2v_routed_to_t2v`) rather than reporting a fake-success i2v.

**Tests**
- Unit: `supports_i2v_interpolation` matrix, exit-17/18 mapping + ordering invariant, i2v Choice excludes omni-flash, default resolution, DTO guard, Layer 1 (fatal/non-fatal/retry-succeeds), Layer 2 (i2v→T2V raises / i2v→StartAndEnd succeeds / t2v→T2V unaffected).
- e2e: `test_e2e_i2v_start_end_frame_attach` defaulted to omni-flash → it was a **false positive** (frame_attached + terminal-success both hold for T2V). Now defaults veo-lite and asserts the captured URL is `StartAndEndImage`.

**Dev tooling (`scripts/dev/`)**
- `capture_i2v_intercept_submit.py`, `capture_i2v_post_bind_state.py`, `capture_i2v_model_select_repro.py` — zero-credit reproducers for future regressions.

## Verification

- 152 scoped unit/integration tests pass; ruff + pyright clean.
- **Live paid run (veo-lite, the stickman frames):** `model_selected` → `batchAsyncGenerateVideoStartAndEndImage` → SUCCESSFUL mp4 (720×1280, 8s). Start frame matches `01-t2i.jpg` (desk, pre-dawn), end frame matches `02-i2i.jpg` lighting (same desk, golden sunrise) — same character + 2D ink style, a genuine interpolation, not a T2V scene-swap. No `model_mode_rejected`, no `i2v_routed_to_t2v`.

## Notes

- The broken veo-lite selector affects **all** i2v on develop, independent of #125's omni-flash angle — this PR carries that fix so it's self-contained.
- Possible follow-up: r2v + omni-flash may share the same drop-on-submit pathology (deferred; the guard pattern extends to it in one line).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
