### PR TITLE
chore(sonar): maintainability cleanup — dedupe literals + flatten ternaries (pass 1)

### DIFF
--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -32,6 +32,9 @@ from gflow_cli.errors import DataStoreError
 
 console = Console()
 
+# DataStoreError ``route`` tag for `gflow data media` lookups (dedupe S1192).
+_ROUTE_DATA_MEDIA = "data.media"
+
 
 # ---------------------------------------------------------------------------
 # Helpers for `gflow data list` output
@@ -264,7 +267,7 @@ async def _run_media(*, profile: str | None, media_id: str) -> None:
                 if scoped is None:
                     raise DataStoreError(
                         detail=f"No local media record found: {media_id} (profile={profile!r})",
-                        route="data.media",
+                        route=_ROUTE_DATA_MEDIA,
                     )
                 return scoped
 
@@ -272,7 +275,7 @@ async def _run_media(*, profile: str | None, media_id: str) -> None:
             if not matches:
                 raise DataStoreError(
                     detail=f"No local media record found: {media_id}",
-                    route="data.media",
+                    route=_ROUTE_DATA_MEDIA,
                 )
             if len(matches) > 1:
                 candidates = sorted({f"{m.profile_name} ({m.kind.value})" for m in matches})
@@ -281,7 +284,7 @@ async def _run_media(*, profile: str | None, media_id: str) -> None:
                         f"Media {media_id!r} exists under multiple profiles: "
                         f"{candidates}. Pass --profile NAME to disambiguate."
                     ),
-                    route="data.media",
+                    route=_ROUTE_DATA_MEDIA,
                 )
             return matches[0]
 

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -423,33 +423,26 @@ class OperationRecorder:
                     if local_path is not None
                     else "video/mp4"
                 )
+                # Persist on-disk path/bytes/hash only for genuinely local files
+                # (single-level conditionals so pyright narrows ``local_path``).
+                resolved_path = (
+                    local_path.resolve() if not is_cloud and local_path is not None else None
+                )
+                file_bytes = (
+                    _file_bytes(local_path) if not is_cloud and local_path is not None else None
+                )
+                file_sha256 = (
+                    _file_sha256(local_path) if not is_cloud and local_path is not None else None
+                )
                 repo.upsert_local_file(
                     LocalFileRecord(
                         id=_new_id(),
                         profile_name=profile_name,
                         asset_id=asset_lookup.id,
-                        path=(
-                            None
-                            if is_cloud
-                            else local_path.resolve()
-                            if local_path is not None
-                            else None
-                        ),
+                        path=resolved_path,
                         media_type=media_type,
-                        bytes=(
-                            None
-                            if is_cloud
-                            else _file_bytes(local_path)
-                            if local_path is not None
-                            else None
-                        ),
-                        sha256=(
-                            None
-                            if is_cloud
-                            else _file_sha256(local_path)
-                            if local_path is not None
-                            else None
-                        ),
+                        bytes=file_bytes,
+                        sha256=file_sha256,
                         storage_provider=(
                             cloud_storage_info.provider if cloud_storage_info else None
                         ),


### PR DESCRIPTION
## Summary

First, fully-verified increment of the **SonarCloud maintainability cleanup** (driving issues toward zero). Behaviour-preserving refactors only.

- **`cli_data.py`** — extract the repeated `"data.media"` route literal into a module constant `_ROUTE_DATA_MEDIA` (**S1192**, ×3 → 0).
- **`data/recorder.py`** — collapse three nested conditional expressions in the local-file record into single-level, pyright-narrowing ternaries (**S3358** ×3 → 0). Logic is identical (`X if (not is_cloud and local_path is not None) else None`).

Verified locally: `ruff check` ✓, `ruff format --check` ✓, `pyright` ✓ on both files.

## Remaining SonarCloud issues (follow-up)

This PR is a partial first pass; the rest are mapped and will land in follow-up commits/PRs:

| Rule | Count | Where | Risk |
|---|---|---|---|
| S1192 `"dict[str, Any]"` → type alias | 3 files | `client.py` ×5, `video.py` ×4, `ui_automation_video.py` ×3 | low (mechanical) |
| S5655 wrong-arg-type | 2 | `client.py` (`_drive_images_generation` calls) | low (cast) |
| S7503 stray `async` | 2 | `ui_automation_video.py`, `cli_video.py` | medium (verify no awaiter) |
| S7632 suppression-comment syntax | 1 | `ui_automation_video.py` | low |
| **S3776 cognitive complexity** | 7 | `ui_automation_video.py` ×2, `cli.py`, `cli_image.py` ×2, `data/recorder.py` ×2 | higher (extract helpers; needs full test run) |

Note: SonarCloud's `main` long-branch analysis (last scan 2026-05-29) lists 17 issues, some already refactored away on develop; the CI scan on this PR gives the current, authoritative count.

## Test plan

- [x] `ruff check` / `ruff format --check` / `pyright` on changed files — clean.
- [ ] Full CI (pytest 3.11–3.13 + SonarCloud) — via this PR.
