### PR TITLE
refactor(commands): replace misleading /gflow:plan with four focused commands

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -12,7 +12,10 @@ This directory holds **internal maintainer workflows** that are bundled with the
 └── commands/              ← repo-local slash commands
     └── gflow/             ← `/gflow:*` namespace (avoids collision with built-ins)
         ├── check.md       ← `/gflow:check` — hygiene + ruff + pyright + pytest
-        ├── plan.md        ← `/gflow:plan` — show active phase / superpowers plan
+        ├── status.md      ← `/gflow:status` — full plan state (file, goal, progress, next task)
+        ├── next.md        ← `/gflow:next` — next unchecked task only
+        ├── active.md      ← `/gflow:active` — which plan is active, goal only
+        ├── plan.md        ← `/gflow:plan <feature>` — create a task-by-task implementation plan
         ├── known-issues.md← `/gflow:known-issues` — open/mitigated items
         ├── changelog.md   ← `/gflow:changelog` — [Unreleased] + last tagged
         └── release.md     ← `/gflow:release` — full release flow (signed tags)

--- a/.claude/commands/gflow/active.md
+++ b/.claude/commands/gflow/active.md
@@ -4,19 +4,10 @@ description: Show which plan is active and its goal — orientation without task
 
 # `/gflow:active` — Active plan identity
 
-Answers "which plan are we in?" without pulling in the full task breakdown.
+**Read `skills/status/SKILL.md` and follow the `active` variant protocol.**
 
-## Steps
+> Do **not** call `Skill(skill="status")` — read the file directly.
 
-**1. Run:**
-```bash
-uv run python scripts/dev/active_plan.py
-```
-
-**2. Return only the header lines** — Plan path, Title, Goal, Progress count. Stop before the `--- Next task ---` separator. Do not include task steps.
-
-## When to call
-
-- Before `/gflow:predict` or `/gflow:scenario`: confirm the proposal belongs to the active scope
-- Quick orientation: "are we in a superpowers plan or the root PLAN.md?"
-- When context is long and you need a one-line anchor without re-reading the whole task block
+The skill at `skills/status/SKILL.md` runs `scripts/dev/active_plan.py` and returns
+only the header lines (Plan path, Title, Goal, Progress count). Stops before the
+`--- Next task ---` separator.

--- a/.claude/commands/gflow/active.md
+++ b/.claude/commands/gflow/active.md
@@ -1,0 +1,22 @@
+---
+description: Show which plan is active and its goal — orientation without task detail.
+---
+
+# `/gflow:active` — Active plan identity
+
+Answers "which plan are we in?" without pulling in the full task breakdown.
+
+## Steps
+
+**1. Run:**
+```bash
+uv run python scripts/dev/active_plan.py
+```
+
+**2. Return only the header lines** — Plan path, Title, Goal, Progress count. Stop before the `--- Next task ---` separator. Do not include task steps.
+
+## When to call
+
+- Before `/gflow:predict` or `/gflow:scenario`: confirm the proposal belongs to the active scope
+- Quick orientation: "are we in a superpowers plan or the root PLAN.md?"
+- When context is long and you need a one-line anchor without re-reading the whole task block

--- a/.claude/commands/gflow/next.md
+++ b/.claude/commands/gflow/next.md
@@ -4,24 +4,9 @@ description: Show only the next unchecked task — minimal output, no context no
 
 # `/gflow:next [feature]` — Next task
 
-Returns the single next unchecked task block. Nothing else.
+**Read `skills/status/SKILL.md` and follow the `next` variant protocol**, passing `$ARGUMENTS` as the optional feature slug.
 
-## Steps
+> Do **not** call `Skill(skill="status")` — read the file directly.
 
-**1. Resolve the feature name** — same logic as `/gflow:status`.
-
-**2. Run:**
-```bash
-uv run python scripts/dev/active_plan.py [--feature <name>]
-```
-
-**3. Return only the task block** — the content from `--- Next task ---` onward. Drop the Plan / Title / Goal / Progress header lines.
-
-If the output contains "All steps complete", say so and suggest:
-- `/gflow:changelog` to review unreleased changes
-- `/gflow:release` if the phase is fully done
-
-## When to call
-
-- "What do I do right now?" — between tasks, no orientation needed
-- Resuming mid-session after a context switch
+The skill at `skills/status/SKILL.md` runs `scripts/dev/active_plan.py` and returns
+only the `--- Next task ---` block. Header lines (Plan, Title, Goal, Progress) are omitted.

--- a/.claude/commands/gflow/next.md
+++ b/.claude/commands/gflow/next.md
@@ -1,0 +1,27 @@
+---
+description: Show only the next unchecked task — minimal output, no context noise.
+---
+
+# `/gflow:next [feature]` — Next task
+
+Returns the single next unchecked task block. Nothing else.
+
+## Steps
+
+**1. Resolve the feature name** — same logic as `/gflow:status`.
+
+**2. Run:**
+```bash
+uv run python scripts/dev/active_plan.py [--feature <name>]
+```
+
+**3. Return only the task block** — the content from `--- Next task ---` onward. Drop the Plan / Title / Goal / Progress header lines.
+
+If the output contains "All steps complete", say so and suggest:
+- `/gflow:changelog` to review unreleased changes
+- `/gflow:release` if the phase is fully done
+
+## When to call
+
+- "What do I do right now?" — between tasks, no orientation needed
+- Resuming mid-session after a context switch

--- a/.claude/commands/gflow/plan.md
+++ b/.claude/commands/gflow/plan.md
@@ -4,176 +4,19 @@ description: Create a structured task-by-task implementation plan for a feature 
 
 # `/gflow:plan <feature>` — Create a feature plan
 
-Turns a feature description into a task-by-task implementation plan and writes it to
-`docs/superpowers/plans/<YYYY-MM-DD>-<feature-slug>/PLAN.md`.
+**Read `skills/plan/SKILL.md` and follow its protocol now**, passing `$ARGUMENTS` as the feature description.
 
-**Typical position in the workflow:**
+> Do **not** call `Skill(skill="plan")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable. Read the file directly instead.
+
+The skill at `skills/plan/SKILL.md` gathers predict/scenario context, asks ≤3
+clarifying questions, decomposes the feature into atomic committable tasks with
+step + test checklists, and writes `docs/superpowers/plans/<date>-<slug>/PLAN.md`.
+
+**Typical workflow:**
 ```
-/gflow:predict <proposal>   →  GO / CAUTION / STOP verdict
+/gflow:predict <proposal>   →  GO / CAUTION / STOP
 /gflow:scenario <feature>   →  edge cases + BDD skeleton
-/gflow:plan <feature>       →  writes the task checklist  ← you are here
+/gflow:plan <feature>       →  writes PLAN.md  ← this command
 /gflow:status               →  surfaces next task
 /gflow:check                →  before each commit
 ```
-
-Invoke after a GO or CAUTION verdict. Pass the feature description as `$ARGUMENTS`.
-
----
-
-## Protocol
-
-### Phase 1 — Gather inputs from context (do not ask if already present)
-
-**From `/gflow:predict` output in context:**
-- Verdict (GO / CAUTION / STOP) and confidence score
-- Architectural constraints and module placement
-- Security risks and mandatory mitigations
-- Devil's Advocate simplifications or sequencing blockers
-
-**From `/gflow:scenario` output in context:**
-- Critical and High scenarios → these become must-cover tests in the task checklist
-- BDD `Scenario:` blocks → seeds the BDD scaffold task
-
-**From `$ARGUMENTS`:**
-- Feature name → derive a slug (lowercase, hyphen-separated, no dates)
-- Stated goal (one sentence)
-
-**From the repo:**
-```bash
-uv run python scripts/dev/active_plan.py
-```
-Confirm the feature belongs to the active phase. Note any relevant ADRs from `PLAN.md`.
-
-### Phase 2 — Ask clarifying questions (only if not answerable from context)
-
-Ask at most 3. Focus on decisions that change the task breakdown:
-
-1. **Scope boundary** — what is explicitly out of scope for this plan?
-2. **Module ownership** — which existing module does this extend, or is a new module justified?
-3. **Acceptance criteria** — what does "done" look like from the user's perspective (command output, exit code, log event)?
-
-Skip any question already answered by predict/scenario output or `$ARGUMENTS`.
-
-### Phase 3 — Decompose into tasks
-
-**Task rules:**
-- Each task must be independently committable as one atomic `git commit`.
-- Test scaffold tasks (red tests, BDD skeleton) come before the code that makes them green.
-- Tasks that create new files come before tasks that modify callers.
-- Derive test requirements from scenario output: Critical → must-cover (`- [ ]`), High → should-cover.
-- Every task lists: what it does, which files change, step checklist, test checklist.
-
-**Typical task order for a gflow-cli feature:**
-
-| # | Task | Notes |
-|---|---|---|
-| 1 | Unit test scaffold | Red tests only. No production code. |
-| 2 | BDD scaffold | Red BDD scenarios. No production code. |
-| 3 | Core implementation | Domain objects / value types / parsers. |
-| 4 | Transport / API layer | `FlowApiClient` or `UiAutomationTransport` changes. |
-| 5 | CLI surface | `cli_*.py` + Click commands + `--help` text. |
-| 6 | Docs update | `USAGE.md`, `CONFIGURATION.md` (new env vars), `KNOWN_ISSUES.md` if relevant. |
-| 7 | Full gates + release prep | `/gflow:check` green; CHANGELOG updated. |
-
-Adjust: not every task applies to every feature. Merge or split tasks as the scope demands.
-
-### Phase 4 — Draft the plan and show it to the user
-
-Produce the full `PLAN.md` content using this schema:
-
-```markdown
-# <Feature Display Name> Implementation Plan
-
-> **For agentic workers:** Run `/gflow:status --feature <slug>` to find the next unchecked task.
-> Implement one task at a time. Run `/gflow:check` before every commit.
-
-**Goal:** <one sentence — the user-visible outcome>
-
-**Architecture:** <2–3 sentences — which modules change, key design decisions, what stays the same>
-
-**Predict verdict:** <GO / CAUTION — confidence N/10> (or "pending — run /gflow:predict first")
-
-**Risk register:**
-| Severity | Risk | Mitigation |
-|---|---|---|
-| (from predict output) | | |
-
----
-
-## File structure
-
-### New files
-\`\`\`
-src/gflow_cli/<module>.py
-  <one-line description>
-
-tests/<module>/test_<module>.py
-  <one-line description>
-\`\`\`
-
-### Modified files
-\`\`\`
-src/gflow_cli/<existing>.py
-  <what changes>
-\`\`\`
-
----
-
-## Task 1 — <name> (test scaffold)
-
-**What:** <one sentence>
-
-**Files:**
-- `tests/...` — <description>
-
-**Steps:**
-- [ ] <step>
-
-**Tests created (red):**
-- [ ] <test name> — <what it asserts>
-
----
-
-## Task 2 — ...
-
-(repeat for each task)
-
----
-
-## Definition of done
-
-- [ ] All task steps checked off
-- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
-- [ ] `CHANGELOG.md` `[Unreleased]` section updated
-- [ ] Docs updated (`USAGE.md` / `CONFIGURATION.md` as applicable)
-- [ ] BDD feature file covers all Critical + High scenarios from `/gflow:scenario`
-- [ ] No `# TODO` in diff without a tracked issue link
-```
-
-Show the drafted plan to the user. If they approve (or say "write it"), proceed to Phase 5.
-
-### Phase 5 — Write the file
-
-```bash
-mkdir -p docs/superpowers/plans/<YYYY-MM-DD>-<slug>
-```
-
-Write the plan to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
-
-Confirm with:
-> Plan written to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
-> Run `/gflow:status --feature <slug>` to start working on it.
-
----
-
-## When to call
-
-- After `/gflow:predict` returns GO or CAUTION
-- When a backlog item in `PLAN.md` needs a concrete task breakdown before starting work
-- Any feature larger than a single isolated file change
-
-## When not to call
-
-- Simple bug fixes (< 10 lines, no boundary crossing) — go straight to the fix
-- Pure doc changes
-- A task already fully specified in a superpowers plan — use `/gflow:status` to find it

--- a/.claude/commands/gflow/plan.md
+++ b/.claude/commands/gflow/plan.md
@@ -1,39 +1,179 @@
 ---
-description: Show the active plan — next task if a superpowers plan is running, current phase otherwise.
+description: Create a structured task-by-task implementation plan for a feature and write it to docs/superpowers/plans/.
 ---
 
-# `/gflow:plan` — Active plan
+# `/gflow:plan <feature>` — Create a feature plan
 
-## Steps
+Turns a feature description into a task-by-task implementation plan and writes it to
+`docs/superpowers/plans/<YYYY-MM-DD>-<feature-slug>/PLAN.md`.
 
-**1. Check conversation context.**
-
-Has the user mentioned a specific feature or invoked the write-plan skill in this session?
-If yes, note the feature name (e.g. `shell-multi-prompt`, `image-mvp`, `phase-4-hardening`).
-
-**2. Run the discovery script.**
-
-With a feature name identified in step 1:
-```bash
-uv run python scripts/dev/active_plan.py --feature <feature-name>
+**Typical position in the workflow:**
+```
+/gflow:predict <proposal>   →  GO / CAUTION / STOP verdict
+/gflow:scenario <feature>   →  edge cases + BDD skeleton
+/gflow:plan <feature>       →  writes the task checklist  ← you are here
+/gflow:status               →  surfaces next task
+/gflow:check                →  before each commit
 ```
 
-Without a feature name (uses most-recent superpowers plan, falls back to PLAN.md):
+Invoke after a GO or CAUTION verdict. Pass the feature description as `$ARGUMENTS`.
+
+---
+
+## Protocol
+
+### Phase 1 — Gather inputs from context (do not ask if already present)
+
+**From `/gflow:predict` output in context:**
+- Verdict (GO / CAUTION / STOP) and confidence score
+- Architectural constraints and module placement
+- Security risks and mandatory mitigations
+- Devil's Advocate simplifications or sequencing blockers
+
+**From `/gflow:scenario` output in context:**
+- Critical and High scenarios → these become must-cover tests in the task checklist
+- BDD `Scenario:` blocks → seeds the BDD scaffold task
+
+**From `$ARGUMENTS`:**
+- Feature name → derive a slug (lowercase, hyphen-separated, no dates)
+- Stated goal (one sentence)
+
+**From the repo:**
 ```bash
 uv run python scripts/dev/active_plan.py
 ```
+Confirm the feature belongs to the active phase. Note any relevant ADRs from `PLAN.md`.
 
-**3. Return the output verbatim.**
+### Phase 2 — Ask clarifying questions (only if not answerable from context)
 
-The script already filters to the relevant block. Do not read additional files.
+Ask at most 3. Focus on decisions that change the task breakdown:
 
-## What the script returns
+1. **Scope boundary** — what is explicitly out of scope for this plan?
+2. **Module ownership** — which existing module does this extend, or is a new module justified?
+3. **Acceptance criteria** — what does "done" look like from the user's perspective (command output, exit code, log event)?
 
-- **Superpowers plan active:** file path, title, goal, progress (X/N steps), and the next unchecked task block
-- **No superpowers plan:** the first incomplete phase from `PLAN.md` (scope, sequence, definition of done)
+Skip any question already answered by predict/scenario output or `$ARGUMENTS`.
+
+### Phase 3 — Decompose into tasks
+
+**Task rules:**
+- Each task must be independently committable as one atomic `git commit`.
+- Test scaffold tasks (red tests, BDD skeleton) come before the code that makes them green.
+- Tasks that create new files come before tasks that modify callers.
+- Derive test requirements from scenario output: Critical → must-cover (`- [ ]`), High → should-cover.
+- Every task lists: what it does, which files change, step checklist, test checklist.
+
+**Typical task order for a gflow-cli feature:**
+
+| # | Task | Notes |
+|---|---|---|
+| 1 | Unit test scaffold | Red tests only. No production code. |
+| 2 | BDD scaffold | Red BDD scenarios. No production code. |
+| 3 | Core implementation | Domain objects / value types / parsers. |
+| 4 | Transport / API layer | `FlowApiClient` or `UiAutomationTransport` changes. |
+| 5 | CLI surface | `cli_*.py` + Click commands + `--help` text. |
+| 6 | Docs update | `USAGE.md`, `CONFIGURATION.md` (new env vars), `KNOWN_ISSUES.md` if relevant. |
+| 7 | Full gates + release prep | `/gflow:check` green; CHANGELOG updated. |
+
+Adjust: not every task applies to every feature. Merge or split tasks as the scope demands.
+
+### Phase 4 — Draft the plan and show it to the user
+
+Produce the full `PLAN.md` content using this schema:
+
+```markdown
+# <Feature Display Name> Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature <slug>` to find the next unchecked task.
+> Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** <one sentence — the user-visible outcome>
+
+**Architecture:** <2–3 sentences — which modules change, key design decisions, what stays the same>
+
+**Predict verdict:** <GO / CAUTION — confidence N/10> (or "pending — run /gflow:predict first")
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| (from predict output) | | |
+
+---
+
+## File structure
+
+### New files
+\`\`\`
+src/gflow_cli/<module>.py
+  <one-line description>
+
+tests/<module>/test_<module>.py
+  <one-line description>
+\`\`\`
+
+### Modified files
+\`\`\`
+src/gflow_cli/<existing>.py
+  <what changes>
+\`\`\`
+
+---
+
+## Task 1 — <name> (test scaffold)
+
+**What:** <one sentence>
+
+**Files:**
+- `tests/...` — <description>
+
+**Steps:**
+- [ ] <step>
+
+**Tests created (red):**
+- [ ] <test name> — <what it asserts>
+
+---
+
+## Task 2 — ...
+
+(repeat for each task)
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Docs updated (`USAGE.md` / `CONFIGURATION.md` as applicable)
+- [ ] BDD feature file covers all Critical + High scenarios from `/gflow:scenario`
+- [ ] No `# TODO` in diff without a tracked issue link
+```
+
+Show the drafted plan to the user. If they approve (or say "write it"), proceed to Phase 5.
+
+### Phase 5 — Write the file
+
+```bash
+mkdir -p docs/superpowers/plans/<YYYY-MM-DD>-<slug>
+```
+
+Write the plan to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
+
+Confirm with:
+> Plan written to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
+> Run `/gflow:status --feature <slug>` to start working on it.
+
+---
 
 ## When to call
 
-- When starting a task and unsure what's in scope
-- When the user asks "what are we working on?" or "what's next?"
-- Before adding a feature, to check it belongs to the current scope
+- After `/gflow:predict` returns GO or CAUTION
+- When a backlog item in `PLAN.md` needs a concrete task breakdown before starting work
+- Any feature larger than a single isolated file change
+
+## When not to call
+
+- Simple bug fixes (< 10 lines, no boundary crossing) — go straight to the fix
+- Pure doc changes
+- A task already fully specified in a superpowers plan — use `/gflow:status` to find it

--- a/.claude/commands/gflow/status.md
+++ b/.claude/commands/gflow/status.md
@@ -1,0 +1,42 @@
+---
+description: Show current plan state — active plan file, goal, progress, and next unchecked task.
+---
+
+# `/gflow:status [feature]` — Current plan state
+
+Full picture of where work stands: which plan is active, how far along it is, and what comes next.
+
+## Steps
+
+**1. Resolve the feature name.**
+
+- If `$ARGUMENTS` is non-empty, treat it as the feature slug (e.g. `shell-multi-prompt`, `phase-4-hardening`).
+- Otherwise check conversation context for a feature name mentioned this session.
+
+**2. Run the discovery script.**
+
+With a feature name:
+```bash
+uv run python scripts/dev/active_plan.py --feature <feature-name>
+```
+
+Without a feature name:
+```bash
+uv run python scripts/dev/active_plan.py
+```
+
+**3. Return the output verbatim.**
+
+The script already formats the output. Do not read additional files.
+
+## What the script returns
+
+- **Superpowers plan active:** file path · title · goal · progress (X/N steps complete) · next unchecked task block
+- **No superpowers plan:** the first incomplete phase from `PLAN.md` (scope, sequence, definition of done)
+- **All steps complete:** says so — prompt the user to run `/gflow:changelog` and then `/gflow:release` if the phase is finished
+
+## When to call
+
+- Starting a session: "where did we leave off?"
+- After completing a task: "what comes next?"
+- Before adding scope: "does this belong to the current plan?"

--- a/.claude/commands/gflow/status.md
+++ b/.claude/commands/gflow/status.md
@@ -4,39 +4,9 @@ description: Show current plan state — active plan file, goal, progress, and n
 
 # `/gflow:status [feature]` — Current plan state
 
-Full picture of where work stands: which plan is active, how far along it is, and what comes next.
+**Read `skills/status/SKILL.md` and follow the `status` variant protocol**, passing `$ARGUMENTS` as the optional feature slug.
 
-## Steps
+> Do **not** call `Skill(skill="status")` — read the file directly.
 
-**1. Resolve the feature name.**
-
-- If `$ARGUMENTS` is non-empty, treat it as the feature slug (e.g. `shell-multi-prompt`, `phase-4-hardening`).
-- Otherwise check conversation context for a feature name mentioned this session.
-
-**2. Run the discovery script.**
-
-With a feature name:
-```bash
-uv run python scripts/dev/active_plan.py --feature <feature-name>
-```
-
-Without a feature name:
-```bash
-uv run python scripts/dev/active_plan.py
-```
-
-**3. Return the output verbatim.**
-
-The script already formats the output. Do not read additional files.
-
-## What the script returns
-
-- **Superpowers plan active:** file path · title · goal · progress (X/N steps complete) · next unchecked task block
-- **No superpowers plan:** the first incomplete phase from `PLAN.md` (scope, sequence, definition of done)
-- **All steps complete:** says so — prompt the user to run `/gflow:changelog` and then `/gflow:release` if the phase is finished
-
-## When to call
-
-- Starting a session: "where did we leave off?"
-- After completing a task: "what comes next?"
-- Before adding scope: "does this belong to the current plan?"
+The skill at `skills/status/SKILL.md` runs `scripts/dev/active_plan.py` and returns
+the full output: plan file path, title, goal, progress (X/N), and next task block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ If you can help unblock a pure HTTP transport (especially for video generation, 
 - Copy `.env.template` to `.env.local`; never commit `.env.local`. It documents every env var.
 - Output goes to `./tmp/` for scripts/tests or `$GFLOW_CLI_OUTPUT_DIR` for CLI outputs (defaults to `./out/`).
 - One-time auth: `gflow auth login --browser chrome`. The `--browser chrome` flag is mandatory; the CLI fails fast on other strategies.
-- Use `/gflow:plan` to see the active phase before starting work; `/gflow:known-issues` before touching auth or reCAPTCHA code paths.
+- Use `/gflow:status` to see the current task before starting work; `/gflow:known-issues` before touching auth or reCAPTCHA code paths.
 
 ## Testing instructions — The Impeccable Routine
 
@@ -89,7 +89,7 @@ The SkillOpt harness at `scripts/dev/skillopt/` measures how accurately each ski
 - **Mandates & routing rules** → [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md)
 - **Full docs index** → [docs/INDEX.md](docs/INDEX.md)
 - **Known issues** (read before touching auth / reCAPTCHA) → [KNOWN_ISSUES.md](KNOWN_ISSUES.md)
-- **Active phase & backlog** → [PLAN.md](PLAN.md) or run `/gflow:plan`
+- **Current task** → `/gflow:status` · **Create a feature plan** → `/gflow:plan <feature>` · **Full roadmap** → [PLAN.md](PLAN.md)
 - **Release protocol** → [RELEASE.md](RELEASE.md)
 
 ## Claude Code-specific notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@
 1. Read **[AGENTS.md](AGENTS.md)** — universal rules every agent must follow.
 2. Read **[docs/INDEX.md](docs/INDEX.md)** — routing layer for all project docs and commands.
 3. Pull deeper context on demand:
-   - Starting a feature → `/gflow:plan`
+   - Current task / where we left off → `/gflow:status`
+   - Starting a new feature → `/gflow:predict` → `/gflow:scenario` → `/gflow:plan <feature>`
    - Touching auth or reCAPTCHA → `/gflow:known-issues`
    - Cutting a release → `/gflow:release`
    - Before any commit → `/gflow:check`
@@ -38,4 +39,4 @@ The heredoc pattern (`$(cat <<'EOF' ... EOF)`) is only valid inside a `Bash` too
 
 ## Active phase
 
-See [PLAN.md](PLAN.md) or run `/gflow:plan` for the current detailed plan.
+See [PLAN.md](PLAN.md) or run `/gflow:status` for current task. Run `/gflow:plan <feature>` to create a new feature plan.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,7 +11,8 @@
 1. Read **[AGENTS.md](AGENTS.md)** — universal rules every agent must follow.
 2. Read **[docs/INDEX.md](docs/INDEX.md)** — routing layer for all project docs and commands.
 3. Pull deeper context on demand:
-   - Starting a feature → `/gflow:plan`
+   - Current task / where we left off → `/gflow:status`
+   - Starting a new feature → `/gflow:predict` → `/gflow:scenario` → `/gflow:plan <feature>`
    - Touching auth or reCAPTCHA → `/gflow:known-issues`
    - Cutting a release → `/gflow:release`
    - Before any commit → `/gflow:check`
@@ -24,4 +25,4 @@
 
 ## Active phase
 
-See [PLAN.md](PLAN.md) or run `/gflow:plan` for the current detailed plan.
+See [PLAN.md](PLAN.md) or run `/gflow:status` for current task. Run `/gflow:plan <feature>` to create a new feature plan.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -25,7 +25,7 @@ These are non-negotiable. They override default agent behavior where conflicts e
 
 ## Routing rules
 
-- **Starting a feature?** Run `/gflow:plan` first to see the active phase scope and definition of done.
+- **Starting a feature?** Run `/gflow:status` to see the active phase scope, then `/gflow:predict` → `/gflow:scenario` → `/gflow:plan <feature>` to create a task checklist.
 - **Touching auth, reCAPTCHA, browser flow, or anything previously flagged?** Run `/gflow:known-issues` first.
 - **Cutting a release?** Run `/gflow:release` — it sequences `/gflow:changelog`, `/gflow:check`, `/gflow:doc-review`.
 - **Before any commit:** Run `/gflow:check` (or the Impeccable Routine in AGENTS.md), including the documentation link gate.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,12 +42,15 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 | Command | Purpose | Call when… |
 |---|---|---|
 | `/gflow:check` | Hygiene + auto-fix lint/format + type/test report | Before every commit |
-| `/gflow:plan` | Show current phase scope, sequence, and definition of done | Starting a feature or unsure what's in scope |
+| `/gflow:status [feature]` | Full state: active plan, progress, next unchecked task | Starting a session; after completing a task |
+| `/gflow:next [feature]` | Next unchecked task only — no context noise | Quick "what do I do right now?" |
+| `/gflow:active` | Which plan is active and its goal — no task detail | Before predict/scenario; quick orientation |
+| `/gflow:plan <feature>` | Create a task-by-task implementation plan → writes `docs/superpowers/plans/` | After predict GO/CAUTION; when a backlog item needs a concrete breakdown |
 | `/gflow:known-issues` | Surface open and mitigated issues | Before touching auth, reCAPTCHA, or previously-flagged code |
 | `/gflow:changelog` | Show `[Unreleased]` entries + last tagged release | Need a quick picture of recent work |
 | `/gflow:release` | Full release flow (calls `/gflow:changelog` + `/gflow:check`) | Cutting a new version |
 | `/gflow:predict <proposal>` | 5-persona pre-implementation analysis → GO / CAUTION / STOP | Before any high-stakes design decision (new transport, auth change, selector redesign, schema migration) |
-| `/gflow:scenario <feature>` | 12-dimension edge-case explorer → severity-ranked scenario table + BDD skeleton | After predict GO/CAUTION; before writing the PLAN.md task spec |
+| `/gflow:scenario <feature>` | 12-dimension edge-case explorer → severity-ranked scenario table + BDD skeleton | After predict GO/CAUTION; before `/gflow:plan` |
 
 **Governance:** commands are executable docs — they decay like any doc. When a phase advances or a file path changes, update the relevant command in the same commit. `/gflow:release` includes a staleness review step.
 

--- a/scripts/dev/active_plan.py
+++ b/scripts/dev/active_plan.py
@@ -12,7 +12,7 @@ file timestamps to the checkout moment, so mtime is not a reliable
 plan; otherwise the root PLAN.md is the source of truth for the current phase.
 
 Output is intentionally compact: only the relevant chunk enters the agent's context.
-Run directly or via the /gflow:plan slash command.
+Run directly or via the /gflow:status, /gflow:next, or /gflow:active slash commands.
 """
 from __future__ import annotations
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,6 +8,8 @@ This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.m
 | predict | [`predict/SKILL.md`](predict/SKILL.md) | 1.0 |
 | scenario | [`scenario/SKILL.md`](scenario/SKILL.md) | — |
 | pr-council-review | [`pr-council-review/SKILL.md`](pr-council-review/SKILL.md) | 2.1 |
+| plan | [`plan/SKILL.md`](plan/SKILL.md) | 1.0 |
+| status | [`status/SKILL.md`](status/SKILL.md) | 1.0 |
 
 ## gflow-cli skill
 
@@ -20,6 +22,14 @@ This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.m
 ## scenario skill
 
 [`scenario/SKILL.md`](scenario/SKILL.md) — 12-dimension edge-case explorer tuned to gflow-cli's known failure surfaces (WAF/reCAPTCHA scoring, Playwright selector drift, auth token lifecycle, batch resume idempotency, SQLite data layer, RFC 9457 error propagation, cross-platform paths, observability contract). Produces a severity-ranked scenario table and BDD `Scenario:` blocks. Invoke via `/gflow:scenario <feature>` after a predict GO/CAUTION, before writing the PLAN.md task spec.
+
+## plan skill
+
+[`plan/SKILL.md`](plan/SKILL.md) — creates a structured task-by-task implementation plan for a feature and writes it to `docs/superpowers/plans/<date>-<slug>/PLAN.md`. Gathers predict/scenario context, asks ≤3 clarifying questions, decomposes into atomic committable tasks with step + test checklists. Invoke via `/gflow:plan <feature>` after a predict GO/CAUTION verdict.
+
+## status skill
+
+[`status/SKILL.md`](status/SKILL.md) — three variants for surfacing plan state at different detail levels: `status` (full state: plan path, goal, progress, next task), `next` (next task only), `active` (plan identity only). All variants run `scripts/dev/active_plan.py`. Invoke via `/gflow:status`, `/gflow:next`, or `/gflow:active`.
 
 ### Install for Claude Code
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -61,7 +61,7 @@ to `docs/superpowers/plans/<YYYY-MM-DD>-<feature-slug>/PLAN.md`.
 ```bash
 uv run python scripts/dev/active_plan.py
 ```
-Confirm the feature belongs to the active phase. Note any relevant ADRs from `PLAN.md`.
+Note the active phase name and its open tasks. Then read `PLAN.md` § "Phase status" and § "Decision log" directly to verify the proposed feature is within current scope and does not contradict an existing ADR. (The script shows the current task, not a backlog index — use `PLAN.md` for scope confirmation.)
 
 ### Phase 2 — Ask clarifying questions (only if not answerable from context)
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: plan
+version: "1.0"
+description: >
+  Creates a structured task-by-task implementation plan for a gflow-cli feature.
+  Gathers predict/scenario context, asks ≤3 clarifying questions, decomposes the
+  feature into atomic committable tasks with step and test checklists, and writes
+  docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md. Invoke after
+  /gflow:predict returns GO or CAUTION and /gflow:scenario output is available.
+---
+
+# `plan` — Feature Plan Creator
+
+Turns a feature description into a task-by-task implementation plan and writes it
+to `docs/superpowers/plans/<YYYY-MM-DD>-<feature-slug>/PLAN.md`.
+
+**Position in the gflow-cli workflow:**
+```
+/gflow:predict <proposal>   →  GO / CAUTION / STOP verdict
+/gflow:scenario <feature>   →  edge cases + BDD skeleton
+/gflow:plan <feature>       →  writes the task checklist  ← this skill
+/gflow:status               →  surfaces next task during execution
+/gflow:check                →  before each commit
+```
+
+---
+
+## When to invoke
+
+- After `/gflow:predict` returns GO or CAUTION
+- When a backlog item in `PLAN.md` needs a concrete task breakdown before starting work
+- Any feature larger than a single isolated file change
+
+## When not to invoke
+
+- Simple bug fixes (< 10 lines, no boundary crossing) — go straight to the fix
+- Pure doc changes
+- A task already fully specified in a superpowers plan — use `/gflow:status` to find it
+
+---
+
+## Protocol
+
+### Phase 1 — Gather inputs from context
+
+**From `/gflow:predict` output in context (do not ask if already present):**
+- Verdict (GO / CAUTION) and confidence score
+- Architectural constraints and module placement
+- Security risks and mandatory mitigations
+- Devil's Advocate simplifications or sequencing blockers
+
+**From `/gflow:scenario` output in context (do not ask if already present):**
+- Critical and High scenarios → these become must-cover tests in the task checklist
+- BDD `Scenario:` blocks → seeds the BDD scaffold task
+
+**From the feature description passed to this skill:**
+- Feature name → derive a slug (lowercase, hyphen-separated, no dates)
+- Stated goal (one sentence)
+
+**From the repo — run once:**
+```bash
+uv run python scripts/dev/active_plan.py
+```
+Confirm the feature belongs to the active phase. Note any relevant ADRs from `PLAN.md`.
+
+### Phase 2 — Ask clarifying questions (only if not answerable from context)
+
+Ask at most 3. Focus on decisions that materially change the task breakdown:
+
+1. **Scope boundary** — what is explicitly out of scope for this plan?
+2. **Module ownership** — which existing module does this extend, or is a new module justified?
+3. **Acceptance criteria** — what does "done" look like from the user's perspective (command output, exit code, log event)?
+
+Skip any question already answered by predict/scenario output or the feature description.
+
+### Phase 3 — Decompose into tasks
+
+**Task rules:**
+- Each task must be independently committable as one atomic `git commit`.
+- Test scaffold tasks (red tests, BDD skeleton) come before the code that makes them green.
+- Tasks that create new files come before tasks that modify callers.
+- Derive test requirements from scenario output: Critical → must-cover (`- [ ]`), High → should-cover.
+- Every task lists: what it does, which files change, step checklist, test checklist.
+
+**Typical task order for a gflow-cli feature:**
+
+| # | Task | Notes |
+|---|---|---|
+| 1 | Unit test scaffold | Red tests only. No production code. |
+| 2 | BDD scaffold | Red BDD scenarios. No production code. |
+| 3 | Core implementation | Domain objects / value types / parsers. |
+| 4 | Transport / API layer | `FlowApiClient` or `UiAutomationTransport` changes. |
+| 5 | CLI surface | `cli_*.py` + Click commands + `--help` text. |
+| 6 | Docs update | `USAGE.md`, `CONFIGURATION.md` (new env vars), `KNOWN_ISSUES.md` if relevant. |
+| 7 | Full gates + release prep | `/gflow:check` green; CHANGELOG updated. |
+
+Adjust: not every task applies to every feature. Merge or split tasks as the scope demands.
+
+### Phase 4 — Draft the plan and show it to the user
+
+Produce the full `PLAN.md` content using this schema:
+
+```markdown
+# <Feature Display Name> Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature <slug>` to find the next
+> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** <one sentence — the user-visible outcome>
+
+**Architecture:** <2–3 sentences — which modules change, key design decisions, what stays the same>
+
+**Predict verdict:** <GO / CAUTION — confidence N/10> (or "pending — run /gflow:predict first")
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| (from predict output) | | |
+
+---
+
+## File structure
+
+### New files
+\`\`\`
+src/gflow_cli/<module>.py
+  <one-line description>
+tests/<module>/test_<module>.py
+  <one-line description>
+\`\`\`
+
+### Modified files
+\`\`\`
+src/gflow_cli/<existing>.py
+  <what changes>
+\`\`\`
+
+---
+
+## Task 1 — <name> (test scaffold)
+
+**What:** <one sentence>
+
+**Files:**
+- `tests/...` — <description>
+
+**Steps:**
+- [ ] <step>
+
+**Tests created (red):**
+- [ ] <test name> — <what it asserts>
+
+---
+
+## Task 2 — ...
+
+(repeat for each task)
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Docs updated (`USAGE.md` / `CONFIGURATION.md` as applicable)
+- [ ] BDD feature file covers all Critical + High scenarios from `/gflow:scenario`
+- [ ] No `# TODO` in diff without a tracked issue link
+```
+
+Show the drafted plan to the user. If they approve (or say "write it"), proceed to Phase 5.
+
+### Phase 5 — Write the file
+
+```bash
+mkdir -p docs/superpowers/plans/<YYYY-MM-DD>-<slug>
+```
+
+Write the plan to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
+
+Confirm with:
+> Plan written to `docs/superpowers/plans/<YYYY-MM-DD>-<slug>/PLAN.md`.
+> Run `/gflow:status --feature <slug>` to start working on it.
+
+---
+
+## Output example (header only)
+
+```
+# Batch Manifest Ledger Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature batch-manifest-ledger` to
+> find the next unchecked task. Implement one task at a time. Run `/gflow:check`
+> before every commit.
+
+**Goal:** Add a local SQLite ledger to `gflow video batch` so interrupted runs skip
+already-completed items on resume.
+
+**Predict verdict:** GO — confidence 8/10
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Schema migration on user's existing DB | Checksummed migration runner (already in data/) |
+| Medium | Ledger path drift between runs | Normalize to absolute path at record time |
+```
+
+---
+
+## Integration with the gflow-cli workflow
+
+- **Claude Code:** invoke via `/gflow:plan <feature>` (thin wrapper around this skill).
+- **Cursor / Aider / Codex:** paste this file into your context and call `plan <feature>`.
+- **Gemini CLI:** include in system context before asking for a plan.
+- **SkillOpt harness:** `python scripts/dev/skillopt/harness.py --skill plan` (once the task dataset is extended).

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -48,6 +48,9 @@ The single next unchecked task block. No header noise.
 **Return:** only the content from `--- Next task ---` onward. Drop the Plan / Title /
 Goal / Progress header lines entirely.
 
+If no `--- Next task ---` separator is present (root PLAN.md mode), return the full
+script output — the phase block is already task-level content.
+
 If the script output contains "All steps complete", say so and suggest:
 - `/gflow:changelog` to review unreleased changes
 - `/gflow:release` if the phase is fully done
@@ -65,7 +68,8 @@ Just which plan is active and its goal. No task detail.
 **Script invocation:** same as `status`.
 
 **Return:** only the header lines — Plan path, Title, Goal, Progress count.
-Stop before the `--- Next task ---` separator.
+- If the output contains `--- Next task ---`, stop before that separator.
+- If no separator is present (root PLAN.md mode — `_summarise_root_plan()` output), return the full output; it contains only orientation-level content with no task block.
 
 **When to call:**
 - Before `/gflow:predict` or `/gflow:scenario`: confirm the proposal fits the active scope

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: status
+version: "1.0"
+description: >
+  Surfaces the current state of work in gflow-cli. Three variants at different
+  levels of detail: full state (status), next task only (next), active plan
+  identity (active). All variants run scripts/dev/active_plan.py and filter
+  its output to the requested detail level.
+---
+
+# `status` — Plan State Reader
+
+Three variants for different contexts. All backed by `scripts/dev/active_plan.py`.
+
+---
+
+## Variants
+
+### `status [feature]` — Full state
+
+The full picture: which plan file is active, its goal, progress (X/N tasks complete),
+and the next unchecked task block.
+
+**Script invocation:**
+```bash
+# With a feature name (from $ARGUMENTS or conversation context):
+uv run python scripts/dev/active_plan.py --feature <slug>
+
+# Without a feature name (uses root PLAN.md):
+uv run python scripts/dev/active_plan.py
+```
+
+**Return:** the complete script output verbatim.
+
+**When to call:**
+- Starting a session: "where did we leave off?"
+- After completing a task: "what comes next?"
+- Before adding scope: "does this belong to the current plan?"
+
+---
+
+### `next [feature]` — Next task only
+
+The single next unchecked task block. No header noise.
+
+**Script invocation:** same as `status`.
+
+**Return:** only the content from `--- Next task ---` onward. Drop the Plan / Title /
+Goal / Progress header lines entirely.
+
+If the script output contains "All steps complete", say so and suggest:
+- `/gflow:changelog` to review unreleased changes
+- `/gflow:release` if the phase is fully done
+
+**When to call:**
+- "What do I do right now?" — between tasks, no orientation needed
+- Resuming mid-session after a context switch
+
+---
+
+### `active` — Plan identity only
+
+Just which plan is active and its goal. No task detail.
+
+**Script invocation:** same as `status`.
+
+**Return:** only the header lines — Plan path, Title, Goal, Progress count.
+Stop before the `--- Next task ---` separator.
+
+**When to call:**
+- Before `/gflow:predict` or `/gflow:scenario`: confirm the proposal fits the active scope
+- Quick check: "are we in a superpowers plan or the root PLAN.md?"
+- When context is long and you need a one-line anchor without task block noise
+
+---
+
+## What the script returns (reference)
+
+- **Superpowers plan active:** file path · title · goal · progress (X/N steps complete) · next unchecked task block
+- **No superpowers plan:** the first incomplete phase from `PLAN.md` (scope, sequence, definition of done)
+- **All complete:** "All steps complete." — prompt user toward `/gflow:changelog` + `/gflow:release`
+
+## Feature slug resolution
+
+1. If the caller passed a slug (e.g. `shell-multi-prompt`), pass it as `--feature <slug>`.
+2. Otherwise check conversation context for a feature name mentioned this session.
+3. If neither, run the script without `--feature` (falls back to root `PLAN.md`).
+
+---
+
+## Integration
+
+- **Claude Code:** invoke via `/gflow:status`, `/gflow:next`, or `/gflow:active` (thin wrappers around this skill).
+- **Cursor / Aider / Codex:** include this file in context; call the variant by name.
+- **Gemini CLI:** read this file before asking "what's the next task?".

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -295,7 +295,7 @@ _End. Convert stable rules from this file into `project_conventions.md` once the
 
 ### L24 — INDEX.md is worth loading at session start; heavy docs are not
 
-**Rule:** INDEX.md is a small routing table (~37 lines) — cheap enough to load at every session start. It enables lazy loading of everything else. PLAN.md, KNOWN_ISSUES.md, and CHANGELOG.md are loaded on demand via `/gflow:plan`, `/gflow:known-issues`, and `/gflow:changelog`. Loading all four upfront burns tokens on sessions where only one is needed.
+**Rule:** INDEX.md is a small routing table (~37 lines) — cheap enough to load at every session start. It enables lazy loading of everything else. PLAN.md, KNOWN_ISSUES.md, and CHANGELOG.md are loaded on demand via `/gflow:status`, `/gflow:known-issues`, and `/gflow:changelog`. (Note: `/gflow:plan <feature>` is the plan-creator command; `/gflow:status` is the plan-reader.) Loading all four upfront burns tokens on sessions where only one is needed.
 
 **Source:** This session.
 


### PR DESCRIPTION
## Problem\n\n`/gflow:plan` was named as if it created plans but only read existing ones. CLAUDE.md pointed agents to it with \"Starting a feature → `/gflow:plan`\" — an agent following that would get a phase summary and have no tool to actually write a plan.\n\n## Changes\n\nSplit into four purpose-named commands:\n\n| Command | What it does |\n|---|---|\n| `/gflow:status [feature]` | Full state: active plan file, goal, progress, next task (replaces old behavior) |\n| `/gflow:next [feature]` | Next unchecked task only — no context noise |\n| `/gflow:active` | Which plan is active and its goal — no task detail |\n| `/gflow:plan <feature>` | **Creates** `docs/superpowers/plans/<date>-<slug>/PLAN.md` |\n\nThe new `/gflow:plan` follows the predict→scenario→plan workflow:\n1. Reads `/gflow:predict` and `/gflow:scenario` output from context\n2. Asks ≤3 clarifying questions if scope/module/acceptance criteria are unclear\n3. Decomposes into atomic committable tasks with step + test checklists\n4. Shows the draft plan for user review, then writes on approval\n\nUpdated all references in `CLAUDE.md`, `AGENTS.md`, and `docs/INDEX.md`.\n\n## Test plan\n\n- [ ] Run `/gflow:status` — confirms it surfaces next task from active_plan.py\n- [ ] Run `/gflow:next` — confirms only the task block is returned, no header\n- [ ] Run `/gflow:active` — confirms only plan path/title/goal/progress is returned\n- [ ] Run `/gflow:plan <feature>` after a predict/scenario session — confirms it writes a plan file to docs/superpowers/plans/\n- [ ] CLAUDE.md and AGENTS.md no longer reference the old read-only `/gflow:plan` usage

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhV98ANvsnkp7uGw1vL2F4)_