### PR TITLE
chore(docs): apply council nice-to-haves from PR #133

### DIFF
--- a/.claude/commands/gflow/predict.md
+++ b/.claude/commands/gflow/predict.md
@@ -16,4 +16,10 @@ The skill at `skills/predict/SKILL.md` runs five independent expert personas
 (Architect · Security/reCAPTCHA · Performance/Playwright · CLI UX · Devil's Advocate),
 resolves conflicts, and returns a GO / CAUTION / STOP verdict with a confidence score.
 
-**Pair with `/gflow:scenario`** after a GO or CAUTION to enumerate edge cases before EXECUTE.
+**Typical workflow after a GO or CAUTION:**
+```
+/gflow:scenario <feature>   →  edge cases + BDD skeleton
+/gflow:plan <feature>       →  writes PLAN.md task checklist
+/gflow:status               →  surfaces next task during execution
+/gflow:check                →  before each commit
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,7 +21,7 @@ This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.m
 
 ## scenario skill
 
-[`scenario/SKILL.md`](scenario/SKILL.md) — 12-dimension edge-case explorer tuned to gflow-cli's known failure surfaces (WAF/reCAPTCHA scoring, Playwright selector drift, auth token lifecycle, batch resume idempotency, SQLite data layer, RFC 9457 error propagation, cross-platform paths, observability contract). Produces a severity-ranked scenario table and BDD `Scenario:` blocks. Invoke via `/gflow:scenario <feature>` after a predict GO/CAUTION, before writing the PLAN.md task spec.
+[`scenario/SKILL.md`](scenario/SKILL.md) — 12-dimension edge-case explorer tuned to gflow-cli's known failure surfaces (WAF/reCAPTCHA scoring, Playwright selector drift, auth token lifecycle, batch resume idempotency, SQLite data layer, RFC 9457 error propagation, cross-platform paths, observability contract). Produces a severity-ranked scenario table and BDD `Scenario:` blocks. Invoke via `/gflow:scenario <feature>` after a predict GO/CAUTION, before `/gflow:plan <feature>`.
 
 ## plan skill
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -212,4 +212,4 @@ already-completed items on resume.
 - **Claude Code:** invoke via `/gflow:plan <feature>` (thin wrapper around this skill).
 - **Cursor / Aider / Codex:** paste this file into your context and call `plan <feature>`.
 - **Gemini CLI:** include in system context before asking for a plan.
-- **SkillOpt harness:** `python scripts/dev/skillopt/harness.py --skill plan` (once the task dataset is extended).
+- **SkillOpt harness:** not yet usable — task dataset not yet populated for this skill.


### PR DESCRIPTION
## Summary\n\nThree nice-to-have nits flagged by the branch council review on #133 but deferred as non-blocking.\n\n- `skills/README.md`: scenario entry now says \"before `/gflow:plan <feature>`\" instead of \"before writing the PLAN.md task spec\"\n- `skills/plan/SKILL.md`: SkillOpt line changed to \"not yet usable — task dataset not yet populated\" (was misleading \"once the task dataset is extended\")\n- `predict.md`: replaces the one-liner \"Pair with /gflow:scenario\" with the full workflow chain: `scenario → plan → status → check`\n\n## Test plan\n\n- [ ] `skills/README.md` scenario description references `/gflow:plan <feature>` not \"PLAN.md task spec\"\n- [ ] `skills/plan/SKILL.md` SkillOpt line makes no false promise of current usability\n- [ ] `predict.md` shows the complete workflow chain after a GO/CAUTION verdict

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhV98ANvsnkp7uGw1vL2F4)_