### PR TITLE
fix(scene): read-back requires ?sceneId=&projectId= query params

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -876,7 +876,7 @@ class FlowApiClient:
     async def get_scene_workflows(self, scene_id: str, *, project_id: str) -> Scene:
         """Read back a scene's clips (order + trims). GET via _get_json."""
         data = await self._get_json(
-            routes.scene_workflows_url(scene_id), route_name="getSceneWorkflows"
+            routes.scene_workflows_url(scene_id, project_id), route_name="getSceneWorkflows"
         )
         return Scene.from_get_response(data, scene_id=scene_id, project_id=project_id)
 

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -78,12 +78,24 @@ def scenes_url(project_id: str) -> str:
     return f"{FLOW_API_BASE}/flow/projects/{project_id}/scenes"
 
 
-def scene_workflows_url(scene_id: str) -> str:
-    """GET target for scene read-back (order + trims + media)."""
+def scene_workflows_url(scene_id: str, project_id: str) -> str:
+    """GET target for scene read-back (order + trims + media).
+
+    Flow requires BOTH ``sceneId`` and ``projectId`` as query params; without
+    them the endpoint returns ``{}`` (empty). Confirmed from labs.google18.har
+    (entries 54/58). Both ids pass the strict allowlist regex (alphanumeric +
+    hyphen only), so direct interpolation into the query string is injection-safe.
+    """
     if not _SCENE_ID_RE.fullmatch(scene_id):
         msg = f"Invalid scene_id: {scene_id!r}"
         raise ValueError(msg)
-    return f"{FLOW_API_BASE}/flow/scene/{scene_id}/workflows"
+    if not _PROJECT_ID_RE.fullmatch(project_id):
+        msg = f"Invalid project_id: {project_id!r}"
+        raise ValueError(msg)
+    return (
+        f"{FLOW_API_BASE}/flow/scene/{scene_id}/workflows"
+        f"?sceneId={scene_id}&projectId={project_id}"
+    )
 
 
 def flow_workflow_url(workflow_id: str) -> str:

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -93,8 +93,7 @@ def scene_workflows_url(scene_id: str, project_id: str) -> str:
         msg = f"Invalid project_id: {project_id!r}"
         raise ValueError(msg)
     return (
-        f"{FLOW_API_BASE}/flow/scene/{scene_id}/workflows"
-        f"?sceneId={scene_id}&projectId={project_id}"
+        f"{FLOW_API_BASE}/flow/scene/{scene_id}/workflows?sceneId={scene_id}&projectId={project_id}"
     )
 
 

--- a/tests/api/test_client_scene.py
+++ b/tests/api/test_client_scene.py
@@ -120,6 +120,8 @@ async def test_get_scene_workflows_reads_back_sorted():
     c = _client_with(page)
     scene = await c.get_scene_workflows("scene-x", project_id="proj-1")
     method, url, _ = page.request.calls[-1]
-    assert method == "GET" and url.endswith("/scene/scene-x/workflows")
+    # read-back requires BOTH sceneId + projectId query params (else Flow returns {})
+    assert method == "GET"
+    assert url.endswith("/scene/scene-x/workflows?sceneId=scene-x&projectId=proj-1")
     assert [w.workflow_id for w in scene.workflows] == ["inst-1", "inst-2"]
     assert scene.workflows[1].metadata.start_time == 3.2

--- a/tests/api/test_routes_scene.py
+++ b/tests/api/test_routes_scene.py
@@ -14,8 +14,19 @@ def test_scenes_url_rejects_injection():
 
 
 def test_scene_workflows_url():
-    url = routes.scene_workflows_url("scene-abc")
-    assert url == "https://aisandbox-pa.googleapis.com/v1/flow/scene/scene-abc/workflows"
+    # Flow requires BOTH sceneId + projectId query params or the GET returns {}.
+    url = routes.scene_workflows_url("scene-abc", "proj-123")
+    assert url == (
+        "https://aisandbox-pa.googleapis.com/v1/flow/scene/scene-abc/workflows"
+        "?sceneId=scene-abc&projectId=proj-123"
+    )
+
+
+def test_scene_workflows_url_rejects_injection():
+    with pytest.raises(ValueError):
+        routes.scene_workflows_url("../evil", "proj-123")
+    with pytest.raises(ValueError):
+        routes.scene_workflows_url("scene-abc", "../evil")
 
 
 def test_scene_workflows_update_url_is_constant():


### PR DESCRIPTION
## Summary

`GET /v1/flow/scene/{id}/workflows` returns `{}` unless **both** `sceneId` and `projectId` are passed as query params (confirmed from a fresh HAR, `labs.google18.har` entries 54/58). gflow's `get_scene_workflows` omitted them, so the endpoint returned empty — making both `gflow scene show` and `scene create`'s final render display an **empty scene** despite a correct server-side compose.

This was caught by running the live `e2e_scene` test for the first time against a real **video** workflowId (the merged L1 had only ever been smoke-tested against a non-composable image id).

## Change
- `routes.scene_workflows_url(scene_id, project_id)` now appends `?sceneId=&projectId=` (both ids are allowlist-validated → injection-safe).
- `client.get_scene_workflows` passes `project_id` through.
- Unit tests updated (URL shape + injection guard on both ids).

## Test plan
- [x] `pyright src` 0 errors; ruff clean
- [x] Unit: `tests/api/test_routes_scene.py` + `test_client_scene.py` (19 passed)
- [x] **Live `e2e_scene` GREEN, credit-free** on denon82 — read-back now returns the 2 composed clips

🤖 Generated with [Claude Code](https://claude.com/claude-code)