### PR TITLE
fix(transports): handle Flow's Agent chat-panel shape in _exit_agent_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Create-project generation failing when Flow opens the Agent _chat panel_.**
+  A follow-up to the earlier Agent-pill fix: Flow now also surfaces Agent mode as
+  a docked chat side-panel ("Untitled session") on some project opens, and while
+  it is up the in-composer Agent pill is absent from the DOM — so the pill-only
+  recovery could not find anything to click and generation still failed with
+  "mode-switch dropdown trigger not found". `_exit_agent_mode` now handles both
+  Agent shapes in one pass: it dismisses the chat panel (locale-stable, aria-free
+  structural close anchor) which reveals the pill, then turns the pill off,
+  looping until the media panel re-mounts. Keyed on the outcome (`crop_*` is
+  back), so it covers pill-only, panel-only, and panel-then-pill without assuming
+  which control is present.
+
 ### Added
 
 - **`gflow scene` command group (Add Clip / Scenes).** Compose ordered,

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -128,6 +128,29 @@ COMPOSER_AGENT_TOGGLE_SELECTOR = (
     "div:has(div[role='textbox'][data-slate-editor='true'])"
     ":has(button:has(i:text('arrow_forward'))) button:has(span.content)"
 )
+
+# Agent CHAT side-panel close (X). Flow's even-newer editor sometimes promotes
+# Agent mode from the in-composer pill (above) to a full chat panel docked on the
+# right ("Untitled session", "What would you like to do?") — it appears on some
+# project opens and not others. While that panel is up, the in-composer pill is
+# NOT in the DOM at all, so the pill selector matches nothing; the panel must be
+# dismissed first (its X), after which the pill reappears (usually still active)
+# and the normal pill path takes over. The panel header carries a New-session
+# button (``edit_square`` icon) next to its close (``close`` icon); we anchor on
+# that pairing so we hit the panel's X and not some other ``close`` icon on the
+# page. ``:text-is`` is EXACT — ``:text('close')`` would also match the sidebar's
+# ``left_panel_close`` ligature. Locale-invariant (Material Symbols ligatures,
+# not UI text) and aria-free, same discipline as the pill selector above.
+AGENT_CHAT_PANEL_CLOSE_SELECTOR = (
+    "div:has(button:has(i:text-is('edit_square'))) button:has(i:text-is('close'))"
+)
+
+# Timing for the Agent-exit loop. The clicks are force=True (immediate), so the
+# click timeout is only a safety cap, not a wait we expect to spend. The settle
+# pause lets Flow re-render the composer (pill → media panel, or panel-close →
+# pill) before the loop re-checks ``crop_*``.
+_AGENT_CLICK_TIMEOUT_MS = 1500
+_AGENT_SETTLE_MS = 500
 # Output-count + duration tabs are selected by aria-label text in
 # `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
 # tab '-trigger-4' and the duration tab '-trigger-4' (4s) share a suffix, so an
@@ -590,47 +613,89 @@ class VideoGenerationMixin:
     async def _exit_agent_mode(page: Page) -> bool:
         """Ensure the composer is in media (Image/Video) mode, not Agent mode.
 
-        When Flow's composer is in "Agent" mode the media-generation panel is
-        absent (see :data:`COMPOSER_AGENT_TOGGLE_SELECTOR`), which makes
-        :meth:`_switch_to_image_mode`, :meth:`_switch_to_video_mode`, and
-        ``_configure_generation_settings`` fail to find their ``crop_*`` trigger.
-        This presses the Agent pill toggle off to re-mount the panel.
+        Flow's "Agent" mode hides the media-generation panel — the ``crop_*``
+        settings trigger that :meth:`_switch_to_image_mode`,
+        :meth:`_switch_to_video_mode`, and ``_configure_generation_settings``
+        probe disappears — so generation fails with "mode-switch dropdown trigger
+        not found". Agent mode shows up in TWO shapes, and which one appears on a
+        given project open is non-deterministic (Flow A/B):
+
+        1. **In-composer pill** (:data:`COMPOSER_AGENT_TOGGLE_SELECTOR`) — an
+           ``Agent`` toggle next to the prompt; clicking it returns to media mode.
+        2. **Chat side-panel** (:data:`AGENT_CHAT_PANEL_CLOSE_SELECTOR`) — a docked
+           "Untitled session" chat on the right; while it is up the pill is not in
+           the DOM at all, so it must be dismissed (its X) first, after which the
+           pill reappears (usually still active) and step 1 applies.
+
+        This drives a small fixed-iteration loop: while the media panel is absent,
+        dismiss whichever Agent affordance is present (chat panel first, then
+        pill) and re-check. The loop is keyed on the OUTCOME (``crop_*`` is back),
+        never on assuming which control exists — so it covers pill-only,
+        panel-only, panel-then-pill, and neither (older UI) without special-casing.
 
         Returns ``True`` only when it actually brought the media panel back,
-        ``False`` otherwise (already in media mode, the toggle is absent on an
-        older UI, or the click did not re-mount the panel). Best-effort,
-        locale-invariant, and never raises — a DOM probe failure must not abort
-        generation.
+        ``False`` otherwise (already in media mode, nothing to act on, or the
+        clicks did not re-mount the panel). Best-effort, locale-invariant
+        (Material Symbols ligatures + structural anchors, no UI text, no ARIA),
+        and never raises — a DOM probe failure must not abort generation.
         """
         try:
             # Common case: the media panel is already mounted → media mode,
-            # nothing to do. This keeps the helper a cheap no-op on every normal
-            # generation and avoids touching the toggle unnecessarily.
+            # nothing to do. Cheap no-op on every normal generation.
             if await VideoGenerationMixin._media_panel_present(page):
                 return False
-            # Panel absent → we are in Agent mode: click the pill (located by its
-            # structural span.content child) to turn Agent off and re-mount the
-            # panel. No ARIA state and no localized label is read — the panel
-            # absence above already established the mode, so the toggle only has
-            # to be found. Works in every Flow UI language.
-            toggle = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
-            if await toggle.count() == 0:
-                return False  # toggle not present (older UI) → leave as-is
-            await toggle.click()
-            await page.wait_for_timeout(700)
-            # Defensive: confirm the click actually re-mounted the panel instead
-            # of blindly trusting it. The pill is a binary toggle, so if the
-            # panel was absent for some other reason — or a future Flow change
-            # flips the click direction — the crop_* trigger stays missing. Don't
-            # claim a false "exited"; warn and let the caller's own trigger probe
-            # fail loudly (with a screenshot) so the real cause surfaces.
+
+            acted = False
+            clicked_pill = False
+            # Bounded loop: dismissing the chat panel can reveal the pill, which
+            # then needs its own click — at most a couple of transitions. The cap
+            # is a backstop against a pathological flip-flop.
+            for _ in range(3):
+                if await VideoGenerationMixin._media_panel_present(page):
+                    break
+                # Shape 2 first: the chat side-panel suppresses the pill entirely,
+                # so it must go before the pill can be found. Closing it is
+                # self-terminating (the X is gone afterwards), so it is safe to
+                # revisit across iterations.
+                chat_close = page.locator(AGENT_CHAT_PANEL_CLOSE_SELECTOR).first
+                if await chat_close.count() > 0:
+                    # force=True: the panel mounts with an entry animation that can
+                    # leave Playwright's actionability check waiting; the element is
+                    # present and the click lands regardless. The short timeout is
+                    # just a safety cap — a forced click is effectively immediate.
+                    await chat_close.click(force=True, timeout=_AGENT_CLICK_TIMEOUT_MS)
+                    await page.wait_for_timeout(_AGENT_SETTLE_MS)
+                    acted = True
+                    continue
+                # Shape 1: the in-composer pill. It is a binary toggle, so click it
+                # AT MOST ONCE — clicking again would just turn Agent mode back on.
+                # If one click doesn't re-mount the panel, stop and let the caller's
+                # own trigger probe fail loudly rather than flip-flopping.
+                if clicked_pill:
+                    break
+                pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
+                if await pill.count() > 0:
+                    await pill.click(force=True, timeout=_AGENT_CLICK_TIMEOUT_MS)
+                    await page.wait_for_timeout(_AGENT_SETTLE_MS)
+                    acted = True
+                    clicked_pill = True
+                    continue
+                # Neither affordance present and panel still absent — nothing this
+                # helper can do (older UI, or an unrecognised Agent shape).
+                break
+
             if await VideoGenerationMixin._media_panel_present(page):
-                log.info("ui_automation_video.exited_agent_mode")
+                if acted:
+                    log.info("ui_automation_video.exited_agent_mode")
                 return True
-            log.warning(
-                "ui_automation_video.exit_agent_mode_no_panel",
-                note="clicked the composer toggle but the media panel did not re-mount",
-            )
+            if acted:
+                # We clicked something but the panel never came back — don't claim
+                # a false "exited"; warn and let the caller's own trigger probe
+                # fail loudly (with a screenshot) so the real cause surfaces.
+                log.warning(
+                    "ui_automation_video.exit_agent_mode_no_panel",
+                    note="dismissed Agent affordance(s) but the media panel did not re-mount",
+                )
             return False
         except Exception as e:  # noqa: BLE001 — best-effort, never fatal
             log.debug("ui_automation_video.agent_toggle_probe_failed", error=str(e)[:80])

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2227,13 +2227,67 @@ class TestSelectImageModel:
         page.locator.assert_not_called()
 
 
-def _agent_loc(count: int) -> MagicMock:
-    """A Playwright-locator mock with a fixed ``.count()`` and chainable ``.first``."""
-    loc = MagicMock()
-    loc.first = loc
-    loc.count = AsyncMock(return_value=count)
-    loc.click = AsyncMock()
-    return loc
+def _exit_agent_page(initial: dict) -> tuple[MagicMock, dict]:
+    """Build a stateful page mock for ``_exit_agent_mode``.
+
+    ``initial`` seeds a mutable DOM state dict with keys ``crop`` / ``pill`` /
+    ``chat`` (each an element count). The click handlers mutate that state to
+    model Flow's real transitions, so the helper's loop is exercised against a
+    DOM that actually changes shape:
+
+    * clicking the **chat-close** removes the chat panel and reveals the pill
+      (``chat`` → 0, ``pill`` → 1), matching the live behaviour;
+    * clicking the **pill** re-mounts the media panel (``crop`` → 1).
+
+    Override either transition by passing ``crop_after_pill`` /
+    ``pill_after_chat`` / ``chat_after_chat`` in ``initial``. Returns
+    ``(page, state)`` so a test can assert final counts + click tallies (the
+    state dict also accrues ``pill_clicks`` / ``chat_clicks``).
+    """
+    from gflow_cli.api.transports.ui_automation_video import (
+        AGENT_CHAT_PANEL_CLOSE_SELECTOR,
+        COMPOSER_AGENT_TOGGLE_SELECTOR,
+    )
+
+    state = {
+        "crop": 0,
+        "pill": 0,
+        "chat": 0,
+        "pill_clicks": 0,
+        "chat_clicks": 0,
+        "crop_after_pill": 1,
+        "pill_after_chat": 1,
+        "chat_after_chat": 0,
+        **initial,
+    }
+
+    async def _pill_click(*_a, **_k) -> None:
+        state["pill_clicks"] += 1
+        state["crop"] = state["crop_after_pill"]
+
+    async def _chat_click(*_a, **_k) -> None:
+        state["chat_clicks"] += 1
+        state["chat"] = state["chat_after_chat"]
+        state["pill"] = state["pill_after_chat"]
+
+    def _loc(key: str, on_click=None) -> MagicMock:
+        loc = MagicMock()
+        loc.first = loc
+        loc.count = AsyncMock(side_effect=lambda: state[key])
+        loc.click = AsyncMock(side_effect=on_click) if on_click else AsyncMock()
+        return loc
+
+    def locator(sel: str) -> MagicMock:
+        if sel == COMPOSER_AGENT_TOGGLE_SELECTOR:
+            return _loc("pill", _pill_click)
+        if sel == AGENT_CHAT_PANEL_CLOSE_SELECTOR:
+            return _loc("chat", _chat_click)
+        return _loc("crop")  # any MODE_SWITCH_TRIGGER_SELECTORS probe
+
+    page = AsyncMock()
+    page.locator = MagicMock(side_effect=locator)
+    page.wait_for_timeout = AsyncMock()
+    return page, state
 
 
 class TestExitAgentMode:
@@ -2272,80 +2326,100 @@ class TestExitAgentMode:
         assert "data-slate-editor" in sel
         assert sel.strip() != "button:has(span.content)"
 
+    def test_chat_close_selector_is_locale_safe_and_aria_free(self) -> None:
+        """The chat-panel close selector is structural — no UI text, no ARIA.
+
+        It anchors on the panel header's New-session (``edit_square``) + close
+        (``close``) Material Symbols ligatures, using ``:text-is`` (EXACT) so it
+        does NOT also match the sidebar's ``left_panel_close`` ligature. No
+        localized text and no ``aria-`` attribute (same discipline as the pill).
+        """
+        from gflow_cli.api.transports.ui_automation_video import (
+            AGENT_CHAT_PANEL_CLOSE_SELECTOR,
+        )
+
+        sel = AGENT_CHAT_PANEL_CLOSE_SELECTOR
+        assert "aria-" not in sel
+        assert ":has-text(" not in sel
+        assert "text-matches" not in sel
+        # Exact icon-ligature matches only (avoids left_panel_close substring).
+        assert ":text-is('edit_square')" in sel
+        assert ":text-is('close')" in sel
+        assert ":text('close')" not in sel  # would over-match left_panel_close
+
     @pytest.mark.asyncio
     async def test_noop_when_media_panel_present(self) -> None:
         """The crop_* media-settings trigger is mounted → media mode already, so
-        the helper returns False and never touches the toggle (common path)."""
-        page = AsyncMock()
-        page.locator = MagicMock(return_value=_agent_loc(1))  # crop trigger present
-        page.wait_for_timeout = AsyncMock()
+        the helper returns False and never touches any toggle (common path)."""
+        page, state = _exit_agent_page({"crop": 1, "pill": 1, "chat": 0})
 
         switched = await UiAutomationTransport._exit_agent_mode(page)
 
         assert switched is False
         page.wait_for_timeout.assert_not_awaited()
+        assert state["pill_clicks"] == 0
+        assert state["chat_clicks"] == 0
 
     @pytest.mark.asyncio
-    async def test_clicks_toggle_and_confirms_panel_remounts(self) -> None:
-        """Panel absent + pill present → click the pill; once the crop_* panel
-        comes back, return True (this is the Agent-mode bug being fixed)."""
-        page = AsyncMock()
-        state = {"clicked": False}
-
-        toggle = MagicMock()
-        toggle.first = toggle
-        toggle.count = AsyncMock(return_value=1)
-        toggle.click = AsyncMock(side_effect=lambda: state.__setitem__("clicked", True))
-
-        def _crop_loc() -> MagicMock:
-            loc = MagicMock()
-            loc.first = loc
-            # crop_* trigger is absent until the toggle is clicked (Agent off).
-            loc.count = AsyncMock(return_value=1 if state["clicked"] else 0)
-            return loc
-
-        def locator(sel: str) -> MagicMock:
-            return toggle if sel == COMPOSER_AGENT_TOGGLE_SELECTOR else _crop_loc()
-
-        page.locator = MagicMock(side_effect=locator)
-        page.wait_for_timeout = AsyncMock()
+    async def test_clicks_pill_and_confirms_panel_remounts(self) -> None:
+        """State B (pill active): panel absent + pill present → click the pill
+        once; when crop_* comes back, return True."""
+        page, state = _exit_agent_page(
+            {"crop": 0, "pill": 1, "chat": 0, "crop_after_pill": 1},
+        )
 
         switched = await UiAutomationTransport._exit_agent_mode(page)
 
         assert switched is True
-        toggle.click.assert_awaited_once()
+        assert state["pill_clicks"] == 1
+        assert state["chat_clicks"] == 0
 
     @pytest.mark.asyncio
-    async def test_returns_false_when_panel_does_not_remount(self) -> None:
-        """Panel absent + pill present, but clicking does NOT bring the crop_*
-        trigger back → return False (no false "exited" claim) and warn, rather
-        than blindly reporting success."""
-        page = AsyncMock()
-        toggle = _agent_loc(1)
+    async def test_closes_chat_panel_then_clicks_revealed_pill(self) -> None:
+        """State A (chat side-panel): panel absent, pill NOT in DOM, chat X
+        present → close the chat (reveals the pill), then click the pill →
+        crop_* returns. Covers the panel-then-pill transition in one call."""
+        page, state = _exit_agent_page(
+            {
+                "crop": 0,
+                "pill": 0,  # pill suppressed while chat panel is up
+                "chat": 1,
+                "pill_after_chat": 1,  # closing chat reveals the pill
+                "chat_after_chat": 0,
+                "crop_after_pill": 1,  # clicking the pill re-mounts the panel
+            },
+        )
 
-        def locator(sel: str) -> MagicMock:
-            # Toggle present; crop_* trigger never appears (before OR after click).
-            return toggle if sel == COMPOSER_AGENT_TOGGLE_SELECTOR else _agent_loc(0)
+        switched = await UiAutomationTransport._exit_agent_mode(page)
 
-        page.locator = MagicMock(side_effect=locator)
-        page.wait_for_timeout = AsyncMock()
+        assert switched is True
+        assert state["chat_clicks"] == 1
+        assert state["pill_clicks"] == 1
+
+    @pytest.mark.asyncio
+    async def test_pill_clicked_at_most_once_when_panel_never_remounts(self) -> None:
+        """State B but the click does NOT re-mount the panel → click the pill
+        exactly ONCE (never flip-flop the binary toggle) and return False."""
+        page, state = _exit_agent_page(
+            {"crop": 0, "pill": 1, "chat": 0, "crop_after_pill": 0},
+        )
 
         switched = await UiAutomationTransport._exit_agent_mode(page)
 
         assert switched is False
-        toggle.click.assert_awaited_once()
+        assert state["pill_clicks"] == 1  # NOT 2/3 — no flip-flop
 
     @pytest.mark.asyncio
-    async def test_noop_when_no_toggle_present(self) -> None:
-        """Crop trigger absent AND no pill toggle (older UI) → clean no-op."""
-        page = AsyncMock()
-        page.locator = MagicMock(return_value=_agent_loc(0))  # nothing present
-        page.wait_for_timeout = AsyncMock()
+    async def test_noop_when_no_affordance_present(self) -> None:
+        """Crop absent AND no pill AND no chat panel (older UI / unknown shape)
+        → clean no-op, nothing clicked, returns False."""
+        page, state = _exit_agent_page({"crop": 0, "pill": 0, "chat": 0})
 
         switched = await UiAutomationTransport._exit_agent_mode(page)
 
         assert switched is False
-        page.wait_for_timeout.assert_not_awaited()
+        assert state["pill_clicks"] == 0
+        assert state["chat_clicks"] == 0
 
     @pytest.mark.asyncio
     async def test_never_raises_on_probe_error(self) -> None:

--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -38,7 +38,10 @@ from gflow_cli.api.transports import make_transport
 from gflow_cli.api.transports.experimental.bearer import BearerTransport
 from gflow_cli.api.transports.experimental.sapisidhash import SapisidhashTransport
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
-from gflow_cli.api.transports.ui_automation_video import COMPOSER_AGENT_TOGGLE_SELECTOR
+from gflow_cli.api.transports.ui_automation_video import (
+    AGENT_CHAT_PANEL_CLOSE_SELECTOR,
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+)
 from gflow_cli.api.video import (
     Aspect,
     GenerateVideoRequest,
@@ -618,6 +621,95 @@ async def test_e2e_agent_mode_recovered_before_mode_switch(
         events = [e["event"] for e in install_log_capture.entries]
         assert "ui_automation_video.exited_agent_mode" in events, (
             f"expected an 'exited_agent_mode' event proving the fix ran; captured events: {events}"
+        )
+    finally:
+        await transport.teardown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_auth
+async def test_e2e_agent_chat_panel_recovered_before_mode_switch(
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """Flow's Agent **chat side-panel** shape no longer breaks the generate path.
+
+    Besides the in-composer pill, Flow sometimes promotes Agent mode to a docked
+    chat panel ("Untitled session") on the right. While it is up the in-composer
+    pill is not in the DOM at all, so the pill-only recovery cannot find it — the
+    panel must be dismissed (its X) first, after which the pill reappears and is
+    clicked. ``_exit_agent_mode`` now handles both shapes in one call.
+
+    This reproduces the chat-panel shape on the **real DOM** (open Agent, then
+    its expand control) and proves ``_switch_to_image_mode`` recovers: the chat
+    panel is gone and the ``crop_*`` media trigger is back. **Zero credits.**
+
+    Skips on accounts whose Flow UI lacks the Agent toggle or the chat-panel
+    expand control (older editor).
+    """
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile name")
+    profile = _resolve_profile_dir(name)
+    if not profile.exists():
+        pytest.skip(f"profile dir not found: {profile}")
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(profile)
+        page = transport._page  # noqa: SLF001
+        assert page is not None, "setup() must acquire a page"
+
+        await transport._enter_editor(page)  # noqa: SLF001
+        await transport._dismiss_blocking_overlays(page)  # noqa: SLF001
+        await transport._wait_video_editor_ready(page)  # noqa: SLF001
+
+        pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR)
+        try:
+            await pill.first.wait_for(state="attached", timeout=15000)
+        except Exception:
+            pytest.skip("Flow account has no Agent composer toggle (older editor UI)")
+
+        # Reproduce the chat-panel shape: enter Agent mode (pill), then promote it
+        # to the docked chat panel via the composer's expand control.
+        if await transport._media_panel_present(page):  # noqa: SLF001
+            await pill.first.click()
+            await page.wait_for_timeout(700)
+        expand = page.locator("button:has(i:text-is('expand_content'))").first
+        if await expand.count() == 0:
+            pytest.skip("Flow account has no Agent chat-panel expand control")
+        await expand.click(force=True)
+        await page.wait_for_timeout(1300)
+
+        # Confirm we actually reproduced State A: media panel absent AND the chat
+        # panel's close (X) is present (so the pill path alone would be stuck).
+        assert not await transport._media_panel_present(page), (  # noqa: SLF001
+            "could not reproduce Agent mode — crop_* trigger still present"
+        )
+        chat_close = page.locator(AGENT_CHAT_PANEL_CLOSE_SELECTOR)
+        if await chat_close.count() == 0:
+            pytest.skip("Agent chat panel did not open (no close X) on this build")
+
+        # The fix: switching to image mode must close the chat panel AND turn the
+        # revealed pill off, re-mounting the media panel.
+        await transport._switch_to_image_mode(page)  # noqa: SLF001
+
+        assert await transport._media_panel_present(page), (  # noqa: SLF001
+            "media panel did not re-mount — chat-panel exit path failed"
+        )
+        assert await chat_close.count() == 0, "agent chat panel still open after recovery"
+        events = [e["event"] for e in install_log_capture.entries]
+        assert "ui_automation_video.exited_agent_mode" in events, (
+            f"expected an 'exited_agent_mode' event; captured events: {events}"
         )
     finally:
         await transport.teardown()


### PR DESCRIPTION
## Problem

Follow-up to the earlier Agent-pill fix (`_exit_agent_mode`). Flow now surfaces Agent mode in **two non-deterministic shapes** on project open:

1. the in-composer **pill** (already handled), and
2. a docked **chat side-panel** ("Untitled session") on the right.

While the chat panel is up, the in-composer pill is **absent from the DOM**, so the pill-only recovery found nothing to click and create-project generation still failed with:

```
RuntimeError: mode-switch dropdown trigger not found on the Flow editor.
```

Which shape appears is non-deterministic per open — the "sometimes it happens, sometimes it doesn't" report.

## Fix

`_exit_agent_mode` now drives a small **bounded loop** handling both shapes in one pass: while the media panel is absent, dismiss whichever Agent affordance is present — the **chat panel first** (its X reveals the pill), then the **pill** — and re-check `crop_*`. It is keyed on the **outcome** (`crop_*` is back), never on assuming which control exists, so it covers pill-only, panel-only, panel-then-pill, and neither (older UI) without special-casing. The pill is clicked **at most once** (it's a binary toggle — clicking twice would re-enter Agent mode).

## New selector — structural, locale-safe, no ARIA

```python
AGENT_CHAT_PANEL_CLOSE_SELECTOR = (
    "div:has(button:has(i:text-is('edit_square'))) button:has(i:text-is('close'))"
)
```

- Anchored on the panel header's New-session (`edit_square`) + close (`close`) Material Symbols ligatures — locale-invariant, no localized text, no `aria-` (same discipline as the pill selector).
- `:text-is` is **EXACT** so it does **not** also match the sidebar's `left_panel_close` ligature (`:text('close')` would over-match).
- Click timeouts are named constants (`_AGENT_CLICK_TIMEOUT_MS` / `_AGENT_SETTLE_MS`), not magic numbers; clicks are `force=True` (the panel's entry animation otherwise stalls Playwright's actionability check).

## Tests

- **Unit** — `TestExitAgentMode` reworked onto a stateful page mock that models Flow's real transitions (chat-close reveals the pill; pill click re-mounts the panel): media-noop, pill, **chat-then-pill**, **pill-clicked-once (no flip-flop)**, no-affordance, plus a locale-safe/aria-free guard for the new chat-close selector. `TestModeSwitchExitsAgentFirst` unchanged.
- **E2E** — adds `test_e2e_agent_chat_panel_recovered_before_mode_switch` (`e2e_auth`, zero credits) reproducing the chat-panel shape on the real DOM and asserting recovery.

## Live verification

Drove the **real code path** (`setup → _enter_editor` [creates a fresh project] → `_switch_to_image_mode` → `_exit_agent_mode`) across profiles **0001–0006, 3 project opens each = 18 runs**. The randomly-appearing Agent shape was caught and recovered every time:

| Profile | Shape (random, not forced) | Recovered |
|---|---|---|
| 0001 | media ×3 | ✅✅✅ |
| 0002 | media ×3 | ✅✅✅ |
| 0003 | **PILL** ×3 | ✅✅✅ |
| 0004 | **CHAT-PANEL** ×3 | ✅✅✅ |
| 0005 | media ×3 | ✅✅✅ |
| 0006 | **CHAT-PANEL** ×3 | ✅✅✅ |

All three shapes (media / pill / chat-panel) occurred organically; **18/18** recovered.

## Validation

- [x] hygiene · doc-links · `ruff check` · `ruff format --check` · `pyright src` (0 errors) — all clean
- [x] `pytest --cov=gflow_cli --cov-fail-under=80` — **1151 passed, 87.25% coverage**
- [x] Live-verified across 6 profiles / 18 project opens (table above)
- [x] CHANGELOG under `[Unreleased] → Fixed`
- [x] DCO `Signed-off-by` present