### PR TITLE
chore(transports): polish _exit_agent_mode per PR #138 council (closes #139)

### DIFF
--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -142,7 +142,8 @@ COMPOSER_AGENT_TOGGLE_SELECTOR = (
 # ``left_panel_close`` ligature. Locale-invariant (Material Symbols ligatures,
 # not UI text) and aria-free, same discipline as the pill selector above.
 AGENT_CHAT_PANEL_CLOSE_SELECTOR = (
-    "div:has(button:has(i:text-is('edit_square'))) button:has(i:text-is('close'))"
+    "div:has(button:has(i.google-symbols:text-is('edit_square'))) "
+    "button:has(i.google-symbols:text-is('close'))"
 )
 
 # Timing for the Agent-exit loop. The clicks are force=True (immediate), so the
@@ -151,6 +152,10 @@ AGENT_CHAT_PANEL_CLOSE_SELECTOR = (
 # pill) before the loop re-checks ``crop_*``.
 _AGENT_CLICK_TIMEOUT_MS = 1500
 _AGENT_SETTLE_MS = 500
+# Iteration cap for the Agent-exit loop. At most a couple of transitions are
+# expected (chat-panel close → pill reveal → pill click); the cap is a backstop
+# against a pathological flip-flop, not a value tuned to a specific shape.
+_AGENT_EXIT_MAX_ITERS = 3
 # Output-count + duration tabs are selected by aria-label text in
 # `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
 # tab '-trigger-4' and the duration tab '-trigger-4' (4s) share a suffix, so an
@@ -650,7 +655,7 @@ class VideoGenerationMixin:
             # Bounded loop: dismissing the chat panel can reveal the pill, which
             # then needs its own click — at most a couple of transitions. The cap
             # is a backstop against a pathological flip-flop.
-            for _ in range(3):
+            for _ in range(_AGENT_EXIT_MAX_ITERS):
                 if await VideoGenerationMixin._media_panel_present(page):
                     break
                 # Shape 2 first: the chat side-panel suppresses the pill entirely,
@@ -675,6 +680,10 @@ class VideoGenerationMixin:
                     break
                 pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
                 if await pill.count() > 0:
+                    # force=True for the same reason as the chat-close above: the
+                    # composer can still be settling from the panel dismissal, which
+                    # stalls Playwright's actionability check; the pill is present and
+                    # the click lands. Timeout is just a safety cap on a forced click.
                     await pill.click(force=True, timeout=_AGENT_CLICK_TIMEOUT_MS)
                     await page.wait_for_timeout(_AGENT_SETTLE_MS)
                     acted = True

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2346,6 +2346,11 @@ class TestExitAgentMode:
         assert ":text-is('edit_square')" in sel
         assert ":text-is('close')" in sel
         assert ":text('close')" not in sel  # would over-match left_panel_close
+        # Both icons are qualified to the Material Symbols font (``google-symbols``),
+        # matching the rest of the module's ligature discipline so a bare
+        # ``<i>close</i>`` text node outside the icon font can never match (#139).
+        assert "i.google-symbols:text-is('edit_square')" in sel
+        assert "i.google-symbols:text-is('close')" in sel
 
     @pytest.mark.asyncio
     async def test_noop_when_media_panel_present(self) -> None:


### PR DESCRIPTION
## Summary

Applies the three low-risk code nice-to-haves surfaced by the `/gflow:pr-council-review` of #138 (which merged GREEN on code). All non-behavioral — hardening + consistency only.

- **Selector hardening** — `AGENT_CHAT_PANEL_CLOSE_SELECTOR` now qualifies both icon anchors as `i.google-symbols:text-is(...)` (was bare `i:text-is(...)`), so a future bare `<i>close</i>` text node outside the Material Symbols font can't match. The `edit_square` structural pairing already de-risked it; this matches the rest of the module's ligature discipline.
- **Named loop cap** — `range(3)` → `_AGENT_EXIT_MAX_ITERS = 3`, beside the other `_AGENT_*` constants this surface introduced.
- **Comment** — justify the in-composer pill click's `force=True` (composer settle stall), mirroring the chat-close rationale already in place.

The memory-hygiene item (the council's actual YELLOW driver) was already applied this session — the `flow-agent-composer-mode-panel-removal` entry documents the second Agent shape.

## Test plan

- [x] `pytest tests/api/transports/test_ui_automation.py` — **134 passed**
- [x] New guard-test assertions for the `.google-symbols` qualifier (TDD: red → green)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pyright src` — 0 errors, 0 warnings
- [x] No behavior change — selectors/constants only; stateful exit-mode mock unaffected (compares against the imported constant by reference)

Closes #139.
