### PR TITLE
feat(chain): add `gflow video chain` — last-frame I2V chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gflow video chain` — last-frame I2V chaining.** Render a JSONL manifest of
+  *links* into one continuous sequence: link 0 is a text-to-video generation,
+  and every later link is an image-to-video generation **seeded by the extracted
+  last frame of the previous clip**, giving visual continuity with no
+  server-side stitching. Each link is a sequential paid Veo generation (**one
+  credit per link**); a cost-confirmation gate (`-y`/`--yes` to skip),
+  `--dry-run` plan preview, `--max-links` cap (exit 11), and
+  `--resume-from <chain-id>` (skips already-paid links, no re-billing) make the
+  spend explicit and recoverable. Per-link wire-route checking aborts loudly if
+  Flow drops the seed frame and routes an i2v link to the text-only endpoint
+  (issue #125), so a misroute can never be reported as a successful chain.
+  Only the Veo 3.1 models (`veo-lite`/`veo-fast`/`veo-quality`/`veo-lite-lp`)
+  are accepted; `omni-flash` is rejected. Chain links are recorded locally
+  (SQLite migration `0005`) to drive `--resume-from`. The frame extractor uses
+  PyAV via a new optional **`[chain]`** extra (`pip install 'gflow-cli[chain]'`)
+  — no system ffmpeg required. Each link is saved as its own mp4; concatenating
+  the clips into one file is a separate step — use `gflow scene` (auto-concat is
+  deferred, see [KNOWN_ISSUES.md](KNOWN_ISSUES.md)).
+
 - **`gflow scene` command group (Add Clip / Scenes).** Compose ordered,
   trimmable video clips into a Flow **Scene** over the credit-free aisandbox
   REST surface (no reCAPTCHA, no credits):

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -461,6 +461,93 @@ sample is captured.
 
 ---
 
+### `gflow video chain` re-exposes the i2v→t2v silent-route risk (issue #125)
+
+- **Status:** Mitigated · **Severity:** Medium · **Affects:** `gflow video chain` (Unreleased)
+
+Every chain link after the first is an image-to-video (I2V) generation seeded by
+the previous clip's last frame. The same silent-route defect that affects
+`gflow video i2v` ([issue #125](https://github.com/ffroliva/gflow-cli/issues/125))
+applies here: if the chosen model can't do i2v interpolation, Flow drops the
+seed frame and routes the request to the plain text-to-video endpoint
+(`batchAsyncGenerateVideoText`) — burning a credit for a text-only clip that
+breaks continuity, with no error from Flow.
+
+**Mitigation (two layers):**
+1. **Model pin.** `omni-flash` (the only model known to silently drop frames) is
+   removed from the chain `--model` choices, and the orchestrator rejects any
+   model whose `supports_i2v_interpolation()` is false **before any spend**
+   (`ModelModeIncompatibilityError`, exit 17).
+2. **Per-link wire-route abort.** For each seeded link the transport inspects the
+   captured generate-response URL; if it observes `batchAsyncGenerateVideoText`
+   for an i2v link it raises `WireFormatError` (logged
+   `ui_automation_video.i2v_routed_to_t2v`, issue #125) rather than reporting a
+   fake success. The chain aborts and preserves every link completed before the
+   failure (`ChainPartialError`).
+
+**Workaround:** stick to the Veo 3.1 models (`veo-lite` / `veo-fast` /
+`veo-quality` / `veo-lite-lp`); these are the only accepted chain models.
+
+---
+
+### `gflow video chain` continuity caveat — black / fade-out final frame
+
+- **Status:** Open · **Severity:** Low · **Affects:** `gflow video chain` (Unreleased)
+
+Chain seeds each link with the **last frame** of the previous clip. If a clip
+fades to black (or to a near-empty frame) at its very end — common with
+cinematic prompts — the extracted seed frame is mostly black, so the next link
+starts from black and continuity visibly breaks.
+
+**Workaround:** pass `--seed-offset MS` to extract the seed frame a few hundred
+milliseconds **before** end-of-file, skipping the fade. For example
+`--seed-offset 200` seeds from 200 ms before EOF. Tune per the fade length of
+your prompts.
+
+---
+
+### `gflow video chain` outputs N clips, not one file — auto-concat is deferred
+
+- **Status:** Open (by design) · **Severity:** Low · **Affects:** `gflow video chain` (Unreleased)
+
+A chain produces **N separate mp4s** (one per link), not a single stitched
+video. Auto-concatenation is deferred: Flow's server-side concatenation
+(`runVideoFxConcatenation`, used by `gflow scene`) is **project-scoped** — every
+clip must live in the same Flow project to be concatenated. But chain links are
+*generated* sequentially and generation cannot pin all links to one shared
+project, so there is no clip set the concat endpoint could combine at the end of
+a chain run.
+
+**Workaround:** stitch the link clips into one file with `gflow scene`
+(server-side, credit-free, no ffmpeg) after the chain completes. The chain
+prints its `chain_id` and a reminder to do this on success.
+
+**Roadmap:** wiring chain links into a single Flow project so the chain can
+auto-concat its own output is under consideration — tracked as backlog.
+
+---
+
+### `gflow video chain --resume-from` re-seeds the first resumed link as T2V
+
+- **Status:** Open · **Severity:** Low · **Affects:** `gflow video chain` (Unreleased)
+
+`--resume-from <chain-id>` skips links already paid for in a prior run (they are
+**not** re-billed) and continues from the first incomplete link. However, the
+first resumed link is generated as a **text-to-video** link, not seeded from the
+last frame of the last completed link — there is no cross-run seed-frame
+hand-off yet. The resume is **credit-safe** (no double-billing), but visual
+continuity restarts at the resume point: the first resumed clip will not flow
+seamlessly from the clip before it.
+
+**Workaround:** if seamless continuity across a resume boundary matters, re-run
+the affected tail of the chain from scratch rather than resuming, or stitch with
+`gflow scene` and accept the cut at the resume boundary.
+
+**Roadmap:** persist and re-extract the boundary seed frame so a resumed link can
+continue as a seeded I2V generation — tracked as backlog.
+
+---
+
 ## Mitigated
 
 ### Auth verification depends on Google's NextAuth session endpoint

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -226,9 +226,44 @@ gflow video t2v "..." --out-dir ./out/
 
 # Video batch: --out-dir overrides the videos/<date>/ root
 gflow video batch ./manifest.tsv --out-dir ./batch-out/
+
+# Video chain: --out-dir holds the per-link mp4s + seed frames
+gflow video chain ./story.jsonl --out-dir ./chain-out/ --yes
 ```
 
 For images, `--out DIR` writes flat as `<DIR>/<media_name>_<n>.png` — file paths are not accepted (rename after the fact if needed). For videos, `--out-dir DIR` controls the local output directory.
+
+## `gflow video chain` flags
+
+`gflow video chain` (last-frame I2V chaining — see
+[USAGE § gflow video chain](USAGE.md#gflow-video-chain)) is configured entirely
+by command-line flags; it adds **no new environment variables**. It reuses
+`GFLOW_CLI_OUTPUT_DIR` (default output root), `GFLOW_CLI_PROFILE`,
+`GFLOW_CLI_DB_PATH` (chain links are recorded for `--resume-from`), and
+`GFLOW_CLI_TIMEOUT_SECONDS` (per-link generation ceiling — the chain waits for
+each link in turn, so total wallclock is the sum of all link waits).
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--model` | `veo-lite` | `veo-lite` / `veo-fast` / `veo-quality` / `veo-lite-lp`. `omni-flash` is rejected — it can't seed i2v links (issue #125). |
+| `--max-links N` | unset | Cap link count; exit 11 (`ConfigurationError`) if the manifest has more. A spend guardrail. |
+| `-y` / `--yes` | off | Skip the per-credit cost confirmation prompt. |
+| `--dry-run` | off | Print the plan + credit estimate and spend nothing. |
+| `--resume-from CHAIN_ID` | unset | Resume a prior chain by its id; already-paid links are skipped (not re-billed). |
+| `--jitter F` | `0.0` | Random `0..F` second pause **between** links (anti-bot cadence; never before link 0). |
+| `--seed-offset MS` | `0` | Extract the seed frame this many ms before EOF (fade-to-black guard). |
+| `--aspect` | `9:16` | `9:16` / `16:9`. Applied uniformly to every link (continuity requirement). |
+| `--out-dir DIR` | output root | Directory for the link mp4s + `linkN_lastframe.jpg` seed frames. |
+| `--profile NAME` | default profile | Per-subcommand profile override. |
+| `--json` | off | Emit a machine-readable JSON result. |
+
+The last-frame extractor needs the **`chain` optional extra** (PyAV — no system
+ffmpeg required):
+
+```bash
+pip install 'gflow-cli[chain]'
+# or:  uv tool install 'gflow-cli[chain]'
+```
 
 Per-call local output flags are not intended as bucket-prefix controls. For
 predictable external storage keys, set the bucket prefix in

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -399,6 +399,101 @@ videos won't appear together in your Flow gallery. The files on disk are
 identical to what `batch` would produce. The same pattern works for
 `gflow video i2v <image> "<prompt>"` and `gflow video r2v "<prompt>" --ref <img>`.
 
+## `gflow video chain`
+
+Render a JSONL manifest of *links* into one continuous last-frame I2V chain.
+Link 0 is a text-to-video (T2V) generation; every later link is an
+image-to-video (I2V) generation **seeded by the extracted last frame of the
+previous clip**, giving visual continuity with no server-side stitching.
+
+> ⚠️ **Costs N credits — one per link.** A chain is N sequential paid Veo
+> generations. Run `--dry-run` first to print the plan and the credit estimate
+> without spending anything. The cost-confirmation prompt is shown unless you
+> pass `-y` / `--yes`.
+
+> **Requires the `chain` extra.** The last-frame extractor decodes the previous
+> clip with [PyAV](https://pyav.org/) (no system ffmpeg needed). Install it
+> with:
+>
+> ```bash
+> pip install 'gflow-cli[chain]'
+> # or:  uv tool install 'gflow-cli[chain]'
+> ```
+
+```text
+gflow video chain MANIFEST [OPTIONS]
+
+Arguments:
+  MANIFEST                  JSONL manifest, one link per line. [required]
+
+Options:
+  --model [veo-lite|veo-fast|veo-quality|veo-lite-lp]
+                            Veo 3.1 model for every link.    [default: veo-lite]
+  --max-links INTEGER       Cap link count; error (exit 11) if the manifest
+                            has more links than this.
+  -y, --yes                 Skip the per-credit cost confirmation prompt.
+  --dry-run                 Resolve the manifest, print the plan + credit cost,
+                            and spend nothing.
+  --resume-from CHAIN_ID    Resume a prior chain by its id; already-paid links
+                            are skipped (not re-billed).
+  --jitter FLOAT            Random 0..JITTER second pause between links
+                            (anti-bot cadence).               [default: 0.0]
+  --seed-offset INTEGER     Extract the seed frame this many ms before EOF
+                            (fade-to-black guard).            [default: 0]
+  --aspect [9:16|16:9]      Uniform aspect for every link.    [default: 9:16]
+  --profile NAME            Profile name (overrides default).
+  --out-dir DIR             Directory for the link mp4s + seed frames.
+  --json                    Emit a machine-readable JSON result.
+```
+
+> **`omni-flash` is rejected.** Only the Veo 3.1 family supports i2v
+> interpolation. `omni-flash` silently drops the seed frame and routes to
+> text-to-video (issue #125), which would break every seeded link, so it is not
+> an accepted `--model` for `chain`. The chain also aborts a link loudly (rather
+> than reporting a fake success) if a generation is observed routing to the
+> text-only endpoint — see [KNOWN_ISSUES](../KNOWN_ISSUES.md).
+
+### JSONL manifest format
+
+One JSON object per line. Only `prompt` is required; `model` / `duration` /
+`aspect` are optional per-link overrides (omit to inherit the chain default).
+Blank lines and `#`-prefixed comment lines are skipped.
+
+```jsonl
+{"prompt": "a lone wolf on a snowy ridge at dawn, cinematic", "model": "veo-lite", "duration": 4, "aspect": "16:9"}
+{"prompt": "it lifts its head and turns to face the camera"}
+{"prompt": "it bounds down the slope toward the valley"}
+```
+
+The chain enforces a **uniform aspect** across links for continuity, so the
+chain-level `--aspect` is applied to every link (a per-link `aspect` override in
+the manifest is currently informational).
+
+### Output — N clips, not one file
+
+Each link is saved as its own mp4 (plus a `linkN_lastframe.jpg` seed frame
+between links) under `--out-dir` (or the default output dir). **Stitching the
+clips into a single video is a separate step — use `gflow scene` to
+concatenate them server-side.** Chain does not auto-concat: see the
+*deferred auto-concat* entry in
+[KNOWN_ISSUES](../KNOWN_ISSUES.md) for why.
+
+**Examples:**
+
+```bash
+# Preview the plan + credit cost — spends nothing
+gflow video chain story.jsonl --dry-run
+
+# Generate the chain (one credit per link), no confirmation prompt
+gflow video chain story.jsonl --model veo-fast --aspect 16:9 --yes
+
+# Resume a chain that died partway — already-paid links are skipped
+gflow video chain story.jsonl --resume-from 1f2e3d4c-...
+
+# Seed 150 ms before EOF to dodge a fade-to-black final frame
+gflow video chain story.jsonl --seed-offset 150 --yes
+```
+
 ## `gflow data list`
 
 Read-only browse over the local SQLite catalog. Shipped in v0.9.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.5.0",
     "pyright>=1.1.0",
+    # video-chain: the last-frame extractor (media.py) decodes with PyAV, and its
+    # tests build synthetic mp4 fixtures with numpy. Declared here so the dev/CI
+    # env actually runs tests/test_media.py instead of importorskip-skipping it.
+    "av>=12",
+    "numpy>=1.24",
 ]
 # Cloud storage extras — install only one at a time.
 # aiobotocore and boto3 pin conflicting botocore versions; avoid mixing [s3]
@@ -112,7 +117,9 @@ markers = [
 
 [dependency-groups]
 dev = [
+    "av>=12",
     "detect-secrets>=1.5.0",
+    "numpy>=1.24",
     "pillow>=12.2.0",
     "pyright>=1.1.409",
     "pytest-asyncio>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ s3 = [
     "universal_pathlib>=0.2.5",
     "s3fs>=2024.2.0",
 ]
+# Video-chain extra — PyAV for the last-frame extractor (no system ffmpeg needed).
+chain = [
+    "av>=12",
+]
 
 [project.scripts]
 gflow = "gflow_cli.cli:main"

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -1,0 +1,255 @@
+"""Sequential last-frame I2V chain orchestrator.
+
+A *chain* renders a list of links into one continuous sequence: link 0 is a
+text-to-video (T2V) generation, and every later link is an image-to-video (I2V)
+generation seeded by the extracted last frame of the previous link's clip. The
+result is visual continuity across links without any server-side stitching.
+
+This module is the pure orchestration core (Task 7). CLI concerns — cost gate,
+``--dry-run``, ``--max-links``, output naming policy — live in the command layer
+(Task 8) and the DTO/transport layers it depends on. The orchestrator drives an
+injected ``client`` (an async ``generate_video``), an injected ``extractor``
+(defaulting to :func:`gflow_cli.media.extract_last_frame`), and an optional
+``recorder`` for crash-safe persistence.
+
+Key invariants:
+
+* **Concurrency = 1.** Links run strictly sequentially; each I2V link depends on
+  the previous link's output, so there is nothing to parallelise.
+* **Reject-up-front.** A model that cannot do i2v interpolation (``omni_flash``)
+  is rejected with :class:`ModelModeIncompatibilityError` BEFORE any spend.
+* **Record-before-extract.** Once a link's clip is downloaded, the recorder is
+  invoked BEFORE the frame extractor runs. A crash in the download->extract gap
+  resumes at extraction, never re-generates the (already paid-for) clip.
+* **Abort-preserves-partials.** A per-link :class:`WireFormatError` (i2v silently
+  routed to the t2v backstop) or :class:`WafRejectionError` (HTTP 403) aborts the
+  chain and raises :class:`ChainPartialError` carrying the ``Path`` of every link
+  completed BEFORE the failure. The failing link's successors are never generated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+import structlog
+
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+)
+from gflow_cli.errors import (
+    ChainPartialError,
+    ModelModeIncompatibilityError,
+    WafRejectionError,
+    WireFormatError,
+)
+from gflow_cli.media import extract_last_frame
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from gflow_cli.api.client import FlowApiClient
+    from gflow_cli.api.video import VideoResult
+
+__all__ = [
+    "ChainLinkResult",
+    "ChainLinkSpec",
+    "ChainRecorder",
+    "FrameExtractor",
+    "run_chain",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ChainLinkSpec:
+    """One link's inputs: a prompt plus optional per-link overrides.
+
+    ``model``/``duration``/``aspect`` override the chain-level defaults for this
+    link only when set; ``None`` means "inherit the chain default". The chain
+    enforces a UNIFORM aspect across links for continuity, so a per-link
+    ``aspect`` override is reserved for future use and currently informational —
+    :func:`run_chain` applies the chain-level aspect to every link.
+    """
+
+    prompt: str
+    model: VideoModel | None = None
+    duration: int | None = None
+    aspect: Aspect | None = None
+
+
+@dataclass(frozen=True)
+class ChainLinkResult:
+    """Outcome of one completed link.
+
+    ``local_path`` is the downloaded clip; ``frame_path`` is the JPEG extracted
+    from it to seed the next link (``None`` for the final link, which seeds
+    nothing). ``media_id`` / ``project_id`` / ``flow_operation_id`` mirror the
+    transport's :class:`~gflow_cli.api.video.VideoResult` for the recorder.
+    """
+
+    index: int
+    prompt: str
+    local_path: Path
+    media_id: str
+    frame_path: Path | None = None
+    project_id: str | None = None
+    flow_operation_id: str | None = None
+
+
+class FrameExtractor(Protocol):
+    """Callable shape of :func:`gflow_cli.media.extract_last_frame`.
+
+    The orchestrator runs it via ``asyncio.to_thread`` (decoding is blocking).
+    """
+
+    def __call__(self, src: Path, dst: Path, *, offset_ms: int = 0) -> Path: ...
+
+
+class ChainRecorder(Protocol):
+    """Persistence hook invoked once per completed link, BEFORE extraction.
+
+    Implementations record the just-downloaded clip so a crash before the next
+    link does not lose the (already paid-for) result. The orchestrator never
+    inspects the return value.
+    """
+
+    def record_chain_link(self, result: ChainLinkResult) -> None: ...
+
+
+async def run_chain(
+    *,
+    client: FlowApiClient,
+    links: Sequence[ChainLinkSpec],
+    out_dir: Path,
+    model: VideoModel,
+    extractor: FrameExtractor = extract_last_frame,
+    recorder: ChainRecorder | None = None,
+    aspect: Aspect = Aspect.PORTRAIT,
+    seed_offset_ms: int = 0,
+    jitter: float = 0.0,
+) -> list[ChainLinkResult]:
+    """Render ``links`` as a sequential last-frame I2V chain.
+
+    Args:
+        client: A ``FlowApiClient`` (or mock) exposing
+            ``async generate_video(*, req: GenerateVideoRequest) -> VideoResult``.
+        links: Ordered per-link specs. Link 0 is T2V; links 1..N are I2V seeded
+            by the previous link's extracted last frame.
+        out_dir: Directory for clips and seed frames.
+        model: The video model. MUST support i2v interpolation (every link after
+            the first is I2V); otherwise raises ``ModelModeIncompatibilityError``
+            before any generation.
+        extractor: Last-frame extractor (defaults to ``extract_last_frame``),
+            run off the event loop via ``asyncio.to_thread``.
+        recorder: Optional persistence hook called BEFORE extraction per link.
+        aspect: Uniform aspect applied to every link (continuity requirement).
+        seed_offset_ms: Passed to the extractor — select a frame this many ms
+            before EOF (the fade-to-black mitigation).
+        jitter: When > 0, sleep a random ``[0, jitter)`` seconds BETWEEN links
+            (anti-bot cadence); never before link 0.
+
+    Returns:
+        One :class:`ChainLinkResult` per link, in order.
+
+    Raises:
+        ModelModeIncompatibilityError: ``model`` cannot do i2v interpolation.
+        ChainPartialError: A link failed with a ``WireFormatError`` (i2v routed
+            to the t2v backstop) or ``WafRejectionError`` (403). Carries the
+            ``Path`` of every link completed before the failure.
+    """
+    if not model.supports_i2v_interpolation():
+        msg = (
+            f"model {model.value!r} does not support i2v interpolation; a chain "
+            f"needs start-frame seeding for every link after the first"
+        )
+        raise ModelModeIncompatibilityError(msg)
+
+    results: list[ChainLinkResult] = []
+    completed_paths: list[Path] = []
+    prev_frame: Path | None = None
+
+    for index, spec in enumerate(links):
+        if index > 0 and jitter > 0:
+            await asyncio.sleep(random.uniform(0.0, jitter))  # noqa: S311 — cadence, not crypto
+
+        link_model = spec.model if spec.model is not None else model
+        is_i2v = index > 0
+        req = GenerateVideoRequest(
+            prompt=spec.prompt,
+            mode=Mode.I2V if is_i2v else Mode.T2V,
+            aspect=aspect,
+            model=link_model,
+            duration=spec.duration,
+            start_image=prev_frame if is_i2v else None,
+        )
+
+        try:
+            result: VideoResult = await client.generate_video(req=req)
+        except (WireFormatError, WafRejectionError) as exc:
+            _log.warning(
+                "chain_link_aborted",
+                index=index,
+                error_class=type(exc).__name__,
+                completed=len(completed_paths),
+            )
+            raise ChainPartialError(
+                detail=f"chain aborted at link {index}: {exc}",
+                partial_results=list(completed_paths),
+                cause=exc,
+            ) from exc
+
+        local_path = result.local_path
+        if local_path is None:
+            msg = f"link {index} returned no local_path (download failed)"
+            raise ChainPartialError(
+                detail=msg,
+                partial_results=list(completed_paths),
+            )
+
+        media_id = result.status.media_id
+        is_last = index == len(links) - 1
+
+        # RECORD-BEFORE-EXTRACT: persist the downloaded clip before decoding it.
+        # The frame_path is the planned seed-frame destination; it is filled in
+        # below for non-final links, but the clip itself is recorded first so a
+        # crash in the download->extract gap resumes at extraction.
+        frame_path = None if is_last else out_dir / f"link{index}_lastframe.jpg"
+        link_result = ChainLinkResult(
+            index=index,
+            prompt=spec.prompt,
+            local_path=local_path,
+            media_id=media_id,
+            frame_path=frame_path,
+            project_id=result.project_id,
+            flow_operation_id=result.flow_operation_id,
+        )
+        if recorder is not None:
+            recorder.record_chain_link(link_result)
+
+        if frame_path is not None:
+            prev_frame = await asyncio.to_thread(
+                extractor,
+                src=local_path,
+                dst=frame_path,
+                offset_ms=seed_offset_ms,
+            )
+
+        results.append(link_result)
+        completed_paths.append(local_path)
+        _log.info(
+            "chain_link_completed",
+            index=index,
+            media_id=media_id,
+            mode=req.mode.value,
+            seeded=is_i2v,
+        )
+
+    return results

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -180,6 +180,7 @@ async def run_chain(
         if index > 0 and jitter > 0:
             await asyncio.sleep(random.uniform(0.0, jitter))  # noqa: S311 — cadence, not crypto
 
+        _log.info("chain_link_started", index=index, total_links=len(links))
         link_model = spec.model if spec.model is not None else model
         is_i2v = index > 0
         req = GenerateVideoRequest(

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -55,13 +55,15 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from gflow_cli.api.client import FlowApiClient
-    from gflow_cli.api.video import VideoResult
+    from gflow_cli.api.video import VideoResult, VideoStartedCallback
 
 __all__ = [
     "ChainLinkResult",
     "ChainLinkSpec",
     "ChainRecorder",
     "FrameExtractor",
+    "LinkCompletedHook",
+    "LinkStartedHook",
     "run_chain",
 ]
 
@@ -124,6 +126,32 @@ class ChainRecorder(Protocol):
     def record_chain_link(self, result: ChainLinkResult) -> None: ...
 
 
+class LinkStartedHook(Protocol):
+    """Factory producing the per-link ``on_started`` forwarded into the transport.
+
+    Called with the link's :class:`GenerateVideoRequest` BEFORE generation; the
+    returned :data:`~gflow_cli.api.video.VideoStartedCallback` (or ``None``) is
+    handed to ``generate_video(on_started=...)`` so the CLI can record the link
+    in the ``videos`` catalog the moment the transport reports it started. The
+    per-link ``request`` is threaded so the catalog row matches the link's mode
+    (link 0 T2V, links N I2V).
+    """
+
+    def __call__(self, request: GenerateVideoRequest) -> VideoStartedCallback | None: ...
+
+
+class LinkCompletedHook(Protocol):
+    """Hook called AFTER each link's clip is downloaded.
+
+    Receives the link's own request + result so the CLI can finalize the
+    ``videos`` catalog row. The implementation MUST absorb its own persistence
+    failures (a post-success error must never abort the already-paid chain); the
+    orchestrator does not guard the call.
+    """
+
+    def __call__(self, request: GenerateVideoRequest, result: VideoResult) -> None: ...
+
+
 async def run_chain(
     *,
     client: FlowApiClient,
@@ -132,6 +160,8 @@ async def run_chain(
     model: VideoModel,
     extractor: FrameExtractor = extract_last_frame,
     recorder: ChainRecorder | None = None,
+    on_link_started: LinkStartedHook | None = None,
+    on_link_completed: LinkCompletedHook | None = None,
     aspect: Aspect = Aspect.PORTRAIT,
     seed_offset_ms: int = 0,
     jitter: float = 0.0,
@@ -149,7 +179,16 @@ async def run_chain(
             before any generation.
         extractor: Last-frame extractor (defaults to ``extract_last_frame``),
             run off the event loop via ``asyncio.to_thread``.
-        recorder: Optional persistence hook called BEFORE extraction per link.
+        recorder: Optional chain-correlation persistence hook called BEFORE
+            extraction per link (records the link into the chain table).
+        on_link_started: Optional factory producing the per-link ``on_started``
+            forwarded into ``generate_video``; lets the CLI record each link in
+            the ``videos`` catalog the moment the transport reports it started.
+            Threaded with the link's own request (link 0 T2V, links N I2V).
+        on_link_completed: Optional hook called AFTER each link's clip is
+            downloaded, with the link's own request + result, so the CLI can
+            finalize the catalog row. The hook MUST absorb its own persistence
+            failures; the orchestrator does not guard it.
         aspect: Uniform aspect applied to every link (continuity requirement).
         seed_offset_ms: Passed to the extractor — select a frame this many ms
             before EOF (the fade-to-black mitigation).
@@ -192,8 +231,13 @@ async def run_chain(
             start_image=prev_frame if is_i2v else None,
         )
 
+        link_on_started = on_link_started(req) if on_link_started is not None else None
+
         try:
-            result: VideoResult = await client.generate_video(req=req)
+            result: VideoResult = await client.generate_video(
+                req=req,
+                on_started=link_on_started,
+            )
         except (WireFormatError, WafRejectionError) as exc:
             _log.warning(
                 "chain_link_aborted",
@@ -234,6 +278,13 @@ async def run_chain(
         )
         if recorder is not None:
             recorder.record_chain_link(link_result)
+
+        # Catalog the link in the `videos` table (parity with t2v/i2v). Uses the
+        # link's OWN request (link 0 T2V, links N I2V) + result so the row mode
+        # matches. The hook absorbs its own DataStoreError so a post-success
+        # persistence failure never aborts the already-paid chain.
+        if on_link_completed is not None:
+            on_link_completed(req, result)
 
         if frame_path is not None:
             prev_frame = await asyncio.to_thread(

--- a/src/gflow_cli/chain_manifest.py
+++ b/src/gflow_cli/chain_manifest.py
@@ -1,0 +1,138 @@
+"""JSONL chain-manifest parser for ``gflow video chain`` (Task 6).
+
+Format: **JSONL** — one JSON object per line, e.g.::
+
+    {"prompt": "a lone wolf on a ridge", "model": "veo-lite", "duration": 4, "aspect": "16:9"}
+    {"prompt": "it turns to face the storm"}
+
+Each object is one chain link, in order. ``prompt`` is required and non-empty;
+``model`` / ``duration`` / ``aspect`` are optional per-link overrides (``None``
+means "inherit the chain default"). Blank lines and ``#``-prefixed comment lines
+are skipped. At least one valid link is required.
+
+**Why JSONL, not a headered TSV?** The chain's per-link overrides are sparse —
+most links carry a prompt alone. A positional TSV would force empty sentinel
+columns on every line and make "field omitted" indistinguishable from "field set
+to empty"; JSON's explicit object keys express optionality directly, type the
+``duration`` as a real number (no string-to-int reparse ambiguity), and tolerate
+field reordering. The batch parser in :mod:`gflow_cli.manifest` stays TSV because
+its five columns are dense and uniform; a chain manifest is sparse, so JSONL is
+the better fit.
+
+Model and aspect strings are mapped through the SAME canonical path the CLI uses
+(:meth:`gflow_cli.api.video.VideoModel.from_cli` /
+:meth:`gflow_cli.api.video.Aspect.from_cli`) — no alias strings are invented
+here. Any malformed input raises :class:`gflow_cli.errors.ChainManifestError`
+citing the offending line number.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+
+from gflow_cli.api.video import Aspect, VideoModel
+from gflow_cli.chain import ChainLinkSpec
+from gflow_cli.errors import ChainManifestError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["parse_chain_manifest"]
+
+_KNOWN_KEYS = frozenset({"prompt", "model", "duration", "aspect"})
+
+
+def _fail(lineno: int, reason: str) -> ChainManifestError:
+    return ChainManifestError(f"line {lineno}: {reason}")
+
+
+def _parse_line(lineno: int, raw: str) -> ChainLinkSpec:
+    """Parse one non-blank, non-comment JSONL line into a ChainLinkSpec."""
+    try:
+        loaded: object = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _fail(lineno, f"not valid JSON ({exc.msg})") from exc
+
+    if not isinstance(loaded, dict):
+        raise _fail(lineno, f"expected a JSON object, got {type(loaded).__name__}")
+
+    obj = cast("dict[str, object]", loaded)
+    unknown = set(obj) - _KNOWN_KEYS
+    if unknown:
+        allowed = ", ".join(sorted(_KNOWN_KEYS))
+        raise _fail(
+            lineno,
+            f"unknown field(s) {sorted(unknown)}; allowed fields are: {allowed}",
+        )
+
+    prompt = obj.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise _fail(lineno, "'prompt' is required and must be a non-empty string")
+
+    model: VideoModel | None = None
+    raw_model = obj.get("model")
+    if raw_model is not None:
+        if not isinstance(raw_model, str):
+            raise _fail(lineno, "'model' must be a string alias")
+        try:
+            model = VideoModel.from_cli(raw_model)
+        except ValueError as exc:
+            raise _fail(lineno, str(exc)) from exc
+
+    duration: int | None = None
+    raw_duration = obj.get("duration")
+    if raw_duration is not None:
+        # bool is a subclass of int; reject it explicitly so a JSON ``true``
+        # cannot masquerade as a duration.
+        if isinstance(raw_duration, bool) or not isinstance(raw_duration, int):
+            raise _fail(lineno, "'duration' must be an integer (seconds)")
+        duration = raw_duration
+
+    aspect: Aspect | None = None
+    raw_aspect = obj.get("aspect")
+    if raw_aspect is not None:
+        if not isinstance(raw_aspect, str):
+            raise _fail(lineno, "'aspect' must be a string (9:16 | 16:9 | 1:1)")
+        try:
+            aspect = Aspect.from_cli(raw_aspect)
+        except ValueError as exc:
+            raise _fail(lineno, str(exc)) from exc
+
+    return ChainLinkSpec(
+        prompt=prompt.strip(),
+        model=model,
+        duration=duration,
+        aspect=aspect,
+    )
+
+
+def parse_chain_manifest(path: Path) -> list[ChainLinkSpec]:
+    """Parse an ordered JSONL chain manifest into per-link specs.
+
+    Args:
+        path: The JSONL manifest file. One JSON object per line; blank lines and
+            ``#``-prefixed comment lines are ignored.
+
+    Returns:
+        One :class:`~gflow_cli.chain.ChainLinkSpec` per link, in file order.
+
+    Raises:
+        ChainManifestError: The file has zero valid links, or a line is
+            malformed (bad JSON, missing/empty ``prompt``, unknown field,
+            unknown model alias, non-int ``duration``, or invalid ``aspect``).
+            The message cites the offending line number.
+    """
+    text = path.read_text(encoding="utf-8")
+    links: list[ChainLinkSpec] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        links.append(_parse_line(lineno, stripped))
+
+    if not links:
+        raise ChainManifestError(
+            "chain manifest contains no links (every line was blank or a comment)",
+        )
+    return links

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -19,6 +19,7 @@ from gflow_cli._cli_helpers import (
     _resolve_profile,
     run_with_handlers,
 )
+from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.video import VideoModel, reference_cap_for
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
@@ -65,7 +66,6 @@ async def _generate_and_report(
     ok/fail status as the exit code) instead of the Rich lines; a failed
     generation still emits its JSON payload and then exits 1.
     """
-    from gflow_cli.api.client import FlowApiClient
     from gflow_cli.api.video import VideoStarted
 
     if not as_json:
@@ -264,6 +264,262 @@ async def _run_r2v(
 async def _run_batch(**kwargs: Any) -> None:  # pragma: no cover
     console.print(_BATCH_UNAVAILABLE)
     raise SystemExit(1)
+
+
+def _resolve_chain_model(model: str | None) -> VideoModel:
+    """Resolve + validate the chain-level ``--model`` BEFORE any spend.
+
+    A chain renders link 0 as T2V and every later link as I2V seeded by the
+    previous clip's last frame, so the model MUST support i2v interpolation.
+    ``omni-flash`` silently drops the start frame at submit and routes to T2V
+    (issue #125), which would break continuity AND burn a credit per link — so
+    reject it at the CLI boundary with ``ModelModeIncompatibilityError`` (exit
+    17). The Click ``Choice`` already excludes ``omni-flash``; this guard also
+    covers a direct programmatic call or a future alias.
+    """
+    from gflow_cli.api.video import I2V_DEFAULT_MODEL
+    from gflow_cli.errors import ModelModeIncompatibilityError
+
+    resolved = VideoModel.from_cli(model)
+    if resolved is None:
+        return I2V_DEFAULT_MODEL
+    if not resolved.supports_i2v_interpolation():
+        msg = (
+            f"{resolved.value!r} does not support image-to-video interpolation; "
+            f"a chain seeds every link after the first with the previous clip's "
+            f"last frame, and Flow silently drops that frame for this model "
+            f"(issue #125). Use a Veo 3.1 model."
+        )
+        raise ModelModeIncompatibilityError(detail=msg)
+    return resolved
+
+
+def _print_chain_plan(
+    *,
+    links: Any,
+    model: VideoModel,
+    aspect: str,
+    skipped: int,
+    chain_id: str,
+) -> None:
+    """Render the resolved plan (used by --dry-run and the pre-spend summary)."""
+    from gflow_cli.chain import ChainLinkSpec
+
+    typed_links: list[ChainLinkSpec] = list(links)
+    remaining = len(typed_links) - skipped
+    console.print(f"[bold]Chain plan[/bold] ([dim]{chain_id}[/dim])")
+    console.print(
+        f"  {len(typed_links)} link(s), aspect {aspect}, model {model.value}"
+        + (f" — {skipped} already completed, {remaining} to generate" if skipped else "")
+    )
+    console.print(f"  [yellow]Estimated cost: {remaining} credit(s)[/yellow] (one per link)")
+    for idx, spec in enumerate(typed_links):
+        mode = "t2v" if idx == 0 else "i2v"
+        link_model = spec.model.value if spec.model is not None else model.value
+        status = " [dim](done)[/dim]" if idx < skipped else ""
+        console.print(f"  [{idx}] {mode} · {link_model} · {spec.prompt!r}{status}")
+
+
+async def _run_chain(
+    *,
+    profile_name: str,
+    profile_dir: Path,
+    manifest: str,
+    model: str | None,
+    aspect: str,
+    out_dir: Path | None,
+    max_links: int | None,
+    resume_from: str | None,
+    jitter: float,
+    seed_offset: int,
+    yes: bool,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Drive a sequential last-frame I2V chain from a JSONL manifest.
+
+    The cost gate (``--yes`` / confirm), ``--max-links`` cap, ``--dry-run``
+    short-circuit, and ``--resume-from`` skip-paid-links logic all run BEFORE a
+    client is created so a rejected/dry run spends nothing and opens no browser.
+    """
+    import uuid
+    from pathlib import Path as _Path
+
+    from gflow_cli import chain as chain_mod
+    from gflow_cli.api.video import Aspect
+    from gflow_cli.chain import ChainLinkSpec
+    from gflow_cli.chain_manifest import parse_chain_manifest
+    from gflow_cli.data.chain_repo import ChainLinkRecorder
+    from gflow_cli.errors import ChainManifestError
+
+    resolved_model = _resolve_chain_model(model)
+    aspect_enum = Aspect.from_cli(aspect)
+
+    links: list[ChainLinkSpec] = parse_chain_manifest(_Path(manifest))
+
+    if max_links is not None and len(links) > max_links:
+        msg = (
+            f"chain manifest has {len(links)} link(s) but --max-links is "
+            f"{max_links}; raise the cap or trim the manifest before spending."
+        )
+        raise ChainManifestError(msg)
+
+    settings = get_settings()
+
+    # Resume: bind the prior chain_id, query already-paid links, skip them so
+    # they are NOT regenerated (no re-billing). A fresh run mints a new id.
+    skipped = 0
+    if resume_from is not None:
+        chain_id = resume_from
+        probe = ChainLinkRecorder.open(
+            settings,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            chain_id=chain_id,
+        )
+        try:
+            skipped = len(probe.completed_links())
+        finally:
+            probe.close()
+        if skipped >= len(links):
+            console.print(
+                f"[green]Chain {chain_id} already complete[/green] "
+                f"({skipped}/{len(links)} links); nothing to do."
+            )
+            return
+    else:
+        chain_id = str(uuid.uuid4())
+
+    remaining_links = links[skipped:]
+    cost = len(remaining_links)
+
+    if dry_run:
+        _print_chain_plan(
+            links=links,
+            model=resolved_model,
+            aspect=aspect,
+            skipped=skipped,
+            chain_id=chain_id,
+        )
+        console.print("[dim]--dry-run: no credits spent, no clips generated.[/dim]")
+        return
+
+    if not as_json:
+        _print_chain_plan(
+            links=links,
+            model=resolved_model,
+            aspect=aspect,
+            skipped=skipped,
+            chain_id=chain_id,
+        )
+
+    if not yes:
+        click.confirm(
+            f"Generate {cost} chain link(s) for ~{cost} credit(s)?",
+            abort=True,
+        )
+
+    resolved_out_dir = out_dir if out_dir is not None else settings.output_dir
+    resolved_out_dir.mkdir(parents=True, exist_ok=True)
+
+    recorder = ChainLinkRecorder.open(
+        settings,
+        profile_name=profile_name,
+        profile_dir=profile_dir,
+        chain_id=chain_id,
+    )
+    total_links = len(remaining_links)
+    partial = False
+    completed_paths: list[Path] = []
+    results: list[Any] = []
+    try:
+        from gflow_cli.errors import ChainPartialError
+
+        async with FlowApiClient(profile_dir=profile_dir, out_dir=resolved_out_dir) as client:
+            try:
+                results = await chain_mod.run_chain(
+                    client=client,
+                    links=remaining_links,
+                    out_dir=resolved_out_dir,
+                    model=resolved_model,
+                    recorder=recorder,
+                    aspect=aspect_enum,
+                    seed_offset_ms=seed_offset,
+                    jitter=jitter,
+                )
+            except ChainPartialError as exc:
+                partial = True
+                completed_paths = list(exc.partial_results)
+                logger.warning(
+                    "chain_link_failed",
+                    chain_id=chain_id,
+                    total_links=total_links,
+                    completed=len(completed_paths),
+                )
+                if as_json:
+                    # Emit the chain-shaped payload (carries the partial flag +
+                    # completed clip paths) and exit directly with the mapped
+                    # code. Re-raising here would let run_with_handlers emit a
+                    # SECOND, error-shaped JSON document on stdout — two
+                    # concatenated objects no json.loads can parse.
+                    import sys as _sys
+
+                    json_output.emit(
+                        _chain_json(
+                            chain_id=chain_id,
+                            results=results,
+                            partial=True,
+                            completed_paths=completed_paths,
+                        )
+                    )
+                    # recorder.close() runs in the finally below.
+                    _sys.exit(json_output.exit_code_for(exc))
+                # Non-json: re-raise so the shared handler maps
+                # ChainPartialError -> exit 21 and prints the resume hint.
+                raise
+    finally:
+        recorder.close()
+
+    if as_json:
+        json_output.emit(
+            _chain_json(
+                chain_id=chain_id,
+                results=results,
+                partial=partial,
+                completed_paths=[r.local_path for r in results],
+            )
+        )
+        return
+
+    console.print(f"[bold green]Chain complete:[/bold green] {len(results)} link(s)")
+    for r in results:
+        console.print(f"  [{r.index}] {r.local_path}")
+    console.print(f"[dim]Stitch into one file with `gflow scene` (chain_id {chain_id}).[/dim]")
+
+
+def _chain_json(
+    *,
+    chain_id: str,
+    results: list[Any],
+    partial: bool,
+    completed_paths: list[Path],
+) -> dict[str, Any]:
+    """Machine-readable chain result payload."""
+    return {
+        "status": "fail" if partial else "ok",
+        "command": "video chain",
+        "chain_id": chain_id,
+        "partial": partial,
+        "links": [
+            {
+                "index": r.index,
+                "media_id": r.media_id,
+                "local_path": str(r.local_path),
+            }
+            for r in results
+        ],
+        "completed_paths": [str(p) for p in completed_paths],
+    }
 
 
 @click.group()
@@ -568,6 +824,140 @@ def r2v(
             as_json=as_json,
         ),
         cli_command="video r2v",
+        as_json=as_json,
+    )
+
+
+@video.command(
+    "chain",
+    short_help="Render a manifest of links into one continuous I2V chain.",
+    help=(
+        "Sequential last-frame chain: link 0 is text-to-video, every later link "
+        "is image-to-video seeded by the previous clip's last frame, giving "
+        "visual continuity with no server-side stitching.\n\n"
+        "COSTS N CREDITS — one per link in the manifest (minus links already "
+        "completed when you --resume-from). Use --dry-run first to print the "
+        "plan and the credit estimate without spending anything.\n\n"
+        "Only Veo 3.1 models are accepted (omni-flash silently drops the seed "
+        "frame and routes to text-to-video, issue #125). The MANIFEST is a JSONL "
+        'file: one JSON object per line, each with a required "prompt" and '
+        'optional "model"/"duration"/"aspect" overrides.\n\n'
+        "Each link is saved as its own mp4. Stitching the clips into a single "
+        "file is a follow-up step — use `gflow scene`.\n\n"
+        "\b\n"
+        "Examples:\n"
+        "  gflow video chain story.jsonl --dry-run\n"
+        "  gflow video chain story.jsonl --model veo-fast --yes\n"
+        "  gflow video chain story.jsonl --resume-from <chain-id>\n"
+    ),
+)
+@click.argument("manifest")
+@click.option(
+    "--model",
+    default="veo-lite",
+    show_default=True,
+    # omni-flash is intentionally absent: it does not support i2v interpolation
+    # and silently routes to T2V (issue #125), which would break every seeded
+    # link in the chain. Use a Veo 3.1 model.
+    type=click.Choice(["veo-lite", "veo-fast", "veo-quality", "veo-lite-lp"]),
+    help="Veo 3.1 model for every link. omni-flash is rejected (no i2v seeding).",
+)
+@click.option(
+    "--max-links",
+    "max_links",
+    default=None,
+    type=click.IntRange(1, None),
+    help="Cap the number of links; error (exit 11) if the manifest has more.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    help="Skip the cost confirmation prompt (each link costs one credit).",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="Resolve the manifest and print the plan + credit cost; spend nothing.",
+)
+@click.option(
+    "--resume-from",
+    "resume_from",
+    default=None,
+    help="Resume a prior chain by its chain id; already-paid links are skipped.",
+)
+@click.option(
+    "--jitter",
+    default=0.0,
+    show_default=True,
+    type=click.FloatRange(0.0, None),
+    help="Random 0..JITTER second pause between links (anti-bot cadence).",
+)
+@click.option(
+    "--seed-offset",
+    "seed_offset",
+    default=0,
+    show_default=True,
+    type=click.IntRange(0, None),
+    help="Extract the seed frame this many ms before EOF (fade-to-black guard).",
+)
+@click.option(
+    "--aspect",
+    default="9:16",
+    show_default=True,
+    type=click.Choice(["9:16", "16:9"]),
+    help="Uniform aspect ratio for every link (continuity requirement).",
+)
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+@click.option(
+    "--out-dir",
+    "out_dir",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory to save the link mp4s + seed frames. Defaults to the output dir.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON result instead of Rich output.",
+)
+def chain(
+    manifest: str,
+    model: str | None,
+    max_links: int | None,
+    yes: bool,
+    dry_run: bool,
+    resume_from: str | None,
+    jitter: float,
+    seed_offset: int,
+    aspect: str,
+    profile: str | None,
+    out_dir: Path | None,
+    as_json: bool,
+) -> None:
+    """Render the chain MANIFEST (one continuous last-frame I2V sequence)."""
+    profile_name = _resolve_profile(profile)
+    provider_dir = _make_provider_dir(profile_name)
+    run_with_handlers(
+        lambda: _run_chain(
+            profile_name=profile_name,
+            profile_dir=provider_dir,
+            manifest=manifest,
+            model=model,
+            aspect=aspect,
+            out_dir=out_dir,
+            max_links=max_links,
+            resume_from=resume_from,
+            jitter=jitter,
+            seed_offset=seed_offset,
+            yes=yes,
+            dry_run=dry_run,
+            as_json=as_json,
+        ),
+        cli_command="video chain",
         as_json=as_json,
     )
 

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -346,7 +346,7 @@ async def _run_chain(
     from pathlib import Path as _Path
 
     from gflow_cli import chain as chain_mod
-    from gflow_cli.api.video import Aspect
+    from gflow_cli.api.video import Aspect, GenerateVideoRequest, VideoResult, VideoStarted
     from gflow_cli.chain import ChainLinkSpec
     from gflow_cli.chain_manifest import parse_chain_manifest
     from gflow_cli.data.chain_repo import ChainLinkRecorder
@@ -428,6 +428,59 @@ async def _run_chain(
         profile_dir=profile_dir,
         chain_id=chain_id,
     )
+    # Catalog recorder: records each chain link into the `videos` catalog
+    # (parity with t2v/i2v), so `gflow data list videos` / `gflow data media`
+    # surface chain clips. Distinct from the chain-correlation `recorder` above.
+    catalog_recorder = OperationRecorder.open(settings)
+
+    def _on_link_started(request: GenerateVideoRequest) -> Any:
+        """Build the per-link ``on_started`` forwarded into ``generate_video``.
+
+        Threaded with the link's OWN request (link 0 T2V, links N I2V) so the
+        catalog row mode matches. The recorder call is wrapped in
+        try/except DataStoreError because it runs INSIDE the transport, where an
+        uncaught exception would abort the PAID generation.
+        """
+
+        def on_started(started: VideoStarted) -> None:
+            try:
+                catalog_recorder.record_started_video(
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    request=request,
+                    started=started,
+                )
+            except DataStoreError as exc:
+                _warn_persistence_failed_after_success(
+                    exc=exc,
+                    flow_media_id=started.media_id,
+                    local_path=None,
+                )
+
+        return on_started
+
+    def _on_link_completed(request: GenerateVideoRequest, result: VideoResult) -> None:
+        """Finalize the catalog row for a downloaded link. A post-success
+        persistence failure WARNS but never aborts the already-paid chain."""
+        try:
+            catalog_recorder.record_completed_video(
+                profile_name=profile_name,
+                _profile_dir=profile_dir,
+                request=request,
+                result=result,
+                cloud_storage_info=(
+                    cloud_info_from_path(result.local_path)
+                    if result.local_path is not None
+                    else None
+                ),
+            )
+        except DataStoreError as exc:
+            _warn_persistence_failed_after_success(
+                exc=exc,
+                flow_media_id=result.status.media_id,
+                local_path=result.local_path,
+            )
+
     total_links = len(remaining_links)
     partial = False
     completed_paths: list[Path] = []
@@ -443,6 +496,8 @@ async def _run_chain(
                     out_dir=resolved_out_dir,
                     model=resolved_model,
                     recorder=recorder,
+                    on_link_started=_on_link_started,
+                    on_link_completed=_on_link_completed,
                     aspect=aspect_enum,
                     seed_offset_ms=seed_offset,
                     jitter=jitter,
@@ -479,6 +534,7 @@ async def _run_chain(
                 raise
     finally:
         recorder.close()
+        catalog_recorder.close()
 
     if as_json:
         json_output.emit(

--- a/src/gflow_cli/data/chain_repo.py
+++ b/src/gflow_cli/data/chain_repo.py
@@ -1,0 +1,128 @@
+"""Concrete :class:`~gflow_cli.chain.ChainRecorder` backed by the SQLite catalog.
+
+The orchestrator (:func:`gflow_cli.chain.run_chain`) calls ``record_chain_link``
+once per link, BEFORE last-frame extraction, so a crash in the download->extract
+gap can be resumed at extraction rather than regenerating a paid clip. This
+module persists each link into the ``chain_links`` table (migration 0005) and
+exposes a resume query the CLI consumes for ``--resume-from`` (Task 8).
+
+Persistence runs AFTER a paid generation. Per the project's post-success rule a
+recorder failure must surface clearly (exit 16 / ``DataStoreError``) but never
+implies the clip was lost — the orchestrator already holds ``local_path`` on
+disk. We therefore re-raise as ``DataStoreError`` and let the caller decide; we
+never swallow the failure silently.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from gflow_cli.data.models import ChainLinkRecord
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataStoreError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from gflow_cli.chain import ChainLinkResult
+    from gflow_cli.config import Settings
+
+_ROUTE = "data.record_chain_link"
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _now_utc_iso() -> str:
+    """UTC timestamp matching the format used elsewhere in the data layer."""
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class ChainLinkRecorder:
+    """Persist each completed chain link into the catalog.
+
+    Implements the structural :class:`gflow_cli.chain.ChainRecorder` protocol
+    (``record_chain_link(result: ChainLinkResult) -> None``). The orchestrator's
+    :class:`~gflow_cli.chain.ChainLinkResult` carries no ``chain_id`` (it is a
+    per-link value); the chain identity + owning profile are bound here at
+    construction, so one recorder instance serves exactly one chain run.
+    """
+
+    repository: DataRepository
+    profile_name: str
+    profile_dir: Path
+    chain_id: str
+
+    def __init__(
+        self,
+        repository: DataRepository,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        chain_id: str,
+    ) -> None:
+        self.repository = repository
+        self.profile_name = profile_name
+        self.profile_dir = profile_dir
+        self.chain_id = chain_id
+
+    @classmethod
+    def open(
+        cls,
+        settings: Settings,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        chain_id: str,
+    ) -> ChainLinkRecorder:
+        store = DataStore.open(settings.resolved_db_path())
+        return cls(
+            DataRepository(store),
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            chain_id=chain_id,
+        )
+
+    def close(self) -> None:
+        self.repository.store.close()
+
+    def record_chain_link(self, result: ChainLinkResult) -> None:
+        """Persist one link's downloaded clip (record-before-extract).
+
+        Idempotent on ``(profile, chain_id, link_index)``: a resumed run that
+        re-records an already-completed link overwrites in place. Wrapping any
+        low-level SQLite failure as :class:`DataStoreError` (exit 16) keeps the
+        recorder's failure mode consistent with the rest of the data layer.
+        """
+        try:
+            self.repository.upsert_profile(self.profile_name, self.profile_dir)
+            self.repository.upsert_chain_link(
+                ChainLinkRecord(
+                    id=_new_id(),
+                    profile_name=self.profile_name,
+                    chain_id=self.chain_id,
+                    link_index=result.index,
+                    flow_project_id=result.project_id,
+                    flow_media_id=result.media_id,
+                    flow_operation_id=result.flow_operation_id,
+                    prompt=result.prompt,
+                    local_path=str(result.local_path),
+                    seed_frame_path=(
+                        str(result.frame_path) if result.frame_path is not None else None
+                    ),
+                    created_at=_now_utc_iso(),
+                ),
+            )
+        except DataStoreError:
+            raise
+        except sqlite3.Error as exc:
+            raise DataStoreError(detail=str(exc), route=_ROUTE) from exc
+
+    def completed_links(self) -> list[ChainLinkRecord]:
+        """Return this chain's recorded links (ordered) for ``--resume-from``."""
+        return self.repository.completed_chain_links(self.profile_name, self.chain_id)

--- a/src/gflow_cli/data/migrations/0005_add_chain_links.sql
+++ b/src/gflow_cli/data/migrations/0005_add_chain_links.sql
@@ -1,0 +1,27 @@
+-- Chain-link correlation for the sequential last-frame I2V chain orchestrator.
+-- One row per completed link, written BEFORE the next link's frame extraction
+-- (record-before-extract). This lets `gflow video chain --resume-from` skip
+-- already-paid links and lets a crash in the download->extract gap resume at
+-- extraction rather than regenerating the (already paid-for) clip:
+--   * a row with seed_frame_path SET    -> link fully done (clip + seed frame)
+--   * a row with seed_frame_path NULL   -> clip on disk, restart at extraction
+--     (also the legitimate state of the FINAL link, which seeds nothing)
+-- Keyed by (chain_id, link_index): the orchestrator owns chain_id; link_index
+-- is the 0-based position. Additive only — no existing table is touched.
+CREATE TABLE chain_links (
+  id TEXT PRIMARY KEY,
+  profile_name TEXT NOT NULL,
+  chain_id TEXT NOT NULL,
+  link_index INTEGER NOT NULL,
+  flow_project_id TEXT,
+  flow_media_id TEXT NOT NULL,
+  flow_operation_id TEXT,
+  prompt TEXT,
+  local_path TEXT NOT NULL,
+  seed_frame_path TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(profile_name) REFERENCES profiles(name),
+  UNIQUE(profile_name, chain_id, link_index)
+);
+
+CREATE INDEX idx_chain_links_chain ON chain_links(profile_name, chain_id, link_index);

--- a/src/gflow_cli/data/models.py
+++ b/src/gflow_cli/data/models.py
@@ -187,6 +187,29 @@ class SceneClipRecord:
 
 
 @dataclass(frozen=True)
+class ChainLinkRecord:
+    """One persisted link of a sequential last-frame I2V chain.
+
+    ``seed_frame_path`` is the last-frame JPEG extracted to seed the NEXT link;
+    it is ``None`` when the clip is recorded but extraction has not yet run
+    (record-before-extract) and also for the final link (which seeds nothing).
+    A resume query distinguishes the two by ``link_index`` vs the chain length.
+    """
+
+    id: str
+    profile_name: str
+    chain_id: str
+    link_index: int
+    flow_project_id: str | None
+    flow_media_id: str
+    flow_operation_id: str | None
+    prompt: str | None
+    local_path: str
+    seed_frame_path: str | None = None
+    created_at: str | None = None
+
+
+@dataclass(frozen=True)
 class AssetLookup:
     id: str
     profile_name: str

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -11,6 +11,7 @@ from gflow_cli.data.models import (
     AssetKind,
     AssetLookup,
     AssetRecord,
+    ChainLinkRecord,
     LocalFileRecord,
     OperationAssetRole,
     OperationKind,
@@ -478,6 +479,92 @@ class DataRepository:
                 start_time=row["start_time"],
                 end_time=row["end_time"],
                 total_duration=row["total_duration"],
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Chain links
+    # ------------------------------------------------------------------
+
+    def upsert_chain_link(self, record: ChainLinkRecord) -> ChainLinkRecord:
+        """Persist one chain link, keyed by (profile_name, chain_id, link_index).
+
+        Idempotent: re-recording the same link (e.g. a resumed run that reaches
+        an already-completed link) overwrites the prior row in place rather than
+        raising. ``seed_frame_path`` is updated too, so attaching the extracted
+        seed frame after the clip was recorded is a plain re-upsert.
+        """
+        created_at = record.created_at or _utc_now()
+        try:
+            with self._store.transaction(immediate=True):
+                self._store.conn.execute(
+                    """
+                    INSERT INTO chain_links(
+                        id, profile_name, chain_id, link_index,
+                        flow_project_id, flow_media_id, flow_operation_id,
+                        prompt, local_path, seed_frame_path, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(profile_name, chain_id, link_index) DO UPDATE SET
+                        flow_project_id = excluded.flow_project_id,
+                        flow_media_id = excluded.flow_media_id,
+                        flow_operation_id = excluded.flow_operation_id,
+                        prompt = excluded.prompt,
+                        local_path = excluded.local_path,
+                        seed_frame_path = excluded.seed_frame_path
+                    """,
+                    (
+                        record.id,
+                        record.profile_name,
+                        record.chain_id,
+                        record.link_index,
+                        record.flow_project_id,
+                        record.flow_media_id,
+                        record.flow_operation_id,
+                        record.prompt,
+                        record.local_path,
+                        record.seed_frame_path,
+                        created_at,
+                    ),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DataIntegrityError(detail=str(exc), route="data.upsert_chain_link") from exc
+        return cast("ChainLinkRecord", dataclasses.replace(record, created_at=created_at))  # pyright: ignore[reportUnnecessaryCast]
+
+    def completed_chain_links(self, profile_name: str, chain_id: str) -> list[ChainLinkRecord]:
+        """Return the recorded links of ``chain_id`` whose clip is on disk.
+
+        Ordered by ``link_index``. A returned link with ``seed_frame_path`` set
+        is fully done (clip + seed frame); one with ``seed_frame_path is None``
+        needs its seed frame re-extracted before the next link can be seeded
+        (unless it is the final link). ``--resume-from`` consumes this to decide
+        the restart point without re-paying for completed clips.
+        """
+        rows = self._store.conn.execute(
+            """
+            SELECT id, profile_name, chain_id, link_index,
+                   flow_project_id, flow_media_id, flow_operation_id,
+                   prompt, local_path, seed_frame_path, created_at
+            FROM chain_links
+            WHERE profile_name = ? AND chain_id = ?
+            ORDER BY link_index
+            """,
+            (profile_name, chain_id),
+        ).fetchall()
+        return [
+            ChainLinkRecord(
+                id=str(row["id"]),
+                profile_name=str(row["profile_name"]),
+                chain_id=str(row["chain_id"]),
+                link_index=int(row["link_index"]),
+                flow_project_id=row["flow_project_id"],
+                flow_media_id=str(row["flow_media_id"]),
+                flow_operation_id=row["flow_operation_id"],
+                prompt=row["prompt"],
+                local_path=str(row["local_path"]),
+                seed_frame_path=row["seed_frame_path"],
                 created_at=row["created_at"],
             )
             for row in rows

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -11,6 +11,7 @@ __all__ = [
     "AuthMissingError",
     "BatchIntegrityError",
     "BatchPartialError",
+    "ChainManifestError",
     "ChainPartialError",
     "ConfigurationError",
     "ContentPolicyError",
@@ -571,6 +572,28 @@ class ChainPartialError(GFlowError):
         )
         self.partial_results: list[Path] = partial_results if partial_results is not None else []
         self.cause = cause
+
+
+class ChainManifestError(ConfigurationError):
+    """Raised when a chain manifest file cannot be parsed into chain links.
+
+    A configuration/input error (bad JSON, missing ``prompt``, unknown model
+    alias, non-int duration, invalid aspect, or an empty manifest). The
+    ``detail`` cites the offending line number where applicable. Inherits
+    ``ConfigurationError``'s exit code (11) via the EXIT_CODE_MAP isinstance
+    walk — no dedicated code is needed because, like other configuration
+    mistakes, it is a "fix your input and re-run" failure.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/chain-manifest"
+    title = "Chain manifest is invalid"
+    _default_remediation = (
+        "Fix the chain manifest: it is a JSONL file with one JSON object per "
+        'line, each requiring a non-empty "prompt"; optional per-link overrides '
+        'are "model", "duration" (int), and "aspect" (9:16 | 16:9 | 1:1). '
+        "Blank lines and lines starting with # are ignored, but at least one "
+        "valid link is required."
+    )
 
 
 # EXIT_CODE_MAP — most-specific class FIRST per isinstance walk semantics.

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, TypedDict
 
 __all__ = [
@@ -10,12 +11,14 @@ __all__ = [
     "AuthMissingError",
     "BatchIntegrityError",
     "BatchPartialError",
+    "ChainPartialError",
     "ConfigurationError",
     "ContentPolicyError",
     "DataIntegrityError",
     "DataMigrationError",
     "DataStoreError",
     "FlowApiError",
+    "FrameExtractionError",
     "GFlowError",
     "ModelModeIncompatibilityError",
     "NetworkError",
@@ -511,10 +514,71 @@ class DataIntegrityError(DataStoreError):
     title = "Data integrity error"
 
 
+class FrameExtractionError(GFlowError):
+    """Raised when the video-chain last-frame extractor cannot produce a frame.
+
+    Covers both the missing-optional-dependency case (PyAV / ``av`` not
+    installed because the ``chain`` extra was skipped) and an undecodable /
+    truncated input video. The remediation points at the install extra so an
+    operator hitting the missing-dependency path can self-serve.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/frame-extraction"
+    title = "Last-frame extraction failed"
+    _default_remediation = (
+        "Could not extract the last frame of the clip. Install the chain extra: "
+        "pip install 'gflow-cli[chain]' (provides PyAV). If already installed, the "
+        "input video may be truncated or undecodable."
+    )
+
+
+class ChainPartialError(GFlowError):
+    """Raised when a sequential video chain fails mid-way after earlier links
+    already produced ready-on-disk clips.
+
+    Mirrors ``BatchPartialError`` but for the video chain: ``partial_results``
+    carries the ``Path`` of each completed link so the already-paid-for clips
+    are surfaced rather than lost. The default is an empty (but present) list —
+    a chain that fails before its first link completes is still a valid partial
+    with zero results, NEVER ``None``.
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/chain-partial"
+    title = "Video chain partially failed"
+    _default_remediation = (
+        "An earlier link in the chain succeeded but a later one failed. The "
+        "completed clips are preserved; re-run with --resume-from to continue "
+        "from the first failed link instead of regenerating the whole chain."
+    )
+
+    def __init__(
+        self,
+        detail: str = "",
+        *,
+        status: int | None = None,
+        instance: str | None = None,
+        route: str = "",
+        remediation_hint: str | None = None,
+        partial_results: list[Path] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(
+            detail,
+            status=status,
+            instance=instance,
+            route=route,
+            remediation_hint=remediation_hint,
+        )
+        self.partial_results: list[Path] = partial_results if partial_results is not None else []
+        self.cause = cause
+
+
 # EXIT_CODE_MAP — most-specific class FIRST per isinstance walk semantics.
 # Subclasses inherit their parent's exit code if they don't have their own
 # entry. New entries MUST go BEFORE their parent class in this dict.
 EXIT_CODE_MAP: dict[type[GFlowError], int] = {
+    ChainPartialError: 21,
+    FrameExtractionError: 20,
     DataMigrationError: 16,
     DataIntegrityError: 16,
     DataStoreError: 16,

--- a/src/gflow_cli/json_output.py
+++ b/src/gflow_cli/json_output.py
@@ -52,12 +52,23 @@ def emit(payload: dict[str, Any]) -> None:
     click.echo(json.dumps(payload, indent=2))
 
 
-def _exit_code(exc: GFlowError) -> int:
-    """Mirror ``_cli_helpers._exit_code_for`` — most-specific class wins."""
+def exit_code_for(exc: GFlowError) -> int:
+    """Mirror ``_cli_helpers._exit_code_for`` — most-specific class wins.
+
+    Public so command modules that emit their own ``--json`` payload (e.g.
+    ``video chain`` on a :class:`~gflow_cli.errors.ChainPartialError`) can exit
+    with the same mapped code the shared handler would have used, without
+    re-raising through the handler (which would emit a second JSON document).
+    """
     for cls, code in EXIT_CODE_MAP.items():
         if isinstance(exc, cls):
             return code
     return 1
+
+
+# Backwards-compatible private alias (kept for the existing error path call
+# sites in this module).
+_exit_code = exit_code_for
 
 
 def error_payload(exc: GFlowError) -> dict[str, Any]:

--- a/src/gflow_cli/media.py
+++ b/src/gflow_cli/media.py
@@ -1,0 +1,120 @@
+"""Video media helpers for the video-chain feature.
+
+Currently exposes :func:`extract_last_frame`, which decodes the final frame of
+an mp4 and writes it as a JPEG. It is the seed image for the next link in a
+sequential video chain (the Task-7 orchestrator calls it between links, wrapped
+in ``asyncio.to_thread`` since decoding is blocking).
+
+PyAV (``av``) is an OPTIONAL dependency shipped via the ``gflow-cli[chain]``
+extra — it bundles ffmpeg, so no system ffmpeg is required. The import is
+deferred to call time and guarded so a missing extra surfaces as a typed
+:class:`~gflow_cli.errors.FrameExtractionError` (exit code 20) with an install
+hint, never a bare ``ModuleNotFoundError``.
+
+PyAV ships no type stubs, so its surface is confined to :func:`_decode_frame`
+where ``av`` is imported as an explicitly ``Any``-typed module. The frame is
+converted to a typed ``PIL.Image.Image`` at that boundary, keeping the rest of
+the module strictly typed.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from gflow_cli.errors import FrameExtractionError
+
+
+def extract_last_frame(src: Path, dst: Path, *, offset_ms: int = 0) -> Path:
+    """Decode the last frame of ``src`` (an mp4) and write it as a JPEG to ``dst``.
+
+    Args:
+        src: Path to a decodable mp4 video.
+        dst: Destination path for the JPEG. Unicode and spaces are supported.
+        offset_ms: When > 0, select the frame roughly ``offset_ms`` milliseconds
+            BEFORE the end of the clip instead of the very last frame. This is the
+            black/fade final-frame mitigation: many generated clips end on a fade
+            to black, which makes a poor seed image for the next link.
+
+    Returns:
+        ``dst`` (the path that was written).
+
+    Raises:
+        FrameExtractionError: If the ``av`` package is unavailable (the
+            ``gflow-cli[chain]`` extra was not installed) or ``src`` is
+            undecodable / contains no video frames.
+    """
+    try:
+        image = _decode_frame(src, offset_ms=offset_ms)
+    except FrameExtractionError:
+        raise
+    except ImportError as exc:  # missing optional [chain] extra
+        raise FrameExtractionError(
+            detail="the optional `av` package (PyAV) is not installed",
+        ) from exc
+    except Exception as exc:  # undecodable / corrupt / non-mp4 input
+        raise FrameExtractionError(
+            detail=f"could not decode {src.name!r}: {exc}",
+        ) from exc
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    image.save(str(dst), format="JPEG", quality=95)
+    return dst
+
+
+def _decode_frame(src: Path, *, offset_ms: int) -> Image.Image:
+    """Open ``src``, seek near the end, and return the target frame as a PIL image.
+
+    For ``offset_ms == 0`` this is the last decoded frame. For a positive
+    ``offset_ms`` it is the decoded frame whose presentation timestamp is closest
+    to ``end - offset_ms``. Decoding happens over a short window near EOF, so we
+    never walk the whole stream.
+
+    ``av`` is untyped (no stubs); it is imported as an ``Any`` module here so the
+    untyped surface stays confined to this function. The returned PIL image is
+    fully typed for callers.
+    """
+    import av  # type: ignore[import]  # optional [chain] extra, ships no stubs
+
+    av_mod: Any = av  # confine the untyped PyAV surface to this local
+
+    with av_mod.open(str(src)) as container:
+        if not container.streams.video:
+            raise FrameExtractionError(detail=f"{src.name!r} has no video stream")
+        stream = container.streams.video[0]
+        time_base = stream.time_base
+        duration = stream.duration
+
+        # Seek a window before EOF so we decode only the tail of the stream.
+        # The window must cover offset_ms plus a margin back to a keyframe.
+        if duration is not None and time_base:
+            one_second = int(Fraction(1, 1) / time_base)
+            offset_ticks = int(Fraction(max(offset_ms, 0), 1000) / time_base)
+            back = max(0, int(duration) - one_second - offset_ticks)
+            container.seek(back, stream=stream, any_frame=False)
+
+        # Target presentation timestamp (in stream ticks) for a positive offset.
+        target_pts: int | None = None
+        if offset_ms > 0 and duration is not None and time_base:
+            target_ticks = int(Fraction(offset_ms, 1000) / time_base)
+            target_pts = max(0, int(duration) - target_ticks)
+
+        best: Image.Image | None = None
+        best_delta: int | None = None
+        for frame in container.decode(stream):
+            pts: int | None = frame.pts
+            if target_pts is None or pts is None:
+                # offset_ms == 0 (or no timestamp to compare): the latest frame
+                # wins, so we never return None when frames exist.
+                best = frame.to_image()
+                continue
+            delta = abs(int(pts) - target_pts)
+            if best_delta is None or delta < best_delta:
+                best, best_delta = frame.to_image(), delta
+
+        if best is None:
+            raise FrameExtractionError(detail=f"{src.name!r} contained no decodable frames")
+        return best

--- a/tests/cli/test_cli_video_chain.py
+++ b/tests/cli/test_cli_video_chain.py
@@ -166,6 +166,98 @@ def test_chain_happy_path_calls_run_chain_with_links_and_recorder(tmp_path: Path
     assert kwargs["model"] is VideoModel.VEO_3_1_LITE
 
 
+def test_chain_wires_operation_recorder_and_records_each_link(tmp_path: Path) -> None:
+    """The chain command opens an OperationRecorder and records EVERY link into
+    the `videos` catalog (parity with t2v/i2v): record_started_video (forwarded
+    as on_started into the transport) + record_completed_video per link, each
+    with that link's own request (link 0 T2V, link 1 I2V).
+
+    Uses the REAL run_chain so the per-link hooks actually fire; only the
+    transport (FlowApiClient.generate_video) is mocked, so no network/credits.
+    """
+    from gflow_cli.api.video import (
+        GenerateVideoRequest,
+        Mode,
+        VideoResult,
+        VideoStarted,
+        VideoStatus,
+    )
+
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 2)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+
+    # Mock OperationRecorder (the catalog recorder).
+    op_recorder = MagicMock()
+
+    # Mock the transport client: generate_video downloads a clip + invokes the
+    # forwarded on_started, then returns a successful VideoResult per link.
+    media_ids = iter(["m0", "m1"])
+
+    async def _gen(*, req: GenerateVideoRequest, on_started: Any = None, **_: Any) -> VideoResult:
+        media_id = next(media_ids)
+        clip = tmp_path / f"{media_id}.mp4"
+        clip.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        if on_started is not None:
+            on_started(VideoStarted(media_id=media_id, project_id="proj", flow_operation_id="op"))
+        return VideoResult(
+            status=VideoStatus(media_id=media_id, status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+            local_path=clip,
+            project_id="proj",
+            flow_operation_id="op",
+        )
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    fake_client.generate_video = AsyncMock(side_effect=_gen)
+
+    # Avoid real frame extraction (no ffmpeg / real mp4): stub the extractor.
+    # The CLI does not pass `extractor=`, so run_chain falls back to its
+    # def-time default kwdefault — patch that binding directly.
+    from gflow_cli.chain import run_chain as _real_run_chain
+
+    def _fake_extract(src: Path, dst: Path, *, offset_ms: int = 0) -> Path:
+        dst.write_bytes(b"\xff\xd8\xff\xd9")
+        return dst
+
+    assert _real_run_chain.__kwdefaults__ is not None
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch("gflow_cli.cli_video.OperationRecorder.open", return_value=op_recorder),
+        patch.dict(_real_run_chain.__kwdefaults__, {"extractor": _fake_extract}),
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--yes"])
+
+    assert result.exit_code == 0, result.output
+
+    # An OperationRecorder was opened and closed.
+    op_recorder.close.assert_called()
+
+    # record_started_video fired once per link, each with the link's own request.
+    assert op_recorder.record_started_video.call_count == 2
+    started_modes = [
+        c.kwargs["request"].mode for c in op_recorder.record_started_video.call_args_list
+    ]
+    assert started_modes == [Mode.T2V, Mode.I2V]
+
+    # record_completed_video fired once per link, each with the link's own request.
+    assert op_recorder.record_completed_video.call_count == 2
+    completed_modes = [
+        c.kwargs["request"].mode for c in op_recorder.record_completed_video.call_args_list
+    ]
+    assert completed_modes == [Mode.T2V, Mode.I2V]
+    # The completed result carries the link's downloaded clip.
+    completed_media = [
+        c.kwargs["result"].status.media_id
+        for c in op_recorder.record_completed_video.call_args_list
+    ]
+    assert completed_media == ["m0", "m1"]
+
+
 def test_chain_partial_error_exits_21_with_resume_hint(tmp_path: Path) -> None:
     runner = CliRunner()
     manifest = _manifest(tmp_path, 3)

--- a/tests/cli/test_cli_video_chain.py
+++ b/tests/cli/test_cli_video_chain.py
@@ -12,9 +12,25 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+import structlog
 from click.testing import CliRunner
 
 from gflow_cli.cli_video import video
+
+
+@pytest.fixture(autouse=True)
+def _route_logs_to_capture(
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """Route structlog into the shared LogCapture (not stdout) for every test here.
+
+    Without it, the warning-level ``chain_link_failed`` event the CLI emits on the
+    ``--json`` partial path renders to stdout and breaks the "single parseable JSON
+    document" assertion when this file runs in isolation. It only passed before
+    because an earlier test in a broader run happened to configure capture first —
+    a test-order dependency, now made deterministic.
+    """
 
 
 def _manifest(tmp_path: Path, n: int) -> Path:

--- a/tests/cli/test_cli_video_chain.py
+++ b/tests/cli/test_cli_video_chain.py
@@ -1,0 +1,265 @@
+"""Click-runner tests for `gflow video chain` (Task 8).
+
+These pin the CLI flag/gate behavior with NO network and NO credits: the
+orchestrator (`run_chain`) and the data recorder are mocked, so the cost gate,
+`--dry-run`, `--max-links`, model validation, and `ChainPartialError` -> exit 21
+are exercised at the Click layer in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from gflow_cli.cli_video import video
+
+
+def _manifest(tmp_path: Path, n: int) -> Path:
+    lines = [f'{{"prompt": "link {i}"}}' for i in range(n)]
+    p = tmp_path / "chain.jsonl"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+def _fake_link_result(index: int, tmp_path: Path) -> Any:
+    from gflow_cli.chain import ChainLinkResult
+
+    clip = tmp_path / f"link{index}.mp4"
+    clip.touch()
+    return ChainLinkResult(
+        index=index,
+        prompt=f"link {index}",
+        local_path=clip,
+        media_id=f"media-{index}",
+    )
+
+
+def _patches(tmp_path: Path):
+    """Common patches: profile resolution + a fake recorder (no DB)."""
+    fake_recorder = MagicMock()
+    fake_recorder.completed_links.return_value = []
+    return (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch(
+            "gflow_cli.data.chain_repo.ChainLinkRecorder.open",
+            return_value=fake_recorder,
+        ),
+        fake_recorder,
+    )
+
+
+def test_chain_requires_manifest() -> None:
+    runner = CliRunner()
+    result = runner.invoke(video, ["chain"])
+    assert result.exit_code != 0
+
+
+def test_chain_missing_manifest_file_errors(tmp_path: Path) -> None:
+    runner = CliRunner()
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    missing = tmp_path / "nope.jsonl"
+    with p_resolve, p_provider, p_rec:
+        result = runner.invoke(video, ["chain", str(missing), "--yes"])
+    assert result.exit_code != 0
+
+
+def test_chain_dry_run_spends_nothing_and_prints_cost(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+        patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    # Plan + credit estimate printed, but nothing generated and no client built.
+    assert "3 credit(s)" in result.output
+    assert "no credits spent" in result.output
+    mock_run.assert_not_awaited()
+    mock_client_init.assert_not_called()
+
+
+def test_chain_max_links_rejects_overlong_manifest(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 5)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+        patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--max-links", "3", "--yes"])
+
+    # ChainManifestError -> ConfigurationError exit code 11.
+    assert result.exit_code == 11, result.output
+    mock_run.assert_not_awaited()
+    mock_client_init.assert_not_called()
+
+
+def test_chain_rejects_non_interpolation_model(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 2)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    with p_resolve, p_provider, p_rec:
+        # omni-flash is not in the Choice -> Click usage error (exit 2).
+        result = runner.invoke(video, ["chain", str(manifest), "--model", "omni-flash", "--yes"])
+    assert result.exit_code == 2
+    assert "omni-flash" in result.output
+
+
+def test_chain_happy_path_calls_run_chain_with_links_and_recorder(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 2)
+    p_resolve, p_provider, p_rec, fake_recorder = _patches(tmp_path)
+    results = [_fake_link_result(0, tmp_path), _fake_link_result(1, tmp_path)]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch(
+            "gflow_cli.chain.run_chain", new_callable=AsyncMock, return_value=results
+        ) as mock_run,
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--yes"])
+
+    assert result.exit_code == 0, result.output
+    mock_run.assert_awaited_once()
+    kwargs = mock_run.await_args.kwargs
+    assert list(kwargs["links"]) and len(kwargs["links"]) == 2
+    assert kwargs["recorder"] is fake_recorder
+    # Model defaulted to veo-lite and resolved to the interpolation-capable enum.
+    from gflow_cli.api.video import VideoModel
+
+    assert kwargs["model"] is VideoModel.VEO_3_1_LITE
+
+
+def test_chain_partial_error_exits_21_with_resume_hint(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+
+    from gflow_cli.errors import ChainPartialError
+
+    done_clip = tmp_path / "link0.mp4"
+    done_clip.touch()
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise ChainPartialError(detail="aborted at link 1", partial_results=[done_clip])
+
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch("gflow_cli.chain.run_chain", side_effect=_boom),
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--yes"])
+
+    assert result.exit_code == 21, result.output
+    # The remediation hint mentions --resume-from.
+    assert "resume" in result.output.lower()
+
+
+def test_chain_resume_skips_completed_links(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+
+    # Recorder reports the first link already paid for.
+    fake_recorder = MagicMock()
+    fake_recorder.completed_links.return_value = [MagicMock()]  # 1 completed
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+    results = [_fake_link_result(0, tmp_path), _fake_link_result(1, tmp_path)]
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch(
+            "gflow_cli.data.chain_repo.ChainLinkRecorder.open",
+            return_value=fake_recorder,
+        ),
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch(
+            "gflow_cli.chain.run_chain", new_callable=AsyncMock, return_value=results
+        ) as mock_run,
+    ):
+        result = runner.invoke(
+            video, ["chain", str(manifest), "--resume-from", "chain-abc", "--yes"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_run.assert_awaited_once()
+    # Only the 2 remaining links are submitted; the paid link is skipped.
+    assert len(mock_run.await_args.kwargs["links"]) == 2
+
+
+def test_chain_partial_json_emits_single_parseable_document(tmp_path: Path) -> None:
+    """--json + ChainPartialError must emit exactly ONE chain-shaped JSON doc.
+
+    Re-raising through the shared handler would emit a second (error-shaped)
+    document, leaving stdout unparseable.
+    """
+    import json
+
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+
+    from gflow_cli.errors import ChainPartialError
+
+    done_clip = tmp_path / "link0.mp4"
+    done_clip.touch()
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise ChainPartialError(detail="aborted at link 1", partial_results=[done_clip])
+
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch("gflow_cli.chain.run_chain", side_effect=_boom),
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--yes", "--json"])
+
+    assert result.exit_code == 21, result.output
+    payload = json.loads(result.output)  # single parseable document
+    assert payload["status"] == "fail"
+    assert payload["partial"] is True
+    assert payload["completed_paths"] == [str(done_clip)]
+
+
+def test_chain_help_states_cost_and_scene_followup() -> None:
+    runner = CliRunner()
+    result = runner.invoke(video, ["chain", "--help"])
+    assert result.exit_code == 0
+    out = result.output.lower()
+    assert "credit" in out
+    assert "gflow scene" in out

--- a/tests/data/test_chain_repo.py
+++ b/tests/data/test_chain_repo.py
@@ -1,0 +1,221 @@
+"""Tests for the chain-link persistence layer (migration 0005 + recorder).
+
+Each test opens its own ``DataStore`` on a ``tmp_path`` DB, so the autouse
+``_isolate_settings`` fixture's redirected DB is never touched and tests cannot
+pollute a real catalog (see memory: data-layer-test-pollution-trap).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.chain import ChainLinkResult, ChainRecorder
+from gflow_cli.data.chain_repo import ChainLinkRecorder
+from gflow_cli.data.models import ChainLinkRecord
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import DataStoreError
+
+
+def _recorder(store: DataStore, tmp_path: Path, chain_id: str = "chain-1") -> ChainLinkRecorder:
+    return ChainLinkRecorder(
+        DataRepository(store),
+        profile_name="default",
+        profile_dir=tmp_path / "profile_default",
+        chain_id=chain_id,
+    )
+
+
+# ----------------------------------------------------------------------
+# Migration
+# ----------------------------------------------------------------------
+
+
+def test_migration_0005_creates_chain_links_table(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        row = store.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='chain_links'",
+        ).fetchone()
+        assert row is not None
+        versions = [
+            r["version"]
+            for r in store.conn.execute("SELECT version FROM schema_migrations").fetchall()
+        ]
+        assert "0005" in versions
+
+
+def test_migration_0005_is_idempotent_and_checksum_valid(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    with DataStore.open(db):
+        pass
+    # Re-opening must not re-apply (checksum match) and must not raise.
+    with DataStore.open(db) as store:
+        rows = store.conn.execute(
+            "SELECT version FROM schema_migrations WHERE version = '0005'",
+        ).fetchall()
+        assert len(rows) == 1
+
+
+# ----------------------------------------------------------------------
+# record_chain_link — insert + retrieve
+# ----------------------------------------------------------------------
+
+
+def test_record_chain_link_inserts_retrievable_row(tmp_path: Path) -> None:
+    clip = tmp_path / "link0.mp4"
+    clip.write_bytes(b"mp4")
+    frame = tmp_path / "link0_lastframe.jpg"
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _recorder(store, tmp_path)
+        recorder.record_chain_link(
+            ChainLinkResult(
+                index=0,
+                prompt="opening shot",
+                local_path=clip,
+                media_id="media-0",
+                frame_path=frame,
+                project_id="flow-project-1",
+                flow_operation_id="op-0",
+            ),
+        )
+        links = recorder.completed_links()
+        assert len(links) == 1
+        link = links[0]
+        assert link.link_index == 0
+        assert link.flow_media_id == "media-0"
+        assert link.local_path == str(clip)
+        assert link.seed_frame_path == str(frame)
+        assert link.flow_project_id == "flow-project-1"
+        assert link.flow_operation_id == "op-0"
+        assert link.prompt == "opening shot"
+
+
+def test_record_chain_link_satisfies_protocol(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder: ChainRecorder = _recorder(store, tmp_path)
+        recorder.record_chain_link(
+            ChainLinkResult(
+                index=0,
+                prompt="p",
+                local_path=tmp_path / "c.mp4",
+                media_id="m",
+            ),
+        )
+        assert isinstance(recorder, ChainLinkRecorder)
+
+
+def test_record_chain_link_is_idempotent_on_index(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _recorder(store, tmp_path)
+        result = ChainLinkResult(
+            index=0,
+            prompt="p",
+            local_path=tmp_path / "c.mp4",
+            media_id="m",
+            frame_path=tmp_path / "f.jpg",
+        )
+        recorder.record_chain_link(result)
+        recorder.record_chain_link(result)  # re-record same link
+        links = recorder.completed_links()
+        assert len(links) == 1
+
+
+# ----------------------------------------------------------------------
+# Resume query — needs-extraction vs fully-done
+# ----------------------------------------------------------------------
+
+
+def test_completed_links_distinguishes_needs_extraction(tmp_path: Path) -> None:
+    """A link with seed_frame_path NULL -> restart at extraction, not regen."""
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _recorder(store, tmp_path)
+        # Link 0: fully done (clip + seed frame).
+        recorder.record_chain_link(
+            ChainLinkResult(
+                index=0,
+                prompt="p0",
+                local_path=tmp_path / "l0.mp4",
+                media_id="m0",
+                frame_path=tmp_path / "l0.jpg",
+            ),
+        )
+        # Link 1: clip recorded but extraction never ran (crash in the gap).
+        recorder.record_chain_link(
+            ChainLinkResult(
+                index=1,
+                prompt="p1",
+                local_path=tmp_path / "l1.mp4",
+                media_id="m1",
+                frame_path=None,
+            ),
+        )
+        links = recorder.completed_links()
+        assert [link.link_index for link in links] == [0, 1]
+        assert links[0].seed_frame_path is not None  # fully done
+        assert links[1].seed_frame_path is None  # needs extraction
+
+
+def test_completed_links_scoped_by_chain_and_ordered(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        rec_a = _recorder(store, tmp_path, chain_id="chain-a")
+        rec_b = _recorder(store, tmp_path, chain_id="chain-b")
+        # Insert out of order to prove ordering by link_index.
+        for idx in (1, 0):
+            rec_a.record_chain_link(
+                ChainLinkResult(
+                    index=idx,
+                    prompt=f"a{idx}",
+                    local_path=tmp_path / f"a{idx}.mp4",
+                    media_id=f"ma{idx}",
+                ),
+            )
+        rec_b.record_chain_link(
+            ChainLinkResult(
+                index=0,
+                prompt="b0",
+                local_path=tmp_path / "b0.mp4",
+                media_id="mb0",
+            ),
+        )
+        a_links = rec_a.completed_links()
+        assert [link.link_index for link in a_links] == [0, 1]
+        b_links = rec_b.completed_links()
+        assert len(b_links) == 1
+        assert b_links[0].flow_media_id == "mb0"
+
+
+def test_completed_links_empty_for_unknown_chain(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _recorder(store, tmp_path, chain_id="never-run")
+        assert recorder.completed_links() == []
+
+
+# ----------------------------------------------------------------------
+# Error semantics — recorder failure -> DataStoreError (exit 16)
+# ----------------------------------------------------------------------
+
+
+def test_record_chain_link_wraps_sqlite_error_as_datastoreerror(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _recorder(store, tmp_path)
+
+        def boom(record: ChainLinkRecord) -> ChainLinkRecord:
+            raise sqlite3.OperationalError("disk I/O error")
+
+        monkeypatch.setattr(recorder.repository, "upsert_chain_link", boom)
+        with pytest.raises(DataStoreError):
+            recorder.record_chain_link(
+                ChainLinkResult(
+                    index=0,
+                    prompt="p",
+                    local_path=tmp_path / "c.mp4",
+                    media_id="m",
+                ),
+            )

--- a/tests/data/test_store_migrations.py
+++ b/tests/data/test_store_migrations.py
@@ -26,7 +26,7 @@ def test_open_creates_schema_and_migration_row(tmp_path: Path) -> None:
     db = tmp_path / "gflow.db"
     with DataStore.open(db) as store:
         rows = store.conn.execute("SELECT version FROM schema_migrations").fetchall()
-        assert [row["version"] for row in rows] == ["0001", "0002", "0003", "0004"]
+        assert [row["version"] for row in rows] == ["0001", "0002", "0003", "0004", "0005"]
         assert store.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert store.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
         assert store.conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"

--- a/tests/e2e/test_chain_e2e.py
+++ b/tests/e2e/test_chain_e2e.py
@@ -1,0 +1,198 @@
+"""Opt-in live e2e for ``gflow video chain`` — last-frame I2V chaining.
+
+Hits the **real Google Flow API** and therefore:
+  - Is NOT collected by default ``pytest`` runs (gated behind ``e2e`` +
+    ``e2e_video``). It NEVER runs in normal CI and spends NO credits unless you
+    explicitly opt in.
+  - Opt-in: ``GFLOW_CLI_E2E_PROFILE=<profile_name> pytest -m e2e_video``.
+  - Requires a logged-in Chrome profile (Pro/Ultra account) AND the ``chain``
+    optional extra (PyAV) for the last-frame extractor:
+    ``pip install 'gflow-cli[chain]'``.
+  - **Burns N Veo credits — one per link.** This test uses a 2-link manifest, so
+    it spends ~2 credits per run. Do NOT run in CI without gating.
+
+Criterion covered:
+  CHAIN-E2E-1 — ``run_chain`` over a 2-link manifest (link 0 = T2V, link 1 = I2V
+    seeded by link 0's extracted last frame) returns one ``ChainLinkResult`` per
+    link, each pointing at an mp4 that exists on disk, and the seeded link's
+    generate request is observed routing to the Start-image endpoint (NOT the
+    text-only endpoint). The route invariant is asserted via the
+    ``ui_automation_video.frame_attached`` structlog event, which fires only when
+    a start frame is bound through the editor's media dialog — i.e. the i2v link
+    actually fired ``...StartImage`` and not ``...Text`` (issue #125). The chain
+    aborts loudly (``WireFormatError``) if a seeded link is misrouted to T2V, so
+    a successful return is itself partial proof of the route; the explicit event
+    assertion guards against a false positive where a clip comes back text-only.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio  # noqa: F401 — ensures asyncio mode is registered
+import structlog
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.video import Aspect, VideoModel
+from gflow_cli.chain import ChainLinkResult, ChainLinkSpec, run_chain
+
+# ---------------------------------------------------------------------------
+# Module-level marker — every test in this file is e2e (opt-in only), and
+# spends Veo credits, so it carries the e2e_video cost sub-marker. Both markers
+# are default-deselected, so the file never runs in a plain ``pytest`` invocation.
+# ---------------------------------------------------------------------------
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_video]
+
+# ---------------------------------------------------------------------------
+# Constants — tuned for minimum credit spend: veo-lite, 4 s, portrait, 2 links.
+# Override via env for variation (per [[e2e-tests-parameterize]]).
+# ---------------------------------------------------------------------------
+
+_E2E_ASPECT_ENV = "GFLOW_CLI_E2E_VIDEO_ASPECT"
+_E2E_MODEL_ENV = "GFLOW_CLI_E2E_VIDEO_MODEL"
+_E2E_DURATION_ENV = "GFLOW_CLI_E2E_CHAIN_DURATION"
+
+# Short, safe prompts — generic enough to pass content-policy, with motion so
+# the seeded I2V link has something to continue.
+_LINK0_PROMPT = "a calm forest clearing at dawn, slow push-in, cinematic"
+_LINK1_PROMPT = "the camera continues drifting forward through the trees"
+
+# The seeded (i2v) link MUST bind a start frame through the media dialog; this
+# event fires only on that path. Its absence means the i2v link routed to the
+# text-only endpoint (issue #125) — a false-positive chain.
+_FRAME_ATTACHED_EVENT = "ui_automation_video.frame_attached"
+
+
+def _aspect() -> Aspect:
+    """Resolve the requested aspect from the environment variable.
+
+    Defaults to PORTRAIT (the chain command's default ``--aspect 9:16``). Skips
+    on unrecognised values so a typo doesn't silently burn credits on the wrong
+    ratio.
+    """
+    raw = os.environ.get(_E2E_ASPECT_ENV, "portrait").strip().lower()
+    if raw == "portrait":
+        return Aspect.PORTRAIT
+    if raw == "landscape":
+        return Aspect.LANDSCAPE
+    pytest.skip(f"Unsupported {_E2E_ASPECT_ENV}={raw!r} — set to 'portrait' or 'landscape'")
+
+
+def _model() -> VideoModel:
+    """Resolve the chain model. Defaults to veo-lite (cheapest i2v-capable Veo).
+
+    omni-flash is intentionally NOT a default — it cannot seed i2v links and the
+    chain rejects it before any spend (issue #125).
+    """
+    raw = os.environ.get(_E2E_MODEL_ENV, "veo-lite").strip().lower()
+    model = VideoModel.from_cli(raw)
+    if model is None:
+        pytest.skip(f"{_E2E_MODEL_ENV}={raw!r} is not a known video model alias")
+    if not model.supports_i2v_interpolation():
+        pytest.skip(
+            f"{_E2E_MODEL_ENV}={raw!r} cannot seed i2v chain links; "
+            "use veo-lite / veo-fast / veo-quality / veo-lite-lp"
+        )
+    return model
+
+
+def _duration() -> int:
+    return int(os.environ.get(_E2E_DURATION_ENV, "4").strip())
+
+
+@pytest.mark.asyncio
+async def test_chain_two_link_seeds_i2v_from_last_frame(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """CHAIN-E2E-1: a 2-link chain renders link 0 (T2V) then link 1 (I2V) seeded
+    by link 0's extracted last frame.
+
+    Asserts the 5-layer-style evidence shape:
+      * one ``ChainLinkResult`` per link, in order;
+      * every link's ``local_path`` mp4 exists on disk (file-count layer);
+      * link 0 produced a seed frame on disk; the final link did not;
+      * the seeded link bound a start frame through the media dialog — the
+        ``frame_attached`` structlog event fired — proving the i2v request routed
+        to ``...StartImage`` and NOT ``...Text`` (the issue-#125 route invariant).
+
+    Spends ~2 Veo credits per run.
+    """
+    # Opt out of the autouse home-redirect so the REAL logged-in profile resolves
+    # (per [[test-isolation-real-env-opt-out]]: without this the e2e silently
+    # skips when intentionally run), but keep a throwaway DB so we never pollute
+    # the real catalog.
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(tmp_path / "e2e_chain.db"))
+    reset_settings()
+
+    name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+    if not name:
+        pytest.skip("set GFLOW_CLI_E2E_PROFILE to a logged-in profile, then run with -m e2e_video")
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+
+    profile = _resolve_profile_dir(name)
+    if not profile.exists():
+        pytest.skip(f"profile not found: {profile} — run `gflow auth login --profile {name}`")
+
+    aspect = _aspect()
+    model = _model()
+    duration = _duration()
+
+    links = [
+        ChainLinkSpec(prompt=_LINK0_PROMPT, duration=duration),
+        ChainLinkSpec(prompt=_LINK1_PROMPT, duration=duration),
+    ]
+
+    async with FlowApiClient(profile_dir=profile) as client:
+        results: list[ChainLinkResult] = await run_chain(
+            client=client,
+            links=links,
+            out_dir=tmp_path,
+            model=model,
+            aspect=aspect,
+        )
+
+    # --- file-count / shape layer -----------------------------------------
+    assert len(results) == len(links), (
+        f"expected one ChainLinkResult per link ({len(links)}), got {len(results)}"
+    )
+    for link in results:
+        assert link.media_id, f"link {link.index} returned an empty media_id"
+        assert link.local_path.exists(), (
+            f"link {link.index} clip is missing on disk: {link.local_path!r}"
+        )
+        assert link.local_path.stat().st_size > 0, (
+            f"link {link.index} clip is empty: {link.local_path!r}"
+        )
+
+    # --- seed-frame layer: non-final links extract a frame, the final one ---
+    # does not (it seeds nothing).
+    assert results[0].frame_path is not None and results[0].frame_path.exists(), (
+        "link 0 must have extracted a last frame to seed link 1; "
+        f"frame_path={results[0].frame_path!r}"
+    )
+    assert results[-1].frame_path is None, (
+        "the final link seeds nothing and must not produce a seed frame; "
+        f"frame_path={results[-1].frame_path!r}"
+    )
+
+    # --- route-invariant layer (issue #125) -------------------------------
+    # The seeded link binds a start frame through the media dialog; this event
+    # fires ONLY on that path, so its presence proves the i2v request routed to
+    # ...StartImage and not the text-only ...Text endpoint. A misroute would have
+    # already aborted the chain with WireFormatError before we got here, but the
+    # explicit assertion guards the false positive where a text-only clip is
+    # returned without the seed frame ever binding.
+    events = [e["event"] for e in install_log_capture.entries]
+    assert _FRAME_ATTACHED_EVENT in events, (
+        f"expected a {_FRAME_ATTACHED_EVENT!r} event proving the seeded link bound "
+        f"its start frame through the media dialog (i2v routed to ...StartImage, "
+        f"not ...Text — issue #125); captured events: {events}"
+    )

--- a/tests/features/test_step_collision_guard.py
+++ b/tests/features/test_step_collision_guard.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 def test_step_modules_coexist() -> None:
     import tests.features.test_auth_steps as auth_steps
     import tests.features.test_image_steps as image_steps
+    import tests.features.test_video_chain_steps as video_chain_steps
 
     assert auth_steps is not None
     assert image_steps is not None
+    assert video_chain_steps is not None

--- a/tests/features/test_video_chain_steps.py
+++ b/tests/features/test_video_chain_steps.py
@@ -1,0 +1,291 @@
+"""Step bindings for video_chain.feature.
+
+Scoped to this feature only — pytest-bdd uses module-scoped step registries
+(per-module ``scenarios()`` call) so the chain step phrases here don't collide
+with the auth or image step modules (proven by
+``test_step_collision_guard.py``).
+
+Mocking strategy (zero credits, zero network): mirror the proven Click-runner
+approach in ``tests/cli/test_cli_video_chain.py``. The orchestrator
+``gflow_cli.chain.run_chain`` is patched (it is the seam every link generation
+flows through), ``FlowApiClient`` is replaced with an async-context-manager
+double, and ``ChainLinkRecorder.open`` returns a ``MagicMock`` so no SQLite
+recorder or browser is ever touched. We assert *observable* outcomes — exit
+code, CLI output, and ``run_chain`` await-args (the link count submitted) —
+never internals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from gflow_cli import config
+from gflow_cli.cli_video import video
+from gflow_cli.errors import ChainPartialError, WireFormatError
+
+scenarios("video_chain.feature")
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_result_holder() -> dict[str, Any]:
+    return {"result": None}
+
+
+@pytest.fixture
+def chain_state() -> dict[str, Any]:
+    """Per-scenario shared state: manifest path, the patched ``run_chain``
+    mock (so Then-steps can read its await-args), the fake recorder, and the
+    earlier-clip paths a partial failure is expected to preserve."""
+    return {
+        "manifest": None,
+        "link_count": 0,
+        "run_chain": None,
+        "recorder": None,
+        "completed": 0,
+        "partial_paths": [],
+        "raised": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch_chain_profile_resolution(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Bypass profile resolution + provider-dir checks so the command reaches
+    the patched ``run_chain`` instead of bailing during profile discovery."""
+    monkeypatch.setattr("gflow_cli.cli_video._resolve_profile", lambda profile: "default")
+    monkeypatch.setattr("gflow_cli.cli_video._make_provider_dir", lambda name: tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> Generator[None, None, None]:
+    config.reset_settings()
+    yield
+    config.reset_settings()
+
+
+def _fake_async_client() -> MagicMock:
+    client = MagicMock(name="FlowApiClient")
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _fake_link_result(index: int, tmp_path: Path) -> Any:
+    from gflow_cli.chain import ChainLinkResult
+
+    clip = tmp_path / f"link{index}.mp4"
+    clip.touch()
+    return ChainLinkResult(
+        index=index,
+        prompt=f"link {index}",
+        local_path=clip,
+        media_id=f"media-{index}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Given steps
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("a chain manifest with {n:d} links"))
+def _manifest_with_links(chain_state: dict[str, Any], tmp_path: Path, n: int) -> None:
+    lines = [f'{{"prompt": "link {i}"}}' for i in range(n)]
+    path = tmp_path / "chain.jsonl"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    chain_state["manifest"] = path
+    chain_state["link_count"] = n
+
+
+@given(parsers.parse("the mocked chain aborts at link {k:d} with a WireFormatError"))
+def _mock_chain_aborts(
+    chain_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path, k: int
+) -> None:
+    """``run_chain`` raises ``ChainPartialError`` carrying the clips from links
+    1..k-1 — exactly what the orchestrator does when link k's wire lands on the
+    text route (``WireFormatError``) and aborts before link k+1. The completed
+    clips are preserved and re-billing must not occur on resume."""
+    completed = [_fake_link_result(i, tmp_path).local_path for i in range(k - 1)]
+    chain_state["partial_paths"] = completed
+
+    error = ChainPartialError(
+        detail=f"link {k} routed to text endpoint",
+        partial_results=completed,
+        cause=WireFormatError(detail="startImage dropped — text route", status=200),
+    )
+    chain_state["raised"] = error
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise error
+
+    mock_run = AsyncMock(side_effect=_boom)
+    monkeypatch.setattr("gflow_cli.chain.run_chain", mock_run)
+    monkeypatch.setattr("gflow_cli.cli_video.FlowApiClient", lambda **_kw: _fake_async_client())
+    chain_state["run_chain"] = mock_run
+
+
+@given(parsers.parse("the recorder reports {n:d} completed link"))
+@given(parsers.parse("the recorder reports {n:d} completed links"))
+def _recorder_completed(
+    chain_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch, n: int
+) -> None:
+    recorder = MagicMock(name="ChainLinkRecorder")
+    recorder.completed_links.return_value = [MagicMock() for _ in range(n)]
+    monkeypatch.setattr(
+        "gflow_cli.data.chain_repo.ChainLinkRecorder.open", lambda *_a, **_kw: recorder
+    )
+    chain_state["recorder"] = recorder
+    chain_state["completed"] = n
+
+
+@given(parsers.parse("the recorder reports {n:d} completed link whose seed frame is absent"))
+def _recorder_completed_no_seed(
+    chain_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch, n: int
+) -> None:
+    """Models the record-before-extract guarantee: the link's clip is recorded
+    (so ``completed_links`` counts it and resume skips regeneration) even though
+    its seed frame file is absent. Resume must therefore re-submit only the
+    remaining links — the recorded link is NOT regenerated."""
+    recorder = MagicMock(name="ChainLinkRecorder")
+    completed_link = MagicMock()
+    completed_link.seed_frame_path = None  # extraction never completed
+    recorder.completed_links.return_value = [completed_link for _ in range(n)]
+    monkeypatch.setattr(
+        "gflow_cli.data.chain_repo.ChainLinkRecorder.open", lambda *_a, **_kw: recorder
+    )
+    chain_state["recorder"] = recorder
+    chain_state["completed"] = n
+
+
+@given("the mocked chain completes the remaining links")
+def _mock_chain_completes(
+    chain_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    remaining = chain_state["link_count"] - chain_state["completed"]
+    results = [_fake_link_result(i, tmp_path) for i in range(remaining)]
+    mock_run = AsyncMock(return_value=results)
+    monkeypatch.setattr("gflow_cli.chain.run_chain", mock_run)
+    monkeypatch.setattr("gflow_cli.cli_video.FlowApiClient", lambda **_kw: _fake_async_client())
+    chain_state["run_chain"] = mock_run
+
+
+# ---------------------------------------------------------------------------
+# When steps
+# ---------------------------------------------------------------------------
+
+
+@when("I run the chain")
+def _run_chain(
+    runner: CliRunner, cli_result_holder: dict[str, Any], chain_state: dict[str, Any]
+) -> None:
+    cli_result_holder["result"] = runner.invoke(
+        video, ["chain", str(chain_state["manifest"]), "--yes"]
+    )
+
+
+@when("I run the chain with --dry-run")
+def _run_chain_dry_run(
+    runner: CliRunner,
+    cli_result_holder: dict[str, Any],
+    chain_state: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--dry-run must short-circuit before any generation. We install a
+    tripwire ``run_chain`` that fails the test if awaited, then assert it was
+    never called (proving zero credits)."""
+    mock_run = AsyncMock(side_effect=AssertionError("run_chain must not run on --dry-run"))
+    monkeypatch.setattr("gflow_cli.chain.run_chain", mock_run)
+    chain_state["run_chain"] = mock_run
+    cli_result_holder["result"] = runner.invoke(
+        video, ["chain", str(chain_state["manifest"]), "--dry-run"]
+    )
+
+
+@when("I resume the chain")
+def _resume_chain(
+    runner: CliRunner, cli_result_holder: dict[str, Any], chain_state: dict[str, Any]
+) -> None:
+    cli_result_holder["result"] = runner.invoke(
+        video,
+        ["chain", str(chain_state["manifest"]), "--resume-from", "chain-abc", "--yes"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then steps
+# ---------------------------------------------------------------------------
+
+
+@then(parsers.parse("the chain exit code is {code:d}"))
+def _check_exit(cli_result_holder: dict[str, Any], code: int) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == code, result.output
+
+
+@then("the chain output mentions resuming")
+def _check_resume_hint(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert "resume" in result.output.lower(), result.output
+
+
+@then("the partial result carries the earlier clip paths")
+def _check_partial_paths(chain_state: dict[str, Any]) -> None:
+    # The orchestrator raised ChainPartialError carrying the completed clips;
+    # the command surfaced it (exit 21) and the preserved paths are the
+    # earlier links 1..k-1, never the failed/later links.
+    err = chain_state["raised"]
+    assert isinstance(err, ChainPartialError)
+    assert err.partial_results == chain_state["partial_paths"]
+    assert err.partial_results, "expected the earlier clip paths to be preserved"
+
+
+@then(parsers.parse("link {k:d} was never generated"))
+def _check_link_never_generated(chain_state: dict[str, Any], k: int) -> None:
+    # The chain aborted (ChainPartialError) before link k; only links 1..k-1
+    # were preserved, so the clip for link k must never have been produced.
+    produced = {p.name for p in chain_state["partial_paths"]}
+    assert f"link{k - 1}.mp4" not in produced, produced
+
+
+@then(parsers.parse("the chain submitted only {n:d} links"))
+def _check_submitted_links(chain_state: dict[str, Any], n: int) -> None:
+    mock_run = chain_state["run_chain"]
+    mock_run.assert_awaited_once()
+    assert len(mock_run.await_args.kwargs["links"]) == n
+
+
+@then("the completed link was not regenerated")
+def _check_not_regenerated(chain_state: dict[str, Any]) -> None:
+    mock_run = chain_state["run_chain"]
+    submitted = len(mock_run.await_args.kwargs["links"])
+    # Resume submitted only the remaining links; the recorded link is excluded.
+    assert submitted == chain_state["link_count"] - chain_state["completed"]
+    chain_state["recorder"].completed_links.assert_called()
+
+
+@then(parsers.parse("the output reports the credit cost for {n:d} links"))
+def _check_credit_cost(cli_result_holder: dict[str, Any], n: int) -> None:
+    result = cli_result_holder["result"]
+    assert f"{n} credit(s)" in result.output, result.output
+
+
+@then("no generation was submitted")
+def _check_no_generation(chain_state: dict[str, Any], cli_result_holder: dict[str, Any]) -> None:
+    chain_state["run_chain"].assert_not_awaited()
+    assert "no credits spent" in cli_result_holder["result"].output

--- a/tests/features/video_chain.feature
+++ b/tests/features/video_chain.feature
@@ -1,0 +1,37 @@
+Feature: Video chain orchestration
+
+  Background:
+    Given a chain manifest with 3 links
+
+  Scenario: Mid-chain failure preserves completed links and does not re-bill on resume
+    Given the mocked chain aborts at link 2 with a WireFormatError
+    When I run the chain
+    Then the chain exit code is 21
+    And the chain output mentions resuming
+    And the partial result carries the earlier clip paths
+    Given the recorder reports 1 completed link
+    And the mocked chain completes the remaining links
+    When I resume the chain
+    Then the chain exit code is 0
+    And the chain submitted only 2 links
+
+  Scenario: A link routing to the text endpoint aborts the chain
+    Given the mocked chain aborts at link 2 with a WireFormatError
+    When I run the chain
+    Then the chain exit code is 21
+    And link 3 was never generated
+    And the partial result carries the earlier clip paths
+
+  Scenario: Dry-run reports cost without spending credits
+    When I run the chain with --dry-run
+    Then the chain exit code is 0
+    And the output reports the credit cost for 3 links
+    And no generation was submitted
+
+  Scenario: A crash between download and extraction resumes at extraction
+    Given the recorder reports 1 completed link whose seed frame is absent
+    And the mocked chain completes the remaining links
+    When I resume the chain
+    Then the chain exit code is 0
+    And the chain submitted only 2 links
+    And the completed link was not regenerated

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -85,17 +85,15 @@ def _make_client(results: list[VideoResult]) -> MagicMock:
     is irrelevant; we still ``touch`` it to mimic a completed download.
     """
     client = MagicMock(name="FlowApiClient")
+    results_iter = iter(results)
 
     async def _gen(*, req: GenerateVideoRequest, **_: Any) -> VideoResult:
-        idx = _gen.call_index
-        _gen.call_index += 1
-        result = results[idx]
+        result = next(results_iter)
         if result.local_path is not None:
             result.local_path.parent.mkdir(parents=True, exist_ok=True)
             result.local_path.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-clip")
         return result
 
-    _gen.call_index = 0
     client.generate_video = AsyncMock(side_effect=_gen)
     return client
 
@@ -233,10 +231,12 @@ async def test_aborts_on_wire_format_error_preserving_partial_results(tmp_path: 
     the failure. The failing link and any later links are NOT generated."""
     good = _ok_result("m0", tmp_path / "link0.mp4")
     client = MagicMock(name="FlowApiClient")
+    calls = 0
 
     async def _gen(*, req: GenerateVideoRequest, **_: Any) -> VideoResult:
-        idx = _gen.call_index
-        _gen.call_index += 1
+        nonlocal calls
+        idx = calls
+        calls += 1
         if idx == 0:
             assert good.local_path is not None
             good.local_path.write_bytes(b"\x00\x00\x00\x18ftypmp42")
@@ -247,7 +247,6 @@ async def test_aborts_on_wire_format_error_preserving_partial_results(tmp_path: 
             discovery={"route_name": "batchAsyncGenerateVideoText"},
         )
 
-    _gen.call_index = 0
     client.generate_video = AsyncMock(side_effect=_gen)
 
     specs = [

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -291,6 +291,65 @@ async def test_rejects_non_interpolation_model_up_front(tmp_path: Path) -> None:
     client.generate_video.assert_not_awaited()
 
 
+async def test_per_link_recording_hooks_threaded_with_own_request(tmp_path: Path) -> None:
+    """run_chain forwards the per-link ``on_started`` into generate_video and
+    calls ``on_link_completed`` once per link — each with that link's OWN request
+    (link 0 T2V, link 1 I2V). This is the catalog-persistence wiring the CLI uses
+    to record every chain link in the ``videos`` table (parity with t2v/i2v).
+    """
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+    ]
+    client = _make_client(results)
+
+    # on_link_started is a factory: given the link's request, it returns the
+    # ``on_started`` callback forwarded into generate_video. Track which request
+    # each factory call saw and return a distinct sentinel per link.
+    started_requests: list[GenerateVideoRequest] = []
+    sentinels: dict[int, Any] = {}
+
+    def _on_link_started(request: GenerateVideoRequest) -> Any:
+        idx = len(started_requests)
+        started_requests.append(request)
+        sentinel = object()
+        sentinels[idx] = sentinel
+        return sentinel
+
+    completed: list[tuple[GenerateVideoRequest, VideoResult]] = []
+
+    def _on_link_completed(request: GenerateVideoRequest, result: VideoResult) -> None:
+        completed.append((request, result))
+
+    await run_chain(
+        client=client,
+        links=_two_link_specs(),
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        extractor=_fake_extractor([]),
+        on_link_started=_on_link_started,
+        on_link_completed=_on_link_completed,
+    )
+
+    # The factory ran once per link, with that link's own request (correct mode).
+    assert len(started_requests) == 2
+    assert started_requests[0].mode is Mode.T2V
+    assert started_requests[1].mode is Mode.I2V
+
+    # generate_video received each link's on_started sentinel (per-link, in order).
+    forwarded = [c.kwargs.get("on_started") for c in client.generate_video.await_args_list]
+    assert forwarded == [sentinels[0], sentinels[1]]
+
+    # on_link_completed fired once per link, with the SAME per-link request that
+    # was sent to generate_video and the matching result.
+    assert len(completed) == 2
+    sent_reqs = [c.kwargs["req"] for c in client.generate_video.await_args_list]
+    assert completed[0][0] is sent_reqs[0]
+    assert completed[1][0] is sent_reqs[1]
+    assert completed[0][1] is results[0]
+    assert completed[1][1] is results[1]
+
+
 async def test_aspect_propagates_to_every_link(tmp_path: Path) -> None:
     """The chain-level aspect is applied to each generated link (continuity
     requires a uniform aspect across the sequence)."""

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -47,7 +47,6 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from gflow_cli.chain import ChainLinkSpec, run_chain
 
 from gflow_cli.api.video import (
     Aspect,
@@ -57,6 +56,7 @@ from gflow_cli.api.video import (
     VideoResult,
     VideoStatus,
 )
+from gflow_cli.chain import ChainLinkSpec, run_chain
 from gflow_cli.errors import (
     ChainPartialError,
     ModelModeIncompatibilityError,

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,314 @@
+"""Unit tests for gflow_cli.chain — sequential last-frame I2V orchestrator (Task 1, RED).
+
+================================================================================
+run_chain SIGNATURE CONTRACT (Task 7 MUST conform to this — keep it stable)
+================================================================================
+
+    async def run_chain(
+        *,
+        client: FlowApiClient,                 # mocked here; async generate_video(req=...)
+        links: list[ChainLinkSpec],            # ordered per-link prompts/overrides
+        out_dir: Path,                         # where clips + seed frames land
+        model: VideoModel,                     # MUST support i2v; else reject up front
+        extractor: FrameExtractor = ...,       # (src, dst, *, offset_ms=0) -> Path
+        recorder: ChainRecorder | None = None, # record_chain_link(...) BEFORE extraction
+        aspect: Aspect = Aspect.PORTRAIT,
+        seed_offset_ms: int = 0,
+        jitter: float = 0.0,
+    ) -> list[ChainLinkResult]
+
+Behavioural contract asserted below:
+  * Links run STRICTLY sequentially (concurrency=1); generate_video is awaited
+    once per link in order.
+  * Link 0 is T2V (no start_image); link N>0 is I2V whose ``start_image`` is the
+    extracted last frame of link N-1.
+  * A per-link ``WireFormatError`` (i2v silently routed to t2v backstop) ABORTS
+    the chain and raises ``ChainPartialError(partial_results=[...])`` carrying the
+    Paths of the links completed BEFORE the failure.
+  * RECORD-BEFORE-EXTRACT: for each completed link the recorder is invoked
+    (clip persisted) BEFORE the extractor runs on that clip — so a crash in the
+    download->extract gap resumes at extraction, never re-generates.
+  * A non-interpolation model (e.g. omni_flash) is REJECTED up front
+    (``ModelModeIncompatibilityError``) before any generate_video call fires.
+
+Types referenced (defined by Task 7 in chain.py): ``ChainLinkSpec`` (prompt +
+optional model/duration/aspect override) and ``ChainLinkResult`` (carries
+``local_path: Path`` + ``media_id``). The tests below are permissive about the
+exact extra fields and only pin the load-bearing ones.
+
+Until Task 7 lands ``src/gflow_cli/chain.py`` this module fails at import /
+collection — that is the EXPECTED red state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from gflow_cli.chain import ChainLinkSpec, run_chain
+
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+    VideoStatus,
+)
+from gflow_cli.errors import (
+    ChainPartialError,
+    ModelModeIncompatibilityError,
+    WireFormatError,
+)
+
+
+# --------------------------------------------------------------------------- #
+# helpers / fixtures
+# --------------------------------------------------------------------------- #
+def _ok_result(media_id: str, local_path: Path) -> VideoResult:
+    """A successful, downloaded VideoResult for one link."""
+    return VideoResult(
+        status=VideoStatus(media_id=media_id, status="MEDIA_GENERATION_STATUS_SUCCESSFUL"),
+        local_path=local_path,
+        project_id=f"proj-{media_id}",
+        flow_operation_id=f"op-{media_id}",
+    )
+
+
+def _make_client(results: list[VideoResult]) -> MagicMock:
+    """A mock FlowApiClient whose ``generate_video`` yields ``results`` in order.
+
+    Each call writes its ``local_path`` to disk so a real extractor (if used)
+    would have a file — but tests inject a fake extractor, so the file content
+    is irrelevant; we still ``touch`` it to mimic a completed download.
+    """
+    client = MagicMock(name="FlowApiClient")
+
+    async def _gen(*, req: GenerateVideoRequest, **_: Any) -> VideoResult:
+        idx = _gen.call_index
+        _gen.call_index += 1
+        result = results[idx]
+        if result.local_path is not None:
+            result.local_path.parent.mkdir(parents=True, exist_ok=True)
+            result.local_path.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-clip")
+        return result
+
+    _gen.call_index = 0
+    client.generate_video = AsyncMock(side_effect=_gen)
+    return client
+
+
+def _fake_extractor(written: list[Path]) -> Any:
+    """A drop-in for ``extract_last_frame``: writes a JPEG-ish file to ``dst``
+    and records the call order in ``written``."""
+
+    def _extract(src: Path, dst: Path, *, offset_ms: int = 0) -> Path:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(b"\xff\xd8\xff\xd9")  # minimal JPEG sentinel
+        written.append(dst)
+        return dst
+
+    return _extract
+
+
+def _two_link_specs() -> list[ChainLinkSpec]:
+    return [
+        ChainLinkSpec(prompt="a cat wakes up"),
+        ChainLinkSpec(prompt="the cat stretches and walks off"),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# tests
+# --------------------------------------------------------------------------- #
+async def test_links_run_strictly_sequentially(tmp_path: Path) -> None:
+    """generate_video is awaited exactly once per link, in link order."""
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+        _ok_result("m2", tmp_path / "link2.mp4"),
+    ]
+    client = _make_client(results)
+    specs = [
+        ChainLinkSpec(prompt="p0"),
+        ChainLinkSpec(prompt="p1"),
+        ChainLinkSpec(prompt="p2"),
+    ]
+
+    out = await run_chain(
+        client=client,
+        links=specs,
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        extractor=_fake_extractor([]),
+    )
+
+    assert client.generate_video.await_count == 3
+    assert len(out) == 3
+    # The prompts went out in order.
+    sent_prompts = [c.kwargs["req"].prompt for c in client.generate_video.await_args_list]
+    assert sent_prompts == ["p0", "p1", "p2"]
+
+
+async def test_link0_is_t2v_and_subsequent_links_chain_last_frame(tmp_path: Path) -> None:
+    """Link 0 is T2V (no start_image); link N's start_image is the extracted
+    last frame of link N-1 (the file the extractor wrote after link N-1)."""
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+    ]
+    client = _make_client(results)
+    written: list[Path] = []
+
+    await run_chain(
+        client=client,
+        links=_two_link_specs(),
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        extractor=_fake_extractor(written),
+    )
+
+    reqs = [c.kwargs["req"] for c in client.generate_video.await_args_list]
+    assert len(reqs) == 2
+
+    # Link 0: text-to-video, no seed frame.
+    assert reqs[0].mode is Mode.T2V
+    assert reqs[0].start_image is None
+
+    # Link 1: image-to-video seeded by the frame the extractor produced for link 0.
+    assert reqs[1].mode is Mode.I2V
+    assert reqs[1].start_image is not None
+    assert written, "extractor must have run on link 0 before link 1 generated"
+    assert reqs[1].start_image == written[0], (
+        "link 1 start_image must be the extracted last frame of link 0"
+    )
+
+
+async def test_record_before_extract_ordering(tmp_path: Path) -> None:
+    """RECORD-BEFORE-EXTRACT: each link's clip is persisted via the recorder
+    BEFORE the extractor is invoked on that clip.
+
+    A shared ``MagicMock`` (manager) records both the recorder call and the
+    extractor call, so ``mock_calls`` preserves their relative ordering.
+    """
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+    ]
+    client = _make_client(results)
+
+    manager = MagicMock()
+    recorder = MagicMock(name="ChainRecorder")
+    recorder.record_chain_link = manager.record  # funnel into the shared manager
+
+    def _spy_extract(src: Path, dst: Path, *, offset_ms: int = 0) -> Path:
+        manager.extract(src, dst)
+        dst.write_bytes(b"\xff\xd8\xff\xd9")
+        return dst
+
+    await run_chain(
+        client=client,
+        links=_two_link_specs(),
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        extractor=_spy_extract,
+        recorder=recorder,
+    )
+
+    # Reduce mock_calls to the ordered sequence of method names.
+    order = [c[0] for c in manager.mock_calls if c[0] in ("record", "extract")]
+    # For link 0: record MUST precede extract.
+    assert order[0] == "record", f"expected record-before-extract, got order={order}"
+    assert "extract" in order
+    assert order.index("record") < order.index("extract"), (
+        f"clip must be persisted before extraction; order={order}"
+    )
+
+
+async def test_aborts_on_wire_format_error_preserving_partial_results(tmp_path: Path) -> None:
+    """A per-link WireFormatError (i2v routed to t2v backstop) aborts the chain
+    and raises ChainPartialError carrying the Paths of the links completed BEFORE
+    the failure. The failing link and any later links are NOT generated."""
+    good = _ok_result("m0", tmp_path / "link0.mp4")
+    client = MagicMock(name="FlowApiClient")
+
+    async def _gen(*, req: GenerateVideoRequest, **_: Any) -> VideoResult:
+        idx = _gen.call_index
+        _gen.call_index += 1
+        if idx == 0:
+            assert good.local_path is not None
+            good.local_path.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+            return good
+        # link 1 silently routed to the text endpoint -> backstop fires.
+        raise WireFormatError(
+            detail="i2v_routed_to_t2v",
+            discovery={"route_name": "batchAsyncGenerateVideoText"},
+        )
+
+    _gen.call_index = 0
+    client.generate_video = AsyncMock(side_effect=_gen)
+
+    specs = [
+        ChainLinkSpec(prompt="p0"),
+        ChainLinkSpec(prompt="p1"),
+        ChainLinkSpec(prompt="p2"),
+    ]
+
+    with pytest.raises(ChainPartialError) as excinfo:
+        await run_chain(
+            client=client,
+            links=specs,
+            out_dir=tmp_path,
+            model=VideoModel.VEO_3_1_LITE,
+            extractor=_fake_extractor([]),
+        )
+
+    # Only the first link generated + the failing link were attempted: 2 calls.
+    assert client.generate_video.await_count == 2, "must NOT generate link 2 after abort"
+
+    partials = excinfo.value.partial_results
+    assert isinstance(partials, list)
+    assert len(partials) == 1, "exactly the one completed link is preserved"
+    assert all(isinstance(p, Path) for p in partials)
+    assert partials[0] == good.local_path
+
+
+async def test_rejects_non_interpolation_model_up_front(tmp_path: Path) -> None:
+    """A non-interpolation model (omni_flash) is rejected BEFORE any spend:
+    ModelModeIncompatibilityError, and generate_video is never awaited."""
+    client = _make_client([])
+
+    with pytest.raises(ModelModeIncompatibilityError):
+        await run_chain(
+            client=client,
+            links=_two_link_specs(),
+            out_dir=tmp_path,
+            model=VideoModel.OMNI_FLASH,
+            extractor=_fake_extractor([]),
+        )
+
+    client.generate_video.assert_not_awaited()
+
+
+async def test_aspect_propagates_to_every_link(tmp_path: Path) -> None:
+    """The chain-level aspect is applied to each generated link (continuity
+    requires a uniform aspect across the sequence)."""
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+    ]
+    client = _make_client(results)
+
+    await run_chain(
+        client=client,
+        links=_two_link_specs(),
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        aspect=Aspect.LANDSCAPE,
+        extractor=_fake_extractor([]),
+    )
+
+    aspects = {c.kwargs["req"].aspect for c in client.generate_video.await_args_list}
+    assert aspects == {Aspect.LANDSCAPE}

--- a/tests/test_chain_manifest.py
+++ b/tests/test_chain_manifest.py
@@ -1,0 +1,243 @@
+"""Unit tests for gflow_cli.chain_manifest — JSONL chain-manifest parser (Task 6).
+
+The parser turns an ordered JSONL manifest into ``list[ChainLinkSpec]``, one
+spec per line, preserving order. ``prompt`` is required; ``model`` / ``duration``
+/ ``aspect`` are optional per-link overrides mapped through the SAME canonical
+path the CLI uses (``VideoModel.from_cli`` / ``Aspect.from_cli``). Blank lines
+and ``#``-comment lines are skipped. Any malformed input raises
+``ChainManifestError`` citing the offending line number.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.api.video import Aspect, VideoModel
+from gflow_cli.chain import ChainLinkSpec
+from gflow_cli.chain_manifest import parse_chain_manifest
+from gflow_cli.errors import ChainManifestError, ConfigurationError
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "chain.jsonl"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+
+def test_parses_minimal_prompt_only_line(tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"prompt": "a lone wolf on a ridge"}\n')
+
+    links = parse_chain_manifest(path)
+
+    assert links == [ChainLinkSpec(prompt="a lone wolf on a ridge")]
+    assert links[0].model is None
+    assert links[0].duration is None
+    assert links[0].aspect is None
+
+
+def test_parses_multi_link_in_order_with_and_without_overrides(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '{"prompt": "first", "model": "veo-lite", "duration": 4, "aspect": "16:9"}\n'
+        '{"prompt": "second"}\n'
+        '{"prompt": "third", "duration": 8}\n',
+    )
+
+    links = parse_chain_manifest(path)
+
+    assert [link.prompt for link in links] == ["first", "second", "third"]
+    # Link 0: full overrides, mapped via the canonical from_cli paths.
+    assert links[0].model is VideoModel.VEO_3_1_LITE
+    assert links[0].duration == 4
+    assert links[0].aspect is Aspect.LANDSCAPE
+    # Link 1: prompt-only — everything inherits (None).
+    assert links[1] == ChainLinkSpec(prompt="second")
+    # Link 2: partial override (duration only).
+    assert links[2].model is None
+    assert links[2].duration == 8
+    assert links[2].aspect is None
+
+
+def test_model_alias_maps_through_from_cli(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '{"prompt": "p", "model": "veo-quality"}\n{"prompt": "q", "model": "veo_3_1_fast"}\n',
+    )
+
+    links = parse_chain_manifest(path)
+
+    assert links[0].model is VideoModel.VEO_3_1_QUALITY
+    assert links[1].model is VideoModel.VEO_3_1_FAST
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("9:16", Aspect.PORTRAIT),
+        ("16:9", Aspect.LANDSCAPE),
+        ("1:1", Aspect.SQUARE),
+    ],
+)
+def test_aspect_token_maps_through_from_cli(tmp_path: Path, token: str, expected: Aspect) -> None:
+    path = _write(tmp_path, f'{{"prompt": "p", "aspect": "{token}"}}\n')
+
+    links = parse_chain_manifest(path)
+
+    assert links[0].aspect is expected
+
+
+# --------------------------------------------------------------------------- #
+# Comment / blank-line skipping
+# --------------------------------------------------------------------------- #
+
+
+def test_skips_blank_and_comment_lines_preserving_order(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '# a leading comment\n\n{"prompt": "first"}\n   \n# mid comment\n{"prompt": "second"}\n',
+    )
+
+    links = parse_chain_manifest(path)
+
+    assert [link.prompt for link in links] == ["first", "second"]
+
+
+# --------------------------------------------------------------------------- #
+# Empty manifest
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_file_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path, "")
+
+    with pytest.raises(ChainManifestError):
+        parse_chain_manifest(path)
+
+
+def test_comments_only_file_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path, "# only a comment\n\n   \n")
+
+    with pytest.raises(ChainManifestError):
+        parse_chain_manifest(path)
+
+
+def test_chain_manifest_error_is_configuration_error(tmp_path: Path) -> None:
+    # Inherits ConfigurationError -> exit code 11 via the EXIT_CODE_MAP walk.
+    path = _write(tmp_path, "")
+
+    with pytest.raises(ConfigurationError):
+        parse_chain_manifest(path)
+
+
+# --------------------------------------------------------------------------- #
+# Malformed rows — each cites the offending line number
+# --------------------------------------------------------------------------- #
+
+
+def test_bad_json_cites_line_number(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '{"prompt": "ok"}\n{not valid json\n',
+    )
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 2" in str(exc_info.value)
+
+
+def test_non_object_json_cites_line_number(tmp_path: Path) -> None:
+    # A JSON array is valid JSON but not a chain-link object.
+    path = _write(tmp_path, '["prompt", "not an object"]\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_missing_prompt_cites_line_number(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '{"prompt": "ok"}\n{"model": "veo-lite"}\n',
+    )
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 2" in str(exc_info.value)
+
+
+def test_empty_prompt_cites_line_number(tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"prompt": "   "}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_non_string_prompt_cites_line_number(tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"prompt": 123}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_unknown_model_cites_line_number(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        '{"prompt": "ok"}\n{"prompt": "bad", "model": "totally-made-up"}\n',
+    )
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 2" in str(exc_info.value)
+
+
+def test_invalid_aspect_cites_line_number(tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"prompt": "p", "aspect": "4:3"}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_non_int_duration_cites_line_number(tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"prompt": "p", "duration": "four"}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_bool_duration_rejected(tmp_path: Path) -> None:
+    # bool is a subclass of int; a JSON true must NOT slip through as duration.
+    path = _write(tmp_path, '{"prompt": "p", "duration": true}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)
+
+
+def test_unknown_key_cites_line_number(tmp_path: Path) -> None:
+    # Surface a typo'd field rather than silently dropping it.
+    path = _write(tmp_path, '{"prompt": "p", "modle": "veo-lite"}\n')
+
+    with pytest.raises(ChainManifestError) as exc_info:
+        parse_chain_manifest(path)
+
+    assert "line 1" in str(exc_info.value)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -11,9 +11,11 @@ from gflow_cli.errors import (
     AuthBrowserRejectedError,
     AuthExpiredError,
     AuthMissingError,
+    ChainPartialError,
     ConfigurationError,
     ContentPolicyError,
     FlowApiError,
+    FrameExtractionError,
     GFlowError,
     ModelModeIncompatibilityError,
     NetworkError,
@@ -394,3 +396,45 @@ def test_exceptions_module_is_alias_for_errors() -> None:
     assert _exceptions.ContentPolicyError is _errors.ContentPolicyError
     assert _exceptions.EXIT_CODE_MAP is _errors.EXIT_CODE_MAP
     assert _exceptions.ProblemDetails is _errors.ProblemDetails
+
+
+# ---------- Video-chain error classes (Task 1 / Task 3) ----------
+
+
+def test_frame_extraction_error_exit_code_20() -> None:
+    """FrameExtractionError -> exit code 20 (current max is 19, so 20 is free).
+
+    Raised by the PyAV last-frame extractor when ``av`` is missing or the input
+    is undecodable; carries an install-hint remediation."""
+    err = FrameExtractionError(detail="av not installed")
+    assert _exit_code_for(err) == 20
+    assert EXIT_CODE_MAP[FrameExtractionError] == 20
+    assert isinstance(err, GFlowError)
+    # Has a remediation hint (the install-the-extra guidance).
+    assert err.remediation_hint != ""
+
+
+def test_chain_partial_error_exit_code_21_and_partial_results() -> None:
+    """ChainPartialError -> exit code 21, carrying the Paths of completed links.
+
+    Mirrors BatchPartialError but for the sequential video chain: a mid-chain
+    failure must surface the already-paid-for clips so they are not lost."""
+    from pathlib import Path
+
+    completed = [Path("link0.mp4"), Path("link1.mp4")]
+    err = ChainPartialError(
+        detail="link 2 routed to t2v",
+        partial_results=completed,
+    )
+    assert _exit_code_for(err) == 21
+    assert EXIT_CODE_MAP[ChainPartialError] == 21
+    assert err.partial_results == completed
+    assert all(isinstance(p, Path) for p in err.partial_results)
+    assert isinstance(err, GFlowError)
+
+
+def test_chain_partial_error_partial_results_defaults_empty() -> None:
+    """A ChainPartialError raised before any link completes carries an empty
+    (but present) ``partial_results`` list — never None."""
+    err = ChainPartialError(detail="first link failed")
+    assert err.partial_results == []

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,158 @@
+"""Unit tests for gflow_cli.media — PyAV last-frame extractor (Task 1, RED).
+
+These tests are written against the Task-5 contract:
+
+    extract_last_frame(src: Path, dst: Path, *, offset_ms: int = 0) -> Path
+
+    - Decodes the LAST frame of ``src`` (an mp4), writes a JPEG to ``dst``,
+      and returns ``dst``.
+    - Raises ``FrameExtractionError`` when the ``av`` package is unavailable
+      (install hint -> ``pip install 'gflow-cli[chain]'``) OR when ``src`` is
+      undecodable.
+    - ``offset_ms`` seeds a frame BEFORE the end (e.g. to avoid a black/fade
+      final frame, scenario #11).
+
+Until Task 5 lands ``src/gflow_cli/media.py`` this module fails at import /
+collection — that is the EXPECTED red state.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from gflow_cli.media import extract_last_frame
+
+from gflow_cli.errors import FrameExtractionError
+
+# ``av`` is an OPTIONAL extra (``gflow-cli[chain]``). The happy-path tests that
+# synthesise a real mp4 require it; skip them (rather than fail) when it is not
+# installed in the current environment.
+av = pytest.importorskip("av", reason="requires the optional `gflow-cli[chain]` extra (av)")
+
+
+def _write_synthetic_mp4(
+    dst: Path, *, frames: int = 10, width: int = 320, height: int = 240
+) -> Path:
+    """Encode a tiny solid-colour mp4 with PyAV so the extractor has a real,
+    decodable input. The final frame is a DISTINCT colour so a test could in
+    principle assert which frame was captured."""
+    import numpy as np
+
+    container = av.open(str(dst), mode="w")
+    try:
+        stream = container.add_stream("mpeg4", rate=10)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        for i in range(frames):
+            # ramp the green channel so the last frame differs from the first.
+            shade = int(20 + (i / max(frames - 1, 1)) * 200)
+            arr = np.full((height, width, 3), 0, dtype="uint8")
+            arr[:, :, 1] = shade
+            frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():  # flush
+            container.mux(packet)
+    finally:
+        container.close()
+    return dst
+
+
+@pytest.fixture
+def synthetic_mp4(tmp_path: Path) -> Path:
+    pytest.importorskip("numpy")
+    return _write_synthetic_mp4(tmp_path / "clip.mp4")
+
+
+def _is_jpeg(path: Path) -> bool:
+    """JPEG magic bytes: FF D8 ... FF D9."""
+    data = path.read_bytes()
+    return len(data) >= 3 and data[:2] == b"\xff\xd8" and data[-2:] == b"\xff\xd9"
+
+
+def test_extract_last_frame_returns_valid_jpeg_path(synthetic_mp4: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "frame.jpg"
+    result = extract_last_frame(synthetic_mp4, dst)
+    assert result == dst
+    assert dst.exists()
+    assert _is_jpeg(dst), "extractor must write a real JPEG (FF D8 .. FF D9)"
+
+
+def test_extract_last_frame_honors_offset_ms(synthetic_mp4: Path, tmp_path: Path) -> None:
+    """``offset_ms`` seeds a frame BEFORE EOF; both calls still produce a JPEG.
+
+    We assert the offset path is exercised without error and yields a valid
+    JPEG — the precise pixel content is a Task-5 concern, not a Task-1 one.
+    A non-zero offset must NOT raise and must still return ``dst``.
+    """
+    dst_eof = tmp_path / "eof.jpg"
+    dst_offset = tmp_path / "offset.jpg"
+
+    out_eof = extract_last_frame(synthetic_mp4, dst_eof, offset_ms=0)
+    out_offset = extract_last_frame(synthetic_mp4, dst_offset, offset_ms=200)
+
+    assert out_eof == dst_eof
+    assert out_offset == dst_offset
+    assert _is_jpeg(dst_eof)
+    assert _is_jpeg(dst_offset)
+
+
+def test_extract_last_frame_unicode_and_space_dst_path(synthetic_mp4: Path, tmp_path: Path) -> None:
+    """Scenario #12: a Unicode + space destination path must work (Windows
+    cp1252 / path-encoding traps)."""
+    dst = tmp_path / "saída de vídeo 日本語.jpg"
+    result = extract_last_frame(synthetic_mp4, dst)
+    assert result == dst
+    assert dst.exists()
+    assert _is_jpeg(dst)
+
+
+def test_extract_last_frame_raises_on_undecodable_input(tmp_path: Path) -> None:
+    """A file that is not a valid mp4 must raise ``FrameExtractionError`` (not a
+    bare PyAV/OSError) so callers get the typed exit code 20."""
+    bogus = tmp_path / "not_a_video.mp4"
+    bogus.write_bytes(b"this is definitely not an mp4 container")
+    dst = tmp_path / "frame.jpg"
+    with pytest.raises(FrameExtractionError):
+        extract_last_frame(bogus, dst)
+
+
+def test_extract_last_frame_raises_when_av_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the optional ``av`` package is not importable, the extractor must
+    raise ``FrameExtractionError`` with an install hint — NOT a bare
+    ``ModuleNotFoundError`` — so the CLI maps it to exit code 20.
+
+    We simulate the missing extra by poisoning ``sys.modules['av']`` to None
+    (which makes ``import av`` raise ImportError) and re-importing the module so
+    a deferred (function-level) import re-evaluates.
+    """
+    # Poison the import: ``import av`` -> ImportError while this is set.
+    monkeypatch.setitem(sys.modules, "av", None)
+
+    # Re-import media so any module-level ``import av`` is re-evaluated under the
+    # poisoned state. If media imports av lazily (inside the function), this is a
+    # harmless no-op and the function-level guard still fires below.
+    import gflow_cli.media as media_module
+
+    media_module = importlib.reload(media_module)
+
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(b"\x00\x00\x00\x18ftypmp42")  # plausible header; never decoded
+    dst = tmp_path / "frame.jpg"
+
+    with pytest.raises(FrameExtractionError) as excinfo:
+        media_module.extract_last_frame(src, dst)
+
+    # Remediation must point users at the optional extra.
+    hint = excinfo.value.remediation_hint
+    assert "chain" in hint.lower(), "FrameExtractionError must hint at gflow-cli[chain]"
+
+    # Restore a clean module import for the rest of the session.
+    monkeypatch.undo()
+    importlib.reload(media_module)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -23,9 +23,9 @@ import sys
 from pathlib import Path
 
 import pytest
-from gflow_cli.media import extract_last_frame
 
 from gflow_cli.errors import FrameExtractionError
+from gflow_cli.media import extract_last_frame
 
 # ``av`` is an OPTIONAL extra (``gflow-cli[chain]``). The happy-path tests that
 # synthesise a real mp4 require it; skip them (rather than fail) when it is not


### PR DESCRIPTION
## Summary

Adds **`gflow video chain`** — last-frame I2V *chaining*: given a JSONL manifest of N prompts, generate clip 1, extract its **last frame** (PyAV, the new `gflow-cli[chain]` extra — no system ffmpeg), feed it as the `startImage` of the next I2V generation, and repeat → visually continuous footage. Complementary to (not a replacement for) the credit-free `gflow scene` concat.

**Credit-safety (the critical concern — each link spends a real credit):**
- Model pinned to an interpolation-capable Veo model; `omni-flash`/non-interpolation rejected up front (`ModelModeIncompatibilityError`, exit 17).
- Per-link wire-route abort: if a link silently routes to the text endpoint, the existing Layer-2 `WireFormatError` backstop fires → `ChainPartialError` (exit 21) **aborting the chain** before the next link (preserves completed clips).
- Stop-on-403 (`WafRejectionError`), inter-link jitter.
- **Record-before-extract** persistence (migration `0005`) so a crash between download↔extract resumes at extraction, never regeneration.
- `--max-links`, `--yes`/cost-estimate, `--dry-run` (creates no client, spends nothing), `--resume-from` (skips already-paid links, no re-billing).

**Deferred (documented in KNOWN_ISSUES):** single-file auto-concat — generation can't pin all links to one project and Flow's concat is project-scoped, so chain outputs **N clips**; stitch via `gflow scene`. Also documented: `--resume-from` re-seeds the first resumed link as T2V (credit-safe, continuity restarts), and the black/fade final-frame caveat (`--seed-offset`).

## Provenance

`/gflow:predict` (GO — a live 2-link continuity smoke passed: link 2 fired `…batchAsyncGenerateVideoStartImage` with a non-null `startImage`, 2 credits) → `/gflow:scenario` (19 scenarios, 7 must-cover) → plan council (caught the auto-concat project-pinning blocker → deferred) → subagent-driven TDD build (9 tasks, two-stage reviewed) → final code review (APPROVE).

## Test plan

- [x] Unit — extractor (`test_media.py`), orchestrator (`test_chain.py`), JSONL manifest (`test_chain_manifest.py`), errors 20/21 + ordering invariant, data recorder + migration `0005`
- [x] CLI (`test_cli_video_chain.py`) — cost gate, `--dry-run` (no client/no spend), `--max-links`, model rejection, `--resume-from`, partial→exit 21, `--json` single-document
- [x] BDD (`video_chain.feature`) — partial-resume-no-rebill, text-route abort, dry-run, mid-link-crash-resumes-at-extraction
- [x] `pyright src` 0 errors · `ruff check`/`format` clean (src+tests) · **318 scoped tests pass**
- [ ] **Opt-in live e2e** (`tests/e2e/test_chain_e2e.py`, `@e2e_video`, default-skipped) — run on an eligible account to confirm the 5-layer continuity ledger end-to-end before release
- [ ] Reviewer: confirm visual continuity on a real run (the wire path is already live-proven)

Refs the deferred auto-concat follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
