### PR TITLE
feat: character-create flow recorder + #153 locale fix

### DIFF
--- a/docs/superpowers/plans/2026-06-04-character-create-recording.md
+++ b/docs/superpowers/plans/2026-06-04-character-create-recording.md
@@ -1,0 +1,428 @@
+# Character-Create Recording Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make gflow's REAL `character create` flow recordable as a browser-only video (for the gflow-cli-remotion promo) without leaking any recording concern into core code.
+
+**Architecture:** The `FlowApiClient` owns the single Playwright browser context that the UI-automation transport shares (client-owned path: `transport.setup(page=self._page)`). Therefore the context that must be recorded is the *client's*, launched in `FlowApiClient._enter_setup` (`client.py:280`). We make exactly one behavior-preserving change to core — extract that `launch_persistent_context(**kwargs)` call's kwargs into an overridable `_persistent_context_kwargs()` seam (no new behavior, no env reads, no recording concept). All recording lives in dev-scoped infra (`scripts/dev/`): a `RecordingFlowApiClient(FlowApiClient)` subclass overrides only that seam to add Playwright `record_video_dir`, and a recorder driver runs the genuine `character_create` service through it. Image generation is free (only video costs credits), so a real recorded run costs nothing.
+
+**Tech Stack:** Python 3.13, Playwright (async, `record_video_dir`), pytest, ruff/pyright, ffmpeg (webm→mp4). gflow services: `services.character_create.character_create`, `api.client.FlowApiClient`, `api.character.CharacterImageRequest`, `data.recorder.OperationRecorder`.
+
+**Process:** Lean — this plan + `/gflow:branch-review` before PR. Skip the 5-persona `/gflow:predict` (behavior-preserving refactor + inert subclass, not a new transport/auth change).
+
+**Why NOT the transport seam:** in the client-owned path the transport reuses the client's page and never calls its own `launch_persistent_context` (`ui_automation.py:574-580`). Recording the transport's context would record a context that is never used. The client's context is the real one.
+
+---
+
+## ⚠️ COUNCIL REVISION (2026-06-04) — READ FIRST; OVERRIDES CONFLICTING TASK TEXT BELOW
+
+A full grounded LLM council reviewed this plan against the real source. **Verdict: GO-WITH-FIXES.** The
+architecture is verified sound (single client-owned persistent context; the Task-1 seam is a
+value-for-value faithful reproduction of `client.py:280-289`; `concurrency` defaults to 1 → exactly one
+`.webm`). Apply the corrections below; where they conflict with the task sections further down, **these win.**
+
+**Base:** `chore/character-create-recording` off `origin/develop` (`7563789`). On this base
+`scripts/dev/record_flow_capture.py` does **not** exist (it lived only on `bugfix/character-editor-title`),
+so Task 3 **CREATES** the driver from scratch (incl. `_transcode()` + argparse `main()` + no-ffmpeg
+fallback) — it is NOT a "rewrite".
+
+**MUST-FIX (blockers):**
+1. Task 3 driver: `from gflow_cli.config import Settings` (NOT `gflow_cli.settings` — that module does not
+   exist; `Settings` is at `config.py:81`). Build `Settings()` AFTER setting `os.environ["GFLOW_CLI_DB_PATH"]`
+   (intentionally bypasses the lru-cached `get_settings()` singleton).
+2. Task 1: promote `from gflow_cli.browser_manager import channel_for_profile` to **module scope** (top of
+   `client.py`) and DELETE the orphaned function-local import at `client.py:278` — else ruff F401 fails CI.
+   Exactly one import site.
+3. Locale/#153 → resolved by new **Task 0** below (land-first).
+
+**Decisions (user, 2026-06-04):**
+- **Locale:** fix #153 FIRST as **Task 0** (normalize BCP-47→short inside `character_editor_url`); the
+  recorder then passes the genuine CLI default `en-US` and stays language-agnostic.
+- **Live T3:** proceed WITHOUT a separate `/gflow:predict` (the council already covered the predict-level
+  risks); harden T3 instead (below). **Pause for explicit user confirmation before the live run.**
+
+**T3 hardening (fold into Task 3):**
+- Isolate `output_dir` too (a temp dir via `GFLOW_CLI_OUTPUT_DIR`), not only the DB — the generated image
+  must not land in the user's real gallery dir.
+- Force `concurrency=1` and FAIL loudly if >1 `.webm` is produced.
+- Add a structlog-event assertion proving the IMAGE path ran (`character` create completed +
+  `image_generated` + a `batchGenerateImages` 200 with **no** `batchAsyncGenerateVideo` call) — `refs=1`
+  alone does not prove image-not-video.
+- `recorder.close()` in a `try/finally` (mirror `cli_character.py`).
+- Confirm `ProjectInfo.project_id` field name before `proj.project_id`; or accept `--project` to mirror the
+  CLI 1:1 (reuse promo-denon82 id `f5d0d08b-0617-40ea-a5b3-1d716c60d07f`).
+- `_transcode()`: `shutil.which("ffmpeg")` guard → keep/copy the `.webm` + warn rather than fail.
+
+**Task 1 test hardening:** also assert the call site routes THROUGH the seam (spy that
+`launch_persistent_context` was called with exactly the dict `_persistent_context_kwargs()` returns) — the
+pin test alone is tautological. Optionally assert `kwargs["channel"] is None` for a marker-less tmp_path.
+
+**Type-gate note:** `scripts/dev/*` is NOT covered by `pyright src` (include = `[src, tests]`); run pyright
+over the new dev files explicitly or accept they're outside the gate.
+
+---
+
+## Task 0: Fix #153 — normalize locale in `character_editor_url` (land-first bugfix)
+
+**Files:**
+- Modify: `src/gflow_cli/api/routes.py:123-132` (`character_editor_url`)
+- Test: `tests/api/test_routes_character.py` (extend)
+
+- [ ] **Step 1 (RED):** add tests asserting BCP-47 inputs are shortened, and that short inputs are unchanged:
+  - `character_editor_url("en-US", "p", "e")` → ends `/fx/en/tools/flow/project/p/character/e`
+  - `character_editor_url("pt-BR", "p", "e")` → contains `/fx/pt/`
+  - `character_editor_url("EN-us", "p", "e")` → `/fx/en/` (lower-cased)
+  - existing short-locale tests (`en`/`pt`/`de`/`ja`) still pass (idempotent).
+- [ ] **Step 2:** run `tests/api/test_routes_character.py` → the `en-US`/`pt-BR`/`EN-us` cases FAIL (verbatim interpolation today).
+- [ ] **Step 3 (GREEN):** normalize before interpolation — `segment = locale.split("-", 1)[0].lower()`,
+  interpolate `{segment}`. Update the docstring to note BCP-47 inputs are reduced to the short Flow URL
+  segment (fixes #153).
+- [ ] **Step 4:** run `tests/api/test_routes_character.py` → all green.
+- [ ] **Step 5:** `pyright src` → 0; `ruff check` + `ruff format --check` clean.
+- [ ] **Step 6:** commit `fix(routes): normalize BCP-47 locale to short Flow URL segment (#153)`.
+
+---
+
+## File Structure
+
+- **Core (1 behavior-preserving change):**
+  - `src/gflow_cli/api/client.py` — extract launch kwargs (`_enter_setup`, ~L280) into `_persistent_context_kwargs(self) -> dict[str, Any]`; call site becomes `launch_persistent_context(**self._persistent_context_kwargs())`.
+- **Tests (core):**
+  - `tests/api/test_client_launch_kwargs.py` (new) — pins the seam's returned dict so the refactor is provably behavior-preserving and the seam stays stable.
+- **Dev/test recording infra (out of core):**
+  - `scripts/dev/_recording_client.py` (new) — `RecordingFlowApiClient(FlowApiClient)` overriding only `_persistent_context_kwargs` to add `record_video_dir`/`record_video_size`.
+  - `scripts/dev/record_flow_capture.py` (REWRITE — replaces the current standalone re-implementation) — driver that runs the real `character_create` through the recording client and transcodes the webm to mp4.
+  - `tests/dev/test_recording_client.py` (new) — asserts the subclass injects recording kwargs and preserves all base kwargs.
+- **Integration (separate repo, final task):**
+  - `gflow-cli-remotion`: `public/captures/character-master.mp4`, `src/remotion/Root.tsx` defaultProps.
+
+---
+
+## Task 1: Core seam — extract `_persistent_context_kwargs()` (behavior-preserving)
+
+**Files:**
+- Modify: `src/gflow_cli/api/client.py:280-289` (inside `_enter_setup`)
+- Test: `tests/api/test_client_launch_kwargs.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_client_launch_kwargs.py
+from pathlib import Path
+
+from gflow_cli.api.client import FlowApiClient
+
+
+def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
+    """The seam returns exactly the kwargs the client launched with before
+    the refactor — proves the extraction changed no behavior."""
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert kwargs["user_data_dir"] == str(tmp_path)
+    assert kwargs["headless"] is True
+    assert kwargs["viewport"] == {"width": 1280, "height": 720}
+    assert kwargs["locale"] == "en-US"
+    assert kwargs["extra_http_headers"] == {"Accept-Language": "en-US,en;q=0.9"}
+    assert kwargs["ignore_default_args"] == [
+        "--enable-automation",
+        "--no-sandbox",
+        "--password-store=basic",
+    ]
+    assert kwargs["args"] == ["--disable-blink-features=AutomationControlled"]
+    # channel is profile-derived; just assert the key is present.
+    assert "channel" in kwargs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/api/test_client_launch_kwargs.py -v`
+Expected: FAIL — `AttributeError: 'FlowApiClient' object has no attribute '_persistent_context_kwargs'`
+
+- [ ] **Step 3: Implement the seam (behavior-preserving)**
+
+In `src/gflow_cli/api/client.py`, replace the inline launch (currently `client.py:280-289`):
+
+```python
+        self._context = await self._pw.chromium.launch_persistent_context(
+            **self._persistent_context_kwargs()
+        )
+```
+
+Add the method just above `_enter_setup` (keep `from gflow_cli.browser_manager import channel_for_profile` available — move it to module scope or import inside the method):
+
+```python
+    def _persistent_context_kwargs(self) -> dict[str, Any]:
+        """Keyword args for the persistent browser context launch.
+
+        Extracted as an overridable seam so out-of-core tooling (e.g. a
+        dev-scoped recording subclass) can augment the launch — without any
+        recording/test concern living in this core path. Behavior here is
+        identical to the previous inline call.
+        """
+        from gflow_cli.browser_manager import channel_for_profile
+
+        return {
+            "user_data_dir": str(self.profile_dir),
+            "headless": self.headless,
+            "viewport": {"width": 1280, "height": 720},
+            "locale": "en-US",
+            "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
+            "channel": channel_for_profile(self.profile_dir),
+            "ignore_default_args": [
+                "--enable-automation",
+                "--no-sandbox",
+                "--password-store=basic",
+            ],
+            "args": ["--disable-blink-features=AutomationControlled"],
+        }
+```
+
+Ensure `Any` is imported (`from typing import Any`) — it almost certainly already is; verify.
+
+- [ ] **Step 4: Run test + the existing client suite to verify no behavior change**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/api/test_client_launch_kwargs.py tests/api -q`
+Expected: PASS (new test + existing client tests green).
+
+- [ ] **Step 5: Type-check the whole tree (CI gate)**
+
+Run: `.venv\Scripts\python.exe -m pyright src`
+Expected: 0 errors. (See memory: pyright must run on the whole `src` tree.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/api/client.py tests/api/test_client_launch_kwargs.py
+git commit -m "refactor(client): extract _persistent_context_kwargs seam (behavior-preserving)"
+```
+
+---
+
+## Task 2: `RecordingFlowApiClient` subclass (dev-scoped, out of core)
+
+**Files:**
+- Create: `scripts/dev/_recording_client.py`
+- Test: `tests/dev/test_recording_client.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/dev/test_recording_client.py
+import sys
+from pathlib import Path
+
+_DEV = Path(__file__).resolve().parents[2] / "scripts" / "dev"
+if str(_DEV) not in sys.path:
+    sys.path.insert(0, str(_DEV))
+
+from _recording_client import RecordingFlowApiClient  # noqa: E402
+
+
+def test_recording_client_injects_video_and_preserves_base(tmp_path: Path) -> None:
+    rec_dir = tmp_path / "rec"
+    client = RecordingFlowApiClient(
+        profile_dir=tmp_path, headless=True, record_video_dir=rec_dir
+    )
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    # Recording kwargs injected:
+    assert kwargs["record_video_dir"] == str(rec_dir)
+    assert kwargs["record_video_size"] == {"width": 1280, "height": 720}
+    # Base kwargs preserved:
+    assert kwargs["user_data_dir"] == str(tmp_path)
+    assert kwargs["args"] == ["--disable-blink-features=AutomationControlled"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/dev/test_recording_client.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '_recording_client'`
+
+- [ ] **Step 3: Implement the subclass**
+
+```python
+# scripts/dev/_recording_client.py
+"""Dev-scoped FlowApiClient subclass that records the browser context.
+
+NOT imported by the gflow_cli package. Adds Playwright video recording to the
+client's persistent context via the core _persistent_context_kwargs() seam, so
+no recording concern lives in core. Used only by scripts/dev recorders/tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+
+_VIDEO_SIZE = {"width": 1280, "height": 720}
+
+
+class RecordingFlowApiClient(FlowApiClient):
+    """FlowApiClient that records its browser context to ``record_video_dir``."""
+
+    def __init__(self, *args: Any, record_video_dir: Path, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._record_video_dir = record_video_dir
+
+    def _persistent_context_kwargs(self) -> dict[str, Any]:
+        kwargs = super()._persistent_context_kwargs()
+        kwargs["record_video_dir"] = str(self._record_video_dir)
+        kwargs["record_video_size"] = dict(_VIDEO_SIZE)
+        return kwargs
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `.venv\Scripts\python.exe -m pytest tests/dev/test_recording_client.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint**
+
+Run: `.venv\Scripts\python.exe -m ruff check scripts/dev/_recording_client.py tests/dev/test_recording_client.py && .venv\Scripts\python.exe -m ruff format --check scripts/dev/_recording_client.py tests/dev/test_recording_client.py`
+Expected: clean (run `ruff format` if needed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev/_recording_client.py tests/dev/test_recording_client.py
+git commit -m "chore(dev): RecordingFlowApiClient subclass (records context via core seam)"
+```
+
+---
+
+## Task 3: Rewrite the recorder driver to run gflow's REAL creation flow
+
+**Files:**
+- Modify (REWRITE): `scripts/dev/record_flow_capture.py` (currently a standalone re-implementation that mis-fired into video — replace it)
+
+Reuses `_spike_common.resolve_profile_dir/step`, the `RecordingFlowApiClient`, and mirrors `cli_character.py:159-185` wiring. Isolates the data store to a temp DB so the real catalog is untouched.
+
+- [ ] **Step 1: Replace the driver body**
+
+Key wiring (mirrors the CLI command, but through the recording client):
+
+```python
+# scripts/dev/record_flow_capture.py  (driver core — full file replaces the old one)
+from __future__ import annotations
+
+import argparse, asyncio, os, shutil, subprocess, sys, tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from _recording_client import RecordingFlowApiClient  # noqa: E402
+from _spike_common import default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api.character import CharacterImageRequest  # noqa: E402
+from gflow_cli.data.recorder import OperationRecorder  # noqa: E402
+from gflow_cli.services.character_create import character_create  # noqa: E402
+from gflow_cli.settings import Settings  # noqa: E402  (verify import path)
+
+_DEFAULT_FACE = "a woman with short dark hair, round glasses, navy sweater, soft studio portrait"
+
+
+async def _run(*, profile: str, profile_dir: Path, face_prompt: str,
+               locale: str, out_path: Path) -> int:
+    rec_dir = out_path.parent / "_rec_tmp"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    # Isolate the data store so the real gflow.db is untouched.
+    db_path = Path(tempfile.mkdtemp(prefix="rec-db-")) / "catalog.db"
+    os.environ["GFLOW_CLI_DB_PATH"] = str(db_path)
+    settings = Settings()  # picks up the temp DB path
+
+    face = CharacterImageRequest(prompt=face_prompt, model="nano2", image_reference_index=0)
+
+    async with RecordingFlowApiClient(
+        profile_dir=profile_dir, headless=False, settings=settings, record_video_dir=rec_dir,
+    ) as client:
+        proj = await client.create_project(title="gflow character — live demo")
+        recorder = OperationRecorder.open(settings)
+        step("rec", f"project={proj.project_id} — running real character_create", prefix="rec")
+        await character_create(
+            client, recorder,
+            profile_name=profile, profile_dir=profile_dir,
+            project_id=proj.project_id, name="Marina", face=face,
+            locale=locale,  # short Flow URL segment handled by gflow; pass e.g. "pt"
+        )
+    # Context closed here -> webm finalized. Transcode newest webm to mp4.
+    webms = sorted(rec_dir.glob("*.webm"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not webms:
+        step("ERR", "no .webm produced", prefix="rec"); return 1
+    _transcode(webms[0], out_path)
+    shutil.rmtree(rec_dir, ignore_errors=True)
+    step("done", f"recorded -> {out_path}", prefix="rec")
+    return 0
+```
+
+Keep the existing `_transcode()` (webm→mp4 via ffmpeg, with no-ffmpeg fallback) and `main()` argparse (`--profile`, `--face-prompt`, `--locale` default `pt`, `--out`). Drop the old `_mint_entity`/`_type_prompt`/`_click_generate`/`_short_locale` re-implementation — `character_create` does the real UI now.
+
+> **Verify import paths during implementation:** `Settings` location (`gflow_cli.settings` vs `gflow_cli.config`), `OperationRecorder.open` signature, and that `character_create`'s `locale` expects BCP-47 vs short code (it forwards to `character_editor_url`; confirm against #153 — pass whatever produces `/fx/pt/...`).
+
+- [ ] **Step 2: Lint + format**
+
+Run: `.venv\Scripts\python.exe -m ruff check scripts/dev/record_flow_capture.py && .venv\Scripts\python.exe -m ruff format scripts/dev/record_flow_capture.py`
+Expected: clean.
+
+- [ ] **Step 3: Live verification run (FREE — image gen only)**
+
+Run:
+```
+$env:GFLOW_CLI_PROFILE='promo-denon82'
+.venv\Scripts\python.exe scripts\dev\record_flow_capture.py --profile promo-denon82 --locale pt --out scripts\dev\_spike_out\flow-create.mp4
+```
+Expected console: `character_create.entity_created` → `prompt_submitted` → **`batchGenerateImages` 200** → `image_generated` → `character_create.completed`.
+
+- [ ] **Step 4: Assert it created a CHARACTER (image, free), NOT a video**
+
+Run: `gflow character list --project <the created project id>`
+Expected: one character with **`refs=1`** (a face was generated). If `refs=0` or any video tile appears, STOP — the flow regressed to the general composer; do not proceed.
+
+- [ ] **Step 5: Assert the video shows the creation (not black, not bouncing)**
+
+Run: `ffmpeg -y -ss 6 -i scripts\dev\_spike_out\flow-create.mp4 -frames:v 1 frame.png` and inspect: empty editor → prompt typed → generated face appears; no scroll-bounce.
+Expected: real editor footage of the creation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/dev/record_flow_capture.py
+git commit -m "chore(dev): record gflow's real character-create flow (image/free) via RecordingFlowApiClient"
+```
+
+---
+
+## Task 4: Integrate the capture into the promo (gflow-cli-remotion)
+
+**Files (separate repo `C:\development\github\gflow-cli-remotion`, branch `feature/character-promo`):**
+- `public/captures/character-master.mp4`, `src/remotion/Root.tsx`
+
+- [ ] **Step 1:** Copy `flow-create.mp4` → `public/captures/character-master.mp4`.
+- [ ] **Step 2:** Set `Root.tsx` defaultProps `captureFile: "captures/character-master.mp4"` (replace the placeholder restored in `8c9c1cb`).
+- [ ] **Step 3:** Render: `pnpm exec remotion render CharacterCapturePromo out/character-capture/character-capture-9x16.mp4`
+- [ ] **Step 4:** Extract a capture-window frame (~12s) and confirm it shows the creation footage.
+- [ ] **Step 5:** Gates: `pnpm lint && pnpm exec tsc --noEmit && pnpm test:ci` (all green).
+- [ ] **Step 6:** Commit + push `feature/character-promo`.
+
+---
+
+## Task 5: Gates, review, PR (gflow-cli)
+
+- [ ] **Step 1:** `/gflow:check` (ruff fix + format, pyright `src`, pytest changed dirs).
+- [ ] **Step 2:** `/gflow:branch-review` (lean council) on the recording branch; address must-fixes.
+- [ ] **Step 3:** Open PR (plain-string body per CLAUDE.md MCP rule). Reference #153 (the locale normalization the recorder dogfoshes) and the gflow-cli-remotion PR #1.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** core seam (T1) ✓; out-of-core recording subclass (T2) ✓; record gflow's REAL flow not a re-implementation (T3) ✓; image/free guard via refs=1 assertion (T3.S4) ✓; no-bounce/creation-visible (T3.S5) ✓; clean separation — only core change is a behavior-preserving seam (T1) ✓; promo integration (T4) ✓; lean process plan+branch-review (T5) ✓; language-agnostic locale (#153) noted in T3.
+- **Open verification (flagged inline, resolve at implementation):** (a) `Settings` import path; (b) `OperationRecorder.open` exact signature; (c) whether `character_create(locale=...)` wants BCP-47 or short code to yield `/fx/pt/...`; (d) confirm the recording client's single context is the one used (no second context) — the live run's `refs=1` + a non-black video is the end-to-end proof.
+- **Type consistency:** `_persistent_context_kwargs()` name identical in T1 (define) and T2 (override); `RecordingFlowApiClient(record_video_dir=...)` ctor matches T2 test and T3 driver usage.

--- a/scripts/dev/_recording_client.py
+++ b/scripts/dev/_recording_client.py
@@ -18,10 +18,6 @@ if _SRC.exists() and str(_SRC) not in sys.path:
 
 from gflow_cli.api.client import FlowApiClient  # noqa: E402
 
-# Match the base persistent context viewport (client.py) so the recorded frame
-# is 1:1 with what the automation sees.
-_VIDEO_SIZE = {"width": 1280, "height": 720}
-
 
 class RecordingFlowApiClient(FlowApiClient):
     """``FlowApiClient`` that records its browser context to ``record_video_dir``.
@@ -38,5 +34,7 @@ class RecordingFlowApiClient(FlowApiClient):
     def _persistent_context_kwargs(self) -> dict[str, Any]:
         kwargs = super()._persistent_context_kwargs()
         kwargs["record_video_dir"] = str(self._record_video_dir)
-        kwargs["record_video_size"] = dict(_VIDEO_SIZE)
+        # Track the base viewport so the recorded frame is always 1:1 with what
+        # the automation sees (no parallel size constant to drift).
+        kwargs["record_video_size"] = dict(kwargs["viewport"])
         return kwargs

--- a/scripts/dev/_recording_client.py
+++ b/scripts/dev/_recording_client.py
@@ -1,0 +1,42 @@
+"""Dev-scoped ``FlowApiClient`` subclass that records the browser context.
+
+NOT imported by the ``gflow_cli`` package. It adds Playwright video recording to
+the client's persistent context purely via the core
+``FlowApiClient._persistent_context_kwargs()`` seam, so no recording concern
+lives in core. Used only by ``scripts/dev`` recorders and their tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+
+# Match the base persistent context viewport (client.py) so the recorded frame
+# is 1:1 with what the automation sees.
+_VIDEO_SIZE = {"width": 1280, "height": 720}
+
+
+class RecordingFlowApiClient(FlowApiClient):
+    """``FlowApiClient`` that records its browser context to ``record_video_dir``.
+
+    Playwright finalizes one ``.webm`` per context page when the context closes.
+    Keep ``Settings.concurrency == 1`` (the default) so exactly one video — the
+    slot-0 editor page — is produced.
+    """
+
+    def __init__(self, *args: Any, record_video_dir: Path, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._record_video_dir = record_video_dir
+
+    def _persistent_context_kwargs(self) -> dict[str, Any]:
+        kwargs = super()._persistent_context_kwargs()
+        kwargs["record_video_dir"] = str(self._record_video_dir)
+        kwargs["record_video_size"] = dict(_VIDEO_SIZE)
+        return kwargs

--- a/scripts/dev/record_flow_capture.py
+++ b/scripts/dev/record_flow_capture.py
@@ -58,6 +58,10 @@ _FACE_EVENTS = {
 # NOT persist, which is exactly what a promo recording needs (display only).
 _FIND_NAME_INPUT_JS = r"""
 () => {
+  // Idempotent: drop any prior tag so [data-gflow-title] stays single-valued.
+  document
+    .querySelectorAll('[data-gflow-title]')
+    .forEach((el) => el.removeAttribute('data-gflow-title'));
   const vis = (el) => {
     const r = el.getBoundingClientRect();
     return r.width > 0 && r.height > 0 && el.offsetParent !== null;
@@ -155,59 +159,82 @@ async def _run(
     # Isolate the data store AND the image output dir so the real catalog/gallery
     # are never touched; force concurrency=1 so exactly one .webm is produced.
     tmp_root = Path(tempfile.mkdtemp(prefix="rec-iso-"))
-    os.environ["GFLOW_CLI_DB_PATH"] = str(tmp_root / "catalog.db")
-    os.environ["GFLOW_CLI_OUTPUT_DIR"] = str(tmp_root / "out")
-    os.environ["GFLOW_CLI_CONCURRENCY"] = "1"
-    settings = Settings()  # re-reads the env vars set above
-
-    face = CharacterImageRequest(prompt=face_prompt)
-    recorder = OperationRecorder.open(settings)
+    iso_env = {
+        "GFLOW_CLI_DB_PATH": str(tmp_root / "catalog.db"),
+        "GFLOW_CLI_OUTPUT_DIR": str(tmp_root / "out"),
+        "GFLOW_CLI_CONCURRENCY": "1",
+    }
+    saved_env = {k: os.environ.get(k) for k in iso_env}
+    cap: list[Any] = []  # bound even if context entry raises early
     try:
-        async with RecordingFlowApiClient(
-            profile_dir=profile_dir,
-            headless=False,
-            settings=settings,
-            record_video_dir=rec_dir,
-        ) as client:
-            proj = await client.create_project(title="gflow character — live demo")
-            step("rec", f"project={proj.project_id} — running real character_create", prefix="rec")
-            with capture_logs() as cap:
-                await character_create(
-                    client,
-                    recorder,
-                    profile_name=profile,
-                    profile_dir=profile_dir,
-                    project_id=proj.project_id,
-                    name=name,
-                    face=face,
-                    locale=locale,
+        os.environ.update(iso_env)
+        settings = Settings()  # re-reads the isolated env vars set above
+        face = CharacterImageRequest(prompt=face_prompt)
+        recorder = OperationRecorder.open(settings)
+        try:
+            async with RecordingFlowApiClient(
+                profile_dir=profile_dir,
+                headless=False,
+                settings=settings,
+                record_video_dir=rec_dir,
+            ) as client:
+                proj = await client.create_project(title="gflow character — live demo")
+                step(
+                    "rec",
+                    f"project={proj.project_id} — running real character_create",
+                    prefix="rec",
                 )
-            # Promo polish: type the name into the editor for ON-SCREEN display
-            # (display-only; the editor title is decoupled from displayName per
-            # #151, so it won't persist — irrelevant to the recorded video).
-            await _type_name_for_display(client._page, name)
+                with capture_logs() as cap:
+                    await character_create(
+                        client,
+                        recorder,
+                        profile_name=profile,
+                        profile_dir=profile_dir,
+                        project_id=proj.project_id,
+                        name=name,
+                        face=face,
+                        locale=locale,
+                    )
+                # Promo polish: type the name into the editor for ON-SCREEN display
+                # (display-only; the editor title is decoupled from displayName per
+                # #151, so it won't persist — irrelevant to the recorded video).
+                # Use the slot-0 page directly (not the deprecated _page alias).
+                await _type_name_for_display(client._pages[0], name)
+        finally:
+            recorder.close()
+
+        # Image-not-video guard (council hardening): prove the real image path ran.
+        err = _verify_image_path({e.get("event", "") for e in cap})
+        if err is not None:
+            step("ERR", err, prefix="rec")
+            return 1
+        step("ok", "image path verified via character_create structlog events", prefix="rec")
+
+        # Context closed -> webm finalized. Expect EXACTLY ONE webm (concurrency=1).
+        webms = sorted(rec_dir.glob("*.webm"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if not webms:
+            step("ERR", "no .webm produced", prefix="rec")
+            return 1
+        if len(webms) > 1:
+            step(
+                "ERR",
+                f"{len(webms)} webms produced (expected 1) — refusing to guess",
+                prefix="rec",
+            )
+            return 1
+        _transcode(webms[0], out_path)
+        shutil.rmtree(rec_dir, ignore_errors=True)
+        step("done", f"recorded -> {out_path}", prefix="rec")
+        return 0
     finally:
-        recorder.close()
-
-    # Image-not-video guard (council hardening): prove the real image path ran.
-    err = _verify_image_path({e.get("event", "") for e in cap})
-    if err is not None:
-        step("ERR", err, prefix="rec")
-        return 1
-    step("ok", "image path verified via character_create structlog events", prefix="rec")
-
-    # Context closed -> webm finalized. Expect EXACTLY ONE webm (concurrency=1).
-    webms = sorted(rec_dir.glob("*.webm"), key=lambda p: p.stat().st_mtime, reverse=True)
-    if not webms:
-        step("ERR", "no .webm produced", prefix="rec")
-        return 1
-    if len(webms) > 1:
-        step("ERR", f"{len(webms)} webms produced (expected 1) — refusing to guess", prefix="rec")
-        return 1
-    _transcode(webms[0], out_path)
-    shutil.rmtree(rec_dir, ignore_errors=True)
-    step("done", f"recorded -> {out_path}", prefix="rec")
-    return 0
+        # Restore the process env and remove the throwaway isolation dir so the
+        # driver is reentrant and leaves no catalog.db behind.
+        for key, prev in saved_env.items():
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+        shutil.rmtree(tmp_root, ignore_errors=True)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/dev/record_flow_capture.py
+++ b/scripts/dev/record_flow_capture.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
@@ -50,6 +51,71 @@ _FACE_EVENTS = {
     "character_create.face_done",
     "character_create.face_skipped_already_recorded",
 }
+
+# Language-agnostic editor name-input locator (proven by the #151 recon spikes):
+# tag the topmost visible, editable text <input> with data-gflow-title. The editor
+# title is decoupled from displayName (#151) — typed text shows on screen but does
+# NOT persist, which is exactly what a promo recording needs (display only).
+_FIND_NAME_INPUT_JS = r"""
+() => {
+  const vis = (el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && el.offsetParent !== null;
+  };
+  const cands = Array.from(document.querySelectorAll('input')).filter((el) => {
+    const t = (el.getAttribute('type') || 'text').toLowerCase();
+    if (['hidden', 'search', 'checkbox', 'radio', 'file', 'range', 'color'].includes(t))
+      return false;
+    if (el.readOnly || el.disabled) return false;
+    if (!vis(el)) return false;
+    if ((el.getAttribute('role') || '').toLowerCase() === 'searchbox') return false;
+    return true;
+  });
+  cands.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+  if (cands.length) cands[0].setAttribute('data-gflow-title', '1');
+  return { count: cands.length };
+}
+"""
+
+# React-controlled inputs ignore plain value sets; set via the native setter then
+# dispatch input/change so React's onChange fires (fallback when keyboard typing
+# does not register on the controlled input).
+_NATIVE_SET_JS = r"""
+(value) => {
+  const el = document.querySelector('[data-gflow-title]');
+  if (!el) return false;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype, 'value'
+  ).set;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+  return true;
+}
+"""
+
+
+async def _type_name_for_display(page: Any, name: str) -> None:
+    """Type *name* into the editor name input for ON-SCREEN display in the video.
+
+    Language-agnostic (tags the topmost editable text input structurally — no
+    localized placeholder). Display-only: the editor title is decoupled from
+    displayName (#151) and will not persist, which is irrelevant to the video.
+    Degrades gracefully if the input cannot be found.
+    """
+    found = await page.evaluate(_FIND_NAME_INPUT_JS)
+    if not found.get("count"):
+        step("warn", "editor name input not found — skipping display typing", prefix="rec")
+        return
+    loc = page.locator("[data-gflow-title]").first
+    await loc.click()
+    await page.keyboard.press("Control+A")
+    await page.keyboard.press("Delete")
+    await page.keyboard.type(name, delay=80)  # slow enough to read on screen
+    if (await loc.input_value()) != name:
+        await page.evaluate(_NATIVE_SET_JS, name)  # React-controlled fallback
+    await page.wait_for_timeout(1500)  # hold so the typed name is readable
+    step("name", f"typed {name!r} into editor name input (display-only)", prefix="rec")
 
 
 def _transcode(src: Path, dst: Path) -> None:
@@ -80,7 +146,7 @@ def _verify_image_path(event_names: set[str]) -> str | None:
 
 
 async def _run(
-    *, profile: str, profile_dir: Path, face_prompt: str, locale: str, out_path: Path
+    *, profile: str, profile_dir: Path, name: str, face_prompt: str, locale: str, out_path: Path
 ) -> int:
     from structlog.testing import capture_logs
 
@@ -112,10 +178,14 @@ async def _run(
                     profile_name=profile,
                     profile_dir=profile_dir,
                     project_id=proj.project_id,
-                    name="Marina",
+                    name=name,
                     face=face,
                     locale=locale,
                 )
+            # Promo polish: type the name into the editor for ON-SCREEN display
+            # (display-only; the editor title is decoupled from displayName per
+            # #151, so it won't persist — irrelevant to the recorded video).
+            await _type_name_for_display(client._page, name)
     finally:
         recorder.close()
 
@@ -145,6 +215,9 @@ def main(argv: list[str] | None = None) -> int:
         description="Record gflow's real character-create flow (image/free)."
     )
     ap.add_argument("--profile", required=True, help="Flow profile name (chrome-strategy).")
+    ap.add_argument(
+        "--name", default="Marina", help="Character name (typed into the editor for display)."
+    )
     ap.add_argument("--face-prompt", default=_DEFAULT_FACE, help="Face reference prompt.")
     ap.add_argument(
         "--locale",
@@ -159,6 +232,7 @@ def main(argv: list[str] | None = None) -> int:
         _run(
             profile=args.profile,
             profile_dir=profile_dir,
+            name=args.name,
             face_prompt=args.face_prompt,
             locale=args.locale,
             out_path=out_path,

--- a/scripts/dev/record_flow_capture.py
+++ b/scripts/dev/record_flow_capture.py
@@ -1,0 +1,170 @@
+"""Record gflow's REAL character-create flow as a browser-only video.
+
+Runs the genuine ``services.character_create.character_create`` saga through a
+``RecordingFlowApiClient`` (Playwright ``record_video`` on the client's
+persistent context), then transcodes the ``.webm`` to ``.mp4``. Character/image
+generation is FREE (only video generation spends credits), so a real recorded
+run costs nothing.
+
+Isolation: the data store (``GFLOW_CLI_DB_PATH``) and the image output dir
+(``GFLOW_CLI_OUTPUT_DIR``) are pointed at throwaway temp dirs so the real
+catalog and gallery are never touched; concurrency is forced to 1 so exactly one
+``.webm`` (the slot-0 editor page) is produced.
+
+Usage (FREE — image gen only):
+    python scripts/dev/record_flow_capture.py --profile promo-denon82 \
+        --out scripts/dev/_spike_out/flow-create.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from _recording_client import RecordingFlowApiClient  # noqa: E402
+from _spike_common import resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api.character import CharacterImageRequest  # noqa: E402
+from gflow_cli.config import Settings  # noqa: E402
+from gflow_cli.data.recorder import OperationRecorder  # noqa: E402
+from gflow_cli.services.character_create import character_create  # noqa: E402
+
+_DEFAULT_FACE = "a woman with short dark hair, round glasses, navy sweater, soft studio portrait"
+
+# Positive structlog events proving the IMAGE creation path ran (character_create
+# only ever generates images — it never calls a video endpoint). Their presence
+# is the "image-not-video" proof the absence of refs=1 alone cannot give.
+_COMPLETED_EVENT = "character_create.completed"
+_FAILED_EVENT = "character_create.failed"
+_FACE_EVENTS = {
+    "character_create.face_done",
+    "character_create.face_skipped_already_recorded",
+}
+
+
+def _transcode(src: Path, dst: Path) -> None:
+    """Transcode webm -> mp4 via ffmpeg; keep the raw .webm if ffmpeg is absent."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        fallback = dst.with_suffix(".webm")
+        shutil.copyfile(src, fallback)
+        step("warn", f"ffmpeg not found — kept raw webm at {fallback}", prefix="rec")
+        return
+    subprocess.run(
+        [ffmpeg, "-y", "-i", str(src), "-c:v", "libx264", "-pix_fmt", "yuv420p", str(dst)],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _verify_image_path(event_names: set[str]) -> str | None:
+    """Return an error string if the captured events don't prove a free image run."""
+    if _FAILED_EVENT in event_names:
+        return "character_create emitted a failure event"
+    if _COMPLETED_EVENT not in event_names:
+        return "character_create did not complete"
+    if not (_FACE_EVENTS & event_names):
+        return "no face image was generated (image path did not run)"
+    return None
+
+
+async def _run(
+    *, profile: str, profile_dir: Path, face_prompt: str, locale: str, out_path: Path
+) -> int:
+    from structlog.testing import capture_logs
+
+    rec_dir = out_path.parent / "_rec_tmp"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    # Isolate the data store AND the image output dir so the real catalog/gallery
+    # are never touched; force concurrency=1 so exactly one .webm is produced.
+    tmp_root = Path(tempfile.mkdtemp(prefix="rec-iso-"))
+    os.environ["GFLOW_CLI_DB_PATH"] = str(tmp_root / "catalog.db")
+    os.environ["GFLOW_CLI_OUTPUT_DIR"] = str(tmp_root / "out")
+    os.environ["GFLOW_CLI_CONCURRENCY"] = "1"
+    settings = Settings()  # re-reads the env vars set above
+
+    face = CharacterImageRequest(prompt=face_prompt)
+    recorder = OperationRecorder.open(settings)
+    try:
+        async with RecordingFlowApiClient(
+            profile_dir=profile_dir,
+            headless=False,
+            settings=settings,
+            record_video_dir=rec_dir,
+        ) as client:
+            proj = await client.create_project(title="gflow character — live demo")
+            step("rec", f"project={proj.project_id} — running real character_create", prefix="rec")
+            with capture_logs() as cap:
+                await character_create(
+                    client,
+                    recorder,
+                    profile_name=profile,
+                    profile_dir=profile_dir,
+                    project_id=proj.project_id,
+                    name="Marina",
+                    face=face,
+                    locale=locale,
+                )
+    finally:
+        recorder.close()
+
+    # Image-not-video guard (council hardening): prove the real image path ran.
+    err = _verify_image_path({e.get("event", "") for e in cap})
+    if err is not None:
+        step("ERR", err, prefix="rec")
+        return 1
+    step("ok", "image path verified via character_create structlog events", prefix="rec")
+
+    # Context closed -> webm finalized. Expect EXACTLY ONE webm (concurrency=1).
+    webms = sorted(rec_dir.glob("*.webm"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not webms:
+        step("ERR", "no .webm produced", prefix="rec")
+        return 1
+    if len(webms) > 1:
+        step("ERR", f"{len(webms)} webms produced (expected 1) — refusing to guess", prefix="rec")
+        return 1
+    _transcode(webms[0], out_path)
+    shutil.rmtree(rec_dir, ignore_errors=True)
+    step("done", f"recorded -> {out_path}", prefix="rec")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Record gflow's real character-create flow (image/free)."
+    )
+    ap.add_argument("--profile", required=True, help="Flow profile name (chrome-strategy).")
+    ap.add_argument("--face-prompt", default=_DEFAULT_FACE, help="Face reference prompt.")
+    ap.add_argument(
+        "--locale",
+        default="en-US",
+        help="UI locale (BCP-47; normalized to the short Flow URL segment, #153).",
+    )
+    ap.add_argument("--out", type=Path, default=None, help="Output .mp4 path.")
+    args = ap.parse_args(argv)
+    out_path: Path = args.out or (_HERE / "_spike_out" / "flow-create.mp4")
+    profile_dir = resolve_profile_dir(args.profile)
+    return asyncio.run(
+        _run(
+            profile=args.profile,
+            profile_dir=profile_dir,
+            face_prompt=args.face_prompt,
+            locale=args.locale,
+            out_path=out_path,
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -60,6 +60,11 @@ if TYPE_CHECKING:
     from gflow_cli.api.image import GenerateImageRequest
     from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStartedCallback
 
+# Shorthand for an untyped JSON-ish string-keyed mapping (request/response
+# bodies, launch kwargs, etc.). A single definition avoids the duplicated-literal
+# smell (SonarCloud S1192) from repeating the bare mapping type across the module.
+JsonObject = dict[str, Any]
+
 # Marker substring used by Playwright when a Page/Context/Browser is closed.
 # Stable across recent Playwright versions; we match on message text to avoid
 # importing from ``playwright._impl._errors`` (private API).
@@ -145,7 +150,7 @@ def _is_supported_image_header(header: bytes) -> bool:
     return header[:6] in (b"GIF87a", b"GIF89a")
 
 
-def _unwrap_trpc(data: Any) -> dict[str, Any]:
+def _unwrap_trpc(data: Any) -> JsonObject:
     """Unwrap the tRPC envelope ``result.data.json`` and return the inner dict.
 
     Only the standard tRPC v10 shape is accepted:
@@ -166,28 +171,28 @@ def _unwrap_trpc(data: Any) -> dict[str, Any]:
             detail=f"tRPC response is not a dict; got {type(data).__name__}",
             route="tRPC",
         )
-    data_dict = cast("dict[str, Any]", data)
+    data_dict = cast("JsonObject", data)
     result = data_dict.get("result")
     if not isinstance(result, dict):
         raise WireFormatError(
             detail="tRPC reply missing 'result' dict",
             route="tRPC",
         )
-    result_dict = cast("dict[str, Any]", result)
+    result_dict = cast("JsonObject", result)
     data_obj = result_dict.get("data")
     if not isinstance(data_obj, dict):
         raise WireFormatError(
             detail="tRPC reply missing result.data dict",
             route="tRPC",
         )
-    data_obj_dict = cast("dict[str, Any]", data_obj)
+    data_obj_dict = cast("JsonObject", data_obj)
     inner: Any = data_obj_dict.get("json")
     if not isinstance(inner, dict):
         raise WireFormatError(
             detail=f"tRPC reply missing result.data.json dict; got {type(inner).__name__}",
             route="tRPC",
         )
-    return cast("dict[str, Any]", inner)
+    return cast("JsonObject", inner)
 
 
 class FlowApiClient:
@@ -268,7 +273,7 @@ class FlowApiClient:
             raise
         return self
 
-    def _persistent_context_kwargs(self) -> dict[str, Any]:
+    def _persistent_context_kwargs(self) -> JsonObject:
         """Keyword arguments for the persistent browser-context launch.
 
         Extracted as an overridable seam so out-of-core tooling (e.g. a
@@ -497,7 +502,7 @@ class FlowApiClient:
                 instance=_make_instance(),
                 route="auth/session",
             ) from exc
-        data = cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
+        data = cast("JsonObject", parsed) if isinstance(parsed, dict) else {}
         token = data.get("access_token")
         if not token:
             raise AisandboxAuthError(
@@ -557,7 +562,7 @@ class FlowApiClient:
     async def _post_json(
         self,
         url: str,
-        body: dict[str, Any],
+        body: JsonObject,
         *,
         content_type: str = _AISANDBOX_CONTENT_TYPE,
         route_name: str | None = None,
@@ -614,7 +619,7 @@ class FlowApiClient:
     async def _patch_json(
         self,
         url: str,
-        body: dict[str, Any],
+        body: JsonObject,
         *,
         route_name: str | None = None,
     ) -> Any:
@@ -1366,7 +1371,7 @@ class FlowApiClient:
         Only the fields supplied are written; absent optional fields are omitted
         from both the request body and the ``updateMask``.
         """
-        character_info: dict[str, Any] = {
+        character_info: JsonObject = {
             "imageReferences": [{"workflowId": w} for w in workflow_ids],
         }
         update_mask_parts = [
@@ -1382,11 +1387,11 @@ class FlowApiClient:
             character_info["audioReferences"] = [{"presetVoiceId": voice}]
             update_mask_parts.append("entityInfo.characterInfo.audioReferences")
 
-        entity_info: dict[str, Any] = {
+        entity_info: JsonObject = {
             "displayName": display_name,
             "characterInfo": character_info,
         }
-        body: dict[str, Any] = {
+        body: JsonObject = {
             "entity": {
                 "projectId": project_id,
                 "entityId": entity_id,
@@ -1468,7 +1473,7 @@ class FlowApiClient:
             locale=locale,
         )
         _images, workflows = cast(
-            "tuple[list[GeneratedImage], list[dict[str, Any]]]",
+            "tuple[list[GeneratedImage], list[JsonObject]]",
             _raw,
         )
 
@@ -1478,7 +1483,7 @@ class FlowApiClient:
                 route="generateCharacterImage",
             )
 
-        wf: dict[str, Any] = workflows[0]
+        wf: JsonObject = workflows[0]
         parent: str | None = wf.get("parentEntityId")
         if parent != entity_id:
             raise WireFormatError(
@@ -1578,7 +1583,7 @@ def _make_instance() -> str:
     return f"gflow:error:{correlation}"
 
 
-def _build_wire_format_discovery(resp: Any, body_text: str, route: str) -> dict[str, Any]:
+def _build_wire_format_discovery(resp: Any, body_text: str, route: str) -> JsonObject:
     """Build the RFC 9457 ``discovery`` payload for a :class:`WireFormatError`.
 
     Shared between the JSON-parse-failure raise site (``_post_json``,
@@ -1599,7 +1604,7 @@ def _build_wire_format_discovery(resp: Any, body_text: str, route: str) -> dict[
     try:
         parsed = json.loads(body_text) if content_type.startswith("application/json") else None
         if isinstance(parsed, dict):
-            top_keys = sorted(cast("dict[str, Any]", parsed).keys())
+            top_keys = sorted(cast("JsonObject", parsed).keys())
     except ValueError:  # json.JSONDecodeError is a ValueError subclass
         top_keys = []
     # SECURITY: redact BEFORE truncating to 200 chars. If we truncated first,
@@ -1678,13 +1683,13 @@ def _redact_for_log(body_str: str) -> str:
     if not isinstance(parsed, dict):
         return body_str
 
-    parsed_dict = cast("dict[str, Any]", parsed)
+    parsed_dict = cast("JsonObject", parsed)
     _redact_in_client_context(parsed_dict.get("clientContext"))
     requests_list = parsed_dict.get("requests")
     if isinstance(requests_list, list):
         for item in cast("list[Any]", requests_list):
             if isinstance(item, dict):
-                _redact_in_client_context(cast("dict[str, Any]", item).get("clientContext"))
+                _redact_in_client_context(cast("JsonObject", item).get("clientContext"))
 
     return json.dumps(parsed_dict)
 
@@ -1707,9 +1712,9 @@ def _redact_in_client_context(client_context: Any) -> None:
     if present. No-op for any non-dict shape."""
     if not isinstance(client_context, dict):
         return
-    ctx_dict = cast("dict[str, Any]", client_context)
+    ctx_dict = cast("JsonObject", client_context)
     recaptcha = ctx_dict.get("recaptchaContext")
     if isinstance(recaptcha, dict):
-        recaptcha_dict = cast("dict[str, Any]", recaptcha)
+        recaptcha_dict = cast("JsonObject", recaptcha)
         if "token" in recaptcha_dict:
             recaptcha_dict["token"] = "<redacted>"

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -34,6 +34,7 @@ from gflow_cli.api.recaptcha import TokenMinter
 from gflow_cli.api.scene import ConcatInput, Scene, SceneWorkflow
 from gflow_cli.api.transports import make_transport
 from gflow_cli.api.transports.base import FlowTransportStrategy, VideoCapableTransport
+from gflow_cli.browser_manager import channel_for_profile
 from gflow_cli.config import Settings
 from gflow_cli.errors import (
     AisandboxAuthError,
@@ -267,6 +268,29 @@ class FlowApiClient:
             raise
         return self
 
+    def _persistent_context_kwargs(self) -> dict[str, Any]:
+        """Keyword arguments for the persistent browser-context launch.
+
+        Extracted as an overridable seam so out-of-core tooling (e.g. a
+        dev-scoped recording subclass that adds ``record_video_dir``) can
+        augment the launch without any recording/test concern living in this
+        core path. The returned dict is identical to the previous inline call.
+        """
+        return {
+            "user_data_dir": str(self.profile_dir),
+            "headless": self.headless,
+            "viewport": {"width": 1280, "height": 720},
+            "locale": "en-US",
+            "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
+            "channel": channel_for_profile(self.profile_dir),
+            "ignore_default_args": [
+                "--enable-automation",
+                "--no-sandbox",
+                "--password-store=basic",
+            ],
+            "args": ["--disable-blink-features=AutomationControlled"],
+        }
+
     async def _enter_setup(self) -> None:
         """Body of __aenter__ after the Playwright driver starts.
 
@@ -275,17 +299,8 @@ class FlowApiClient:
         """
         # Invariant: __aenter__ sets self._pw immediately before calling us.
         assert self._pw is not None
-        from gflow_cli.browser_manager import channel_for_profile
-
         self._context = await self._pw.chromium.launch_persistent_context(
-            user_data_dir=str(self.profile_dir),
-            headless=self.headless,
-            viewport={"width": 1280, "height": 720},
-            locale="en-US",
-            extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
-            channel=channel_for_profile(self.profile_dir),
-            ignore_default_args=["--enable-automation", "--no-sandbox", "--password-store=basic"],
-            args=["--disable-blink-features=AutomationControlled"],
+            **self._persistent_context_kwargs()
         )
         # Hide the automation flag so reCAPTCHA Enterprise doesn't score
         # the session as a bot — navigator.webdriver=true causes low-score

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -125,8 +125,15 @@ def character_editor_url(locale: str, project_id: str, entity_id: str) -> str:
 
     Returns the browser-navigable page URL (not an API endpoint) at which the
     Flow UI renders the character editor for *entity_id* inside *project_id*,
-    localised to *locale* (e.g. ``"en"``, ``"pt"``).
+    localised to *locale*.
 
-    Pattern: ``https://labs.google/fx/{locale}/tools/flow/project/{project_id}/character/{entity_id}``
+    *locale* may be a full BCP-47 tag (e.g. ``"en-US"``, ``"pt-BR"``). Flow's UI
+    only routes under the *short* primary-subtag segment — the full tag 404s
+    (issue #153) — so the tag is reduced to its lower-cased primary subtag
+    (``"en-US" -> "en"``, ``"pt-BR" -> "pt"``); already-short inputs pass
+    through unchanged.
+
+    Pattern: ``https://labs.google/fx/{seg}/tools/flow/project/{project_id}/character/{entity_id}``
     """
-    return f"{LABS_FX_BASE}/{locale}/tools/flow/project/{project_id}/character/{entity_id}"
+    segment = locale.split("-", 1)[0].lower()
+    return f"{LABS_FX_BASE}/{segment}/tools/flow/project/{project_id}/character/{entity_id}"

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -135,5 +135,5 @@ def character_editor_url(locale: str, project_id: str, entity_id: str) -> str:
 
     Pattern: ``https://labs.google/fx/{seg}/tools/flow/project/{project_id}/character/{entity_id}``
     """
-    segment = locale.split("-", 1)[0].lower()
+    segment = locale.strip().split("-", 1)[0].lower() or "en"
     return f"{LABS_FX_BASE}/{segment}/tools/flow/project/{project_id}/character/{entity_id}"

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -284,11 +284,15 @@ async def test_enter_setup_routes_launch_through_kwargs_seam(
         return kwargs
 
     monkeypatch.setattr(FlowApiClient, "_persistent_context_kwargs", spy)
-    async with FlowApiClient(profile_dir=tmp_path, transport=fake):
-        pass
-    # Consulted exactly once during setup -> the launch routes through the seam.
-    # A future re-inline of the dict would drop this to 0.
+    launch_mock = None
+    async with FlowApiClient(profile_dir=tmp_path, transport=fake) as client:
+        launch_mock = client._pw.chromium.launch_persistent_context
+    # The seam was consulted exactly once AND the launch was invoked with its
+    # exact output. A re-inlined / stale dict at the call site fails the kwargs
+    # equality here, not merely the consult count.
     assert len(seam_calls) == 1
+    assert launch_mock is not None
+    assert launch_mock.call_args.kwargs == seam_calls[0]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -265,6 +265,33 @@ async def test_client_with_preinitialized_transport_does_not_own_lifecycle(
 
 
 @pytest.mark.asyncio
+async def test_enter_setup_routes_launch_through_kwargs_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """__aenter__ must launch the persistent context via the
+    _persistent_context_kwargs() seam, not a stale inline dict, so a dev-scoped
+    recording subclass override actually takes effect. The pin test alone cannot
+    catch a re-inlined call site; this can."""
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    _patch_playwright(monkeypatch)
+    fake = _FakeTransport()
+    seam_calls: list[object] = []
+    original = FlowApiClient._persistent_context_kwargs
+
+    def spy(self: FlowApiClient) -> dict[str, object]:
+        kwargs = original(self)
+        seam_calls.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(FlowApiClient, "_persistent_context_kwargs", spy)
+    async with FlowApiClient(profile_dir=tmp_path, transport=fake):
+        pass
+    # Consulted exactly once during setup -> the launch routes through the seam.
+    # A future re-inline of the dict would drop this to 0.
+    assert len(seam_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_client_with_string_transport_owns_lifecycle(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -1,0 +1,35 @@
+"""Pins the ``FlowApiClient._persistent_context_kwargs()`` seam.
+
+The seam was extracted from the inline ``launch_persistent_context(...)`` call so
+a dev-scoped recording subclass can augment the launch without any recording
+concern living in core (see ``scripts/dev/_recording_client.py``). This test
+proves the extraction is value-for-value behavior-preserving and keeps the
+seam's contract stable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gflow_cli.api.client import FlowApiClient
+
+
+def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
+    """The seam returns exactly the kwargs the client launched with before the
+    refactor — proving the extraction changed no behavior."""
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert kwargs["user_data_dir"] == str(tmp_path)
+    assert kwargs["headless"] is True
+    assert kwargs["viewport"] == {"width": 1280, "height": 720}
+    assert kwargs["locale"] == "en-US"
+    assert kwargs["extra_http_headers"] == {"Accept-Language": "en-US,en;q=0.9"}
+    assert kwargs["ignore_default_args"] == [
+        "--enable-automation",
+        "--no-sandbox",
+        "--password-store=basic",
+    ]
+    assert kwargs["args"] == ["--disable-blink-features=AutomationControlled"]
+    # channel is profile-derived; a marker-less tmp_path has no
+    # .gflow_browser_strategy file, so channel_for_profile() returns None.
+    assert kwargs["channel"] is None

--- a/tests/api/test_routes_character.py
+++ b/tests/api/test_routes_character.py
@@ -33,3 +33,9 @@ def test_character_editor_url_normalizes_bcp47_region():
 def test_character_editor_url_lowercases_segment():
     # Case-insensitive: "EN-us" -> "/fx/en/".
     assert "/fx/en/tools/flow/" in routes.character_editor_url("EN-us", "p", "e")
+
+
+def test_character_editor_url_empty_locale_falls_back_to_en():
+    # A degenerate/empty tag must not produce a double-slash URL (/fx//...).
+    assert "/fx/en/tools/flow/" in routes.character_editor_url("", "p", "e")
+    assert "/fx/en/tools/flow/" in routes.character_editor_url("-US", "p", "e")

--- a/tests/api/test_routes_character.py
+++ b/tests/api/test_routes_character.py
@@ -18,3 +18,18 @@ def test_character_editor_url_various_locales():
         url = routes.character_editor_url(locale, "proj-1", "ent-1")
         assert url.startswith("https://labs.google/fx/")
         assert f"/fx/{locale}/tools/flow/project/proj-1/character/ent-1" in url
+
+
+def test_character_editor_url_normalizes_bcp47_region():
+    # #153: a full BCP-47 tag like "en-US" 404s the Flow editor page — only the
+    # short primary subtag is a valid /fx/<seg>/ segment. The builder must reduce
+    # the tag so callers can pass the genuine CLI default ("en-US") safely.
+    assert routes.character_editor_url("en-US", "p", "e").endswith(
+        "/fx/en/tools/flow/project/p/character/e"
+    )
+    assert "/fx/pt/tools/flow/" in routes.character_editor_url("pt-BR", "p", "e")
+
+
+def test_character_editor_url_lowercases_segment():
+    # Case-insensitive: "EN-us" -> "/fx/en/".
+    assert "/fx/en/tools/flow/" in routes.character_editor_url("EN-us", "p", "e")

--- a/tests/dev/test_record_flow_capture.py
+++ b/tests/dev/test_record_flow_capture.py
@@ -1,0 +1,75 @@
+"""Wiring tests for the dev-scoped ``record_flow_capture`` driver.
+
+These exercise the driver's pure-Python wiring (the image-path guard, the
+no-ffmpeg transcode fallback, and argparse dispatch) WITHOUT launching a real
+browser or generating anything — the genuine Flow interaction is validated by
+the gated live run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DEV = Path(__file__).resolve().parents[2] / "scripts" / "dev"
+if str(_DEV) not in sys.path:
+    sys.path.insert(0, str(_DEV))
+
+import record_flow_capture as rfc  # noqa: E402
+
+
+def test_verify_image_path_accepts_completed_face_run() -> None:
+    events = {"character_create.completed", "character_create.face_done"}
+    assert rfc._verify_image_path(events) is None
+
+
+def test_verify_image_path_rejects_failure() -> None:
+    err = rfc._verify_image_path(
+        {"character_create.failed", "character_create.completed", "character_create.face_done"}
+    )
+    assert err is not None and "failure" in err
+
+
+def test_verify_image_path_rejects_incomplete() -> None:
+    assert rfc._verify_image_path({"character_create.face_done"}) is not None
+
+
+def test_verify_image_path_rejects_no_face() -> None:
+    # Completed but the image path never ran (no face event) -> reject.
+    assert rfc._verify_image_path({"character_create.completed"}) is not None
+
+
+def test_transcode_falls_back_to_webm_without_ffmpeg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(rfc.shutil, "which", lambda _: None)
+    src = tmp_path / "rec.webm"
+    src.write_bytes(b"fake-webm-bytes")
+    dst = tmp_path / "out" / "flow-create.mp4"
+    rfc._transcode(src, dst)
+    fallback = dst.with_suffix(".webm")
+    assert fallback.exists()
+    assert fallback.read_bytes() == b"fake-webm-bytes"
+    assert not dst.exists()  # no ffmpeg -> no mp4
+
+
+def test_main_dispatches_run_with_parsed_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(rfc, "_run", fake_run)
+    monkeypatch.setattr(rfc, "resolve_profile_dir", lambda p: tmp_path / "profiles" / p)
+    out = tmp_path / "x.mp4"
+    rc = rfc.main(["--profile", "promo", "--out", str(out)])
+    assert rc == 0
+    assert captured["profile"] == "promo"
+    assert captured["locale"] == "en-US"  # genuine default; normalized by #153 fix
+    assert captured["out_path"] == out
+    assert captured["profile_dir"] == tmp_path / "profiles" / "promo"

--- a/tests/dev/test_record_flow_capture.py
+++ b/tests/dev/test_record_flow_capture.py
@@ -8,6 +8,7 @@ the gated live run.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -70,6 +71,18 @@ def test_main_dispatches_run_with_parsed_args(
     rc = rfc.main(["--profile", "promo", "--out", str(out)])
     assert rc == 0
     assert captured["profile"] == "promo"
+    assert captured["name"] == "Marina"  # genuine default
     assert captured["locale"] == "en-US"  # genuine default; normalized by #153 fix
     assert captured["out_path"] == out
     assert captured["profile_dir"] == tmp_path / "profiles" / "promo"
+
+
+def test_type_name_for_display_skips_when_no_input() -> None:
+    """When the editor name input can't be located, the helper degrades
+    gracefully — no exception, no typing attempt."""
+
+    class _FakePage:
+        async def evaluate(self, _js: str, *_args: object) -> dict[str, int]:
+            return {"count": 0}
+
+    asyncio.run(rfc._type_name_for_display(_FakePage(), "Marina"))

--- a/tests/dev/test_recording_client.py
+++ b/tests/dev/test_recording_client.py
@@ -1,0 +1,31 @@
+"""Tests for the dev-scoped ``RecordingFlowApiClient`` subclass.
+
+The subclass lives under ``scripts/dev`` (NOT in the ``gflow_cli`` package) and
+adds Playwright video recording to the client's persistent context purely via
+the core ``_persistent_context_kwargs()`` seam — so no recording concern leaks
+into core.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DEV = Path(__file__).resolve().parents[2] / "scripts" / "dev"
+if str(_DEV) not in sys.path:
+    sys.path.insert(0, str(_DEV))
+
+from _recording_client import RecordingFlowApiClient  # noqa: E402
+
+
+def test_recording_client_injects_video_and_preserves_base(tmp_path: Path) -> None:
+    rec_dir = tmp_path / "rec"
+    client = RecordingFlowApiClient(profile_dir=tmp_path, headless=True, record_video_dir=rec_dir)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    # Recording kwargs injected:
+    assert kwargs["record_video_dir"] == str(rec_dir)
+    assert kwargs["record_video_size"] == {"width": 1280, "height": 720}
+    # Base kwargs preserved untouched:
+    assert kwargs["user_data_dir"] == str(tmp_path)
+    assert kwargs["headless"] is True
+    assert kwargs["args"] == ["--disable-blink-features=AutomationControlled"]


### PR DESCRIPTION
## Summary

Makes gflow's **real** `character create` flow recordable as a browser-only video (for the `gflow-cli-remotion` character promo), with the recording concern kept entirely out of core. Bundles a real production bug fix found along the way.

### Production changes (src/)
- **fix #153** — `routes.character_editor_url` interpolated the locale verbatim, so the genuine CLI default `en-US` produced `/fx/en-US/…` which **404s** the Flow character editor. Now normalizes a BCP-47 tag to its short Flow URL segment (`en-US → en`, `pt-BR → pt`), with an `en` fallback for degenerate input. Language-agnostic.
- **refactor(client)** — extract the inline `launch_persistent_context(**kwargs)` call into an overridable `_persistent_context_kwargs()` seam (value-for-value **behavior-preserving**), so dev tooling can augment the launch without any recording concern in core. `channel_for_profile` promoted to a module-scope import.

### Dev tooling (scripts/dev/, NOT in the package)
- `RecordingFlowApiClient` — subclasses the client and overrides only the seam to add Playwright `record_video_dir` (size tracks the viewport).
- `record_flow_capture.py` — drives the genuine `character_create` saga through the recording client, then transcodes the `.webm` to `.mp4`. Isolates the DB **and** the image output dir to throwaway temp dirs, forces `concurrency=1` (exactly one webm), guards image-not-video via `character_create` structlog events, and types the name into the editor for on-screen display (display-only; the editor title is decoupled from `displayName` per #151).

## Process
Full grounded plan-council (verdict GO-WITH-FIXES — all MUST-FIX applied) → TDD per task → grounded branch-review council. Image generation is **free** (only video spends credits).

## Live verification (promo-denon82, free)
Real headed run produced a **36.7 s / 1280×720** mp4 showing the genuine character editor: "Marina" typed in the name field + the generated face in the hero canvas. `character list` shows the created character with **`refs=1`** (a face was generated). `#153` confirmed live: `--locale en-US` → `/fx/en/` loaded with no 404.

## Test plan
- [x] `pyright src` 0 errors
- [x] ruff check + format clean
- [x] new unit tests: #153 normalization (incl. degenerate), seam pin + call-site routing assertion, recording subclass, driver wiring + image-path guard + ffmpeg fallback
- [x] full `tests/api` + `tests/dev` green locally (664+); CI runs the full matrix
- [x] live e2e (free image capture)

Refs #153. Feeds the `gflow-cli-remotion` character promo (PR #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)