### PR TITLE
docs(changelog): record the #153 locale-404 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   described in
   [`docs/AGENT_GUIDE.md` § Governance & Enforcement](docs/AGENT_GUIDE.md#governance--enforcement).
 
+### Fixed
+
+- **Character editor 404 on non-English locales (#153).** `gflow character`'s
+  editor URL interpolated the locale verbatim, so the genuine default BCP-47
+  `en-US` produced `/fx/en-US/…`, which 404s the Flow character editor (only the
+  short primary subtag is a valid `/fx/<seg>/` segment). `character_editor_url`
+  now normalizes a BCP-47 tag to its lower-cased short segment (`en-US → en`,
+  `pt-BR → pt`), so the tool stays language-agnostic with the real default
+  locale.
+
 ## [0.12.0] — 2026-06-03
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds a `### Fixed` entry to CHANGELOG `[Unreleased]` for the **#153** locale-404 fix shipped in #158: `character_editor_url` now normalizes a BCP-47 tag to its short Flow segment (`en-US` → `en`), so the editor URL no longer 404s on the genuine default locale.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)