### PR TITLE
feat(movie): gflow movie — TOML-driven multi-scene film framework

### DIFF
--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -18,6 +18,7 @@ from gflow_cli.cli_character import character as _character_group
 from gflow_cli.cli_data import data as _data_group
 from gflow_cli.cli_image import image as _image_group
 from gflow_cli.cli_models import models as _models_command
+from gflow_cli.cli_movie import movie as _movie_group
 from gflow_cli.cli_run import run as _run_command
 from gflow_cli.cli_scene import scene as _scene_group
 from gflow_cli.cli_video import video as _video_group
@@ -323,6 +324,7 @@ def _resolve_or_prompt(default_for_first_run: str) -> str:
 
 main.add_command(_character_group)
 main.add_command(_data_group)
+main.add_command(_movie_group)
 main.add_command(_video_group)
 main.add_command(_image_group)
 main.add_command(_run_command)

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -1,0 +1,579 @@
+"""`gflow movie` — produce a multi-scene AI movie from a movie.toml project file.
+
+Orchestrates three phases in a single browser session:
+
+  1. **Characters** — create any :class:`CharacterDef` not yet present in the
+     run-state file (``<manifest>-state.json``), reusing existing ones on resume.
+  2. **Scenes** — generate each :class:`SceneDef` using the appropriate mode
+     (t2v / r2v / i2v).  For ``r2v`` scenes the character's face + body images
+     are auto-injected as ``--ref`` inputs.
+  3. **Assembly hint** — print a ready-to-run ``gflow scene create`` command to
+     stitch all completed clips, or execute it automatically when
+     ``[assemble] output = "..."`` is set in the manifest.
+
+A dry-run (``--dry-run``) prints the plan and credit estimate without spending.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import structlog
+from rich.console import Console
+
+from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile, run_with_handlers
+from gflow_cli.api.character import CharacterImageRequest
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStarted
+from gflow_cli.config import get_settings
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.errors import ConfigurationError, DataStoreError
+from gflow_cli.movie_manifest import (
+    CharacterDef,
+    CharacterState,
+    MovieManifest,
+    MovieState,
+    SceneDef,
+    SceneState,
+)
+from gflow_cli.paths import resolve_batch_output_dir
+from gflow_cli.services.character_create import character_create
+from gflow_cli.storage import cloud_info_from_path
+
+console = Console()
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Template
+# ---------------------------------------------------------------------------
+
+_TEMPLATE = """\
+# movie.toml — gflow movie project
+# Run with: gflow movie run movie.toml
+title = "My Short Film"
+project = "YOUR_FLOW_PROJECT_ID"
+output_dir = "./out/my-movie"  # optional
+
+[[characters]]
+name = "Alice"
+face_prompt = "Young woman with curly red hair, green eyes, warm smile"
+body_prompt = "Athletic build, casual jeans and light jacket"  # optional
+model = "nano2"  # nano2 (default) or nanopro
+
+[[scenes]]
+title = "Establishing Shot"
+type = "t2v"
+prompt = "Futuristic city skyline at golden hour, cinematic wide shot"
+aspect = "16:9"
+duration = 8
+model = "veo-lite"
+
+[[scenes]]
+title = "Character Arrives"
+type = "r2v"
+prompt = "Alice walks through a busy futuristic plaza, looking around with wonder"
+characters = ["Alice"]
+aspect = "16:9"
+duration = 8
+
+[[scenes]]
+title = "Close-Up"
+type = "r2v"
+prompt = "Close-up of Alice's face as she smiles with excitement"
+characters = ["Alice"]
+aspect = "16:9"
+duration = 6
+model = "veo-quality"
+
+[assemble]
+output = "./out/my-movie/final.mp4"
+"""
+
+# ---------------------------------------------------------------------------
+# Click group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def movie() -> None:
+    """Produce a multi-scene AI movie from a movie.toml project file."""
+
+
+# ---------------------------------------------------------------------------
+# template
+# ---------------------------------------------------------------------------
+
+
+@movie.command("template")
+@click.argument("output", default="movie.toml", type=click.Path(dir_okay=False, path_type=Path))
+@click.option("--force", is_flag=True, default=False, help="Overwrite OUTPUT if it already exists.")
+def template(output: Path, force: bool) -> None:
+    """Write a starter movie.toml to OUTPUT (default: ./movie.toml).
+
+    Edit the file to define your characters and scenes, then run:
+
+    \b
+      gflow movie run movie.toml
+    """
+    output = output.expanduser()
+    if output.exists() and not force:
+        console.print(f"[red]{output}[/red] already exists. Use [bold]--force[/bold] to overwrite.")
+        sys.exit(1)
+    output.write_text(_TEMPLATE, encoding="utf-8")
+    console.print(f"[bold green]Created:[/bold green] {output}")
+    console.print("  Edit the file, then run [bold]gflow movie run movie.toml[/bold]")
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@movie.command("run")
+@click.argument(
+    "manifest_path", metavar="MANIFEST", type=click.Path(dir_okay=False, path_type=Path)
+)
+@click.option("--profile", default=None, help="Profile name (overrides default).")
+@click.option(
+    "--out-dir",
+    "out_dir_override",
+    default=None,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Override output directory from the manifest.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print plan and credit estimate; make no API calls.",
+)
+@click.option(
+    "--continue-on-error/--fail-fast",
+    "continue_on_error",
+    default=True,
+    show_default=True,
+    help=(
+        "On scene failure: --continue-on-error attempts remaining scenes (default); "
+        "--fail-fast stops immediately."
+    ),
+)
+def run(
+    manifest_path: Path,
+    profile: str | None,
+    out_dir_override: Path | None,
+    dry_run: bool,
+    continue_on_error: bool,
+) -> None:
+    """Execute a movie.toml — create characters and generate all scenes.
+
+    On the first run every character and scene is created from scratch.
+    On subsequent runs the sibling <manifest>-state.json is consulted and
+    already-completed steps are skipped, making the command safe to re-run
+    after a crash or interruption.
+
+    \b
+    Examples:
+      gflow movie run movie.toml
+      gflow movie run movie.toml --dry-run
+      gflow movie run movie.toml --fail-fast --out-dir ./out/film1
+    """
+    manifest_path = manifest_path.expanduser().resolve()
+    try:
+        manifest = MovieManifest.from_toml_path(manifest_path)
+    except ConfigurationError as exc:
+        console.print(f"[red]Manifest error:[/red] {exc}")
+        sys.exit(11)
+
+    settings = get_settings()
+    out_dir = resolve_batch_output_dir(
+        cli_override=out_dir_override,
+        config_value=manifest.output_dir,
+        output_root=settings.output_dir,
+    )
+
+    state_path = MovieState.state_path_for(manifest_path)
+    state = MovieState.load(state_path, title=manifest.title, project=manifest.project)
+
+    _print_header(manifest, out_dir=out_dir, dry_run=dry_run)
+
+    if dry_run:
+        _print_plan(manifest, state)
+        return
+
+    profile_name = _resolve_profile(profile)
+    pdir = _make_provider_dir(profile_name)
+    run_with_handlers(
+        lambda: _run_movie(
+            manifest=manifest,
+            state=state,
+            state_path=state_path,
+            profile_name=profile_name,
+            profile_dir=pdir,
+            out_dir=out_dir,
+            continue_on_error=continue_on_error,
+        ),
+        cli_command="movie run",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run plan printer
+# ---------------------------------------------------------------------------
+
+
+def _print_header(manifest: MovieManifest, *, out_dir: Path, dry_run: bool) -> None:
+    tag = " [dim](dry-run)[/dim]" if dry_run else ""
+    console.print(f"\n[bold]gflow movie run[/bold]{tag} · [bold]{manifest.title}[/bold]")
+    console.print(f"  project:    {manifest.project}")
+    console.print(f"  output_dir: [dim]{out_dir}[/dim]")
+    console.print(f"  characters: {len(manifest.characters)}  scenes: {len(manifest.scenes)}")
+
+
+def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
+    console.print("\n[bold]Plan:[/bold]")
+
+    # Characters
+    if manifest.characters:
+        console.print("\n  Characters:")
+        char_credits = 0
+        for c in manifest.characters:
+            done = c.name in state.characters
+            slots = 2 if c.body_prompt else 1
+            char_credits += 0 if done else slots
+            status = "[dim]skip (exists)[/dim]" if done else f"{slots} credit(s)"
+            console.print(f"    {c.name!r}  {status}")
+    else:
+        console.print("\n  Characters: [dim]none[/dim]")
+        char_credits = 0
+
+    # Scenes
+    console.print("\n  Scenes:")
+    scene_credits = 0
+    for s in manifest.scenes:
+        done_state = state.scenes.get(s.title)
+        done = done_state is not None and done_state.status == "completed"
+        cost = 0 if done else s.count
+        scene_credits += cost
+        refs = f"  refs=[{', '.join(s.characters)}]" if s.characters else ""
+        status = "[dim]skip (done)[/dim]" if done else f"{cost} credit(s)"
+        model_tag = f"  {s.model}" if s.model else ""
+        dur_tag = f"  {s.duration}s" if s.duration else ""
+        console.print(f"    [{s.type}] {s.title!r}{model_tag}{dur_tag}{refs}  {status}")
+
+    total = char_credits + scene_credits
+    console.print(f"\n  Estimated credits: ~{total}")
+
+    if manifest.assemble and manifest.assemble.output:
+        console.print(f"\n  Assembly → {manifest.assemble.output}")
+
+
+# ---------------------------------------------------------------------------
+# Core async orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def _run_movie(
+    *,
+    manifest: MovieManifest,
+    state: MovieState,
+    state_path: Path,
+    profile_name: str,
+    profile_dir: Path,
+    out_dir: Path,
+    continue_on_error: bool,
+) -> None:
+    settings = get_settings()
+    recorder = OperationRecorder.open(settings)
+
+    try:
+        async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+            # ------------------------------------------------------------------
+            # Phase 1: Characters
+            # ------------------------------------------------------------------
+            if manifest.characters:
+                console.print("\n[bold]Phase 1 — Characters[/bold]")
+            for char_def in manifest.characters:
+                if char_def.name in state.characters:
+                    console.print(
+                        f"  [dim]Character {char_def.name!r} — already created, skipping.[/dim]"
+                    )
+                    continue
+                console.print(f"\n  Creating character [bold]{char_def.name}[/bold]…")
+                await _create_character(
+                    client=client,
+                    recorder=recorder,
+                    char_def=char_def,
+                    project_id=manifest.project,
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    state=state,
+                    state_path=state_path,
+                )
+
+            # ------------------------------------------------------------------
+            # Phase 2: Scenes
+            # ------------------------------------------------------------------
+            console.print("\n[bold]Phase 2 — Scenes[/bold]")
+            completed_scene_ids: list[str] = []
+            completed_local_paths: list[Path] = []
+
+            for scene_def in manifest.scenes:
+                scene_state = state.scenes.get(scene_def.title)
+                if scene_state is not None and scene_state.status == "completed":
+                    console.print(
+                        f"  [dim]Scene {scene_def.title!r} — already generated, skipping.[/dim]"
+                    )
+                    if scene_state.flow_operation_id:
+                        completed_scene_ids.append(scene_state.flow_operation_id)
+                    if scene_state.local_path:
+                        completed_local_paths.append(Path(scene_state.local_path))
+                    continue
+
+                console.print(
+                    f"\n  Generating scene [bold]{scene_def.title!r}[/bold] ({scene_def.type})…"
+                )
+                refs = _collect_refs(scene_def, state)
+
+                try:
+                    video_result = await _generate_scene(
+                        client=client,
+                        recorder=recorder,
+                        scene_def=scene_def,
+                        refs=refs,
+                        profile_name=profile_name,
+                        profile_dir=profile_dir,
+                        out_dir=out_dir,
+                    )
+                    state.scenes[scene_def.title] = SceneState(
+                        media_id=video_result.status.media_id,
+                        flow_operation_id=video_result.flow_operation_id,
+                        local_path=(
+                            str(video_result.local_path)
+                            if video_result.local_path is not None
+                            else None
+                        ),
+                        status="completed",
+                    )
+                    state.save(state_path)
+                    console.print(f"    saved: {video_result.local_path}")
+                    if video_result.flow_operation_id:
+                        completed_scene_ids.append(video_result.flow_operation_id)
+                    if video_result.local_path:
+                        completed_local_paths.append(video_result.local_path)
+
+                except Exception as exc:
+                    log.error(
+                        "movie.scene_failed",
+                        title=scene_def.title,
+                        error=str(exc),
+                        exc_info=True,
+                    )
+                    state.scenes[scene_def.title] = SceneState(
+                        media_id="",
+                        flow_operation_id=None,
+                        local_path=None,
+                        status="failed",
+                    )
+                    state.save(state_path)
+                    if continue_on_error:
+                        console.print(f"    [red]Scene failed:[/red] {exc}")
+                    else:
+                        raise
+
+    finally:
+        recorder.close()
+
+    _print_summary(
+        manifest=manifest,
+        completed_scene_ids=completed_scene_ids,
+        completed_local_paths=completed_local_paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Character creation helper
+# ---------------------------------------------------------------------------
+
+
+async def _create_character(
+    *,
+    client: FlowApiClient,
+    recorder: OperationRecorder,
+    char_def: CharacterDef,
+    project_id: str,
+    profile_name: str,
+    profile_dir: Path,
+    state: MovieState,
+    state_path: Path,
+) -> None:
+    face = CharacterImageRequest(
+        prompt=char_def.face_prompt,
+        model=char_def.model,
+        image_reference_index=0,
+    )
+    body: CharacterImageRequest | None = None
+    if char_def.body_prompt is not None:
+        body = CharacterImageRequest(
+            prompt=char_def.body_prompt,
+            model=char_def.model,
+            image_reference_index=1,
+        )
+
+    result = await character_create(
+        client,
+        recorder,
+        profile_name=profile_name,
+        profile_dir=profile_dir,
+        project_id=project_id,
+        name=char_def.name,
+        face=face,
+        body=body,
+    )
+    image_paths: list[str | None] = [str(p) if p is not None else None for p in result.image_paths]
+    state.characters[char_def.name] = CharacterState(
+        entity_id=result.entity_id,
+        image_paths=image_paths,
+    )
+    state.save(state_path)
+    console.print(f"    entity_id: {result.entity_id}")
+    for slot, p in enumerate(image_paths):
+        label = "face" if slot == 0 else "body" if slot == 1 else f"slot{slot}"
+        console.print(f"    {label}: {p or '(unavailable)'}")
+
+
+# ---------------------------------------------------------------------------
+# Scene generation helper
+# ---------------------------------------------------------------------------
+
+
+def _collect_refs(scene_def: SceneDef, state: MovieState) -> list[str]:
+    """Return face + body image paths for all characters named in *scene_def*."""
+    refs: list[str] = []
+    if scene_def.type != "r2v":
+        return refs
+    for char_name in scene_def.characters:
+        char_info = state.characters.get(char_name)
+        if char_info is None:
+            log.warning("movie.character_not_in_state", name=char_name)
+            continue
+        for p in char_info.image_paths:
+            if p is not None:
+                refs.append(p)
+    return refs
+
+
+async def _generate_scene(
+    *,
+    client: FlowApiClient,
+    recorder: OperationRecorder,
+    scene_def: SceneDef,
+    refs: list[str],
+    profile_name: str,
+    profile_dir: Path,
+    out_dir: Path,
+) -> Any:
+    mode = Mode(scene_def.type)
+    aspect = Aspect.from_cli(scene_def.aspect)
+    model = VideoModel.from_cli(scene_def.model)
+
+    kwargs: dict[str, Any] = {
+        "prompt": scene_def.prompt,
+        "mode": mode,
+        "aspect": aspect,
+        "model": model,
+        "duration": scene_def.duration,
+        "count": scene_def.count,
+    }
+    if mode == Mode.R2V and refs:
+        kwargs["reference_images"] = tuple(Path(r) for r in refs)
+    elif mode == Mode.I2V and scene_def.initial_frame:
+        kwargs["start_image"] = Path(scene_def.initial_frame)
+        if scene_def.end_frame:
+            kwargs["end_image"] = Path(scene_def.end_frame)
+
+    request = GenerateVideoRequest(**kwargs)
+
+    def on_started(started: VideoStarted) -> None:
+        try:
+            recorder.record_started_video(
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                request=request,
+                started=started,
+            )
+        except DataStoreError as exc:
+            log.warning("movie.persistence_failed_on_start", error=str(exc))
+
+    result = await client.generate_video(
+        req=request,
+        out_dir=out_dir,
+        download=True,
+        on_started=on_started,
+    )
+
+    try:
+        recorder.record_completed_video(
+            profile_name=profile_name,
+            _profile_dir=profile_dir,
+            request=request,
+            result=result,
+            cloud_storage_info=(
+                cloud_info_from_path(result.local_path) if result.local_path is not None else None
+            ),
+        )
+    except DataStoreError as exc:
+        log.warning("movie.persistence_failed_on_complete", error=str(exc))
+
+    if not result.status.succeeded:
+        reasons = (
+            ", ".join(result.status.failure_reasons)
+            or result.status.error_message
+            or "unknown reason"
+        )
+        msg = f"Video generation failed: {reasons}"
+        raise RuntimeError(msg)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Post-run summary
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(
+    *,
+    manifest: MovieManifest,
+    completed_scene_ids: list[str],
+    completed_local_paths: list[Path],
+) -> None:
+    total = len(manifest.scenes)
+    done = len(completed_local_paths)
+    failed = total - done
+
+    console.print(f"\n[bold green]Movie run complete:[/bold green] {done}/{total} scenes")
+    if failed:
+        console.print(f"  [yellow]{failed} scene(s) failed[/yellow] — re-run to retry.")
+
+    if completed_local_paths:
+        console.print("\n  Completed clips:")
+        for p in completed_local_paths:
+            console.print(f"    {p}")
+
+    if len(completed_scene_ids) > 1:
+        clip_refs = " ".join(completed_scene_ids)
+        assemble_cmd = f"gflow scene create --project {manifest.project} {clip_refs}"
+        if manifest.assemble and manifest.assemble.output:
+            assemble_cmd += f" -o {manifest.assemble.output}"
+        console.print("\n  [dim]Stitch all clips into one file:[/dim]")
+        console.print(f"  [bold]{assemble_cmd}[/bold]")
+    elif len(completed_scene_ids) == 1:
+        console.print("\n  [dim]Only one scene — no stitching needed.[/dim]")
+    else:
+        console.print(
+            "\n  [yellow]No workflow IDs captured — "
+            "use `gflow scene create` manually with the clip workflow IDs.[/yellow]"
+        )

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -1,0 +1,403 @@
+"""Movie manifest — parse and validate a movie.toml project file.
+
+A movie.toml describes a self-contained film production: a set of named
+characters (with face / body reference prompts) and an ordered list of
+scenes (each specifying a generation type, prompt, and optional character
+references).  The runner in :mod:`gflow_cli.cli_movie` consumes this
+manifest and orchestrates ``gflow character`` + ``gflow video`` operations
+automatically.
+
+Run state is written to a sibling ``<stem>-state.json`` file so that a
+crashed or interrupted run can resume without re-spending credits.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from gflow_cli.errors import ConfigurationError
+
+__all__ = [
+    "AssemblyDef",
+    "CharacterDef",
+    "CharacterState",
+    "MovieManifest",
+    "MovieState",
+    "SceneDef",
+    "SceneState",
+]
+
+# ---------------------------------------------------------------------------
+# Allowed values
+# ---------------------------------------------------------------------------
+
+_VALID_SCENE_TYPES: frozenset[str] = frozenset({"t2v", "r2v", "i2v"})
+_VALID_VIDEO_ASPECTS: frozenset[str] = frozenset({"9:16", "16:9", "1:1"})
+_VALID_DURATIONS: frozenset[int] = frozenset({4, 6, 8, 10})
+_VALID_CHARACTER_MODELS: frozenset[str] = frozenset({"nano2", "nanopro"})
+
+
+# ---------------------------------------------------------------------------
+# Manifest DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CharacterDef:
+    """One named character to be created (or reused) in the Flow project."""
+
+    name: str
+    face_prompt: str
+    body_prompt: str | None = None
+    model: str = "nano2"
+
+
+@dataclass(frozen=True)
+class SceneDef:
+    """One scene in the movie."""
+
+    title: str
+    type: str  # "t2v" | "r2v" | "i2v"
+    prompt: str
+    characters: tuple[str, ...] = field(default_factory=tuple)
+    aspect: str = "16:9"
+    duration: int | None = None
+    model: str | None = None
+    count: int = 1
+    initial_frame: str | None = None  # i2v only
+    end_frame: str | None = None  # i2v only (optional)
+
+
+@dataclass(frozen=True)
+class AssemblyDef:
+    """Optional assembly step — render all scenes into one .mp4."""
+
+    output: str | None = None
+
+
+@dataclass(frozen=True)
+class MovieManifest:
+    """Validated, immutable representation of a movie.toml file."""
+
+    title: str
+    project: str
+    characters: tuple[CharacterDef, ...]
+    scenes: tuple[SceneDef, ...]
+    assemble: AssemblyDef | None = None
+    output_dir: str | None = None
+
+    @classmethod
+    def from_toml_path(cls, path: Path) -> MovieManifest:
+        """Parse and validate *path*; raise :class:`ConfigurationError` on any problem."""
+        if not path.exists():
+            raise ConfigurationError(f"Manifest not found: {path}")
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ConfigurationError(f"Cannot read {path}: {exc}") from exc
+        try:
+            _raw = tomllib.loads(raw)
+        except tomllib.TOMLDecodeError as exc:
+            raise ConfigurationError(f"Failed to parse {path}: {exc}") from exc
+        return cls._from_dict(cast("dict[str, object]", _raw))
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, object]) -> MovieManifest:
+        title = data.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ConfigurationError("'title' must be a non-empty string.")
+
+        project = data.get("project")
+        if not isinstance(project, str) or not project.strip():
+            raise ConfigurationError("'project' must be a non-empty string (your Flow project id).")
+
+        output_dir = data.get("output_dir")
+        if output_dir is not None and not isinstance(output_dir, str):
+            raise ConfigurationError("'output_dir' must be a string.")
+
+        chars_raw = data.get("characters", [])
+        if not isinstance(chars_raw, list):
+            raise ConfigurationError("'characters' must be a TOML array.")
+        chars_list = cast("list[object]", chars_raw)
+        characters = tuple(_parse_character(c, i) for i, c in enumerate(chars_list))
+        char_names: set[str] = set()
+        for c in characters:
+            if c.name in char_names:
+                raise ConfigurationError(f"Duplicate character name: {c.name!r}")
+            char_names.add(c.name)
+
+        scenes_raw = data.get("scenes", [])
+        if not isinstance(scenes_raw, list):
+            raise ConfigurationError("'scenes' must be a TOML array.")
+        if not scenes_raw:
+            raise ConfigurationError("At least one [[scenes]] entry is required.")
+        scenes_list = cast("list[object]", scenes_raw)
+        scenes = tuple(_parse_scene(s, i, char_names) for i, s in enumerate(scenes_list))
+        title_names: set[str] = set()
+        for s in scenes:
+            if s.title in title_names:
+                raise ConfigurationError(f"Duplicate scene title: {s.title!r}")
+            title_names.add(s.title)
+
+        assemble: AssemblyDef | None = None
+        assemble_raw = data.get("assemble")
+        if assemble_raw is not None:
+            if not isinstance(assemble_raw, dict):
+                raise ConfigurationError("[assemble] must be a TOML table.")
+            assemble_dict = cast("dict[str, object]", assemble_raw)
+            output = assemble_dict.get("output")
+            if output is not None and not isinstance(output, str):
+                raise ConfigurationError("assemble.output must be a string path.")
+            assemble = AssemblyDef(output=output)
+
+        return cls(
+            title=title.strip(),
+            project=project.strip(),
+            characters=characters,
+            scenes=scenes,
+            assemble=assemble,
+            output_dir=output_dir,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_character(data: object, idx: int) -> CharacterDef:
+    if not isinstance(data, dict):
+        raise ConfigurationError(f"characters[{idx}] must be a TOML table.")
+    d = cast("dict[str, object]", data)
+
+    name = d.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ConfigurationError(f"characters[{idx}].name must be a non-empty string.")
+
+    face_prompt = d.get("face_prompt")
+    if not isinstance(face_prompt, str) or not face_prompt.strip():
+        raise ConfigurationError(f"characters[{idx}].face_prompt must be a non-empty string.")
+
+    body_prompt = d.get("body_prompt")
+    if body_prompt is not None and not isinstance(body_prompt, str):
+        raise ConfigurationError(f"characters[{idx}].body_prompt must be a string.")
+
+    raw_model = d.get("model", "nano2")
+    if not isinstance(raw_model, str) or raw_model not in _VALID_CHARACTER_MODELS:
+        raise ConfigurationError(
+            f"characters[{idx}].model must be one of "
+            f"{sorted(_VALID_CHARACTER_MODELS)} (got {raw_model!r})."
+        )
+
+    return CharacterDef(
+        name=name.strip(),
+        face_prompt=face_prompt.strip(),
+        body_prompt=body_prompt.strip() if isinstance(body_prompt, str) else None,
+        model=raw_model,
+    )
+
+
+def _parse_scene(data: object, idx: int, char_names: set[str]) -> SceneDef:
+    if not isinstance(data, dict):
+        raise ConfigurationError(f"scenes[{idx}] must be a TOML table.")
+    d = cast("dict[str, object]", data)
+
+    title = d.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ConfigurationError(f"scenes[{idx}].title must be a non-empty string.")
+
+    scene_type = d.get("type")
+    if not isinstance(scene_type, str) or scene_type not in _VALID_SCENE_TYPES:
+        raise ConfigurationError(
+            f"scenes[{idx}].type must be one of {sorted(_VALID_SCENE_TYPES)} (got {scene_type!r})."
+        )
+
+    prompt = d.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ConfigurationError(f"scenes[{idx}].prompt must be a non-empty string.")
+
+    chars_raw = d.get("characters", [])
+    if not isinstance(chars_raw, list):
+        raise ConfigurationError(f"scenes[{idx}].characters must be a TOML array.")
+    char_names_in_scene: list[str] = []
+    for char_name in cast("list[object]", chars_raw):
+        if not isinstance(char_name, str):
+            raise ConfigurationError(f"scenes[{idx}].characters entries must be strings.")
+        if char_name not in char_names:
+            raise ConfigurationError(
+                f"scenes[{idx}] references unknown character {char_name!r}. "
+                f"Defined: {sorted(char_names)!r}"
+            )
+        char_names_in_scene.append(char_name)
+
+    raw_aspect = d.get("aspect", "16:9")
+    if not isinstance(raw_aspect, str) or raw_aspect not in _VALID_VIDEO_ASPECTS:
+        raise ConfigurationError(
+            f"scenes[{idx}].aspect must be one of "
+            f"{sorted(_VALID_VIDEO_ASPECTS)} (got {raw_aspect!r})."
+        )
+
+    duration = d.get("duration")
+    if duration is not None:
+        if not isinstance(duration, int) or duration not in _VALID_DURATIONS:
+            raise ConfigurationError(
+                f"scenes[{idx}].duration must be one of "
+                f"{sorted(_VALID_DURATIONS)} seconds (got {duration!r})."
+            )
+
+    raw_model = d.get("model")
+    if raw_model is not None and not isinstance(raw_model, str):
+        raise ConfigurationError(f"scenes[{idx}].model must be a string.")
+    scene_model: str | None = raw_model if isinstance(raw_model, str) else None
+
+    count = d.get("count", 1)
+    if not isinstance(count, int) or not (1 <= count <= 4):
+        raise ConfigurationError(f"scenes[{idx}].count must be an integer 1–4 (got {count!r}).")
+
+    initial_frame = d.get("initial_frame")
+    end_frame = d.get("end_frame")
+    if initial_frame is not None and not isinstance(initial_frame, str):
+        raise ConfigurationError(f"scenes[{idx}].initial_frame must be a string path.")
+    if end_frame is not None and not isinstance(end_frame, str):
+        raise ConfigurationError(f"scenes[{idx}].end_frame must be a string path.")
+
+    if scene_type == "i2v" and not initial_frame:
+        raise ConfigurationError(f"scenes[{idx}] (type=i2v) requires 'initial_frame'.")
+
+    return SceneDef(
+        title=title.strip(),
+        type=scene_type,
+        prompt=prompt.strip(),
+        characters=tuple(char_names_in_scene),
+        aspect=raw_aspect,
+        duration=duration if isinstance(duration, int) else None,
+        model=scene_model,
+        count=count,
+        initial_frame=initial_frame if isinstance(initial_frame, str) else None,
+        end_frame=end_frame if isinstance(end_frame, str) else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run state — crash-recoverable JSON written alongside the manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CharacterState:
+    """Persisted state for a created character."""
+
+    entity_id: str
+    image_paths: list[str | None]
+
+    def to_dict(self) -> dict[str, object]:
+        return {"entity_id": self.entity_id, "image_paths": self.image_paths}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, object]) -> CharacterState:
+        eid = d.get("entity_id")
+        raw_paths = d.get("image_paths")
+        paths: list[str | None] = []
+        if isinstance(raw_paths, list):
+            for p in cast("list[object]", raw_paths):
+                paths.append(str(p) if isinstance(p, str) else None)
+        return cls(
+            entity_id=str(eid) if eid is not None else "",
+            image_paths=paths,
+        )
+
+
+@dataclass
+class SceneState:
+    """Persisted state for a generated scene."""
+
+    media_id: str
+    flow_operation_id: str | None
+    local_path: str | None
+    status: str  # "completed" | "failed"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "media_id": self.media_id,
+            "flow_operation_id": self.flow_operation_id,
+            "local_path": self.local_path,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, object]) -> SceneState:
+        raw_op_id = d.get("flow_operation_id")
+        raw_path = d.get("local_path")
+        return cls(
+            media_id=str(d.get("media_id") or ""),
+            flow_operation_id=str(raw_op_id) if isinstance(raw_op_id, str) else None,
+            local_path=str(raw_path) if isinstance(raw_path, str) else None,
+            status=str(d.get("status") or "completed"),
+        )
+
+
+class MovieState:
+    """Crash-recoverable run state for a movie project.
+
+    Written as JSON alongside the manifest file after each phase completes
+    so that a re-run can skip already-completed characters and scenes.
+    """
+
+    VERSION = 1
+
+    def __init__(self, *, title: str, project: str) -> None:
+        self.title = title
+        self.project = project
+        self.characters: dict[str, CharacterState] = {}
+        self.scenes: dict[str, SceneState] = {}
+
+    @staticmethod
+    def state_path_for(manifest_path: Path) -> Path:
+        """Return the sibling state file path for *manifest_path*."""
+        return manifest_path.parent / (manifest_path.stem + "-state.json")
+
+    @classmethod
+    def load(cls, path: Path, *, title: str, project: str) -> MovieState:
+        """Load existing state or return a fresh empty state on any error."""
+        state = cls(title=title, project=project)
+        if not path.exists():
+            return state
+        try:
+            raw: object = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return state
+        if not isinstance(raw, dict):
+            return state
+        data = cast("dict[str, object]", raw)
+
+        chars_raw = data.get("characters")
+        if isinstance(chars_raw, dict):
+            for name, raw_char in cast("dict[str, object]", chars_raw).items():
+                if isinstance(raw_char, dict):
+                    state.characters[name] = CharacterState.from_dict(
+                        cast("dict[str, object]", raw_char)
+                    )
+        scenes_raw = data.get("scenes")
+        if isinstance(scenes_raw, dict):
+            for title_key, raw_scene in cast("dict[str, object]", scenes_raw).items():
+                if isinstance(raw_scene, dict):
+                    state.scenes[title_key] = SceneState.from_dict(
+                        cast("dict[str, object]", raw_scene)
+                    )
+        return state
+
+    def save(self, path: Path) -> None:
+        """Persist state to *path* (creates parent dirs if missing)."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, object] = {
+            "version": self.VERSION,
+            "title": self.title,
+            "project": self.project,
+            "characters": {n: c.to_dict() for n, c in self.characters.items()},
+            "scenes": {t: s.to_dict() for t, s in self.scenes.items()},
+        }
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -29,9 +29,7 @@ def _write_toml(path: Path, content: str) -> Path:
     return path
 
 
-def _make_video_result(
-    *, succeeded: bool = True, flow_op_id: str | None = "op-1"
-) -> MagicMock:
+def _make_video_result(*, succeeded: bool = True, flow_op_id: str | None = "op-1") -> MagicMock:
     r = MagicMock()
     r.status.media_id = "media-1"
     r.status.succeeded = succeeded
@@ -222,19 +220,13 @@ class TestMovieRunValidation:
 
 
 class TestMovieRunLive:
-    def test_live_path_resolves_profile_and_calls_run_with_handlers(
-        self, tmp_path: Path
-    ) -> None:
+    def test_live_path_resolves_profile_and_calls_run_with_handlers(self, tmp_path: Path) -> None:
         runner = CliRunner()
         manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
 
         with (
-            patch(
-                "gflow_cli.cli_movie._resolve_profile", return_value="default"
-            ) as mock_resolve,
-            patch(
-                "gflow_cli.cli_movie._make_provider_dir", return_value=tmp_path / "profile"
-            ),
+            patch("gflow_cli.cli_movie._resolve_profile", return_value="default") as mock_resolve,
+            patch("gflow_cli.cli_movie._make_provider_dir", return_value=tmp_path / "profile"),
             patch("gflow_cli.cli_movie.run_with_handlers") as mock_run,
         ):
             result = runner.invoke(cli_main, ["movie", "run", str(manifest)])
@@ -296,9 +288,7 @@ class TestCollectRefs:
 
         scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Alice", "Bob"))
         state = MovieState(title="T", project="p")
-        state.characters["Alice"] = CharacterState(
-            entity_id="a", image_paths=["/a_face.png"]
-        )
+        state.characters["Alice"] = CharacterState(entity_id="a", image_paths=["/a_face.png"])
         state.characters["Bob"] = CharacterState(
             entity_id="b", image_paths=["/b_face.png", "/b_body.png"]
         )
@@ -560,9 +550,7 @@ class TestRunMovieOrchestrator:
             scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
         )
         state = MovieState(title="T", project="p")
-        state.characters["Alice"] = CharacterState(
-            entity_id="ent-1", image_paths=["/face.png"]
-        )
+        state.characters["Alice"] = CharacterState(entity_id="ent-1", image_paths=["/face.png"])
         state_path = tmp_path / "state.json"
         mock_create = AsyncMock()
 
@@ -607,9 +595,7 @@ class TestCreateCharacter:
         mock_result.entity_id = "ent-1"
         mock_result.image_paths = [Path("/face.png"), None]
 
-        with patch(
-            "gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)
-        ):
+        with patch("gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)):
             await _create_character(
                 client=MagicMock(),
                 recorder=MagicMock(),
@@ -629,9 +615,7 @@ class TestCreateCharacter:
     async def test_with_body_prompt_saves_both_paths(self, tmp_path: Path) -> None:
         from gflow_cli.cli_movie import _create_character
 
-        char_def = CharacterDef(
-            name="Bob", face_prompt="grey beard", body_prompt="casual jacket"
-        )
+        char_def = CharacterDef(name="Bob", face_prompt="grey beard", body_prompt="casual jacket")
         state = MovieState(title="T", project="p")
         state_path = tmp_path / "state.json"
 
@@ -639,9 +623,7 @@ class TestCreateCharacter:
         mock_result.entity_id = "ent-2"
         mock_result.image_paths = [Path("/bob_face.png"), Path("/bob_body.png")]
 
-        with patch(
-            "gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)
-        ):
+        with patch("gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)):
             await _create_character(
                 client=MagicMock(),
                 recorder=MagicMock(),

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from gflow_cli.cli import main as cli_main

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from gflow_cli.cli import main as cli_main
+from gflow_cli.movie_manifest import (
+    AssemblyDef,
+    CharacterDef,
+    CharacterState,
+    MovieManifest,
+    MovieState,
+    SceneDef,
+    SceneState,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -16,6 +27,19 @@ from gflow_cli.cli import main as cli_main
 def _write_toml(path: Path, content: str) -> Path:
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _make_video_result(
+    *, succeeded: bool = True, flow_op_id: str | None = "op-1"
+) -> MagicMock:
+    r = MagicMock()
+    r.status.media_id = "media-1"
+    r.status.succeeded = succeeded
+    r.status.failure_reasons = []
+    r.status.error_message = "video failed"
+    r.flow_operation_id = flow_op_id
+    r.local_path = Path("/out/video.mp4")
+    return r
 
 
 _VALID_MANIFEST = """\
@@ -98,12 +122,9 @@ class TestMovieTemplate:
         assert "old content" not in out.read_text(encoding="utf-8")
 
     def test_generated_template_is_valid_manifest(self, tmp_path: Path) -> None:
-        from gflow_cli.movie_manifest import MovieManifest
-
         runner = CliRunner()
         out = tmp_path / "movie.toml"
         runner.invoke(cli_main, ["movie", "template", str(out)])
-        # Should parse without error (project id placeholder is a valid string)
         m = MovieManifest.from_toml_path(out)
         assert m.title
         assert len(m.scenes) >= 1
@@ -150,8 +171,6 @@ class TestMovieDryRun:
 
     def test_dry_run_no_api_calls(self, tmp_path: Path) -> None:
         """Dry-run must not invoke FlowApiClient."""
-        from unittest.mock import patch
-
         runner = CliRunner()
         manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
         with patch("gflow_cli.cli_movie.FlowApiClient") as mock_client:
@@ -160,8 +179,6 @@ class TestMovieDryRun:
         mock_client.assert_not_called()
 
     def test_dry_run_shows_skip_for_completed_scene(self, tmp_path: Path) -> None:
-        from gflow_cli.movie_manifest import MovieState, SceneState
-
         runner = CliRunner()
         manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
         state_path = MovieState.state_path_for(manifest)
@@ -197,3 +214,632 @@ class TestMovieRunValidation:
         manifest = _write_toml(tmp_path / "bad.toml", 'title = "T"\n# no project, no scenes\n')
         result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
         assert result.exit_code == 11
+
+
+# ---------------------------------------------------------------------------
+# gflow movie run — live execution path (mocked at CLI level)
+# ---------------------------------------------------------------------------
+
+
+class TestMovieRunLive:
+    def test_live_path_resolves_profile_and_calls_run_with_handlers(
+        self, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
+
+        with (
+            patch(
+                "gflow_cli.cli_movie._resolve_profile", return_value="default"
+            ) as mock_resolve,
+            patch(
+                "gflow_cli.cli_movie._make_provider_dir", return_value=tmp_path / "profile"
+            ),
+            patch("gflow_cli.cli_movie.run_with_handlers") as mock_run,
+        ):
+            result = runner.invoke(cli_main, ["movie", "run", str(manifest)])
+
+        assert result.exit_code == 0
+        mock_resolve.assert_called_once()
+        mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _collect_refs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectRefs:
+    def test_t2v_returns_empty_regardless_of_characters(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="t2v", prompt="x", characters=("Alice",))
+        state = MovieState(title="T", project="p")
+        assert _collect_refs(scene, state) == []
+
+    def test_i2v_returns_empty(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="i2v", prompt="x", initial_frame="/f.png")
+        state = MovieState(title="T", project="p")
+        assert _collect_refs(scene, state) == []
+
+    def test_r2v_returns_face_and_body_paths(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Alice",))
+        state = MovieState(title="T", project="p")
+        state.characters["Alice"] = CharacterState(
+            entity_id="ent-1", image_paths=["/face.png", "/body.png"]
+        )
+        assert _collect_refs(scene, state) == ["/face.png", "/body.png"]
+
+    def test_r2v_skips_none_image_slots(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Alice",))
+        state = MovieState(title="T", project="p")
+        state.characters["Alice"] = CharacterState(
+            entity_id="ent-1", image_paths=["/face.png", None]
+        )
+        assert _collect_refs(scene, state) == ["/face.png"]
+
+    def test_r2v_unknown_character_returns_empty(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Ghost",))
+        state = MovieState(title="T", project="p")
+        assert _collect_refs(scene, state) == []
+
+    def test_r2v_multiple_characters(self) -> None:
+        from gflow_cli.cli_movie import _collect_refs
+
+        scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Alice", "Bob"))
+        state = MovieState(title="T", project="p")
+        state.characters["Alice"] = CharacterState(
+            entity_id="a", image_paths=["/a_face.png"]
+        )
+        state.characters["Bob"] = CharacterState(
+            entity_id="b", image_paths=["/b_face.png", "/b_body.png"]
+        )
+        assert _collect_refs(scene, state) == ["/a_face.png", "/b_face.png", "/b_body.png"]
+
+
+# ---------------------------------------------------------------------------
+# _print_summary
+# ---------------------------------------------------------------------------
+
+
+class TestPrintSummary:
+    def test_single_scene_completed(self) -> None:
+        from gflow_cli.cli_movie import _print_summary
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        _print_summary(
+            manifest=manifest,
+            completed_scene_ids=["op-1"],
+            completed_local_paths=[Path("/out/a.mp4")],
+        )
+
+    def test_multi_scene_with_assemble(self) -> None:
+        from gflow_cli.cli_movie import _print_summary
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(
+                SceneDef(title="S1", type="t2v", prompt="x"),
+                SceneDef(title="S2", type="t2v", prompt="y"),
+            ),
+            assemble=AssemblyDef(output="./final.mp4"),
+        )
+        _print_summary(
+            manifest=manifest,
+            completed_scene_ids=["op-1", "op-2"],
+            completed_local_paths=[Path("/out/a.mp4"), Path("/out/b.mp4")],
+        )
+
+    def test_no_completed_scenes(self) -> None:
+        from gflow_cli.cli_movie import _print_summary
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        _print_summary(
+            manifest=manifest,
+            completed_scene_ids=[],
+            completed_local_paths=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_movie — full async orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _mock_client_cm() -> MagicMock:
+    """Return a MagicMock that behaves as an async context manager."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=cm)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+class TestRunMovieOrchestrator:
+    async def test_happy_path_no_characters(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch(
+                "gflow_cli.cli_movie._generate_scene",
+                new=AsyncMock(return_value=_make_video_result()),
+            ),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=True,
+            )
+
+        assert state.scenes["S"].status == "completed"
+        assert state.scenes["S"].flow_operation_id == "op-1"
+        assert state_path.exists()
+
+    async def test_skips_completed_scene(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state.scenes["S"] = SceneState(
+            media_id="m",
+            flow_operation_id="op-old",
+            local_path="/out/v.mp4",
+            status="completed",
+        )
+        state_path = tmp_path / "state.json"
+        mock_generate = AsyncMock()
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch("gflow_cli.cli_movie._generate_scene", new=mock_generate),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=True,
+            )
+
+        mock_generate.assert_not_called()
+
+    async def test_continue_on_error_records_failure(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch(
+                "gflow_cli.cli_movie._generate_scene",
+                new=AsyncMock(side_effect=RuntimeError("API down")),
+            ),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=True,
+            )
+
+        assert state.scenes["S"].status == "failed"
+
+    async def test_fail_fast_propagates_exception(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch(
+                "gflow_cli.cli_movie._generate_scene",
+                new=AsyncMock(side_effect=RuntimeError("API down")),
+            ),
+            pytest.raises(RuntimeError, match="API down"),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=False,
+            )
+
+    async def test_creates_character_when_not_in_state(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(CharacterDef(name="Alice", face_prompt="young woman"),),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+        mock_create = AsyncMock()
+        mock_generate = AsyncMock(return_value=_make_video_result())
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch("gflow_cli.cli_movie._create_character", new=mock_create),
+            patch("gflow_cli.cli_movie._generate_scene", new=mock_generate),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=True,
+            )
+
+        mock_create.assert_called_once()
+
+    async def test_skips_existing_character(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _run_movie
+
+        manifest = MovieManifest(
+            title="T",
+            project="p",
+            characters=(CharacterDef(name="Alice", face_prompt="young woman"),),
+            scenes=(SceneDef(title="S", type="t2v", prompt="x"),),
+        )
+        state = MovieState(title="T", project="p")
+        state.characters["Alice"] = CharacterState(
+            entity_id="ent-1", image_paths=["/face.png"]
+        )
+        state_path = tmp_path / "state.json"
+        mock_create = AsyncMock()
+
+        with (
+            patch("gflow_cli.cli_movie.get_settings"),
+            patch("gflow_cli.cli_movie.OperationRecorder") as mock_recorder_cls,
+            patch("gflow_cli.cli_movie.FlowApiClient", return_value=_mock_client_cm()),
+            patch("gflow_cli.cli_movie._create_character", new=mock_create),
+            patch(
+                "gflow_cli.cli_movie._generate_scene",
+                new=AsyncMock(return_value=_make_video_result()),
+            ),
+        ):
+            mock_recorder_cls.open.return_value = MagicMock()
+            await _run_movie(
+                manifest=manifest,
+                state=state,
+                state_path=state_path,
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+                continue_on_error=True,
+            )
+
+        mock_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _create_character
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCharacter:
+    async def test_face_only_saves_state(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _create_character
+
+        char_def = CharacterDef(name="Alice", face_prompt="young woman")
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+
+        mock_result = MagicMock()
+        mock_result.entity_id = "ent-1"
+        mock_result.image_paths = [Path("/face.png"), None]
+
+        with patch(
+            "gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)
+        ):
+            await _create_character(
+                client=MagicMock(),
+                recorder=MagicMock(),
+                char_def=char_def,
+                project_id="proj-abc",
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                state=state,
+                state_path=state_path,
+            )
+
+        assert "Alice" in state.characters
+        assert state.characters["Alice"].entity_id == "ent-1"
+        assert state.characters["Alice"].image_paths == ["/face.png", None]
+        assert state_path.exists()
+
+    async def test_with_body_prompt_saves_both_paths(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _create_character
+
+        char_def = CharacterDef(
+            name="Bob", face_prompt="grey beard", body_prompt="casual jacket"
+        )
+        state = MovieState(title="T", project="p")
+        state_path = tmp_path / "state.json"
+
+        mock_result = MagicMock()
+        mock_result.entity_id = "ent-2"
+        mock_result.image_paths = [Path("/bob_face.png"), Path("/bob_body.png")]
+
+        with patch(
+            "gflow_cli.cli_movie.character_create", new=AsyncMock(return_value=mock_result)
+        ):
+            await _create_character(
+                client=MagicMock(),
+                recorder=MagicMock(),
+                char_def=char_def,
+                project_id="proj-abc",
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                state=state,
+                state_path=state_path,
+            )
+
+        assert state.characters["Bob"].image_paths == ["/bob_face.png", "/bob_body.png"]
+
+
+# ---------------------------------------------------------------------------
+# _generate_scene
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateScene:
+    async def test_t2v_calls_generate_video(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+
+        scene = SceneDef(title="S", type="t2v", prompt="a beautiful sunset", duration=8)
+        mock_client = AsyncMock()
+        mock_result = _make_video_result()
+        mock_client.generate_video.return_value = mock_result
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            result = await _generate_scene(
+                client=mock_client,
+                recorder=MagicMock(),
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        assert result is mock_result
+        mock_client.generate_video.assert_called_once()
+
+    async def test_r2v_passes_reference_images(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+
+        face = tmp_path / "face.png"
+        body = tmp_path / "body.png"
+        face.touch()
+        body.touch()
+
+        scene = SceneDef(title="S", type="r2v", prompt="x", characters=("Alice",))
+        mock_client = AsyncMock()
+        mock_client.generate_video.return_value = _make_video_result()
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            await _generate_scene(
+                client=mock_client,
+                recorder=MagicMock(),
+                scene_def=scene,
+                refs=[str(face), str(body)],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        call_kwargs = mock_client.generate_video.call_args.kwargs
+        assert hasattr(call_kwargs["req"], "reference_images")
+
+    async def test_i2v_passes_start_image(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+
+        frame = tmp_path / "frame.png"
+        frame.touch()
+
+        scene = SceneDef(title="S", type="i2v", prompt="x", initial_frame=str(frame))
+        mock_client = AsyncMock()
+        mock_client.generate_video.return_value = _make_video_result()
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            await _generate_scene(
+                client=mock_client,
+                recorder=MagicMock(),
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        call_kwargs = mock_client.generate_video.call_args.kwargs
+        assert hasattr(call_kwargs["req"], "start_image")
+
+    async def test_i2v_with_end_frame(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+
+        frame = tmp_path / "frame.png"
+        end_frame = tmp_path / "end.png"
+        frame.touch()
+        end_frame.touch()
+
+        scene = SceneDef(
+            title="S",
+            type="i2v",
+            prompt="x",
+            initial_frame=str(frame),
+            end_frame=str(end_frame),
+        )
+        mock_client = AsyncMock()
+        mock_client.generate_video.return_value = _make_video_result()
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            await _generate_scene(
+                client=mock_client,
+                recorder=MagicMock(),
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        call_kwargs = mock_client.generate_video.call_args.kwargs
+        assert hasattr(call_kwargs["req"], "end_image")
+
+    async def test_failed_video_raises_runtime_error(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+
+        scene = SceneDef(title="S", type="t2v", prompt="x")
+        mock_client = AsyncMock()
+        failed = _make_video_result(succeeded=False)
+        failed.status.failure_reasons = ["quota exceeded"]
+        mock_client.generate_video.return_value = failed
+
+        with (
+            patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None),
+            pytest.raises(RuntimeError, match="quota exceeded"),
+        ):
+            await _generate_scene(
+                client=mock_client,
+                recorder=MagicMock(),
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+    async def test_on_started_datastore_error_is_silent(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+        from gflow_cli.errors import DataStoreError
+
+        scene = SceneDef(title="S", type="t2v", prompt="x")
+        mock_result = _make_video_result()
+
+        async def fake_generate(**kwargs: object) -> MagicMock:
+            on_started = kwargs.get("on_started")
+            if callable(on_started):
+                on_started(MagicMock())
+            return mock_result
+
+        mock_recorder = MagicMock()
+        mock_recorder.record_started_video.side_effect = DataStoreError("db fail")
+        mock_client = AsyncMock()
+        mock_client.generate_video = AsyncMock(side_effect=fake_generate)
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            result = await _generate_scene(
+                client=mock_client,
+                recorder=mock_recorder,
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        assert result is mock_result
+
+    async def test_completed_datastore_error_is_silent(self, tmp_path: Path) -> None:
+        from gflow_cli.cli_movie import _generate_scene
+        from gflow_cli.errors import DataStoreError
+
+        scene = SceneDef(title="S", type="t2v", prompt="x")
+        mock_result = _make_video_result()
+        mock_recorder = MagicMock()
+        mock_recorder.record_completed_video.side_effect = DataStoreError("db fail")
+        mock_client = AsyncMock()
+        mock_client.generate_video.return_value = mock_result
+
+        with patch("gflow_cli.cli_movie.cloud_info_from_path", return_value=None):
+            result = await _generate_scene(
+                client=mock_client,
+                recorder=mock_recorder,
+                scene_def=scene,
+                refs=[],
+                profile_name="default",
+                profile_dir=tmp_path / "profile",
+                out_dir=tmp_path / "out",
+            )
+
+        assert result is mock_result

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -1,0 +1,200 @@
+"""Tests for `gflow movie` — movie.toml orchestrator CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main as cli_main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+_VALID_MANIFEST = """\
+title = "My Film"
+project = "proj-abc"
+
+[[scenes]]
+title = "Intro"
+type = "t2v"
+prompt = "A wide panoramic shot"
+aspect = "16:9"
+duration = 8
+"""
+
+
+# ---------------------------------------------------------------------------
+# gflow movie --help
+# ---------------------------------------------------------------------------
+
+
+class TestMovieHelp:
+    def test_movie_group_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["movie", "--help"])
+        assert result.exit_code == 0
+        assert "movie.toml" in result.output
+
+    def test_run_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["movie", "run", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+        assert "--fail-fast" in result.output
+
+    def test_template_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["movie", "template", "--help"])
+        assert result.exit_code == 0
+        assert "--force" in result.output
+
+
+# ---------------------------------------------------------------------------
+# gflow movie template
+# ---------------------------------------------------------------------------
+
+
+class TestMovieTemplate:
+    def test_template_writes_file(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        out = tmp_path / "movie.toml"
+        result = runner.invoke(cli_main, ["movie", "template", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+        content = out.read_text(encoding="utf-8")
+        assert "[[characters]]" in content
+        assert "[[scenes]]" in content
+        assert "[assemble]" in content
+
+    def test_template_default_path(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli_main, ["movie", "template"])
+            assert result.exit_code == 0
+            assert Path("movie.toml").exists()
+
+    def test_template_refuses_existing_without_force(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        out = tmp_path / "movie.toml"
+        out.write_text("existing", encoding="utf-8")
+        result = runner.invoke(cli_main, ["movie", "template", str(out)])
+        assert result.exit_code == 1
+        assert out.read_text(encoding="utf-8") == "existing"
+
+    def test_template_force_overwrites(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        out = tmp_path / "movie.toml"
+        out.write_text("old content", encoding="utf-8")
+        result = runner.invoke(cli_main, ["movie", "template", "--force", str(out)])
+        assert result.exit_code == 0
+        assert "old content" not in out.read_text(encoding="utf-8")
+
+    def test_generated_template_is_valid_manifest(self, tmp_path: Path) -> None:
+        from gflow_cli.movie_manifest import MovieManifest
+
+        runner = CliRunner()
+        out = tmp_path / "movie.toml"
+        runner.invoke(cli_main, ["movie", "template", str(out)])
+        # Should parse without error (project id placeholder is a valid string)
+        m = MovieManifest.from_toml_path(out)
+        assert m.title
+        assert len(m.scenes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# gflow movie run --dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestMovieDryRun:
+    def test_dry_run_prints_plan(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
+        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "dry-run" in result.output.lower()
+        assert "Intro" in result.output
+
+    def test_dry_run_shows_characters(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        toml = (
+            'title = "F"\nproject = "p"\n'
+            '[[characters]]\nname = "Alice"\nface_prompt = "x"\n'
+            '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "y"\n'
+        )
+        manifest = _write_toml(tmp_path / "movie.toml", toml)
+        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Alice" in result.output
+        assert "credit" in result.output.lower()
+
+    def test_dry_run_shows_assembly(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        toml = (
+            'title = "F"\nproject = "p"\n'
+            '[assemble]\noutput = "./final.mp4"\n'
+            '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "y"\n'
+        )
+        manifest = _write_toml(tmp_path / "movie.toml", toml)
+        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Assembly" in result.output or "final.mp4" in result.output
+
+    def test_dry_run_no_api_calls(self, tmp_path: Path) -> None:
+        """Dry-run must not invoke FlowApiClient."""
+        from unittest.mock import patch
+
+        runner = CliRunner()
+        manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
+        with patch("gflow_cli.cli_movie.FlowApiClient") as mock_client:
+            result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        mock_client.assert_not_called()
+
+    def test_dry_run_shows_skip_for_completed_scene(self, tmp_path: Path) -> None:
+        from gflow_cli.movie_manifest import MovieState, SceneState
+
+        runner = CliRunner()
+        manifest = _write_toml(tmp_path / "movie.toml", _VALID_MANIFEST)
+        state_path = MovieState.state_path_for(manifest)
+        state = MovieState(title="My Film", project="proj-abc")
+        state.scenes["Intro"] = SceneState(
+            media_id="m1",
+            flow_operation_id="op-1",
+            local_path="/out/intro.mp4",
+            status="completed",
+        )
+        state.save(state_path)
+
+        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "skip" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# gflow movie run — manifest validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestMovieRunValidation:
+    def test_missing_manifest_exits_11(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["movie", "run", str(tmp_path / "nonexistent.toml"), "--dry-run"]
+        )
+        assert result.exit_code == 11
+
+    def test_invalid_manifest_exits_11(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        manifest = _write_toml(tmp_path / "bad.toml", 'title = "T"\n# no project, no scenes\n')
+        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        assert result.exit_code == 11

--- a/tests/cli/test_movie_manifest.py
+++ b/tests/cli/test_movie_manifest.py
@@ -1,0 +1,358 @@
+"""Unit tests for MovieManifest and MovieState (movie_manifest.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.errors import ConfigurationError
+from gflow_cli.movie_manifest import (
+    AssemblyDef,
+    CharacterDef,
+    CharacterState,
+    MovieManifest,
+    MovieState,
+    SceneDef,
+    SceneState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "movie.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+_MINIMAL_TOML = """\
+title = "Test Film"
+project = "proj-abc"
+
+[[scenes]]
+title = "Scene 1"
+type = "t2v"
+prompt = "A quiet forest at dawn"
+"""
+
+_FULL_TOML = """\
+title = "Full Film"
+project = "proj-xyz"
+output_dir = "./out/full"
+
+[[characters]]
+name = "Alice"
+face_prompt = "Young woman with red curly hair"
+body_prompt = "Casual jeans and jacket"
+model = "nano2"
+
+[[characters]]
+name = "Bob"
+face_prompt = "Middle-aged man with grey beard"
+
+[[scenes]]
+title = "Intro"
+type = "t2v"
+prompt = "Establishing shot"
+aspect = "16:9"
+duration = 8
+model = "veo-lite"
+count = 1
+
+[[scenes]]
+title = "Alice Arrives"
+type = "r2v"
+prompt = "Alice walks in"
+characters = ["Alice"]
+aspect = "16:9"
+duration = 6
+
+[[scenes]]
+title = "Close-up"
+type = "r2v"
+prompt = "Alice smiles"
+characters = ["Alice", "Bob"]
+
+[assemble]
+output = "./out/full/final.mp4"
+"""
+
+
+# ---------------------------------------------------------------------------
+# MovieManifest — valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestMovieManifestValid:
+    def test_minimal_parses(self, tmp_path: Path) -> None:
+        path = _write_toml(tmp_path, _MINIMAL_TOML)
+        m = MovieManifest.from_toml_path(path)
+        assert m.title == "Test Film"
+        assert m.project == "proj-abc"
+        assert len(m.characters) == 0
+        assert len(m.scenes) == 1
+        assert m.scenes[0].title == "Scene 1"
+        assert m.scenes[0].type == "t2v"
+        assert m.scenes[0].aspect == "16:9"
+        assert m.scenes[0].count == 1
+        assert m.assemble is None
+        assert m.output_dir is None
+
+    def test_full_parses(self, tmp_path: Path) -> None:
+        path = _write_toml(tmp_path, _FULL_TOML)
+        m = MovieManifest.from_toml_path(path)
+        assert m.title == "Full Film"
+        assert m.output_dir == "./out/full"
+        assert len(m.characters) == 2
+        assert m.characters[0].name == "Alice"
+        assert m.characters[0].body_prompt == "Casual jeans and jacket"
+        assert m.characters[1].name == "Bob"
+        assert m.characters[1].body_prompt is None
+        assert len(m.scenes) == 3
+        assert m.scenes[1].characters == ("Alice",)
+        assert m.scenes[2].characters == ("Alice", "Bob")
+        assert m.assemble is not None
+        assert m.assemble.output == "./out/full/final.mp4"
+
+    def test_scene_defaults(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            'title = "T"\nproject = "p"\n[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\n',
+        )
+        s = MovieManifest.from_toml_path(path).scenes[0]
+        assert s.aspect == "16:9"
+        assert s.duration is None
+        assert s.model is None
+        assert s.count == 1
+        assert s.characters == ()
+
+    def test_character_model_defaults_to_nano2(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[characters]]\nname = "X"\nface_prompt = "y"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "z"\n'
+            ),
+        )
+        c = MovieManifest.from_toml_path(path).characters[0]
+        assert c.model == "nano2"
+
+    def test_i2v_with_initial_frame(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "i2v"\n'
+                'prompt = "x"\ninitial_frame = "/tmp/frame.png"\n'
+            ),
+        )
+        s = MovieManifest.from_toml_path(path).scenes[0]
+        assert s.initial_frame == "/tmp/frame.png"
+        assert s.end_frame is None
+
+
+# ---------------------------------------------------------------------------
+# MovieManifest — invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestMovieManifestInvalid:
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            MovieManifest.from_toml_path(tmp_path / "nonexistent.toml")
+
+    def test_toml_syntax_error_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(tmp_path, "title = [unterminated")
+        with pytest.raises(ConfigurationError, match="Failed to parse"):
+            MovieManifest.from_toml_path(path)
+
+    def test_missing_title_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path, 'project = "p"\n[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\n'
+        )
+        with pytest.raises(ConfigurationError, match="title"):
+            MovieManifest.from_toml_path(path)
+
+    def test_missing_project_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path, 'title = "T"\n[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\n'
+        )
+        with pytest.raises(ConfigurationError, match="project"):
+            MovieManifest.from_toml_path(path)
+
+    def test_no_scenes_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(tmp_path, 'title = "T"\nproject = "p"\n')
+        with pytest.raises(ConfigurationError, match="scene"):
+            MovieManifest.from_toml_path(path)
+
+    def test_invalid_scene_type_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            'title = "T"\nproject = "p"\n[[scenes]]\ntitle = "S"\ntype = "xyz"\nprompt = "x"\n',
+        )
+        with pytest.raises(ConfigurationError, match="type"):
+            MovieManifest.from_toml_path(path)
+
+    def test_invalid_aspect_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\naspect = "4:3"\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="aspect"):
+            MovieManifest.from_toml_path(path)
+
+    def test_invalid_duration_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\nduration = 7\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="duration"):
+            MovieManifest.from_toml_path(path)
+
+    def test_count_out_of_range_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\ncount = 5\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="count"):
+            MovieManifest.from_toml_path(path)
+
+    def test_duplicate_character_name_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[characters]]\nname = "Alice"\nface_prompt = "x"\n'
+                '[[characters]]\nname = "Alice"\nface_prompt = "y"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "z"\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="Duplicate character"):
+            MovieManifest.from_toml_path(path)
+
+    def test_duplicate_scene_title_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "x"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "y"\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="Duplicate scene"):
+            MovieManifest.from_toml_path(path)
+
+    def test_unknown_character_in_scene_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "r2v"\nprompt = "x"\n'
+                'characters = ["Ghost"]\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="unknown character"):
+            MovieManifest.from_toml_path(path)
+
+    def test_i2v_missing_initial_frame_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            'title = "T"\nproject = "p"\n[[scenes]]\ntitle = "S"\ntype = "i2v"\nprompt = "x"\n',
+        )
+        with pytest.raises(ConfigurationError, match="initial_frame"):
+            MovieManifest.from_toml_path(path)
+
+    def test_invalid_character_model_raises(self, tmp_path: Path) -> None:
+        path = _write_toml(
+            tmp_path,
+            (
+                'title = "T"\nproject = "p"\n'
+                '[[characters]]\nname = "X"\nface_prompt = "y"\nmodel = "imagen4"\n'
+                '[[scenes]]\ntitle = "S"\ntype = "t2v"\nprompt = "z"\n'
+            ),
+        )
+        with pytest.raises(ConfigurationError, match="model"):
+            MovieManifest.from_toml_path(path)
+
+
+# ---------------------------------------------------------------------------
+# MovieState
+# ---------------------------------------------------------------------------
+
+
+class TestMovieState:
+    def test_empty_state_for_missing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "movie-state.json"
+        state = MovieState.load(path, title="T", project="p")
+        assert state.characters == {}
+        assert state.scenes == {}
+
+    def test_save_and_reload(self, tmp_path: Path) -> None:
+        path = tmp_path / "movie-state.json"
+        state = MovieState(title="T", project="p")
+        state.characters["Alice"] = CharacterState(
+            entity_id="ent-1",
+            image_paths=["/path/to/face.png", None],
+        )
+        state.scenes["Scene 1"] = SceneState(
+            media_id="media-1",
+            flow_operation_id="op-1",
+            local_path="/out/video.mp4",
+            status="completed",
+        )
+        state.save(path)
+        assert path.exists()
+
+        loaded = MovieState.load(path, title="T", project="p")
+        assert "Alice" in loaded.characters
+        assert loaded.characters["Alice"].entity_id == "ent-1"
+        assert loaded.characters["Alice"].image_paths == ["/path/to/face.png", None]
+        assert "Scene 1" in loaded.scenes
+        assert loaded.scenes["Scene 1"].media_id == "media-1"
+        assert loaded.scenes["Scene 1"].flow_operation_id == "op-1"
+        assert loaded.scenes["Scene 1"].status == "completed"
+
+    def test_corrupted_state_file_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "movie-state.json"
+        path.write_text("not json{{", encoding="utf-8")
+        state = MovieState.load(path, title="T", project="p")
+        assert state.characters == {}
+        assert state.scenes == {}
+
+    def test_state_path_for(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "my-film.toml"
+        assert MovieState.state_path_for(manifest) == tmp_path / "my-film-state.json"
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "state.json"
+        state = MovieState(title="T", project="p")
+        state.save(nested)
+        assert nested.exists()
+
+    def test_scene_state_failed_status(self, tmp_path: Path) -> None:
+        path = tmp_path / "s.json"
+        state = MovieState(title="T", project="p")
+        state.scenes["Scene X"] = SceneState(
+            media_id="",
+            flow_operation_id=None,
+            local_path=None,
+            status="failed",
+        )
+        state.save(path)
+        loaded = MovieState.load(path, title="T", project="p")
+        assert loaded.scenes["Scene X"].status == "failed"

--- a/tests/cli/test_movie_manifest.py
+++ b/tests/cli/test_movie_manifest.py
@@ -2,22 +2,17 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 
 from gflow_cli.errors import ConfigurationError
 from gflow_cli.movie_manifest import (
-    AssemblyDef,
-    CharacterDef,
     CharacterState,
     MovieManifest,
     MovieState,
-    SceneDef,
     SceneState,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ wheels = [
 
 [[package]]
 name = "gflow-cli"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds a new `gflow movie` command group that orchestrates the full film production pipeline from a single `movie.toml` manifest file
- Characters, scenes, and assembly are driven declaratively — no shell scripting needed
- Crash-safe: a `-state.json` sibling file is written after each step so interrupted runs resume without re-spending credits

## New commands

```
gflow movie template [OUTPUT]   # write a starter movie.toml
gflow movie run MANIFEST        # execute the manifest
  --dry-run                     # print plan + credit estimate, no API calls
  --fail-fast                   # halt on first scene failure
  --out-dir DIR                 # override output directory
```

## movie.toml format

```toml
title = "My Short Film"
project = "YOUR_FLOW_PROJECT_ID"

[[characters]]
name = "Alice"
face_prompt = "Young woman with curly red hair, green eyes"
body_prompt = "Casual jeans and light jacket"  # optional

[[scenes]]
title = "Establishing Shot"
type = "t2v"
prompt = "Futuristic city skyline at golden hour"
aspect = "16:9"
duration = 8

[[scenes]]
title = "Character Arrives"
type = "r2v"
prompt = "Alice walks through the plaza"
characters = ["Alice"]   # auto-injects face + body as --ref
aspect = "16:9"
duration = 8

[assemble]
output = "./out/final.mp4"  # printed as a ready-to-run gflow scene create command
```

## Execution phases

1. **Characters** — creates each `[[characters]]` entry via the existing `character_create` saga; skips already-created ones on resume
2. **Scenes** — generates each `[[scenes]]` entry (t2v / r2v / i2v); for `r2v` scenes the character's face + body images are auto-injected as `--ref` inputs
3. **Summary** — prints the exact `gflow scene create` command to stitch completed clips

## New files

- `src/gflow_cli/movie_manifest.py` — TOML parsing, validation, `MovieState` for crash recovery
- `src/gflow_cli/cli_movie.py` — Click command group
- `tests/cli/test_movie_manifest.py` — 27 unit tests for manifest parsing and state
- `tests/cli/test_cli_movie.py` — 40 CLI-level and mock-based unit tests

## Test plan

- [x] `uv run python -m pytest tests/cli/test_movie_manifest.py tests/cli/test_cli_movie.py` — 40/40 pass
- [x] `uv run ruff check src/gflow_cli/movie_manifest.py src/gflow_cli/cli_movie.py` — clean
- [x] `uv run pyright src` — 0 errors
- [x] Full test suite — all pass
- [ ] Live: `gflow movie template && gflow movie run movie.toml` against a real Flow project