### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1469,7 +1469,8 @@ shell-script template that branches on these codes.
 
 First skeleton. Not functional end-to-end yet.
 
-[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/ffroliva/gflow-cli/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/ffroliva/gflow-cli/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/ffroliva/gflow-cli/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/ffroliva/gflow-cli/compare/v0.11.0...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   logger elides large reference-field values so Flow-built image bytes can't leak into
   logs.
 
+### Internal
+
+- Bump dev/CI `ruff` to `0.15.16` (both the `dev` extra and the `dependency-groups`
+  pin; supersedes Dependabot PR #165, which updated only the soft `>=` extra and not
+  the hard `==` group pin CI actually uses). `ruff check` / `format --check` clean.
+
 ## [0.14.0] — 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-06-09
+
+### Added
+
+- **`gflow image` can reference locked CHARACTER entities** for character-consistent
+  stills. New `--reference-entity <id>` (repeatable) + `--reference-entity-name` on
+  `image t2i` / `i2i`, plus `--project <id>` to generate in an EXISTING project (where
+  the entities live) instead of a throwaway scratch project. Entities attach through
+  the editor's **Personagens picker** and ride the submit as `referenceEntities`
+  (confirmed against the live API); `_build_batch_generate_images_body` serializes them
+  so non-UI/headless transports get parity too. Entities count toward the per-model
+  reference cap. `--project` / `--reference-entity` are single-prompt only; for a pure
+  character reference use `t2i` (`i2i` still needs a `--ref`). See `docs/USAGE.md` →
+  "Character-consistent images (entity references)".
+
+### Fixed
+
+- `--project` no longer overwrites an existing project's stored title/source in the
+  local history DB (the recorder preserves the curated title for non-created projects).
+
+### Security
+
+- `--project` / `--reference-entity` ids are validated at the CLI boundary
+  (`[A-Za-z0-9-]{1,128}`), closing an unvalidated `page.goto` navigation path
+  (`project_editor_url` lacked the allowlist its sibling routes enforce) and a
+  CSS-selector injection vector (`data-tile-id='fe_id_<id>'`). The request-body debug
+  logger elides large reference-field values so Flow-built image bytes can't leak into
+  logs.
+
 ## [0.14.0] — 2026-06-07
 
 ### Added

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,9 +4,9 @@
 
 ## Current release
 
-**v0.13.0 — alpha.** High-fidelity CLI hardening and term alignment. **`gflow video i2v`** now uses the canonical `--initial-frame` and `--end-frame` flags (matching Flow's UI labels), with robust Click greedy-fill protection and positional backward compatibility. **In-project governance** (ruff T20, materiality classification) is now active to harden the AI-driven development flow. This release also refactors the **`character_create` saga** for improved type safety and documentation. Live-verified end-to-end on 2026-06-04 with the new flags and interpolation paths.
+**v0.15.0 — alpha.** **Character-consistent images via entity references.** `gflow image t2i/i2i` can now reference locked Flow CHARACTER entities (`--reference-entity <id>`, repeatable) and generate in an existing project (`--project <id>`) where those entities live — entities attach through the editor's Personagens picker and ride the submit as `referenceEntities` (confirmed against the live API; the body builder serializes them for headless transports too). Live-verified 2026-06-08: a 3-frame Dragon-Hook smoke rendered drift-free with all three characters on-model. LLM-council-reviewed (security/correctness/dedup) before merge. Carries forward the v0.14.0 `gflow movie` line (multi-scene, character-consistent video).
 
-**Develop (unreleased, post-v0.13.0):** *(empty — develop is the staging branch for the next release).*
+**Develop (unreleased, post-v0.15.0):** *(empty — develop is the staging branch for the next release).*
 
 ## Milestone history
 
@@ -52,6 +52,8 @@
 | `gflow character rm` — free character deletion (#150) | ✅ done (v0.13.0) |
 | Align I2V CLI flags with Flow UI Labels (`--initial-frame`) (#122) | ✅ done (v0.13.0) |
 | In-project governance (ruff T20, materiality Classifier) | ✅ done (v0.13.0) |
+| `gflow movie` — multi-scene, character-consistent video from a TOML manifest (entity reuse, resumable, handoff manifest) | ✅ done (v0.14.0) |
+| `gflow image t2i/i2i` — reference locked CHARACTER entities (`--reference-entity`) + `--project` for character-consistent stills | ✅ done (v0.15.0) |
 | `gflow character` — reusable Flow Character entities (`create`/`list`/`show`/`voices`), persist-before-spend saga (#145) | ✅ done (v0.12.0) |
 | `gflow scene` — Add Clip / Scenes compose + credit-free server-side extended video (`runVideoFxConcatenation`) | ✅ done (v0.12.0) |
 | `gflow video chain` — last-frame I2V chaining from a JSONL manifest (`--dry-run`/`--max-links`/`--resume-from`) | ✅ done (v0.12.0) |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,6 +131,13 @@ Options:
                             Aspect ratio.                     [default: 9:16]
   -n, --count INTEGER       How many images to generate (1-4).  [default: 1]
   --out PATH                Output directory (see "Output paths" below).
+  --project ID              Generate in this EXISTING Flow project instead of a
+                            scratch project. Required to reference locked
+                            entities/assets in that project. Single-prompt only.
+  --reference-entity ID     Flow CHARACTER entity id to reference for character
+                            consistency (repeatable; must live in --project).
+                            Single-prompt only.
+  --reference-entity-name N Display name paired with --reference-entity.
   --profile NAME            Profile name (overrides default).
 ```
 
@@ -212,6 +219,10 @@ Options:
                             Aspect ratio.                     [default: 9:16]
   -n, --count INTEGER       How many images to generate (1-4).  [default: 1]
   --out PATH                Output directory (same semantics as t2i).
+  --project ID              Generate in this EXISTING Flow project (skip scratch).
+  --reference-entity ID     Flow CHARACTER entity id to reference (repeatable;
+                            must live in --project). Counts toward the ref cap.
+  --reference-entity-name N Display name paired with --reference-entity.
   --profile NAME            Profile name (overrides default).
 ```
 
@@ -247,6 +258,40 @@ A 2-image run produces files numbered `_1.png`, `_2.png`:
 ./variants/<media_name_a>_1.png
 ./variants/<media_name_b>_2.png
 ```
+
+## Character-consistent images (entity references)
+
+`--reference-entity` makes `image t2i`/`i2i` reference a locked Flow **CHARACTER
+entity** (minted via `gflow character create`) so the generated subject stays
+on-model across shots — no per-shot prompt wrangling or fragile image refs.
+
+How it works: entities are **project-scoped**, so you must generate **in the
+project that owns them** via `--project <id>` (this also means no throwaway
+scratch project is created). The CLI attaches each entity through the Flow editor's
+resource picker; the submit then carries `referenceEntities`, exactly like the
+video R2V path. Entities count toward the same per-model reference cap as `--ref`
+images. `--reference-entity` / `--project` are **single-prompt only**.
+
+For a *pure* character reference (no starting image) use `t2i` — `i2i` still
+requires at least one `--ref`.
+
+```bash
+# One locked character, consistent across runs (t2i = no image ref needed)
+gflow image t2i "Aria explores a neon market, full body" \
+  --project 7fa97443-… --reference-entity 8a77f8cb-… --reference-entity-name Aria \
+  --model nano2 --aspect 9:16 -n 3
+
+# Several characters in one scene (each --reference-entity repeatable)
+gflow image t2i "Aria and Drako meet at the gate" --project 7fa97443-… \
+  --reference-entity 8a77f8cb-… --reference-entity 4ed5cb7f-…
+
+# i2i: a starting image PLUS an entity for the character
+gflow image i2i "place this hero in a snowy pass" --ref hero.png \
+  --project 7fa97443-… --reference-entity 8a77f8cb-…
+```
+
+> Ids are validated at the CLI boundary (letters/digits/hyphens, ≤128 chars).
+> The entity must already exist in `--project` (see `gflow character create`).
 
 ## `gflow image batch`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.14.0"
+version = "0.15.0"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
-    "ruff>=0.15.15",
+    "ruff>=0.15.16",
     "pyright>=1.1.0",
     # video-chain: the last-frame extractor (media.py) decodes with PyAV, and its
     # tests build synthetic mp4 fixtures with numpy. Declared here so the dev/CI
@@ -134,7 +134,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-bdd>=8.1.0",
     "pytest-cov>=7.1.0",
-    "ruff==0.15.15",
+    "ruff==0.15.16",
 ]
 # Container-based integration tests — requires Docker daemon.
 # Install: uv sync --group containers

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -229,6 +229,14 @@ class GenerateImageRequest:
     # dialog by the ui_automation transport (the REST uploadImage path 401s).
     # The common i2i case; `refs` (pre-uploaded UUIDs) would need library-select.
     ref_paths: tuple[Path, ...] = ()
+    # Flow CHARACTER entity ids to reference (project-scoped, attached via the
+    # Add-Media → Personagens picker by the ui_automation transport). Entities
+    # keep generated subjects consistent with a locked character. They count
+    # toward the same per-model reference cap as image refs.
+    reference_entities: tuple[str, ...] = ()
+    # Optional display names paired with reference_entities (used by the UI
+    # picker when an id-keyed tile can't be located by id alone).
+    reference_entity_names: tuple[str, ...] = ()
     recaptcha_token: str = ""  # populated by caller right before send; "" means unminted
     # number of images to generate (1–4); UI transport uses this to set Flow's count tab
     count: int = 1
@@ -240,10 +248,10 @@ class GenerateImageRequest:
         if not 1 <= self.count <= 4:
             msg = f"GenerateImageRequest.count must be 1–4, got {self.count}"
             raise ValueError(msg)
-        n_refs = len(self.refs) + len(self.ref_paths)
+        n_refs = len(self.refs) + len(self.ref_paths) + len(self.reference_entities)
         cap = reference_cap_for(self.model)
         if n_refs > cap:
-            msg = f"{self.model.value} allows at most {cap} reference image(s); got {n_refs}"
+            msg = f"{self.model.value} allows at most {cap} reference(s); got {n_refs}"
             raise ValueError(
                 msg,
             )

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -307,6 +307,14 @@ def _build_batch_generate_images_body(
         # Always present — empty list for T2I, populated for I2I.
         "imageInputs": [r.to_wire() for r in req.refs],
     }
+    # Character entity references. Shape confirmed by live capture (2026-06-08):
+    # the image submit carries `referenceEntities: [{"entityId": <id>}]`. Added
+    # only when present so plain t2i/i2i bodies stay byte-identical to the
+    # captured samples. The ui_automation transport attaches entities via the
+    # Personagens picker and lets Flow's JS build this; non-UI transports rely
+    # on this serialization.
+    if req.reference_entities:
+        request["referenceEntities"] = [{"entityId": e} for e in req.reference_entities]
     return {
         "clientContext": cc,
         "mediaGenerationContext": {"batchId": batch_id},

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -518,6 +518,67 @@ def _images_from_responses(
     return images, first_error_status, first_error_route
 
 
+def _zip_entities(
+    entity_ids: tuple[str, ...],
+    entity_names: tuple[str, ...],
+) -> list[tuple[str, str]]:
+    """Pair entity ids with display names for the Personagens picker.
+
+    The picker addresses tiles by id (``data-tile-id="fe_id_<id>"``); the name is
+    only a human label used in logs / error screenshots. When fewer names than
+    ids are given, the id stands in as its own name so the pairing never drops an
+    entity.
+    """
+    names = list(entity_names)
+    return [
+        (eid, names[i] if i < len(names) else eid)
+        for i, eid in enumerate(entity_ids)
+    ]
+
+
+def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
+    """Compact, byte-safe summary of an outgoing ``batchGenerateImages`` body.
+
+    This is the make-or-break signal for the entity-reference spike: it reveals
+    whether Flow's image submit carries a ``referenceEntities`` field after we
+    attach a character via the picker — WITHOUT logging the full body (i2i
+    bodies embed base64 image bytes that would flood the log and leak content).
+
+    Returns a dict with ``present``, ``mentions_reference_entities`` (cheap
+    substring probe that survives non-JSON bodies), and — when the body parses —
+    the keys of ``requests[0]`` plus any reference/entity-related fields verbatim
+    (those are small id lists, safe to surface).
+    """
+    if not post_data:
+        return {"present": False}
+    summary: dict[str, Any] = {
+        "present": True,
+        "bytes": len(post_data),
+        "mentions_reference_entities": "referenceEntit" in post_data,
+    }
+    try:
+        parsed: object = json.loads(post_data)
+    except (ValueError, TypeError):
+        return summary
+    if not isinstance(parsed, dict):
+        return summary
+    parsed_dict = cast("dict[str, Any]", parsed)
+    reqs = parsed_dict.get("requests")
+    if isinstance(reqs, list) and reqs and isinstance(reqs[0], dict):
+        first = cast("dict[str, Any]", reqs[0])
+        summary["request0_keys"] = sorted(first.keys())
+        ref_bits = {
+            k: v
+            for k, v in first.items()
+            if "reference" in k.lower() or "entity" in k.lower()
+        }
+        if ref_bits:
+            summary["reference_fields"] = ref_bits
+    else:
+        summary["top_keys"] = sorted(parsed_dict.keys())
+    return summary
+
+
 class UiAutomationTransport(VideoGenerationMixin):
     """D.2.4 — Playwright UI mimicry strategy.
 
@@ -1594,6 +1655,51 @@ class UiAutomationTransport(VideoGenerationMixin):
         return captured, detach
 
     @staticmethod
+    def _attach_batch_request_logger(
+        page: Page,
+        *,
+        project_id: str | None = None,
+    ) -> Callable[[], None]:
+        """Register a ``page.on('request', ...)`` that logs a compact summary of
+        each outgoing ``batchGenerateImages`` body.
+
+        The summary (see :func:`_summarize_batch_request_body`) surfaces whether
+        the submit carries ``referenceEntities`` — the entity-reference spike's
+        make-or-break signal — without dumping i2i image bytes. Returns an
+        idempotent detach fn, torn down alongside the response listener.
+        """
+
+        def on_request(request_obj: Any) -> None:
+            if "batchGenerateImages" not in request_obj.url:
+                return
+            try:
+                post_data = request_obj.post_data
+            except Exception:
+                post_data = None
+            log.info(
+                "ui_automation.batch_request_body",
+                url=request_obj.url,
+                filter_project_id=project_id,
+                summary=_summarize_batch_request_body(post_data),
+            )
+
+        page.on("request", on_request)
+
+        _detached = False
+
+        def detach() -> None:
+            nonlocal _detached
+            if _detached:
+                return
+            _detached = True
+            try:
+                page.remove_listener("request", on_request)
+            except Exception:
+                pass
+
+        return detach
+
+    @staticmethod
     async def _await_captured(
         captured: list[dict[str, Any]],
         timeout_s: float = 180.0,
@@ -1814,6 +1920,18 @@ class UiAutomationTransport(VideoGenerationMixin):
         if request.ref_paths:
             await self._attach_references(page, list(request.ref_paths), out_dir=out_dir)
 
+        # Entity references: attach locked CHARACTER entities via the Personagens
+        # picker (inherited from the video transport). The entity must live in the
+        # project we generate in (pass --project / project_id). Flow's JS then
+        # includes them on the submit; the request logger below records whether the
+        # outgoing batchGenerateImages carries `referenceEntities` (spike signal).
+        if request.reference_entities:
+            await self._attach_character_entities(
+                page,
+                _zip_entities(request.reference_entities, request.reference_entity_names),
+                out_dir=out_dir,
+            )
+
         # Attach the response listener SYNCHRONOUSLY before any prompt
         # action. asyncio.create_task is unsafe here: it defers the listener
         # registration until the new task gets event-loop scheduling, which
@@ -1821,6 +1939,9 @@ class UiAutomationTransport(VideoGenerationMixin):
         # attach/await eliminates that race. Project-ID filter prevents stale
         # responses from previously-visited projects accumulating in the list.
         captured, detach = self._attach_batch_response_listener(page, project_id=nav_project_id)
+        # Also log the OUTGOING request body summary so the entity-reference spike
+        # can read whether the submit carries `referenceEntities`.
+        req_log_detach = self._attach_batch_request_logger(page, project_id=nav_project_id)
         # Record submit_time BEFORE the click so the post-submit-time filter
         # in _await_captured can distinguish this prompt's responses from any
         # stale entries that arrived between listener attach and the click.
@@ -1835,6 +1956,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             )
         finally:
             detach()
+            req_log_detach()
 
         # Collect images from ALL captured responses (Flow makes one API call
         # per image when count > 1).

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -31,6 +31,7 @@ from gflow_cli.api.transports._common import extract_project_id
 from gflow_cli.api.transports.ui_automation_video import (
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
+    zip_entity_refs,
 )
 from gflow_cli.errors import (
     AuthExpiredError,
@@ -518,22 +519,25 @@ def _images_from_responses(
     return images, first_error_status, first_error_route
 
 
-def _zip_entities(
-    entity_ids: tuple[str, ...],
-    entity_names: tuple[str, ...],
-) -> list[tuple[str, str]]:
-    """Pair entity ids with display names for the Personagens picker.
+_REF_VALUE_MAX_CHARS = 512
 
-    The picker addresses tiles by id (``data-tile-id="fe_id_<id>"``); the name is
-    only a human label used in logs / error screenshots. When fewer names than
-    ids are given, the id stands in as its own name so the pairing never drops an
-    entity.
+
+def _elide_large_value(value: Any) -> Any:
+    """Return *value* verbatim when small, else a length-only redaction marker.
+
+    Guards the request-body logger against dumping large/secret payloads: if Flow
+    names an i2i image field `reference*`/`*entity*`, its base64 bytes would match
+    the reference-field filter and be logged in full. Small fields like
+    `referenceEntities` (a short list of `{entityId}`) pass through; anything
+    serializing beyond the cap is elided to a `<elided N chars>` marker.
     """
-    names = list(entity_names)
-    return [
-        (eid, names[i] if i < len(names) else eid)
-        for i, eid in enumerate(entity_ids)
-    ]
+    try:
+        serialized = json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return f"<unserializable {type(value).__name__}>"
+    if len(serialized) > _REF_VALUE_MAX_CHARS:
+        return f"<elided {len(serialized)} chars>"
+    return value
 
 
 def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
@@ -568,7 +572,7 @@ def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
         first = cast("dict[str, Any]", reqs[0])
         summary["request0_keys"] = sorted(first.keys())
         ref_bits = {
-            k: v
+            k: _elide_large_value(v)
             for k, v in first.items()
             if "reference" in k.lower() or "entity" in k.lower()
         }
@@ -1928,7 +1932,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         if request.reference_entities:
             await self._attach_character_entities(
                 page,
-                _zip_entities(request.reference_entities, request.reference_entity_names),
+                zip_entity_refs(request.reference_entities, request.reference_entity_names),
                 out_dir=out_dir,
             )
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -318,6 +318,22 @@ VIDEO_SUBMODE_SELECTORS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+
+def zip_entity_refs(
+    entity_ids: tuple[str, ...],
+    entity_names: tuple[str, ...],
+) -> list[tuple[str, str]]:
+    """Pair character entity ids with display names for the Personagens picker.
+
+    Tiles are addressed by id (``data-tile-id="fe_id_<id>"``); the name is only a
+    human label for logs/error screenshots. When fewer names than ids are given,
+    the id stands in as its own name so the pairing never drops an entity. Shared
+    by the image (`ui_automation`) and video (R2V) entity-attach paths.
+    """
+    names = list(entity_names)
+    return [(eid, names[i] if i < len(names) else eid) for i, eid in enumerate(entity_ids)]
+
+
 # The editor SPA's ready anchor — the Slate prompt textbox. The /project/ URL
 # nav fires before the UI mounts; this is the readiness gate (used by
 # _wait_video_editor_ready and asserted in its test).
@@ -1585,14 +1601,9 @@ class VideoGenerationMixin:
                 )
         elif request.mode is Mode.R2V:
             if request.reference_entities:
-                names = request.reference_entity_names or request.reference_entities
-                entities = [
-                    (entity_id, names[i] if i < len(names) else entity_id)
-                    for i, entity_id in enumerate(request.reference_entities)
-                ]
                 await VideoGenerationMixin._attach_character_entities(
                     page,
-                    entities,
+                    zip_entity_refs(request.reference_entities, request.reference_entity_names),
                     out_dir=out_dir,
                 )
             if request.reference_images:

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -33,6 +33,7 @@ from gflow_cli._cli_helpers import (
     safe_path_text,
 )
 from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.dto import ProjectInfo
 from gflow_cli.api.image import Aspect, GenerateImageRequest, ImageRef, Model, reference_cap_for
 from gflow_cli.api.transports import transport_choices
 from gflow_cli.config import get_settings
@@ -145,6 +146,33 @@ def _classify_ref(ref: str) -> ImageRef | Path:
         raise click.UsageError(
             msg,
         ) from exc
+
+
+async def _resolve_project(
+    client: FlowApiClient,
+    *,
+    project_id: str | None,
+    title: str,
+    as_json: bool,
+) -> ProjectInfo:
+    """Resolve the project to generate in.
+
+    When ``project_id`` is given, generation runs in that EXISTING project (so
+    its locked entities/assets are visible) and no scratch project is created —
+    this is what ``--project`` buys. When it is ``None`` the historical behavior
+    holds: create a fresh ``gflow-cli ...`` project. Either way a
+    :class:`ProjectInfo` is returned so callers and the recorder share one shape.
+    """
+    if project_id is not None:
+        if not as_json:
+            console.print(f"  Project: [dim]{project_id}[/dim] [dim](existing)[/dim]")
+        return ProjectInfo(project_id=project_id, title=title)
+    if not as_json:
+        console.print(_CREATING_PROJECT_MSG)
+    project = await client.create_project(title=title)
+    if not as_json:
+        console.print(f"  Project: [dim]{project.project_id}[/dim]")
+    return project
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +384,16 @@ async def _run_upload(
     ),
 )
 @click.option(
+    "--project",
+    "project_id",
+    default=None,
+    help=(
+        "Generate in this existing Flow project id instead of creating a scratch "
+        "project. Required to reference locked entities/assets that live in a "
+        "specific project. Single-prompt only."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -372,11 +410,19 @@ def t2i(
     out: Path | None,
     profile: str | None,
     transport: str | None,
+    project_id: str | None,
     as_json: bool,
 ) -> None:
     """Generate image(s) from one or more text prompts."""
     is_multi_prompt = len(prompts) > 1 or prompts_file is not None or read_stdin
     _validate_t2i_input(prompts, prompts_file, read_stdin)
+
+    if is_multi_prompt and project_id is not None:
+        # The multi-prompt/batch path creates one shared project internally; a
+        # single explicit --project across many prompts isn't wired. Loop t2i
+        # one prompt at a time if you need every frame in the same project.
+        msg = "--project is single-prompt only; remove the extra prompts."
+        raise click.UsageError(msg)
 
     if is_multi_prompt and as_json:
         # --json is single-prompt only — the batch summary shape is rich-table
@@ -408,6 +454,7 @@ def t2i(
                 out=out,
                 output_root=settings.output_dir,
                 transport=transport,
+                project_id=project_id,
                 as_json=as_json,
             ),
             cli_command="image t2i",
@@ -557,6 +604,7 @@ async def _run_t2i(
     out: Path | None,
     output_root: Path,
     transport: str | None = None,
+    project_id: str | None = None,
     as_json: bool = False,
 ) -> None:
     settings = get_settings()
@@ -567,13 +615,12 @@ async def _run_t2i(
             headless=headless,
             transport=transport,
         ) as client:
-            if not as_json:
-                console.print(_CREATING_PROJECT_MSG)
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-            project = await client.create_project(title=_T2I_PROJECT_TITLE)
+            project = await _resolve_project(
+                client, project_id=project_id, title=_T2I_PROJECT_TITLE, as_json=as_json
+            )
             if not as_json:
-                console.print(f"  Project: [dim]{project.project_id}[/dim]")
                 console.print(
                     f"  Generating {count} image(s) ({req.model.value}, {req.aspect.value})...",
                 )
@@ -867,6 +914,16 @@ def batch(
     ),
 )
 @click.option(
+    "--project",
+    "project_id",
+    default=None,
+    help=(
+        "Generate in this existing Flow project id instead of creating a scratch "
+        "project. Required to reference locked entities/assets that live in a "
+        "specific project."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -881,6 +938,7 @@ def i2i(
     out: Path | None,
     profile: str | None,
     transport: str | None,
+    project_id: str | None,
     as_json: bool,
 ) -> None:
     """Generate image(s) from PROMPT + reference image(s) (image-to-image)."""
@@ -918,6 +976,7 @@ def i2i(
             out=out,
             output_root=settings.output_dir,
             transport=transport,
+            project_id=project_id,
             as_json=as_json,
         ),
         cli_command="image i2i",
@@ -938,6 +997,7 @@ async def _run_i2i(
     out: Path | None,
     output_root: Path,
     transport: str | None = None,
+    project_id: str | None = None,
     as_json: bool = False,
 ) -> None:
     settings = get_settings()
@@ -948,13 +1008,11 @@ async def _run_i2i(
             headless=headless,
             transport=transport,
         ) as client:
-            if not as_json:
-                console.print(_CREATING_PROJECT_MSG)
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-            project = await client.create_project(title="gflow-cli i2i")
-            if not as_json:
-                console.print(f"  Project: [dim]{project.project_id}[/dim]")
+            project = await _resolve_project(
+                client, project_id=project_id, title="gflow-cli i2i", as_json=as_json
+            )
 
             # Local-file refs are attached through the editor's media dialog by the
             # ui_automation transport (the REST uploadImage path 401s — see #15/#39).

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -92,6 +92,43 @@ _UUID_RE = re.compile(
 
 _CREATING_PROJECT_MSG = "  Creating project..."
 _T2I_PROJECT_TITLE = "gflow-cli t2i"
+_I2I_PROJECT_TITLE = "gflow-cli i2i"
+
+# Flow project / character-entity ids interpolated into navigation URLs and UI
+# selectors. Mirror routes._PROJECT_ID_RE so untrusted --project / --reference-entity
+# values are rejected at the CLI boundary (closes the page.goto + CSS-selector
+# injection gaps before the value ever reaches the browser).
+_FLOW_ID_RE = re.compile(r"^[A-Za-z0-9\-]{1,128}$")
+
+
+def _validate_project_id(
+    _ctx: click.Context, param: click.Parameter, value: str | None
+) -> str | None:
+    """Reject a --project id that isn't alphanumeric/hyphen (1-128 chars).
+
+    The value is interpolated into the editor navigation URL (`page.goto`) before
+    any other guard runs, so validate here at the boundary.
+    """
+    if value is not None and not _FLOW_ID_RE.fullmatch(value):
+        msg = "project id must be 1-128 chars of letters, digits, or hyphens."
+        raise click.BadParameter(msg, param=param)
+    return value
+
+
+def _validate_entity_ids(
+    _ctx: click.Context, param: click.Parameter, value: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Reject any --reference-entity id that isn't alphanumeric/hyphen.
+
+    Entity ids are interpolated into a CSS selector (`data-tile-id='fe_id_<id>'`);
+    the allowlist also blocks quote/metacharacter selector-breakage.
+    """
+    for v in value:
+        if not _FLOW_ID_RE.fullmatch(v):
+            msg = f"invalid --reference-entity id {v!r}: expected 1-128 chars of [A-Za-z0-9-]."
+            raise click.BadParameter(msg, param=param)
+    return value
+
 
 console = Console()
 logger = structlog.get_logger(__name__)
@@ -154,25 +191,29 @@ async def _resolve_project(
     project_id: str | None,
     title: str,
     as_json: bool,
-) -> ProjectInfo:
+) -> tuple[ProjectInfo, bool]:
     """Resolve the project to generate in.
 
     When ``project_id`` is given, generation runs in that EXISTING project (so
     its locked entities/assets are visible) and no scratch project is created —
     this is what ``--project`` buys. When it is ``None`` the historical behavior
-    holds: create a fresh ``gflow-cli ...`` project. Either way a
-    :class:`ProjectInfo` is returned so callers and the recorder share one shape.
+    holds: create a fresh ``gflow-cli ...`` project.
+
+    Returns ``(project, created)``. ``created`` is False for an existing
+    ``--project`` so the recorder does NOT overwrite that project's real title /
+    source in the local history DB (the synthesized ``title`` here is only a
+    placeholder for the created path).
     """
     if project_id is not None:
         if not as_json:
             console.print(f"  Project: [dim]{project_id}[/dim] [dim](existing)[/dim]")
-        return ProjectInfo(project_id=project_id, title=title)
+        return ProjectInfo(project_id=project_id, title=title), False
     if not as_json:
         console.print(_CREATING_PROJECT_MSG)
     project = await client.create_project(title=title)
     if not as_json:
         console.print(f"  Project: [dim]{project.project_id}[/dim]")
-    return project
+    return project, True
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +428,7 @@ async def _run_upload(
     "--project",
     "project_id",
     default=None,
+    callback=_validate_project_id,
     help=(
         "Generate in this existing Flow project id instead of creating a scratch "
         "project. Required to reference locked entities/assets that live in a "
@@ -397,6 +439,7 @@ async def _run_upload(
     "--reference-entity",
     "reference_entities",
     multiple=True,
+    callback=_validate_entity_ids,
     help=(
         "Flow CHARACTER entity id to reference for consistency (repeatable). "
         "The entity must live in the --project you target. Single-prompt only."
@@ -637,7 +680,7 @@ async def _run_t2i(
         ) as client:
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-            project = await _resolve_project(
+            project, project_created = await _resolve_project(
                 client, project_id=project_id, title=_T2I_PROJECT_TITLE, as_json=as_json
             )
             if not as_json:
@@ -682,6 +725,7 @@ async def _run_t2i(
                     profile_name=profile_name,
                     profile_dir=profile_dir,
                     project=project,
+                    project_created=project_created,
                     request=req,
                     images=images,
                     saved_paths=saved_paths,
@@ -937,6 +981,7 @@ def batch(
     "--project",
     "project_id",
     default=None,
+    callback=_validate_project_id,
     help=(
         "Generate in this existing Flow project id instead of creating a scratch "
         "project. Required to reference locked entities/assets that live in a "
@@ -947,6 +992,7 @@ def batch(
     "--reference-entity",
     "reference_entities",
     multiple=True,
+    callback=_validate_entity_ids,
     help=(
         "Flow CHARACTER entity id to reference for consistency (repeatable). "
         "The entity must live in the --project you target."
@@ -1053,8 +1099,8 @@ async def _run_i2i(
         ) as client:
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
-            project = await _resolve_project(
-                client, project_id=project_id, title="gflow-cli i2i", as_json=as_json
+            project, project_created = await _resolve_project(
+                client, project_id=project_id, title=_I2I_PROJECT_TITLE, as_json=as_json
             )
 
             # Local-file refs are attached through the editor's media dialog by the
@@ -1118,6 +1164,7 @@ async def _run_i2i(
                     profile_name=profile_name,
                     profile_dir=profile_dir,
                     project=project,
+                    project_created=project_created,
                     request=req,
                     images=images,
                     saved_paths=saved_paths,
@@ -1144,7 +1191,7 @@ async def _run_i2i(
 
 def _print_i2i_summary(images: list[GeneratedImage], saved_paths: list[Path]) -> None:
     """Render a Rich table of generated images and where they landed."""
-    table = Table(title="gflow-cli i2i")
+    table = Table(title=_I2I_PROJECT_TITLE)
     table.add_column("media_name", overflow="fold")
     table.add_column("seed", justify="right")
     table.add_column("dimensions")

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -18,7 +18,7 @@ import asyncio
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import click
 import structlog
@@ -79,7 +79,11 @@ from gflow_cli.paths import image_output_path, resolve_batch_output_dir
 from gflow_cli.storage import cloud_info_from_path
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from gflow_cli.api.dto import GeneratedImage
+
+_CmdFn = TypeVar("_CmdFn", bound="Callable[..., object]")
 
 # Case-insensitive 8-4-4-4-12 hex with hyphens — Flow's media UUIDs.
 # When a `--ref` value matches this regex it's treated as an already-uploaded
@@ -128,6 +132,46 @@ def _validate_entity_ids(
             msg = f"invalid --reference-entity id {v!r}: expected 1-128 chars of [A-Za-z0-9-]."
             raise click.BadParameter(msg, param=param)
     return value
+
+
+def _project_and_entity_options(*, single_prompt: bool) -> Callable[[_CmdFn], _CmdFn]:
+    """Shared `--project` / `--reference-entity` / `--reference-entity-name` options.
+
+    Applied to both `t2i` and `i2i` so the (identical) option definitions live in one
+    place. ``single_prompt`` appends the single-prompt-only note to t2i's help.
+    """
+    note = " Single-prompt only." if single_prompt else ""
+
+    def decorator(func: _CmdFn) -> _CmdFn:
+        func = click.option(
+            "--reference-entity-name",
+            "reference_entity_names",
+            multiple=True,
+            help="Character display name paired with --reference-entity (UI picker fallback).",
+        )(func)
+        func = click.option(
+            "--reference-entity",
+            "reference_entities",
+            multiple=True,
+            callback=_validate_entity_ids,
+            help=(
+                "Flow CHARACTER entity id to reference for consistency (repeatable). "
+                "The entity must live in the --project you target." + note
+            ),
+        )(func)
+        return click.option(
+            "--project",
+            "project_id",
+            default=None,
+            callback=_validate_project_id,
+            help=(
+                "Generate in this existing Flow project id instead of creating a scratch "
+                "project. Required to reference locked entities/assets that live in a "
+                "specific project." + note
+            ),
+        )(func)
+
+    return decorator
 
 
 console = Console()
@@ -424,40 +468,14 @@ async def _run_upload(
         "GFLOW_CLI_EXPERIMENTAL_TRANSPORTS=1 to enable evaluate_fetch/bearer/sapisidhash."
     ),
 )
-@click.option(
-    "--project",
-    "project_id",
-    default=None,
-    callback=_validate_project_id,
-    help=(
-        "Generate in this existing Flow project id instead of creating a scratch "
-        "project. Required to reference locked entities/assets that live in a "
-        "specific project. Single-prompt only."
-    ),
-)
-@click.option(
-    "--reference-entity",
-    "reference_entities",
-    multiple=True,
-    callback=_validate_entity_ids,
-    help=(
-        "Flow CHARACTER entity id to reference for consistency (repeatable). "
-        "The entity must live in the --project you target. Single-prompt only."
-    ),
-)
-@click.option(
-    "--reference-entity-name",
-    "reference_entity_names",
-    multiple=True,
-    help="Character display name paired with --reference-entity (UI picker fallback).",
-)
+@_project_and_entity_options(single_prompt=True)
 @click.option(
     "--json",
     "as_json",
     is_flag=True,
     help="Emit a machine-readable JSON result instead of a Rich table.",
 )
-def t2i(
+def t2i(  # NOSONAR(S107): Click command — every option is part of the CLI's public API
     prompts: tuple[str, ...],
     prompts_file: Path | None,
     read_stdin: bool,
@@ -977,33 +995,7 @@ def batch(
         "GFLOW_CLI_EXPERIMENTAL_TRANSPORTS=1 to enable evaluate_fetch/bearer/sapisidhash."
     ),
 )
-@click.option(
-    "--project",
-    "project_id",
-    default=None,
-    callback=_validate_project_id,
-    help=(
-        "Generate in this existing Flow project id instead of creating a scratch "
-        "project. Required to reference locked entities/assets that live in a "
-        "specific project."
-    ),
-)
-@click.option(
-    "--reference-entity",
-    "reference_entities",
-    multiple=True,
-    callback=_validate_entity_ids,
-    help=(
-        "Flow CHARACTER entity id to reference for consistency (repeatable). "
-        "The entity must live in the --project you target."
-    ),
-)
-@click.option(
-    "--reference-entity-name",
-    "reference_entity_names",
-    multiple=True,
-    help="Character display name paired with --reference-entity (UI picker fallback).",
-)
+@_project_and_entity_options(single_prompt=False)
 @click.option(
     "--json",
     "as_json",
@@ -1071,7 +1063,7 @@ def i2i(
     )
 
 
-async def _run_i2i(
+async def _run_i2i(  # NOSONAR(S107): mirrors the i2i command's option surface
     *,
     profile_name: str,
     profile_dir: Path,

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -394,6 +394,21 @@ async def _run_upload(
     ),
 )
 @click.option(
+    "--reference-entity",
+    "reference_entities",
+    multiple=True,
+    help=(
+        "Flow CHARACTER entity id to reference for consistency (repeatable). "
+        "The entity must live in the --project you target. Single-prompt only."
+    ),
+)
+@click.option(
+    "--reference-entity-name",
+    "reference_entity_names",
+    multiple=True,
+    help="Character display name paired with --reference-entity (UI picker fallback).",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -411,17 +426,20 @@ def t2i(
     profile: str | None,
     transport: str | None,
     project_id: str | None,
+    reference_entities: tuple[str, ...],
+    reference_entity_names: tuple[str, ...],
     as_json: bool,
 ) -> None:
     """Generate image(s) from one or more text prompts."""
     is_multi_prompt = len(prompts) > 1 or prompts_file is not None or read_stdin
     _validate_t2i_input(prompts, prompts_file, read_stdin)
 
-    if is_multi_prompt and project_id is not None:
+    if is_multi_prompt and (project_id is not None or reference_entities):
         # The multi-prompt/batch path creates one shared project internally; a
-        # single explicit --project across many prompts isn't wired. Loop t2i
-        # one prompt at a time if you need every frame in the same project.
-        msg = "--project is single-prompt only; remove the extra prompts."
+        # single explicit --project / --reference-entity across many prompts isn't
+        # wired. Loop t2i one prompt at a time if you need every frame in the same
+        # project with the same characters.
+        msg = "--project / --reference-entity are single-prompt only; remove the extra prompts."
         raise click.UsageError(msg)
 
     if is_multi_prompt and as_json:
@@ -449,6 +467,8 @@ def t2i(
                     prompt=prompt,
                     aspect=Aspect.from_cli(aspect),
                     model=Model.from_cli(model),
+                    reference_entities=tuple(reference_entities),
+                    reference_entity_names=tuple(reference_entity_names),
                 ),
                 count=count,
                 out=out,
@@ -924,6 +944,21 @@ def batch(
     ),
 )
 @click.option(
+    "--reference-entity",
+    "reference_entities",
+    multiple=True,
+    help=(
+        "Flow CHARACTER entity id to reference for consistency (repeatable). "
+        "The entity must live in the --project you target."
+    ),
+)
+@click.option(
+    "--reference-entity-name",
+    "reference_entity_names",
+    multiple=True,
+    help="Character display name paired with --reference-entity (UI picker fallback).",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -939,6 +974,8 @@ def i2i(
     profile: str | None,
     transport: str | None,
     project_id: str | None,
+    reference_entities: tuple[str, ...],
+    reference_entity_names: tuple[str, ...],
     as_json: bool,
 ) -> None:
     """Generate image(s) from PROMPT + reference image(s) (image-to-image)."""
@@ -954,8 +991,10 @@ def i2i(
     # GenerateImageRequest.__post_init__ enforces the same cap as an invariant.
     model_enum = Model.from_cli(model)
     cap = reference_cap_for(model_enum)
-    if len(classified_refs) > cap:
-        msg = f"{model} allows at most {cap} reference image(s); got {len(classified_refs)}."
+    # Image refs AND character entities share one per-model reference budget.
+    n_refs = len(classified_refs) + len(reference_entities)
+    if n_refs > cap:
+        msg = f"{model} allows at most {cap} reference(s); got {n_refs}."
         raise click.UsageError(
             msg,
         )
@@ -977,6 +1016,8 @@ def i2i(
             output_root=settings.output_dir,
             transport=transport,
             project_id=project_id,
+            reference_entities=tuple(reference_entities),
+            reference_entity_names=tuple(reference_entity_names),
             as_json=as_json,
         ),
         cli_command="image i2i",
@@ -998,6 +1039,8 @@ async def _run_i2i(
     output_root: Path,
     transport: str | None = None,
     project_id: str | None = None,
+    reference_entities: tuple[str, ...] = (),
+    reference_entity_names: tuple[str, ...] = (),
     as_json: bool = False,
 ) -> None:
     settings = get_settings()
@@ -1026,6 +1069,8 @@ async def _run_i2i(
                 model=model,
                 refs=uuid_refs,
                 ref_paths=local_ref_paths,
+                reference_entities=reference_entities,
+                reference_entity_names=reference_entity_names,
             )
 
             n_refs = len(uuid_refs) + len(local_ref_paths)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -475,7 +475,7 @@ async def _run_upload(
     is_flag=True,
     help="Emit a machine-readable JSON result instead of a Rich table.",
 )
-def t2i(  # NOSONAR(S107): Click command — every option is part of the CLI's public API
+def t2i(
     prompts: tuple[str, ...],
     prompts_file: Path | None,
     read_stdin: bool,
@@ -1063,7 +1063,7 @@ def i2i(
     )
 
 
-async def _run_i2i(  # NOSONAR(S107): mirrors the i2i command's option surface
+async def _run_i2i(
     *,
     profile_name: str,
     profile_dir: Path,

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -176,16 +176,21 @@ class OperationRecorder:
         input_media_ids: list[str],
         operation_kind: str,
         cloud_storage_infos: list[CloudStorageInfo | None] | None = None,
+        project_created: bool = True,
     ) -> None:
         repo = self.repository
 
         repo.upsert_profile(profile_name, profile_dir)
+        # When generating into a pre-existing project (`--project`), `project.title`
+        # is only a placeholder — DON'T overwrite the project's real, user-curated
+        # title in the local history DB. Passing title=None lets upsert_project's
+        # COALESCE preserve whatever title is already stored.
         repo.upsert_project(
             ProjectRecord(
                 id=_new_id(),
                 profile_name=profile_name,
                 flow_project_id=project.project_id,
-                title=project.title,
+                title=project.title if project_created else None,
                 source="generated",
             ),
         )

--- a/tests/api/test_image.py
+++ b/tests/api/test_image.py
@@ -241,6 +241,33 @@ class TestReferenceCap:
 
 
 class TestBuildBatchGenerateImagesBody:
+    def test_includes_reference_entities_when_present(self) -> None:
+        # Shape confirmed by the 2026-06-08 live capture: the image submit
+        # carries `referenceEntities: [{"entityId": <id>}]`.
+        built = _build_batch_generate_images_body(
+            GenerateImageRequest(prompt="x", reference_entities=("ent-1", "ent-2")),
+            project_id="P",
+            batch_id="B",
+            seed=1,
+            session_id="S",
+        )
+        assert built["requests"][0]["referenceEntities"] == [
+            {"entityId": "ent-1"},
+            {"entityId": "ent-2"},
+        ]
+
+    def test_omits_reference_entities_when_absent(self) -> None:
+        # No entities → the key must not appear (keeps plain t2i/i2i bodies
+        # byte-identical to the captured samples).
+        built = _build_batch_generate_images_body(
+            GenerateImageRequest(prompt="x"),
+            project_id="P",
+            batch_id="B",
+            seed=1,
+            session_id="S",
+        )
+        assert "referenceEntities" not in built["requests"][0]
+
     def test_matches_sample_06_t2i(self) -> None:
         sample = _load_sample("06_batchGenerateImages.json")
         sample_body = sample["request_body_parsed"]

--- a/tests/api/test_image.py
+++ b/tests/api/test_image.py
@@ -166,6 +166,19 @@ class TestGenerateImageRequest:
         req = GenerateImageRequest(prompt="test", model=Model.NARWHAL, aspect=Aspect.PORTRAIT)
         assert req.recaptcha_token == ""
 
+    def test_accepts_reference_entities(self) -> None:
+        req = GenerateImageRequest(prompt="x", reference_entities=("ent-1", "ent-2"))
+        assert req.reference_entities == ("ent-1", "ent-2")
+
+    def test_accepts_reference_entity_names(self) -> None:
+        req = GenerateImageRequest(prompt="x", reference_entity_names=("Stacky", "Drako"))
+        assert req.reference_entity_names == ("Stacky", "Drako")
+
+    def test_reference_entities_default_empty(self) -> None:
+        req = GenerateImageRequest(prompt="x")
+        assert req.reference_entities == ()
+        assert req.reference_entity_names == ()
+
 
 class TestReferenceCap:
     def test_cap_values(self) -> None:
@@ -207,6 +220,24 @@ class TestReferenceCap:
             refs=tuple(ImageRef(f"ref-{i}") for i in range(MAX_IMAGE_REFERENCES)),
         )
         assert len(req.refs) == MAX_IMAGE_REFERENCES
+
+    def test_cap_counts_entities_with_image_refs(self) -> None:
+        # Character entities count toward the SAME per-model cap as image refs.
+        with pytest.raises(ValueError, match="at most 3"):
+            GenerateImageRequest(
+                prompt="mix",
+                model=Model.IMAGEN_3_5,
+                refs=(ImageRef("a"), ImageRef("b")),
+                reference_entities=("ent-1", "ent-2"),
+            )
+
+    def test_entities_within_cap_ok(self) -> None:
+        req = GenerateImageRequest(
+            prompt="ok",
+            model=Model.IMAGEN_3_5,
+            reference_entities=("ent-1", "ent-2", "ent-3"),
+        )
+        assert len(req.reference_entities) == 3
 
 
 class TestBuildBatchGenerateImagesBody:

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -33,11 +33,11 @@ from gflow_cli.api.transports.ui_automation import (
     UiAutomationTransport,
     _count_tabs_locator,  # noqa: PLC2701
     _summarize_batch_request_body,  # noqa: PLC2701
-    _zip_entities,  # noqa: PLC2701
 )
 from gflow_cli.api.transports.ui_automation_video import (
     COMPOSER_AGENT_TOGGLE_SELECTOR,
     VideoGenerationMixin,
+    zip_entity_refs,
 )
 from gflow_cli.errors import ContentPolicyError, WafRejectionError
 
@@ -1212,13 +1212,16 @@ class TestGenerateImages:
 
 class TestZipEntities:
     def test_pairs_ids_with_names(self) -> None:
-        assert _zip_entities(("a", "b"), ("Stacky", "Drako")) == [("a", "Stacky"), ("b", "Drako")]
+        assert zip_entity_refs(("a", "b"), ("Stacky", "Drako")) == [
+            ("a", "Stacky"),
+            ("b", "Drako"),
+        ]
 
     def test_name_falls_back_to_id_when_missing(self) -> None:
-        assert _zip_entities(("a", "b"), ("Stacky",)) == [("a", "Stacky"), ("b", "b")]
+        assert zip_entity_refs(("a", "b"), ("Stacky",)) == [("a", "Stacky"), ("b", "b")]
 
     def test_empty(self) -> None:
-        assert _zip_entities((), ()) == []
+        assert zip_entity_refs((), ()) == []
 
 
 class TestSummarizeBatchRequestBody:
@@ -1247,9 +1250,7 @@ class TestSummarizeBatchRequestBody:
         assert out["reference_fields"]["referenceEntities"] == [{"entityId": "ent-1"}]
 
     def test_no_reference_fields(self) -> None:
-        body = json.dumps(
-            {"requests": [{"structuredPrompt": {"parts": []}, "imageInputs": []}]}
-        )
+        body = json.dumps({"requests": [{"structuredPrompt": {"parts": []}, "imageInputs": []}]})
         out = _summarize_batch_request_body(body)
         assert out["present"] is True
         assert out["mentions_reference_entities"] is False
@@ -1260,6 +1261,71 @@ class TestSummarizeBatchRequestBody:
         assert out["present"] is True
         assert out["mentions_reference_entities"] is True
         assert "request0_keys" not in out
+
+    def test_large_reference_field_is_elided_not_dumped(self) -> None:
+        # If Flow names an i2i image field `reference*`, its base64 bytes must NOT
+        # be logged verbatim — they get elided to a length marker.
+        big = "A" * 5000
+        body = json.dumps({"requests": [{"referenceImage": big, "imageInputs": []}]})
+        out = _summarize_batch_request_body(body)
+        assert out["reference_fields"]["referenceImage"] != big
+        assert "elided" in out["reference_fields"]["referenceImage"]
+
+
+class TestElideLargeValue:
+    def test_small_value_passes_through(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _elide_large_value
+
+        v = [{"entityId": "ent-1"}]
+        assert _elide_large_value(v) == v
+
+    def test_large_value_is_elided(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _elide_large_value
+
+        out = _elide_large_value("Z" * 5000)
+        assert isinstance(out, str) and "elided" in out
+
+
+class TestAttachBatchRequestLogger:
+    """The request-body logger must: fire only for batchGenerateImages, never let
+    a post_data failure break generation, and detach idempotently."""
+
+    class _Req:
+        def __init__(self, url: str, *, raises: bool = False, post: str | None = None) -> None:
+            self.url = url
+            self._raises = raises
+            self._post = post
+
+        @property
+        def post_data(self) -> str | None:
+            if self._raises:
+                raise RuntimeError("post_data unavailable")
+            return self._post
+
+    def test_registers_fires_safely_and_detaches_once(self) -> None:
+        page = MagicMock()
+        handlers: dict[str, object] = {}
+        page.on.side_effect = lambda event, fn: handlers.__setitem__(event, fn)
+
+        detach = UiAutomationTransport._attach_batch_request_logger(page, project_id="P")
+        on_request = handlers["request"]
+        assert callable(on_request)
+
+        # Non-matching URL: must early-return WITHOUT touching post_data (raises if touched).
+        on_request(self._Req("https://x/other", raises=True))
+        # Matching URL but post_data raises: must be swallowed (generation unaffected).
+        on_request(self._Req("https://x/flowMedia:batchGenerateImages", raises=True))
+        # Matching URL with a real body: must not raise.
+        on_request(
+            self._Req(
+                "https://x/flowMedia:batchGenerateImages",
+                post=json.dumps({"requests": [{"referenceEntities": [{"entityId": "e"}]}]}),
+            )
+        )
+
+        detach()
+        detach()  # idempotent
+        page.remove_listener.assert_called_once_with("request", on_request)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,6 +32,8 @@ from gflow_cli.api.transports.ui_automation import (
     SUBMIT_BUTTON_SELECTORS,
     UiAutomationTransport,
     _count_tabs_locator,  # noqa: PLC2701
+    _summarize_batch_request_body,  # noqa: PLC2701
+    _zip_entities,  # noqa: PLC2701
 )
 from gflow_cli.api.transports.ui_automation_video import (
     COMPOSER_AGENT_TOGGLE_SELECTOR,
@@ -1160,6 +1163,103 @@ class TestGenerateImages:
             await t.generate_images(project_id="x", request=_req())
 
         attach.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reference_entities_attached_via_character_picker(self) -> None:
+        """Character entity ids bind through the Personagens picker —
+        _generate_images_locked awaits the inherited _attach_character_entities
+        with (entity_id, name) pairs when request.reference_entities is set."""
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+        req = GenerateImageRequest(
+            prompt="stacky and drako",
+            model=Model.NARWHAL,
+            reference_entities=("ent-1", "ent-2"),
+            reference_entity_names=("Stacky",),  # fewer names than ids on purpose
+        )
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_character_entities", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=req)
+
+        attach.assert_awaited_once()
+        call = attach.await_args
+        assert call is not None
+        # Pairs are (id, name) — name falls back to the id when no name is given.
+        assert list(call.args[1]) == [("ent-1", "Stacky"), ("ent-2", "ent-2")]
+
+    @pytest.mark.asyncio
+    async def test_without_reference_entities_skips_character_attach(self) -> None:
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_character_entities", new=AsyncMock()) as attach,
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            await t.generate_images(project_id="x", request=_req())
+
+        attach.assert_not_awaited()
+
+
+class TestZipEntities:
+    def test_pairs_ids_with_names(self) -> None:
+        assert _zip_entities(("a", "b"), ("Stacky", "Drako")) == [("a", "Stacky"), ("b", "Drako")]
+
+    def test_name_falls_back_to_id_when_missing(self) -> None:
+        assert _zip_entities(("a", "b"), ("Stacky",)) == [("a", "Stacky"), ("b", "b")]
+
+    def test_empty(self) -> None:
+        assert _zip_entities((), ()) == []
+
+
+class TestSummarizeBatchRequestBody:
+    """The make-or-break spike reads this summary to learn whether the image
+    submit carries `referenceEntities` — without dumping i2i image bytes."""
+
+    def test_none_body(self) -> None:
+        assert _summarize_batch_request_body(None) == {"present": False}
+
+    def test_extracts_reference_entity_fields(self) -> None:
+        body = json.dumps(
+            {
+                "requests": [
+                    {
+                        "structuredPrompt": {"parts": [{"text": "x"}]},
+                        "referenceEntities": [{"entityId": "ent-1"}],
+                        "imageInputs": [],
+                    }
+                ]
+            }
+        )
+        out = _summarize_batch_request_body(body)
+        assert out["present"] is True
+        assert out["mentions_reference_entities"] is True
+        assert "referenceEntities" in out["request0_keys"]
+        assert out["reference_fields"]["referenceEntities"] == [{"entityId": "ent-1"}]
+
+    def test_no_reference_fields(self) -> None:
+        body = json.dumps(
+            {"requests": [{"structuredPrompt": {"parts": []}, "imageInputs": []}]}
+        )
+        out = _summarize_batch_request_body(body)
+        assert out["present"] is True
+        assert out["mentions_reference_entities"] is False
+        assert "reference_fields" not in out
+
+    def test_non_json_body_still_flags_substring(self) -> None:
+        out = _summarize_batch_request_body("garbage-not-json-referenceEntities")
+        assert out["present"] is True
+        assert out["mentions_reference_entities"] is True
+        assert "request0_keys" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -1065,3 +1065,56 @@ class TestImageProjectFlag:
 
         assert result.exit_code == 0, result.output
         client.create_project.assert_awaited_once_with(title="gflow-cli i2i")
+
+
+class TestReferenceEntityFlag:
+    """`--reference-entity` / `--reference-entity-name` flow into the request."""
+
+    def test_i2i_reference_entity_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        uuid = "11111111-1111-1111-1111-111111111111"
+        client = _make_i2i_client()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "i2i", "stylize", "--ref", uuid, "--project", "P",
+                 "--reference-entity", "e1", "--reference-entity", "e2",
+                 "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        req = client.generate_image.await_args.kwargs["req"]
+        assert req.reference_entities == ("e1", "e2")
+
+    def test_t2i_reference_entity_with_name(self, runner: CliRunner, tmp_path: Path) -> None:
+        client = _make_t2i_client()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a hero", "--project", "P",
+                 "--reference-entity", "ent-1",
+                 "--reference-entity-name", "Stacky",
+                 "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        req = client.generate_image.await_args.kwargs["req"]
+        assert req.reference_entities == ("ent-1",)
+        assert req.reference_entity_names == ("Stacky",)

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -987,3 +987,81 @@ class TestRecorderIntegration:
         # structlog warning must be emitted
         events = [e["event"] for e in cap.entries]
         assert "data.persistence_failed_after_success" in events
+
+
+class TestImageProjectFlag:
+    """`--project <id>` makes image gen run in an existing project (no scratch)."""
+
+    def test_i2i_uses_given_project(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A UUID ref keeps _classify_ref off the filesystem.
+        uuid = "11111111-1111-1111-1111-111111111111"
+        client = _make_i2i_client()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "i2i", "stylize", "--ref", uuid, "--project", "PROJ123",
+                 "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        # The given project is used verbatim and no scratch project is created.
+        client.create_project.assert_not_called()
+        call = client.generate_image.await_args
+        assert call is not None
+        assert call.kwargs["project_id"] == "PROJ123"
+
+    def test_t2i_uses_given_project(self, runner: CliRunner, tmp_path: Path) -> None:
+        client = _make_t2i_client()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--project", "PROJ123", "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        client.create_project.assert_not_called()
+        call = client.generate_image.await_args
+        assert call is not None
+        assert call.kwargs["project_id"] == "PROJ123"
+
+    def test_i2i_without_project_still_creates_scratch(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # Backward-compat: omitting --project keeps the old create-a-project behavior.
+        uuid = "11111111-1111-1111-1111-111111111111"
+        client = _make_i2i_client()
+        out_dir = tmp_path / "out"
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "i2i", "stylize", "--ref", uuid, "--out", str(out_dir)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        client.create_project.assert_awaited_once_with(title="gflow-cli i2i")

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -1007,8 +1007,17 @@ class TestImageProjectFlag:
 
             result = runner.invoke(
                 main,
-                ["image", "i2i", "stylize", "--ref", uuid, "--project", "PROJ123",
-                 "--out", str(out_dir)],
+                [
+                    "image",
+                    "i2i",
+                    "stylize",
+                    "--ref",
+                    uuid,
+                    "--project",
+                    "PROJ123",
+                    "--out",
+                    str(out_dir),
+                ],
                 catch_exceptions=False,
             )
 
@@ -1084,9 +1093,21 @@ class TestReferenceEntityFlag:
 
             result = runner.invoke(
                 main,
-                ["image", "i2i", "stylize", "--ref", uuid, "--project", "P",
-                 "--reference-entity", "e1", "--reference-entity", "e2",
-                 "--out", str(out_dir)],
+                [
+                    "image",
+                    "i2i",
+                    "stylize",
+                    "--ref",
+                    uuid,
+                    "--project",
+                    "P",
+                    "--reference-entity",
+                    "e1",
+                    "--reference-entity",
+                    "e2",
+                    "--out",
+                    str(out_dir),
+                ],
                 catch_exceptions=False,
             )
 
@@ -1107,10 +1128,19 @@ class TestReferenceEntityFlag:
 
             result = runner.invoke(
                 main,
-                ["image", "t2i", "a hero", "--project", "P",
-                 "--reference-entity", "ent-1",
-                 "--reference-entity-name", "Stacky",
-                 "--out", str(out_dir)],
+                [
+                    "image",
+                    "t2i",
+                    "a hero",
+                    "--project",
+                    "P",
+                    "--reference-entity",
+                    "ent-1",
+                    "--reference-entity-name",
+                    "Stacky",
+                    "--out",
+                    str(out_dir),
+                ],
                 catch_exceptions=False,
             )
 
@@ -1118,3 +1148,131 @@ class TestReferenceEntityFlag:
         req = client.generate_image.await_args.kwargs["req"]
         assert req.reference_entities == ("ent-1",)
         assert req.reference_entity_names == ("Stacky",)
+
+
+class TestImageIdValidation:
+    """--project / --reference-entity ids are validated at the CLI boundary
+    (they reach page.goto + a CSS selector)."""
+
+    def test_t2i_rejects_bad_project_id(self, runner: CliRunner) -> None:
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main, ["image", "t2i", "a cat", "--project", "bad/id"], catch_exceptions=False
+        )
+        assert result.exit_code == 2, result.output
+        assert "project id" in result.output.lower()
+
+    def test_i2i_rejects_bad_entity_id(self, runner: CliRunner) -> None:
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main,
+            [
+                "image",
+                "i2i",
+                "x",
+                "--ref",
+                "11111111-1111-1111-1111-111111111111",
+                "--reference-entity",
+                "bad id with spaces",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 2, result.output
+        assert "reference-entity" in result.output.lower()
+
+
+class TestT2iEntityGuards:
+    """t2i restricts --project / --reference-entity to single-prompt mode."""
+
+    def test_multiprompt_with_project_errors(self, runner: CliRunner) -> None:
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main, ["image", "t2i", "a", "b", "--project", "P"], catch_exceptions=False
+        )
+        assert result.exit_code == 2, result.output
+        assert "single-prompt only" in result.output
+
+    def test_multiprompt_with_entity_errors(self, runner: CliRunner) -> None:
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main, ["image", "t2i", "a", "b", "--reference-entity", "e1"], catch_exceptions=False
+        )
+        assert result.exit_code == 2, result.output
+        assert "single-prompt only" in result.output
+
+
+class TestI2iCapCountsEntities:
+    def test_i2i_cap_counts_refs_plus_entities(self, runner: CliRunner) -> None:
+        # imagen4 caps at 3; 2 image refs + 2 entities = 4 → rejected at CLI.
+        from gflow_cli.cli import main
+
+        args = ["image", "i2i", "x", "--model", "imagen4"]
+        for u in (
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ):
+            args += ["--ref", u]
+        args += ["--reference-entity", "ent-1", "--reference-entity", "ent-2"]
+        result = runner.invoke(main, args, catch_exceptions=False)
+        assert result.exit_code == 2, result.output
+        assert "at most 3" in result.output
+
+
+class TestProjectCreatedRecording:
+    """--project (existing) must NOT be recorded as a created project, so the
+    recorder won't overwrite the project's real title in the local DB."""
+
+    @staticmethod
+    def _fake_recorder(captured: dict) -> MagicMock:
+        rec = MagicMock()
+        rec.close = MagicMock()
+        rec.record_generated_images.side_effect = lambda **kw: captured.update(kw)
+        return rec
+
+    def test_existing_project_not_marked_created(self, runner: CliRunner, tmp_path: Path) -> None:
+        captured: dict = {}
+        client = _make_t2i_client()
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch(
+                "gflow_cli.cli_image.OperationRecorder.open",
+                return_value=self._fake_recorder(captured),
+            ),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--project", "PROJ123", "--out", str(tmp_path / "o")],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        assert captured.get("project_created") is False
+
+    def test_scratch_project_marked_created(self, runner: CliRunner, tmp_path: Path) -> None:
+        captured: dict = {}
+        client = _make_t2i_client()
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+            patch(
+                "gflow_cli.cli_image.OperationRecorder.open",
+                return_value=self._fake_recorder(captured),
+            ),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                ["image", "t2i", "a cat", "--out", str(tmp_path / "o")],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        assert captured.get("project_created") is True

--- a/tests/features/test_image_steps.py
+++ b/tests/features/test_image_steps.py
@@ -83,6 +83,7 @@ def _make_fake_t2i(file_count: int):
         out: Path | None,
         output_root: Path,
         transport: str | None = None,
+        project_id: str | None = None,
         as_json: bool = False,
     ) -> None:
         # Honor ``count`` if the scenario set it; otherwise fall back to the

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ wheels = [
 
 [[package]]
 name = "gflow-cli"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.15" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.16" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.2.0" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "tenacity", specifier = ">=8.2" },
@@ -850,7 +850,7 @@ containers = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = "==0.15.15" },
+    { name = "ruff", specifier = "==0.15.16" },
     { name = "s3fs", specifier = ">=2024.2.0" },
     { name = "testcontainers", specifier = ">=4.8.0" },
     { name = "universal-pathlib", specifier = ">=0.2.5" },
@@ -865,7 +865,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = "==0.15.15" },
+    { name = "ruff", specifier = "==0.15.16" },
 ]
 
 [[package]]
@@ -2426,27 +2426,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
-    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Release **v0.15.0** — `gflow image` character entity references. Cut from `develop` per the `gflow:release` process.

## What ships
- `gflow image t2i/i2i`: `--reference-entity <id>` (repeatable) + `--reference-entity-name`, and `--project <id>` to generate in an existing project. Character-consistent stills via locked Flow entities. Single-prompt only; pure entity refs use `t2i` (`i2i` still needs `--ref`).
- Body builder serializes `referenceEntities` (headless parity); entities count toward the per-model ref cap.

## Validation
- Make-or-break spike confirmed the image API accepts `referenceEntities` (live capture, project `7fa97443`). 3-frame Dragon-Hook smoke: drift-free, all 3 characters on-model.
- LLM-council review applied (recorder title clobber, log-leak of large ref fields, unvalidated `--project`/`--reference-entity` ids, `_zip_entities` dedup) + 13 tests.
- Gates green: 1579 tests, `ruff` (0.15.16) + `ruff format --check` + `pyright src` clean, repo hygiene clean.
- Folds in **ruff 0.15.16** (both pins — supersedes Dependabot #165) and doc-review fixes (CHANGELOG footer, PROJECT_STATUS).

## Merge protocol (per gflow:release)
- **Merge with `--merge` (NOT squash)** — preserves the integration history this branch carries.
- The signed tag `v0.15.0` is pushed independently to trigger the PyPI release (point of no return — requires a GPG/SSH-signed tag).