### PR TITLE
fix: locale-free picker include selectors + entity submit backstop (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--reference-entity` no longer fails on non-Portuguese Flow accounts** ([#170](https://github.com/ffroliva/gflow-cli/issues/170)) — the resource-picker include selectors hardcoded the pt-BR caption "Incluir no comando"; they are now locale-free tier cascades (context-menu `add`-ligature anchor + pt/ru/en text fallback), fixing `gflow image t2i --reference-entity`, movie R2V entity attach, and Vozes voice attach for every account language. Failures are now typed (`TransportTimeoutError`, exit 9) with a locale-neutral remediation hint, the matched selector tier is logged (`include_selector_tier`) for drift telemetry, and a new image-side submit backstop raises `WireFormatError` (exit 7) if a staged character never reaches the wire instead of silently returning a text-only generation. Thanks @papushin7987 for the live-verified report
+
 ### Added
 
 - **`gflow image upscale <mediaId> --scale 2k|4k`** — upscale a platform-generated image to 2K or 4K (Flow's download-menu 1K/2K/4K options) and save it locally; credit-free. The owning project is resolved from the local catalog (or pass `--project` for images gflow didn't record). 4K requires a Flow Ultra subscription — a non-Ultra 4K request fails fast with exit code 22 (`UpscaleUnavailableError`) rather than a generic 403. Reverse-engineered wire documented in [docs/IMAGE_UPSCALE_RECON.md](docs/IMAGE_UPSCALE_RECON.md); live-verified end-to-end (issue #171)

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -348,7 +348,7 @@ issue and not blocked by any code change in this repo.
 
 ### `UiAutomationTransport` selectors locale-agnostic — issue #24 Phase 5 complete
 
-- **Status:** Resolved (pending owner live e2e on non-EN profile) · **Severity:** Low · **Tracking:** [issue #24](https://github.com/ffroliva/gflow-cli/issues/24), [issue #94](https://github.com/ffroliva/gflow-cli/issues/94)
+- **Status:** Resolved (pending owner live e2e on non-EN profile) · **Severity:** Low · **Tracking:** [issue #24](https://github.com/ffroliva/gflow-cli/issues/24), [issue #94](https://github.com/ffroliva/gflow-cli/issues/94), [issue #170](https://github.com/ffroliva/gflow-cli/issues/170)
 
   `--lang=en-US` removed in PR #127 (2026-05-30). All selector groups now use
   locale-stable anchors: `IMAGE_MODEL_OPTION_SELECTORS` and
@@ -358,6 +358,20 @@ issue and not blocked by any code change in this repo.
   Google-branded identifiers. Locale is controlled by the `locale=locale_env`
   Playwright kwarg (persists across all in-session navigations). Full resolution
   gate: live e2e with `gflow image t2i` (each model) on a non-EN Chrome profile.
+
+  **2026-06-12 correction (issue #170):** the "all selector groups" claim above
+  had two stragglers — `PICKER_INCLUDE_BUTTON` and `PICKER_CONTEXT_INCLUDE`
+  hardcoded the pt-BR caption "Incluir no comando", breaking
+  `--reference-entity` (image t2i), movie R2V entity attach, and Vozes voice
+  attach on every non-Portuguese account (Flow renders in the ACCOUNT language;
+  `?hl=en` cannot override it). Fixed by converting both constants to sequential
+  tier cascades — context-menu Tier 1 is the locale-free `add`-ligature menuitem
+  scoped to the open menu; the Vozes button has no ligature, so pt/ru/en text
+  leads with a lone-iconless-dialog-button structural fallback. The matched tier
+  is emitted as `ui_automation_video.include_selector_tier` (drift telemetry),
+  exhaustion raises typed `TransportTimeoutError` (exit 9) with a locale-neutral
+  remediation hint, and an image-side submit backstop now raises
+  `WireFormatError` when a requested entity never rode the wire.
 
 **Phase 2 progress (2026-05-25, develop / post-v0.8.1, unreleased):**
 

--- a/docs/CHARACTER.md
+++ b/docs/CHARACTER.md
@@ -375,7 +375,8 @@ convenience later.
     generate) so Flow's JS sets `entityContext` and passes the WAF; gflow captures `media[]`/`workflows[]`
     from the response. Reuse gflow's prompt-submit + response-capture machinery (`ui_automation.py`), but in
     the character-editor context (NOT the new-project flow). Video `--character` reuse = resource picker
-    (`Pesquisar recursos` → Personagens → *Incluir no comando*) → generate; mirrors #123 `_attach_likeness`.
+    (search resources → Personagens → *include-in-prompt* context-menu action; captions are localized,
+    selectors locale-free since issue #170) → generate; mirrors #123 `_attach_likeness`.
     All selectors **ligature/structural only** (language-agnostic).
   - **Cost reality:** the feature is UI-automation-heavy (new character-editor + picker selectors), not the
     "mostly REST" earlier framing. Structural metadata is REST; the value-generating steps are UI.

--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -100,10 +100,13 @@ attached by driving Flow's resource picker:
 1. Click **Add Media** in the composer (references sub-mode).
 2. Switch to the **Personagens** (Characters) tab.
 3. **Right-click** the entity tile — addressed by entity id as
-   `data-tile-id="fe_id_<entityId>"` — and choose **"Incluir no comando"** from
-   the context menu. *(A plain left-click navigates into the character editor;
-   the inline "Incluir" button on the **Tudo** tab attaches the character's
-   thumbnail as a plain image, not the entity.)*
+   `data-tile-id="fe_id_<entityId>"` — and choose the **include-in-prompt**
+   action from the context menu (the `add`-ligature menu item; its caption is
+   localized per account language, e.g. "Incluir no comando" on pt-BR or
+   "Добавить в запрос" on ru — selectors are locale-free since issue #170).
+   *(A plain left-click navigates into the character editor; the inline include
+   button on the **Tudo** tab attaches the character's thumbnail as a plain
+   image, not the entity.)*
 
 This puts `referenceEntities:[{entityId}]` on the
 `video:batchAsyncGenerateVideoReferenceImages` **request**. Flow's **response**

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -90,20 +90,26 @@ tier telemetry. Updates the two pt-literal assertions.
 - `tests/api/transports/test_ui_automation_video.py` — new + updated tests
 
 **Steps:**
-- [ ] Replace `assert "Incluir no comando" in selectors` (≈ line 1057) with cascade-composition asserts: icon tier first, scoped to `[role='menu']`; pt/ru/en text tier follows
-- [ ] Replace `pytest.raises(RuntimeError, match="Incluir no comando")` (≈ line 1080) with a locale-neutral match (e.g. `"context-menu include action"`); assert message carries screenshot path + remediation hint, NOT the pt literal
-- [ ] Add ru-locale picker DOM fixture and a test that the cascade matches its menu item via the icon tier alone
-- [ ] Add test: failure path closes the picker dialog/menu before raising (no `[data-state='open']` dialog left)
-- [ ] Add test: `include_selector_tier` structlog event emitted with `tier` key on successful attach
-- [ ] Verify all new tests are red (`.venv/Scripts/python.exe -m pytest tests/api/transports/test_ui_automation_video.py -q`)
+- [x] Replace `assert "Incluir no comando" in selectors` with cascade-composition asserts: icon tier (`text-is('add')`) is what a fully-matching page uses
+- [x] Replace `pytest.raises(RuntimeError, match="Incluir no comando")` with a locale-neutral match (`"include action"`); assert message carries the entity id and NOT the pt literal
+- [x] ~~ru-locale DOM fixture~~ → replaced by the established `TestSelectorLocaleInvariance` string-pinning pattern (PR #127): Tier 1 locked verbatim + no-localized-text invariant; behavioral ru coverage lands in BDD (Task 3) and the reporter's live run (Task 7)
+- [x] Add test: failure path presses Escape before raising (no open dialog returns to the pool)
+- [x] Add test: `include_selector_tier` structlog event emitted with `tier` + `surface` keys on successful attach (both context-menu and Vozes surfaces)
+- [x] Verify all new tests are red — 12 failed as expected, 2026-06-11
+
+**Design contract pinned by the tests (Task 4 must implement):**
+- `PICKER_CONTEXT_INCLUDE: tuple[str, str]` — `("[role='menu'][data-state='open'] [role='menuitem']:has(i.google-symbols:text-is('add'))", "<menu-scoped pt/ru/en captions>")`
+- `PICKER_INCLUDE_BUTTON: tuple[str, str]` — `("<pt/ru/en button captions>", "[role='dialog'][data-state='open'] button:not(:has(i.google-symbols))")`
+- Tiers probed sequentially (a flat comma-join resolves in DOM order and can't report which tier matched); matched tier emitted as `ui_automation_video.include_selector_tier` (tier=icon|text|structural, surface=context_menu|vozes_button)
 
 **Tests created (red):**
-- [ ] `test_picker_context_include_cascade_icon_first_menu_scoped`
-- [ ] `test_picker_context_include_text_fallback_covers_pt_ru_en`
-- [ ] `test_attach_entity_failure_message_locale_neutral`
-- [ ] `test_attach_entity_failure_closes_picker_dialog`
-- [ ] `test_attach_entity_matches_ru_locale_fixture_via_icon_tier`
-- [ ] `test_attach_entity_logs_selector_tier`
+- [x] `TestPickerIncludeSelectorLocaleInvariance` — 7 static-invariant tests (tier shape, Tier-1 verbatim lock, no localized text in Tier 1, pt/ru/en coverage, menu/dialog scoping)
+- [x] `test_attach_right_clicks_personagens_entity_tile` — updated: icon tier drives the match
+- [x] `test_attach_logs_which_selector_tier_matched` — tier=icon, surface=context_menu
+- [x] `test_attach_raises_when_context_menu_absent` — locale-neutral message, carries entity id
+- [x] `test_attach_failure_closes_picker_before_raising` — Escape cleanup
+- [x] `TestAttachReferenceAudio::test_attach_audio_logs_selector_tier` — tier=text, surface=vozes_button
+- [x] `TestAttachReferenceAudio::test_attach_audio_raises_locale_neutral_when_button_absent`
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -166,15 +166,14 @@ requested entity id, else raise `WireFormatError` (no silent text-only generatio
 - `tests/api/transports/test_ui_automation.py` — unit tests
 
 **Steps:**
-- [ ] Extract requested-vs-captured entity-id comparison from the captured submit body summary
-- [ ] Raise `WireFormatError` with discovery payload (redaction-safe — ids only, never body bytes) when any requested entity id is missing
-- [ ] Unit tests: missing-entity raises; present-entity passes; no-entities-requested path untouched
-- [ ] BDD scenario 4 green
+- [x] `_entity_ids_from_request_body` extracts `requests[].referenceEntities[].entityId` from the outgoing body (ids only, never body bytes)
+- [x] `_attach_batch_request_logger` grows an optional `sink` that collects `{url, entity_ids}` per captured submit
+- [x] `_assert_image_entities_attached` raises `WireFormatError` when any requested id is missing from every captured submit; logs `image_entities_attached` on success; wired into `_generate_images_locked` post-success, guarded by `request.reference_entities`
+- [x] Unit tests: extractor (valid/garbage/absent), sink collection, assert missing/empty/present, end-to-end wiring raise + pass (8 tests, red-first)
+- [x] BDD backstop scenario green; full image transport suite 155 passed; pyright src 0 errors; ruff clean
 
 **Tests:**
-- [ ] `test_image_submit_backstop_raises_when_entity_missing`
-- [ ] `test_image_submit_backstop_passes_when_entities_present`
-- [ ] `test_image_submit_backstop_inert_without_reference_entities`
+- [x] `TestImageEntityBackstop` — 8 tests (extractor, sink, assert, wiring)
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -66,18 +66,18 @@ so the pt DOM answers whether (a) the Vozes "Incluir no comando" button carries 
 (b) the right-click context menu renders as `[role='menu'] > [role='menuitem']` in a portal.
 
 **Files:**
-- none committed (recon evidence noted in this PLAN.md and/or `_RECON` notes; reuse
-  `scripts/dev/dump_character_selectors.js` / `spike_movie_picker_select.py`)
+- `scripts/dev/spike_issue170_picker_locale_recon.py` — new credit-free recon harness (spike family)
 
 **Steps:**
-- [ ] Run the existing dump/spike harness against the resource picker on denon82 (headed real-Chrome profile, zero credits)
-- [ ] Record: context-menu container role + `data-state`, menuitem roles, exact ligature names (`add` expected)
-- [ ] Record: Vozes include button markup — icon ligature present? structural anchor available (dialog-footer primary button)?
-- [ ] Decide Tier 1 for `PICKER_INCLUDE_BUTTON` based on findings; note decision below
+- [x] Run the dump/spike harness against the resource picker on denon82 (headed real-Chrome profile, zero credits) — `scripts/dev/spike_issue170_picker_locale_recon.py`, run 2026-06-11 (`_spike_out/spike_issue170_picker_locale_recon_20260611_234140.json`)
+- [x] Record: context-menu container role + `data-state`, menuitem roles, exact ligature names (`add` expected)
+- [x] Record: Vozes include button markup — icon ligature present? structural anchor available (dialog-footer primary button)?
+- [x] Decide Tier 1 for `PICKER_INCLUDE_BUTTON` based on findings; note decision below
 
-**Recon findings (fill in):**
-- Context menu container/selector: _
-- Vozes include button Tier 1 anchor: _
+**Recon findings (verified live on denon82, pt-BR, 2026-06-11):**
+- Context menu: `<div role='menu' data-state='open'>` with 4 `[role='menuitem']` items, ligatures `add` («Incluir no comando»), `content_cut`, `content_copy`, `delete` — identical icon set to the ru report on #170. **Tier 1 for `PICKER_CONTEXT_INCLUDE`:** `[role='menu'][data-state='open'] [role='menuitem']:has(i.google-symbols:text-is('add'))` — `add` unique within the menu.
+- Vozes include button: **NO ligature icon** (text-only `<button>Incluir no comando</button>`), but it is the **lone iconless button inside the open picker dialog** (all other dialog buttons carry ligatures: tabs, `play_arrow` preview, `arrow_drop_down` sort). Same structural situation as the documented `ADD_TO_PROMPT_DIALOG` pattern. **Decision:** multi-locale text tier primary (pt/ru/en) + structural fallback (lone iconless dialog button).
+- Side observation: clicking a Vozes `[role='option']` closed the picker dialog outright — the include button shows for an already-selected resource state; `_attach_reference_audio`'s search-then-click-tile flow is unaffected.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -119,18 +119,18 @@ tier telemetry. Updates the two pt-literal assertions.
 signatures (memory: BDD stubs break with TypeError when kwargs drift — update fakes in same commit).
 
 **Files:**
-- `tests/features/locale_picker_include.feature` — 4 scenarios
-- `tests/features/` step/conftest fakes — wire new steps
+- `tests/features/locale_picker_include.feature` — 3 scenarios
+- `tests/features/test_locale_picker_include_steps.py` — step bindings (seam: `cli_image._run_t2i`, per repo BDD convention)
 
-**Steps:**
-- [ ] Scenario: ru-locale attach succeeds via icon tier (asserts `character_entity_attached` + `referenceEntities` in captured payload)
-- [ ] Scenario: pt-BR regression guard (attach succeeds; tier event reports which tier matched)
-- [ ] Scenario: both tiers miss → locale-neutral typed failure + screenshot + dialog closed
-- [ ] Scenario: include click lands but entity never staged → `WireFormatError` before success is reported (drives Task 5)
-- [ ] Verify scenarios are red
+**Steps (adapted to the repo's BDD seam — mocked at `_run_t2i`, so locale/selector
+mechanics live in the Task-2 unit tests; BDD pins the CLI contract):**
+- [x] Scenario: t2i passes the reference entity through to the runner (exit 0, `req.reference_entities`/`_names` recorded, image written)
+- [x] Scenario: include-action timeout → typed `TransportTimeoutError`, exit 9, output contains the locale-neutral phrase and NOT the pt caption
+- [x] Scenario: submit backstop `WireFormatError` → exit 7, "File a bug" (drives Task 5)
+- [x] Scenarios pass by construction at this seam (stubs raise the typed errors) — they are regression contracts for the exit-code mapping discovered in Task 3: an untyped `RuntimeError` would surface as privacy-hashed "Unexpected error." exit 1, burying the remediation hint. **This upgraded the design: the attach failure must raise `TransportTimeoutError` (exit 9, instance `remediation_hint`), not RuntimeError** — Task-2 tests updated accordingly in the same commit.
 
-**Tests created (red):**
-- [ ] `locale_picker_include.feature` — 4 scenarios above
+**Tests created:**
+- [x] `locale_picker_include.feature` — 3 scenarios above (green at seam; unit red drives Task 4)
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -142,16 +142,16 @@ mechanics live in the Task-2 unit tests; BDD pins the CLI contract):**
 - `src/gflow_cli/api/transports/ui_automation_video.py`
 
 **Steps:**
-- [ ] `PICKER_CONTEXT_INCLUDE` → Tier 1 `[role='menu'] [role='menuitem']:has(i.google-symbols:text-is('add'))` (exact container per Task 1 recon); Tier 2 menu-scoped text for `'Incluir no comando'`, `'Добавить в запрос'`, `'Add to prompt'`
-- [ ] `PICKER_INCLUDE_BUTTON` → per Task 1 recon: icon/structural Tier 1 if confirmed, else multi-locale text primary (document why in the constant's comment)
-- [ ] `_attach_character_entities`: locale-neutral error message ("context-menu include action did not appear…" + remediation hint + screenshot path); close picker dialog/menu (Escape + state check) before raising
-- [ ] `_attach_character_entities` / `_attach_reference_audio`: emit `ui_automation_video.include_selector_tier` (tier=icon|text) on success
-- [ ] Update docstrings/comments (mechanism notes reference the caption generically, not the pt string)
-- [ ] Task 2 unit tests green; BDD scenarios 1–3 green
+- [x] `PICKER_CONTEXT_INCLUDE` → Tier 1 `[role='menu'][data-state='open'] [role='menuitem']:has(i.google-symbols:text-is('add'))` (container per Task 1 recon); Tier 2 menu-scoped text for `'Incluir no comando'`, `'Добавить в запрос'`, `'Add to prompt'`
+- [x] `PICKER_INCLUDE_BUTTON` → multi-locale text primary + lone-iconless-dialog-button structural fallback (recon: no ligature on the button; rationale in the constant's comment)
+- [x] New `_resolve_include_action` helper: sequential tier probe, `include_selector_tier` event (tier + surface), screenshot + double-Escape cleanup + typed `TransportTimeoutError` with remediation hint on exhaustion — shared by both attach helpers
+- [x] Docstrings reference the caption generically; spike_movie_attach_payload.py updated for the tuple constant
+- [x] Task 2 unit tests green; BDD scenarios green (72 passed)
 
 **Tests:**
-- [ ] All Task 2 tests green
-- [ ] `pyright src` clean (whole tree — per repo gate)
+- [x] All Task 2 tests green (68 unit + 3 BDD + collision guard)
+- [x] `pyright src` clean (0 errors, whole tree, worktree venv)
+- [x] ruff check + format clean on all touched files
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -198,9 +198,9 @@ requested entity id, else raise `WireFormatError` (no silent text-only generatio
 **What:** Prove both locales, run gates, open the PR.
 
 **Steps:**
-- [ ] Credit-free route-abort verification on denon82 (pt-BR): attach fires, captured payload carries `referenceEntities` (reuse `spike_movie_attach_payload.py` harness)
-- [ ] `/gflow:check` green (ruff lint + format, `pyright src`, scoped pytest; trust CI for full sweep)
-- [ ] `uv lock --check` (no dep changes expected — cheap guard)
+- [x] **Live verification GREEN on promo-denon82 (pt-BR, 2026-06-12, credit-free real `gflow image t2i --reference-entity`):** `include_selector_tier tier=icon` → `character_entity_attached` → submit carried `referenceEntities:[{entityId:814284ce-…}]` → backstop `image_entities_attached`. Full pipeline verified end-to-end.
+- [x] **Bonus: the new backstop caught a real Flow-side drift on denon82** — that account has a NEW full-page media-library UI (Add Media navigates instead of opening the picker dialog); the include click lands (selectors fine, old and new click the same element) but the staged entity does NOT ride the wire (`request0_keys` has no reference fields at all, video + image paths alike). Pre-PR this returned a silent text-only "success"; now it raises `WireFormatError` exit 7. → file as a separate issue (Flow library-UI A/B drift), out of #170 scope.
+- [x] Gates green: ruff check+format (touched files), `pyright src` 0 errors, `uv lock --check` clean, scoped sweep `tests/api/transports + tests/features` = 396 passed
 - [ ] PR from `bugfix/issue-170-locale-picker-selectors` → `develop`; body links #170 + SCENARIO.md; `Closes #170`
 - [ ] Post candidate-build instructions on #170 for the reporter's ru-locale test (their offer); reporter confirmation OR maintainer ru-profile run before merge
 - [ ] After reporter/ru confirmation: merge per branch workflow

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -187,9 +187,9 @@ requested entity id, else raise `WireFormatError` (no silent text-only generatio
 - `docs/CHARACTER.md` / `docs/MOVIE.md` — replace "Incluir no comando" prose with locale-generic wording ("the include-in-prompt context-menu action") per docs-language-agnostic rule
 
 **Steps:**
-- [ ] KNOWN_ISSUES entry updated
-- [ ] CHANGELOG entry (note: predicted by `docs/superpowers/character-scenario.md:35`, fixture now added)
-- [ ] Localized UI strings scrubbed from user-facing docs (raw `_RECON.md` may keep them)
+- [x] KNOWN_ISSUES "locale-agnostic — Phase 5 complete" entry corrected with the #170 stragglers + fix summary
+- [x] CHANGELOG `[Unreleased]` Fixed entry — all three affected paths, typed error, telemetry, backstop, reporter credit
+- [x] Localized UI strings scrubbed from `docs/MOVIE.md` + `docs/CHARACTER.md` (raw `_RECON.md` keeps verbatim captions by design)
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md
@@ -1,0 +1,213 @@
+# Locale-Free Picker Include Selectors (Issue #170) Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature issue-170-locale-selectors` to find the next
+> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** `--reference-entity` (image t2i), movie R2V entity attach, and Vozes voice attach work on
+every Flow account locale — not just pt-BR — by replacing the two hardcoded "Incluir no comando"
+selectors with icon-first, text-fallback cascades.
+
+**Architecture:** Only `ui_automation_video.py` (selector constants + the two attach helpers) and
+`ui_automation.py` (new image-side `referenceEntities` submit backstop) change. The fix follows the
+established `UPLOAD_MEDIA_BUTTON` tiering doctrine: locale-free anchor (Material Symbols ligature,
+scoped to the open menu/dialog) as Tier 1, multi-locale text (`pt`/`ru`/`en`) as Tier 2 — the same
+pattern as `_ONBOARDING_TEXT_SELECTORS` (14-locale fallback behind structural tiers). The failure
+path keeps `RuntimeError` (no new exception class — minimal bugfix diff) but the message becomes
+locale-neutral with a remediation hint, and the picker dialog is closed before raising so a pooled
+Page is never returned dirty. Wire shape, auth, data layer: untouched.
+
+**Predict verdict:** skipped — approach is settled selector doctrine (PR #60 / PR #127 tiering);
+`/gflow:scenario` run 2026-06-11 instead (see `SCENARIO.md` in this directory).
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| Critical | pt-BR regression for existing users | pt text retained in Tier 2; credit-free route-abort live run on denon82 before merge (Task 7) |
+| Critical | Icon tier matches a wrong `add` element → image t2i silently degrades to text-only (image path has no submit backstop, only a structlog summary at `ui_automation.py:1688`) | Scope icon selector to the open menu portal; add image-side `WireFormatError` backstop (Task 5) |
+| High | Vozes `PICKER_INCLUDE_BUTTON` may carry no ligature icon (recon gap) | Local recon on denon82 first (Task 1) — icons are locale-invariant, so pt-BR DOM answers it; text list stays primary for that constant until icon confirmed |
+| High | Page-pool contamination when attach fails mid-dialog | Escape/close cleanup in the failure path before raising (Task 4) |
+| Medium | Silent tier drift (icon tier dies, text tier masks it) | `include_selector_tier` structlog event on every successful attach (Task 4) |
+
+---
+
+## File structure
+
+### New files
+```
+tests/features/locale_picker_include.feature
+  BDD scenarios from SCENARIO.md (ru-locale attach, pt regression guard, both-tiers-miss, wire backstop)
+tests/api/transports/fixtures/picker_context_menu_ru.html  (or inline fixture in test module — implementer's choice)
+  Russian-locale picker context-menu DOM fixture (items: add «Добавить в запрос», content_cut, content_copy, delete)
+```
+
+### Modified files
+```
+src/gflow_cli/api/transports/ui_automation_video.py
+  PICKER_INCLUDE_BUTTON / PICKER_CONTEXT_INCLUDE → tiered cascades; _attach_character_entities
+  (neutral error, dialog cleanup, tier logging); _attach_reference_audio (per Task 1 recon outcome)
+src/gflow_cli/api/transports/ui_automation.py
+  Image submit backstop: raise WireFormatError when captured batchGenerateImages body lacks the
+  requested referenceEntities
+tests/api/transports/test_ui_automation_video.py
+  Lines ~1046-1080: pt-literal assertions → locale-neutral + new tier/cascade/cleanup tests
+KNOWN_ISSUES.md
+  §349 "selectors locale-agnostic — Phase 5 complete" amended: picker include constants were the
+  exception; resolved by this fix (issue #170)
+CHANGELOG.md
+  [Unreleased] Fixed entry referencing #170; note loop-closure of character-scenario.md:35 prediction
+```
+
+---
+
+## Task 1 — Local recon: Vozes include button + context-menu structure (credit-free)
+
+**What:** Close the recon gap on the pt-BR denon82 account — ligature icons are locale-invariant,
+so the pt DOM answers whether (a) the Vozes "Incluir no comando" button carries an icon, and
+(b) the right-click context menu renders as `[role='menu'] > [role='menuitem']` in a portal.
+
+**Files:**
+- none committed (recon evidence noted in this PLAN.md and/or `_RECON` notes; reuse
+  `scripts/dev/dump_character_selectors.js` / `spike_movie_picker_select.py`)
+
+**Steps:**
+- [ ] Run the existing dump/spike harness against the resource picker on denon82 (headed real-Chrome profile, zero credits)
+- [ ] Record: context-menu container role + `data-state`, menuitem roles, exact ligature names (`add` expected)
+- [ ] Record: Vozes include button markup — icon ligature present? structural anchor available (dialog-footer primary button)?
+- [ ] Decide Tier 1 for `PICKER_INCLUDE_BUTTON` based on findings; note decision below
+
+**Recon findings (fill in):**
+- Context menu container/selector: _
+- Vozes include button Tier 1 anchor: _
+
+---
+
+## Task 2 — Unit test scaffold (red)
+
+**What:** Red unit tests pinning the new selector cascade composition, locale-neutral failure, and
+tier telemetry. Updates the two pt-literal assertions.
+
+**Files:**
+- `tests/api/transports/test_ui_automation_video.py` — new + updated tests
+
+**Steps:**
+- [ ] Replace `assert "Incluir no comando" in selectors` (≈ line 1057) with cascade-composition asserts: icon tier first, scoped to `[role='menu']`; pt/ru/en text tier follows
+- [ ] Replace `pytest.raises(RuntimeError, match="Incluir no comando")` (≈ line 1080) with a locale-neutral match (e.g. `"context-menu include action"`); assert message carries screenshot path + remediation hint, NOT the pt literal
+- [ ] Add ru-locale picker DOM fixture and a test that the cascade matches its menu item via the icon tier alone
+- [ ] Add test: failure path closes the picker dialog/menu before raising (no `[data-state='open']` dialog left)
+- [ ] Add test: `include_selector_tier` structlog event emitted with `tier` key on successful attach
+- [ ] Verify all new tests are red (`.venv/Scripts/python.exe -m pytest tests/api/transports/test_ui_automation_video.py -q`)
+
+**Tests created (red):**
+- [ ] `test_picker_context_include_cascade_icon_first_menu_scoped`
+- [ ] `test_picker_context_include_text_fallback_covers_pt_ru_en`
+- [ ] `test_attach_entity_failure_message_locale_neutral`
+- [ ] `test_attach_entity_failure_closes_picker_dialog`
+- [ ] `test_attach_entity_matches_ru_locale_fixture_via_icon_tier`
+- [ ] `test_attach_entity_logs_selector_tier`
+
+---
+
+## Task 3 — BDD scaffold (red)
+
+**What:** Gherkin feature file from SCENARIO.md's suggested scenarios; step stubs mirror runtime
+signatures (memory: BDD stubs break with TypeError when kwargs drift — update fakes in same commit).
+
+**Files:**
+- `tests/features/locale_picker_include.feature` — 4 scenarios
+- `tests/features/` step/conftest fakes — wire new steps
+
+**Steps:**
+- [ ] Scenario: ru-locale attach succeeds via icon tier (asserts `character_entity_attached` + `referenceEntities` in captured payload)
+- [ ] Scenario: pt-BR regression guard (attach succeeds; tier event reports which tier matched)
+- [ ] Scenario: both tiers miss → locale-neutral typed failure + screenshot + dialog closed
+- [ ] Scenario: include click lands but entity never staged → `WireFormatError` before success is reported (drives Task 5)
+- [ ] Verify scenarios are red
+
+**Tests created (red):**
+- [ ] `locale_picker_include.feature` — 4 scenarios above
+
+---
+
+## Task 4 — Selector cascade + attach-helper hardening (makes Task 2/3 green except backstop)
+
+**What:** The core fix in `ui_automation_video.py`.
+
+**Files:**
+- `src/gflow_cli/api/transports/ui_automation_video.py`
+
+**Steps:**
+- [ ] `PICKER_CONTEXT_INCLUDE` → Tier 1 `[role='menu'] [role='menuitem']:has(i.google-symbols:text-is('add'))` (exact container per Task 1 recon); Tier 2 menu-scoped text for `'Incluir no comando'`, `'Добавить в запрос'`, `'Add to prompt'`
+- [ ] `PICKER_INCLUDE_BUTTON` → per Task 1 recon: icon/structural Tier 1 if confirmed, else multi-locale text primary (document why in the constant's comment)
+- [ ] `_attach_character_entities`: locale-neutral error message ("context-menu include action did not appear…" + remediation hint + screenshot path); close picker dialog/menu (Escape + state check) before raising
+- [ ] `_attach_character_entities` / `_attach_reference_audio`: emit `ui_automation_video.include_selector_tier` (tier=icon|text) on success
+- [ ] Update docstrings/comments (mechanism notes reference the caption generically, not the pt string)
+- [ ] Task 2 unit tests green; BDD scenarios 1–3 green
+
+**Tests:**
+- [ ] All Task 2 tests green
+- [ ] `pyright src` clean (whole tree — per repo gate)
+
+---
+
+## Task 5 — Image-side referenceEntities submit backstop
+
+**What:** Mirror the video path's `_assert_entities_attached` defense on the image path: when
+`request.reference_entities` is set, the captured `batchGenerateImages` submit must contain every
+requested entity id, else raise `WireFormatError` (no silent text-only generation).
+
+**Files:**
+- `src/gflow_cli/api/transports/ui_automation.py` — backstop using the already-captured request body (`_summarize_batch_request_body` machinery at ≈ line 543/1688)
+- `tests/api/transports/test_ui_automation.py` — unit tests
+
+**Steps:**
+- [ ] Extract requested-vs-captured entity-id comparison from the captured submit body summary
+- [ ] Raise `WireFormatError` with discovery payload (redaction-safe — ids only, never body bytes) when any requested entity id is missing
+- [ ] Unit tests: missing-entity raises; present-entity passes; no-entities-requested path untouched
+- [ ] BDD scenario 4 green
+
+**Tests:**
+- [ ] `test_image_submit_backstop_raises_when_entity_missing`
+- [ ] `test_image_submit_backstop_passes_when_entities_present`
+- [ ] `test_image_submit_backstop_inert_without_reference_entities`
+
+---
+
+## Task 6 — Docs + changelog
+
+**What:** Close the documentation loop.
+
+**Files:**
+- `KNOWN_ISSUES.md` — amend §"selectors locale-agnostic — Phase 5 complete" (≈ line 349): picker include constants were the exception, resolved via #170
+- `CHANGELOG.md` — `[Unreleased]` → Fixed: issue #170, all three affected paths named
+- `docs/CHARACTER.md` / `docs/MOVIE.md` — replace "Incluir no comando" prose with locale-generic wording ("the include-in-prompt context-menu action") per docs-language-agnostic rule
+
+**Steps:**
+- [ ] KNOWN_ISSUES entry updated
+- [ ] CHANGELOG entry (note: predicted by `docs/superpowers/character-scenario.md:35`, fixture now added)
+- [ ] Localized UI strings scrubbed from user-facing docs (raw `_RECON.md` may keep them)
+
+---
+
+## Task 7 — Live verification + gates + PR
+
+**What:** Prove both locales, run gates, open the PR.
+
+**Steps:**
+- [ ] Credit-free route-abort verification on denon82 (pt-BR): attach fires, captured payload carries `referenceEntities` (reuse `spike_movie_attach_payload.py` harness)
+- [ ] `/gflow:check` green (ruff lint + format, `pyright src`, scoped pytest; trust CI for full sweep)
+- [ ] `uv lock --check` (no dep changes expected — cheap guard)
+- [ ] PR from `bugfix/issue-170-locale-picker-selectors` → `develop`; body links #170 + SCENARIO.md; `Closes #170`
+- [ ] Post candidate-build instructions on #170 for the reporter's ru-locale test (their offer); reporter confirmation OR maintainer ru-profile run before merge
+- [ ] After reporter/ru confirmation: merge per branch workflow
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Docs updated (`KNOWN_ISSUES.md`, `docs/CHARACTER.md` / `docs/MOVIE.md` locale-generic wording)
+- [ ] BDD feature file covers all Critical + High scenarios from `SCENARIO.md`
+- [ ] pt-BR live route-abort verification recorded; ru-locale confirmation from reporter (or equivalent)
+- [ ] No `# TODO` in diff without a tracked issue link

--- a/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/SCENARIO.md
+++ b/docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/SCENARIO.md
@@ -1,0 +1,101 @@
+# Scenario: Issue #170 — locale-free picker include selectors
+
+> `/gflow:scenario` artifact, 2026-06-11. Feeds the PLAN.md task for fixing
+> [#170](https://github.com/ffroliva/gflow-cli/issues/170): `PICKER_INCLUDE_BUTTON`
+> and `PICKER_CONTEXT_INCLUDE` (`src/gflow_cli/api/transports/ui_automation_video.py:296-302`)
+> hardcode pt-BR "Incluir no comando", breaking `--reference-entity` (image t2i),
+> movie R2V entity attach, and Vozes voice attach on every non-Portuguese account.
+> Fix shape: icon-first selector (context-menu `add` ligature scoped to the open
+> menu) with a multi-locale text fallback tier, per the `UPLOAD_MEDIA_BUTTON`
+> tiering doctrine (lines 270-275).
+
+## Coverage map
+
+**Active dimensions**
+
+- **D3 Selector cascade drift** — the core of the change; every tier interaction is a scenario.
+- **D5 Concurrency & Page pool** — the failure path raises with the picker dialog / context menu still open; pool contamination risk.
+- **D7 Error propagation & exit codes** — error message currently embeds the pt-BR literal; `RuntimeError` is untyped.
+- **D11 Input validation** — adjacent pre-existing selector-injection trap in the voice tile locator.
+- **D12 Observability** — selector-tier telemetry is the early-warning system for the next drift.
+- **D10 Headless vs headed** — only for the live verification matrix (account language, not platform, drives rendering).
+
+**Skipped dimensions**
+
+- D1 auth, D2 WAF/reCAPTCHA — attach is a UI-only, credit-free, token-free interaction; no auth or token-mint surface changes.
+- D4 batch/resume — multi-prompt + `--reference-entity` is already rejected at `cli_image.py:674`; movie per-scene failure is covered via D5/D7.
+- D6 data layer, D9 transport — no schema, recorder, or wire-shape change.
+- D8 cross-platform — no new paths; debug screenshot reuses the existing `_capture_debug_screenshot` helper.
+
+## Scenario table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D3 | **pt-BR regression**: new icon-first selector breaks the currently-working pt-BR path (menu item is a `button` not `[role='menuitem']`, or the Radix menu portal isn't under `[role='menu']`) | Critical | pt-BR attach keeps working: pt text retained in the fallback tier; live route-abort verification on denon82 before merge | Unit + E2E live |
+| 2 | D3+D7 | **Silent wrong-element click on the image path**: icon tier matches a *different* `add` element, click lands elsewhere, entity never staged. Image t2i has **no submit backstop** — only a structlog summary (`ui_automation.py:1688`) — so the run degrades to a text-only generation reported as success | Critical | Scope icon selector to the open menu (`[role='menu'] [role='menuitem']:has(i.google-symbols:text-is('add'))`) AND add an image-side backstop mirroring `_assert_entities_attached`: raise `WireFormatError` when the captured submit lacks `referenceEntities` for the requested ids | Integration + E2E live |
+| 3 | D3 | **Both tiers miss**: account locale outside pt/ru/en *and* Google renames the `add` ligature | High | Locale-neutral typed error with debug screenshot + remediation hint ("set Flow account language to a supported locale; attach the screenshot to a new issue"); never the pt literal in the message | Unit + Integration |
+| 4 | D3 | **Vozes recon gap**: `PICKER_INCLUDE_BUTTON` (line 1293) may carry no ligature icon; voice attach still pt-only after the fix | High | Recon the Vozes include button on ru/en (`scripts/dev/dump_character_selectors.js`); until icon verified, multi-locale text list is the conservative primary; failure raises the same locale-neutral error (today it's a generic click timeout) | Live recon + Integration |
+| 5 | D5 | **Pool contamination on failure**: attach raises with the picker dialog or context menu still open; the Page returns to the pool and the next checkout finds the composer blocked by a modal | High | Failure path closes the dialog/menu (Escape + dialog-state check) before raising, or the page is disposed instead of returned | Integration |
+| 6 | D7 | **Untyped RuntimeError + pt-embedded message**: current raise at `ui_automation_video.py:1259-1263` embeds 'Incluir no comando' and maps to the generic exit code | High | Message becomes locale-neutral ("context-menu include action did not appear"); prefer a typed error carrying an RFC 9457 remediation hint; exit-code mapping asserted in unit tests | Unit |
+| 7 | D7 | **Test-suite literal drift**: `tests/api/transports/test_ui_automation_video.py:1057` and `:1080` assert the pt-BR literal (`pytest.raises(match="Incluir no comando")`) | High | Tests updated to assert the locale-neutral phrase + selector-tier composition; add a non-pt (ru) picker DOM fixture | Unit |
+| 8 | D12 | **No drift telemetry**: when the icon tier silently stops matching and the text tier carries the load, nobody notices until the text tier also breaks | Medium | Emit `ui_automation_video.include_selector_tier` (tier=icon\|text) on every successful attach; key documented in `docs/ARCHITECTURE.md` | Unit |
+| 9 | D3 | **BDD stub drift**: `tests/features/` fakes mirror runtime signatures; the new selector constants/kwargs change breaks `_fake_*` stubs with TypeError hidden by CI structlog | Medium | Update BDD stubs in the same commit; run the feature files locally before push | BDD |
+| 10 | D3 | **User-named collision in text tier**: a character display name equal to a menu caption (e.g. "Add to prompt") matches the text fallback outside the menu | Low | Text-tier selectors also scoped to `[role='menu']` / dialog container, so tile text can't collide | Unit |
+| 11 | D11 | **Selector injection (pre-existing, adjacent)**: `voice_id` interpolated into `button:has-text('{voice_id}')` (`ui_automation_video.py:1288-1290`) breaks on quotes in the id | Low | Log as a separate issue; do not fix in this PR (keep the diff reviewable) | — |
+| 12 | D10 | **Live verification matrix**: ru locale cannot be verified locally (account language wins over `?hl=en`); pt verified on denon82 | Medium | Credit-free route-abort run on denon82 (pt) + candidate build to the issue reporter (ru, offered); headed real-Chrome profile per repo doctrine | E2E live |
+
+Severity: **Critical** (data loss / billed twice / unrecoverable) · **High** (feature broken, workaround exists) · **Medium** (degraded UX, explicit error) · **Low** (cosmetic or edge-only)
+
+## Must-cover before merge (Critical + High)
+
+1. pt-BR keeps working: pt text in fallback tier + credit-free route-abort live run on denon82 (#1).
+2. Icon selector scoped to the open context menu; image-side `referenceEntities` backstop added so a missed attach raises instead of silently generating text-only (#2).
+3. Both-tiers-miss path raises a locale-neutral, screenshot-carrying, remediation-hinted error (#3, #6).
+4. Vozes include button recon completed on a non-pt locale before deciding its tier order (#4).
+5. Failure path leaves no open dialog/menu on a pooled Page (#5).
+6. pt-literal test assertions replaced; ru-locale picker fixture added (#7).
+
+## Deferred (Medium + Low — log as issues, not blockers)
+
+1. Selector-tier telemetry event (#8) — small, ideally in-PR, but not a merge blocker.
+2. Voice-id selector injection (#11) — file as a separate issue.
+3. Text-tier scoping for user-named collisions (#10) — falls out of #2's scoping for free; assert in unit test.
+
+## Suggested BDD scenarios (for `tests/features/`)
+
+```gherkin
+Feature: Locale-free character entity attach (issue #170)
+
+  Scenario: Entity attach succeeds on a Russian-locale picker via the icon tier
+    Given a Flow resource picker rendered in the "ru" locale
+    And a character entity tile with id "ent-123" on the Personagens tab
+    When I run image t2i with --reference-entity "ent-123"
+    Then the context-menu include item is matched by its "add" ligature icon
+    And the structlog event "character_entity_attached" fires for "ent-123"
+    And the captured submit payload contains referenceEntities ["ent-123"]
+
+  Scenario: Entity attach still succeeds on a pt-BR picker (regression guard)
+    Given a Flow resource picker rendered in the "pt-BR" locale
+    When I run image t2i with --reference-entity "ent-123"
+    Then the attach succeeds via icon tier or pt text fallback
+    And the structlog event reports which selector tier matched
+
+  Scenario: Both selector tiers miss — locale-neutral failure
+    Given a Flow resource picker whose context menu carries neither the "add"
+      ligature nor any known include caption
+    When I run image t2i with --reference-entity "ent-123"
+    Then a typed error is raised whose message does not contain "Incluir no comando"
+    And the message includes a debug screenshot path and a remediation hint
+    And the picker dialog is closed before the page returns to the pool
+
+  Scenario: Attach click lands but the entity never rides the wire
+    Given the include click is intercepted so referenceEntities is never staged
+    When I run image t2i with --reference-entity "ent-123"
+    Then a WireFormatError is raised before the run is reported as success
+```
+
+## Known-issues cross-reference
+
+- **`KNOWN_ISSUES.md:349` — "UiAutomationTransport selectors locale-agnostic — issue #24 Phase 5 complete"**: #170 disproves this claim for the two picker constants. Update the entry in the same PR (the claim becomes true again once merged).
+- **`docs/superpowers/character-scenario.md:35`** predicted this exact gap as D3/High ("never localized text; test in a non-EN locale fixture") — the fixture was never added. This PR closes that loop; note it in the CHANGELOG entry.
+- **`_ONBOARDING_TEXT_SELECTORS` precedent** (KNOWN_ISSUES.md:374): 14-locale text fallback behind structural-first tiers — the established template for the fallback tier here.

--- a/scripts/dev/spike_issue170_picker_locale_recon.py
+++ b/scripts/dev/spike_issue170_picker_locale_recon.py
@@ -55,7 +55,8 @@ _ENTITY_TILE = "[data-tile-id^='fe_id_']"
 # derive a scoped Tier-1 selector without guessing the container shape.
 _DUMP_MENUS_JS = """
 () => {
-  const ICON = "i.google-symbols,.google-symbols,.material-symbols-outlined,.material-symbols-rounded";
+  const ICON = "i.google-symbols,.google-symbols," +
+    ".material-symbols-outlined,.material-symbols-rounded";
   const vis = (el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; };
   const lig = (el) => { const i = el.querySelector(ICON); return i ? i.textContent.trim() : null; };
   const desc = (el) => ({
@@ -88,7 +89,8 @@ _DUMP_MENUS_JS = """
 # icon, aria, or position — is identifiable even if its caption is localized.
 _DUMP_BUTTONS_JS = """
 () => {
-  const ICON = "i.google-symbols,.google-symbols,.material-symbols-outlined,.material-symbols-rounded";
+  const ICON = "i.google-symbols,.google-symbols," +
+    ".material-symbols-outlined,.material-symbols-rounded";
   const vis = (el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; };
   const lig = (el) => { const i = el.querySelector(ICON); return i ? i.textContent.trim() : null; };
   return [...document.querySelectorAll("button,[role='option']")].filter(vis).map((el) => ({

--- a/scripts/dev/spike_issue170_picker_locale_recon.py
+++ b/scripts/dev/spike_issue170_picker_locale_recon.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+r"""Issue #170 spike — Tier 1 (0 credits): picker include-action DOM recon.
+
+Answers the two recon questions blocking the locale-free selector fix
+(docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/PLAN.md Task 1).
+Ligature icons are locale-invariant, so a pt-BR account answers both:
+
+  Q1. Right-click context menu on a Personagens entity tile — what container
+      does it render in ([role='menu']? data-state? portal parent chain) and
+      what ligature does the include item carry ('add' expected, per the ru
+      report on issue #170)?
+  Q2. The Vozes-flow include button (PICKER_INCLUDE_BUTTON) — does it carry a
+      ligature icon / structural anchor, or is localized text its only handle?
+
+No generation request is ever fired: the spike opens the resource picker,
+right-clicks a tile, dumps DOM, and exits. Nothing is submitted.
+
+Usage (headed, supervised):
+
+    ! .venv\Scripts\python.exe scripts\dev\spike_issue170_picker_locale_recon.py \
+        --profile denon82 --project 580a6bbf-d433-4153-80b9-1842b5a560ea
+
+Outputs (gitignored): scripts/dev/_spike_out/spike_issue170_picker_locale_recon_<ts>.{json,png}
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    ADD_MEDIA_BUTTON,
+    PICKER_PERSONAGENS_TAB,
+    PICKER_VOZES_TAB,
+    VideoGenerationMixin,
+)
+
+_ENTITY_TILE = "[data-tile-id^='fe_id_']"
+
+# Dump every visible menu / menuitem plus the portal parent chain — enough to
+# derive a scoped Tier-1 selector without guessing the container shape.
+_DUMP_MENUS_JS = """
+() => {
+  const ICON = "i.google-symbols,.google-symbols,.material-symbols-outlined,.material-symbols-rounded";
+  const vis = (el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; };
+  const lig = (el) => { const i = el.querySelector(ICON); return i ? i.textContent.trim() : null; };
+  const desc = (el) => ({
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute("role"),
+    dataState: el.getAttribute("data-state"),
+    ariaLabel: el.getAttribute("aria-label"),
+    ligature: lig(el),
+    text: (el.textContent || "").trim().slice(0, 80),
+  });
+  const chain = (el) => {
+    const out = []; let p = el.parentElement;
+    for (let i = 0; i < 5 && p; i++) { out.push(desc(p)); p = p.parentElement; }
+    return out;
+  };
+  const menus = [...document.querySelectorAll("[role='menu']")].filter(vis).map((m) => ({
+    container: desc(m),
+    parentChain: chain(m),
+    items: [...m.querySelectorAll("[role='menuitem'],button")].filter(vis).map(desc),
+  }));
+  const orphanItems = [...document.querySelectorAll("[role='menuitem']")]
+    .filter(vis).filter((mi) => !mi.closest("[role='menu']")).map((mi) => ({
+      ...desc(mi), parentChain: chain(mi),
+    }));
+  return { menus, orphanItems };
+}
+"""
+
+# Dump every visible button (ligature + text) so the include button's anchor —
+# icon, aria, or position — is identifiable even if its caption is localized.
+_DUMP_BUTTONS_JS = """
+() => {
+  const ICON = "i.google-symbols,.google-symbols,.material-symbols-outlined,.material-symbols-rounded";
+  const vis = (el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; };
+  const lig = (el) => { const i = el.querySelector(ICON); return i ? i.textContent.trim() : null; };
+  return [...document.querySelectorAll("button,[role='option']")].filter(vis).map((el) => ({
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute("role"),
+    ariaLabel: el.getAttribute("aria-label"),
+    ligature: lig(el),
+    text: (el.textContent || "").trim().slice(0, 60),
+    dialogScoped: !!el.closest("[role='dialog']"),
+  }));
+}
+"""
+
+
+async def _open_picker(page: Any) -> None:
+    add = page.locator(ADD_MEDIA_BUTTON).first
+    await add.wait_for(state="visible", timeout=8000)
+    await add.click()
+    await page.wait_for_timeout(900)
+
+
+async def _run(*, profile_dir: Path, project_id: str, locale: str, out_path: Path) -> int:
+    out_dir = out_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Any] = {
+        "spike": "issue170-picker-locale-recon",
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "project": project_id,
+        "locale": locale,
+    }
+
+    async with build_client(profile_dir, headless=False) as client:
+        page = await client._checkout_page()  # noqa: SLF001
+        try:
+            url = routes.project_editor_url(locale, project_id)
+            step("1", f"goto {url}")
+            await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            await page.wait_for_timeout(4_000)
+            await page.keyboard.press("Escape")
+            await VideoGenerationMixin._exit_agent_mode(page)  # noqa: SLF001
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)  # noqa: SLF001
+            await VideoGenerationMixin._switch_video_sub_mode(page, "references", out_dir=None)  # noqa: SLF001
+            await page.wait_for_timeout(800)
+
+            # ---- Q1: Personagens right-click context menu -------------------
+            step("2", "open picker -> Personagens -> right-click first entity tile")
+            await _open_picker(page)
+            ptab = page.locator(PICKER_PERSONAGENS_TAB).first
+            await ptab.wait_for(state="visible", timeout=8000)
+            await ptab.click()
+            await page.wait_for_timeout(900)
+            tile = page.locator(_ENTITY_TILE).first
+            await tile.wait_for(state="visible", timeout=8000)
+            result["entityTileId"] = await tile.get_attribute("data-tile-id")
+            await tile.scroll_into_view_if_needed(timeout=8000)
+            await tile.click(button="right")
+            await page.wait_for_timeout(700)
+            result["contextMenu"] = await page.evaluate(_DUMP_MENUS_JS)
+            await page.screenshot(path=str(out_dir / "Q1_context_menu.png"))
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(400)
+
+            # ---- Q2: Vozes include button -----------------------------------
+            # The Escape above may have closed the whole picker (not just the
+            # context menu) — reopen it if the Vozes tab is gone. Q2 failures
+            # are recorded, never fatal: Q1 findings must survive to the JSON.
+            step("3", "Vozes tab -> select first option -> dump buttons")
+            try:
+                vtab = page.locator(PICKER_VOZES_TAB).first
+                if not await vtab.is_visible():
+                    await _open_picker(page)
+                    vtab = page.locator(PICKER_VOZES_TAB).first
+                await vtab.wait_for(state="visible", timeout=8000)
+                await vtab.click()
+                await page.wait_for_timeout(900)
+                result["vozesButtonsBeforeSelect"] = await page.evaluate(_DUMP_BUTTONS_JS)
+                opt = page.locator("[role='option']").first
+                await opt.wait_for(state="visible", timeout=5000)
+                await opt.click()
+                await page.wait_for_timeout(700)
+                result["vozesButtonsAfterSelect"] = await page.evaluate(_DUMP_BUTTONS_JS)
+                await page.screenshot(path=str(out_dir / "Q2_vozes_include.png"))
+            except Exception as e:  # noqa: BLE001
+                result["vozesError"] = f"{type(e).__name__}: {e}"
+                await page.screenshot(path=str(out_dir / "Q2_vozes_FAILED.png"))
+            await page.keyboard.press("Escape")
+        finally:
+            client._checkin_page(page)  # noqa: SLF001
+
+    out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # ---- compact findings ----------------------------------------------------
+    print(f"\n[recon] full dump: {out_path}")
+    for menu in result.get("contextMenu", {}).get("menus", []):
+        c = menu["container"]
+        print(
+            f"[recon] Q1 menu container: <{c['tag']} role={c['role']} "
+            f"data-state={c['dataState']}> items:"
+        )
+        for it in menu["items"]:
+            print(f"[recon]   - role={it['role']} ligature={it['ligature']!r} text={it['text']!r}")
+    if not result.get("contextMenu", {}).get("menus"):
+        print("[recon] Q1: NO [role='menu'] container found — see orphanItems in the dump")
+        for it in result.get("contextMenu", {}).get("orphanItems", []):
+            print(f"[recon]   orphan role=menuitem ligature={it['ligature']!r} text={it['text']!r}")
+    include_like = [
+        b
+        for b in result.get("vozesButtonsAfterSelect", result.get("vozesButtonsBeforeSelect", []))
+        if "Incluir" in (b.get("text") or "")
+    ]
+    if include_like:
+        for b in include_like:
+            print(
+                f"[recon] Q2 include button: ligature={b['ligature']!r} "
+                f"aria-label={b['ariaLabel']!r} text={b['text']!r} dialog={b['dialogScoped']}"
+            )
+    else:
+        print("[recon] Q2: no 'Incluir' button visible — inspect vozesButtons* in the dump")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--locale", default="pt")
+    args = ap.parse_args()
+    profile_dir = resolve_profile_dir(args.profile)
+    out_path = default_out_path("spike_issue170_picker_locale_recon", ".json")
+    return asyncio.run(
+        _run(
+            profile_dir=profile_dir,
+            project_id=args.project,
+            locale=args.locale,
+            out_path=out_path,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/spike_movie_attach_payload.py
+++ b/scripts/dev/spike_movie_attach_payload.py
@@ -131,7 +131,9 @@ async def _run(
                 await tile.scroll_into_view_if_needed(timeout=8000)
                 await tile.click()
                 await page.wait_for_timeout(400)
-                include = page.locator(PICKER_INCLUDE_BUTTON).first
+                # PICKER_INCLUDE_BUTTON is a tier tuple since #170; the spike
+                # only needs "any tier matches", so a flat comma-join is fine.
+                include = page.locator(", ".join(PICKER_INCLUDE_BUTTON)).first
                 await include.wait_for(state="visible", timeout=8000)
                 await include.click()
                 await page.wait_for_timeout(800)

--- a/scripts/dev/spike_movie_attach_payload.py
+++ b/scripts/dev/spike_movie_attach_payload.py
@@ -189,6 +189,16 @@ async def _run(
             result["referenceImages"] = imgs
             result["videoModelKeys"] = keys
             result["route"] = (captured.get("url") or "").split("/")[-1]
+            # Discovery aid (#170 follow-up): the wire shape may drift — record
+            # request keys + any entity/reference-ish field (elided, never raw
+            # image bytes) so an empty referenceEntities is diagnosable.
+            if reqs and isinstance(reqs[0], dict):
+                result["request0_keys"] = sorted(reqs[0].keys())
+                result["reference_like"] = {
+                    k: (v if len(json.dumps(v, default=str)) <= 600 else "<elided>")
+                    for k, v in reqs[0].items()
+                    if "entit" in k.lower() or "reference" in k.lower() or "input" in k.lower()
+                }
         except Exception as e:  # noqa: BLE001
             result["parse_error"] = f"{type(e).__name__}: {e}"
             result["post_data_head"] = pd[:500]

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -583,6 +583,40 @@ def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
     return summary
 
 
+def _entity_ids_from_request_body(post_data: str | None) -> set[str]:
+    """Entity ids carried by an outgoing ``batchGenerateImages`` body.
+
+    Request shape (live-verified — issue #170 report + movie spike):
+    ``requests[].referenceEntities[].entityId``. Feeds the #170 submit
+    backstop: a UI attach miss must not degrade to a text-only generation
+    reported as success.
+    """
+    if not post_data:
+        return set()
+    try:
+        parsed: object = json.loads(post_data)
+    except (ValueError, TypeError):
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+    out: set[str] = set()
+    reqs = cast("dict[str, Any]", parsed).get("requests")
+    if not isinstance(reqs, list):
+        return out
+    for req in cast("list[Any]", reqs):
+        if not isinstance(req, dict):
+            continue
+        ents = cast("dict[str, Any]", req).get("referenceEntities")
+        if not isinstance(ents, list):
+            continue
+        for ent in cast("list[Any]", ents):
+            if isinstance(ent, dict):
+                entity_id = cast("dict[str, Any]", ent).get("entityId")
+                if isinstance(entity_id, str):
+                    out.add(entity_id)
+    return out
+
+
 class UiAutomationTransport(VideoGenerationMixin):
     """D.2.4 — Playwright UI mimicry strategy.
 
@@ -1664,6 +1698,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         page: Page,
         *,
         project_id: str | None = None,
+        sink: list[dict[str, Any]] | None = None,
     ) -> Callable[[], None]:
         """Register a ``page.on('request', ...)`` that logs a compact summary of
         each outgoing ``batchGenerateImages`` body.
@@ -1672,6 +1707,10 @@ class UiAutomationTransport(VideoGenerationMixin):
         the submit carries ``referenceEntities`` — the entity-reference spike's
         make-or-break signal — without dumping i2i image bytes. Returns an
         idempotent detach fn, torn down alongside the response listener.
+
+        When *sink* is given, each matching request also appends
+        ``{"url", "entity_ids"}`` so the caller can enforce the #170 submit
+        backstop (:meth:`_assert_image_entities_attached`) after the run.
         """
 
         def on_request(request_obj: Any) -> None:
@@ -1687,6 +1726,13 @@ class UiAutomationTransport(VideoGenerationMixin):
                 filter_project_id=project_id,
                 summary=_summarize_batch_request_body(post_data),
             )
+            if sink is not None:
+                sink.append(
+                    {
+                        "url": request_obj.url,
+                        "entity_ids": _entity_ids_from_request_body(post_data),
+                    }
+                )
 
         page.on("request", on_request)
 
@@ -1944,9 +1990,12 @@ class UiAutomationTransport(VideoGenerationMixin):
         # attach/await eliminates that race. Project-ID filter prevents stale
         # responses from previously-visited projects accumulating in the list.
         captured, detach = self._attach_batch_response_listener(page, project_id=nav_project_id)
-        # Also log the OUTGOING request body summary so the entity-reference spike
-        # can read whether the submit carries `referenceEntities`.
-        req_log_detach = self._attach_batch_request_logger(page, project_id=nav_project_id)
+        # Also log the OUTGOING request body summary AND collect the entity ids
+        # it carries — the #170 submit backstop reads the sink after the run.
+        request_bodies: list[dict[str, Any]] = []
+        req_log_detach = self._attach_batch_request_logger(
+            page, project_id=nav_project_id, sink=request_bodies
+        )
         # Record submit_time BEFORE the click so the post-submit-time filter
         # in _await_captured can distinguish this prompt's responses from any
         # stale entries that arrived between listener attach and the click.
@@ -1979,7 +2028,46 @@ class UiAutomationTransport(VideoGenerationMixin):
                 detail="batchGenerateImages returned 200 but no parseable media items",
                 route=first_error_route or "",
             )
+        # Submit backstop (issue #170): the run is only a success if every
+        # requested character entity actually rode the wire. A missed UI attach
+        # (e.g. the include selector clicked the wrong element) would otherwise
+        # return a plain text-only generation as if it used the character.
+        if request.reference_entities:
+            self._assert_image_entities_attached(
+                request_bodies, expected=list(request.reference_entities)
+            )
         return images
+
+    @staticmethod
+    def _assert_image_entities_attached(
+        request_bodies: list[dict[str, Any]],
+        *,
+        expected: list[str],
+    ) -> None:
+        """Defense-in-depth mirror of the video path's _assert_entities_attached.
+
+        *request_bodies* is the sink filled by :meth:`_attach_batch_request_logger`
+        (one entry per captured outgoing ``batchGenerateImages`` body). Every
+        *expected* entity id must appear in at least one captured submit;
+        otherwise raise :class:`WireFormatError` — never report a text-only
+        generation as an entity-referenced success.
+        """
+        seen: set[str] = set()
+        for body in request_bodies:
+            ids = body.get("entity_ids")
+            if isinstance(ids, set):
+                seen |= cast("set[str]", ids)
+        missing = [e for e in expected if e not in seen]
+        if missing:
+            raise WireFormatError(
+                detail=(
+                    f"captured batchGenerateImages submit is missing "
+                    f"referenceEntities {missing} — the staged character "
+                    f"never rode the wire"
+                ),
+                route="flowMedia:batchGenerateImages",
+            )
+        log.info("ui_automation.image_entities_attached", entity_ids=sorted(seen))
 
     # ------------------------------------------------------------------
     # Public batch API — generate_images_batch (stay-mounted, v3-3)

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -40,6 +40,7 @@ from gflow_cli.api.video import (
 from gflow_cli.errors import (
     AuthExpiredError,
     ModelModeIncompatibilityError,
+    TransportTimeoutError,
     VideoModelSelectionError,
     WafRejectionError,
     WireFormatError,
@@ -293,13 +294,37 @@ PICKER_VOZES_TAB = (
     "[role='tab']:has(i.google-symbols:text-is('voice_selection')),"
     " button:has(i.google-symbols:text-is('voice_selection'))"
 )
-PICKER_INCLUDE_BUTTON = "button:has-text('Incluir no comando')"
-# Context-menu 'Incluir no comando' shown on RIGHT-CLICK of a Personagens entity
+# Picker include button (Vozes flow). Issue #170: the original single pt-BR
+# has-text selector broke every non-Portuguese account — Flow renders in the
+# ACCOUNT language and `?hl=en` cannot override it. Recon (denon82 pt-BR,
+# 2026-06-11): the button carries NO ligature icon, so known localized captions
+# lead; the structural fallback is the LONE iconless button inside the open
+# picker dialog (every other dialog button has a ligature: tabs, `play_arrow`
+# preview, `arrow_drop_down` sort) — same situation as ADD_TO_PROMPT_DIALOG.
+# Tiers are probed sequentially (see _resolve_include_action), never flattened
+# into one comma list: comma lists resolve in DOM order, not tier priority.
+PICKER_INCLUDE_BUTTON: tuple[str, str] = (
+    "button:has-text('Incluir no comando'), button:has-text('Добавить в запрос'),"
+    " button:has-text('Add to prompt')",
+    "[role='dialog'][data-state='open'] button:not(:has(i.google-symbols))",
+)
+_INCLUDE_BUTTON_TIER_NAMES = ("text", "structural")
+# Context-menu include action shown on RIGHT-CLICK of a Personagens entity
 # tile. This is what stages a `referenceEntity` (the inline Tudo button instead
 # stages a `referenceImage` of the thumbnail). Verified 2026-06-06.
-PICKER_CONTEXT_INCLUDE = (
-    "[role='menuitem']:has-text('Incluir no comando'), button:has-text('Incluir no comando')"
+# Issue #170 + recon 2026-06-11 (pt-BR denon82, matching the ru report): the
+# menu is `div[role='menu'][data-state='open']` with menuitem ligatures
+# add / content_cut / content_copy / delete — `add` is unique within the menu,
+# so the icon tier is locale-free. The text tier keeps known captions, menu-
+# scoped so a user-named tile (e.g. a character called 'Add to prompt') can
+# never match.
+PICKER_CONTEXT_INCLUDE: tuple[str, str] = (
+    "[role='menu'][data-state='open'] [role='menuitem']:has(i.google-symbols:text-is('add'))",
+    "[role='menu'] [role='menuitem']:has-text('Incluir no comando'),"
+    " [role='menu'] [role='menuitem']:has-text('Добавить в запрос'),"
+    " [role='menu'] [role='menuitem']:has-text('Add to prompt')",
 )
+_CONTEXT_INCLUDE_TIER_NAMES = ("icon", "text")
 # The picker grid is virtualised (react-virtuoso): off-screen tiles are not in
 # the DOM. When the target entity tile is not initially rendered, scroll the grid
 # in steps until it appears (or we exhaust the attempts).
@@ -1214,6 +1239,60 @@ class VideoGenerationMixin:
         return tile
 
     @staticmethod
+    async def _resolve_include_action(
+        page: Page,
+        tiers: tuple[str, ...],
+        tier_names: tuple[str, ...],
+        *,
+        surface: str,
+        detail: str,
+        out_dir: Path | None,
+        screenshot_name: str,
+    ) -> Locator:
+        """Probe the include-action selector tiers IN ORDER; return the first
+        visible match.
+
+        Issue #170: a single localized has-text selector broke every
+        non-Portuguese account. Tiers are probed sequentially (not flattened
+        into one comma list — comma lists resolve in DOM order, not tier
+        priority) and the matched tier is logged so a dead locale-free tier
+        silently carried by the text fallback stays observable.
+
+        On exhaustion: capture a screenshot, press Escape twice (context menu
+        + picker dialog — a Page must never return to the pool with an open
+        overlay), and raise a typed, locale-neutral
+        :class:`TransportTimeoutError` so the CLI surfaces the remediation
+        hint with exit 9 instead of the privacy-hashed 'Unexpected error.'.
+        """
+        last_exc: Exception | None = None
+        for tier, selector in zip(tier_names, tiers, strict=True):
+            loc = page.locator(selector).first
+            try:
+                await loc.wait_for(state="visible", timeout=4000)
+            except Exception as e:  # noqa: BLE001 — try the next tier
+                last_exc = e
+                continue
+            log.info(
+                "ui_automation_video.include_selector_tier",
+                surface=surface,
+                tier=tier,
+            )
+            return loc
+        shot = await _capture_debug_screenshot(page, out_dir, screenshot_name)
+        await page.keyboard.press("Escape")
+        await page.keyboard.press("Escape")
+        raise TransportTimeoutError(
+            f"{detail} include action did not appear (no selector tier "
+            f"matched on surface {surface!r}). Screenshot: {shot}",
+            remediation_hint=(
+                "Flow's resource picker may have changed, or your account's "
+                "UI language is not yet covered by the selector fallbacks. "
+                "Report the visible menu/button captions (plus the screenshot) "
+                "at https://github.com/ffroliva/gflow-cli/issues."
+            ),
+        ) from last_exc
+
+    @staticmethod
     async def _attach_character_entities(
         page: Page,
         entities: list[tuple[str, str]],
@@ -1225,9 +1304,10 @@ class VideoGenerationMixin:
 
         Mechanism (verified credit-free via route-abort payload capture,
         2026-06-06): open 'Add Media' -> Personagens tab -> RIGHT-CLICK the entity
-        tile -> context-menu 'Incluir no comando'. This stages
+        tile -> the context-menu include action (`add`-ligature menu item; the
+        caption is localized, e.g. 'Incluir no comando' on pt-BR). This stages
         `referenceEntities:[{entityId}]` on the submit payload. A LEFT-click on a
-        Tudo-tab tile + the inline 'Incluir' button instead stages a plain
+        Tudo-tab tile + the inline include button instead stages a plain
         `referenceImage` (the character thumbnail) — which the submit backstop
         (`_assert_entities_attached`) correctly rejects. A plain left-click on the
         Personagens tile navigates into the character editor (it is an
@@ -1251,16 +1331,15 @@ class VideoGenerationMixin:
             await tile.scroll_into_view_if_needed(timeout=8000)
             await tile.click(button="right")
             await page.wait_for_timeout(400)
-            include = page.locator(PICKER_CONTEXT_INCLUDE).first
-            try:
-                await include.wait_for(state="visible", timeout=8000)
-            except Exception as e:
-                shot = await _capture_debug_screenshot(page, out_dir, "debug_entity_ctx_menu.png")
-                msg = (
-                    f"character {name!r} ({entity_id}) context-menu 'Incluir no "
-                    f"comando' did not appear after right-click. Screenshot: {shot}"
-                )
-                raise RuntimeError(msg) from e
+            include = await VideoGenerationMixin._resolve_include_action(
+                page,
+                PICKER_CONTEXT_INCLUDE,
+                _CONTEXT_INCLUDE_TIER_NAMES,
+                surface="context_menu",
+                detail=f"character {name!r} ({entity_id})",
+                out_dir=out_dir,
+                screenshot_name="debug_entity_ctx_menu.png",
+            )
             await include.click()
             await page.wait_for_timeout(600)
             log.info(
@@ -1276,7 +1355,7 @@ class VideoGenerationMixin:
         *,
         out_dir: Path | None,
     ) -> None:
-        """R2V: attach a voice resource via the Vozes picker -> 'Incluir no comando'."""
+        """R2V: attach a voice resource via the Vozes picker -> include button."""
         add = page.locator(ADD_MEDIA_BUTTON).first
         await add.wait_for(state="visible", timeout=8000)
         await add.click()
@@ -1290,7 +1369,16 @@ class VideoGenerationMixin:
         ).first
         await tile.click()
         await page.wait_for_timeout(300)
-        await page.locator(PICKER_INCLUDE_BUTTON).first.click()
+        include = await VideoGenerationMixin._resolve_include_action(
+            page,
+            PICKER_INCLUDE_BUTTON,
+            _INCLUDE_BUTTON_TIER_NAMES,
+            surface="vozes_button",
+            detail=f"voice {voice_id!r}",
+            out_dir=out_dir,
+            screenshot_name="debug_voice_include.png",
+        )
+        await include.click()
         await page.wait_for_timeout(600)
         log.info("ui_automation_video.reference_audio_attached", voice=voice_id)
 

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -16,6 +16,7 @@ import asyncio
 import inspect
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1179,10 +1180,21 @@ class TestGenerateImages:
             reference_entity_names=("Stacky",),  # fewer names than ids on purpose
         )
 
+        def _seeding_logger(page: Any, *, project_id: Any = None, sink: Any = None) -> Any:
+            # Feed the #170 submit backstop: pretend the captured submit
+            # carried both staged entities (the real logger fills the sink
+            # from outgoing batchGenerateImages bodies).
+            if sink is not None:
+                sink.append({"entity_ids": {"ent-1", "ent-2"}})
+            return lambda: None
+
         with (
             patch.object(t, "_enter_editor", new=AsyncMock()),
             patch.object(t, "_send_prompt", new=AsyncMock()),
             patch.object(t, "_attach_character_entities", new=AsyncMock()) as attach,
+            patch.object(
+                t, "_attach_batch_request_logger", new=MagicMock(side_effect=_seeding_logger)
+            ),
             patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
         ):
             await t.generate_images(project_id="x", request=req)
@@ -1326,6 +1338,137 @@ class TestAttachBatchRequestLogger:
         detach()
         detach()  # idempotent
         page.remove_listener.assert_called_once_with("request", on_request)
+
+
+class TestImageEntityBackstop:
+    """Issue #170: when reference entities were requested, the captured
+    batchGenerateImages submit must carry them — otherwise a missed UI attach
+    silently degrades to a text-only generation reported as success (the
+    image path previously only LOGGED the summary; the video path has
+    _assert_entities_attached)."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_image_mode_switch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Same orchestration stub as TestGenerateImages — mode-switch coverage
+        lives in test_ui_automation_image_mode.py."""
+        monkeypatch.setattr(UiAutomationTransport, "_switch_to_image_mode", AsyncMock())
+
+    def test_entity_ids_extracted_from_request_body(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _entity_ids_from_request_body
+
+        body = json.dumps(
+            {
+                "requests": [
+                    {"referenceEntities": [{"entityId": "ent-1"}, {"entityId": "ent-2"}]},
+                    {"referenceEntities": [{"entityId": "ent-3"}]},
+                ]
+            }
+        )
+        assert _entity_ids_from_request_body(body) == {"ent-1", "ent-2", "ent-3"}
+
+    def test_entity_ids_empty_for_none_garbage_or_absent(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _entity_ids_from_request_body
+
+        assert _entity_ids_from_request_body(None) == set()
+        assert _entity_ids_from_request_body("garbage-not-json") == set()
+        assert _entity_ids_from_request_body(json.dumps({"requests": [{}]})) == set()
+        assert _entity_ids_from_request_body(json.dumps({"requests": "nope"})) == set()
+
+    def test_request_logger_sink_collects_entity_ids(self) -> None:
+        page = MagicMock()
+        handlers: dict[str, object] = {}
+        page.on.side_effect = lambda event, fn: handlers.__setitem__(event, fn)
+        sink: list[dict[str, object]] = []
+
+        detach = UiAutomationTransport._attach_batch_request_logger(page, project_id="P", sink=sink)
+        on_request = handlers["request"]
+        assert callable(on_request)
+        on_request(
+            TestAttachBatchRequestLogger._Req(
+                "https://x/flowMedia:batchGenerateImages",
+                post=json.dumps({"requests": [{"referenceEntities": [{"entityId": "ent-1"}]}]}),
+            )
+        )
+        # Non-matching URLs never reach the sink.
+        on_request(TestAttachBatchRequestLogger._Req("https://x/other", post="{}"))
+        detach()
+
+        assert len(sink) == 1
+        assert sink[0]["entity_ids"] == {"ent-1"}
+
+    def test_assert_raises_when_entity_missing(self) -> None:
+        from gflow_cli.errors import WireFormatError
+
+        with pytest.raises(WireFormatError, match="referenceEntities"):
+            UiAutomationTransport._assert_image_entities_attached(
+                [{"entity_ids": set()}], expected=["ent-1"]
+            )
+
+    def test_assert_raises_when_nothing_was_captured(self) -> None:
+        from gflow_cli.errors import WireFormatError
+
+        with pytest.raises(WireFormatError, match="referenceEntities"):
+            UiAutomationTransport._assert_image_entities_attached([], expected=["ent-1"])
+
+    def test_assert_passes_when_entities_present_across_bodies(self) -> None:
+        UiAutomationTransport._assert_image_entities_attached(
+            [{"entity_ids": {"ent-1"}}, {"entity_ids": {"ent-2"}}],
+            expected=["ent-1", "ent-2"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_images_raises_when_entities_never_rode_the_wire(self) -> None:
+        """The wiring: entities requested + no captured submit carries them →
+        WireFormatError instead of returning images as a success."""
+        from gflow_cli.errors import WireFormatError
+
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+        req = GenerateImageRequest(
+            prompt="stacky",
+            model=Model.NARWHAL,
+            reference_entities=("ent-1",),
+            reference_entity_names=("Stacky",),
+        )
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_character_entities", new=AsyncMock()),
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+            pytest.raises(WireFormatError, match="referenceEntities"),
+        ):
+            await t.generate_images(project_id="x", request=req)
+
+    @pytest.mark.asyncio
+    async def test_generate_images_passes_when_submit_carries_entities(self) -> None:
+        t = UiAutomationTransport()
+        t._setup_done = True  # type: ignore[attr-defined]
+        t._page = MagicMock()  # type: ignore[attr-defined]
+        req = GenerateImageRequest(
+            prompt="stacky",
+            model=Model.NARWHAL,
+            reference_entities=("ent-1",),
+            reference_entity_names=("Stacky",),
+        )
+
+        def _seeding_logger(page: Any, *, project_id: Any = None, sink: Any = None) -> Any:
+            if sink is not None:
+                sink.append({"entity_ids": {"ent-1"}})
+            return lambda: None
+
+        with (
+            patch.object(t, "_enter_editor", new=AsyncMock()),
+            patch.object(t, "_send_prompt", new=AsyncMock()),
+            patch.object(t, "_attach_character_entities", new=AsyncMock()),
+            patch.object(
+                t, "_attach_batch_request_logger", new=MagicMock(side_effect=_seeding_logger)
+            ),
+            patch.object(t, "_await_captured", new=AsyncMock(return_value=[_flow_200_capture()])),
+        ):
+            images = await t.generate_images(project_id="x", request=req)
+        assert images
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -14,6 +14,8 @@ from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.api.transports.ui_automation_video import (
     FRAME_SLOT_BY_LABEL,
     FRAME_SLOTS_STRUCT,
+    PICKER_CONTEXT_INCLUDE,
+    PICKER_INCLUDE_BUTTON,
     VideoGenerationMixin,
 )
 from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStatus
@@ -1020,6 +1022,58 @@ class TestI2vT2vRoutingBackstop:
         assert result.status.succeeded is True
 
 
+class TestPickerIncludeSelectorLocaleInvariance:
+    """Issue #170: the picker include selectors must be tiered cascades —
+    locale-free anchor first where one exists, localized text as fallback.
+
+    Recon (denon82 pt-BR 2026-06-11 + ru report on #170): the right-click
+    context menu is `div[role='menu'][data-state='open']` and its include item
+    carries the `add` ligature (unique within the menu: content_cut /
+    content_copy / delete). The Vozes include button has NO ligature — it is
+    the lone iconless button in the open picker dialog.
+    """
+
+    def test_context_include_is_a_two_tier_cascade(self) -> None:
+        assert isinstance(PICKER_CONTEXT_INCLUDE, tuple)
+        assert len(PICKER_CONTEXT_INCLUDE) == 2
+
+    def test_context_include_tier1_is_menu_scoped_add_icon(self) -> None:
+        """Tier 1 locked verbatim so a drift can't silently slip past."""
+        assert PICKER_CONTEXT_INCLUDE[0] == (
+            "[role='menu'][data-state='open'] "
+            "[role='menuitem']:has(i.google-symbols:text-is('add'))"
+        ), f"PICKER_CONTEXT_INCLUDE[0] drifted: {PICKER_CONTEXT_INCLUDE[0]!r}"
+
+    def test_context_include_tier1_has_no_localized_text(self) -> None:
+        for word in ("Incluir", "Добавить", "Add to prompt"):
+            assert word not in PICKER_CONTEXT_INCLUDE[0]
+
+    def test_context_include_text_tier_covers_pt_ru_en_menu_scoped(self) -> None:
+        text_tier = PICKER_CONTEXT_INCLUDE[1]
+        for caption in ("Incluir no comando", "Добавить в запрос", "Add to prompt"):
+            assert caption in text_tier, f"missing caption {caption!r}"
+        # Every comma-segment must be scoped to the open menu so a user-named
+        # tile (e.g. a character called 'Add to prompt') can never match.
+        for segment in text_tier.split(","):
+            assert segment.strip().startswith("[role='menu']"), (
+                f"unscoped text segment: {segment.strip()!r}"
+            )
+
+    def test_include_button_is_a_two_tier_cascade(self) -> None:
+        assert isinstance(PICKER_INCLUDE_BUTTON, tuple)
+        assert len(PICKER_INCLUDE_BUTTON) == 2
+
+    def test_include_button_text_tier_covers_pt_ru_en(self) -> None:
+        text_tier = PICKER_INCLUDE_BUTTON[0]
+        for caption in ("Incluir no comando", "Добавить в запрос", "Add to prompt"):
+            assert caption in text_tier, f"missing caption {caption!r}"
+
+    def test_include_button_structural_tier_is_lone_iconless_dialog_button(self) -> None:
+        structural = PICKER_INCLUDE_BUTTON[1]
+        assert structural.startswith("[role='dialog'][data-state='open']")
+        assert ":not(:has(i.google-symbols))" in structural
+
+
 class TestAttachCharacterEntities:
     @staticmethod
     def _picker_page() -> MagicMock:
@@ -1030,6 +1084,7 @@ class TestAttachCharacterEntities:
         loc.last = loc
         loc.click = AsyncMock()
         loc.hover = AsyncMock()
+        loc.fill = AsyncMock()
         loc.wait_for = AsyncMock()
         loc.scroll_into_view_if_needed = AsyncMock()
         loc.count = AsyncMock(return_value=1)
@@ -1037,14 +1092,18 @@ class TestAttachCharacterEntities:
         page.wait_for_timeout = AsyncMock()
         page.mouse = MagicMock()
         page.mouse.wheel = AsyncMock()
+        page.keyboard = MagicMock()
+        page.keyboard.press = AsyncMock()
+        page.screenshot = AsyncMock()
         return page
 
     @pytest.mark.asyncio
     async def test_attach_right_clicks_personagens_entity_tile(self) -> None:
         """A character is staged as a referenceEntity via: Personagens tab ->
-        RIGHT-CLICK the `data-tile-id=fe_id_<entityId>` tile -> context-menu
-        'Incluir no comando'. The tile is addressed by entity id (not name), and
-        the click MUST be a right-click (a left-click navigates to the editor)."""
+        RIGHT-CLICK the `data-tile-id=fe_id_<entityId>` tile -> the context-menu
+        include action, matched by its locale-free `add` ligature (Tier 1). The
+        tile is addressed by entity id (not name), and the click MUST be a
+        right-click (a left-click navigates to the editor)."""
         page = self._picker_page()
 
         await VideoGenerationMixin._attach_character_entities(
@@ -1054,7 +1113,7 @@ class TestAttachCharacterEntities:
         selectors = " ".join(str(c.args[0]) for c in page.locator.call_args_list)
         assert "accessibility_new" in selectors  # Personagens tab
         assert "fe_id_ent-123" in selectors  # tile keyed by entity id
-        assert "Incluir no comando" in selectors  # context-menu action
+        assert "text-is('add')" in selectors  # icon-tier context-menu action
         assert "add-menu-input" not in selectors  # NOT the prompt box
         # The selection click is a right-click (button='right').
         right_clicks = [
@@ -1065,22 +1124,105 @@ class TestAttachCharacterEntities:
         assert right_clicks, "expected a right-click on the entity tile"
 
     @pytest.mark.asyncio
-    async def test_attach_raises_when_context_menu_absent(self) -> None:
-        """If the right-click context menu never shows 'Incluir no comando', the
-        attach fails loudly (with a screenshot) instead of silently dropping the
-        entity — the submit backstop must never see an empty referenceEntities."""
+    async def test_attach_logs_which_selector_tier_matched(
+        self, install_log_capture: structlog.testing.LogCapture
+    ) -> None:
+        """Drift telemetry: a successful attach reports the matched tier so the
+        icon tier dying (text tier silently carrying the load) is observable."""
         page = self._picker_page()
-        # wait_for succeeds for add-media / Personagens tab / tile, then raises on
-        # the context-menu include item (the menu never appeared).
-        page.locator.return_value.wait_for = AsyncMock(
-            side_effect=[None, None, None, TimeoutError("boom")]
-        )
-        page.screenshot = AsyncMock()
 
-        with pytest.raises(RuntimeError, match="Incluir no comando"):
+        await VideoGenerationMixin._attach_character_entities(
+            page, [("ent-123", "Stickman")], out_dir=None
+        )
+
+        tier_events = [
+            e
+            for e in install_log_capture.entries
+            if e["event"] == "ui_automation_video.include_selector_tier"
+        ]
+        assert tier_events, "expected an include_selector_tier event"
+        assert tier_events[0]["tier"] == "icon"
+        assert tier_events[0]["surface"] == "context_menu"
+
+    @pytest.mark.asyncio
+    async def test_attach_raises_when_context_menu_absent(self) -> None:
+        """If the right-click context menu never shows the include action (any
+        tier), the attach fails loudly (with a screenshot) instead of silently
+        dropping the entity — and the message is locale-neutral (issue #170:
+        it used to embed the pt-BR caption)."""
+        page = self._picker_page()
+        # wait_for succeeds for add-media / Personagens tab / tile, then raises
+        # for every include tier probe (the menu item never appeared).
+        page.locator.return_value.wait_for = AsyncMock(
+            side_effect=[None, None, None] + [TimeoutError("boom")] * 4
+        )
+
+        with pytest.raises(RuntimeError, match="include action") as excinfo:
             await VideoGenerationMixin._attach_character_entities(
                 page, [("ent-123", "Stickman")], out_dir=None
             )
+        message = str(excinfo.value)
+        assert "Incluir" not in message, "error message must be locale-neutral"
+        assert "ent-123" in message
+
+    @pytest.mark.asyncio
+    async def test_attach_failure_closes_picker_before_raising(self) -> None:
+        """The failure path must not return a Page to the pool with the picker
+        dialog / context menu still open (state contamination for the next
+        checkout) — Escape is pressed before the error propagates."""
+        page = self._picker_page()
+        page.locator.return_value.wait_for = AsyncMock(
+            side_effect=[None, None, None] + [TimeoutError("boom")] * 4
+        )
+
+        with pytest.raises(RuntimeError, match="include action"):
+            await VideoGenerationMixin._attach_character_entities(
+                page, [("ent-123", "Stickman")], out_dir=None
+            )
+        escapes = [
+            c for c in page.keyboard.press.call_args_list if c.args and c.args[0] == "Escape"
+        ]
+        assert escapes, "expected Escape cleanup before raising"
+
+
+class TestAttachReferenceAudio:
+    @pytest.mark.asyncio
+    async def test_attach_audio_logs_selector_tier(
+        self, install_log_capture: structlog.testing.LogCapture
+    ) -> None:
+        """The Vozes include button has no ligature (recon 2026-06-11): the
+        text tier is primary and its match must be reported for telemetry."""
+        page = TestAttachCharacterEntities._picker_page()
+
+        await VideoGenerationMixin._attach_reference_audio(page, "Alnilam", out_dir=None)
+
+        tier_events = [
+            e
+            for e in install_log_capture.entries
+            if e["event"] == "ui_automation_video.include_selector_tier"
+        ]
+        assert tier_events, "expected an include_selector_tier event"
+        assert tier_events[0]["tier"] == "text"
+        assert tier_events[0]["surface"] == "vozes_button"
+
+    @pytest.mark.asyncio
+    async def test_attach_audio_raises_locale_neutral_when_button_absent(self) -> None:
+        """When no include-button tier matches, the failure is loud,
+        locale-neutral, and leaves no open dialog behind."""
+        page = TestAttachCharacterEntities._picker_page()
+        # add-media wait succeeds; both include-button tier probes time out.
+        page.locator.return_value.wait_for = AsyncMock(
+            side_effect=[None] + [TimeoutError("boom")] * 4
+        )
+
+        with pytest.raises(RuntimeError, match="include action") as excinfo:
+            await VideoGenerationMixin._attach_reference_audio(page, "Alnilam", out_dir=None)
+        message = str(excinfo.value)
+        assert "Incluir" not in message, "error message must be locale-neutral"
+        escapes = [
+            c for c in page.keyboard.press.call_args_list if c.args and c.args[0] == "Escape"
+        ]
+        assert escapes, "expected Escape cleanup before raising"
 
 
 class TestAssertEntitiesAttached:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -19,7 +19,7 @@ from gflow_cli.api.transports.ui_automation_video import (
     VideoGenerationMixin,
 )
 from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStatus
-from gflow_cli.errors import AuthExpiredError, WireFormatError
+from gflow_cli.errors import AuthExpiredError, TransportTimeoutError, WireFormatError
 
 
 def _make_listener_page() -> tuple[MagicMock, list]:
@@ -1148,8 +1148,10 @@ class TestAttachCharacterEntities:
     async def test_attach_raises_when_context_menu_absent(self) -> None:
         """If the right-click context menu never shows the include action (any
         tier), the attach fails loudly (with a screenshot) instead of silently
-        dropping the entity — and the message is locale-neutral (issue #170:
-        it used to embed the pt-BR caption)."""
+        dropping the entity — and the error is TYPED with a locale-neutral
+        message (issue #170: a RuntimeError embedding the pt-BR caption reached
+        the user only as a privacy-hashed 'Unexpected error.', burying the
+        remediation hint)."""
         page = self._picker_page()
         # wait_for succeeds for add-media / Personagens tab / tile, then raises
         # for every include tier probe (the menu item never appeared).
@@ -1157,13 +1159,15 @@ class TestAttachCharacterEntities:
             side_effect=[None, None, None] + [TimeoutError("boom")] * 4
         )
 
-        with pytest.raises(RuntimeError, match="include action") as excinfo:
+        with pytest.raises(TransportTimeoutError, match="include action") as excinfo:
             await VideoGenerationMixin._attach_character_entities(
                 page, [("ent-123", "Stickman")], out_dir=None
             )
         message = str(excinfo.value)
         assert "Incluir" not in message, "error message must be locale-neutral"
         assert "ent-123" in message
+        assert excinfo.value.remediation_hint, "expected a remediation hint"
+        assert "Incluir" not in excinfo.value.remediation_hint
 
     @pytest.mark.asyncio
     async def test_attach_failure_closes_picker_before_raising(self) -> None:
@@ -1175,7 +1179,7 @@ class TestAttachCharacterEntities:
             side_effect=[None, None, None] + [TimeoutError("boom")] * 4
         )
 
-        with pytest.raises(RuntimeError, match="include action"):
+        with pytest.raises(TransportTimeoutError, match="include action"):
             await VideoGenerationMixin._attach_character_entities(
                 page, [("ent-123", "Stickman")], out_dir=None
             )
@@ -1207,7 +1211,7 @@ class TestAttachReferenceAudio:
 
     @pytest.mark.asyncio
     async def test_attach_audio_raises_locale_neutral_when_button_absent(self) -> None:
-        """When no include-button tier matches, the failure is loud,
+        """When no include-button tier matches, the failure is loud, typed,
         locale-neutral, and leaves no open dialog behind."""
         page = TestAttachCharacterEntities._picker_page()
         # add-media wait succeeds; both include-button tier probes time out.
@@ -1215,7 +1219,7 @@ class TestAttachReferenceAudio:
             side_effect=[None] + [TimeoutError("boom")] * 4
         )
 
-        with pytest.raises(RuntimeError, match="include action") as excinfo:
+        with pytest.raises(TransportTimeoutError, match="include action") as excinfo:
             await VideoGenerationMixin._attach_reference_audio(page, "Alnilam", out_dir=None)
         message = str(excinfo.value)
         assert "Incluir" not in message, "error message must be locale-neutral"

--- a/tests/features/locale_picker_include.feature
+++ b/tests/features/locale_picker_include.feature
@@ -1,0 +1,25 @@
+Feature: Locale-free character entity attach (issue 170)
+  The picker include selectors are locale-free cascades; the CLI surface must
+  pass reference entities through, fail typed-and-locale-neutral when the
+  include action never appears, and refuse to report success when the staged
+  entity did not ride the wire (submit backstop).
+
+  Scenario: t2i passes the reference entity to the generation runner
+    Given the mocked t2i runner records the request and writes one image
+    When I run "gflow image t2i a knight --project proj-1 --reference-entity ent-123 --reference-entity-name Lukas"
+    Then the exit code is 0
+    And the runner received reference entity "ent-123" named "Lukas"
+    And one image file is created
+
+  Scenario: missing include action fails typed and locale-neutral
+    Given the mocked t2i runner raises the include-action timeout
+    When I run "gflow image t2i a knight --project proj-1 --reference-entity ent-123 --reference-entity-name Lukas"
+    Then the exit code is 9
+    And the output contains "include action"
+    And the output does not contain "Incluir no comando"
+
+  Scenario: entity absent from the captured submit payload fails loudly
+    Given the mocked t2i runner raises the reference-entity submit backstop
+    When I run "gflow image t2i a knight --project proj-1 --reference-entity ent-123 --reference-entity-name Lukas"
+    Then the exit code is 7
+    And the output contains "File a bug"

--- a/tests/features/test_locale_picker_include_steps.py
+++ b/tests/features/test_locale_picker_include_steps.py
@@ -1,0 +1,206 @@
+"""Step bindings for locale_picker_include.feature (issue #170).
+
+Scoped to this feature only — pytest-bdd uses module-scoped step registries.
+
+Patching strategy: replace ``gflow_cli.cli_image._run_t2i`` with async stubs
+(same seam as test_image_steps.py). The selector-tier mechanics are unit-tested
+in tests/api/transports/test_ui_automation_video.py; these scenarios pin the
+CLI contract: entity pass-through, typed locale-neutral failure (exit 9), and
+the submit backstop (exit 7).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+from pytest_bdd import given, scenarios, then, when
+
+from gflow_cli import config
+from gflow_cli.cli import main
+from gflow_cli.errors import TransportTimeoutError, WireFormatError
+
+scenarios("locale_picker_include.feature")
+
+
+_T2I_CMD = [
+    "image",
+    "t2i",
+    "a knight",
+    "--project",
+    "proj-1",
+    "--reference-entity",
+    "ent-123",
+    "--reference-entity-name",
+    "Lukas",
+]
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_result_holder() -> dict[str, Any]:
+    return {"result": None}
+
+
+@pytest.fixture
+def runner_state() -> dict[str, Any]:
+    return {"req": None}
+
+
+@pytest.fixture(autouse=True)
+def _patch_image_profile_resolution(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Bypass profile resolution + provider-dir existence checks so image
+    commands reach the patched ``_run_t2i`` instead of bailing out with
+    exit 2 during profile discovery."""
+    monkeypatch.setattr("gflow_cli.cli_image._resolve_profile", lambda profile: "test")
+    monkeypatch.setattr("gflow_cli.cli_image._make_provider_dir", lambda name: tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache() -> Generator[None, None, None]:
+    config.reset_settings()
+    yield
+    config.reset_settings()
+
+
+# ---------------------------------------------------------------------------
+# Given steps
+# ---------------------------------------------------------------------------
+
+
+@given("the mocked t2i runner records the request and writes one image")
+def _mock_recording_runner(
+    monkeypatch: pytest.MonkeyPatch, runner_state: dict[str, Any]
+) -> None:
+    async def _fake_t2i(
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        headless: bool,
+        req: Any,
+        count: int,
+        out: Path | None,
+        output_root: Path,
+        transport: str | None = None,
+        project_id: str | None = None,
+        as_json: bool = False,
+    ) -> None:
+        runner_state["req"] = req
+        base = out if out is not None else output_root / "images"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "fake_1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    monkeypatch.setattr("gflow_cli.cli_image._run_t2i", _fake_t2i)
+
+
+@given("the mocked t2i runner raises the include-action timeout")
+def _mock_include_timeout_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The transport's locale-neutral failure when no include-selector tier
+    matched (issue #170: previously an untyped RuntimeError embedding the
+    pt-BR caption, surfaced only as a privacy-hashed 'Unexpected error.')."""
+
+    async def _fake_t2i(**_kwargs: Any) -> None:
+        raise TransportTimeoutError(
+            "character 'Lukas' (ent-123) include action did not appear "
+            "in the right-click context menu",
+            remediation_hint=(
+                "Flow's context menu may have changed or your account language "
+                "is not yet covered — open the menu manually and report its "
+                "captions on https://github.com/ffroliva/gflow-cli/issues."
+            ),
+        )
+
+    monkeypatch.setattr("gflow_cli.cli_image._run_t2i", _fake_t2i)
+
+
+@given("the mocked t2i runner raises the reference-entity submit backstop")
+def _mock_backstop_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The image-side submit backstop: the staged entity never rode the wire,
+    so the run must fail loudly instead of reporting a text-only success."""
+
+    async def _fake_t2i(**_kwargs: Any) -> None:
+        raise WireFormatError(
+            "captured batchGenerateImages submit is missing referenceEntities ['ent-123']"
+        )
+
+    monkeypatch.setattr("gflow_cli.cli_image._run_t2i", _fake_t2i)
+
+
+# ---------------------------------------------------------------------------
+# When steps
+# ---------------------------------------------------------------------------
+
+
+@when(
+    'I run "gflow image t2i a knight --project proj-1 '
+    '--reference-entity ent-123 --reference-entity-name Lukas"'
+)
+def _run_t2i_with_entity(runner: CliRunner, cli_result_holder: dict[str, Any]) -> None:
+    cli_result_holder["result"] = runner.invoke(main, _T2I_CMD)
+
+
+# ---------------------------------------------------------------------------
+# Then steps
+# ---------------------------------------------------------------------------
+
+
+@then("the exit code is 0")
+def _check_exit_0(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == 0, result.output
+
+
+@then("the exit code is 9")
+def _check_exit_9(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == 9, f"exit={result.exit_code}\n{result.output}"
+
+
+@then("the exit code is 7")
+def _check_exit_7(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == 7, f"exit={result.exit_code}\n{result.output}"
+
+
+@then('the runner received reference entity "ent-123" named "Lukas"')
+def _check_entity_passthrough(runner_state: dict[str, Any]) -> None:
+    req = runner_state["req"]
+    assert req is not None, "the t2i runner was never invoked"
+    assert req.reference_entities == ("ent-123",)
+    assert req.reference_entity_names == ("Lukas",)
+
+
+@then("one image file is created")
+def _check_one_image(tmp_path: Path) -> None:
+    files = list(tmp_path.rglob("*.png"))
+    assert len(files) == 1, f"expected 1 png, found {files}"
+
+
+@then('the output contains "include action"')
+def _check_output_include_action(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert "include action" in result.output, result.output
+
+
+@then('the output does not contain "Incluir no comando"')
+def _check_output_locale_neutral(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert "Incluir no comando" not in result.output, result.output
+
+
+@then('the output contains "File a bug"')
+def _check_output_file_a_bug(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert "File a bug" in result.output, result.output

--- a/tests/features/test_locale_picker_include_steps.py
+++ b/tests/features/test_locale_picker_include_steps.py
@@ -81,9 +81,7 @@ def _reset_settings_cache() -> Generator[None, None, None]:
 
 
 @given("the mocked t2i runner records the request and writes one image")
-def _mock_recording_runner(
-    monkeypatch: pytest.MonkeyPatch, runner_state: dict[str, Any]
-) -> None:
+def _mock_recording_runner(monkeypatch: pytest.MonkeyPatch, runner_state: dict[str, Any]) -> None:
     async def _fake_t2i(
         *,
         profile_name: str,


### PR DESCRIPTION
## Summary

Fixes #170 — `--reference-entity` (image t2i), movie R2V entity attach, and Vozes voice attach failed on every non-Portuguese Flow account because `PICKER_INCLUDE_BUTTON` / `PICKER_CONTEXT_INCLUDE` hardcoded the pt-BR caption "Incluir no comando" (Flow renders in the *account* language; `?hl=en` cannot override it).

Closes #170

### What changed

- **Tiered, locale-free selectors** (`ui_automation_video.py`): both constants are now 2-tuples of sequentially-probed tiers. Context menu Tier 1 = the `add`-ligature menuitem scoped to the open `[role='menu'][data-state='open']` (recon-verified on pt-BR denon82, identical icon set to the ru report); Tier 2 = menu-scoped pt/ru/en captions. The Vozes button carries **no** ligature (recon), so pt/ru/en text leads with a lone-iconless-dialog-button structural fallback. Sequential probing (not a flat comma list) because comma lists resolve in DOM order, not tier priority.
- **Typed, locale-neutral failure**: exhaustion raises `TransportTimeoutError` (exit 9) with an instance `remediation_hint` — previously an untyped `RuntimeError` embedding the pt caption surfaced to users only as the privacy-hashed "Unexpected error." (exit 1), burying the hint. The failure path also presses Escape twice so a pooled Page never returns with an open overlay.
- **Drift telemetry**: every successful attach emits `ui_automation_video.include_selector_tier` (tier=icon|text|structural, surface=context_menu|vozes_button) so a dead Tier 1 silently carried by the text fallback stays observable.
- **Image-side submit backstop** (`ui_automation.py`): mirrors the video path's `_assert_entities_attached` — the request logger now collects entity ids from each captured `batchGenerateImages` body (ids only, redaction-safe) and the run raises `WireFormatError` (exit 7) when a requested entity never rode the wire, instead of silently returning a text-only generation.
- **Docs**: KNOWN_ISSUES "locale-agnostic — complete" claim corrected; CHANGELOG; pt strings scrubbed from `docs/MOVIE.md` / `docs/CHARACTER.md`; new credit-free recon harness `scripts/dev/spike_issue170_picker_locale_recon.py`.

Planning artifacts: `docs/superpowers/plans/2026-06-11-issue-170-locale-selectors/` (SCENARIO.md + PLAN.md).

### Verification

- **Live e2e GREEN on promo-denon82 (pt-BR, credit-free)**: real `gflow image t2i --reference-entity` → `include_selector_tier tier=icon` → `character_entity_attached` → submit carried `referenceEntities:[{entityId}]` → backstop `image_entities_attached`.
- **The backstop already caught a real regression**: the denon82 account has a new full-page media-library UI where the staged entity does not ride the wire at all (both image + video paths; selectors click the same element old code clicked). Pre-PR that returned a silent text-only "success"; now it fails loudly. Filed separately.
- Gates: `pyright src` 0 errors · ruff check + format clean · `uv lock --check` clean · `tests/api/transports` + `tests/features` = **396 passed** (12 new unit tests red-first, 8 backstop tests, 3 BDD scenarios, 7 selector-invariance tests).

### Test plan

- [x] Unit: tier cascade composition + verbatim Tier-1 lock + no-localized-text invariant
- [x] Unit: locale-neutral typed failure, Escape cleanup, tier telemetry (both surfaces)
- [x] Unit: backstop extractor/sink/assert + end-to-end wiring (raise + pass)
- [x] BDD: entity pass-through (exit 0), include timeout (exit 9, no pt caption in output), backstop (exit 7)
- [x] Live pt-BR e2e (promo-denon82, credit-free)
- [ ] ru-locale confirmation by @papushin7987 on a candidate build (offered in #170) — pre-merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
