### PR TITLE
chore(skills): housekeeping from the v0.16.0 session retro

### DIFF
--- a/.claude/commands/gflow/check.md
+++ b/.claude/commands/gflow/check.md
@@ -50,3 +50,10 @@ If the coverage run crashes the current MCP/sandbox session with `Connection clo
 same marker-filtered suite in smaller chunks without coverage and rely on CI for the coverage XML.
 Project pytest defaults already exclude `e2e` and `live`; those markers are explicit,
 credit-spending gates and must be requested with a separate `-m e2e` / `-m live` command.
+
+**Windows agent sessions:** `uv run pytest` is unreliable — invoke
+`.venv/Scripts/python.exe -m pytest` directly, and prefix Python invocations with
+`PYTHONUTF8=1` when output contains non-ASCII. The unscoped full-coverage sweep
+(step 4) can OOM locally (exit 137 / SIGKILL): run the suites scoped to the dirs you
+touched and trust CI for the full coverage gate — **a green full-suite CI run on the
+same tree (e.g. the just-merged PR) satisfies step 4 for release purposes.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Slash commands live under `.claude/commands/gflow/` (all prefixed `/gflow:`).
 - Skills under `skills/` are auto-discoverable; `gflow-cli` ships its own at [`skills/gflow-cli/SKILL.md`](skills/gflow-cli/SKILL.md).
 - Auto-memory at `~/.claude/projects/C--development-github-gflow-cli/memory/MEMORY.md` carries cross-session feedback and project state.
+- **Worktrees:** the native `EnterWorktree` tool branches from `origin/main` (the default branch). Feature work integrates via `develop` — after entering a fresh worktree, immediately `git switch -c <type>/<name> origin/develop` and delete the auto-created `worktree-*` branch. On Windows, worktree removal can fail on a file lock (the worktree's `.venv`); `git worktree prune` + manual delete later is fine.
 
 ## MCP GitHub tool — PR body rule (non-negotiable)
 

--- a/scripts/dev/active_plan.py
+++ b/scripts/dev/active_plan.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from pathlib import Path
+
+# Windows consoles default to cp1252, which cannot encode the arrows/emoji
+# used in PLAN.md — reconfigure stdout so the script works without a
+# PYTHONUTF8=1 prefix (bit the /gflow:plan flow on 2026-06-11).
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
 
 ROOT = Path(__file__).resolve().parents[2]
 SUPERPOWERS_DIR = ROOT / "docs" / "superpowers" / "plans"

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -144,6 +144,13 @@ it propagate into the new code path or is it missing from the event?
 
 ---
 
+## Artifact location
+
+Write the analysis to **`docs/superpowers/plans/<YYYY-MM-DD>-<feature-slug>/SCENARIO.md`**
+(same directory the subsequent `/gflow:plan` writes its `PLAN.md` into) and commit it
+with the plan on the feature branch. Established by the image-upscale (#171) and
+locale-selectors (#170) cycles — do not leave the analysis only in conversation.
+
 ## Output format
 
 ```


### PR DESCRIPTION
Four small fixes for friction hit during the #170 → v0.16.0 cycle:

- **`scripts/dev/active_plan.py`** — self-reconfigures stdout to UTF-8; it crashed with `UnicodeEncodeError` (cp1252) when invoked by `/gflow:plan` without a `PYTHONUTF8=1` prefix.
- **`skills/scenario/SKILL.md`** — documents the artifact path convention (`docs/superpowers/plans/<date>-<slug>/SCENARIO.md`); previously implicit, had to be reverse-engineered from the #171 commit history.
- **`/gflow:check`** — Windows agent notes: `.venv/Scripts/python.exe -m pytest` invocation, scoped-local + trust-CI pattern for the full coverage sweep (the unscoped run OOMs locally), and its release-gate equivalence (a green full-suite CI run on the same tree satisfies step 4).
- **`CLAUDE.md`** — worktree guidance: the native EnterWorktree tool branches from `origin/main`; re-branch off `origin/develop` immediately; Windows worktree-removal file-lock note.

Doc/tooling only — no production code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)