### PR TITLE
fix(errors): issue #174 interim — entity-attach exit-7 remediation hint + library-UI recon spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Entity-attach `WireFormatError` failures (exit 7) now carry a remediation hint pointing at Flow's new full-page media-library UI rollout ([#174](https://github.com/ffroliva/gflow-cli/issues/174)) — affected accounts can stage entities via the include action but the submit never carries `referenceEntities`; the error now explains how to tell which UI an account has and where to follow the fix, instead of the generic file-a-bug hint. Both backstops also emit an `entity_attach_context` discovery field (`video`/`image`) for drift telemetry. New KNOWN_ISSUES entry documents the rollout
+
 ## [0.16.0] — 2026-06-12
 
 ### Fixed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,6 +14,34 @@ Living list of behaviour that's broken, surprising, or limited by design — alo
 
 ## Open
 
+### Flow's new full-page media-library UI breaks entity attach (A/B rollout)
+
+- **Status:** **Open** — Flow-side staged rollout; tracked in
+  [#174](https://github.com/ffroliva/gflow-cli/issues/174)
+- **Severity:** High · **Affects:** `gflow image t2i --reference-entity` and
+  movie R2V entity attach on accounts that received the new UI, any locale
+
+Flow is A/B-rolling a new full-page media-library UI: clicking **Add Media**
+in the composer **navigates to a library page** (sidebar: All media /
+Characters / Scenes / Tools, with a floating quick-create composer) instead of
+opening the resource-picker dialog. On affected accounts the right-click
+include action still lands (a chip appears), **but the staged entity never
+reaches the submit** — the request carries no `referenceEntities`, so the
+submit backstops raise `WireFormatError` (**exit 7**) instead of silently
+returning a text-only generation as success.
+
+**How to tell which UI your account has:** in the Flow web editor, click
+**Add Media** — a small dialog means the old (working) UI; a navigation to a
+full-page library means the affected new UI.
+
+**Workaround:** none yet on affected accounts — the attach gesture for the new
+UI is being reverse-engineered (recon plan in
+[docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md](docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md)).
+If you have a second profile/account still on the old UI, entity attach works
+there. Follow [#174](https://github.com/ffroliva/gflow-cli/issues/174) for
+status; please report whether your account shows the dialog or the full-page
+library (plus your locale) on that issue.
+
 ### 4K image upscale requires a Flow Ultra subscription
 
 - **Status:** **Open** (by design — a Flow platform limit, not a gflow bug)

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,6 +34,11 @@ returning a text-only generation as success.
 **Add Media** — a small dialog means the old (working) UI; a navigation to a
 full-page library means the affected new UI.
 
+**Note:** the experiment appears to flap — the affected account observed on
+2026-06-12 00:13 was back on the old dialog UI by 12:48 the same day (variant
+probe, issue #174). If you hit exit 7 on entity attach, re-running later the
+same day may simply work again.
+
 **Workaround:** none yet on affected accounts — the attach gesture for the new
 UI is being reverse-engineered (recon plan in
 [docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md](docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md)).

--- a/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
+++ b/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
@@ -123,14 +123,18 @@ change. Reuses the `spike_movie_attach_payload.py` route-abort harness and
 profile) — headed real-Chrome strategy mandatory.
 
 **Steps:**
-- [ ] Run `spike_issue174_library_ui_recon.py` on **denon82** (new UI) — one pass through the
-      gesture matrix
-- [ ] Re-probe **promo-denon82**: still old dialog UI? (rollout-scope datapoint)
-- [ ] Post findings to issue #174 (filtered: `request0_keys` / gesture verdicts, no raw payloads;
-      screenshots only if redacted)
-- [ ] Record findings summary in this plan under Task 4
+- [x] Run `spike_issue174_library_ui_recon.py` on **denon82** — 2026-06-12 12:48 (UTC+1):
+      **variant = `dialog` (12 ms)** — the account is BACK on the old picker-dialog UI; the
+      A/B has rolled back (or is flapping) since the 00:13 capture that opened #174. Gesture
+      matrix correctly self-skipped. Evidence: `scripts/dev/_spike_out/
+      spike_issue174_library_ui_20260612_124734.json` + `A_after_add_media.png` (local).
+- [x] Re-probe **promo-denon82**: SKIPPED — moot once denon82 itself reverted (both would show
+      dialog); WAF discipline says don't spend runs on a question with no remaining signal.
+- [x] Post findings to issue #174 (filtered: variant verdict + timing, no raw payloads)
+- [x] Findings recorded under Task 4
 
-**Verification:** the spike JSON shows, per gesture, whether `referenceEntities` rode the wire.
+**Verification:** the spike JSON shows, per gesture, whether `referenceEntities` rode the wire —
+on this run, Phase A exited before any gesture (old UI), which is itself the answer.
 
 ---
 
@@ -150,9 +154,15 @@ implementation tasks below.
   N days; Task 1's hint carries users meanwhile.
 
 **Steps:**
-- [ ] Decision recorded: ______ (a / b / c) on ______
-- [ ] `/gflow:scenario` run on the chosen shape (Critical/High scenarios → test checklist)
-- [ ] Implementation tasks appended (test scaffold first, per plan-skill task rules)
+- [x] Decision recorded: **(c) HOLD** on 2026-06-12 — the A/B rolled back off denon82 within
+      ~12 h; there is no stable new-UI account to recon against, so building a variant branch
+      now would target a moving (currently absent) UI. Task 1's hint + KNOWN_ISSUES carry any
+      user the experiment re-touches; the spike is committed and ready the moment an affected
+      account reappears (re-probe denon82 in ~3–7 days or on the next exit-7 report with
+      `entity_attach_context` discovery telemetry).
+- [ ] `/gflow:scenario` — deferred with the hold (runs when an implementation shape exists)
+- [ ] Implementation tasks — deferred with the hold (re-open Task 4 when a stable new-UI
+      account is available; decision matrix above still applies)
 
 ---
 

--- a/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
+++ b/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
@@ -99,19 +99,19 @@ change. Reuses the `spike_movie_attach_payload.py` route-abort harness and
 - `scripts/dev/spike_issue174_library_ui_recon.py`
 
 **Steps:**
-- [ ] Phase A — variant detection: click Add Media, race `[role='dialog'][data-state='open']`
-      appearance vs URL change; record which won + timing
-- [ ] Phase B (new UI only) — gesture matrix, each with route-abort submit capture:
-      1. right-click include on Personagens tile → submit **from the floating quick-create
-         composer** on the library page
-      2. right-click include → navigate back to the editor → submit from the editor composer
-         (does staging survive navigation?)
-      3. any new "use in prompt"-style affordance discovered in the DOM dump
-- [ ] Phase C — DOM dump of the library page: sidebar items, tile structure
-      (`data-tile-id`?), floating composer, all ligature icons (locale-invariant anchors)
-- [ ] Capture asserts: request0 `referenceEntities` presence per gesture; JSON +
-      screenshots to `scripts/dev/_spike_out/` (local only — never committed; PII)
-- [ ] Windows: `PYTHONUTF8=1`; parameterize profile via env (memory: e2e scripts parameterize)
+- [x] Phase A — variant detection: click Add Media, poll `[role='dialog'][data-state='open']`
+      appearance vs URL change; record which won + timing (old-UI accounts exit here —
+      doubles as the rollout re-probe)
+- [x] Phase B (new UI only) — gesture matrix, each with route-abort submit capture
+      (`--gestures b1,b2`): b1 = include → submit from the floating quick-create composer;
+      b2 = include → navigate back to editor → submit (does staging survive navigation?);
+      gesture 3 (new affordances) is driven manually off the Phase C dump
+- [x] Phase C — DOM dump of the library page: nav/sidebar items, `data-tile-id` tiles,
+      composer candidates (slate textbox + sibling button ligatures), full ligature inventory
+- [x] Capture asserts: request0 `referenceEntities`/`request0_keys`/`reference_like` per
+      gesture; JSON + screenshots to `scripts/dev/_spike_out/` (local only — never committed)
+- [x] Windows: `PYTHONUTF8=1` documented in usage; profile via `GFLOW_CLI_PROFILE` env;
+      both video and image generate routes aborted (credit-free)
 
 **Tests:** none (dev spike script, excluded from coverage like existing `spike_*.py`).
 

--- a/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
+++ b/docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md
@@ -1,0 +1,176 @@
+# Issue #174 — Library-UI Attach Drift Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature issue-174-library-ui-attach` to find the
+> next unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** Restore entity attach (`gflow image t2i --reference-entity`, movie R2V) on accounts
+with Flow's new full-page media-library UI — recon-first, with implementation explicitly gated
+on recon findings.
+
+**Architecture:** No code-shape decision yet by design (predict: Devil's Advocate — the A/B may
+still be mutating; the fix may be a gesture/selector change, not a branch). If a branch proves
+necessary, it lands as a shared `_detect_add_media_variant(page) -> "dialog" | "navigate"` static
+helper on `VideoGenerationMixin` (race pattern: dialog-appears vs URL-changes, ~100–200 ms),
+called on **every** attach (A/B can flap per page-load), single checked-out Page only (size-1
+pool — never a 2nd checkout). The interim UX task touches only `errors.py` remediation text +
+`KNOWN_ISSUES.md`.
+
+**Predict verdict:** CAUTION — 7/10 (Architect 7.5 · Security 8 · Performance 7 · CLI UX 7 ·
+Devil's Advocate 7). Recon: unanimous GO. Implementation: gated on Task 4.
+
+**Scenario:** deferred to Task 4 — `/gflow:scenario` on an unknown gesture would be speculation;
+it runs once recon fixes the fix shape.
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Staging context may be scoped to the library page's floating quick-create composer — navigating back to the editor discards it | Recon explicitly tests submit **from the floating composer** AND the navigate-back-then-submit path |
+| High | WAF heat on denon82 (known-hot profile) from repeated spike runs | One disciplined recon run; no iterative debug loops; 24 h+ between reruns |
+| Medium | A/B may mutate or roll back mid-work — variant code becomes stale debt | Task 4 gate: re-probe rollout scope (denon82 + promo-denon82) before committing to implementation |
+| Medium | Affected users today get exit 7 with no context → duplicate bug reports on #174 | Task 1 ships the #174-aware remediation hint independently of the recon |
+| Medium | reCAPTCHA/WAF behaviour on full-page library navigation unknown | Recon observes; REST-side injection of `referenceEntities` is a dead end (reCAPTCHA-gated; server would reject unstaged data) |
+
+---
+
+## File structure
+
+### New files
+```
+scripts/dev/spike_issue174_library_ui_recon.py
+  Credit-free recon spike: dialog-vs-navigate detection, floating-composer submit
+  test, navigate-back submit test, library-page DOM dump, route-abort capture.
+tests/api/test_wire_format_remediation.py  (or extend existing errors tests)
+  Asserts the #174 remediation hint rides the typed WireFormatError.
+```
+
+### Modified files
+```
+src/gflow_cli/errors.py
+  Entity-attach WireFormatError remediation hint names the library-UI A/B + issue #174.
+KNOWN_ISSUES.md
+  New § Open entry for the library-UI A/B (probe: dialog opens vs page navigates).
+CHANGELOG.md
+  [Unreleased] entry for the remediation-hint change.
+src/gflow_cli/api/transports/ui_automation_video.py   (Task 4+, shape TBD)
+src/gflow_cli/api/transports/ui_automation.py          (Task 4+, shape TBD)
+```
+
+---
+
+## Task 1 — Interim UX: point exit-7 at issue #174 (committable now, no recon needed)
+
+**What:** Affected users hitting the PR #173 backstops get an actionable message instead of
+generic "file a bug".
+
+**Files:**
+- `src/gflow_cli/errors.py` — remediation hint on the entity-attach `WireFormatError` raises
+  (or per-raise `remediation_hint=` at the two raise sites)
+- `src/gflow_cli/api/transports/ui_automation_video.py:1424` — `_assert_entities_attached` raise
+- `src/gflow_cli/api/transports/ui_automation.py:~2062` — `_assert_image_entities_attached` raise
+- `KNOWN_ISSUES.md` — new § Open entry
+- `CHANGELOG.md` — `[Unreleased]`
+
+**Steps:**
+- [x] Add `remediation_hint` naming the new-library-UI A/B and linking
+      https://github.com/ffroliva/gflow-cli/issues/174 to both entity-attach raise sites
+      (`ENTITY_ATTACH_DRIFT_HINT` constant in `ui_automation_video.py`, imported image-side)
+- [x] Add `discovery={"entity_attach_context": "video" | "image"}` to the raises (telemetry)
+- [x] `KNOWN_ISSUES.md` § Open entry with the variant probe: "does Add Media open a
+      `[role='dialog']` or navigate to a full-page library?"
+- [x] `CHANGELOG.md` `[Unreleased]` entry
+
+**Tests:**
+- [x] Unit test: hint text rides the typed error and surfaces in `to_problem_details()`
+      (TDD red→green; one per surface: `test_backstop_error_carries_issue_174_hint_and_discovery`
+      / `test_assert_error_carries_issue_174_hint_and_discovery`)
+- [x] Existing backstop tests still green (tests/api/transports: 364 passed, 1 skipped;
+      pyright src 0 errors; ruff clean — 2026-06-12)
+
+---
+
+## Task 2 — Recon spike script (credit-free; no live run in this task)
+
+**What:** A purpose-built spike answering the make-or-break questions before any attach-code
+change. Reuses the `spike_movie_attach_payload.py` route-abort harness and
+`spike_issue170_picker_locale_recon.py` DOM-dump utilities.
+
+**Files:**
+- `scripts/dev/spike_issue174_library_ui_recon.py`
+
+**Steps:**
+- [ ] Phase A — variant detection: click Add Media, race `[role='dialog'][data-state='open']`
+      appearance vs URL change; record which won + timing
+- [ ] Phase B (new UI only) — gesture matrix, each with route-abort submit capture:
+      1. right-click include on Personagens tile → submit **from the floating quick-create
+         composer** on the library page
+      2. right-click include → navigate back to the editor → submit from the editor composer
+         (does staging survive navigation?)
+      3. any new "use in prompt"-style affordance discovered in the DOM dump
+- [ ] Phase C — DOM dump of the library page: sidebar items, tile structure
+      (`data-tile-id`?), floating composer, all ligature icons (locale-invariant anchors)
+- [ ] Capture asserts: request0 `referenceEntities` presence per gesture; JSON +
+      screenshots to `scripts/dev/_spike_out/` (local only — never committed; PII)
+- [ ] Windows: `PYTHONUTF8=1`; parameterize profile via env (memory: e2e scripts parameterize)
+
+**Tests:** none (dev spike script, excluded from coverage like existing `spike_*.py`).
+
+---
+
+## Task 3 — Run recon on denon82 + rollout re-probe (ONE run; owner-gated)
+
+**What:** Single disciplined live run. Requires the user's machine free (no other Chrome on the
+profile) — headed real-Chrome strategy mandatory.
+
+**Steps:**
+- [ ] Run `spike_issue174_library_ui_recon.py` on **denon82** (new UI) — one pass through the
+      gesture matrix
+- [ ] Re-probe **promo-denon82**: still old dialog UI? (rollout-scope datapoint)
+- [ ] Post findings to issue #174 (filtered: `request0_keys` / gesture verdicts, no raw payloads;
+      screenshots only if redacted)
+- [ ] Record findings summary in this plan under Task 4
+
+**Verification:** the spike JSON shows, per gesture, whether `referenceEntities` rode the wire.
+
+---
+
+## Task 4 — GATE: decide the fix shape (no code until this is recorded)
+
+**What:** Convert recon findings into the implementation decision. Record the decision + date
+here, then run `/gflow:scenario issue-174-library-ui-attach` on the chosen shape and append
+implementation tasks below.
+
+**Decision matrix:**
+- **(a) Gesture fix** — a working new-UI gesture exists and the old code path can reach it with
+  selector/flow changes only → small PR, no variant branch.
+- **(b) Variant branch** — both UIs must coexist → `_detect_add_media_variant` helper (race
+  pattern, per-attach call), new-UI attach path, `ui_automation.library_ui_variant_detected`
+  structlog event, `GFLOW_CLI_LIBRARY_UI_VARIANT` env override (`auto|old|new`) for testing.
+- **(c) Hold** — A/B unstable or no working gesture found → KNOWN_ISSUES stays, re-probe in
+  N days; Task 1's hint carries users meanwhile.
+
+**Steps:**
+- [ ] Decision recorded: ______ (a / b / c) on ______
+- [ ] `/gflow:scenario` run on the chosen shape (Critical/High scenarios → test checklist)
+- [ ] Implementation tasks appended (test scaffold first, per plan-skill task rules)
+
+---
+
+## Out of scope
+
+- `abra_r2v_8s` default-model drift — separate bug; file its own issue (noted in #174).
+- Voice attach (`_attach_reference_audio`) new-UI path — follow-up unless recon shows the fix
+  is trivially shared.
+- REST-side `referenceEntities` injection — rejected by predict (reCAPTCHA-gated; dead end).
+
+---
+
+## Definition of done
+
+- [ ] Tasks 1–3 checked; Task 4 decision recorded with date
+- [ ] `/gflow:check` green (ruff / format / pyright `src` whole-tree / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` updated (Task 1)
+- [ ] `KNOWN_ISSUES.md` entry live (Task 1)
+- [ ] Issue #174 updated with recon findings (Task 3)
+- [ ] Post-gate implementation tasks carry Critical + High scenario coverage from `/gflow:scenario`
+- [ ] No `# TODO` in diff without a tracked issue link

--- a/scripts/dev/spike_issue174_library_ui_recon.py
+++ b/scripts/dev/spike_issue174_library_ui_recon.py
@@ -64,6 +64,10 @@ _OPEN_DIALOG = "[role='dialog'][data-state='open']"
 _PROMPT_BOX = "div[role='textbox'][data-slate-editor='true']"
 _SUBMIT_BTN = "button:has(i.google-symbols:text('arrow_forward'))"
 _ENTITY_TILE_PREFIX = "[data-tile-id^='fe_id_']"
+# ADD_MEDIA_BUTTON requires aria-haspopup='dialog'; a new-UI account may drop
+# that attribute (the button navigates) — fall back to the bare icon anchor.
+_ADD_MEDIA_FALLBACK = "button:has(i.google-symbols:text-is('add_2'))"
+_SPIKE_PROMPT = "Stands on a clifftop at sunset, waves at the camera."
 # New-UI sidebar: Personagens entry carries the same accessibility_new
 # ligature as the old picker tab (locale-invariant) but may be an <a>.
 _LIBRARY_PERSONAGENS = (
@@ -167,6 +171,8 @@ async def _detect_variant(page: Any) -> dict[str, Any]:
     """
     url_before = page.url
     add = page.locator(ADD_MEDIA_BUTTON).first
+    if await add.count() == 0:
+        add = page.locator(_ADD_MEDIA_FALLBACK).first
     await add.wait_for(state="visible", timeout=8000)
     await add.click()
     t0 = time.monotonic()
@@ -268,9 +274,9 @@ async def _run(
             # ABORT — the request never reaches Google; no credit is charged.
             await route.abort()
 
-        for glob in _GEN_ROUTE_GLOBS:
-            await page.route(glob, _on_route)
         try:
+            for glob in _GEN_ROUTE_GLOBS:
+                await page.route(glob, _on_route)
             editor_url = routes.project_editor_url(locale, project_id)
             step("A", f"goto {editor_url}", prefix="174")
             await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
@@ -314,11 +320,7 @@ async def _run(
                         await page.wait_for_timeout(900)
                     stage = await _stage_entity(page, entity_id, out_dir, "B1")
                     cap = await _submit_and_capture(
-                        page,
-                        captured,
-                        out_dir,
-                        "B1",
-                        prompt="Stands on a clifftop at sunset, waves at the camera.",
+                        page, captured, out_dir, "B1", prompt=_SPIKE_PROMPT
                     )
                     result["gestures"]["b1_floating_composer"] = {"stage": stage, **cap}
                 except Exception as e:  # noqa: BLE001
@@ -354,12 +356,18 @@ async def _run(
                     await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
                     await page.wait_for_timeout(3_000)
                     await page.keyboard.press("Escape")
+                    # The remounted editor can land in agent/image mode — re-run
+                    # the mode-switch sequence or _PROMPT_BOX/_SUBMIT_BTN hit the
+                    # wrong composer and B2 reports a false "staging lost".
+                    await VideoGenerationMixin._exit_agent_mode(page)  # noqa: SLF001
+                    await VideoGenerationMixin._switch_to_video_mode(  # noqa: SLF001
+                        page, out_dir=None
+                    )
+                    await VideoGenerationMixin._switch_video_sub_mode(  # noqa: SLF001
+                        page, "references", out_dir=None
+                    )
                     cap = await _submit_and_capture(
-                        page,
-                        captured,
-                        out_dir,
-                        "B2",
-                        prompt="Stands on a clifftop at sunset, waves at the camera.",
+                        page, captured, out_dir, "B2", prompt=_SPIKE_PROMPT
                     )
                     result["gestures"]["b2_back_to_editor"] = {"stage": stage, **cap}
                 except Exception as e:  # noqa: BLE001
@@ -394,7 +402,11 @@ def main(argv: list[str] | None = None) -> int:
         description="Issue #174: recon the new library UI attach gesture (0 credits)."
     )
     p.add_argument("--profile", default=os.environ.get("GFLOW_CLI_PROFILE", "denon82"))
-    p.add_argument("--project", required=True)
+    p.add_argument(
+        "--project",
+        default=os.environ.get("GFLOW_CLI_PROJECT"),
+        required="GFLOW_CLI_PROJECT" not in os.environ,
+    )
     p.add_argument("--entity-id", dest="entity_id", default="", help="entityId for fe_id_ tile")
     p.add_argument("--name", default="Stickman")
     p.add_argument("--locale", default=os.environ.get("GFLOW_CLI_LOCALE", "pt"))

--- a/scripts/dev/spike_issue174_library_ui_recon.py
+++ b/scripts/dev/spike_issue174_library_ui_recon.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+r"""Issue #174 recon — new full-page media-library UI attach gesture (0 credits).
+
+Flow is A/B-rolling a full-page media-library UI: on affected accounts the
+composer's 'Add Media' button NAVIGATES to a library page instead of opening
+the `[role='dialog']` resource picker. The right-click include still lands (a
+chip appears in the library page's floating quick-create composer) but the
+staged entity never reaches the submit — no `referenceEntities` on the wire.
+
+This spike answers, credit-free (all generate routes are route-aborted):
+
+  Phase A  — variant probe: after clicking Add Media, does a dialog open or
+             does the page navigate? (rollout re-probe answer on any account)
+  Phase C  — new-UI DOM dump: sidebar items, entity tiles, floating-composer
+             candidates, full ligature inventory (selector design input).
+  Phase B1 — stage entity via right-click include, then submit FROM the
+             library page's floating quick-create composer. Capture payload.
+  Phase B2 — stage entity, navigate BACK to the editor, submit from the
+             editor composer (does staging survive navigation?). Capture.
+
+Every phase is non-fatal: errors are recorded in the JSON and the run
+continues. Output JSON + screenshots land in scripts/dev/_spike_out/ —
+LOCAL ONLY, never commit (screenshots may carry account avatar/email).
+
+Usage (headed, supervised; ONE disciplined run — WAF heat, see #174 plan):
+
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_issue174_library_ui_recon.py \
+        --profile denon82 --project <project-uuid> \
+        --entity-id <entityId> --name Stickman --locale pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    ADD_MEDIA_BUTTON,
+    PICKER_CONTEXT_INCLUDE,
+    VideoGenerationMixin,
+)
+
+# Abort BOTH generation families — the library page may submit either.
+_GEN_ROUTE_GLOBS = (
+    "**/video:batchAsyncGenerateVideo*",
+    "**/*batchGenerateImages*",
+)
+_OPEN_DIALOG = "[role='dialog'][data-state='open']"
+_PROMPT_BOX = "div[role='textbox'][data-slate-editor='true']"
+_SUBMIT_BTN = "button:has(i.google-symbols:text('arrow_forward'))"
+_ENTITY_TILE_PREFIX = "[data-tile-id^='fe_id_']"
+# New-UI sidebar: Personagens entry carries the same accessibility_new
+# ligature as the old picker tab (locale-invariant) but may be an <a>.
+_LIBRARY_PERSONAGENS = (
+    "a:has(i.google-symbols:text-is('accessibility_new')),"
+    " [role='tab']:has(i.google-symbols:text-is('accessibility_new')),"
+    " button:has(i.google-symbols:text-is('accessibility_new'))"
+)
+
+# DOM dump of the library page: nav/sidebar entries, tile inventory,
+# composer candidates (any slate textbox + sibling button ligatures), and the
+# full ligature inventory — everything selector design needs, no PII fields.
+_DUMP_LIBRARY_JS = """
+() => {
+  const lig = (el) => {
+    const i = el.querySelector("i.google-symbols, i[class*='symbols']");
+    return i ? (i.textContent || "").trim() : null;
+  };
+  const brief = (el) => ({
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute("role"),
+    href: el.getAttribute("href"),
+    ligature: lig(el),
+    text: (el.textContent || "").trim().slice(0, 60),
+  });
+  const navItems = [...document.querySelectorAll(
+    "nav a, nav button, aside a, aside button, [role='navigation'] a, [role='navigation'] button"
+  )].map(brief);
+  const tiles = [...document.querySelectorAll("[data-tile-id]")].slice(0, 30).map((el) => ({
+    tileId: el.getAttribute("data-tile-id"),
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute("role"),
+  }));
+  const composers = [...document.querySelectorAll(
+    "div[role='textbox'][data-slate-editor='true']"
+  )].map((box) => {
+    const host = box.closest("form, [class*='composer'], [class*='prompt']") ||
+      box.parentElement?.parentElement || box;
+    return {
+      inDialog: !!box.closest("[role='dialog']"),
+      hostTag: host.tagName.toLowerCase(),
+      buttons: [...host.querySelectorAll("button")].map((b) => ({
+        ligature: lig(b),
+        ariaLabel: b.getAttribute("aria-label"),
+        haspopup: b.getAttribute("aria-haspopup"),
+        disabled: b.disabled,
+      })).slice(0, 20),
+    };
+  });
+  const ligatures = {};
+  for (const i of document.querySelectorAll("i.google-symbols")) {
+    const t = (i.textContent || "").trim();
+    if (t) ligatures[t] = (ligatures[t] || 0) + 1;
+  }
+  return { url: location.href, navItems, tiles, composers, ligatures };
+}
+"""
+
+
+def _parse_capture(captured: dict[str, Any]) -> dict[str, Any]:
+    """Shared payload parse (same discovery shape as spike_movie_attach_payload)."""
+    out: dict[str, Any] = {
+        "url": captured.get("url"),
+        "captured": bool(captured.get("post_data")),
+        "route": (captured.get("url") or "").split("/")[-1],
+    }
+    pd = captured.get("post_data")
+    if not pd:
+        return out
+    try:
+        body = json.loads(pd)
+        reqs = body.get("requests") or []
+        ents: list[Any] = []
+        imgs: list[Any] = []
+        keys: list[Any] = []
+        for r in reqs:
+            ents += [e.get("entityId") for e in (r.get("referenceEntities") or [])]
+            imgs += [i.get("mediaId") for i in (r.get("referenceImages") or [])]
+            if r.get("videoModelKey"):
+                keys.append(r.get("videoModelKey"))
+        out["referenceEntities"] = ents
+        out["referenceImages"] = imgs
+        out["videoModelKeys"] = keys
+        if reqs and isinstance(reqs[0], dict):
+            out["request0_keys"] = sorted(reqs[0].keys())
+            out["reference_like"] = {
+                k: (v if len(json.dumps(v, default=str)) <= 600 else "<elided>")
+                for k, v in reqs[0].items()
+                if "entit" in k.lower() or "reference" in k.lower() or "input" in k.lower()
+            }
+    except Exception as e:  # noqa: BLE001
+        out["parse_error"] = f"{type(e).__name__}: {e}"
+        out["post_data_head"] = pd[:500]
+    return out
+
+
+async def _detect_variant(page: Any) -> dict[str, Any]:
+    """Phase A: click Add Media, then poll dialog-appears vs URL-changes.
+
+    A poll loop (100 ms) instead of two racing wait tasks keeps the spike
+    simple and shows the timing; the production branch will use a race.
+    """
+    url_before = page.url
+    add = page.locator(ADD_MEDIA_BUTTON).first
+    await add.wait_for(state="visible", timeout=8000)
+    await add.click()
+    t0 = time.monotonic()
+    verdict: dict[str, Any] = {"urlBefore": url_before}
+    while time.monotonic() - t0 < 5.0:
+        if await page.locator(_OPEN_DIALOG).count() > 0:
+            verdict["variant"] = "dialog"
+            break
+        if page.url != url_before:
+            verdict["variant"] = "navigate"
+            break
+        await asyncio.sleep(0.1)
+    else:
+        verdict["variant"] = "unknown"
+    verdict["elapsedMs"] = round((time.monotonic() - t0) * 1000)
+    verdict["urlAfter"] = page.url
+    return verdict
+
+
+async def _stage_entity(page: Any, entity_id: str, out_dir: Path, label: str) -> dict[str, Any]:
+    """Right-click the entity tile and click the include action. Tolerant —
+    records what it found rather than raising."""
+    info: dict[str, Any] = {}
+    tile_sel = f"[data-tile-id='fe_id_{entity_id}']" if entity_id else _ENTITY_TILE_PREFIX
+    tile = page.locator(tile_sel).first
+    await tile.wait_for(state="visible", timeout=8000)
+    info["tileId"] = await tile.get_attribute("data-tile-id")
+    await tile.scroll_into_view_if_needed(timeout=8000)
+    await tile.click(button="right")
+    await page.wait_for_timeout(700)
+    include = page.locator(", ".join(PICKER_CONTEXT_INCLUDE)).first
+    await include.wait_for(state="visible", timeout=5000)
+    await include.click()
+    await page.wait_for_timeout(800)
+    await page.screenshot(path=str(out_dir / f"{label}_after_include.png"))
+    return info
+
+
+async def _submit_and_capture(
+    page: Any,
+    captured: dict[str, Any],
+    out_dir: Path,
+    label: str,
+    *,
+    prompt: str,
+) -> dict[str, Any]:
+    """Fill the visible (non-dialog) composer textbox, click its submit, and
+    wait for the route-aborted capture."""
+    captured.clear()
+    box = page.locator(_PROMPT_BOX).first
+    await box.wait_for(state="visible", timeout=8000)
+    await box.click()
+    await page.keyboard.press("Control+A")
+    await page.keyboard.type(prompt, delay=15)
+    await page.wait_for_timeout(400)
+    submit = page.locator(_SUBMIT_BTN).first
+    await submit.wait_for(state="visible", timeout=8000)
+    await submit.click()
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline and not captured:
+        await asyncio.sleep(0.3)
+    await page.screenshot(path=str(out_dir / f"{label}_after_submit.png"))
+    return _parse_capture(captured)
+
+
+async def _run(
+    *,
+    profile_dir: Path,
+    project_id: str,
+    entity_id: str,
+    name: str,
+    locale: str,
+    gestures: list[str],
+    out_path: Path,
+) -> int:
+    out_dir = out_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    captured: dict[str, Any] = {}
+    result: dict[str, Any] = {
+        "spike": "issue174-library-ui-recon",
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "project": project_id,
+        "locale": locale,
+        "entity": {"id": entity_id, "name": name},
+        "gestures": {},
+    }
+
+    async with build_client(profile_dir, headless=False) as client:
+        page = await client._checkout_page()  # noqa: SLF001
+
+        async def _on_route(route: Any) -> None:
+            req = route.request
+            if not captured:  # first generate request per gesture (cleared between)
+                try:
+                    captured["url"] = req.url
+                    captured["post_data"] = req.post_data
+                except Exception as e:  # noqa: BLE001
+                    captured["error"] = f"{type(e).__name__}: {e}"
+            # ABORT — the request never reaches Google; no credit is charged.
+            await route.abort()
+
+        for glob in _GEN_ROUTE_GLOBS:
+            await page.route(glob, _on_route)
+        try:
+            editor_url = routes.project_editor_url(locale, project_id)
+            step("A", f"goto {editor_url}", prefix="174")
+            await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
+            await page.wait_for_timeout(4_000)
+            await page.keyboard.press("Escape")
+            await VideoGenerationMixin._exit_agent_mode(page)  # noqa: SLF001
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)  # noqa: SLF001
+            await VideoGenerationMixin._switch_video_sub_mode(  # noqa: SLF001
+                page, "references", out_dir=None
+            )
+            await page.wait_for_timeout(800)
+
+            step("A", "variant probe: Add Media -> dialog or navigate?", prefix="174")
+            result["phaseA"] = await _detect_variant(page)
+            await page.screenshot(path=str(out_dir / "A_after_add_media.png"))
+            print(f"[174] phaseA = {result['phaseA']}", flush=True)
+
+            new_ui = result["phaseA"]["variant"] == "navigate"
+            if not new_ui:
+                # Old UI (or unknown): nothing more to recon here. This IS the
+                # rollout re-probe answer for this account.
+                result["note"] = "account does not show the new library UI; Phase B/C skipped"
+                gestures = []
+
+            # ---- Phase C: DOM dump of the library page ----------------------
+            if new_ui:
+                step("C", "library page DOM dump", prefix="174")
+                try:
+                    result["libraryDom"] = await page.evaluate(_DUMP_LIBRARY_JS)
+                    await page.screenshot(path=str(out_dir / "C_library_page.png"))
+                except Exception as e:  # noqa: BLE001
+                    result["libraryDomError"] = f"{type(e).__name__}: {e}"
+
+            # ---- Phase B1: stage + submit from the floating composer --------
+            if "b1" in gestures:
+                step("B1", "stage entity -> submit from floating composer", prefix="174")
+                try:
+                    ptab = page.locator(_LIBRARY_PERSONAGENS).first
+                    if await ptab.count() > 0 and await ptab.is_visible():
+                        await ptab.click()
+                        await page.wait_for_timeout(900)
+                    stage = await _stage_entity(page, entity_id, out_dir, "B1")
+                    cap = await _submit_and_capture(
+                        page,
+                        captured,
+                        out_dir,
+                        "B1",
+                        prompt="Stands on a clifftop at sunset, waves at the camera.",
+                    )
+                    result["gestures"]["b1_floating_composer"] = {"stage": stage, **cap}
+                except Exception as e:  # noqa: BLE001
+                    result["gestures"]["b1_floating_composer"] = {
+                        "error": f"{type(e).__name__}: {e}"
+                    }
+                    await page.screenshot(path=str(out_dir / "B1_FAILED.png"))
+
+            # ---- Phase B2: stage, navigate back to editor, submit -----------
+            if "b2" in gestures:
+                step("B2", "stage entity -> back to editor -> submit", prefix="174")
+                try:
+                    # Re-enter the library fresh (B1 may have consumed staging).
+                    await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
+                    await page.wait_for_timeout(3_000)
+                    await page.keyboard.press("Escape")
+                    await VideoGenerationMixin._exit_agent_mode(page)  # noqa: SLF001
+                    await VideoGenerationMixin._switch_to_video_mode(  # noqa: SLF001
+                        page, out_dir=None
+                    )
+                    await VideoGenerationMixin._switch_video_sub_mode(  # noqa: SLF001
+                        page, "references", out_dir=None
+                    )
+                    probe = await _detect_variant(page)
+                    result["gestures"]["b2_probe"] = probe
+                    if probe["variant"] != "navigate":
+                        raise RuntimeError(f"expected navigate, got {probe['variant']}")
+                    ptab = page.locator(_LIBRARY_PERSONAGENS).first
+                    if await ptab.count() > 0 and await ptab.is_visible():
+                        await ptab.click()
+                        await page.wait_for_timeout(900)
+                    stage = await _stage_entity(page, entity_id, out_dir, "B2")
+                    await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
+                    await page.wait_for_timeout(3_000)
+                    await page.keyboard.press("Escape")
+                    cap = await _submit_and_capture(
+                        page,
+                        captured,
+                        out_dir,
+                        "B2",
+                        prompt="Stands on a clifftop at sunset, waves at the camera.",
+                    )
+                    result["gestures"]["b2_back_to_editor"] = {"stage": stage, **cap}
+                except Exception as e:  # noqa: BLE001
+                    result["gestures"]["b2_back_to_editor"] = {"error": f"{type(e).__name__}: {e}"}
+                    await page.screenshot(path=str(out_dir / "B2_FAILED.png"))
+        finally:
+            for glob in _GEN_ROUTE_GLOBS:
+                try:
+                    await page.unroute(glob, _on_route)
+                except Exception:  # noqa: BLE001, S110
+                    pass
+            client._checkin_page(page)  # noqa: SLF001
+            out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # ---- compact findings ----------------------------------------------------
+    print(f"\n[174] json -> {out_path}", flush=True)
+    print(f"[174] variant = {result.get('phaseA', {}).get('variant')}", flush=True)
+    for label, g in result.get("gestures", {}).items():
+        if "error" in g:
+            print(f"[174] {label}: ERROR {g['error']}", flush=True)
+        elif "captured" in g:
+            print(
+                f"[174] {label}: captured={g.get('captured')} "
+                f"route={g.get('route')} referenceEntities={g.get('referenceEntities')}",
+                flush=True,
+            )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Issue #174: recon the new library UI attach gesture (0 credits)."
+    )
+    p.add_argument("--profile", default=os.environ.get("GFLOW_CLI_PROFILE", "denon82"))
+    p.add_argument("--project", required=True)
+    p.add_argument("--entity-id", dest="entity_id", default="", help="entityId for fe_id_ tile")
+    p.add_argument("--name", default="Stickman")
+    p.add_argument("--locale", default=os.environ.get("GFLOW_CLI_LOCALE", "pt"))
+    p.add_argument(
+        "--gestures",
+        default="b1,b2",
+        help="comma list of gestures to run (b1=floating composer, b2=back-to-editor)",
+    )
+    p.add_argument("--out", default=None)
+    args = p.parse_args(argv)
+
+    profile_dir = resolve_profile_dir(args.profile)
+    out_path = (
+        Path(args.out) if args.out else default_out_path("spike_issue174_library_ui", ".json")
+    )
+    gestures = [g.strip() for g in args.gestures.split(",") if g.strip()]
+    step("--", f"profile={args.profile} project={args.project} gestures={gestures}", prefix="174")
+    try:
+        return asyncio.run(
+            _run(
+                profile_dir=profile_dir,
+                project_id=args.project,
+                entity_id=args.entity_id,
+                name=args.name,
+                locale=args.locale,
+                gestures=gestures,
+                out_path=out_path,
+            )
+        )
+    except KeyboardInterrupt:
+        print("[174] aborted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -29,6 +29,7 @@ from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports._common import extract_project_id
 from gflow_cli.api.transports.ui_automation_video import (
+    ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
     zip_entity_refs,
@@ -2066,6 +2067,8 @@ class UiAutomationTransport(VideoGenerationMixin):
                     f"never rode the wire"
                 ),
                 route="flowMedia:batchGenerateImages",
+                remediation_hint=ENTITY_ATTACH_DRIFT_HINT,
+                discovery={"entity_attach_context": "image"},
             )
         log.info("ui_automation.image_entities_attached", entity_ids=sorted(seen))
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -332,8 +332,10 @@ _CONTEXT_INCLUDE_TIER_NAMES = ("icon", "text")
 ENTITY_ATTACH_DRIFT_HINT = (
     "If clicking 'Add Media' on this account opens a full-page media library "
     "instead of a picker dialog, this is Flow's new library UI rollout, where "
-    "the include action no longer stages entities. Follow "
-    "https://github.com/ffroliva/gflow-cli/issues/174 for status and workarounds."
+    "the include action no longer stages entities — follow "
+    "https://github.com/ffroliva/gflow-cli/issues/174 for status and progress. "
+    "Otherwise, file a bug at https://github.com/ffroliva/gflow-cli/issues "
+    "(do NOT include captured tokens or signed URLs)."
 )
 # The picker grid is virtualised (react-virtuoso): off-screen tiles are not in
 # the DOM. When the target entity tile is not initially rendered, scroll the grid

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -325,6 +325,16 @@ PICKER_CONTEXT_INCLUDE: tuple[str, str] = (
     " [role='menu'] [role='menuitem']:has-text('Add to prompt')",
 )
 _CONTEXT_INCLUDE_TIER_NAMES = ("icon", "text")
+# Issue #174: Flow is A/B-rolling a full-page media-library UI where the
+# include action lands (a chip appears) but the staged entity never reaches
+# the submit. Both entity-attach backstops (video + image) point affected
+# users at the tracking issue instead of the generic file-a-bug hint.
+ENTITY_ATTACH_DRIFT_HINT = (
+    "If clicking 'Add Media' on this account opens a full-page media library "
+    "instead of a picker dialog, this is Flow's new library UI rollout, where "
+    "the include action no longer stages entities. Follow "
+    "https://github.com/ffroliva/gflow-cli/issues/174 for status and workarounds."
+)
 # The picker grid is virtualised (react-virtuoso): off-screen tiles are not in
 # the DOM. When the target entity tile is not initially rendered, scroll the grid
 # in steps until it appears (or we exhaust the attempts).
@@ -1428,6 +1438,8 @@ class VideoGenerationMixin:
                     f"report success"
                 ),
                 route="video:batchAsyncGenerateVideoReferenceImages",
+                remediation_hint=ENTITY_ATTACH_DRIFT_HINT,
+                discovery={"entity_attach_context": "video"},
             )
 
     @staticmethod

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1416,6 +1416,19 @@ class TestImageEntityBackstop:
             expected=["ent-1", "ent-2"],
         )
 
+    def test_assert_error_carries_issue_174_hint_and_discovery(self) -> None:
+        """Issue #174: an attach miss on the new library UI must point the
+        user at the tracking issue (typed-error remediation hint) and tag
+        the surface in the discovery payload."""
+        from gflow_cli.errors import WireFormatError
+
+        with pytest.raises(WireFormatError) as exc_info:
+            UiAutomationTransport._assert_image_entities_attached([], expected=["ent-1"])
+        err = exc_info.value
+        assert "github.com/ffroliva/gflow-cli/issues/174" in err.remediation_hint
+        assert err.to_problem_details().get("remediation_hint") == err.remediation_hint
+        assert err.discovery == {"entity_attach_context": "image"}
+
     @pytest.mark.asyncio
     async def test_generate_images_raises_when_entities_never_rode_the_wire(self) -> None:
         """The wiring: entities requested + no captured submit carries them →

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1281,3 +1281,18 @@ class TestAssertEntitiesAttached:
         # request-body shape (referenceEntities) is also accepted.
         captured = {"body": {"requests": [{"referenceEntities": [{"entityId": "ent-1"}]}]}}
         VideoGenerationMixin._assert_entities_attached(captured, expected=["ent-1"])
+
+    def test_backstop_error_carries_issue_174_hint_and_discovery(self) -> None:
+        """Issue #174: an attach miss on the new library UI must point the
+        user at the tracking issue (typed-error remediation hint) and tag
+        the surface in the discovery payload."""
+        from gflow_cli.api.transports.ui_automation_video import VideoGenerationMixin
+        from gflow_cli.errors import WireFormatError
+
+        captured = {"body": {"media": [{"mediaMetadata": {"requestData": {}}}]}}
+        with pytest.raises(WireFormatError) as exc_info:
+            VideoGenerationMixin._assert_entities_attached(captured, expected=["ent-1"])
+        err = exc_info.value
+        assert "github.com/ffroliva/gflow-cli/issues/174" in err.remediation_hint
+        assert err.to_problem_details().get("remediation_hint") == err.remediation_hint
+        assert err.discovery == {"entity_attach_context": "video"}

--- a/tests/features/locale_picker_include.feature
+++ b/tests/features/locale_picker_include.feature
@@ -22,4 +22,4 @@ Feature: Locale-free character entity attach (issue 170)
     Given the mocked t2i runner raises the reference-entity submit backstop
     When I run "gflow image t2i a knight --project proj-1 --reference-entity ent-123 --reference-entity-name Lukas"
     Then the exit code is 7
-    And the output contains "File a bug"
+    And the output contains "issues/174"

--- a/tests/features/test_locale_picker_include_steps.py
+++ b/tests/features/test_locale_picker_include_steps.py
@@ -129,8 +129,15 @@ def _mock_backstop_runner(monkeypatch: pytest.MonkeyPatch) -> None:
     so the run must fail loudly instead of reporting a text-only success."""
 
     async def _fake_t2i(**_kwargs: Any) -> None:
+        # Mirror the real raise site (ui_automation._assert_image_entities_attached):
+        # since issue #174 it carries the library-UI drift hint + discovery payload.
+        from gflow_cli.api.transports.ui_automation_video import ENTITY_ATTACH_DRIFT_HINT
+
         raise WireFormatError(
-            "captured batchGenerateImages submit is missing referenceEntities ['ent-123']"
+            "captured batchGenerateImages submit is missing referenceEntities ['ent-123']",
+            route="flowMedia:batchGenerateImages",
+            remediation_hint=ENTITY_ATTACH_DRIFT_HINT,
+            discovery={"entity_attach_context": "image"},
         )
 
     monkeypatch.setattr("gflow_cli.cli_image._run_t2i", _fake_t2i)
@@ -198,7 +205,7 @@ def _check_output_locale_neutral(cli_result_holder: dict[str, Any]) -> None:
     assert "Incluir no comando" not in result.output, result.output
 
 
-@then('the output contains "File a bug"')
-def _check_output_file_a_bug(cli_result_holder: dict[str, Any]) -> None:
+@then('the output contains "issues/174"')
+def _check_output_issue_174(cli_result_holder: dict[str, Any]) -> None:
     result = cli_result_holder["result"]
-    assert "File a bug" in result.output, result.output
+    assert "issues/174" in result.output, result.output


### PR DESCRIPTION
## Summary

Interim ship for #174 (Flow's full-page media-library A/B breaking entity attach). The attach fix itself is **deliberately not here** — the A/B rolled back off the affected account mid-recon (variant probe: `dialog`, 12 ms, ~12 h after the original capture), so the plan's Task 4 gate decision is **HOLD** until a stable affected account reappears.

- **Remediation hint (both backstops):** entity-attach `WireFormatError` (exit 7) raises now carry `ENTITY_ATTACH_DRIFT_HINT` — the dialog-vs-navigate self-diagnosis probe + link to #174 + fallback file-a-bug with token-redaction warning — plus `discovery={'entity_attach_context': 'video'|'image'}` telemetry.
- **Recon spike:** `scripts/dev/spike_issue174_library_ui_recon.py` — credit-free (route-aborts both video and image generate families); Phase A variant probe (doubles as rollout re-probe), Phase C library-page DOM dump, Phase B gesture matrix (floating quick-create composer submit; stage → navigate-back → submit). Live-exercised once on denon82 (Phase A verdict above).
- **Docs:** KNOWN_ISSUES.md § Open entry (incl. the observed flap), CHANGELOG `[Unreleased]`, recon-first plan with predict verdict (CAUTION 7/10) and recorded HOLD decision.
- **BDD:** backstop stub now mirrors the real raise site; scenario asserts `issues/174`.

## Review

LLM branch council (8 dimensions) on `c6ff818`: 7 GREEN, 1 YELLOW (D13) — the single must-fix (spike B2 mode-switch after editor remount) and selected nice-to-haves applied in `0127317`.

## Test plan

- [x] TDD red→green: `test_backstop_error_carries_issue_174_hint_and_discovery` (video) / `test_assert_error_carries_issue_174_hint_and_discovery` (image)
- [x] tests/api/transports: 364 passed, 1 skipped; BDD locale_picker_include: green
- [x] `pyright src`: 0 errors; ruff check + format: clean; repo hygiene: clean
- [x] Spike live-exercised credit-free on denon82 (Phase A; no credits spent — all generate routes aborted)

Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)