### PR TITLE
docs(auth): close PR #168 follow-up doc drift

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -628,6 +628,15 @@ success. The expected authenticated response shape is pinned by the
 change surfaces there as a failing test. Start any investigation of a sudden
 `gflow auth login` verification failure at that fixture and `verification.py`.
 
+Since PR #168 the production entry point is `verify_flow_profile`, which reads
+the session cookie **directly from Chrome's SQLite store** via `browser_cookie3`
+(a no-browser fast path) and only falls back to launching Playwright when that
+decryption fails. This adds two more local surfaces to check when verification
+fails unexpectedly: a Windows **DPAPI decrypt failure** (cross-user / cross-machine
+key — surfaces as a `RuntimeError` that `auth/cookies.py` normalizes to
+`PermissionError` to trigger the Playwright fallback) and a **locked cookie DB**
+(Chrome still running holds an exclusive SQLite lock). Both degrade fail-closed.
+
 ---
 
 ## Resolved

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -214,6 +214,12 @@ async def verify_flow_session(
 ) -> FlowSessionStatus:
     """Headlessly probe `profile_dir` for a usable Flow app session.
 
+    NOTE: since PR #168, `verify_flow_profile` is the production entry point
+    (`RealChromeStrategy.login` calls it): it reads cookies straight from
+    Chrome's SQLite store via `browser_cookie3` and only launches Playwright
+    when that decryption fails. This function is the original full-Playwright
+    probe, retained for the tests and as a standalone verification primitive.
+
     Launches a headless persistent context on the profile, reads cookies, and
     calls the NextAuth session endpoint. Fail-closed: any failure — boundary
     violation aside — yields VERIFICATION_ERROR, never AUTHENTICATED.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -86,7 +86,7 @@ def e2e_profile_dir(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
 def e2e_nosession_profile() -> Iterator[Path]:
     """Yield a fresh, empty profile dir INSIDE the gflow home.
 
-    ``verify_flow_session`` enforces a boundary check that the profile dir
+    ``verify_flow_profile`` enforces a boundary check that the profile dir
     resolves inside ``GFLOW_CLI_HOME``, so a pytest ``tmp_path`` dir (system
     temp) cannot be used. The dir is UUID-named so it can never collide with a
     real ``profile_<name>`` dir, and is removed in teardown — ``ignore_errors=True``


### PR DESCRIPTION
## Summary

Tidies the three doc spots that still read as if `verify_flow_session` were the live verification path, now that #168 wired `verify_flow_profile` as the production entry point. Doc/comment-only — no behavior change.

- **`verify_flow_session` docstring** — notes `verify_flow_profile` is the production entry (cookie fast-path via `browser_cookie3`); this function stays the full-Playwright probe retained for tests / as a standalone primitive.
- **KNOWN_ISSUES "Auth verification depends on NextAuth endpoint"** — adds the two new *local* failure surfaces #168 introduced (Windows DPAPI decrypt failure → normalized to `PermissionError`→ Playwright fallback; locked cookie SQLite), so the canonical 'where to debug auth failures' pointer is complete.
- **e2e `conftest.py` fixture docstring** — names `verify_flow_profile` (the current boundary-check caller).

Found while resolving loose ends after the #168 merge. The historical capability table under the *resolved* image-401 issue keeps `verify_flow_session` — that's an accurate record of the 2026-05-17 diagnostic, deliberately not touched.

## Test plan
- [x] `pyright src`: 0 errors; ruff check + format: clean; repo hygiene: clean
- [x] tests/auth: 54 passed
- [x] No production code changed (docstring + markdown only)

Refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)