### PR TITLE
ci(hygiene): P2 — fail on stray root docs (allowlist gate)

### DIFF
--- a/scripts/ci/check_repo_hygiene.py
+++ b/scripts/ci/check_repo_hygiene.py
@@ -3,7 +3,9 @@
 
 Fails (exit 1) if:
   1. Forbidden file types are tracked by git (images, CDP lock files, generated artefacts).
-  2. Any Python file in src/, tests/, or scripts/ contains hardcoded Windows absolute paths
+  2. A tracked top-level *.md / *.py file is outside ROOT_DOC_ALLOWLIST (stray
+     planning / review / session artefact at the repo root).
+  3. Any Python file in src/, tests/, or scripts/ contains hardcoded Windows absolute paths
      or writes output to test_assets/ instead of tmp/.
 
 Run manually:
@@ -66,6 +68,33 @@ SOURCE_DENYLIST: list[tuple[re.Pattern[str], str]] = [
 SCAN_DIRS = ["scripts", "src", "tests"]
 
 # ---------------------------------------------------------------------------
+# 2b. Root-level doc/script allowlist
+#    Tracked top-level *.md and *.py files must be in this set. Anything else is
+#    a stray planning / review / session artifact (e.g. a shipped-PR review doc
+#    or an agent session marker) that belongs in docs/, auto-memory, or nowhere.
+#    This is what would have caught PR162_MOVIE_CHARACTER_REVIEW.md and
+#    .continue-here.md before they were committed (project-health audit, 2026-06).
+#    Add a genuinely new canonical root doc here; route everything else into docs/.
+# ---------------------------------------------------------------------------
+ROOT_DOC_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "AGENTS.md",
+        "CHANGELOG.md",
+        "CLAUDE.md",
+        "CONFIGURATION.md",
+        "CONTRIBUTING.md",
+        "DISCLAIMER.md",
+        "GEMINI.md",
+        "KNOWN_ISSUES.md",
+        "PLAN.md",
+        "README.md",
+        "RELEASE.md",
+        "ROADMAP.md",
+        "conftest.py",  # root pytest conftest (basetemp + directory-based marker tagging)
+    }
+)
+
+# ---------------------------------------------------------------------------
 # 3. Branch-naming advisory
 #    AGENTS.md mandates conventional branch prefixes. This is ADVISORY only:
 #    it warns but never fails the gate. Rationale: it no-ops in CI (pull_request
@@ -101,6 +130,25 @@ def _check_tracked(files: list[str]) -> list[str]:
             if pattern.search(f):
                 violations.append(f"  TRACKED   {f!r:60s}  ← {label}")
                 break
+    return violations
+
+
+def _check_root_docs(files: list[str]) -> list[str]:
+    """Flag tracked top-level ``*.md`` / ``*.py`` files outside the allowlist.
+
+    Top-level = no ``/`` in the git path. Dotfiles like ``.continue-here.md`` are
+    included (they have no path separator and end in ``.md``).
+    """
+    violations: list[str] = []
+    for f in files:
+        if "/" in f:
+            continue
+        if f.endswith((".md", ".py")) and f not in ROOT_DOC_ALLOWLIST:
+            violations.append(
+                f"  ROOTDOC   {f!r:60s}  ← stray root doc/script; move it under docs/ "
+                "(or extract to memory and delete), or add it to ROOT_DOC_ALLOWLIST "
+                "in scripts/ci/check_repo_hygiene.py if it is a new canonical root doc"
+            )
     return violations
 
 
@@ -163,6 +211,7 @@ def main() -> int:
 
     tracked = _git_ls_files()
     errors += _check_tracked(tracked)
+    errors += _check_root_docs(tracked)
     errors += _check_sources()
 
     # Advisory: warn on non-conventional branch names but never fail the gate.
@@ -179,6 +228,8 @@ def main() -> int:
         print(
             "\nRemediation:\n"
             "  Tracked artefact  →  git rm --cached <file>  and add pattern to .gitignore\n"
+            "  Stray root doc    →  move under docs/ (or extract to memory + delete), or\n"
+            "                       add to ROOT_DOC_ALLOWLIST if it is a new canonical root doc\n"
             "  Hardcoded path    →  replace with auth.profile_dir(args.profile)\n"
             "  Output to test_assets/  →  change OUT to Path('tmp/...')\n"
         )

--- a/tests/scripts/test_check_repo_hygiene.py
+++ b/tests/scripts/test_check_repo_hygiene.py
@@ -49,3 +49,48 @@ def test_claude_automation_branch_is_advisory_not_error() -> None:
     out = hygiene._check_branch_name("claude/some-session")
     assert len(out) == 1
     assert "advisory" in out[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# Root-doc allowlist (project-health audit, 2026-06): stray top-level *.md / *.py
+# files are blocked so shipped-PR reviews and session markers can't accumulate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stray",
+    ["PR162_MOVIE_CHARACTER_REVIEW.md", ".continue-here.md", "NOTES.py", "scratch.md"],
+)
+def test_stray_root_doc_is_flagged(stray: str) -> None:
+    out = hygiene._check_root_docs([stray])
+    assert len(out) == 1
+    assert stray in out[0]
+    assert "ROOT_DOC_ALLOWLIST" in out[0]
+
+
+@pytest.mark.parametrize("allowed", sorted(hygiene.ROOT_DOC_ALLOWLIST))
+def test_allowlisted_root_doc_passes(allowed: str) -> None:
+    assert hygiene._check_root_docs([allowed]) == []
+
+
+def test_nested_docs_are_never_flagged() -> None:
+    # Files under any directory are out of scope — only the repo root is policed.
+    nested = [
+        "docs/USAGE.md",
+        "docs/superpowers/plans/2026-06-12-issue-174-library-ui-attach/PLAN.md",
+        "src/gflow_cli/cli.py",
+        "tests/conftest.py",
+    ]
+    assert hygiene._check_root_docs(nested) == []
+
+
+def test_non_doc_root_files_are_ignored() -> None:
+    # Only *.md / *.py at root are policed; config/data files are out of scope.
+    others = ["pyproject.toml", "uv.lock", "docker-compose.yml", "llms.txt", "LICENSE"]
+    assert hygiene._check_root_docs(others) == []
+
+
+def test_real_tree_passes_root_doc_check() -> None:
+    # The live tracked tree must already satisfy the allowlist (guards against a
+    # regression landing a stray root doc that the gate would then start failing on).
+    assert hygiene._check_root_docs(hygiene._git_ls_files()) == []


### PR DESCRIPTION
## Summary

Project-health audit, **P2 (enforcement)** — the gate that stops the cleanliness drift from recurring. `check_repo_hygiene.py` now fails (exit 1) if a tracked top-level `*.md` / `*.py` file is outside `ROOT_DOC_ALLOWLIST`. This is exactly what would have blocked `PR162_MOVIE_CHARACTER_REVIEW.md` and `.continue-here.md` (removed in P0 / #179) at commit time.

- **`ROOT_DOC_ALLOWLIST`** — the 12 canonical root docs + `conftest.py` (the legit root pytest config). A genuinely new canonical root doc gets added here; everything else routes into `docs/` or memory.
- **`_check_root_docs()`** — root = no `/` in the git path (dotfiles like `.continue-here.md` included).
- **12 new unit tests** — stray flagged (incl. the two real offenders), every allowlisted file passes, nested docs never flagged, non-doc root files ignored, plus a **live-tree guard** asserting the current tracked tree already satisfies the gate.

Runs in CI **and** pre-commit (same entry point), so it catches stray docs before they're ever committed. Closes the loop with P1 (#180), whose RELEASE.md text references this allowlist.

## Test plan
- [x] Gate self-run green: `check_repo_hygiene.py` → 405 files, no violations
- [x] `tests/scripts/test_check_repo_hygiene.py`: 33 passed
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)