### PR TITLE
fix(errors): add UiSelectorDriftError; replace RuntimeError in mode-switch probes (issue #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `UiSelectorDriftError` (exit code 23): UI-automation selector-probe failures — e.g. the
+  mode-switch `crop_*` trigger missing from the Flow editor (issue #183) — now raise a typed
+  error carrying the probe name, the debug-screenshot path, and a remediation hint, instead
+  of an opaque "Unexpected error" (exit 1) whose message was hashed away in logs. Converted
+  probes: mode-switch trigger, Image/Video mode tabs, and video sub-mode tabs, in both the
+  image and video transports.
+
+### Fixed
+
+- `gflow image` commands (`t2i` / `i2i` / `upscale` / `upload`) now plumb their output
+  directory into the API client, so debug screenshots are actually captured on
+  UI-automation failures. Previously the transport's screenshot directory was never set on
+  the image path and drift errors reported `Screenshot: None` even with `--verbose`.
+
 ## [0.17.0] — 2026-06-12
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1022,9 +1022,15 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `12` | `AuthLoginTimeoutError` | Browser sign-in was not completed in time       | Re-run login or raise `GFLOW_CLI_AUTH_LOGIN_TIMEOUT`       |
 | `13` | `SecurityError`       | Unsafe local profile or secret handling blocked   | Follow the error's safety guidance                         |
 | `14` | `AuthBrowserRejectedError` | Google rejected the login browser             | `gflow auth login --browser chrome`                        |
+| `15` | `BrowserSessionClosedError` | The automation browser window was closed mid-operation | Re-run; keep the browser window open until the command finishes |
 | `16` | `DataStoreError`      | Local database cannot be opened, a migration failed, or the DB schema is newer than the installed gflow-cli | See below                                  |
 | `17` | `ModelModeIncompatibilityError` | The chosen video model can't do the requested mode (e.g. `--model omni-flash` with an `i2v` start/end frame — issue #125) | Use `--model veo-lite` (or veo-fast / veo-quality / veo-lite-lp) for `i2v` |
 | `18` | `VideoModelSelectionError` | gflow could not select the requested video model in Flow's editor for an `i2v` run (model-picker option not found) | Usually transient — retry; if it persists, Flow's model-picker UI changed (report referencing #125) |
+| `19` | `SceneConcatError`    | Server-side scene render/concat failed (`gflow scene --output`) | Retry; the recorded compose survives, so re-render is safe |
+| `20` | `FrameExtractionError` | Could not extract the last frame for a video chain link | Check the source video downloaded intact; retry the link  |
+| `21` | `ChainPartialError`   | A video chain stopped mid-way; earlier links completed | Resume from the last completed link shown in the error     |
+| `22` | `UpscaleUnavailableError` | 4K upscale is gated to Flow **Ultra** accounts (HTTP 403) | Use `--scale 2k`, or upgrade the Flow plan                |
+| `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issue #183) | Update gflow-cli; file a bug with the probe name + debug screenshot from the error message |
 | `130`| SIGINT                | User-interrupted (Ctrl-C)                        | —                                                          |
 
 **Exit code 16 — data store / migration error.** Fires when:

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -39,6 +39,7 @@ from gflow_cli.errors import (
     BatchPartialError,
     ContentPolicyError,
     GFlowError,
+    UiSelectorDriftError,
     WafRejectionError,
     WireFormatError,
 )
@@ -989,9 +990,9 @@ class UiAutomationTransport(VideoGenerationMixin):
         )
         if trigger is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
-            msg = f"mode-switch dropdown trigger not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(
-                msg,
+            raise UiSelectorDriftError(
+                f"probe=mode_switch_trigger: no matching element found on the Flow editor. "
+                f"Screenshot: {shot}"
             )
         await trigger.click()
         await page.wait_for_timeout(800)
@@ -1002,8 +1003,10 @@ class UiAutomationTransport(VideoGenerationMixin):
         )
         if image_tab is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_image_tab.png")
-            msg = f"Image tab not found in the mode dropdown. Screenshot: {shot}"
-            raise RuntimeError(msg)
+            raise UiSelectorDriftError(
+                f"probe=image_mode_tab: Image tab not found in the mode dropdown. "
+                f"Screenshot: {shot}"
+            )
         await image_tab.click()
         await page.wait_for_timeout(1200)
         await page.keyboard.press("Escape")

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -32,6 +32,7 @@ from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
+    selector_drift_detail,
     zip_entity_refs,
 )
 from gflow_cli.errors import (
@@ -991,8 +992,11 @@ class UiAutomationTransport(VideoGenerationMixin):
         if trigger is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
             raise UiSelectorDriftError(
-                f"probe=mode_switch_trigger: no matching element found on the Flow editor. "
-                f"Screenshot: {shot}"
+                selector_drift_detail(
+                    "mode_switch_trigger",
+                    "no matching element found on the Flow editor.",
+                    shot,
+                )
             )
         await trigger.click()
         await page.wait_for_timeout(800)
@@ -1004,8 +1008,11 @@ class UiAutomationTransport(VideoGenerationMixin):
         if image_tab is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_image_tab.png")
             raise UiSelectorDriftError(
-                f"probe=image_mode_tab: Image tab not found in the mode dropdown. "
-                f"Screenshot: {shot}"
+                selector_drift_detail(
+                    "image_mode_tab",
+                    "Image tab not found in the mode dropdown.",
+                    shot,
+                )
             )
         await image_tab.click()
         await page.wait_for_timeout(1200)

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -41,6 +41,7 @@ from gflow_cli.errors import (
     AuthExpiredError,
     ModelModeIncompatibilityError,
     TransportTimeoutError,
+    UiSelectorDriftError,
     VideoModelSelectionError,
     WafRejectionError,
     WireFormatError,
@@ -811,9 +812,9 @@ class VideoGenerationMixin:
         )
         if trigger is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
-            msg = f"mode-switch dropdown trigger not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(
-                msg,
+            raise UiSelectorDriftError(
+                f"probe=mode_switch_trigger: no matching element found on the Flow editor. "
+                f"Screenshot: {shot}"
             )
         await trigger.click()
         await page.wait_for_timeout(800)
@@ -824,8 +825,10 @@ class VideoGenerationMixin:
         )
         if video_tab is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_video_tab.png")
-            msg = f"Video tab not found in the mode dropdown. Screenshot: {shot}"
-            raise RuntimeError(msg)
+            raise UiSelectorDriftError(
+                f"probe=video_mode_tab: Video tab not found in the mode dropdown. "
+                f"Screenshot: {shot}"
+            )
         await video_tab.click()
         await page.wait_for_timeout(1200)
         log.info("ui_automation_video.video_mode_entered")

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -397,6 +397,20 @@ async def _capture_debug_screenshot(page: Any, out_dir: Path | None, filename: s
     return shot_path
 
 
+def selector_drift_detail(probe: str, what: str, shot: Path | None) -> str:
+    """Build a :class:`UiSelectorDriftError` detail string for a probe miss.
+
+    Shared by the image and video transports so the message shape stays
+    symmetric, and so the ``Screenshot:`` clause is omitted (rather than
+    rendering a literal ``None``) when no debug screenshot was captured —
+    the caller had no ``out_dir`` to write into.
+    """
+    detail = f"probe={probe}: {what}"
+    if shot is not None:
+        detail = f"{detail} Screenshot: {shot}"
+    return detail
+
+
 def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
     """Privacy-safe summary of the image inputs in a generate request body:
     presence of startImage/endImage + referenceImages count, each as an 8-char
@@ -813,8 +827,11 @@ class VideoGenerationMixin:
         if trigger is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
             raise UiSelectorDriftError(
-                f"probe=mode_switch_trigger: no matching element found on the Flow editor. "
-                f"Screenshot: {shot}"
+                selector_drift_detail(
+                    "mode_switch_trigger",
+                    "no matching element found on the Flow editor.",
+                    shot,
+                )
             )
         await trigger.click()
         await page.wait_for_timeout(800)
@@ -826,8 +843,11 @@ class VideoGenerationMixin:
         if video_tab is None:
             shot = await _capture_debug_screenshot(page, out_dir, "debug_no_video_tab.png")
             raise UiSelectorDriftError(
-                f"probe=video_mode_tab: Video tab not found in the mode dropdown. "
-                f"Screenshot: {shot}"
+                selector_drift_detail(
+                    "video_mode_tab",
+                    "Video tab not found in the mode dropdown.",
+                    shot,
+                )
             )
         await video_tab.click()
         await page.wait_for_timeout(1200)
@@ -999,9 +1019,12 @@ class VideoGenerationMixin:
         )
         if tab is None:
             shot = await _capture_debug_screenshot(page, out_dir, f"debug_no_submode_{sub}.png")
-            msg = f"video sub-mode tab {sub!r} not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(
-                msg,
+            raise UiSelectorDriftError(
+                selector_drift_detail(
+                    f"video_submode_{sub}",
+                    f"video sub-mode tab {sub!r} not found on the Flow editor.",
+                    shot,
+                )
             )
         await tab.click()
         await page.wait_for_timeout(900)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -353,6 +353,7 @@ async def _run_upload(
             profile_dir=profile_dir,
             headless=headless,
             transport=transport,
+            out_dir=settings.output_dir,
         ) as client:
             console.print(_CREATING_PROJECT_MSG)
             project = await client.create_project(title="gflow-cli upload")
@@ -544,6 +545,7 @@ async def _run_upscale(
         profile_dir=profile_dir,
         headless=headless,
         transport=transport,
+        out_dir=output_root,
     ) as client:
         console.print(f"Upscaling [bold]{media_id}[/bold] to {scale_label.upper()}...")
         target = await client.upsample_image(
@@ -871,6 +873,7 @@ async def _run_t2i(
             profile_dir=profile_dir,
             headless=headless,
             transport=transport,
+            out_dir=out if out is not None else output_root,
         ) as client:
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.
@@ -1264,6 +1267,7 @@ async def _run_i2i(
             profile_dir=profile_dir,
             headless=headless,
             transport=transport,
+            out_dir=out if out is not None else output_root,
         ) as client:
             # Title is a `gflow-cli ...` prefix per project convention (post-rename a02684f).
             # cli_video.py's _run_t2v / _run_i2v don't currently set a title — tracked separately.

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -28,6 +28,7 @@ __all__ = [
     "SceneConcatError",
     "SecurityError",
     "TransportTimeoutError",
+    "UiSelectorDriftError",
     "UpscaleUnavailableError",
     "VideoModelSelectionError",
     "WafRejectionError",
@@ -381,6 +382,30 @@ class UpscaleUnavailableError(GFlowError):
     )
 
 
+class UiSelectorDriftError(GFlowError):
+    """Raised when a UI-automation selector cascade finds no matching element.
+
+    Indicates that Flow's frontend has changed in a way that invalidates one
+    of the selector probes (mode-switch trigger, mode tab, sub-mode tab, etc.).
+    The ``detail`` names the probe label and includes the debug screenshot path
+    when one was captured.
+
+    This is a hard failure — gflow cannot safely proceed without the control —
+    but it is *diagnosed*, not opaque: the user gets the probe name and the
+    screenshot for inspection.  Exit code 23 lets scripted callers branch on
+    "the UI changed and needs a selector update" versus generic error (1).
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/ui-selector-drift"
+    title = "Flow UI selector drift"
+    _default_remediation = (
+        "A Flow editor UI element could not be located — Google may have updated "
+        "their frontend. Re-run with --verbose to capture a debug screenshot, then "
+        "file a bug at https://github.com/ffroliva/gflow-cli/issues referencing the "
+        "probe name and the screenshot (do NOT include tokens or signed URLs)."
+    )
+
+
 class SecurityError(GFlowError):
     """Raised when a security boundary is violated (e.g. profile_dir outside HOME)."""
 
@@ -643,6 +668,10 @@ EXIT_CODE_MAP: dict[type[GFlowError], int] = {
     # from WafRejectionError's 10 even though both are HTTP 403. Direct GFlowError
     # subclass, so unconstrained by the ordering invariant.
     UpscaleUnavailableError: 22,
+    # UiSelectorDriftError (issue #183): Flow UI changed, selector probe failed.
+    # Direct GFlowError subclass; exit 23 lets scripts distinguish "UI drifted"
+    # from generic error (1) without parsing stderr.
+    UiSelectorDriftError: 23,
     # ModelModeIncompatibilityError + VideoModelSelectionError BEFORE
     # ConfigurationError (their parent) so the isinstance walk lands on 17/18,
     # not 11. Per [[exit-code-map-ordering-invariant-test-pitfall]].

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -400,9 +400,11 @@ class UiSelectorDriftError(GFlowError):
     title = "Flow UI selector drift"
     _default_remediation = (
         "A Flow editor UI element could not be located — Google may have updated "
-        "their frontend. Re-run with --verbose to capture a debug screenshot, then "
-        "file a bug at https://github.com/ffroliva/gflow-cli/issues referencing the "
-        "probe name and the screenshot (do NOT include tokens or signed URLs)."
+        "their frontend. Check for a newer gflow-cli release, then file a bug at "
+        "https://github.com/ffroliva/gflow-cli/issues referencing the probe name "
+        "and attaching the debug screenshot from this message, if one was captured "
+        "(review it first — the viewport may show your account name/avatar; do NOT "
+        "include tokens or signed URLs)."
     )
 
 

--- a/src/gflow_cli/exceptions.py
+++ b/src/gflow_cli/exceptions.py
@@ -24,6 +24,7 @@ from gflow_cli.errors import ProblemDetails as ProblemDetails
 from gflow_cli.errors import RateLimitError as RateLimitError
 from gflow_cli.errors import SecurityError as SecurityError
 from gflow_cli.errors import TransportTimeoutError as TransportTimeoutError
+from gflow_cli.errors import UiSelectorDriftError as UiSelectorDriftError
 from gflow_cli.errors import UpscaleUnavailableError as UpscaleUnavailableError
 from gflow_cli.errors import WafRejectionError as WafRejectionError
 from gflow_cli.errors import WireFormatError as WireFormatError

--- a/tests/api/transports/test_ui_automation_image_mode.py
+++ b/tests/api/transports/test_ui_automation_image_mode.py
@@ -18,6 +18,7 @@ from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.api.transports.ui_automation_video import (
     MODE_SWITCH_TRIGGER_SELECTORS,
 )
+from gflow_cli.errors import UiSelectorDriftError
 
 
 def _cascade_page(visible: set[str]) -> MagicMock:
@@ -53,13 +54,13 @@ class TestSwitchToImageMode:
     @pytest.mark.asyncio
     async def test_raises_when_trigger_missing(self) -> None:
         page = _cascade_page(set())
-        with pytest.raises(RuntimeError, match="mode-switch"):
+        with pytest.raises(UiSelectorDriftError, match="mode_switch_trigger"):
             await UiAutomationTransport._switch_to_image_mode(page, out_dir=None)
 
     @pytest.mark.asyncio
     async def test_raises_when_image_tab_missing(self) -> None:
         page = _cascade_page({MODE_SWITCH_TRIGGER_SELECTORS[0]})
-        with pytest.raises(RuntimeError, match="Image tab"):
+        with pytest.raises(UiSelectorDriftError, match="Image tab"):
             await UiAutomationTransport._switch_to_image_mode(page, out_dir=None)
 
 

--- a/tests/api/transports/test_ui_automation_image_mode.py
+++ b/tests/api/transports/test_ui_automation_image_mode.py
@@ -9,6 +9,7 @@ otherwise an account whose last-used mode was Video silently routes
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -62,6 +63,26 @@ class TestSwitchToImageMode:
         page = _cascade_page({MODE_SWITCH_TRIGGER_SELECTORS[0]})
         with pytest.raises(UiSelectorDriftError, match="Image tab"):
             await UiAutomationTransport._switch_to_image_mode(page, out_dir=None)
+
+    @pytest.mark.asyncio
+    async def test_trigger_miss_detail_carries_screenshot_path(self, tmp_path: Path) -> None:
+        # The screenshot path is the diagnostic payload issue-#183 reporters
+        # need — assert it survives into the user-visible detail.
+        page = _cascade_page(set())
+        page.screenshot = AsyncMock()
+        with pytest.raises(UiSelectorDriftError, match="debug_no_mode_trigger.png"):
+            await UiAutomationTransport._switch_to_image_mode(page, out_dir=tmp_path)
+        page.screenshot.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_trigger_miss_detail_omits_screenshot_clause_without_out_dir(self) -> None:
+        # No out_dir → no capture; the detail must drop the clause entirely
+        # rather than render a literal "Screenshot: None".
+        page = _cascade_page(set())
+        with pytest.raises(UiSelectorDriftError) as excinfo:
+            await UiAutomationTransport._switch_to_image_mode(page, out_dir=None)
+        assert "Screenshot" not in str(excinfo.value)
+        assert "None" not in str(excinfo.value)
 
 
 class TestModeSwitchCallSite:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -243,6 +243,14 @@ class TestSwitchToVideoMode:
         with pytest.raises(UiSelectorDriftError, match="Video tab"):
             await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
 
+    @pytest.mark.asyncio
+    async def test_submode_miss_raises_drift_error(self) -> None:
+        # The sub-mode probe is the same selector-cascade pattern as the
+        # mode-switch trigger and must carry the same typed-error contract.
+        page = _cascade_page(set())
+        with pytest.raises(UiSelectorDriftError, match="video_submode_references"):
+            await VideoGenerationMixin._switch_video_sub_mode(page, "references", out_dir=None)
+
 
 class TestWaitVideoEditorReady:
     @pytest.mark.asyncio

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -19,7 +19,7 @@ from gflow_cli.api.transports.ui_automation_video import (
     VideoGenerationMixin,
 )
 from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStatus
-from gflow_cli.errors import AuthExpiredError, TransportTimeoutError, WireFormatError
+from gflow_cli.errors import AuthExpiredError, TransportTimeoutError, UiSelectorDriftError, WireFormatError
 
 
 def _make_listener_page() -> tuple[MagicMock, list]:
@@ -227,7 +227,7 @@ class TestSwitchToVideoMode:
     @pytest.mark.asyncio
     async def test_raises_when_trigger_missing(self) -> None:
         page = _cascade_page(set())
-        with pytest.raises(RuntimeError, match="mode-switch"):
+        with pytest.raises(UiSelectorDriftError, match="mode_switch_trigger"):
             await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
 
     @pytest.mark.asyncio
@@ -235,7 +235,7 @@ class TestSwitchToVideoMode:
         from gflow_cli.api.transports import ui_automation_video as mod
 
         page = _cascade_page({mod.MODE_SWITCH_TRIGGER_SELECTORS[0]})
-        with pytest.raises(RuntimeError, match="Video tab"):
+        with pytest.raises(UiSelectorDriftError, match="Video tab"):
             await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
 
 

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -19,7 +19,12 @@ from gflow_cli.api.transports.ui_automation_video import (
     VideoGenerationMixin,
 )
 from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStatus
-from gflow_cli.errors import AuthExpiredError, TransportTimeoutError, UiSelectorDriftError, WireFormatError
+from gflow_cli.errors import (
+    AuthExpiredError,
+    TransportTimeoutError,
+    UiSelectorDriftError,
+    WireFormatError,
+)
 
 
 def _make_listener_page() -> tuple[MagicMock, list]:

--- a/tests/cli/test_cli_image_selector_drift.py
+++ b/tests/cli/test_cli_image_selector_drift.py
@@ -1,0 +1,74 @@
+"""CLI tests for the ``UiSelectorDriftError`` surface (issue #183).
+
+Proves the two user-visible guarantees the typed error exists for:
+
+1. exit code 23 with the probe name in the output — instead of the old bare
+   ``RuntimeError`` whose message was hashed by the unhandled-error handler,
+   leaving the user with an opaque "Unexpected error" (exit 1);
+2. the ``out_dir`` wiring on the image surface — the transport can only
+   capture debug screenshots when ``FlowApiClient`` receives ``out_dir``,
+   and it was silently ``None`` for every ``gflow image`` command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from gflow_cli.errors import UiSelectorDriftError
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _drifting_client() -> MagicMock:
+    """Stub FlowApiClient whose generate_image hits selector drift."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.create_project = AsyncMock(
+        return_value=MagicMock(project_id="proj-1", title="gflow-cli t2i")
+    )
+    client.generate_image = AsyncMock(
+        side_effect=UiSelectorDriftError(
+            "probe=mode_switch_trigger: no matching element found on the Flow editor."
+        )
+    )
+    return client
+
+
+def _invoke_t2i(runner: CliRunner, tmp_path: Path, out_dir: Path) -> tuple[Result, MagicMock]:
+    client = _drifting_client()
+    with (
+        patch("gflow_cli.cli_image.FlowApiClient", return_value=client) as client_cls,
+        patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+        patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+    ):
+        from gflow_cli.cli import main
+
+        result = runner.invoke(
+            main,
+            ["image", "t2i", "a cat", "--out", str(out_dir)],
+            catch_exceptions=False,
+        )
+    return result, client_cls
+
+
+def test_t2i_selector_drift_maps_exit_23_with_probe_name(runner: CliRunner, tmp_path: Path) -> None:
+    result, _ = _invoke_t2i(runner, tmp_path, tmp_path / "out")
+    assert result.exit_code == 23, result.output
+    assert "mode_switch_trigger" in result.output
+    # Regression guard for the issue-#183 root cause: the typed error's real
+    # message must reach the user, not the hashed "Unexpected error" fallback.
+    assert "Unexpected error" not in result.output
+
+
+def test_t2i_wires_out_dir_into_client(runner: CliRunner, tmp_path: Path) -> None:
+    out_dir = tmp_path / "out"
+    _, client_cls = _invoke_t2i(runner, tmp_path, out_dir)
+    assert client_cls.call_args.kwargs["out_dir"] == out_dir

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -22,6 +22,7 @@ from gflow_cli.errors import (
     ProblemDetails,
     RateLimitError,
     TransportTimeoutError,
+    UiSelectorDriftError,
     UpscaleUnavailableError,
     VideoModelSelectionError,
     WafRejectionError,
@@ -452,3 +453,39 @@ def test_chain_partial_error_partial_results_defaults_empty() -> None:
     (but present) ``partial_results`` list — never None."""
     err = ChainPartialError(detail="first link failed")
     assert err.partial_results == []
+
+
+# ---------- UiSelectorDriftError (issue #183) ----------
+
+
+def test_ui_selector_drift_error_exit_code_23() -> None:
+    """UiSelectorDriftError -> exit code 23 (issue #183).
+
+    Raised when a UI-automation selector cascade finds no matching element,
+    indicating that Flow's frontend has changed.  Exit 23 lets scripted
+    callers distinguish "UI drifted" from generic error (1)."""
+    err = UiSelectorDriftError(
+        detail="probe=mode_switch_trigger: no matching element found on the Flow editor."
+    )
+    assert _exit_code_for(err) == 23
+    assert EXIT_CODE_MAP[UiSelectorDriftError] == 23
+    assert isinstance(err, GFlowError)
+    assert err.remediation_hint != ""
+
+
+def test_ui_selector_drift_error_problem_details() -> None:
+    """UiSelectorDriftError carries RFC 9457 Problem Details with a stable type URI."""
+    err = UiSelectorDriftError(detail="probe=image_mode_tab: Image tab not found.")
+    pd = err.to_problem_details()
+    assert pd["type"] == "https://gflow-cli.dev/errors/ui-selector-drift"
+    assert pd["title"] == "Flow UI selector drift"
+    assert "image_mode_tab" in pd.get("detail", "")
+    assert "remediation_hint" in pd
+
+
+def test_ui_selector_drift_error_not_a_subclass_of_flow_api_error() -> None:
+    """UiSelectorDriftError is a direct GFlowError subclass — it is NOT a
+    FlowApiError (it is a UI-automation concern, not a wire-protocol error)."""
+    err = UiSelectorDriftError(detail="probe=mode_switch_trigger: selector cascade failed.")
+    assert isinstance(err, GFlowError)
+    assert not isinstance(err, FlowApiError)


### PR DESCRIPTION
## Summary

Fixes the error-quality half of issue #183. When `gflow image t2i` fails to find the mode-switch trigger, it now raises a structured, actionable `UiSelectorDriftError` (exit 23) instead of a bare `RuntimeError` that surfaces as `error_unhandled`.

- **Add `UiSelectorDriftError`** (`errors.py`) — direct `GFlowError` subclass, exit code 23, stable `problem_type` URI, remediation hint pointing at the debug screenshot and the issue tracker.
- **Replace `raise RuntimeError`** in `_switch_to_image_mode` (trigger + `image_mode_tab` misses), `_switch_to_video_mode` (trigger + `video_mode_tab` misses), **and `_switch_video_sub_mode`** with `raise UiSelectorDriftError`, carrying the probe label and screenshot path via a shared `selector_drift_detail()` helper (omits the `Screenshot:` clause when no capture happened, instead of rendering a literal `None`).
- **Wire `out_dir` into `FlowApiClient`** on the whole image surface (`t2i` / `i2i` / `upscale` / `upload`): the transport's screenshot directory was never set on the image path, so debug screenshots were silently dead code — found by a live e2e drift simulation. Video/movie already passed it.
- **Fix the remediation hint** — it claimed `--verbose` enables screenshot capture (it never did); it now points at the captured screenshot and warns that the viewport may show account details before attaching it to an issue.
- **Re-export** `UiSelectorDriftError` through `exceptions.py`.
- **Tests**: exit-code 23 map + RFC 9457 shape + lineage invariant (unit); CliRunner test proving `image t2i` surfaces exit 23 with the probe name; regression test that `t2i` passes `out_dir` to `FlowApiClient`; screenshot-path and no-`None`-clause assertions at the probe sites; video sub-mode drift test.
- **Docs**: CHANGELOG `[Unreleased]` entry; `docs/USAGE.md` exit-code table backfilled (15, 19–22) + row 23.

## What this does NOT fix

The `MODE_SWITCH_TRIGGER_SELECTORS` (`button[aria-haspopup='menu']:has(i.google-symbols:text('crop_*'))`) may have drifted with Google's Flow UI A/B (#174) on affected accounts. On those accounts `t2i` still fails — now diagnosably with exit 23 + screenshot. Restoring generation there requires reconnaissance of the new UI (tracked in #183 / #174); it is not reproducible on the maintainer accounts, which currently probe as the old dialog UI. Sibling selector probes still raising bare `RuntimeError` (model picker, prompt box, frame slots, etc.) are a follow-up migration.

## User experience after this fix

Before:
```
Unexpected error. Re-run with --verbose to capture details.    (exit 1)
```

After (live-verified):
```
Flow UI selector drift: probe=mode_switch_trigger: no matching element found
on the Flow editor. Screenshot: <out-dir>/debug_no_mode_trigger.png
Remediation: A Flow editor UI element could not be located — Google may have
updated their frontend. Check for a newer gflow-cli release, then file a bug ...
Exit code: 23
```

## Test plan

- [x] `pytest tests/test_errors.py tests/api/transports/... tests/cli/...` — 192 passed (scoped)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pyright src` — 0 errors outside a known local-env `browser_cookie3` resolution quirk (CI authoritative)
- [x] E2E happy path (live, credit-free): `gflow --verbose image t2i ... --out <dir>` → exit 0, valid JPEG 768×1376, `image_mode_entered` fired — mode-switch unregressed
- [x] E2E failure path (live drift simulation — `MODE_SWITCH_TRIGGER_SELECTORS` patched to a guaranteed-miss selector, reproducing the reporter's DOM condition): exit **23**, probe name + real screenshot path in the user-visible message, `debug_no_mode_trigger.png` written (valid 1280×720 PNG), structlog `error_raised` with full Problem Details, **zero** `error_unhandled`/`message_hash` events
- [ ] Reporter confirmation on an affected account (new-UI cohort): error now actionable

Refs #183 (error-quality half — the issue stays open for the selector/new-UI restoration fix, tracked with #174).