### PR TITLE
chore: resolve mechanical SonarCloud code smells (S1192/S7632/S3358)

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -118,6 +118,8 @@ MAX_UPSAMPLE_B64_LEN = 50 * 1024 * 1024
 
 # aisandbox-pa rejects application/json — see samples/captured/*.json.
 _AISANDBOX_CONTENT_TYPE = "text/plain;charset=UTF-8"
+# Content type for the labs.google BFF (tRPC) endpoints, which DO accept JSON.
+_APPLICATION_JSON = "application/json"
 
 # aisandbox-pa POSTs return 401 to page.request unless an Authorization: Bearer
 # <access_token> is attached — the SPA's OAuth2 token, fetched from the BFF
@@ -756,7 +758,7 @@ class FlowApiClient:
         """
         title = title or _default_project_title()
         body = {"json": {"projectTitle": title, "toolName": "PINHOLE"}}
-        data = await self._post_json(routes.CREATE_PROJECT, body, content_type="application/json")
+        data = await self._post_json(routes.CREATE_PROJECT, body, content_type=_APPLICATION_JSON)
         return ProjectInfo.from_create_response(data)
 
     async def upload_image(self, project_id: str, image_path: Path) -> AssetInfo:
@@ -1434,7 +1436,7 @@ class FlowApiClient:
         data = await self._post_json(
             routes.CREATE_ENTITY_URL,
             body,
-            content_type="application/json",
+            content_type=_APPLICATION_JSON,
             route_name="createEntity",
         )
         payload = _unwrap_trpc(data)
@@ -1775,7 +1777,7 @@ def _build_wire_format_discovery(resp: Any, body_text: str, route: str) -> JsonO
         content_type = ""
     top_keys: list[str] = []
     try:
-        parsed = json.loads(body_text) if content_type.startswith("application/json") else None
+        parsed = json.loads(body_text) if content_type.startswith(_APPLICATION_JSON) else None
         if isinstance(parsed, dict):
             top_keys = sorted(cast("JsonObject", parsed).keys())
     except ValueError:  # json.JSONDecodeError is a ValueError subclass

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -72,7 +72,9 @@ async def _any_present(page: Page, selectors: Iterable[str]) -> bool:
         try:
             if await page.locator(sel).count() > 0:
                 return True
-        except Exception:  # noqa: BLE001 — best-effort probe, continue on any locator error
+        # Best-effort probe: swallow any locator error so one bad selector never
+        # aborts detection — the next selector (and the safe default) still run.
+        except Exception:  # noqa: BLE001
             continue
     return False
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -62,6 +62,12 @@ except ImportError:  # pragma: no cover — Playwright is an install dependency
 
 log = structlog.get_logger(__name__)
 
+# Type aliases for JSON-shaped ``cast(...)`` targets. Extracted so the quoted
+# cast strings are not duplicated (SonarCloud S1192); a module-level alias keeps
+# ruff's TC006 happy since the call sites pass a bare name, not a subscript.
+_JsonObj = dict[str, Any]
+_AnyList = list[Any]
+
 # Flow editor entrypoint — ``?hl=en`` locks locale for selector stability.
 FLOW_URL = "https://labs.google/fx/tools/flow?hl=en"
 # URL fragment that distinguishes the project editor from the gallery.
@@ -415,6 +421,10 @@ _COUNT_TAB_COUNT = 4
 # (duplicate literal) and keep the spelling consistent across log sites.
 _EVT_COUNT_SETTER_COMPLETED = "ui_automation.count_setter_completed"
 
+# Structured event name emitted at every overlay-dismissal exit path.
+# Extracted to a module-level constant to satisfy SonarCloud S1192.
+_EVT_OVERLAY_DISMISSED = "ui_automation.overlay_dismissed"
+
 # Regex that matches count-tab text exactly: "1x", "x2", "x3", "x4".
 # These are the ONLY role="tab" elements whose text fits this pattern —
 # Mode tabs ("image\nImagem") and Aspect tabs ("16:9", "crop_square") do not.
@@ -486,10 +496,10 @@ def _collect_images_from_body(body: dict[str, Any], images: list[GeneratedImage]
     media_list_raw = body.get("media", [])
     if not isinstance(media_list_raw, list):
         return
-    for item_raw in cast("list[Any]", media_list_raw):
+    for item_raw in cast(_AnyList, media_list_raw):
         if not isinstance(item_raw, dict):
             continue
-        item: dict[str, Any] = cast("dict[str, Any]", item_raw)
+        item: dict[str, Any] = cast(_JsonObj, item_raw)
         try:
             images.append(GeneratedImage.from_response_item(item))
         except ValueError as e:
@@ -511,7 +521,7 @@ def _images_from_responses(
 
     for response in responses:
         status = response.get("status")
-        body: dict[str, Any] = cast("dict[str, Any]", response.get("body") or {})
+        body: dict[str, Any] = cast(_JsonObj, response.get("body") or {})
         route_str: str = str(response.get("url", ""))
 
         if status == 401:
@@ -591,10 +601,10 @@ def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
         return summary
     if not isinstance(parsed, dict):
         return summary
-    parsed_dict = cast("dict[str, Any]", parsed)
+    parsed_dict = cast(_JsonObj, parsed)
     reqs = parsed_dict.get("requests")
     if isinstance(reqs, list) and reqs and isinstance(reqs[0], dict):
-        first = cast("dict[str, Any]", reqs[0])
+        first = cast(_JsonObj, reqs[0])
         summary["request0_keys"] = sorted(first.keys())
         ref_bits = {
             k: _elide_large_value(v)
@@ -625,18 +635,18 @@ def _entity_ids_from_request_body(post_data: str | None) -> set[str]:
     if not isinstance(parsed, dict):
         return set()
     out: set[str] = set()
-    reqs = cast("dict[str, Any]", parsed).get("requests")
+    reqs = cast(_JsonObj, parsed).get("requests")
     if not isinstance(reqs, list):
         return out
-    for req in cast("list[Any]", reqs):
+    for req in cast(_AnyList, reqs):
         if not isinstance(req, dict):
             continue
-        ents = cast("dict[str, Any]", req).get("referenceEntities")
+        ents = cast(_JsonObj, req).get("referenceEntities")
         if not isinstance(ents, list):
             continue
-        for ent in cast("list[Any]", ents):
+        for ent in cast(_AnyList, ents):
             if isinstance(ent, dict):
-                entity_id = cast("dict[str, Any]", ent).get("entityId")
+                entity_id = cast(_JsonObj, ent).get("entityId")
                 if isinstance(entity_id, str):
                     out.add(entity_id)
     return out
@@ -881,7 +891,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                     await loc.click(force=True)
                     await page.wait_for_timeout(1000)
                     log.info(
-                        "ui_automation.overlay_dismissed",
+                        _EVT_OVERLAY_DISMISSED,
                         selector=close_sel,
                         method="close_button_page",
                     )
@@ -899,7 +909,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                         await loc.click(force=True)
                         await page.wait_for_timeout(1000)
                         log.info(
-                            "ui_automation.overlay_dismissed",
+                            _EVT_OVERLAY_DISMISSED,
                             selector=close_sel,
                             method="close_button_frame",
                         )
@@ -912,7 +922,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             await page.keyboard.press("Escape")
             await page.wait_for_timeout(1000)
             log.info(
-                "ui_automation.overlay_dismissed",
+                _EVT_OVERLAY_DISMISSED,
                 selector="<none>",
                 method="escape",
             )
@@ -2694,14 +2704,14 @@ class UiAutomationTransport(VideoGenerationMixin):
         for response in responses:
             if response.get("status") != 200:
                 continue
-            body: dict[str, Any] = cast("dict[str, Any]", response.get("body") or {})
+            body: dict[str, Any] = cast(_JsonObj, response.get("body") or {})
             raw_workflows = body.get("workflows", [])
             if not isinstance(raw_workflows, list):
                 continue
-            for wf_raw in cast("list[Any]", raw_workflows):
+            for wf_raw in cast(_AnyList, raw_workflows):
                 if not isinstance(wf_raw, dict):
                     continue
-                wf: dict[str, Any] = cast("dict[str, Any]", wf_raw)
+                wf: dict[str, Any] = cast(_JsonObj, wf_raw)
                 # Only surface workflows that carry the character-binding field.
                 if "parentEntityId" not in wf:
                     log.debug(

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -54,6 +54,11 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
+# Type alias for the JSON request-list ``cast(...)`` target. Extracted so the
+# quoted cast string is not duplicated (SonarCloud S1192); a module-level alias
+# keeps ruff's TC006 happy since call sites pass a bare name, not a subscript.
+_JsonObjList = list[dict[str, Any]]
+
 # The three mode-specific generate routes (spec §2.1). The listener filters on
 # these substrings only — video generate URLs carry no /projects/{id}/ path
 # segment, so a project-id URL filter is impossible (deviation from §5.4).
@@ -434,7 +439,7 @@ def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
         if not raw:
             return {"parsed": False}
         data = cast("dict[str, Any]", json.loads(raw))
-        reqs = cast("list[dict[str, Any]]", data.get("requests") or [])
+        reqs = cast(_JsonObjList, data.get("requests") or [])
         first: dict[str, Any] = reqs[0] if reqs else {}
 
         def _mid(obj: Any) -> str | None:
@@ -443,7 +448,7 @@ def _summarize_request_image_inputs(request: Any) -> dict[str, Any]:
             mid = cast("dict[str, Any]", obj).get("mediaId")
             return mid[:8] if isinstance(mid, str) else None
 
-        refs = cast("list[dict[str, Any]]", first.get("referenceImages") or [])
+        refs = cast(_JsonObjList, first.get("referenceImages") or [])
         return {
             "parsed": True,
             "startImage": _mid(first.get("startImage")),
@@ -1477,17 +1482,17 @@ class VideoGenerationMixin:
         body = cast("dict[str, Any]", generate_resp.get("body") or {})
         got: list[str] = []
         # Response shape (the live one): media[] -> ...videoGenerationEntityInputs.
-        for media in cast("list[dict[str, Any]]", body.get("media") or []):
+        for media in cast(_JsonObjList, body.get("media") or []):
             meta = cast("dict[str, Any]", media.get("mediaMetadata") or {})
             req_data = cast("dict[str, Any]", meta.get("requestData") or {})
             vgrd = cast("dict[str, Any]", req_data.get("videoGenerationRequestData") or {})
-            for e in cast("list[dict[str, Any]]", vgrd.get("videoGenerationEntityInputs") or []):
+            for e in cast(_JsonObjList, vgrd.get("videoGenerationEntityInputs") or []):
                 entity_id = cast("str | None", e.get("entityId"))
                 if entity_id:
                     got.append(entity_id)
         # Request shape (fallback): requests[].referenceEntities.
-        for r in cast("list[dict[str, Any]]", body.get("requests") or []):
-            for e in cast("list[dict[str, Any]]", r.get("referenceEntities") or []):
+        for r in cast(_JsonObjList, body.get("requests") or []):
+            for e in cast(_JsonObjList, r.get("referenceEntities") or []):
                 entity_id = cast("str | None", e.get("entityId"))
                 if entity_id:
                     got.append(entity_id)

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -534,7 +534,12 @@ async def _create_character(
     state.save(state_path)
     console.print(f"    entity_id: {result.entity_id}")
     for slot, p in enumerate(image_paths):
-        label = "face" if slot == 0 else "body" if slot == 1 else f"slot{slot}"
+        if slot == 0:
+            label = "face"
+        elif slot == 1:
+            label = "body"
+        else:
+            label = f"slot{slot}"
         console.print(f"    {label}: {p or '(unavailable)'}")
 
 
@@ -700,7 +705,9 @@ def _ffmpeg_concat(clips: list[Path], out: Path) -> None:
             f.write(f"file '{c.as_posix()}'\n")
         listfile = f.name
     try:
-        subprocess.run(  # noqa: S603 — ffmpeg path from shutil.which, args fixed
+        # ffmpeg path comes from shutil.which and all args are fixed literals —
+        # no shell, no user-controlled tokens.
+        subprocess.run(  # noqa: S603
             [
                 ffmpeg,
                 "-y",

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -30,6 +30,12 @@ __all__ = [
     "SceneState",
 ]
 
+# Type aliases for TOML-shaped ``cast(...)`` targets. Extracted so the quoted
+# cast strings are not duplicated (SonarCloud S1192); module-level aliases keep
+# ruff's TC006 happy since call sites pass a bare name, not a subscript.
+_TomlObj = dict[str, object]
+_TomlList = list[object]
+
 # ---------------------------------------------------------------------------
 # Allowed values
 # ---------------------------------------------------------------------------
@@ -78,7 +84,7 @@ class MovieManifest:
             _raw = tomllib.loads(raw)
         except tomllib.TOMLDecodeError as exc:
             raise ConfigurationError(f"Failed to parse {path}: {exc}") from exc
-        return cls._from_dict(cast("dict[str, object]", _raw))
+        return cls._from_dict(cast(_TomlObj, _raw))
 
     @classmethod
     def _from_dict(cls, data: dict[str, object]) -> MovieManifest:
@@ -103,7 +109,7 @@ class MovieManifest:
         chars_raw = data.get("characters", [])
         if not isinstance(chars_raw, list):
             raise ConfigurationError("'characters' must be a TOML array.")
-        chars_list = cast("list[object]", chars_raw)
+        chars_list = cast(_TomlList, chars_raw)
         characters: dict[str, Character] = {}
         for i, c in enumerate(chars_list):
             parsed = _parse_character(c, i)
@@ -116,7 +122,7 @@ class MovieManifest:
             raise ConfigurationError("'scenes' must be a TOML array.")
         if not scenes_raw:
             raise ConfigurationError("At least one [[scenes]] entry is required.")
-        scenes_list = cast("list[object]", scenes_raw)
+        scenes_list = cast(_TomlList, scenes_raw)
         char_names = set(characters)
         scenes = tuple(
             _parse_scene(s, i, char_names, characters) for i, s in enumerate(scenes_list)
@@ -130,7 +136,7 @@ class MovieManifest:
         continuity = "independent"
         movie_raw = data.get("movie")
         if isinstance(movie_raw, dict):
-            raw_cont = cast("dict[str, object]", movie_raw).get("continuity", "independent")
+            raw_cont = cast(_TomlObj, movie_raw).get("continuity", "independent")
             if not isinstance(raw_cont, str):
                 raise ConfigurationError("movie.continuity must be a string.")
             continuity = raw_cont
@@ -140,7 +146,7 @@ class MovieManifest:
         if assemble_raw is not None:
             if not isinstance(assemble_raw, dict):
                 raise ConfigurationError("[assemble] must be a TOML table.")
-            assemble_dict = cast("dict[str, object]", assemble_raw)
+            assemble_dict = cast(_TomlObj, assemble_raw)
             output = assemble_dict.get("output")
             if output is not None and not isinstance(output, str):
                 raise ConfigurationError("assemble.output must be a string path.")
@@ -169,7 +175,7 @@ def _parse_style(data: object) -> StyleSpec:
         return StyleSpec()
     if not isinstance(data, dict):
         raise ConfigurationError("[style] must be a TOML table.")
-    d = cast("dict[str, object]", data)
+    d = cast(_TomlObj, data)
 
     def s(key: str) -> str | None:
         v = d.get(key)
@@ -191,7 +197,7 @@ def _parse_style(data: object) -> StyleSpec:
 def _parse_character(data: object, idx: int) -> Character:
     if not isinstance(data, dict):
         raise ConfigurationError(f"characters[{idx}] must be a TOML table.")
-    d = cast("dict[str, object]", data)
+    d = cast(_TomlObj, data)
 
     name = d.get("name")
     if not isinstance(name, str) or not name.strip():
@@ -204,7 +210,7 @@ def _parse_character(data: object, idx: int) -> Character:
     variants_raw = d.get("variants", {})
     if not isinstance(variants_raw, dict):
         raise ConfigurationError(f"characters[{idx}].variants must be a table.")
-    variants = {str(k): str(v) for k, v in cast("dict[str, object]", variants_raw).items()}
+    variants = {str(k): str(v) for k, v in cast(_TomlObj, variants_raw).items()}
 
     model = d.get("model", "nano2")
     if not isinstance(model, str) or model not in _VALID_CHARACTER_MODELS:
@@ -243,7 +249,7 @@ def _parse_scene(
 ) -> Scene:
     if not isinstance(data, dict):
         raise ConfigurationError(f"scenes[{idx}] must be a TOML table.")
-    d = cast("dict[str, object]", data)
+    d = cast(_TomlObj, data)
 
     sid = d.get("id")
     if not isinstance(sid, str) or not sid.strip():
@@ -263,7 +269,7 @@ def _parse_scene(
     if not isinstance(chars_raw, list):
         raise ConfigurationError(f"scenes[{idx}].characters must be an array.")
     chars: list[str] = []
-    for cn in cast("list[object]", chars_raw):
+    for cn in cast(_TomlList, chars_raw):
         if not isinstance(cn, str) or cn not in char_names:
             raise ConfigurationError(f"scenes[{idx}] references unknown character {cn!r}.")
         chars.append(cn)
@@ -289,10 +295,10 @@ def _parse_scene(
         dialogue.append(DialogueLine(speaker=str(speaker), line=line.strip()))
 
     if isinstance(per_char, list):
-        for e in cast("list[object]", per_char):
+        for e in cast(_TomlList, per_char):
             if not isinstance(e, dict):
                 continue
-            ed = cast("dict[str, object]", e)
+            ed = cast(_TomlObj, e)
             nm = ed.get("name")
             ln = ed.get("line")
             if nm not in chars:
@@ -372,7 +378,7 @@ class CharacterState:
         raw_paths = d.get("image_paths")
         paths: list[str | None] = []
         if isinstance(raw_paths, list):
-            for p in cast("list[object]", raw_paths):
+            for p in cast(_TomlList, raw_paths):
                 paths.append(str(p) if isinstance(p, str) else None)
         return cls(
             entity_id=str(eid) if eid is not None else "",
@@ -449,22 +455,18 @@ class MovieState:
             return state
         if not isinstance(raw, dict):
             return state
-        data = cast("dict[str, object]", raw)
+        data = cast(_TomlObj, raw)
 
         chars_raw = data.get("characters")
         if isinstance(chars_raw, dict):
-            for name, raw_char in cast("dict[str, object]", chars_raw).items():
+            for name, raw_char in cast(_TomlObj, chars_raw).items():
                 if isinstance(raw_char, dict):
-                    state.characters[name] = CharacterState.from_dict(
-                        cast("dict[str, object]", raw_char)
-                    )
+                    state.characters[name] = CharacterState.from_dict(cast(_TomlObj, raw_char))
         scenes_raw = data.get("scenes")
         if isinstance(scenes_raw, dict):
-            for title_key, raw_scene in cast("dict[str, object]", scenes_raw).items():
+            for title_key, raw_scene in cast(_TomlObj, scenes_raw).items():
                 if isinstance(raw_scene, dict):
-                    state.scenes[title_key] = SceneState.from_dict(
-                        cast("dict[str, object]", raw_scene)
-                    )
+                    state.scenes[title_key] = SceneState.from_dict(cast(_TomlObj, raw_scene))
         return state
 
     def save(self, path: Path) -> None:


### PR DESCRIPTION
## Summary

Pass 1 of zeroing the SonarCloud OPEN/CONFIRMED queue — safe, behavior-preserving fixes only.

| Rule | Sites | Fix |
|---|---|---|
| `S1192` duplicate literals | 7 | Module-level type aliases (`_JsonObj`, `_AnyList`, `_JsonObjList`, `_TomlObj`, `_TomlList`), an `_APPLICATION_JSON` constant, and `_EVT_OVERLAY_DISMISSED`. Aliases chosen over string constants because the quoted `cast(...)` strings exist to satisfy ruff TC006 — a bare alias name keeps both tools happy. |
| `S7632` malformed `# noqa` | 2 | Moved the prose reason off the suppression line so the analyzer sees a clean code-only `# noqa`. |
| `S3358` nested ternary | 1 | Expanded the slot-label conditional into `if/elif/else`. |

No behavior change.

## Deferred (separate branch)
Cognitive-complexity (`S3776`, biggest is `movie_manifest.py:238` 51→15) and too-many-params (`S107`) refactors — higher risk, want per-function TDD.

## Marked won't-fix in SonarCloud UI (not code defects)
Protocol-mandated unused `page`/`out_dir` params (`S1172`), async-without-await (`S7503`), override signature (`S2638`) on the `FlowUiDriver` drivers, plus the genuine backlog `TODO` (`S1135`).

## Test plan
- [x] repo hygiene clean
- [x] ruff check + format clean
- [x] pyright 0 errors
- [x] 703 tests pass (touched areas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)