### PR TITLE
feat(tools): broaden --tool surface + record metadata_json.tool (Tools framework PR 2/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,12 +32,15 @@ htmlcov/
 .DS_Store
 
 # Project-specific — secrets / session storage (NEVER commit)
-auth/                  # any project-local auth dir
-profile_*/             # Chromium persistent contexts (any name)
-*.cookies.json         # exported cookie jars
-storage_state.json     # Playwright storage_state output
-secrets.json           # generic secrets file
-.env                   # local env overrides (the .env.template IS committed)
+# NOTE: git does NOT support trailing inline comments in .gitignore — a `#` only
+# starts a comment at the START of a line. Keep each pattern on its own line so
+# the comment text isn't folded into the pattern (which silently un-ignores it).
+/auth/
+profile_*/
+*.cookies.json
+storage_state.json
+secrets.json
+.env
 .env.local
 .env.*.local
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `creative-director` as the first built-in tool, exposed via two surfaces:
   - **`gflow tools list/show/run`** — discover tools, inspect their styles, and run them
     standalone (e.g. `gflow tools run creative-director "a cat" --style cinema --json`).
-  - **`-t` / `--tool` option** on `gflow image t2i` and `gflow video t2v` — apply one or
-    more tools before generating (e.g. `--tool creative-director:style=cinema`). Repeatable;
-    single-prompt only. Replaces the never-released `-e/--expand` flag.
+  - **`-t` / `--tool` option** on every generation command — `image t2i` / `i2i` / `batch`,
+    `video t2v` / `i2v` / `r2v` / `chain` — apply one or more tools before generating
+    (e.g. `--tool creative-director:style=cinema`). Repeatable. On multi-prompt batches and
+    chains the tool is applied per prompt/link. Replaces the never-released `-e/--expand` flag.
   - The `creative-director` tool rewrites a terse prompt into a vivid one using Google's
     five-component formula (Subject + Action + Context/Location + Composition/Camera + Style)
     via the public Gemini API. Requires `GFLOW_CLI_GEMINI_API_KEY`
     ([get one](https://aistudio.google.com/apikey)); optional `GFLOW_CLI_GEMINI_MODEL`
     (default `gemini-2.5-flash`). Domain-vocabulary modes (`--style cinema`, `portrait`,
-    `product`, etc.) inject specialized lens/lighting/colour vocabulary.
+    `product`, etc.) inject specialized lens/lighting/colour vocabulary; styles are
+    **category-gated**, so image styles apply to image commands and video styles to video.
   - Tool application is **never fatal** — missing key, rate limit, or any API/network fault
     degrades gracefully to the original prompt.
-  - MCP parity: `gflow_list_tools` tool and a `tools` array parameter on
-    `gflow_generate_image` / `gflow_generate_video`.
+  - **History**: a generation rewritten by a tool records the user's original prompt in the
+    `prompt` column, the submitted expansion in `expanded_prompt`, and the applied tool
+    (`{name, version, model, params, config_hash}`) in `operations.metadata_json.tool` — all
+    honoring `GFLOW_CLI_HISTORY_PROMPTS=redacted` (the redacted form stores only
+    `{name, version, params_hash, config_hash}`).
+  - MCP parity: `gflow_list_tools` tool and a `tools` array parameter (`[{name, options}]`) on
+    `gflow_generate_image` / `gflow_generate_video`, validated and adapted to the CLI
+    `--tool` form.
 
 ## [0.21.0] — 2026-06-26
 

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -124,14 +124,18 @@ def apply_tool_option(
                 raise click.UsageError(
                     f"tool {name!r}: unknown option(s) {unknown_keys!r}; valid options: {valid!r}"
                 )
-        # Validate the style value when provided — must match a declared domain.
+        # Validate the style value when provided — must match a declared domain
+        # for THIS generation category (an image style is invalid on video, etc).
         style_val = options.get("style")
-        if style_val is not None and spec.config.domain(style_val) is None:
-            valid_styles = sorted(d.name for d in spec.config.domains)
-            raise click.UsageError(
-                f"tool {name!r}: unknown style {style_val!r}; valid styles: {valid_styles!r}"
+        if style_val is not None and spec.config.domain(style_val, category) is None:
+            valid_styles = sorted(
+                d.name for d in spec.config.domains if d.category in (category, "both")
             )
-        result = apply_tool(spec, current, options)
+            raise click.UsageError(
+                f"tool {name!r}: unknown {category} style {style_val!r}; "
+                f"valid {category} styles: {valid_styles!r}"
+            )
+        result = apply_tool(spec, current, options, category=category)
         if result.was_expanded:
             changed = True
             current = result.expanded

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -55,6 +55,8 @@ from gflow_cli.tools.runtime import apply_tool
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
+    from gflow_cli.tools.invocation import AppliedTool
+
 _logger = structlog.get_logger(__name__)
 _console = Console()
 
@@ -94,20 +96,27 @@ def apply_tool_option(
     *,
     category: Literal["image", "video"],
     quiet: bool,
-) -> tuple[str, str | None]:
+) -> tuple[str, str | None, AppliedTool | None]:
     """Apply ``--tool name[:k=v]`` specs in sequence. Returns ``(prompt_to_send,
-    original_prompt|None)``. Unknown tool / wrong category → UsageError (pre-network).
+    original_prompt|None, applied_tool|None)``. Unknown tool / wrong category →
+    UsageError (pre-network).
 
-    ``apply_tool`` is imported at MODULE scope so tests can monkeypatch it.
+    ``applied_tool`` is the provenance snapshot of the LAST tool that rewrote the
+    prompt — recorded in ``operations.metadata_json.tool``. It is built from the
+    resolved spec + options (not the tool's output), so it stays accurate even
+    under a monkeypatched ``apply_tool`` in tests. ``apply_tool`` is imported at
+    MODULE scope so tests can monkeypatch it.
     """
     from gflow_cli.errors import ConfigurationError
+    from gflow_cli.tools.invocation import applied_tool_from_spec
     from gflow_cli.tools.registry import get_tool
 
     if not tool_specs:
-        return text, None
+        return text, None, None
     original = text
     current = text
     changed = False
+    applied: AppliedTool | None = None
     for spec_str in tool_specs:
         name, options = _parse_tool_spec(spec_str)
         try:
@@ -139,11 +148,12 @@ def apply_tool_option(
         if result.was_expanded:
             changed = True
             current = result.expanded
+            applied = applied_tool_from_spec(spec, options)
             if not quiet:
                 _console.print(f"[cyan]{spec.title} applied:[/cyan] [dim]{current}[/dim]")
         elif not quiet:
             _console.print(f"[yellow]{spec.title} skipped[/yellow] (unavailable).")
-    return current, (original if changed else None)
+    return current, (original if changed else None), applied
 
 
 def safe_path_text(path: Path) -> str:

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -77,7 +77,30 @@ __all__ = [
     "apply_tool_option",
     "run_with_handlers",
     "safe_path_text",
+    "tool_option",
 ]
+
+
+_TOOL_OPTION_HELP = (
+    "Apply a prompt tool before generating, e.g. --tool creative-director or "
+    "--tool creative-director:style=cinema. Repeatable. Requires "
+    "GFLOW_CLI_GEMINI_API_KEY; falls back to the original prompt if unset or on error."
+)
+
+
+def tool_option(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Reusable ``-t/--tool`` Click option (DRY across t2i/i2i/t2v/i2v/r2v/chain).
+
+    Binds to the ``tool_specs: tuple[str, ...]`` parameter. One definition keeps
+    the help text and flag spelling identical on every generation command.
+    """
+    return click.option(
+        "-t",
+        "--tool",
+        "tool_specs",
+        multiple=True,
+        help=_TOOL_OPTION_HELP,
+    )(func)
 
 
 def _parse_tool_spec(spec: str) -> tuple[str, dict[str, str]]:

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
 
+    from gflow_cli.tools.invocation import AppliedTool
+
 __all__ = [
     "Aspect",
     "GenerateImageRequest",
@@ -240,6 +242,12 @@ class GenerateImageRequest:
     recaptcha_token: str = ""  # populated by caller right before send; "" means unminted
     # number of images to generate (1–4); UI transport uses this to set Flow's count tab
     count: int = 1
+    # Tool provenance (recorded, never sent on the wire). ``original_prompt`` is
+    # the user's pre-tool text when a ``--tool`` rewrote ``prompt``; ``tool`` is
+    # the applied-tool snapshot for ``operations.metadata_json.tool``. Both are
+    # ignored by the body builders. (PR2 §8)
+    original_prompt: str | None = None
+    tool: AppliedTool | None = None
 
     def __post_init__(self) -> None:
         if not self.prompt or not self.prompt.strip():

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from gflow_cli.tools.invocation import AppliedTool
+
 # Type alias used with cast() in response parsers — avoids repeating the
 # string-form annotation "dict[str, Any]" on every call (SonarCloud S1192).
 _StrAnyDict = dict[str, Any]
@@ -207,6 +209,11 @@ class GenerateVideoRequest:
         str, ...
     ] = ()  # R2V — character DISPLAY names (UI picker selection)
     reference_audio: str | None = None  # R2V — voice resource mediaId (e.g. "alnilam")
+    # Tool provenance (recorded, never sent on the wire). ``original_prompt`` is
+    # the user's pre-tool text when a ``--tool`` rewrote ``prompt``; ``tool`` is
+    # the applied-tool snapshot for ``operations.metadata_json.tool``. (PR2 §8)
+    original_prompt: str | None = None
+    tool: AppliedTool | None = None
 
     def __post_init__(self) -> None:
         self._validate_prompt()

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 
     from gflow_cli.api.client import FlowApiClient
     from gflow_cli.api.video import VideoResult, VideoStartedCallback
+    from gflow_cli.tools.invocation import AppliedTool
 
 __all__ = [
     "ChainLinkResult",
@@ -85,6 +86,10 @@ class ChainLinkSpec:
     model: VideoModel | None = None
     duration: int | None = None
     aspect: Aspect | None = None
+    # Tool provenance — set when a ``--tool`` rewrote this link's prompt (PR2).
+    # ``prompt`` is then the rewritten text; these are recorded, not sent.
+    original_prompt: str | None = None
+    tool: AppliedTool | None = None
 
 
 @dataclass(frozen=True)
@@ -170,6 +175,8 @@ def _build_link_request(
         model=link_model,
         duration=spec.duration,
         start_image=prev_frame if is_i2v else None,
+        original_prompt=spec.original_prompt,
+        tool=spec.tool,
     )
 
 

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -716,7 +716,7 @@ def t2i(  # NOSONAR
         profile_name = _resolve_profile(profile)
         provider_dir = _make_provider_dir(profile_name)
         settings = get_settings()
-        prompt_to_send, original_prompt = apply_tool_option(
+        prompt_to_send, original_prompt, applied_tool = apply_tool_option(
             prompt, tool_specs, category="image", quiet=as_json
         )
         run_with_handlers(
@@ -730,6 +730,8 @@ def t2i(  # NOSONAR
                     model=Model.from_cli(model),
                     reference_entities=tuple(reference_entities),
                     reference_entity_names=tuple(reference_entity_names),
+                    original_prompt=original_prompt,
+                    tool=applied_tool,
                 ),
                 count=count,
                 out=out,
@@ -737,7 +739,6 @@ def t2i(  # NOSONAR
                 transport=transport,
                 project_id=project_id,
                 as_json=as_json,
-                original_prompt=original_prompt,
             ),
             cli_command="image t2i",
             as_json=as_json,
@@ -907,9 +908,12 @@ def _record_generated_images_safe(
     saved_paths: list[Path],
     input_media_ids: list[str],
     operation_kind: str,
-    original_prompt: str | None = None,
 ) -> None:
-    """Persist generation metadata; warn on DataStoreError (never abort success)."""
+    """Persist generation metadata; warn on DataStoreError (never abort success).
+
+    Tool provenance (``original_prompt`` / ``tool``) travels on ``request``, so
+    the recorder reads it directly — no separate kwarg to drift out of sync.
+    """
     try:
         recorder.record_generated_images(
             profile_name=profile_name,
@@ -922,7 +926,6 @@ def _record_generated_images_safe(
             cloud_storage_infos=[cloud_info_from_path(path) for path in saved_paths],
             input_media_ids=input_media_ids,
             operation_kind=operation_kind,
-            original_prompt=original_prompt,
         )
     except DataStoreError as exc:
         first_image = images[0] if images else None
@@ -946,7 +949,6 @@ async def _run_t2i(
     transport: str | None = None,
     project_id: str | None = None,
     as_json: bool = False,
-    original_prompt: str | None = None,
 ) -> None:
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
@@ -1002,7 +1004,6 @@ async def _run_t2i(
                 saved_paths=saved_paths,
                 input_media_ids=[],
                 operation_kind="t2i",
-                original_prompt=original_prompt,
             )
     finally:
         recorder.close()

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -34,6 +34,7 @@ from gflow_cli._cli_helpers import (
     apply_tool_option,
     run_with_handlers,
     safe_path_text,
+    tool_option,
 )
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.dto import ProjectInfo
@@ -88,6 +89,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from gflow_cli.api.dto import GeneratedImage
+    from gflow_cli.tools.invocation import AppliedTool
 
 _CmdFn = TypeVar("_CmdFn", bound="Callable[..., object]")
 
@@ -638,16 +640,7 @@ async def _run_upscale(
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
-@click.option(
-    "-t",
-    "--tool",
-    "tool_specs",
-    multiple=True,
-    help=(
-        "Apply a tool before generating, e.g. --tool creative-director or "
-        "--tool creative-director:style=cinema. Repeatable. Single-prompt only."
-    ),
-)
+@tool_option
 @click.option(
     "--transport",
     type=click.Choice(transport_choices(), case_sensitive=False),
@@ -700,12 +693,6 @@ def t2i(  # NOSONAR
         msg = "--json is single-prompt only; remove the extra prompts."
         raise click.UsageError(msg)
 
-    if is_multi_prompt and tool_specs:
-        # --tool calls Gemini per prompt; that belongs on the single-prompt
-        # path. Loop t2i one prompt at a time if you want every prompt processed.
-        msg = "-t/--tool is single-prompt only; remove the extra prompts."
-        raise click.UsageError(msg)
-
     if not is_multi_prompt:
         if not prompts:
             msg = "Provide a prompt, multiple prompts, --prompts-file, or --stdin."
@@ -753,7 +740,35 @@ def t2i(  # NOSONAR
         model,
         count,
     )
+    # --tool now works on the batch path too (PR2): apply each tool per prompt
+    # before submission (sequential Gemini calls, never fatal). Validation of an
+    # unknown tool/style raises a UsageError here, before any browser opens.
+    if tool_specs:
+        batch_prompts = _apply_tools_to_batch_prompts(batch_prompts, tool_specs)
     _execute_t2i_batch(batch_prompts, count, continue_on_error, profile, out, transport)
+
+
+def _apply_tools_to_batch_prompts(
+    batch_prompts: tuple[BatchPromptItem, ...],
+    tool_specs: tuple[str, ...],
+) -> tuple[BatchPromptItem, ...]:
+    """Apply ``--tool`` to each batch item's text (sequential, ≤50 prompts).
+
+    Returns new items carrying the rewritten ``text`` plus ``original_prompt`` /
+    ``tool`` provenance. ``apply_tool_option`` is never-fatal per prompt (a
+    missing key / API error degrades to the original text); an unknown tool or
+    style still raises ``click.UsageError`` (pre-network) so the whole batch
+    fails fast rather than silently skipping the tool.
+    """
+    from dataclasses import replace
+
+    applied: list[BatchPromptItem] = []
+    for item in batch_prompts:
+        sent, original, tool = apply_tool_option(
+            item.text, tool_specs, category="image", quiet=True
+        )
+        applied.append(replace(item, text=sent, original_prompt=original, tool=tool))
+    return tuple(applied)
 
 
 def _build_t2i_batch_prompts(
@@ -1097,6 +1112,7 @@ _BATCH_TITLE = "gflow-cli image batch"
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
+@tool_option
 @click.option(
     "--transport",
     type=click.Choice(transport_choices(), case_sensitive=False),
@@ -1111,6 +1127,7 @@ def batch(
     continue_on_error: bool,
     out: Path | None,
     profile: str | None,
+    tool_specs: tuple[str, ...],
     transport: str | None,
 ) -> None:
     """Run MANIFEST (JSON or TSV) through Flow's image generator."""
@@ -1123,6 +1140,11 @@ def batch(
         )
     except ConfigurationError as exc:
         raise _as_usage_error(exc) from exc
+
+    # Apply --tool to each manifest row before submission (≤5 prompts, sequential,
+    # never-fatal per row; unknown tool/style fails fast pre-network).
+    if tool_specs:
+        prompts = _apply_tools_to_batch_prompts(prompts, tool_specs)
 
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
@@ -1183,6 +1205,9 @@ class _I2IParams:
     model: Model
     reference_entities: tuple[str, ...]
     reference_entity_names: tuple[str, ...]
+    # Tool provenance (set when a --tool rewrote the prompt; recorded only).
+    original_prompt: str | None = None
+    tool: AppliedTool | None = None
 
 
 @image.command(
@@ -1248,6 +1273,7 @@ class _I2IParams:
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
+@tool_option
 @click.option(
     "--transport",
     type=click.Choice(transport_choices(), case_sensitive=False),
@@ -1273,6 +1299,7 @@ def i2i(
     count: int,
     out: Path | None,
     profile: str | None,
+    tool_specs: tuple[str, ...],
     transport: str | None,
     project_id: str | None,
     reference_entities: tuple[str, ...],
@@ -1303,13 +1330,18 @@ def i2i(
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
     settings = get_settings()
+    prompt_to_send, original_prompt, applied_tool = apply_tool_option(
+        prompt, tool_specs, category="image", quiet=as_json
+    )
     i2i_params = _I2IParams(
-        prompt=prompt,
+        prompt=prompt_to_send,
         classified_refs=classified_refs,
         aspect=Aspect.from_cli(aspect),
         model=model_enum,
         reference_entities=tuple(reference_entities),
         reference_entity_names=tuple(reference_entity_names),
+        original_prompt=original_prompt,
+        tool=applied_tool,
     )
     run_with_handlers(
         lambda: _run_i2i(
@@ -1371,6 +1403,8 @@ async def _run_i2i(
                 ref_paths=local_ref_paths,
                 reference_entities=params.reference_entities,
                 reference_entity_names=params.reference_entity_names,
+                original_prompt=params.original_prompt,
+                tool=params.tool,
             )
 
             n_refs = len(uuid_refs) + len(local_ref_paths)

--- a/src/gflow_cli/cli_tools.py
+++ b/src/gflow_cli/cli_tools.py
@@ -55,7 +55,15 @@ def show_tool(name: str) -> None:
     if spec.requires_env:
         console.print(f"Requires env: {', '.join(spec.requires_env)}")
     if spec.config.domains:
-        console.print("Styles: " + ", ".join(d.name for d in spec.config.domains))
+        # A style name can exist for both image and video (e.g. "product"); show
+        # the category in parentheses so the two are distinguishable.
+        console.print(
+            "Styles: "
+            + ", ".join(
+                d.name if d.category == "both" else f"{d.name} ({d.category})"
+                for d in spec.config.domains
+            )
+        )
 
 
 @tools.command("run")

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 import structlog
@@ -28,6 +28,9 @@ from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import DataStoreError
 from gflow_cli.storage import cloud_info_from_path
+
+if TYPE_CHECKING:
+    from gflow_cli.tools.invocation import AppliedTool
 
 console = Console()
 logger = structlog.get_logger(__name__)
@@ -61,10 +64,12 @@ async def _generate_and_report(
     out_dir: Path | None,
     command: str = "video",
     as_json: bool = False,
-    original_prompt: str | None = None,
 ) -> None:
     """Drive FlowApiClient for a single GenerateVideoRequest and print the
     result (or fail with a non-zero exit). Shared by t2v, i2v, and r2v.
+
+    Tool provenance (``original_prompt`` / ``tool``) travels on ``request``, so
+    the recorder reads it directly — no separate kwarg to drift out of sync.
 
     With ``as_json`` the result is emitted as a JSON object (carrying the same
     ok/fail status as the exit code) instead of the Rich lines; a failed
@@ -86,7 +91,6 @@ async def _generate_and_report(
                         profile_dir=profile_dir,
                         request=request,
                         started=started,
-                        original_prompt=original_prompt,
                     )
                 except DataStoreError as exc:
                     _warn_persistence_failed_after_success(
@@ -113,7 +117,6 @@ async def _generate_and_report(
                     if result.local_path is not None
                     else None
                 ),
-                original_prompt=original_prompt,
             )
         except DataStoreError as exc:
             _warn_persistence_failed_after_success(
@@ -154,6 +157,7 @@ async def _run_t2v(
     count: int = 1,
     as_json: bool = False,
     original_prompt: str | None = None,
+    tool: AppliedTool | None = None,
 ) -> None:
     from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
 
@@ -164,6 +168,8 @@ async def _run_t2v(
         model=VideoModel.from_cli(model),
         duration=duration,
         count=count,
+        original_prompt=original_prompt,
+        tool=tool,
     )
     await _generate_and_report(
         request,
@@ -172,7 +178,6 @@ async def _run_t2v(
         out_dir=out_dir,
         command="video t2v",
         as_json=as_json,
-        original_prompt=original_prompt,
     )
 
 
@@ -754,7 +759,7 @@ def t2v(
     """Generate a video from PROMPT."""
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
-    prompt_to_send, original_prompt = apply_tool_option(
+    prompt_to_send, original_prompt, applied_tool = apply_tool_option(
         prompt, tool_specs, category="video", quiet=as_json
     )
     run_with_handlers(
@@ -769,6 +774,7 @@ def t2v(
             count=count,
             as_json=as_json,
             original_prompt=original_prompt,
+            tool=applied_tool,
         ),
         cli_command="video t2v",
         as_json=as_json,

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -21,6 +21,7 @@ from gflow_cli._cli_helpers import (
     _resolve_profile,
     apply_tool_option,
     run_with_handlers,
+    tool_option,
 )
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.video import VideoModel, reference_cap_for
@@ -30,6 +31,7 @@ from gflow_cli.errors import DataStoreError
 from gflow_cli.storage import cloud_info_from_path
 
 if TYPE_CHECKING:
+    from gflow_cli.chain import ChainLinkSpec
     from gflow_cli.tools.invocation import AppliedTool
 
 console = Console()
@@ -194,6 +196,8 @@ async def _run_i2v(
     duration: int | None = None,
     count: int = 1,
     as_json: bool = False,
+    original_prompt: str | None = None,
+    tool: AppliedTool | None = None,
 ) -> None:
     from gflow_cli.api.video import (
         I2V_DEFAULT_MODEL,
@@ -229,6 +233,8 @@ async def _run_i2v(
         count=count,
         start_image=Path(image),
         end_image=Path(end_frame) if end_frame else None,
+        original_prompt=original_prompt,
+        tool=tool,
     )
     await _generate_and_report(
         request,
@@ -252,6 +258,8 @@ async def _run_r2v(
     duration: int | None = None,
     count: int = 1,
     as_json: bool = False,
+    original_prompt: str | None = None,
+    tool: AppliedTool | None = None,
 ) -> None:
     from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel
 
@@ -263,6 +271,8 @@ async def _run_r2v(
         duration=duration,
         count=count,
         reference_images=tuple(Path(r) for r in refs),
+        original_prompt=original_prompt,
+        tool=tool,
     )
     await _generate_and_report(
         request,
@@ -316,7 +326,6 @@ def _print_chain_plan(
     chain_id: str,
 ) -> None:
     """Render the resolved plan (used by --dry-run and the pre-spend summary)."""
-    from gflow_cli.chain import ChainLinkSpec
 
     typed_links: list[ChainLinkSpec] = list(links)
     remaining = len(typed_links) - skipped
@@ -504,6 +513,27 @@ async def _execute_chain_links(
         raise
 
 
+def _apply_tools_to_chain_links(
+    links: list[ChainLinkSpec],
+    tool_specs: tuple[str, ...],
+) -> list[ChainLinkSpec]:
+    """Apply ``--tool`` to each chain link's prompt (sequential, never-fatal).
+
+    Returns new ``ChainLinkSpec`` objects carrying the rewritten ``prompt`` plus
+    ``original_prompt`` / ``tool`` provenance. An unknown tool/style raises
+    ``click.UsageError`` (pre-network) so the chain fails fast.
+    """
+    from dataclasses import replace
+
+    applied: list[ChainLinkSpec] = []
+    for link in links:
+        sent, original, tool = apply_tool_option(
+            link.prompt, tool_specs, category="video", quiet=True
+        )
+        applied.append(replace(link, prompt=sent, original_prompt=original, tool=tool))
+    return applied
+
+
 async def _run_chain(
     *,
     profile_name: str,
@@ -519,6 +549,7 @@ async def _run_chain(
     yes: bool,
     dry_run: bool,
     as_json: bool,
+    tool_specs: tuple[str, ...] = (),
 ) -> None:
     """Drive a sequential last-frame I2V chain from a JSONL manifest.
 
@@ -530,7 +561,6 @@ async def _run_chain(
 
     from gflow_cli import chain as chain_mod
     from gflow_cli.api.video import Aspect
-    from gflow_cli.chain import ChainLinkSpec
     from gflow_cli.chain_manifest import parse_chain_manifest
     from gflow_cli.data.chain_repo import ChainLinkRecorder
     from gflow_cli.errors import ChainManifestError
@@ -593,6 +623,13 @@ async def _run_chain(
             f"Generate {cost} chain link(s) for ~{cost} credit(s)?",
             abort=True,
         )
+
+    # Apply --tool per link AFTER the dry-run/confirm gate so a rejected or
+    # dry run spends nothing and makes no Gemini calls. Each link's prompt is
+    # rewritten in place; provenance rides ChainLinkSpec into the per-link
+    # GenerateVideoRequest for metadata_json.tool recording (never-fatal).
+    if tool_specs:
+        remaining_links = _apply_tools_to_chain_links(remaining_links, tool_specs)
 
     resolved_out_dir = out_dir if out_dir is not None else settings.output_dir
     resolved_out_dir.mkdir(parents=True, exist_ok=True)
@@ -892,6 +929,7 @@ def _resolve_i2v_args(
     help="How many videos to generate (1-4).",
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
+@tool_option
 @click.option(
     "--out-dir",
     "out_dir",
@@ -916,6 +954,7 @@ def i2v(
     duration: str | None,
     count: int,
     profile: str | None,
+    tool_specs: tuple[str, ...],
     out_dir: Path | None,
     as_json: bool,
 ) -> None:
@@ -934,12 +973,15 @@ def i2v(
 
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
+    prompt_to_send, original_prompt, applied_tool = apply_tool_option(
+        resolved_prompt, tool_specs, category="video", quiet=as_json
+    )
     run_with_handlers(
         lambda: _run_i2v(
             profile_name=profile_name,
             profile_dir=provider_dir,
             image=resolved_image,
-            prompt=resolved_prompt,
+            prompt=prompt_to_send,
             end_frame=end_frame,
             aspect=aspect,
             model=model,
@@ -947,6 +989,8 @@ def i2v(
             count=count,
             out_dir=out_dir,
             as_json=as_json,
+            original_prompt=original_prompt,
+            tool=applied_tool,
         ),
         cli_command="video i2v",
         as_json=as_json,
@@ -1006,6 +1050,7 @@ def i2v(
     help="How many videos to generate (1-4).",
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
+@tool_option
 @click.option(
     "--out-dir",
     "out_dir",
@@ -1027,6 +1072,7 @@ def r2v(
     duration: str | None,
     count: int,
     profile: str | None,
+    tool_specs: tuple[str, ...],
     out_dir: Path | None,
     as_json: bool,
 ) -> None:
@@ -1051,11 +1097,14 @@ def r2v(
 
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)
+    prompt_to_send, original_prompt, applied_tool = apply_tool_option(
+        prompt, tool_specs, category="video", quiet=as_json
+    )
     run_with_handlers(
         lambda: _run_r2v(
             profile_name=profile_name,
             profile_dir=provider_dir,
-            prompt=prompt,
+            prompt=prompt_to_send,
             refs=refs,
             aspect=aspect,
             model=model,
@@ -1063,6 +1112,8 @@ def r2v(
             count=count,
             out_dir=out_dir,
             as_json=as_json,
+            original_prompt=original_prompt,
+            tool=applied_tool,
         ),
         cli_command="video r2v",
         as_json=as_json,
@@ -1152,6 +1203,7 @@ def r2v(
     help="Uniform aspect ratio for every link (continuity requirement).",
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
+@tool_option
 @click.option(
     "--out-dir",
     "out_dir",
@@ -1176,6 +1228,7 @@ def chain(
     seed_offset: int,
     aspect: str,
     profile: str | None,
+    tool_specs: tuple[str, ...],
     out_dir: Path | None,
     as_json: bool,
 ) -> None:
@@ -1197,6 +1250,7 @@ def chain(
             yes=yes,
             dry_run=dry_run,
             as_json=as_json,
+            tool_specs=tool_specs,
         ),
         cli_command="video chain",
         as_json=as_json,

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import mimetypes
 import uuid
 from datetime import UTC, datetime
@@ -31,6 +32,10 @@ if TYPE_CHECKING:
     from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStarted
     from gflow_cli.config import Settings
     from gflow_cli.storage import CloudStorageInfo
+    from gflow_cli.tools.invocation import AppliedTool
+
+    # Both generation requests carry the tool-provenance fields the recorder reads.
+    _ToolableRequest = GenerateImageRequest | GenerateVideoRequest
 
 
 def _new_id() -> str:
@@ -74,23 +79,61 @@ class OperationRecorder:
 
     def _resolve_prompts(
         self,
-        sent_prompt: str | None,
-        original_prompt: str | None,
+        request: _ToolableRequest,
     ) -> tuple[PromptFields, str | None]:
         """Resolve the recorded prompt fields and the expansion-to-store.
 
-        ``sent_prompt`` is what was actually submitted to Flow. When
-        ``original_prompt`` is provided (i.e. ``--tool`` rewrote the prompt),
-        the user's *original* prompt is recorded as the operation prompt and the
-        ``sent_prompt`` is persisted separately as ``expanded_prompt`` — withheld
-        when ``history_prompts='redacted'``, exactly like the original prompt.
+        ``request.prompt`` is what was actually submitted to Flow. When
+        ``request.original_prompt`` is set (i.e. a ``--tool`` rewrote the
+        prompt), the user's *original* prompt is recorded as the operation
+        prompt and the submitted prompt is persisted separately as
+        ``expanded_prompt`` — withheld when ``history_prompts='redacted'``,
+        exactly like the original prompt.
+
+        Reading both off the request (rather than a separate ``original_prompt``
+        kwarg) keeps the recorded original in lockstep with the submitted prompt
+        — they can no longer drift apart at the call site (PR2 §8 / prior-review
+        silent-misrecord hazard).
         """
+        sent_prompt = request.prompt
+        original_prompt = request.original_prompt
         recorded = original_prompt if original_prompt is not None else sent_prompt
         pf = prompt_fields(recorded, mode=self.prompt_mode)
         expanded = (
             sent_prompt if (original_prompt is not None and self.prompt_mode == "store") else None
         )
         return pf, expanded
+
+    def _tool_metadata(self, tool: AppliedTool | None) -> dict[str, object] | None:
+        """Build the redaction-aware ``metadata_json.tool`` payload for a
+        generation operation, or ``None`` when no tool was applied.
+
+        ``redact_metadata`` only redacts by key-name / sensitive-URL markers, so
+        a free-text option (e.g. ``params.style``) would pass through verbatim.
+        We therefore branch on :class:`PromptMode` here: in ``redacted`` mode we
+        store only ``{name, version, params_hash, config_hash}`` — never the raw
+        ``model``/``params`` — reusing :func:`prompt_fields`' sha256 for the
+        params digest (council D7).
+        """
+        if tool is None:
+            return None
+        params = tool.params_dict()
+        if self.prompt_mode == "redacted":
+            params_blob = json.dumps(params, sort_keys=True)
+            params_hash = prompt_fields(params_blob, mode="store").prompt_hash
+            return {
+                "name": tool.name,
+                "version": tool.version,
+                "params_hash": params_hash,
+                "config_hash": tool.config_hash,
+            }
+        return {
+            "name": tool.name,
+            "version": tool.version,
+            "model": tool.model,
+            "params": params,
+            "config_hash": tool.config_hash,
+        }
 
     # ------------------------------------------------------------------
     # Image upload
@@ -250,7 +293,6 @@ class OperationRecorder:
         operation_kind: str,
         cloud_storage_infos: list[CloudStorageInfo | None] | None = None,
         project_created: bool = True,
-        original_prompt: str | None = None,
     ) -> None:
         repo = self.repository
 
@@ -269,7 +311,7 @@ class OperationRecorder:
             ),
         )
 
-        pf, expanded_prompt = self._resolve_prompts(request.prompt, original_prompt)
+        pf, expanded_prompt = self._resolve_prompts(request)
         op_id = _new_id()
         repo.insert_operation(
             OperationRecord(
@@ -296,6 +338,9 @@ class OperationRecorder:
         # downstream queries like "SELECT * FROM operations WHERE completed_at
         # IS NULL" don't surface successful runs.
         repo.update_operation_status(op_id, OperationStatus.SUCCEEDED, _now_utc_iso(), None, None)
+        tool_meta = self._tool_metadata(request.tool)
+        if tool_meta is not None:
+            repo.set_operation_metadata(op_id, {"tool": tool_meta})
 
         # Link input assets (I2I seed images)
         for i, media_id in enumerate(input_media_ids):
@@ -422,7 +467,6 @@ class OperationRecorder:
         profile_dir: Path,
         request: GenerateVideoRequest,
         started: VideoStarted,
-        original_prompt: str | None = None,
     ) -> None:
         repo = self.repository
 
@@ -459,7 +503,7 @@ class OperationRecorder:
             ),
         )
 
-        pf, expanded_prompt = self._resolve_prompts(request.prompt, original_prompt)
+        pf, expanded_prompt = self._resolve_prompts(request)
         op_id = _new_id()
         repo.insert_operation(
             OperationRecord(
@@ -482,6 +526,9 @@ class OperationRecorder:
             ),
         )
         repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, 0)
+        tool_meta = self._tool_metadata(request.tool)
+        if tool_meta is not None:
+            repo.set_operation_metadata(op_id, {"tool": tool_meta})
 
     def _insert_fallback_video_operation(
         self,
@@ -491,10 +538,9 @@ class OperationRecorder:
         flow_media_id: str,
         request: GenerateVideoRequest,
         result: VideoResult,
-        original_prompt: str | None = None,
     ) -> None:
         """Insert a completed video operation when on_started failed or was skipped."""
-        pf, expanded_prompt = self._resolve_prompts(request.prompt, original_prompt)
+        pf, expanded_prompt = self._resolve_prompts(request)
         op_id = _new_id()
         repo.insert_operation(
             OperationRecord(
@@ -519,6 +565,9 @@ class OperationRecorder:
         asset_lookup = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)
         if asset_lookup is not None:
             repo.link_operation_asset(op_id, asset_lookup.id, OperationAssetRole.OUTPUT, 0)
+        tool_meta = self._tool_metadata(request.tool)
+        if tool_meta is not None:
+            repo.set_operation_metadata(op_id, {"tool": tool_meta})
 
     def _persist_completed_video_file(
         self,
@@ -564,7 +613,6 @@ class OperationRecorder:
         request: GenerateVideoRequest,
         result: VideoResult,
         cloud_storage_info: CloudStorageInfo | None = None,
-        original_prompt: str | None = None,
     ) -> None:
         # VideoResult carries status.media_id (the flow_media_id) and local_path
 
@@ -611,7 +659,6 @@ class OperationRecorder:
                 flow_media_id=flow_media_id,
                 request=request,
                 result=result,
-                original_prompt=original_prompt,
             )
 
         if result.local_path is not None or cloud_storage_info is not None:

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from gflow_cli.api.dto import GeneratedImage
     from gflow_cli.data.recorder import OperationRecorder
+    from gflow_cli.tools.invocation import AppliedTool
 
 console = Console()
 logger = structlog.get_logger(__name__)
@@ -86,7 +87,12 @@ _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 @dataclass(frozen=True)
 class BatchPromptItem:
-    """One prompt entry for image batch execution."""
+    """One prompt entry for image batch execution.
+
+    ``text`` is the prompt actually submitted (already tool-expanded when a
+    ``--tool`` was applied). ``original_prompt`` / ``tool`` carry the provenance
+    the recorder writes; both are ``None`` when no tool ran.
+    """
 
     text: str
     aspect_ratio: str = DEFAULT_ASPECT_RATIO
@@ -94,6 +100,8 @@ class BatchPromptItem:
     count: int = DEFAULT_COUNT
     output_filename: str | None = None
     index: int = 0
+    original_prompt: str | None = None
+    tool: AppliedTool | None = None
 
 
 @dataclass(frozen=True)
@@ -387,6 +395,8 @@ async def run_one_image_prompt(
         prompt=item.text,
         aspect=Aspect.from_cli(item.aspect_ratio),
         model=Model.from_cli(item.model),
+        original_prompt=item.original_prompt,
+        tool=item.tool,
     )
     stem = item.output_filename or f"prompt_{idx}"
     try:
@@ -727,6 +737,8 @@ def _to_request(item: BatchPromptItem) -> GenerateImageRequest:
         aspect=Aspect.from_cli(item.aspect_ratio),
         model=Model.from_cli(item.model),
         count=item.count,
+        original_prompt=item.original_prompt,
+        tool=item.tool,
     )
 
 

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -69,6 +69,30 @@ def _get_profile_lock(profile: str) -> asyncio.Lock:
     return _profile_locks[profile]
 
 
+def _adapt_tools(tools: list[dict[str, Any]] | None) -> tuple[str, ...] | dict[str, Any]:
+    """Validate + adapt the MCP ``tools`` array to CLI ``--tool`` specs.
+
+    Returns the spec tuple on success, or a structured error dict (to return to
+    the agent) when an item is malformed — so a bad ``tools`` payload fails
+    cleanly rather than as an uncaught error once generation is wired.
+    """
+    from pydantic import ValidationError
+
+    from gflow_cli.tools.invocation import tool_specs_from_invocations
+
+    try:
+        return tool_specs_from_invocations(tools)
+    except ValidationError as exc:
+        log.warning("mcp.tool.invalid_tools", error=str(exc))
+        return {
+            "status": "invalid_tools",
+            "error": (
+                "Each item in 'tools' must be {'name': <slug>, 'options': {k: v}}. "
+                f"Validation failed: {exc}"
+            ),
+        }
+
+
 # ---------------------------------------------------------------------------
 # MCP Tools
 # ---------------------------------------------------------------------------
@@ -131,6 +155,14 @@ async def gflow_generate_image(
             profile=profile,
         )
 
+        # Validate + adapt the agent-supplied tools array to CLI --tool specs now
+        # (fail cleanly on malformed input) even though generation is not yet
+        # wired — the daemon will feed these specs to apply_tool_option.
+        adapted = _adapt_tools(tools)
+        if isinstance(adapted, dict):
+            return adapted
+        tool_specs = adapted
+
         # TODO: Wire to FlowApiClient when daemon integration lands.
         # For now, return a structured placeholder that validates the schema.
         return {
@@ -146,6 +178,7 @@ async def gflow_generate_image(
                 "count": count,
                 "seed": seed,
                 "tools": tools or [],
+                "tool_specs": list(tool_specs),
                 "profile": profile,
             },
         }
@@ -204,6 +237,11 @@ async def gflow_generate_video(
             profile=profile,
         )
 
+        adapted = _adapt_tools(tools)
+        if isinstance(adapted, dict):
+            return adapted
+        tool_specs = adapted
+
         # TODO: Wire to FlowApiClient when daemon integration lands.
         return {
             "status": "pending",
@@ -217,6 +255,7 @@ async def gflow_generate_video(
                 "aspect": aspect,
                 "image_path": image_path,
                 "tools": tools or [],
+                "tool_specs": list(tool_specs),
                 "profile": profile,
             },
         }

--- a/src/gflow_cli/tools/builtin/creative-director.toml
+++ b/src/gflow_cli/tools/builtin/creative-director.toml
@@ -106,6 +106,7 @@ Bad: "photorealistic, 8K, masterpiece"
 
 [[config.domains]]
 name = "cinema"
+category = "image"
 vocabulary = """Cameras: RED V-Raptor, ARRI Alexa 65, Sony Venice 2, Blackmagic URSA.
 Lenses: Cooke S7/i, Zeiss Supreme Prime, Atlas Orion anamorphic.
 Film stocks: Kodak Vision3 500T (tungsten), Kodak Vision3 250D (daylight), Fuji Eterna Vivid.
@@ -115,6 +116,7 @@ Color grading: teal and orange, desaturated cold, warm vintage, high-contrast no
 
 [[config.domains]]
 name = "product"
+category = "image"
 vocabulary = """Surfaces: polished marble, brushed concrete, raw linen, acrylic riser, gradient sweep.
 Lighting: softbox diffused, hard key with fill card, rim separation, tent lighting, light painting.
 Angles: 45-degree hero, flat lay, three-quarter, straight-on, worm's-eye.
@@ -122,6 +124,7 @@ Style refs: Apple product photography, Aesop minimal, Bang & Olufsen clean, luxu
 
 [[config.domains]]
 name = "portrait"
+category = "image"
 vocabulary = """Focal lengths: 85mm (classic bokeh), 105mm (compression), 135mm (telephoto isolation), 50mm (environmental context).
 Apertures: f/1.4 (dreamy bokeh), f/2.8 (subject-sharp), f/5.6 (environmental context visible).
 Pose language: candid mid-gesture, direct-to-camera confrontational, profile silhouette, over-shoulder glance.
@@ -129,6 +132,7 @@ Skin/texture: freckles visible, pores at macro distance, catch light in eyes, su
 
 [[config.domains]]
 name = "editorial"
+category = "image"
 vocabulary = """Publication refs: Vogue Italia, Harper's Bazaar, GQ, National Geographic, Kinfolk.
 Styling notes: layered textures, statement accessories, monochromatic palette, contrast patterns.
 Locations: marble staircase, rooftop at golden hour, industrial loft, desert dunes, neon-lit alley.
@@ -136,6 +140,7 @@ Poses: power stance, relaxed editorial lean, movement blur, fabric in wind."""
 
 [[config.domains]]
 name = "ui"
+category = "image"
 vocabulary = """Styles: flat vector, isometric 3D, line art, glassmorphism, neumorphism, material design.
 Colors: specify exact hex or descriptive palette (e.g., "cool blues #2563EB to #1E40AF").
 Sizing: design at 2x for retina, specify exact pixel dimensions needed.
@@ -143,6 +148,7 @@ Backgrounds: transparent (request solid white then post-process), gradient, soli
 
 [[config.domains]]
 name = "logo"
+category = "image"
 vocabulary = """Construction: geometric primitives, golden ratio, grid-based, negative space.
 Typography: bold sans-serif, elegant serif, custom lettermark, monogram.
 Colors: max 2-3 colors, works in monochrome, high contrast for all sizes.
@@ -150,6 +156,7 @@ Output: request on solid white background, post-process to transparent."""
 
 [[config.domains]]
 name = "landscape"
+category = "image"
 vocabulary = """Depth layers: foreground interest, midground subject, background atmosphere.
 Atmospherics: fog, mist, haze, volumetric light rays, dust particles in sunbeams.
 Time of day: blue hour (pre-dawn), golden hour, magic hour (post-sunset), midnight blue.
@@ -157,6 +164,7 @@ Weather: dramatic storm clouds, clearing after rain, snow-covered, sun-dappled t
 
 [[config.domains]]
 name = "infographic"
+category = "image"
 vocabulary = """Layout: modular sections, clear visual hierarchy, bento grid, flow top-to-bottom.
 Text: use quotes for exact text, descriptive font style, specify size hierarchy (headline / subhead / body).
 Data viz: bar charts, pie charts, flow diagrams, timelines, comparison tables.
@@ -164,6 +172,7 @@ Colors: high-contrast, accessible palette, consistent brand colors throughout.""
 
 [[config.domains]]
 name = "abstract"
+category = "image"
 vocabulary = """Geometry: fractals, voronoi tessellation, spirals, fibonacci sequences, organic flow, crystalline structures.
 Textures: marble veining, fluid dynamics, smoke wisps, ink diffusion, watercolor bleed.
 Color palettes: analogous harmony, complementary clash, monochromatic gradient, neon-on-black.
@@ -173,6 +182,7 @@ Styles: generative art, data visualization art, glitch aesthetic, procedural, ma
 
 [[config.domains]]
 name = "cinematic"
+category = "video"
 vocabulary = """Motion: tracking shots, dolly zoom, slow push-in, handheld verité, crane sweep.
 Timing: slow-motion 120fps, speed ramping, long uncut takes, match-on-action edits.
 Transitions: cross-dissolve, match cut, whip pan, smash cut, J-cut / L-cut.
@@ -180,6 +190,7 @@ Color: teal-orange grade, bleach bypass, desaturated cool, warm vintage film loo
 
 [[config.domains]]
 name = "documentary"
+category = "video"
 vocabulary = """Style: observational fly-on-the-wall, handheld immediacy, direct-to-camera interview.
 Coverage: wide establishing shot, cutaway B-roll, tight reaction close-up, insert detail.
 Pacing: real-time continuous sequence, thematic montage, archival insert, interview talking-head.
@@ -187,6 +198,7 @@ Aesthetic: natural available light, vérité film grain, muted naturalistic colo
 
 [[config.domains]]
 name = "animation"
+category = "video"
 vocabulary = """Style: cel animation, 3D CGI, stop motion, kinetic typography, motion graphics loop.
 Easing: ease-in-out curves, spring bounce, overshoot-and-settle, anticipation and follow-through.
 Visual language: flat 2D vector, isometric 3D world, paper cut-out layering, pixel art.
@@ -194,20 +206,23 @@ Color: bold flat fills, gradient mesh surfaces, neon glow effects, palette-limit
 
 [[config.domains]]
 name = "social"
+category = "video"
 vocabulary = """Format: vertical 9:16 story / Reel, square 1:1 feed post, horizontal 16:9 YouTube.
 Pacing: hook established within first 2 seconds, quick cuts under 3 seconds each, CTA in final 3 seconds.
 Aesthetic: authentic UGC handheld, polished branded production, lo-fi relatable aesthetic.
 Platform: Instagram Reel, TikTok trend, YouTube Shorts, LinkedIn professional video."""
 
 [[config.domains]]
-name = "video-product"
+name = "product"
+category = "video"
 vocabulary = """Movement: 360-degree orbit reveal, slow beauty pass, macro zoom-in on detail, product hero sweep.
 Lighting: studio LED softbox, ring light catchlight, gradient sweep background, practical props.
 Background: infinity white cove, lifestyle context environment, abstract gradient wash.
 Pacing: product reveal build-up, logo sting end card, call-to-action lower-third overlay."""
 
 [[config.domains]]
-name = "video-abstract"
+name = "abstract"
+category = "video"
 vocabulary = """Motion: particle systems cascade, fluid simulation flow, morphing geometric shapes, generative growth.
 Textures: smoke plume, ink-in-water diffusion, chromatic aberration glitch, light leak sweep.
 Color: gradient shift over time, neon on black, complementary color clash pulse, monochromatic breathe.

--- a/src/gflow_cli/tools/invocation.py
+++ b/src/gflow_cli/tools/invocation.py
@@ -1,0 +1,53 @@
+"""Value object describing a tool applied to a generation prompt.
+
+Lives in its own leaf module (stdlib-only imports) so the pure ``api.image`` /
+``api.video`` request DTOs can carry an :class:`AppliedTool` for the recorder
+without importing the heavier ``tools.runtime`` / ``tools.expander`` machinery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gflow_cli.tools.spec import ToolConfig, ToolSpec
+
+
+@dataclass(frozen=True)
+class AppliedTool:
+    """Provenance of one tool applied to a prompt — recorded in
+    ``operations.metadata_json.tool``.
+
+    ``params`` is a sorted tuple of ``(key, value)`` option pairs (hashable, so
+    this dataclass stays frozen/hashable). ``config_hash`` is a tamper-evidence
+    digest of the tool's resolved :class:`~gflow_cli.tools.spec.ToolConfig`,
+    paired with the hand-bumped ``version`` (council D7).
+    """
+
+    name: str
+    version: str
+    model: str
+    config_hash: str
+    params: tuple[tuple[str, str], ...] = ()
+
+    def params_dict(self) -> dict[str, str]:
+        return {k: v for k, v in self.params}
+
+
+def config_hash(config: ToolConfig) -> str:
+    """Stable sha256 of a tool's resolved config (tamper-evidence)."""
+    return hashlib.sha256(config.model_dump_json().encode("utf-8")).hexdigest()
+
+
+def applied_tool_from_spec(spec: ToolSpec, options: dict[str, str]) -> AppliedTool:
+    """Build an :class:`AppliedTool` snapshot from a resolved spec + run options."""
+    params = tuple(sorted((str(k), str(v)) for k, v in options.items()))
+    return AppliedTool(
+        name=spec.name,
+        version=spec.version,
+        model=spec.config.model,
+        config_hash=config_hash(spec.config),
+        params=params,
+    )

--- a/src/gflow_cli/tools/invocation.py
+++ b/src/gflow_cli/tools/invocation.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from gflow_cli.tools.spec import ToolConfig, ToolSpec
@@ -51,3 +53,35 @@ def applied_tool_from_spec(spec: ToolSpec, options: dict[str, str]) -> AppliedTo
         config_hash=config_hash(spec.config),
         params=params,
     )
+
+
+class ToolInvocation(BaseModel):
+    """One MCP-side tool request: ``{"name": str, "options": {k: v}}``.
+
+    Validates agent-supplied input so a malformed ``tools`` array fails cleanly
+    at the MCP boundary instead of as an uncaught ``TypeError`` once generation
+    is wired. ``to_spec`` renders the CLI ``--tool name[:k=v,...]`` form so the
+    MCP surface and the CLI share one tool-application path (council D3).
+    """
+
+    model_config = ConfigDict(frozen=True)
+    name: str = Field(pattern=r"^[a-z0-9-]+$")
+    options: dict[str, str] = Field(default_factory=dict)
+
+    def to_spec(self) -> str:
+        if not self.options:
+            return self.name
+        opts = ",".join(f"{k}={v}" for k, v in self.options.items())
+        return f"{self.name}:{opts}"
+
+
+def tool_specs_from_invocations(items: list[dict[str, Any]] | None) -> tuple[str, ...]:
+    """Adapt an MCP ``tools`` array (``list[dict]``) to CLI ``--tool`` specs.
+
+    Returns a tuple of ``name[:k=v,...]`` strings consumable by
+    ``_cli_helpers.apply_tool_option``. Raises ``pydantic.ValidationError`` on a
+    malformed item. Empty / ``None`` input → ``()``.
+    """
+    if not items:
+        return ()
+    return tuple(ToolInvocation.model_validate(item).to_spec() for item in items)

--- a/src/gflow_cli/tools/loader.py
+++ b/src/gflow_cli/tools/loader.py
@@ -34,7 +34,8 @@ def _validate(name: str, data: dict[str, object]) -> ToolSpec:
 def load_builtin_tools() -> dict[str, ToolSpec]:
     tools: dict[str, ToolSpec] = {}
     root = resources.files(_BUILTIN_PACKAGE)
-    for entry in root.iterdir():
+    # Sorted for deterministic load order (stable across platforms / packagers).
+    for entry in sorted(root.iterdir(), key=lambda e: e.name):
         if entry.name.endswith(".toml"):
             label = Path(entry.name).stem  # strip .toml for error labels
             spec = _validate(label, _parse(label, entry.read_text(encoding="utf-8")))

--- a/src/gflow_cli/tools/registry.py
+++ b/src/gflow_cli/tools/registry.py
@@ -2,25 +2,22 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from gflow_cli.errors import ConfigurationError
 from gflow_cli.tools.loader import load_builtin_tools
 from gflow_cli.tools.spec import ToolSpec
 
-# Lowercase: pyright treats UPPERCASE module globals as constants and forbids
-# reassignment (reportConstantRedefinition); this cache is intentionally mutable.
-_registry_cache: dict[str, ToolSpec] | None = None
 
-
+@lru_cache(maxsize=1)
 def _registry() -> dict[str, ToolSpec]:
-    global _registry_cache
-    if _registry_cache is None:
-        _registry_cache = load_builtin_tools()
-    return _registry_cache
+    # Built once, lazily, and memoized — mirrors ``config.get_settings``'s
+    # ``@lru_cache`` discipline. ``reset_registry`` clears it for tests.
+    return load_builtin_tools()
 
 
 def reset_registry() -> None:
-    global _registry_cache
-    _registry_cache = None
+    _registry.cache_clear()
 
 
 def tool_names() -> tuple[str, ...]:

--- a/src/gflow_cli/tools/runtime.py
+++ b/src/gflow_cli/tools/runtime.py
@@ -12,19 +12,24 @@ from gflow_cli.tools.banned import strip_banned_keywords
 from gflow_cli.tools.expander import ExpansionResult, PromptExpander
 
 if TYPE_CHECKING:
-    from gflow_cli.tools.spec import ToolConfig, ToolSpec
+    from gflow_cli.tools.spec import DomainCategory, ToolConfig, ToolSpec
 
 log = structlog.get_logger(__name__)
 
 
-def build_instruction(config: ToolConfig, style: str | None) -> str:
+def build_instruction(
+    config: ToolConfig,
+    style: str | None,
+    category: DomainCategory | None = None,
+) -> str:
     # The TOML system_template carries ONLY the formula (no trailing marker);
     # build_instruction appends the user-prompt marker EXACTLY ONCE, after any
     # domain vocabulary — so the domain and no-domain branches never duplicate it.
+    # ``category`` gates which same-named domain (image vs video) is selected.
     parts = [config.system_template.rstrip()]
-    domain = config.domain(style)
+    domain = config.domain(style, category)
     if style is not None and domain is None:
-        log.warning("tool_unknown_style", style=style)
+        log.warning("tool_unknown_style", style=style, category=category)
     if domain is not None:
         parts.append(f"Apply this {domain.name} style vocabulary: {domain.vocabulary}")
     return "\n\n".join(parts) + "\n\nUser prompt: "
@@ -35,10 +40,11 @@ def apply_tool(
     prompt: str,
     options: Mapping[str, str],
     *,
+    category: DomainCategory | None = None,
     expander: PromptExpander | None = None,
 ) -> ExpansionResult:
     style = options.get("style")
-    instruction = build_instruction(spec.config, style)
+    instruction = build_instruction(spec.config, style, category)
     if expander is None:
         settings = get_settings()
         expander = PromptExpander(

--- a/src/gflow_cli/tools/spec.py
+++ b/src/gflow_cli/tools/spec.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# A domain may target image generation, video generation, or both. "both" is
+# the permissive default so a domain with no explicit category matches either.
+DomainCategory = Literal["image", "video", "both"]
 
 
 class DomainMode(BaseModel):
     model_config = ConfigDict(frozen=True)
     name: str
     vocabulary: str
+    # Which generation category this domain applies to. Lets an image style and
+    # a video style share a name (e.g. "product") without colliding — the
+    # ``ToolConfig.domain()`` lookup disambiguates by category. (review fold-in)
+    category: DomainCategory = "both"
 
 
 class ToolConfig(BaseModel):
@@ -22,11 +32,24 @@ class ToolConfig(BaseModel):
     max_input_chars: int = 4000
     max_output_chars: int = 3500
 
-    def domain(self, name: str | None) -> DomainMode | None:
+    def domain(self, name: str | None, category: DomainCategory | None = None) -> DomainMode | None:
+        """Resolve a domain by *name*, optionally gated to a *category*.
+
+        With ``category=None`` the first name match wins (category-agnostic,
+        used by the standalone ``gflow tools run`` preview). With a concrete
+        ``"image"``/``"video"`` category, only a domain that targets that
+        category (or ``"both"``) matches — so an image style is invisible to a
+        video generation and vice versa.
+        """
         if name is None:
             return None
         lowered = name.lower()
-        return next((d for d in self.domains if d.name.lower() == lowered), None)
+        for d in self.domains:
+            if d.name.lower() != lowered:
+                continue
+            if category is None or d.category in (category, "both"):
+                return d
+        return None
 
 
 class ToolSpec(BaseModel):
@@ -40,8 +63,16 @@ class ToolSpec(BaseModel):
     author: str = "gflow"
     version: str
     requires_env: tuple[str, ...] = ()
-    options_schema: dict[str, str] = {}
+    options_schema: Mapping[str, str] = Field(default_factory=dict)
     config: ToolConfig
+
+    @field_validator("options_schema", mode="after")
+    @classmethod
+    def _freeze_options_schema(cls, value: Mapping[str, str]) -> Mapping[str, str]:
+        # The model is frozen, but a plain dict attribute would still be mutable
+        # in place. Wrap it read-only so a tool's declared schema is truly
+        # immutable post-load. (review fold-in)
+        return MappingProxyType(dict(value))
 
     def supports(self, category: Literal["image", "video"]) -> bool:
         return self.category in (category, "both")

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -460,6 +460,57 @@ class TestImageI2I:
         assert len(req.ref_paths) == 1
         assert req.ref_paths[0] == png.resolve()
 
+    def test_i2i_applies_tool_and_records_provenance(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--tool` on i2i rewrites the prompt and threads original_prompt + tool
+        onto the GenerateImageRequest for recording (PR2 broaden)."""
+        from gflow_cli import cli_image
+        from gflow_cli.tools.invocation import AppliedTool
+
+        png = tmp_path / "hero.png"
+        png.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = _make_i2i_client(upload_uuid="unused")
+        out_dir = tmp_path / "out"
+        sentinel = AppliedTool(
+            name="creative-director", version="1", model="gemini-2.5-flash", config_hash="z" * 64
+        )
+
+        def fake_apply(text, tool_specs, *, category, quiet):  # noqa: ANN001, ANN202
+            assert category == "image"
+            return "EXPANDED CINEMATIC", text, sentinel
+
+        monkeypatch.setattr(cli_image, "apply_tool_option", fake_apply)
+
+        with (
+            patch("gflow_cli.cli_image.FlowApiClient", return_value=client),
+            patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path / "prof"),
+            patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        ):
+            from gflow_cli.cli import main
+
+            result = runner.invoke(
+                main,
+                [
+                    "image",
+                    "i2i",
+                    "make it cinematic",
+                    "--ref",
+                    str(png),
+                    "--tool",
+                    "creative-director",
+                    "--out",
+                    str(out_dir),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        req = client.generate_image.await_args.kwargs["req"]
+        assert req.prompt == "EXPANDED CINEMATIC"
+        assert req.original_prompt == "make it cinematic"
+        assert req.tool is sentinel
+
     def test_i2i_passes_through_uuid_refs(self, runner: CliRunner, tmp_path: Path) -> None:
         """Bare-UUID --ref must NOT trigger upload_image and must be used verbatim."""
         uuid_str = "ddb6ef97-262d-49f4-8269-4a28c0fae6a2"

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from gflow_cli.cli_video import video
@@ -793,3 +794,106 @@ def test_t2v_help_shows_tool_option() -> None:
     result = CliRunner().invoke(main, ["video", "t2v", "--help"])
     assert "--tool" in result.output
     assert "--expand" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --tool broaden (PR2 §8): i2v / r2v / chain.
+# ---------------------------------------------------------------------------
+
+
+def _tool_sentinel() -> object:
+    from gflow_cli.tools.invocation import AppliedTool
+
+    return AppliedTool(
+        name="creative-director", version="1", model="gemini-2.5-flash", config_hash="z" * 64
+    )
+
+
+def test_i2v_run_threads_tool_provenance(tmp_path: Path) -> None:
+    import asyncio
+
+    from gflow_cli.cli_video import _run_i2v
+
+    captured: dict[str, object] = {}
+
+    async def _capture(request: object, **_kwargs: object) -> None:
+        captured["request"] = request
+
+    start = tmp_path / "start.png"
+    start.write_bytes(b"\x89PNG\r\n\x1a\n")
+    tool = _tool_sentinel()
+
+    with patch("gflow_cli.cli_video._generate_and_report", new=_capture):
+        asyncio.run(
+            _run_i2v(
+                profile_name="default",
+                profile_dir=tmp_path,
+                image=str(start),
+                prompt="EXPANDED",
+                aspect="9:16",
+                out_dir=None,
+                original_prompt="cat",
+                tool=tool,  # type: ignore[arg-type]
+            )
+        )
+
+    request = captured["request"]
+    assert request.original_prompt == "cat"  # type: ignore[attr-defined]
+    assert request.tool is tool  # type: ignore[attr-defined]
+
+
+def test_r2v_run_threads_tool_provenance(tmp_path: Path) -> None:
+    import asyncio
+
+    from gflow_cli.cli_video import _run_r2v
+
+    captured: dict[str, object] = {}
+
+    async def _capture(request: object, **_kwargs: object) -> None:
+        captured["request"] = request
+
+    ref = tmp_path / "ref.png"
+    ref.write_bytes(b"\x89PNG\r\n\x1a\n")
+    tool = _tool_sentinel()
+
+    with patch("gflow_cli.cli_video._generate_and_report", new=_capture):
+        asyncio.run(
+            _run_r2v(
+                profile_name="default",
+                profile_dir=tmp_path,
+                prompt="EXPANDED",
+                refs=(str(ref),),
+                aspect="9:16",
+                out_dir=None,
+                model="omni-flash",
+                original_prompt="cat",
+                tool=tool,  # type: ignore[arg-type]
+            )
+        )
+
+    request = captured["request"]
+    assert request.original_prompt == "cat"  # type: ignore[attr-defined]
+    assert request.tool is tool  # type: ignore[attr-defined]
+
+
+def test_apply_tools_to_chain_links_rewrites_each_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gflow_cli import cli_video
+    from gflow_cli.chain import ChainLinkSpec
+
+    def fake_apply(text, tool_specs, *, category, quiet):  # noqa: ANN001, ANN202
+        assert category == "video"
+        return f"X:{text}", text, "TOOLOBJ"
+
+    monkeypatch.setattr(cli_video, "apply_tool_option", fake_apply)
+    links = [ChainLinkSpec(prompt="a"), ChainLinkSpec(prompt="b")]
+    out = cli_video._apply_tools_to_chain_links(links, ("creative-director",))
+    assert [link.prompt for link in out] == ["X:a", "X:b"]
+    assert [link.original_prompt for link in out] == ["a", "b"]
+    assert all(link.tool == "TOOLOBJ" for link in out)
+
+
+def test_tool_option_present_on_video_generation_commands() -> None:
+    runner = CliRunner()
+    for cmd in ("t2v", "i2v", "r2v", "chain"):
+        result = runner.invoke(video, [cmd, "--help"])
+        assert "--tool" in result.output, f"{cmd} --help missing --tool"

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -161,9 +161,10 @@ def test_make_provider_dir_exits_when_profile_missing(
 def test_apply_tool_option_no_tools_is_identity() -> None:
     from gflow_cli._cli_helpers import apply_tool_option
 
-    sent, original = apply_tool_option("cat", (), category="image", quiet=True)
+    sent, original, applied = apply_tool_option("cat", (), category="image", quiet=True)
     assert sent == "cat"
     assert original is None
+    assert applied is None
 
 
 def test_apply_tool_option_unknown_tool_raises_usage_error() -> None:
@@ -187,11 +188,17 @@ def test_apply_tool_option_runs_creative_director(monkeypatch: pytest.MonkeyPatc
             original=text, expanded="EXPANDED", was_expanded=True
         ),
     )
-    sent, original = _cli_helpers.apply_tool_option(
+    sent, original, applied = _cli_helpers.apply_tool_option(
         "cat", ("creative-director",), category="image", quiet=True
     )
     assert sent == "EXPANDED"
     assert original == "cat"
+    # The applied-tool snapshot is built from the real spec (not apply_tool's
+    # monkeypatched output) for metadata_json.tool recording.
+    assert applied is not None
+    assert applied.name == "creative-director"
+    assert applied.version == "1"
+    assert len(applied.config_hash) == 64
 
 
 def test_apply_tool_option_wrong_category_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -290,7 +297,7 @@ def test_apply_tool_option_valid_style_does_not_raise(
             original=text, expanded="EXPANDED", was_expanded=True
         ),
     )
-    sent, original = _cli_helpers.apply_tool_option(
+    sent, original, _applied = _cli_helpers.apply_tool_option(
         "cat",
         ("creative-director:style=cinema",),
         category="image",

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -278,9 +278,7 @@ def test_apply_tool_option_rejects_cross_category_style() -> None:
         )
     # "cinema" is an image domain — invalid on a video command.
     with pytest.raises(click.UsageError, match="unknown video style 'cinema'"):
-        apply_tool_option(
-            "cat", ("creative-director:style=cinema",), category="video", quiet=True
-        )
+        apply_tool_option("cat", ("creative-director:style=cinema",), category="video", quiet=True)
 
 
 def test_apply_tool_option_valid_style_does_not_raise(

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -248,12 +248,31 @@ def test_apply_tool_option_unknown_style_raises_usage_error() -> None:
 
     from gflow_cli._cli_helpers import apply_tool_option
 
-    with pytest.raises(click.UsageError, match="unknown style"):
+    with pytest.raises(click.UsageError, match="unknown image style"):
         apply_tool_option(
             "cat",
             ("creative-director:style=cinmaaatic",),
             category="image",
             quiet=True,
+        )
+
+
+def test_apply_tool_option_rejects_cross_category_style() -> None:
+    """An image generation must reject a video-only style and vice versa
+    (category-gated domain resolution, review fold-in)."""
+    import click
+
+    from gflow_cli._cli_helpers import apply_tool_option
+
+    # "cinematic" is a video domain — invalid on an image command.
+    with pytest.raises(click.UsageError, match="unknown image style 'cinematic'"):
+        apply_tool_option(
+            "cat", ("creative-director:style=cinematic",), category="image", quiet=True
+        )
+    # "cinema" is an image domain — invalid on a video command.
+    with pytest.raises(click.UsageError, match="unknown video style 'cinema'"):
+        apply_tool_option(
+            "cat", ("creative-director:style=cinema",), category="video", quiet=True
         )
 
 

--- a/tests/cli/test_t2i_multi_prompt.py
+++ b/tests/cli/test_t2i_multi_prompt.py
@@ -138,13 +138,51 @@ def test_t2i_rejects_multiple_prompt_sources_before_profile_resolution(tmp_path:
     resolve_profile.assert_not_called()
 
 
-def test_t2i_rejects_tool_with_multiple_prompts() -> None:
-    with patch("gflow_cli.cli_image._resolve_profile") as resolve_profile:
-        result = _invoke_t2i(["one", "two", "--tool", "creative-director"])
+def test_t2i_applies_tool_per_prompt_in_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR2 removed the single-prompt --tool guard: a multi-prompt batch now
+    applies the tool to each prompt and carries the provenance per item."""
+    from gflow_cli import cli_image
 
-    assert result.exit_code == 2
-    assert "single-prompt only" in result.output.lower()
-    resolve_profile.assert_not_called()
+    calls: list[str] = []
+
+    def fake_apply(text, tool_specs, *, category, quiet):  # noqa: ANN001, ANN202
+        calls.append(text)
+        return f"EXPANDED:{text}", text, None
+
+    captured: dict[str, object] = {}
+
+    def fake_exec(batch_prompts, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        captured["items"] = batch_prompts
+
+    monkeypatch.setattr(cli_image, "apply_tool_option", fake_apply)
+    monkeypatch.setattr(cli_image, "_execute_t2i_batch", fake_exec)
+
+    result = _invoke_t2i(["one", "two", "--tool", "creative-director"])
+
+    assert result.exit_code == 0
+    # The tool is applied once per prompt (no single-prompt rejection).
+    assert calls == ["one", "two"]
+    items = captured["items"]
+    assert [it.text for it in items] == ["EXPANDED:one", "EXPANDED:two"]  # type: ignore[union-attr]
+    assert [it.original_prompt for it in items] == ["one", "two"]  # type: ignore[union-attr]
+
+
+def test_apply_tools_to_batch_prompts_unit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gflow_cli import cli_image
+    from gflow_cli.image_batch import BatchPromptItem
+
+    def fake_apply(text, tool_specs, *, category, quiet):  # noqa: ANN001, ANN202
+        assert category == "image"
+        return f"X:{text}", text, "TOOLOBJ"
+
+    monkeypatch.setattr(cli_image, "apply_tool_option", fake_apply)
+    items = (BatchPromptItem(text="a", index=0), BatchPromptItem(text="b", index=1))
+    out = cli_image._apply_tools_to_batch_prompts(items, ("creative-director",))
+    assert [i.text for i in out] == ["X:a", "X:b"]
+    assert [i.original_prompt for i in out] == ["a", "b"]
+    assert all(i.tool == "TOOLOBJ" for i in out)
+    # index/aspect/model preserved
+    assert [i.index for i in out] == [0, 1]
 
 
 def test_t2i_rejects_empty_stdin_before_profile_resolution() -> None:

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from pathlib import Path
 
 from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
@@ -103,12 +105,13 @@ def test_record_generated_images_persists_original_and_expanded_prompt(tmp_path:
     with DataStore.open(tmp_path / "gflow.db") as store:
         recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
         project = ProjectInfo(project_id="flow-project-1", title="gflow-cli t2i")
-        # The request carries the EXPANDED prompt (what was submitted to Flow);
-        # the user's original prompt is passed separately.
+        # The request carries the EXPANDED prompt (what was submitted to Flow)
+        # AND the user's original prompt (recorder reads both off the request).
         req = GenerateImageRequest(
             prompt="a richly detailed expanded prompt",
             aspect=Aspect.PORTRAIT,
             model=Model.NARWHAL,
+            original_prompt="cat in space",
         )
         recorder.record_generated_images(
             profile_name="default",
@@ -119,7 +122,6 @@ def test_record_generated_images_persists_original_and_expanded_prompt(tmp_path:
             saved_paths=[saved],
             input_media_ids=[],
             operation_kind="t2i",
-            original_prompt="cat in space",
         )
         row = store.conn.execute(
             "SELECT prompt, expanded_prompt, prompt_redacted FROM operations WHERE mode='t2i'"
@@ -140,6 +142,7 @@ def test_expanded_prompt_withheld_when_history_redacted(tmp_path: Path) -> None:
             prompt="a richly detailed expanded prompt",
             aspect=Aspect.PORTRAIT,
             model=Model.NARWHAL,
+            original_prompt="cat in space",
         )
         recorder.record_generated_images(
             profile_name="default",
@@ -150,7 +153,6 @@ def test_expanded_prompt_withheld_when_history_redacted(tmp_path: Path) -> None:
             saved_paths=[saved],
             input_media_ids=[],
             operation_kind="t2i",
-            original_prompt="cat in space",
         )
         row = store.conn.execute(
             "SELECT prompt, prompt_hash, expanded_prompt, prompt_redacted "
@@ -198,6 +200,7 @@ def test_record_started_video_persists_expanded_prompt(tmp_path: Path) -> None:
             prompt="a cinematic expanded video prompt",
             mode=Mode.T2V,
             aspect=VideoAspect.PORTRAIT,
+            original_prompt="a dog surfing",
         )
         recorder.record_started_video(
             profile_name="default",
@@ -208,7 +211,6 @@ def test_record_started_video_persists_expanded_prompt(tmp_path: Path) -> None:
                 project_id="flow-project-video-1",
                 flow_operation_id="operation-video-1",
             ),
-            original_prompt="a dog surfing",
         )
         row = store.conn.execute(
             "SELECT prompt, expanded_prompt FROM operations WHERE mode='t2v'"
@@ -346,3 +348,141 @@ def test_record_completed_video_with_cloud_storage_uses_cloud_columns(
         assert asset is not None
         assert asset.local_files[0].path is None
         assert asset.local_files[0].cloud_uri == cloud_info.uri
+
+
+# ---------------------------------------------------------------------------
+# metadata_json.tool — applied-tool provenance (PR2 §8)
+# ---------------------------------------------------------------------------
+
+
+def _applied_tool() -> object:
+    from gflow_cli.tools.invocation import AppliedTool
+
+    return AppliedTool(
+        name="creative-director",
+        version="1",
+        model="gemini-2.5-flash",
+        config_hash="a" * 64,
+        params=(("style", "cinema"),),
+    )
+
+
+def _op_tool_meta(store: DataStore, mode: str) -> dict[str, object]:
+    row = store.conn.execute(
+        "SELECT metadata_json FROM operations WHERE mode = ?", (mode,)
+    ).fetchone()
+    assert row["metadata_json"]
+    return json.loads(row["metadata_json"])["tool"]
+
+
+def test_record_generated_images_persists_tool_metadata_store_mode(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(
+            prompt="a richly detailed expanded prompt",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            original_prompt="cat",
+            tool=_applied_tool(),  # type: ignore[arg-type]
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        tool = _op_tool_meta(store, "t2i")
+        assert tool["name"] == "creative-director"
+        assert tool["version"] == "1"
+        assert tool["model"] == "gemini-2.5-flash"
+        assert tool["params"] == {"style": "cinema"}
+        assert tool["config_hash"] == "a" * 64
+        # Store mode does NOT carry a params_hash (the raw params are stored).
+        assert "params_hash" not in tool
+
+
+def test_record_generated_images_redacts_tool_metadata(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="redacted")
+        req = GenerateImageRequest(
+            prompt="expanded",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            original_prompt="cat",
+            tool=_applied_tool(),  # type: ignore[arg-type]
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        tool = _op_tool_meta(store, "t2i")
+        # Redacted mode stores only name/version/params_hash/config_hash — never
+        # the raw model or free-text params (redact_metadata wouldn't catch them).
+        assert tool == {
+            "name": "creative-director",
+            "version": "1",
+            "params_hash": hashlib.sha256(
+                json.dumps({"style": "cinema"}, sort_keys=True).encode("utf-8")
+            ).hexdigest(),
+            "config_hash": "a" * 64,
+        }
+        assert "model" not in tool
+        assert "params" not in tool
+
+
+def test_record_generated_images_without_tool_writes_no_tool_metadata(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(prompt="cat", aspect=Aspect.PORTRAIT, model=Model.NARWHAL)
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        row = store.conn.execute("SELECT metadata_json FROM operations WHERE mode='t2i'").fetchone()
+        # No tool applied → metadata_json carries no tool key (NULL or no 'tool').
+        meta = json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+        assert "tool" not in meta
+
+
+def test_record_started_video_persists_tool_metadata(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="expanded video prompt",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+            original_prompt="a dog",
+            tool=_applied_tool(),  # type: ignore[arg-type]
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(media_id="m1", project_id="pv1", flow_operation_id="o1"),
+        )
+        tool = _op_tool_meta(store, "t2v")
+        assert tool["name"] == "creative-director"
+        assert tool["model"] == "gemini-2.5-flash"
+        assert tool["params"] == {"style": "cinema"}

--- a/tests/e2e/test_tools_e2e.py
+++ b/tests/e2e/test_tools_e2e.py
@@ -53,13 +53,19 @@ def _run_gflow(
     args: list[str], *, env: dict[str, str], timeout: int
 ) -> subprocess.CompletedProcess[str]:
     """Run `python -m gflow_cli <args>` as an isolated subprocess (real CLI path)."""
+    sub_env = dict(env)
+    # The autouse `_isolate_settings` fixture points GFLOW_CLI_HOME at a per-test
+    # tmp dir, which `e2e_env` copies — but the real authenticated profiles live
+    # under the DEFAULT home. Drop it so the subprocess resolves the real profile;
+    # the DB and output dir stay isolated via their own explicit env vars.
+    sub_env.pop("GFLOW_CLI_HOME", None)
     return subprocess.run(
         [sys.executable, "-m", "gflow_cli", *args],
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
-        env=env,
+        env=sub_env,
     )
 
 

--- a/tests/e2e/test_tools_e2e.py
+++ b/tests/e2e/test_tools_e2e.py
@@ -1,0 +1,195 @@
+"""Live e2e for the Tools framework (`--tool creative-director`).
+
+Verifies, against the real Flow API, that applying a tool before generation
+(a) still produces real media and (b) records the applied-tool provenance in the
+local catalog — `operations.prompt` = the user's ORIGINAL prompt,
+`operations.expanded_prompt` = the submitted Gemini expansion, and
+`operations.metadata_json.tool` = the `{name, version, model, params, config_hash}`
+snapshot.
+
+Gating (all opt-in):
+- `GFLOW_CLI_E2E_PROFILE` — a logged-in Chrome-strategy profile (handled by the
+  `e2e_env` fixture; the test is skipped without it).
+- `GFLOW_CLI_GEMINI_API_KEY` — REQUIRED here: the tool is never-fatal and falls
+  back to the original prompt without a key, in which case NO expansion happens
+  and `metadata_json.tool` is (correctly) not written. So these tests skip
+  without the key — otherwise they would assert on provenance that, by design,
+  is only recorded when the prompt was actually rewritten.
+- `GFLOW_CLI_E2E_RUN_VIDEO=1` — the video case additionally gates on this (Veo
+  credits), mirroring `test_data_layer_e2e.py`.
+
+Run:
+    GFLOW_CLI_E2E_PROFILE=<profile> GFLOW_CLI_GEMINI_API_KEY=<key> \
+        pytest -m e2e_image tests/e2e/test_tools_e2e.py
+    # + GFLOW_CLI_E2E_RUN_VIDEO=1 and -m e2e_video for the video case.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_GEMINI_KEY_ENV = "GFLOW_CLI_GEMINI_API_KEY"
+_E2E_RUN_VIDEO_ENV = "GFLOW_CLI_E2E_RUN_VIDEO"
+
+# Terse prompts so the Creative Director has something to expand.
+_IMAGE_PROMPT = "a red fox in snow"
+_VIDEO_PROMPT = "a paper boat drifting downstream"
+_TOOL = "creative-director"
+_IMAGE_TIMEOUT_S = 240
+_VIDEO_TIMEOUT_S = 600
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _run_gflow(
+    args: list[str], *, env: dict[str, str], timeout: int
+) -> subprocess.CompletedProcess[str]:
+    """Run `python -m gflow_cli <args>` as an isolated subprocess (real CLI path)."""
+    return subprocess.run(
+        [sys.executable, "-m", "gflow_cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+    )
+
+
+def _open_db(env: dict[str, str]):  # noqa: ANN202 — sqlite3.Connection, imported lazily
+    import sqlite3
+
+    db_path = Path(env["GFLOW_CLI_DB_PATH"])
+    assert db_path.exists(), f"data layer never wrote to {db_path}"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _require_gemini_key() -> None:
+    if not os.environ.get(_GEMINI_KEY_ENV, "").strip():
+        pytest.skip(
+            f"{_GEMINI_KEY_ENV} unset — the tool falls back to the original prompt "
+            "and records no metadata_json.tool, so there is nothing to verify."
+        )
+
+
+def _assert_tool_metadata(meta_json: str | None, *, model: str = "gemini-2.5-flash") -> None:
+    """Assert the operations.metadata_json.tool provenance shape."""
+    assert meta_json, "metadata_json is empty — the tool snapshot was not recorded"
+    meta = json.loads(meta_json)
+    tool = meta.get("tool")
+    assert isinstance(tool, dict), f"metadata_json.tool not a dict: {meta!r}"
+    assert tool["name"] == _TOOL
+    assert tool["model"] == model
+    # config_hash is a sha256 hexdigest; version is the hand-bumped tool version.
+    assert len(tool["config_hash"]) == 64
+    assert tool["version"]
+
+
+@pytest.mark.e2e_image
+@pytest.mark.e2e_data
+def test_t2i_with_tool_records_provenance(e2e_env: dict[str, str]) -> None:
+    """`image t2i --tool creative-director` generates a real image AND records the
+    original prompt, the expansion, and the tool snapshot."""
+    _require_gemini_key()
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    out_dir = Path(e2e_env["GFLOW_CLI_OUTPUT_DIR"])
+
+    result = _run_gflow(
+        ["image", "t2i", _IMAGE_PROMPT, "--aspect", "1:1", "--tool", _TOOL, "--profile", profile],
+        env=e2e_env,
+        timeout=_IMAGE_TIMEOUT_S,
+    )
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    images = [
+        p
+        for p in sorted(out_dir.rglob("*"))
+        if p.is_file() and p.suffix.lower() in (".png", ".jpg", ".jpeg", ".webp")
+    ]
+    assert images, "no image written"
+    assert images[0].stat().st_size > 1024
+    assert images[0].read_bytes()[:8] == _PNG_MAGIC
+
+    conn = _open_db(e2e_env)
+    try:
+        op = conn.execute(
+            "SELECT prompt, expanded_prompt, prompt_redacted, metadata_json "
+            "FROM operations WHERE mode='t2i'"
+        ).fetchone()
+        assert op is not None, "no t2i operation recorded"
+        # prompt column = the user's ORIGINAL terse prompt; the expansion is stored
+        # separately (history_prompts=store in the e2e_env fixture).
+        assert op["prompt"] == _IMAGE_PROMPT
+        assert op["prompt_redacted"] == 0
+        assert op["expanded_prompt"], "expanded_prompt not recorded"
+        assert op["expanded_prompt"] != _IMAGE_PROMPT, "prompt was not actually expanded"
+        _assert_tool_metadata(op["metadata_json"])
+    finally:
+        conn.close()
+
+
+@pytest.mark.e2e_video
+@pytest.mark.e2e_data
+def test_t2v_with_tool_records_provenance(e2e_env: dict[str, str]) -> None:
+    """`video t2v --tool creative-director` generates a real video AND records the
+    tool snapshot on the (started→succeeded) operation."""
+    if os.environ.get(_E2E_RUN_VIDEO_ENV, "0").strip() != "1":
+        pytest.skip(f"{_E2E_RUN_VIDEO_ENV}=0 — skipping live Veo run")
+    _require_gemini_key()
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    out_dir = Path(e2e_env["GFLOW_CLI_OUTPUT_DIR"])
+
+    result = _run_gflow(
+        # t2v ignores GFLOW_CLI_OUTPUT_DIR — pass --out-dir explicitly. Cheapest
+        # config: omni-flash / 4s / 1 output.
+        [
+            "video",
+            "t2v",
+            _VIDEO_PROMPT,
+            "--aspect",
+            "16:9",
+            "--model",
+            "omni-flash",
+            "--duration",
+            "4",
+            "--count",
+            "1",
+            "--tool",
+            _TOOL,
+            "--profile",
+            profile,
+            "--out-dir",
+            str(out_dir),
+        ],
+        env=e2e_env,
+        timeout=_VIDEO_TIMEOUT_S,
+    )
+    assert result.returncode == 0, f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    videos = [p for p in sorted(out_dir.rglob("*")) if p.is_file() and p.suffix.lower() == ".mp4"]
+    assert videos, "no video written"
+    assert videos[0].stat().st_size > 100 * 1024
+    assert videos[0].read_bytes()[4:8] == b"ftyp"
+
+    conn = _open_db(e2e_env)
+    try:
+        rows = conn.execute(
+            "SELECT status, prompt, expanded_prompt, metadata_json FROM operations WHERE mode='t2v'"
+        ).fetchall()
+        succeeded = [r for r in rows if r["status"] == "succeeded"]
+        assert succeeded, f"no succeeded t2v operation; rows={[dict(r) for r in rows]}"
+        op = succeeded[0]
+        assert op["prompt"] == _VIDEO_PROMPT
+        assert op["expanded_prompt"] and op["expanded_prompt"] != _VIDEO_PROMPT
+        _assert_tool_metadata(op["metadata_json"])
+    finally:
+        conn.close()

--- a/tests/features/test_image_steps.py
+++ b/tests/features/test_image_steps.py
@@ -85,7 +85,6 @@ def _make_fake_t2i(file_count: int):
         transport: str | None = None,
         project_id: str | None = None,
         as_json: bool = False,
-        original_prompt: str | None = None,
     ) -> None:
         # Honor ``count`` if the scenario set it; otherwise fall back to the
         # builder-bound ``file_count`` (lets us write exactly the right

--- a/tests/features/test_locale_picker_include_steps.py
+++ b/tests/features/test_locale_picker_include_steps.py
@@ -94,7 +94,6 @@ def _mock_recording_runner(monkeypatch: pytest.MonkeyPatch, runner_state: dict[s
         transport: str | None = None,
         project_id: str | None = None,
         as_json: bool = False,
-        original_prompt: str | None = None,
     ) -> None:
         runner_state["req"] = req
         base = out if out is not None else output_root / "images"

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -221,6 +221,38 @@ class TestToolExecution:
         assert result["params"]["mode"] == "t2v"
 
     @pytest.mark.asyncio
+    async def test_generate_image_adapts_tools_to_specs(self) -> None:
+        """A valid MCP `tools` array is adapted to CLI --tool specs in params."""
+        from gflow_cli.mcp.tools import gflow_generate_image
+
+        result = await gflow_generate_image(
+            prompt="a cat",
+            tools=[{"name": "creative-director", "options": {"style": "cinema"}}],
+        )
+        assert result["status"] == "pending"
+        assert result["params"]["tool_specs"] == ["creative-director:style=cinema"]
+
+    @pytest.mark.asyncio
+    async def test_generate_image_rejects_malformed_tools(self) -> None:
+        """A malformed `tools` item returns a clean invalid_tools error."""
+        from gflow_cli.mcp.tools import gflow_generate_image
+
+        result = await gflow_generate_image(prompt="a cat", tools=[{"options": {"style": "x"}}])
+        assert result["status"] == "invalid_tools"
+        assert "tools" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_generate_video_adapts_tools_to_specs(self) -> None:
+        from gflow_cli.mcp.tools import gflow_generate_video
+
+        result = await gflow_generate_video(
+            prompt="a dog",
+            tools=[{"name": "creative-director"}],
+        )
+        assert result["status"] == "pending"
+        assert result["params"]["tool_specs"] == ["creative-director"]
+
+    @pytest.mark.asyncio
     async def test_list_projects_returns_empty_list(self) -> None:
         """gflow_list_projects should return an empty list when no data."""
         from gflow_cli.mcp.tools import gflow_list_projects

--- a/tests/tools/test_invocation.py
+++ b/tests/tools/test_invocation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from gflow_cli.tools.invocation import applied_tool_from_spec, config_hash
+from gflow_cli.tools.spec import ToolConfig, ToolSpec
+
+
+def _spec() -> ToolSpec:
+    return ToolSpec(
+        name="creative-director",
+        title="Creative Director",
+        description="d",
+        category="both",
+        version="3",
+        config=ToolConfig(system_template="t", model="gemini-2.5-flash"),
+    )
+
+
+def test_applied_tool_from_spec_snapshots_fields() -> None:
+    at = applied_tool_from_spec(_spec(), {"style": "cinema"})
+    assert at.name == "creative-director"
+    assert at.version == "3"
+    assert at.model == "gemini-2.5-flash"
+    assert at.params == (("style", "cinema"),)
+    assert at.params_dict() == {"style": "cinema"}
+    assert len(at.config_hash) == 64  # sha256 hexdigest
+
+
+def test_applied_tool_is_frozen_hashable() -> None:
+    at = applied_tool_from_spec(_spec(), {})
+    assert at.params == ()
+    # Frozen + hashable (params is a tuple of pairs, not a dict).
+    assert isinstance(hash(at), int)
+
+
+def test_config_hash_is_stable_and_sensitive() -> None:
+    spec_a = _spec()
+    spec_b = _spec().model_copy(update={"version": "99"})  # version not in config
+    # Same config → same hash regardless of spec-level version.
+    assert config_hash(spec_a.config) == config_hash(spec_b.config)
+    spec_c = ToolSpec(
+        name="x",
+        title="x",
+        description="d",
+        category="both",
+        version="1",
+        config=ToolConfig(system_template="DIFFERENT", model="gemini-2.5-flash"),
+    )
+    assert config_hash(spec_a.config) != config_hash(spec_c.config)

--- a/tests/tools/test_invocation.py
+++ b/tests/tools/test_invocation.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from gflow_cli.tools.invocation import applied_tool_from_spec, config_hash
+import pytest
+from pydantic import ValidationError
+
+from gflow_cli.tools.invocation import (
+    ToolInvocation,
+    applied_tool_from_spec,
+    config_hash,
+    tool_specs_from_invocations,
+)
 from gflow_cli.tools.spec import ToolConfig, ToolSpec
 
 
@@ -46,3 +54,35 @@ def test_config_hash_is_stable_and_sensitive() -> None:
         config=ToolConfig(system_template="DIFFERENT", model="gemini-2.5-flash"),
     )
     assert config_hash(spec_a.config) != config_hash(spec_c.config)
+
+
+def test_tool_invocation_to_spec() -> None:
+    assert ToolInvocation(name="creative-director").to_spec() == "creative-director"
+    assert (
+        ToolInvocation(name="creative-director", options={"style": "cinema"}).to_spec()
+        == "creative-director:style=cinema"
+    )
+
+
+def test_tool_invocation_rejects_bad_name() -> None:
+    with pytest.raises(ValidationError):
+        ToolInvocation(name="Bad Name!")
+
+
+def test_tool_specs_from_invocations_adapts_list() -> None:
+    assert tool_specs_from_invocations(None) == ()
+    assert tool_specs_from_invocations([]) == ()
+    specs = tool_specs_from_invocations(
+        [
+            {"name": "creative-director", "options": {"style": "cinema"}},
+            {"name": "creative-director"},
+        ]
+    )
+    assert specs == ("creative-director:style=cinema", "creative-director")
+
+
+def test_tool_specs_from_invocations_raises_on_malformed() -> None:
+    with pytest.raises(ValidationError):
+        tool_specs_from_invocations([{"options": {"style": "cinema"}}])  # missing name
+    with pytest.raises(ValidationError):
+        tool_specs_from_invocations([{"name": "Bad Name!"}])

--- a/tests/tools/test_spec.py
+++ b/tests/tools/test_spec.py
@@ -59,3 +59,39 @@ def test_name_slug_validated() -> None:
             version="1",
             config=ToolConfig(system_template="t"),
         )
+
+
+def test_domain_category_gating() -> None:
+    """Two domains can share a name when their categories differ; ``domain()``
+    disambiguates by the requested category (review fold-in)."""
+    cfg = ToolConfig(
+        system_template="t",
+        domains=(
+            DomainMode(name="product", vocabulary="IMAGE product vocab", category="image"),
+            DomainMode(name="product", vocabulary="VIDEO product vocab", category="video"),
+            DomainMode(name="cinema", vocabulary="image cinema", category="image"),
+        ),
+    )
+    # category=None → first name match (backward compatible).
+    assert cfg.domain("product").vocabulary == "IMAGE product vocab"
+    # category gates which "product" is returned.
+    assert cfg.domain("product", "image").vocabulary == "IMAGE product vocab"
+    assert cfg.domain("product", "video").vocabulary == "VIDEO product vocab"
+    # an image-only domain is invisible to a video request.
+    assert cfg.domain("cinema", "video") is None
+    assert cfg.domain("cinema", "image").vocabulary == "image cinema"
+
+
+def test_domain_both_category_matches_any() -> None:
+    cfg = ToolConfig(
+        system_template="t",
+        domains=(DomainMode(name="universal", vocabulary="v"),),  # default category="both"
+    )
+    assert cfg.domain("universal", "image").vocabulary == "v"
+    assert cfg.domain("universal", "video").vocabulary == "v"
+
+
+def test_options_schema_is_immutable() -> None:
+    spec = _spec()
+    with pytest.raises(TypeError):
+        spec.options_schema["style"] = "mutated"  # type: ignore[index]


### PR DESCRIPTION
## Summary

PR **2 of 3** for the Tools framework (follows #210). Broadens the `--tool` surface to every generation command, records applied-tool provenance in the catalog, and folds in the deferred PR1 code-review items.

### Broaden `--tool` (spec §8)
- Wired into `image i2i` / `batch` (multi-prompt) / manifest `batch`, and `video i2v` / `r2v` / `chain` — previously only `t2i` / `t2v`. The single-prompt guard is removed; batches/chains apply the tool per prompt/link (sequential, never-fatal; unknown tool/style fails fast pre-network).
- Reusable `tool_option` Click decorator (DRY across all six commands).

### Record `metadata_json.tool` (spec §8, council D7)
- `GenerateImageRequest` / `GenerateVideoRequest` gain `original_prompt` + `tool` fields (frozen, ignored by body builders). The recorder reads `request.original_prompt` instead of a separate kwarg — they can no longer drift apart (prior-review silent-misrecord hazard).
- New `AppliedTool` value object (`tools/invocation.py`); recorder writes `operations.metadata_json.tool = {name, version, model, params, config_hash}` via a redaction-aware helper that branches on `PromptMode` (redacted → `{name, version, params_hash, config_hash}` only). Rides the existing post-success safety wrapper. No migration (reuses `metadata_json`).

### Deferred review items folded in
- `DomainMode.category` + `ToolConfig.domain(name, category)` gating — image/video styles can share a name without colliding (renamed `video-product`/`video-abstract` back to `product`/`abstract`); cross-category styles now rejected.
- MCP `list[dict]` → CLI tuple adapter + pydantic `ToolInvocation` (`tool_specs_from_invocations`); `gflow_generate_image/video` validate the `tools` container (malformed → clean `invalid_tools`).
- registry `@lru_cache`, immutable `options_schema` (`MappingProxyType`), `load_builtin_tools` `sorted()`.

## Test plan
- [x] `pyright src` clean, `ruff check` + `ruff format` clean
- [x] Full tree green (minus live e2e): **1801 passed, 7 skipped**
- [x] New tests: recorder `metadata_json.tool` (store + redacted + no-tool), DTO/helper provenance, category-gating, batch/i2i/i2v/r2v/chain `--tool` wiring, MCP adapter (valid + malformed)
- [ ] Live e2e (credit-spending; run separately once stable)

## Notes
- Docs (`docs/TOOLS.md`, `docs/PROMPT_EXPANSION.md`) land in PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)