### PR TITLE
chore(workflow): enforce + document the SonarCloud quality gate

### DIFF
--- a/.claude/commands/gflow/pr-council-review.md
+++ b/.claude/commands/gflow/pr-council-review.md
@@ -8,4 +8,10 @@ description: Multi-dimensional LLM council review of an open PR. Five baseline d
 
 > Do **not** call `Skill(skill="pr-council-review")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not registered as Skill-tool-invocable (only `.claude/commands/gflow/*` are). Invoking it errors with `Unknown skill: pr-council-review`. Read the file directly instead.
 
+**Required gate — SonarCloud must be green.** The council reviews the *diff*; it does
+not see SonarCloud's verdict. Before declaring the final verdict, run **`/gflow:sonar`**
+for this PR — the `SonarCloud analysis` gate must be green (zero new issues). A red gate
+is a blocking finding regardless of the council's own conclusions; report it with the
+exact failing conditions and do not call the PR merge-ready until it is green.
+
 Sibling: `/review` is the single-agent Claude-Code built-in (fast, one-pass). Use it for spot-checks; use this command for pre-merge multi-dim audits.

--- a/.claude/commands/gflow/release.md
+++ b/.claude/commands/gflow/release.md
@@ -198,8 +198,10 @@ gh pr create --base main --head chore/release-v<NEW_VERSION> \
   --title "chore(release): v<NEW_VERSION>"
 ```
 
-Wait for PR CI to go green (`gh pr checks <N> --watch`), then merge with a **merge
-commit** — never squash:
+Wait for PR CI to go green (`gh pr checks <N> --watch`). **The `SonarCloud analysis`
+check must be green (gate passed) — not just the test matrix.** If it is red or you
+want the verdict, run `/gflow:sonar <N>` and drive it to zero before merging. Then
+merge with a **merge commit** — never squash:
 
 ```bash
 gh pr merge <N> --merge --delete-branch

--- a/.claude/commands/gflow/sonar.md
+++ b/.claude/commands/gflow/sonar.md
@@ -1,0 +1,82 @@
+---
+description: Check the SonarCloud quality gate for a PR (or the current branch) and drive it to zero. Reports GREEN, or the exact PR-scoped new issues/hotspots/coverage gaps to fix.
+---
+
+# `/gflow:sonar [PR#]` — SonarCloud quality gate
+
+The reusable Sonar primitive. `/gflow:check` is **local** and cannot see Sonar (it
+is server-side, post-push); `/gflow:pr-council-review` is an LLM diff review, not the
+gate verdict. This command answers one question: **is the SonarCloud gate green
+(zero new issues) for this PR, and if not, exactly what must be fixed?**
+
+`$ARGUMENTS` is the PR number. If empty, resolve it from the current branch
+(`gh pr view --json number -q .number`).
+
+Project: key `ffroliva_gflow-cli`, org `ffroliva-github` (see `sonar-project.properties`).
+The CI scan sets `sonar.qualitygate.wait=true`, so a **green `SonarCloud analysis`
+check means the gate genuinely passed** — but the gate **API is stale until that
+check finishes**, so always check the GitHub check FIRST.
+
+## Steps
+
+**1. Check the GitHub check first (never trust the gate API while it's pending).**
+
+```bash
+gh pr checks <N> --json name,state,bucket | \
+  jq -r '.[] | select(.name=="SonarCloud analysis") | "\(.bucket) \(.state)"'
+```
+
+- `pass` → **gate is GREEN / zero new issues. Done.** Report GREEN and stop.
+- `pending` → the SonarCloud job (~50s) runs *after* the ~3.5min test matrix; wait
+  (`gh pr checks <N> --watch`) before reading the API, or the API returns the
+  previous commit's verdict.
+- `fail` → continue to step 2 to enumerate the exact failing conditions.
+
+**2. Enumerate the failing conditions (PR-scoped — this is the #1 gotcha).**
+
+New-code issues live on the PR branch, NOT `main`. **Scope every call with
+`&pullRequest=<N>`** or the API reports 0 and you chase phantoms. Token is in
+`.env.local` as `SONAR_TOKEN` — read it inside a sandbox so it never lands in chat.
+`curl` may be blocked by the context-mode hook → use `ctx_execute` (javascript
+`fetch` with `Authorization: Basic base64(token+":")`).
+
+```bash
+# Which gate conditions are ERROR:
+GET /api/qualitygates/project_status?projectKey=ffroliva_gflow-cli&pullRequest=<N>
+# New issues (bugs/smells) with file:line + rule + creationDate:
+GET /api/issues/search?componentKeys=ffroliva_gflow-cli&pullRequest=<N>&resolved=false
+# Unreviewed security hotspots:
+GET /api/hotspots/search?projectKey=ffroliva_gflow-cli&pullRequest=<N>&status=TO_REVIEW
+```
+
+**3. Fix by condition — no gaming.**
+
+- **`new_coverage < 80%`** → add **real** unit tests for the uncovered new lines
+  (usually a new orchestration/`_run_*`/helper). There is NO mark-safe shortcut and
+  NEVER widen `sonar.coverage.exclusions` to dodge it.
+- **`new_code_smells` / `new_maintainability_rating` (e.g. S1192 duplicated literal,
+  S3776 cognitive complexity)** → fix at source. For a duplicated literal your diff
+  merely *touched*, collapse it to one module-scope alias so it falls under the
+  threshold (pyright/tests prove it's safe). For S7497, re-raise swallowed
+  `asyncio.CancelledError`.
+- **`new_security_hotspots_reviewed < 100%`** → only for a **genuine** false positive:
+  `POST /api/hotspots/change_status` form body
+  `hotspot=<key>&status=REVIEWED&resolution=SAFE&comment=<justification>` (204 = ok),
+  then **re-run the SonarCloud job** so it reposts the GitHub status
+  (`gh run rerun <run-id> --job <sonar-job-id>` — the coverage artifact is reused).
+  Never mark a real hotspot SAFE.
+
+**4. Push fixes, then re-verify from step 1** (the check must read `pass`).
+
+## Output
+
+- Verdict: **GREEN** (gate passed, zero new issues) or **RED** with the exact failing
+  conditions and a fix list (`file:line · rule · what to do`).
+- After any fix: re-confirm via step 1 — green check = gate passed.
+
+## See also
+
+- `docs/GITHUB.md` § SonarCloud Quality Gate — full policy + coverage-exclusion rationale.
+- `/gflow:check` — the local pre-commit gates (coverage floor pre-empts `new_coverage`).
+- Memory: [[sonarcloud-pr-issues-scope-s7497]], [[sonarcloud-new-code-gotchas]],
+  [[sonarcloud-hotspot-review-workflow]], [[sonarcloud-setup]].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Or invoke the wrapper: `/gflow:check`.
 - Use `pytest -m "not live and not e2e and not smoke"` locally; full suite OOMs on small dev machines. Scope to changed dirs; trust CI for the full sweep.
 - TDD is non-negotiable. Coverage floor: 80% overall.
 - Documentation is a first-class deliverable. Every behavior, workflow, config, or operator-facing change must update the relevant docs or state why no docs changed in the PR/checklist. `scripts/ci/check_doc_links.py` is a merge gate.
+- **A PR is not done until its SonarCloud gate is green (zero new issues).** The six gates above are local/pre-commit; SonarCloud is server-side and runs in CI (`sonar.qualitygate.wait=true` → a red gate turns the `SonarCloud analysis` check red). Before calling a PR merge-ready, verify it with `/gflow:sonar <N>` (it is skipped on fork PRs — maintainer-checked there).
 - Live tests (`@pytest.mark.live`) opt in via `GFLOW_LIVE=1`. E2E tests require `GFLOW_CLI_E2E_PROFILE`.
 
 ## Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,23 @@ pip install pre-commit && pre-commit install
 
 The `.pre-commit-config.yaml` already ships ruff and the hygiene gate.
 
+### SonarCloud quality gate
+
+On top of the six gates, CI runs a **SonarCloud** analysis whose quality gate must be
+**green** before a PR is merge-ready — the target is **zero new issues** on changed code
+(new bugs, vulnerabilities, and code smells = 0; coverage of new lines ≥ 80%; security
+hotspots reviewed = 100%). The local `--cov-fail-under=80` gate already pre-empts the
+coverage condition, so if your tests are green locally you have usually cleared the part
+of the gate you can run yourself.
+
+SonarCloud is **server-side and maintainer-run**: it needs a repo secret (`SONAR_TOKEN`)
+that, for security, GitHub does **not** share with pull requests from forks. So **on a
+fork PR the SonarCloud check is skipped** — you cannot run it, and that is expected. A
+maintainer checks the gate before merging (and, for fork PRs, may re-run the branch
+internally to produce an analysis). Don't worry if you see the SonarCloud check absent or
+skipped on your PR; focus on keeping the six local gates green and your diff free of new
+smells. Full policy: [`docs/GITHUB.md`](docs/GITHUB.md) § SonarCloud Quality Gate.
+
 ### Script output convention
 
 All runtime output — smoke runs, debug dumps, generated images — **must** go


### PR DESCRIPTION
## Summary

Makes **\"Sonar zero\"** an explicit, discoverable part of the dev workflow (in answer to: *how do we enforce it, and how are contributors affected?*).

- **New `/gflow:sonar` command** — the reusable primitive that checks a PR's SonarCloud gate and drives it to zero. `/gflow:check` is local and can't see Sonar (server-side); this fills the gap. Encodes the `&pullRequest=N` scoping + gate-API-staleness gotchas and the no-gaming fix guidance (coverage → real tests, S1192 → alias, hotspots → verified-safe + rerun).
- **`/gflow:pr-council-review` + `/gflow:release`** now require a green Sonar gate before a PR is called merge-ready (they reference `/gflow:sonar`).
- **AGENTS.md**: \"a PR is not done until its SonarCloud gate is green.\"
- **CONTRIBUTING.md**: documents the gate for contributors — what \"zero new issues\" means **and** that it is maintainer-run / **skipped on fork PRs** (forks don't get `SONAR_TOKEN`), so external contributors aren't blocked by a check they can't satisfy.

## Why this shape (contributor impact)

A blanket *required* SonarCloud status check would **block every fork PR** — GitHub treats the skipped check as missing, and the contributor cannot run Sonar on their fork. So this PR does the contributor-facing groundwork (docs + an explicit, maintainer-run gate) and **leaves branch protection as a deliberate, fork-aware admin decision** rather than wiring a hard merge-blocker that strands external contributors.

## Scope

Docs/commands only — no code change. Already enforced in CI today via `sonar.qualitygate.wait=true` (red gate → red `SonarCloud analysis` check); this PR makes it *visible and required in the workflow*, not just present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)