### PR TITLE
chore(mcp): deprecate expand_prompt in favor of the creative-director tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `gflow_generate_image` / `gflow_generate_video`, validated and adapted to the CLI
     `--tool` form.
 
+### Deprecated
+
+- **`expand_prompt` MCP prompt**: superseded by the `creative-director` tool, which performs the
+  rewrite server-side (calls Gemini, strips banned keywords, supports domain styles, records
+  provenance). The prompt still works and now carries a `[DEPRECATED]` marker in its
+  client-visible description; it is slated for removal in a future major release. Use
+  `gflow tools run creative-director` / `--tool` (CLI) or `gflow_list_tools` + the `tools` array
+  param (MCP) instead.
+
 ## [0.21.0] — 2026-06-26
 
 ### Added

--- a/docs/PROMPT_EXPANSION.md
+++ b/docs/PROMPT_EXPANSION.md
@@ -190,7 +190,7 @@ a recording failure warns and returns exit 0 — never a non-zero exit after a p
 
 ## 9. Relationship to the `expand_prompt` MCP prompt
 
-The MCP server also exposes an older **prompt template** named `expand_prompt`
+The MCP server also exposes an older, now-**deprecated** **prompt template** named `expand_prompt`
 ([`mcp/prompts.py`](../src/gflow_cli/mcp/prompts.py)). It predates the tools framework and overlaps
 functionally with `creative-director`, but they are **different surfaces**:
 
@@ -205,10 +205,12 @@ functionally with `creative-director`, but they are **different surfaces**:
 | Formula | Treats lighting as a 5th separate component. | Folds lighting into the Style component. |
 
 **Guidance:** prefer the `creative-director` tool (`--tool` / the MCP `tools` array) for actual
-generation — it is the maintained, provenance-recording, server-side path. The `expand_prompt`
-prompt remains available for MCP clients that want a structured-slot template to feed their own
-model and is left in place for backward compatibility; consolidating the two (or retiring the
-prompt) is tracked as a follow-up. See [TOOLS.md §8](TOOLS.md#8-mcp-exposure).
+generation — it is the maintained, provenance-recording, server-side path. `expand_prompt` is
+**deprecated** as of the unreleased line: its client-visible description carries a `[DEPRECATED]`
+marker pointing to the tool, and it is **slated for removal in a future major release**. It remains
+functional for now because some MCP clients surface prompts as user-pickable templates (a distinct
+UX from agent-invoked tools), but no new work should depend on it. See
+[TOOLS.md §8](TOOLS.md#8-mcp-exposure).
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -266,11 +266,13 @@ than raising.
 
 ### Relationship to the `expand_prompt` MCP *prompt*
 
-The MCP server also registers an older `expand_prompt` **prompt template** (`mcp/prompts.py`).
-That is a distinct surface from the `creative-director` **tool**: a prompt template returns text
-for the *client's* model to expand (no API call, no banned-keyword stripping, no styles, no
-provenance), whereas the tool runs server-side and records provenance. The two overlap
-functionally; see [PROMPT_EXPANSION.md §9](PROMPT_EXPANSION.md#9-relationship-to-the-expand_prompt-mcp-prompt)
+The MCP server also registers an older `expand_prompt` **prompt template** (`mcp/prompts.py`),
+now **deprecated** in favor of this tool. That is a distinct surface from the `creative-director`
+**tool**: a prompt template returns text for the *client's* model to expand (no API call, no
+banned-keyword stripping, no styles, no provenance), whereas the tool runs server-side and records
+provenance. `expand_prompt` carries a `[DEPRECATED]` marker in its client-visible description and
+is slated for removal in a future major release; see
+[PROMPT_EXPANSION.md §9](PROMPT_EXPANSION.md#9-relationship-to-the-expand_prompt-mcp-prompt)
 for the full comparison and migration guidance.
 
 ---

--- a/src/gflow_cli/mcp/prompts.py
+++ b/src/gflow_cli/mcp/prompts.py
@@ -11,14 +11,18 @@ def expand_prompt(
     camera: str = "",
     lighting: str = "",
 ) -> str:
-    """Expand a simple prompt concept into Google Flow's official 5-component prompt formula.
+    """[DEPRECATED: use the creative-director tool] Build the 5-component prompt formula.
 
     This is a *prompt template* — it returns an instruction string for the calling
-    client's own model to expand. For a server-side rewrite that calls Gemini directly,
-    strips banned keywords, supports domain styles, and records provenance, prefer the
-    ``creative-director`` tool (``gflow_list_tools`` / the ``tools`` array param on the
-    generation tools, or ``gflow tools run creative-director`` / ``--tool`` on the CLI).
-    See docs/PROMPT_EXPANSION.md for the comparison.
+    client's own model to expand. It is superseded by the ``creative-director``
+    tool, which performs the rewrite server-side (calls Gemini directly), strips
+    banned keywords, supports domain styles, and records provenance. Reach it via
+    ``gflow_list_tools`` / the ``tools`` array param on the generation tools, or
+    ``gflow tools run creative-director`` / ``--tool`` on the CLI.
+
+    This template is retained for backward compatibility (some MCP clients surface
+    prompts as user-pickable templates, a distinct UX from agent-invoked tools) and
+    is slated for removal in a future major release. See docs/PROMPT_EXPANSION.md.
 
     Inputs:
     - subject: The primary subject of the generation.

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -366,6 +366,18 @@ class TestMcpPrompts:
         assert "Creative Director" in result
 
     @pytest.mark.asyncio
+    async def test_expand_prompt_is_marked_deprecated(self) -> None:
+        """The client-visible description (docstring) must flag deprecation and
+        point to the creative-director tool, so MCP clients steer to the
+        maintained surface. Functionality is retained for backward compatibility."""
+        from gflow_cli.mcp.prompts import expand_prompt
+
+        doc = expand_prompt.__doc__ or ""
+        first_line = doc.lstrip().splitlines()[0]
+        assert "DEPRECATED" in first_line
+        assert "creative-director" in doc
+
+    @pytest.mark.asyncio
     async def test_expand_prompt_with_all_params(self) -> None:
         """expand_prompt must include all provided parameters."""
         from gflow_cli.mcp.prompts import expand_prompt


### PR DESCRIPTION
## Summary

Retires the legacy `expand_prompt` MCP prompt (backlog item from PR #213). It shipped in v0.21.0 and overlaps with the `creative-director` tool, which supersedes it (server-side Gemini rewrite, banned-keyword stripping, 15 domain styles, provenance recording).

**Decision: deprecate, not hard-delete.** `expand_prompt` is a *released* public surface, and an MCP *prompt* (a user-pickable template in the client UI) serves a distinct UX from an agent-invoked *tool*. So a clean, non-breaking retirement:

- A client-visible `[DEPRECATED]` marker on the prompt's description (the docstring FastMCP surfaces to clients), pointing to `creative-director`. Function kept fully working.
- Slated for **removal in a future major release**.
- Docs (`TOOLS.md` §8, `PROMPT_EXPANSION.md` §9) + a CHANGELOG `[Unreleased]` **Deprecated** entry.

No behavior change to the returned template text (existing tests unchanged).

## Test plan

- [x] `pyright` 0 errors; `ruff` / `ruff format --check` clean.
- [x] `tests/mcp` — 36 passed (new `test_expand_prompt_is_marked_deprecated` asserts the marker + tool pointer; existing content tests unchanged).
- [x] `scripts/ci/check_doc_links.py` — all links resolved.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)