### PR TITLE
docs: live-verify v0.22.0 tool/expander/My-Tools (real Gemini)

### DIFF
--- a/docs/LIVE_VERIFICATION_v0.22.0.md
+++ b/docs/LIVE_VERIFICATION_v0.22.0.md
@@ -82,5 +82,29 @@ Owner checklist (run after publish, then fill **Post-tag evidence**):
 
 ## Post-tag evidence
 
-_(fill after the owner live run: the 5-layer ledger — command, exit code, catalog row JSON,
-structlog events, and a user-confirmable artifact.)_
+### Tool / expander / My-Tools — ✅ live-verified 2026-06-28 (real Gemini API)
+
+Run with the owner's `GFLOW_CLI_GEMINI_API_KEY` (from `.env.local`), CLI v0.22.0:
+
+| # | Check | Command | Result |
+|---|---|---|---|
+| 1 | Tool registered | `gflow tools list` | `creative-director` listed (Title/Category/Description correct) ✅ |
+| 2 | Real expansion | `gflow tools run creative-director "a cat on a couch" --style cinema --json` | `was_expanded: true`; 16→1189 chars; vivid 5-component prose naming a real camera (Sony A7R IV / Cooke S7/i) + prestige anchor (Kinfolk); structlog `prompt_expanded` (model `gemini-2.5-flash`) ✅ |
+| 3 | Banned-keyword guarantee | `gflow tools run creative-director "a luxury watch" --style product` | output scanned against all 13 banned terms → **none present** ✅ |
+| 4 | Never-fatal (bad key) | `GFLOW_CLI_GEMINI_API_KEY=invalid-key-xyz gflow tools run creative-director "a dog" --json` | `was_expanded: false`, original returned, no error/exit ✅ |
+| 5 | Video category style | `gflow tools run creative-director "a city at night" --style cinematic` | rewrites with cinematic vocabulary (video-gated style resolves) ✅ |
+| 6 | "My Tools" loader | wrote `<HOME>/tools/haiku-bot.toml`; `GFLOW_CLI_HOME=<tmp> gflow tools list` | user tool `haiku-bot` listed **alongside** the builtin `creative-director` ✅ |
+
+These exercise the whole prompt-tool path (registry → `apply_tool` → `build_instruction` → live
+`PromptExpander.expand` → `strip_banned_keywords`), the never-fatal contract, category gating, and
+the user-dir loader — end to end against the real Gemini endpoint.
+
+### Generation recording (`expanded_prompt` + `metadata_json.tool` + redaction) — ⏳ pending
+
+Requires a real Flow generation (headed-browser UI automation against an authenticated profile,
+e.g. `denon82`; image gen is credit-free). To complete: run
+`gflow image t2i "a fox in the snow" --tool creative-director:style=cinema --profile denon82`,
+then `gflow data show <op_id> --json` and assert `prompt` = original, `expanded_prompt` = the
+rewrite, and `metadata_json.tool = {name, version, model, params, config_hash}`; repeat with
+`GFLOW_CLI_HISTORY_PROMPTS=redacted` to confirm the reduced `{name, version, params_hash,
+config_hash}` descriptor and withheld `expanded_prompt`.

--- a/docs/LIVE_VERIFICATION_v0.22.0.md
+++ b/docs/LIVE_VERIFICATION_v0.22.0.md
@@ -99,12 +99,22 @@ These exercise the whole prompt-tool path (registry → `apply_tool` → `build_
 `PromptExpander.expand` → `strip_banned_keywords`), the never-fatal contract, category gating, and
 the user-dir loader — end to end against the real Gemini endpoint.
 
-### Generation recording (`expanded_prompt` + `metadata_json.tool` + redaction) — ⏳ pending
+### Generation recording (`expanded_prompt` + `metadata_json.tool` + redaction) — ✅ live-verified 2026-06-28
 
-Requires a real Flow generation (headed-browser UI automation against an authenticated profile,
-e.g. `denon82`; image gen is credit-free). To complete: run
-`gflow image t2i "a fox in the snow" --tool creative-director:style=cinema --profile denon82`,
-then `gflow data show <op_id> --json` and assert `prompt` = original, `expanded_prompt` = the
-rewrite, and `metadata_json.tool = {name, version, model, params, config_hash}`; repeat with
-`GFLOW_CLI_HISTORY_PROMPTS=redacted` to confirm the reduced `{name, version, params_hash,
-config_hash}` descriptor and withheld `expanded_prompt`.
+Real credit-free `image t2i` generations on the authenticated `denon82` profile (agentic UI
+cohort, model NARWHAL), CLI v0.22.0:
+
+**Store mode** — `gflow image t2i "a fox in the snow" --tool creative-director:style=cinema --profile denon82`:
+- File: a real **729 KB JPEG** (magic bytes `ff d8 ff`) written to the `--out` dir ✅
+- `prompt` = `"a fox in the snow"` (the **original**) ✅
+- `expanded_prompt` = the 971-char rewrite (`"A sleek, mature red fox, …"`) ✅
+- `operations.metadata_json.tool` = `{name: "creative-director", version: "1", model: "gemini-2.5-flash", params: {style: "cinema"}, config_hash: "e8399085…"}` ✅
+
+**Redacted mode** — same command with `GFLOW_CLI_HISTORY_PROMPTS=redacted` (`"a red barn at dusk"`):
+- `prompt` = `None`, `prompt_redacted` = `1`, `expanded_prompt` = `None` (both withheld) ✅
+- `metadata_json.tool` = `{name, version, params_hash, config_hash}` only — no `model`, no raw
+  `params` (replaced by `params_hash`) ✅
+- `config_hash` identical to store mode (same resolved `ToolConfig`) — tamper-evidence confirmed ✅
+
+**All 5 ledger layers cleared** (file + magic bytes + real generation + DB rows in both prompt
+modes + structlog `prompt_expanded`/`ui_driver.bound`). v0.22.0 live verification is **complete**.


### PR DESCRIPTION
Fills the **Post-tag evidence** section of `docs/LIVE_VERIFICATION_v0.22.0.md` for v0.22.0.

Live-verified against the real Gemini API (owner's key) on CLI v0.22.0:
- `creative-director` real expansion (`was_expanded: true`, 16→1189 chars, real-camera + prestige-anchor 5-component prose, `prompt_expanded` structlog)
- banned-keyword scan: none of the 13 terms present
- never-fatal: bad key → `was_expanded: false`, original returned, no error
- video-category style (`cinematic`) resolves
- **My Tools**: a user `haiku-bot.toml` loads alongside the builtin

Still pending (needs a real Flow generation / headed browser): recording `expanded_prompt` + `metadata_json.tool` + redaction — checklist in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)