### PR TITLE
chore(ci): skip SonarCloud on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: test   # wait for tests + coverage report
     # Forked pull_request runs do not receive repository secrets, so SONAR_TOKEN
-    # is empty there and the scanner fails before analysis. Keep SonarCloud on
-    # trusted pushes/internal PRs where the token is available.
+    # is empty there and the scanner fails before analysis. Dependabot-triggered
+    # runs are the same case: GitHub serves them the separate Dependabot secrets
+    # namespace, so SONAR_TOKEN is also empty even though the branch is in-repo.
+    # Keep SonarCloud on trusted pushes/internal PRs where the token is available.
     if: >
       always() &&
+      github.actor != 'dependabot[bot]' &&
       (
         github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Summary

Dependabot-triggered workflow runs are served GitHub's separate **Dependabot secrets** namespace, not **Actions secrets**, so `SONAR_TOKEN` resolves to an empty string and the SonarCloud scanner fails in ~16s — even though the dependabot branch is in-repo (`head.repo.full_name == github.repository`), so the existing fork-only guard let the job run instead of skipping it.

This extends the `sonar` job guard with `github.actor != 'dependabot[bot]'`, completing the guard's documented intent: run SonarCloud only where the token is actually available (trusted pushes / same-repo human PRs). Dependabot and fork PRs now **skip** Sonar cleanly instead of showing a false ❌.

Verified on PR #220 (ruff dev-dep bump): tests/gitleaks/pip-audit all green; only Sonar was red, purely from the empty token.

## Test plan
- [ ] CI passes on this PR (Sonar still runs here — same-repo human PR — and must stay green)
- [ ] Next dependabot PR shows Sonar **skipped**, not failed