### PR TITLE
fix(browser): diagnose + fail loud on chrome→bundled strategy downgrade (Refs #222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Extra-image observability**: `generate_image()` now logs a
   `client.generate_image_extra_returned` warning when the transport returns more images
   than the requested `count=1`, so silent over-generation is surfaced to the user (#219).
+- **macOS generation 401 — fail loud (#222)**: a `chrome`-strategy profile that is
+  silently downgraded to bundled Chromium at generation launch now raises instead of
+  running logged-out, so the macOS auth failure surfaces at its cause rather than as an
+  opaque later `401`.
+
+### Diagnostics
+
+- **Persistent-context cookie state (#222)**: generation launch now logs the resolved
+  `cookies_db_path` (`client.persistent_context_launch`) and the launched context's own
+  cookie state (`client.context_cookie_state`: `flow_session_cookie_present` / count /
+  expiry — **never values**, safe to paste publicly). This splits a cookie-**load**
+  failure (the macOS persistent context cannot decrypt the profile's cookies) from a
+  server-side rejection. Root cause of the macOS `401` is localized but not yet fixed —
+  see [KNOWN_ISSUES.md](KNOWN_ISSUES.md) and
+  [#222](https://github.com/ffroliva/gflow-cli/issues/222).
 
 ## [0.22.0] — 2026-06-28
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,6 +14,46 @@ Living list of behaviour that's broken, surprising, or limited by design — alo
 
 ## Open
 
+### macOS: generation runs logged-out → HTTP 401, even with `--browser chrome`
+
+- **Status:** **Open** — root cause localized, no fix yet; tracked in
+  [#222](https://github.com/ffroliva/gflow-cli/issues/222)
+- **Severity:** High · **Affects:** all `gflow` generation (`image`, `video`)
+  on **macOS** with a `chrome`-strategy profile; Windows is unaffected
+
+On macOS, generation calls fail with **HTTP 401** (`AuthExpiredError` at
+`project.createProject`) on a profile that `gflow auth login` and verification
+accept — the account *is* authorized, but the generation run is logged out.
+
+**Root cause.** Generation drives a **persistent Chrome context** (the
+`ui_automation` transport). On macOS that context cannot decrypt the profile's
+on-disk cookies — Chrome encrypts them with a per-app Keychain key ("Chrome
+Safe Storage") the Playwright-launched context does not hold — so the Flow
+session cookie (`__Secure-next-auth.session-token`) never loads into the context
+jar and the run is anonymous. `gflow auth login` / verification succeed only
+because they read cookies a different way (`browser_cookie3`, when Chrome is not
+holding the profile lock).
+
+**Diagnostics (shipped).** gflow logs, at generation launch, the resolved
+`cookies_db_path` (`client.persistent_context_launch`) and the launched
+context's own cookie state — `client.context_cookie_state` with
+`flow_session_cookie_present` / `context_cookie_count` / expiry; **cookie values
+are never logged**, so the lines are safe to paste into a public issue. On an
+affected macOS run you will see `flow_session_cookie_present=False` with
+`context_cookie_count=3`, which splits a cookie-**load** failure from a
+server-side rejection.
+
+**Why no fix yet.** Seeding the cookie into the context by re-reading it via
+`browser_cookie3` at launch was attempted and **disproven on macOS**: while the
+generation context holds the profile lock, `browser_cookie3` *also* fails to
+read the cookie (`PermissionError`), so there is nothing to inject. A robust fix
+must obtain the session credential by a path that works while Chrome holds the
+profile — still being investigated.
+
+**Workaround:** none on macOS yet; Windows is unaffected. If you hit this, add
+your `client.persistent_context_launch` / `client.context_cookie_state` log
+lines to [#222](https://github.com/ffroliva/gflow-cli/issues/222).
+
 ### Flow's new full-page media-library UI breaks entity attach (A/B rollout)
 
 - **Status:** **Open** — Flow-side staged rollout; tracked in

--- a/scripts/dev/spike_patchright.py
+++ b/scripts/dev/spike_patchright.py
@@ -110,8 +110,15 @@ def _launch_kwargs(profile_dir: Path) -> dict[str, Any]:
         "locale": "en-US",
         "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
         "channel": channel_for_profile(profile_dir),
-        "ignore_default_args": ["--enable-automation", "--no-sandbox", "--password-store=basic"],
-        "args": ["--disable-blink-features=AutomationControlled", "--disable-dev-shm-usage"],
+        # issue #222: --password-store=basic must be in args (not ignore_default_args),
+        # matching client._persistent_context_kwargs — otherwise this replica drifts
+        # and the spike launches Chrome with a different cookie store than generation.
+        "ignore_default_args": ["--enable-automation", "--no-sandbox"],
+        "args": [
+            "--password-store=basic",
+            "--disable-blink-features=AutomationControlled",
+            "--disable-dev-shm-usage",
+        ],
     }
 
 

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -334,18 +334,28 @@ class FlowApiClient:
             "locale": "en-US",
             "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
             "channel": channel_for_profile(self.profile_dir),
-            # Do NOT suppress Playwright's default --password-store=basic here.
-            # auth login (auth/real_chrome.py) seals the profile's cookies with
-            # the *basic* store; if generation lets Chrome fall back to the OS
-            # keychain (macOS "Chrome Safe Storage") the basic-sealed cookies
-            # can't be decrypted -> logged-out context -> 401 on createProject.
-            # Keeping the flag (via Playwright's default) makes both paths
-            # symmetric. See issue #222.
             "ignore_default_args": [
                 "--enable-automation",
                 "--no-sandbox",
             ],
-            "args": ["--disable-blink-features=AutomationControlled", "--disable-dev-shm-usage"],
+            # Pass --password-store=basic EXPLICITLY (issue #222). auth login
+            # (auth/real_chrome.py:69) and verification (auth/verification.py:246)
+            # seal and read the profile's cookies with Chrome's *basic* store —
+            # as does every other launch site in the codebase (auth/cookies.py,
+            # auth/internal_chromium.py, browser_manager.py, ui_automation.py).
+            # This shared generation context was the ONE path that omitted the
+            # flag and merely relied on Playwright's internal default; on macOS
+            # that let Chrome read cookies via the OS Keychain ("Chrome Safe
+            # Storage"), which cannot decrypt the basic-sealed cookies -> a
+            # logged-out context -> HTTP 401 at project.createProject (login and
+            # verify succeed, generation fails). #225 added a comment but never
+            # the flag here. Passing it explicitly keeps all paths symmetric
+            # regardless of Playwright's defaults.
+            "args": [
+                "--password-store=basic",
+                "--disable-blink-features=AutomationControlled",
+                "--disable-dev-shm-usage",
+            ],
         }
 
     def _log_and_guard_launch(self, kwargs: dict[str, Any]) -> None:
@@ -384,6 +394,7 @@ class FlowApiClient:
             cookies_db = get_cookies_path(self.profile_dir)
         except FileNotFoundError:
             pass
+        launch_args: list[str] = kwargs.get("args") or []
         logger.info(
             "client.persistent_context_launch",
             channel=channel,
@@ -393,6 +404,12 @@ class FlowApiClient:
             cookies_db_present=cookies_db is not None,
             cookies_db_path=str(cookies_db) if cookies_db else None,
             platform=sys.platform,
+            # issue #222: surface the actual launch args so we can confirm the
+            # generation context passes --password-store=basic (cookie-store
+            # symmetry with login/verification) on the failing macOS path.
+            launch_args=launch_args,
+            ignore_default_args=kwargs.get("ignore_default_args"),
+            password_store_basic="--password-store=basic" in launch_args,
         )
         if wants_chrome and channel is None:
             msg = (

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -414,13 +414,15 @@ class FlowApiClient:
         if wants_chrome and channel is None:
             msg = (
                 "Profile requests the 'chrome' browser strategy "
-                "(.gflow_browser_strategy=chrome) but system Chrome was not found, so "
-                "generation would fall back to Playwright's bundled Chromium. On macOS "
-                "the bundled Chromium cannot decrypt cookies written by real Chrome "
-                "(Keychain 'Chrome Safe Storage'), yielding a logged-out session and an "
-                "HTTP 401 at project.createProject. Install Google Chrome (or set "
-                "CHROME_BINARY), then retry; or re-run `gflow auth login` to re-capture "
-                "the session."
+                "(.gflow_browser_strategy=chrome) but Playwright's 'chrome' channel is "
+                "unavailable (Google Chrome is not at the location Playwright probes — "
+                "note a Chrome binary resolved elsewhere is logged as chrome_executable "
+                "but does not satisfy the channel), so generation would fall back to "
+                "Playwright's bundled Chromium. On macOS the bundled Chromium cannot "
+                "decrypt cookies written by real Chrome (Keychain 'Chrome Safe Storage'), "
+                "yielding a logged-out session and an HTTP 401 at project.createProject. "
+                "Install Google Chrome in its default location (or set CHROME_BINARY), "
+                "then retry; or re-run `gflow auth login` to re-capture the session."
             )
             if sys.platform == "darwin":
                 raise ConfigurationError(msg)

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -426,6 +426,45 @@ class FlowApiClient:
                 raise ConfigurationError(msg)
             logger.warning("client.chrome_strategy_downgraded", detail=msg)
 
+    async def _log_context_cookie_state(self) -> None:
+        """Diagnostic (issue #222): log whether the launched persistent context
+        actually loaded the Flow session cookie.
+
+        The accepting path (auth ``verify_flow_profile``) reads cookies via
+        browser_cookie3 + httpx and never uses a persistent context; generation
+        uses THIS persistent Chrome context. Logging the context's own cookie jar
+        (presence / count / expiry only — never values, so it is safe to paste
+        into a public issue) splits a cookie-LOAD failure (the context could not
+        decrypt or find the Flow session cookie) from a server-side rejection
+        (cookie present yet createProject still 401s). Pure observability — it
+        must never raise and never break the launch.
+        """
+        if self._context is None:
+            return
+        try:
+            cookies = await self._context.cookies()
+            now = time.time()
+            flow_cookie = next(
+                (c for c in cookies if c.get("name") == "__Secure-next-auth.session-token"),
+                None,
+            )
+            flow_expires = flow_cookie.get("expires") if flow_cookie is not None else None
+            logger.info(
+                "client.context_cookie_state",
+                context_cookie_count=len(cookies),
+                flow_session_cookie_present=flow_cookie is not None,
+                # expires == -1 -> a session cookie (no persisted expiry); otherwise
+                # epoch seconds. Chromium prunes already-expired cookies from the
+                # jar, so the common "logged out" signal is present=False; this flag
+                # only catches a near-boundary expiry that survived into the jar.
+                flow_session_cookie_expired=(
+                    flow_expires is not None and flow_expires != -1 and flow_expires < now
+                ),
+                google_sapisid_present=any(c.get("name") == "SAPISID" for c in cookies),
+            )
+        except Exception as exc:  # noqa: BLE001 — a diagnostic must never break the launch
+            logger.warning("client.context_cookie_probe_error", error=type(exc).__name__)
+
     async def _enter_setup(self) -> None:
         """Body of __aenter__ after the Playwright driver starts.
 
@@ -443,6 +482,9 @@ class FlowApiClient:
         await self._context.add_init_script(
             "Object.defineProperty(navigator,'webdriver',{get:()=>undefined})",
         )
+        # issue #222 diagnostic: confirm the persistent context actually loaded
+        # the Flow session cookie (the load-vs-send discriminator).
+        await self._log_context_cookie_state()
         # Open ``Settings.concurrency`` Pages inside the one persistent
         # BrowserContext. ``launch_persistent_context`` opens one Page by
         # default; reuse it as slot 0 to avoid an unused N+1 Page.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -369,18 +369,29 @@ class FlowApiClient:
             chrome_strategy_requested,
             resolved_chrome_binary,
         )
+        from gflow_cli.paths import get_cookies_path
 
         channel = kwargs.get("channel")
         wants_chrome = chrome_strategy_requested(self.profile_dir)
         executable = resolved_chrome_binary()
-        cookies_db = self.profile_dir / "Default" / "Cookies"
+        # Resolve the cookie file the way auth/verification does (Chrome 130+
+        # Default/Network/Cookies, then legacy Default/Cookies, then bundled
+        # Cookies). Logging the actual path discriminates the H2 cookie-location
+        # mismatch (the persistent context reading a different file than the one
+        # the session was written to) from a plain decryption failure. See #222.
+        cookies_db = None
+        try:
+            cookies_db = get_cookies_path(self.profile_dir)
+        except FileNotFoundError:
+            pass
         logger.info(
             "client.persistent_context_launch",
             channel=channel,
             chrome_strategy_requested=wants_chrome,
             chrome_executable=executable,
             user_data_dir=str(self.profile_dir),
-            cookies_db_present=cookies_db.exists(),
+            cookies_db_present=cookies_db is not None,
+            cookies_db_path=str(cookies_db) if cookies_db else None,
             platform=sys.platform,
         )
         if wants_chrome and channel is None:

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -17,6 +17,7 @@ import asyncio
 import base64
 import json
 import os
+import sys
 import time
 from dataclasses import replace as _dataclass_replace
 from datetime import datetime
@@ -347,6 +348,56 @@ class FlowApiClient:
             "args": ["--disable-blink-features=AutomationControlled", "--disable-dev-shm-usage"],
         }
 
+    def _log_and_guard_launch(self, kwargs: dict[str, Any]) -> None:
+        """Log the resolved browser-launch identity and fail loud on a silent
+        chrome->bundled downgrade (issue #222).
+
+        Under the 'chrome' strategy ``channel`` must resolve to ``"chrome"``
+        (system Chrome). If it resolved to ``None`` Chrome wasn't found and
+        Playwright would fall back to bundled Chromium. On macOS that bundled
+        Chromium cannot decrypt cookies written by real Chrome (per-app Keychain
+        'Chrome Safe Storage'), producing a logged-out context and a confusing
+        HTTP 401 at project.createProject. Make that fatal with a clear
+        remediation. On other platforms the bundled fallback may still work
+        (e.g. Windows DPAPI cookie key is per-user), so warn instead of raising.
+
+        The diagnostic event names the resolved channel / executable /
+        user-data-dir / cookie-db presence — the data needed to tell a channel
+        downgrade apart from a cookie-decryption failure.
+        """
+        from gflow_cli.browser_manager import (
+            chrome_strategy_requested,
+            resolved_chrome_binary,
+        )
+
+        channel = kwargs.get("channel")
+        wants_chrome = chrome_strategy_requested(self.profile_dir)
+        executable = resolved_chrome_binary()
+        cookies_db = self.profile_dir / "Default" / "Cookies"
+        logger.info(
+            "client.persistent_context_launch",
+            channel=channel,
+            chrome_strategy_requested=wants_chrome,
+            chrome_executable=executable,
+            user_data_dir=str(self.profile_dir),
+            cookies_db_present=cookies_db.exists(),
+            platform=sys.platform,
+        )
+        if wants_chrome and channel is None:
+            msg = (
+                "Profile requests the 'chrome' browser strategy "
+                "(.gflow_browser_strategy=chrome) but system Chrome was not found, so "
+                "generation would fall back to Playwright's bundled Chromium. On macOS "
+                "the bundled Chromium cannot decrypt cookies written by real Chrome "
+                "(Keychain 'Chrome Safe Storage'), yielding a logged-out session and an "
+                "HTTP 401 at project.createProject. Install Google Chrome (or set "
+                "CHROME_BINARY), then retry; or re-run `gflow auth login` to re-capture "
+                "the session."
+            )
+            if sys.platform == "darwin":
+                raise ConfigurationError(msg)
+            logger.warning("client.chrome_strategy_downgraded", detail=msg)
+
     async def _enter_setup(self) -> None:
         """Body of __aenter__ after the Playwright driver starts.
 
@@ -355,9 +406,9 @@ class FlowApiClient:
         """
         # Invariant: __aenter__ sets self._pw immediately before calling us.
         assert self._pw is not None
-        self._context = await self._pw.chromium.launch_persistent_context(
-            **self._persistent_context_kwargs()
-        )
+        kwargs = self._persistent_context_kwargs()
+        self._log_and_guard_launch(kwargs)
+        self._context = await self._pw.chromium.launch_persistent_context(**kwargs)
         # Hide the automation flag so reCAPTCHA Enterprise doesn't score
         # the session as a bot — navigator.webdriver=true causes low-score
         # tokens and HTTP 403 on batchGenerateImages.

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -229,12 +229,16 @@ def resolved_chrome_binary() -> str | None:
     """Return the system Chrome binary path, or ``None`` if Chrome can't be found.
 
     Public, exception-free wrapper around :func:`_find_chrome_binary` for
-    diagnostics/logging callers that want the path without handling
-    :class:`ConfigurationError`.
+    diagnostics/logging callers that want the path without handling errors. It
+    must NEVER raise: it feeds ``_log_and_guard_launch``'s observability log, and
+    a best-effort path probe should never abort a launch. Besides
+    :class:`ConfigurationError` (no binary found), ``shutil.which`` can raise on
+    odd environments (e.g. an OS-detection mismatch), so any error resolves to
+    ``None``.
     """
     try:
         return _find_chrome_binary()
-    except ConfigurationError:
+    except Exception:  # noqa: BLE001 — exception-free by contract; any failure → None
         return None
 
 

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -225,6 +225,19 @@ def is_chrome_available() -> bool:
         return False
 
 
+def resolved_chrome_binary() -> str | None:
+    """Return the system Chrome binary path, or ``None`` if Chrome can't be found.
+
+    Public, exception-free wrapper around :func:`_find_chrome_binary` for
+    diagnostics/logging callers that want the path without handling
+    :class:`ConfigurationError`.
+    """
+    try:
+        return _find_chrome_binary()
+    except ConfigurationError:
+        return None
+
+
 def channel_for_profile(profile_dir: Path) -> str | None:
     """Return the Playwright channel to use for ``profile_dir``, or None.
 
@@ -268,6 +281,23 @@ def channel_for_profile(profile_dir: Path) -> str | None:
         "you need the Chrome channel.",
     )
     return None
+
+
+def chrome_strategy_requested(profile_dir: Path) -> bool:
+    """True if the profile's ``.gflow_browser_strategy`` marker requests system Chrome.
+
+    Distinct from :func:`channel_for_profile`, which returns ``None`` both when no
+    marker is present (legitimate bundled-Chromium use) AND when the marker says
+    ``chrome`` but Chrome can't be found (a silent downgrade). Callers use this to
+    tell those two cases apart — see ``FlowApiClient._log_and_guard_launch`` and
+    issue #222 (macOS: a chrome→bundled downgrade yields cookies the bundled
+    Chromium can't decrypt → 401).
+    """
+    marker = profile_dir / ".gflow_browser_strategy"
+    try:
+        return marker.exists() and marker.read_text(encoding="utf-8").strip() == "chrome"
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -133,3 +133,67 @@ def test_guard_ok_when_channel_resolved(tmp_path: Path, monkeypatch: pytest.Monk
     client = FlowApiClient(profile_dir=tmp_path, headless=True)
     monkeypatch.setattr(sys, "platform", "darwin")
     client._log_and_guard_launch({"channel": "chrome"})  # noqa: SLF001  (no raise)
+
+
+# --- issue #222: persistent-context cookie-state diagnostic --------------------
+#
+# These pin the load-vs-send discriminator: the launched context's own cookie
+# jar tells us whether the Flow session cookie was loaded (vs a server-side 401).
+# A fresh LogCapture-wrapped logger is injected so no cached structlog config
+# bleeds in (see auto-memory: structlog cache-logger-off-for-tests).
+
+
+def _capture_cookie_state(client: FlowApiClient) -> dict:
+    import asyncio
+
+    import structlog
+
+    cap = structlog.testing.LogCapture()
+    with patch("gflow_cli.api.client.logger", structlog.wrap_logger(None, processors=[cap])):
+        asyncio.run(client._log_context_cookie_state())  # noqa: SLF001
+    return dict(next(e for e in cap.entries if e["event"] == "client.context_cookie_state"))
+
+
+def _client_with_cookies(tmp_path: Path, cookies: list[dict]) -> FlowApiClient:
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    ctx = MagicMock()
+    ctx.cookies = AsyncMock(return_value=cookies)
+    client._context = ctx  # noqa: SLF001
+    return client
+
+
+def test_context_cookie_state_present_and_unexpired(tmp_path: Path) -> None:
+    """Flow session cookie present + future expiry → present=True, expired=False."""
+    client = _client_with_cookies(
+        tmp_path,
+        [
+            {"name": "__Secure-next-auth.session-token", "expires": 9_999_999_999.0},
+            {"name": "SAPISID", "expires": -1},
+        ],
+    )
+    ev = _capture_cookie_state(client)
+    assert ev["flow_session_cookie_present"] is True
+    assert ev["flow_session_cookie_expired"] is False
+    assert ev["google_sapisid_present"] is True
+    assert ev["context_cookie_count"] == 2
+
+
+def test_context_cookie_state_flags_expired(tmp_path: Path) -> None:
+    """A past expiry on the Flow session cookie → expired=True."""
+    client = _client_with_cookies(
+        tmp_path,
+        [{"name": "__Secure-next-auth.session-token", "expires": 1_000.0}],
+    )
+    ev = _capture_cookie_state(client)
+    assert ev["flow_session_cookie_present"] is True
+    assert ev["flow_session_cookie_expired"] is True
+
+
+def test_context_cookie_state_absent(tmp_path: Path) -> None:
+    """No Flow session cookie in the jar → present=False (the cookie-LOAD failure
+    signal we expect if the persistent context can't decrypt/find it)."""
+    client = _client_with_cookies(tmp_path, [{"name": "SAPISID", "expires": -1}])
+    ev = _capture_cookie_state(client)
+    assert ev["flow_session_cookie_present"] is False
+    assert ev["flow_session_cookie_expired"] is False
+    assert ev["google_sapisid_present"] is True

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -9,6 +9,7 @@ seam's contract stable.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,10 @@ import pytest
 
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.browser_manager import chrome_strategy_requested
+from gflow_cli.errors import ConfigurationError
+
+_MARKER = ".gflow_browser_strategy"
 
 
 def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
@@ -80,3 +85,47 @@ async def test_ui_automation_setup_passes_disable_dev_shm_usage(tmp_path: Path) 
         _call_kwargs.args[1] if len(_call_kwargs.args) > 1 else [],
     )
     assert "--disable-dev-shm-usage" in args_passed
+
+
+# --- issue #222: chrome-strategy downgrade guard --------------------------------
+
+
+def test_chrome_strategy_requested_reads_marker(tmp_path: Path) -> None:
+    """chrome_strategy_requested is True only when the marker says 'chrome'."""
+    assert chrome_strategy_requested(tmp_path) is False  # no marker
+    (tmp_path / _MARKER).write_text("chrome", encoding="utf-8")
+    assert chrome_strategy_requested(tmp_path) is True
+    (tmp_path / _MARKER).write_text("internal-chromium", encoding="utf-8")
+    assert chrome_strategy_requested(tmp_path) is False
+
+
+def test_guard_raises_on_macos_when_chrome_strategy_downgrades(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """marker=chrome but channel=None on macOS → fatal (bundled Chromium can't
+    decrypt real-Chrome cookies via the per-app Keychain key)."""
+    (tmp_path / _MARKER).write_text("chrome", encoding="utf-8")
+    # Construct BEFORE patching sys.platform: construction resolves dirs via
+    # platformdirs, whose backend is sensitive to sys.platform. The guard path
+    # itself does not touch platformdirs, so patch only around the call.
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with pytest.raises(ConfigurationError, match="chrome"):
+        client._log_and_guard_launch({"channel": None})  # noqa: SLF001
+
+
+def test_guard_warns_not_raises_off_macos(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same downgrade off macOS is non-fatal (e.g. Windows DPAPI cookie key is
+    per-user, so bundled Chromium can still decrypt) — must not raise."""
+    (tmp_path / _MARKER).write_text("chrome", encoding="utf-8")
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    monkeypatch.setattr(sys, "platform", "win32")
+    client._log_and_guard_launch({"channel": None})  # noqa: SLF001  (no raise)
+
+
+def test_guard_ok_when_channel_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """channel resolved to 'chrome' → no downgrade → no raise, even on macOS."""
+    (tmp_path / _MARKER).write_text("chrome", encoding="utf-8")
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    client._log_and_guard_launch({"channel": "chrome"})  # noqa: SLF001  (no raise)

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -37,13 +37,17 @@ def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
         "--enable-automation",
         "--no-sandbox",
     ]
-    # Regression for #222: generation must NOT suppress --password-store=basic.
-    # auth login seals the profile cookies with the *basic* store; if generation
-    # lets Chrome fall back to the macOS keychain, those cookies can't be
-    # decrypted -> logged-out -> 401 on createProject. (Unit-level proxy: the
-    # real failure only reproduces on a headed Chrome on macOS.)
+    # Regression for #222: generation must pass --password-store=basic EXPLICITLY
+    # in args (not merely keep it out of ignore_default_args). auth login and
+    # verification seal/read the profile cookies with the *basic* store; if
+    # generation lets Chrome fall back to the macOS keychain, those cookies can't
+    # be decrypted -> logged-out -> 401 on createProject. Every other launch site
+    # passes the flag; this shared context must too. (Unit-level proxy: the real
+    # failure only reproduces on a headed Chrome on macOS.)
     assert "--password-store=basic" not in kwargs["ignore_default_args"]
+    assert "--password-store=basic" in kwargs["args"]
     assert kwargs["args"] == [
+        "--password-store=basic",
         "--disable-blink-features=AutomationControlled",
         "--disable-dev-shm-usage",
     ]

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -120,11 +120,18 @@ def test_guard_raises_on_macos_when_chrome_strategy_downgrades(
 
 def test_guard_warns_not_raises_off_macos(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Same downgrade off macOS is non-fatal (e.g. Windows DPAPI cookie key is
-    per-user, so bundled Chromium can still decrypt) — must not raise."""
+    per-user, so bundled Chromium can still decrypt) — must not raise, but MUST
+    still log the ``client.chrome_strategy_downgraded`` warning so the silent
+    downgrade is visible to operators."""
+    import structlog
+
     (tmp_path / _MARKER).write_text("chrome", encoding="utf-8")
     client = FlowApiClient(profile_dir=tmp_path, headless=True)
     monkeypatch.setattr(sys, "platform", "win32")
-    client._log_and_guard_launch({"channel": None})  # noqa: SLF001  (no raise)
+    cap = structlog.testing.LogCapture()
+    with patch("gflow_cli.api.client.logger", structlog.wrap_logger(None, processors=[cap])):
+        client._log_and_guard_launch({"channel": None})  # noqa: SLF001  (no raise)
+    assert any(e["event"] == "client.chrome_strategy_downgraded" for e in cap.entries)
 
 
 def test_guard_ok_when_channel_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -133,6 +140,35 @@ def test_guard_ok_when_channel_resolved(tmp_path: Path, monkeypatch: pytest.Monk
     client = FlowApiClient(profile_dir=tmp_path, headless=True)
     monkeypatch.setattr(sys, "platform", "darwin")
     client._log_and_guard_launch({"channel": "chrome"})  # noqa: SLF001  (no raise)
+
+
+def test_persistent_context_launch_event_fields(tmp_path: Path) -> None:
+    """The launch diagnostic emits the fields needed to remotely root-cause #222:
+    channel, the cookie-db path/presence (H2 location discriminator), platform,
+    and the ``--password-store=basic`` flag (cookie-store symmetry). A regression
+    that drops or renames one of these would otherwise ship green."""
+    import structlog
+
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    kwargs = {
+        "channel": None,
+        "args": ["--password-store=basic", "--disable-dev-shm-usage"],
+        "ignore_default_args": ["--enable-automation"],
+    }
+    cap = structlog.testing.LogCapture()
+    # No marker -> chrome_strategy_requested is False, so the guard neither raises
+    # nor warns: this isolates the launch event itself.
+    with patch("gflow_cli.api.client.logger", structlog.wrap_logger(None, processors=[cap])):
+        client._log_and_guard_launch(kwargs)  # noqa: SLF001
+    ev = next(e for e in cap.entries if e["event"] == "client.persistent_context_launch")
+    assert ev["channel"] is None
+    assert ev["chrome_strategy_requested"] is False
+    assert ev["password_store_basic"] is True
+    assert ev["launch_args"] == kwargs["args"]
+    assert ev["user_data_dir"] == str(tmp_path)
+    assert ev["platform"] == sys.platform
+    assert "cookies_db_present" in ev
+    assert "cookies_db_path" in ev
 
 
 # --- issue #222: persistent-context cookie-state diagnostic --------------------
@@ -197,3 +233,24 @@ def test_context_cookie_state_absent(tmp_path: Path) -> None:
     assert ev["flow_session_cookie_present"] is False
     assert ev["flow_session_cookie_expired"] is False
     assert ev["google_sapisid_present"] is True
+
+
+def test_context_cookie_state_swallows_probe_error(tmp_path: Path) -> None:
+    """Contract: the diagnostic is pure observability — if ``context.cookies()``
+    raises (e.g. a closing context), it must NOT propagate (it is awaited inside
+    ``_enter_setup``, so a raise would abort the whole generation launch). It logs
+    ``client.context_cookie_probe_error`` and emits no ``context_cookie_state``."""
+    import asyncio
+
+    import structlog
+
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    ctx = MagicMock()
+    ctx.cookies = AsyncMock(side_effect=PermissionError("locked"))
+    client._context = ctx  # noqa: SLF001
+    cap = structlog.testing.LogCapture()
+    with patch("gflow_cli.api.client.logger", structlog.wrap_logger(None, processors=[cap])):
+        asyncio.run(client._log_context_cookie_state())  # noqa: SLF001  (must not raise)
+    events = [e["event"] for e in cap.entries]
+    assert "client.context_cookie_probe_error" in events
+    assert "client.context_cookie_state" not in events

--- a/tests/dev/test_recording_client.py
+++ b/tests/dev/test_recording_client.py
@@ -29,6 +29,7 @@ def test_recording_client_injects_video_and_preserves_base(tmp_path: Path) -> No
     assert kwargs["user_data_dir"] == str(tmp_path)
     assert kwargs["headless"] is True
     assert kwargs["args"] == [
+        "--password-store=basic",
         "--disable-blink-features=AutomationControlled",
         "--disable-dev-shm-usage",
     ]

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -222,6 +222,20 @@ class TestChromeBinaryDetection:
 
         assert "chrome.exe" in result.lower() or "Chrome" in result
 
+    def test_resolved_chrome_binary_swallows_non_configuration_errors(self) -> None:
+        """resolved_chrome_binary is exception-free by contract: a non-ConfigurationError
+        from _find_chrome_binary (e.g. shutil.which raising AttributeError under an
+        OS-detection mismatch — faking sys.platform='win32' on Linux) must resolve to
+        None, never propagate. It feeds the _log_and_guard_launch diagnostic and must
+        not abort a launch."""
+        from gflow_cli.browser_manager import resolved_chrome_binary
+
+        with patch(
+            "gflow_cli.browser_manager._find_chrome_binary",
+            side_effect=AttributeError("NeedCurrentDirectoryForExePath"),
+        ):
+            assert resolved_chrome_binary() is None
+
 
 class TestPlaywrightChromeChannelAvailable:
     """Gate for Playwright's ``channel="chrome"`` — Chromium must NOT satisfy it.


### PR DESCRIPTION
## Summary

Ships the **diagnosability + fail-loud** half of #222 (macOS: generation runs on bundled / undecryptable Chromium despite the `chrome` strategy → HTTP 401). This PR does **not** claim to fix the macOS 401 — see *Seeding attempt (removed)* — it makes the failure observable and loud, and records the localized root cause.

## Changes

**Diagnostics**
- `browser_manager.chrome_strategy_requested()` — detects `marker == "chrome"`, distinguishing a legit no-marker bundled launch from a silent downgrade.
- `browser_manager.resolved_chrome_binary()` — public, exception-free Chrome-path resolver.
- `FlowApiClient._log_and_guard_launch()` — logs `client.persistent_context_launch` (channel / `chrome_executable` / `cookies_db_path` / `password_store_basic` / `launch_args` / platform) and **raises `ConfigurationError` on macOS** when the chrome strategy silently downgrades to bundled Chromium; **warns** (`client.chrome_strategy_downgraded`) on other platforms.
- `FlowApiClient._log_context_cookie_state()` — logs `client.context_cookie_state` (presence / count / expiry of the Flow session cookie — **never values**, safe to paste publicly): the load-vs-send discriminator. Pure observability, never raises.

**Docs**
- `KNOWN_ISSUES.md`: macOS generation-401 entry (root cause, the shipped diagnostics, why seeding was disproven). `CHANGELOG.md`: `[Unreleased]` fail-loud + diagnostics notes.

## Seeding attempt (removed)

An earlier revision seeded the session cookie into the context by re-reading it via `browser_cookie3` at launch. The reporter's macOS run **disproved** it: while the generation context holds the profile lock, `browser_cookie3` *also* fails (`PermissionError`), so there is nothing to inject — still 401. That commit was dropped; #222 stays **open** for a real fix. (Trail: issue #222 comments.)

## Review

`/code-review` (4 parallel finders: correctness / cleanup-altitude / conventions / tests) — **no correctness bugs, no dangling refs** to the removed seeding code. Applied: accurate fail-loud message (it previously said "system Chrome was not found" while a real `chrome_executable` path was logged), plus coverage for the launch-event fields, the off-macOS warning, and the never-raise probe contract.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pyright src` — 0 errors
- [x] `pytest tests/api/test_client_launch_kwargs.py tests/test_browser_manager.py` — 69 passed
- [x] `check_doc_links.py` / `check_repo_hygiene.py` — green
- [ ] macOS reporter to attach `client.context_cookie_state` logs on a fresh run (#222)