### PR TITLE
feat(skills): issue-assessment + issue-resolve workflow

### DIFF
--- a/.claude/commands/gflow/issue-assessment.md
+++ b/.claude/commands/gflow/issue-assessment.md
@@ -1,0 +1,28 @@
+---
+description: >
+  Triage a gflow-cli GitHub issue: verify the reporter's claim against code,
+  tests, docs, KNOWN_ISSUES, and memory; classify it (CONFIRMED / NEEDS-E2E /
+  NEEDS-INFO / DUPLICATE / INVALID / WONTFIX); judge whether it is verifiable
+  end-to-end in the current environment; and draft a reporter-facing reply.
+  Read-only — changes nothing and posts nothing on its own.
+---
+
+# `/gflow:issue-assessment [issue number or URL]`
+
+**Read `skills/issue-assessment/SKILL.md` and follow its protocol now**, passing `$ARGUMENTS` as the issue to assess.
+
+> Do **not** call `Skill(skill="issue-assessment")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not Skill-tool-invocable (only `.claude/commands/gflow/*` are). Read the file directly instead.
+
+The skill at `skills/issue-assessment/SKILL.md` ingests the issue, verifies the
+claim (dispatching a search agent to keep context clean), assigns one verdict,
+applies the **e2e-gate** (never claim a fix is verified on an unverifiable
+surface), and emits a standard report artifact. On a `CONFIRMED` / `LIKELY-BUG`
+verdict with localized, verifiable scope it hands off to `issue-resolve`;
+otherwise it replies only.
+
+**Typical chain:**
+```
+/gflow:issue-assessment <N>   →  verdict + e2e-gate + reply artifact
+   ↓ (if scope clear & verifiable)
+issue-resolve <N>             →  worktree + TDD + draft PR for human review
+```

--- a/.claude/commands/gflow/issue-resolve.md
+++ b/.claude/commands/gflow/issue-resolve.md
@@ -1,0 +1,18 @@
+---
+description: >
+  Drive an assessed gflow-cli issue (verdict CONFIRMED-BUG or LIKELY-BUG, with
+  localized verifiable scope) to a fix: isolated worktree off develop, test-first
+  fix, /gflow:check, then a DRAFT PR for human review. Mutating and gated — runs
+  inside a strict action envelope (never merges, never spends credits, never
+  marks a PR ready, never claims an unverified fix verified).
+---
+
+# `/gflow:issue-resolve [issue number]`
+
+**Read `skills/issue-resolve/SKILL.md` and follow its protocol now**, passing `$ARGUMENTS` as the issue to resolve.
+
+> Do **not** call `Skill(skill="issue-resolve")` — the repo's `skills/*/SKILL.md` files are plain Markdown, not Skill-tool-invocable (only `.claude/commands/gflow/*` are). Read the file directly instead.
+
+Preconditions (from `/gflow:issue-assessment`): verdict ∈ {`CONFIRMED-BUG`, `LIKELY-BUG`}, scope single-surface, and the fix is verifiable in this environment (or the gap is carried into the PR as "needs human e2e"). The skill isolates a `bugfix/` worktree off `develop`, gates high-stakes changes through `/gflow:predict` + `/gflow:scenario`, fixes test-first (Opus plans → Sonnet codes → Opus reviews for non-trivial work), runs `/gflow:check`, opens a **draft** PR with a Verification-status section, runs `/gflow:pr-council-review`, and **stops** for a human to promote and merge.
+
+**Chain:** `/gflow:issue-assessment <N>` → (if scope clear) `/gflow:issue-resolve <N>` → human promotes draft → human runs any headed/e2e check → merge.

--- a/docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md
@@ -1,0 +1,125 @@
+# Issue-assessment workflow — design
+
+> Status: **approved design** (2026-06-29). Next step: `writing-plans` → author skills with `writing-skills`.
+> Scope: two new project skills that let an agent triage a GitHub issue, report to the reporter, and — when scope is clear — drive a guard-railed fix to a draft PR. Built to run both interactively and autonomously (hermes-ops on the VPS).
+
+## Problem
+
+Incoming GitHub issues (e.g. #222) need a **systematic, repeatable** assessment instead of ad-hoc investigation. We want a process that:
+
+1. Reads the reporter's claim and verifies it against code, tests, docs, `KNOWN_ISSUES.md`, and auto-memory.
+2. Produces a defensible verdict and a reply to the reporter.
+3. **Requires e2e evidence before claiming a fix works** — and is honest when e2e is impossible in the current environment.
+4. When scope is clear, performs the full development workflow in an isolated worktree and opens a PR **for human review** (never merges).
+5. Can run **autonomously** (hermes-ops VPS) without taking wrong outward-facing actions.
+6. Tells the agent **which project skill to use for what**, so it does not hallucinate skill names.
+
+## Key environmental constraint
+
+The hermes-ops VPS is **headless Linux**. Flow generation auth requires a **headed real-Chrome** session (`real-browser-auth-mandatory` in memory). Therefore, for any Flow-generation/selector/auth bug, the autonomous agent **cannot e2e-verify** — it can only get the problem review-ready and hand to a human. This is encoded as a **standing known limitation**, never hidden. The design goal is to make a wrong autonomous action *rare*, not to pretend the agent can verify everything.
+
+## Architecture — two skills
+
+The repo already ships the fix pipeline as skills (`/gflow:predict` → `/gflow:scenario` → `/gflow:plan` → `/gflow:check` → `/gflow:pr-council-review`) plus superpowers TDD/worktrees. The new work is a **conductor** on top, split for a clean safety boundary:
+
+- **`issue-assessment`** — READ-ONLY. Always safe to run, VPS-friendly. Ingest → verify → classify → e2e-gate → report. Decides (graded, not a hard stop) whether to chain into `issue-resolve`.
+- **`issue-resolve`** — MUTATING, gated, autonomous-with-guardrails. Worktree off `develop` → predict/scenario/plan → TDD with Opus-orchestrated review loop → check → browser-free verification → **draft** PR → council review → STOP.
+
+```
+GitHub issue ─► issue-assessment (read-only)
+                  1. Ingest    gh issue view → claim, env, repro
+                  2. Verify    Explore agent over code/tests/docs + KNOWN_ISSUES.md + memory
+                  3. Classify  verdict taxonomy
+                  4. e2e-gate  is verification possible here & now?
+                  5. Report    comment to reporter (verdict + next step)
+                       ├─ INVALID / DUP / WONTFIX / NEEDS-INFO ─► stop (comment only)
+                       └─ CONFIRMED/LIKELY-BUG & scope clear ──► issue-resolve (if autonomy gate allows)
+
+                issue-resolve (mutating, gated)
+                  worktree off develop → /gflow:predict → /gflow:scenario → /gflow:plan
+                  → TDD (Opus plans, Sonnet codes, Opus reviews, loop to consensus)
+                  → /gflow:check → browser-free verification only
+                  → DRAFT PR → /gflow:pr-council-review → STOP
+                  Human: promote draft → headed e2e → merge.
+```
+
+## `issue-assessment` detail
+
+### Verdict taxonomy (exactly one per assessment)
+
+- `CONFIRMED-BUG` — reproduced or root-caused in code with line-level evidence.
+- `LIKELY-BUG / NEEDS-E2E` — strong code hypothesis, unverifiable here (e.g. #222: macOS-only, no headed browser). **The common VPS outcome.**
+- `NEEDS-INFO` — reporter must supply a discriminating diagnostic first.
+- `DUPLICATE` / `KNOWN-ISSUE` — matches `KNOWN_ISSUES.md` or an open issue/PR.
+- `WORKING-AS-INTENDED` / `INVALID` — usage error or expected behavior.
+- `WONTFIX / OUT-OF-SCOPE` — real but deliberately not addressed.
+
+### e2e-gate (the honesty mechanism)
+
+Before claiming any verification, classify what verification *requires*:
+
+- **Browser-free** (Gemini tool-path, unit, lint, pyright, recording-verif) → runnable autonomously; run it.
+- **Headed-Flow-browser required** (generation, selector, auth) → NOT possible on VPS → mark `NEEDS-E2E`, never claim success, hand to human.
+
+### Report format
+
+A reporter-facing comment: restated claim, verdict + confidence, evidence (`file:line`), root-cause hypothesis, the discriminating diagnostic requested (if `NEEDS-INFO`/`NEEDS-E2E`), and the next step (draft PR link if `issue-resolve` ran, else what we need).
+
+## `issue-resolve` guardrails
+
+Autonomous allow-list:
+- ✅ Post issue comment (text reply to reporter).
+- ✅ Open a **draft** PR (push branch + open PR in draft state).
+- ✅ Browser-free / credit-free verification.
+- ❌ **Never** spend Veo credits (no credit-spending e2e).
+- ❌ Never mark a PR ready; ❌ never merge; ❌ never push to `main`/`develop` (always a `bugfix/`-prefixed branch off `develop`).
+
+Hard preconditions before opening even a draft PR:
+1. Verdict ∈ {`CONFIRMED-BUG`, `LIKELY-BUG`} **and** scope single-surface / localized.
+2. A failing test exists first (TDD) and passes after the fix.
+3. `/gflow:check` clean (ruff + pyright + tests).
+4. If verification needed a headed browser → PR body states **"NOT e2e-verified — requires human macOS/headed run"** explicitly.
+
+Trigger gate (autonomy safety): the agent acts **only on issues a human labels** (e.g. `triage`), never on every new issue.
+
+### Orchestration model
+
+Opus plans → delegates coding to Sonnet → Opus reviews → loop until consensus → `/gflow:pr-council-review`. Gemini (`agy`) as an optional extra reviewer **if available** — soft dependency, never blocks.
+
+## Anti-hallucination skill routing
+
+The skill ships a **literal routing table** mapping situation → skill → how to invoke. Critical trap (in memory `skill-wrapper-registration-trap`): this repo's `skills/*/SKILL.md` are plain markdown invoked by **reading** `.claude/commands/gflow/*`, NOT by `Skill()`. Superpowers skills ARE `Skill()`-invocable. The skill instructs the agent to **re-derive** the table from `ls skills/` + `ls .claude/commands/gflow/` rather than trust a possibly-stale list.
+
+| Situation | Use | How |
+|---|---|---|
+| High-stakes change (auth/transport/selector/schema) | `/gflow:predict` | Read `skills/predict/SKILL.md` |
+| Edge cases + BDD skeleton | `/gflow:scenario` | Read `skills/scenario/SKILL.md` |
+| Write task checklist | `/gflow:plan` | Read `skills/plan/SKILL.md` |
+| Before any commit | `/gflow:check` | `.claude/commands/gflow/check.md` |
+| Pre-PR / PR review | `/gflow:pr-council-review`, `branch-review` | Read `skills/pr-council-review/SKILL.md` |
+| Touching auth/reCAPTCHA | `/gflow:known-issues` | `.claude/commands/gflow/known-issues.md` |
+| Worktree, TDD, finishing a branch | superpowers | `Skill()` tool (these are invocable) |
+
+## File layout
+
+```
+skills/issue-assessment/SKILL.md     # read-only conductor
+skills/issue-resolve/SKILL.md        # mutating, gated
+.claude/commands/gflow/issue-assessment.md   # thin wrapper: "read skills/.../SKILL.md"
+.claude/commands/gflow/issue-resolve.md
+```
+
+## Worked example — issue #222 (validation case)
+
+macOS, v0.22.0: `image t2i` launches a logged-out browser → 401 on `createProject` despite `.gflow_browser_strategy=chrome`. Code investigation hypothesis: `channel_for_profile()` returns `None` because macOS `is_chrome_available()` (`src/gflow_cli/browser_manager.py:146`) only checks the hardcoded `/Applications/Google Chrome.app/...` path with no `shutil.which()` fallback (unlike Windows/Linux), so generation falls back to bundled Chromium, which can't decrypt Keychain-protected cookies. **Caveat:** if detection failed, a `browser_manager.chrome_marker_but_unavailable` warning should fire — the reporter didn't mention it, so the channel may instead never be resolved on the `setup_shared_page` path. This ambiguity is exactly why the verdict is `LIKELY-BUG / NEEDS-E2E` (macOS + headed browser, unverifiable on Windows or the VPS) rather than `CONFIRMED-BUG`. Expected workflow output: a reporter reply requesting the discriminating diagnostic (does the warning appear? actual Chrome path? DEBUG run with channel logging), plus optionally a draft PR adding the `shutil.which` fallback with a unit test, flagged NOT-e2e-verified.
+
+## VPS deployment (later phase)
+
+To be completed from hermes-ops documentation (host, deploy path, agent-memory format, workflow activation, GitHub credentials). Deferred until after build + local e2e validation. This section will be filled before any remote action; nothing remote runs until the user confirms the target.
+
+## Out of scope (YAGNI)
+
+- A standalone reusable agent-orchestration skill (the Opus/Sonnet loop lives inside `issue-resolve` for now).
+- Auto-merging or auto-promoting PRs.
+- Acting on unlabeled issues.
+- Cross-repo generalization beyond gflow-cli.

--- a/docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md
@@ -18,7 +18,16 @@ Incoming GitHub issues (e.g. #222) need a **systematic, repeatable** assessment 
 
 The hermes-ops VPS is **headless Linux**. Flow generation auth requires a **headed real-Chrome** session (`real-browser-auth-mandatory` in memory). Therefore, for any Flow-generation/selector/auth bug, the autonomous agent **cannot e2e-verify** — it can only get the problem review-ready and hand to a human. This is encoded as a **standing known limitation**, never hidden. The design goal is to make a wrong autonomous action *rare*, not to pretend the agent can verify everything.
 
-## Architecture — two skills
+## Two-layer architecture (orchestration vs domain)
+
+Separation of concerns across two repos, with a one-way dependency:
+
+- **hermes-ops = orchestration layer (project-agnostic "HOW the agent operates").** Triggers (cron/webhook/label), the autonomy gate, the `skills/`→`blessed/` blessing procedure, secret access (SOPS `GH_TOKEN`), the Opus→Sonnet→Opus delegation loop, Telegram delivery, idempotency. Hosts an `autopilot-core` reused by `dependabot-autopilot` (deterministic), `issue-autopilot` (LLM), and `release-autopilot` (weekly patch-bump-if-safe).
+- **gflow-cli = domain layer (project-specific "WHAT the work means").** `issue-assessment` / `issue-resolve` + the existing `/gflow:*` pipeline. Encodes gflow-cli's e2e-gate (headed-browser truth), `KNOWN_ISSUES`, branch workflow.
+
+**Rule:** hermes orchestration *calls into* a target repo's domain skills; gflow-cli never imports hermes. A gflow-cli skill must run standalone (interactive) **and** be invokable by hermes. The safety boundary lands on the blessing gate — the autonomous machinery (hermes layer) is exactly what a human blesses; domain skills are ordinary repo content. The two skills below are the **domain layer**; the orchestration layer is a later phase in the hermes-ops repo.
+
+## Architecture — two skills (domain layer)
 
 The repo already ships the fix pipeline as skills (`/gflow:predict` → `/gflow:scenario` → `/gflow:plan` → `/gflow:check` → `/gflow:pr-council-review`) plus superpowers TDD/worktrees. The new work is a **conductor** on top, split for a clean safety boundary:
 
@@ -113,13 +122,22 @@ skills/issue-resolve/SKILL.md        # mutating, gated
 
 macOS, v0.22.0: `image t2i` launches a logged-out browser → 401 on `createProject` despite `.gflow_browser_strategy=chrome`. Code investigation hypothesis: `channel_for_profile()` returns `None` because macOS `is_chrome_available()` (`src/gflow_cli/browser_manager.py:146`) only checks the hardcoded `/Applications/Google Chrome.app/...` path with no `shutil.which()` fallback (unlike Windows/Linux), so generation falls back to bundled Chromium, which can't decrypt Keychain-protected cookies. **Caveat:** if detection failed, a `browser_manager.chrome_marker_but_unavailable` warning should fire — the reporter didn't mention it, so the channel may instead never be resolved on the `setup_shared_page` path. This ambiguity is exactly why the verdict is `LIKELY-BUG / NEEDS-E2E` (macOS + headed browser, unverifiable on Windows or the VPS) rather than `CONFIRMED-BUG`. Expected workflow output: a reporter reply requesting the discriminating diagnostic (does the warning appear? actual Chrome path? DEBUG run with channel logging), plus optionally a draft PR adding the `shutil.which` fallback with a unit test, flagged NOT-e2e-verified.
 
-## VPS deployment (later phase)
+## hermes-ops orchestration layer (later phase, hermes-ops repo)
 
-To be completed from hermes-ops documentation (host, deploy path, agent-memory format, workflow activation, GitHub credentials). Deferred until after build + local e2e validation. This section will be filled before any remote action; nothing remote runs until the user confirms the target.
+Confirmed facts about the target runtime (`C:\development\github\hermes-ops`, deployed):
 
-## Out of scope (YAGNI)
+- **VPS:** `89.167.1.15` (`cgserver01`), headless Hetzner Linux. SSH `deploy@89.167.1.15` (key-based). hermes-agent v0.16.0 as a systemd unit (`HERMES_HOME=/opt/hermes`); repo at `/opt/hermes-ops` (git-pull deploy: `git fetch && git reset --hard origin/main`).
+- **GitHub creds:** `GH_TOKEN` already provisioned in SOPS (`secrets/vps-prod.env.sops.yaml`), fine-grained PAT scoped to **gflow-cli `pull_requests:write + contents:write`**. Decrypted by `hermes.service` `ExecStartPre` to `/opt/hermes/.env` (600, owner `hermes`); `gh` reads it automatically.
+- **Knowledge (T1):** git-versioned markdown in `hermes-ops/knowledge/`; update = branch → human review → merge → VPS pulls.
+- **Triggers:** `hermes cron create "<expr>" "<prompt>" --skills … --deliver telegram` (v1); `hermes webhook subscribe --events … --skills … --deliver …` (v2, deferred).
+- **Blessing gate (NOT yet implemented):** `skills/` (unprivileged staging) → human signoff → `blessed/` (executable). Skill file format + promotion procedure are undefined on disk — `autopilot-core` defines them once.
+- **Headless confirmation:** no headed Chrome on the VPS → Flow-generation/selector/auth bugs are **never** e2e-verifiable autonomously. This is the standing known limitation that forces the `LIKELY-BUG / NEEDS-E2E` + draft-PR-for-human terminal behavior.
 
-- A standalone reusable agent-orchestration skill (the Opus/Sonnet loop lives inside `issue-resolve` for now).
-- Auto-merging or auto-promoting PRs.
+Reconciliation: the same-day `hermes-ops/docs/specs/2026-06-29-dependabot-autopilot-design.md` becomes the first (deterministic) specialization of `autopilot-core`. Nothing runs on the remote until the user confirms; this section is reference for the orchestration-layer spec to be written in the hermes-ops repo.
+
+## Out of scope (this spec — domain layer only)
+
+- The hermes-ops orchestration layer (`autopilot-core`, `issue-autopilot`, `release-autopilot`) — designed separately in the hermes-ops repo.
+- Auto-merging or auto-promoting PRs (always draft, human promotes).
 - Acting on unlabeled issues.
-- Cross-repo generalization beyond gflow-cli.
+- Onboarding target repos other than gflow-cli.

--- a/skills/issue-assessment/SKILL.md
+++ b/skills/issue-assessment/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: issue-assessment
+version: "1.0"
+description: >
+  Use when triaging a GitHub issue for gflow-cli — a reporter's bug claim, a
+  freshly-filed issue, or deciding whether and how to act on one. Also use when
+  an autonomous agent (hermes-ops) picks up a labelled issue. Read-only: produces
+  a verdict, an end-to-end-verifiability judgment, and a reporter-facing reply.
+  Does not modify code or post anything on its own.
+---
+
+# `issue-assessment` — triage a gflow-cli issue honestly
+
+Read-only conductor. Verify the reporter's claim against the code, tests, docs,
+`KNOWN_ISSUES.md`, and auto-memory; classify it; judge whether it can be
+verified end-to-end *in the current environment*; and draft a reply. The output
+is a standard artifact a human or the `issue-resolve` skill can act on.
+
+**Core principle:** never assert more than the evidence supports. A claim is
+`CONFIRMED` only with line-level code evidence or a reproduction; a fix is
+"verified" only after running it on the **affected surface**. Honest
+"can't verify here" beats a false green check — a bounced fix costs more trust
+than an accurate "not yet."
+
+---
+
+## When to invoke
+
+- A new or updated GitHub issue needs a verdict before anyone spends effort.
+- An autonomous run (hermes-ops) reacts to an issue labelled for triage.
+- You're about to "just fix" a reported bug — assess first; the scope decision
+  (reply-only vs hand to `issue-resolve`) depends on this.
+
+Skip for: issues that are obviously feature requests routed elsewhere, or
+already-triaged issues entering implementation.
+
+---
+
+## Invocation
+
+```
+/gflow:issue-assessment <issue number or URL>
+```
+
+This repo's `skills/*/SKILL.md` are plain Markdown — invoke by **reading** the
+file (via the `.claude/commands/gflow/*` wrapper), never `Skill(skill=...)`.
+
+---
+
+## Protocol
+
+### 1. Ingest
+`gh issue view <N> --json title,body,comments,labels,author,state`. Extract: the
+claimed symptom, environment (OS, version, install method), exact repro steps,
+and any logs/error classes the reporter pasted.
+
+### 2. Verify (read-only)
+Dispatch a search/Explore agent (keep your own context clean) to corroborate or
+refute the claim against the real tree. Always check, in order:
+- the source path(s) the symptom implicates — cite `file_path:line_number`;
+- `KNOWN_ISSUES.md` (is this Open / Mitigated / Resolved already?);
+- open issues/PRs (`gh pr list`, `gh issue list`) for duplicates or in-flight fixes;
+- auto-memory for prior context on the surface.
+Disprove parts of the reporter's framing where the code says otherwise (e.g.
+`browser_engine: playwright` is the engine axis, not the channel) — a precise
+correction is more useful than agreement.
+
+### 3. Classify — exactly one verdict
+
+| Verdict | Meaning |
+|---|---|
+| `CONFIRMED-BUG` | Reproduced, or root-caused in code with line-level evidence. |
+| `LIKELY-BUG / NEEDS-E2E` | Strong code hypothesis, but unverifiable in this environment (e.g. macOS-only or headed-browser bug on a headless/Windows host). |
+| `NEEDS-INFO` | A specific discriminating diagnostic is required before deciding. |
+| `DUPLICATE` / `KNOWN-ISSUE` | Matches an open issue/PR or a `KNOWN_ISSUES.md` entry. |
+| `WORKING-AS-INTENDED` / `INVALID` | Usage error or expected behavior. |
+| `WONTFIX / OUT-OF-SCOPE` | Real but deliberately not addressed. |
+
+### 4. e2e-gate — what would verification actually require?
+Classify the verification cost before claiming anything is fixed:
+- **Browser-free** (pure-Python logic, Gemini tool-path, unit/lint/type, recording-verif) → verifiable anywhere, including the headless VPS. Run it.
+- **Headed-Flow-browser required** (generation, selector, auth, reCAPTCHA) → **not** verifiable on a headless or wrong-OS host. Verdict tilts to `LIKELY-BUG / NEEDS-E2E`; never claim success; the final check is a human on the affected surface. (See memory: `done-means-e2e-verified`, `pr-must-verify-on-affected-surface`.)
+
+### 5. Report (the artifact)
+Produce the reply below. Post it only if the autonomy gate allows (autonomous
+runs may comment; otherwise surface for a human to send).
+
+```
+**Assessment of #<N>: <verdict>** (confidence <N>/10)
+
+Restated claim: <one line>.
+
+Findings:
+- <evidence as file:line> …
+- <corrections to the reporter's framing, if any> …
+
+Root cause / hypothesis: <what and why, or "unconfirmed because …">.
+
+What we need next:
+- <the single discriminating diagnostic — for NEEDS-INFO/NEEDS-E2E>, or
+- <draft PR link — if issue-resolve ran>, or
+- <why this is a dup/invalid/wontfix>.
+```
+
+### 6. Hand-off decision (graded, not a hard stop)
+- Verdict ∈ {`CONFIRMED-BUG`, `LIKELY-BUG`} **and** scope is single-surface/localized
+  **and** a fix is verifiable in this environment → chain to **`issue-resolve`**.
+- Otherwise → reply only; the next step is a human or more info.
+
+---
+
+## Skill routing (do not hallucinate skill names)
+
+Re-derive this from `ls skills/` + `ls .claude/commands/gflow/` before relying on
+it — names drift. Current map:
+
+| Need | Use | How |
+|---|---|---|
+| High-stakes change (auth/transport/selector/schema) | `/gflow:predict` | read `skills/predict/SKILL.md` |
+| Edge cases + BDD skeleton | `/gflow:scenario` | read `skills/scenario/SKILL.md` |
+| Touching auth/reCAPTCHA | `/gflow:known-issues` | `.claude/commands/gflow/known-issues.md` |
+| Drive the fix | `issue-resolve` | read `skills/issue-resolve/SKILL.md` |
+| Worktree / TDD | superpowers | `Skill()` tool (these *are* invocable) |
+
+---
+
+## Output format
+
+A single Markdown block: the verdict line, findings with citations, root-cause
+hypothesis, and the "what we need next" step. No code changes, no posting unless
+the autonomy gate permits.
+
+---
+
+## Provenance
+
+Designed 2026-06-29 (`docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md`).
+Validated against issue #222 (a `LIKELY-BUG / NEEDS-E2E` case: macOS + headed
+browser, unverifiable on Windows/headless). Authored recipe-shaped after three
+baseline runs showed capable agents already comply with the project's discipline
+rules — the skill standardizes the procedure and artifact, it does not enforce
+discipline the agent lacks.

--- a/skills/issue-resolve/SKILL.md
+++ b/skills/issue-resolve/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: issue-resolve
+version: "1.0"
+description: >
+  Use when an assessed gflow-cli issue (verdict CONFIRMED-BUG or LIKELY-BUG)
+  has localized, verifiable scope and should be driven to a fix. Mutating and
+  gated: it works in an isolated worktree, fixes test-first, and opens a DRAFT
+  PR for human review. Built to run autonomously (hermes-ops) within a strict
+  action envelope — never merges, never spends credits, never claims unverified.
+---
+
+# `issue-resolve` — drive an assessed issue to a draft PR
+
+Takes a verdict from `issue-assessment` and produces a reviewable fix. The
+terminal state is a **draft PR a human promotes** — never an autonomous merge.
+
+**Core principle:** the agent's job is to get the problem *review-ready*, not
+to declare victory. A fix is "verified" only after it runs green on the
+**affected surface**; when that surface can't be reached here (headed Flow
+browser, macOS-only, credits), say so in the PR and stop. (Memory:
+`done-means-e2e-verified`, `pr-must-verify-on-affected-surface`.)
+
+---
+
+## Preconditions (all required before any code change)
+
+1. An `issue-assessment` verdict of `CONFIRMED-BUG` or `LIKELY-BUG`.
+2. Scope is single-surface / localized (not a cross-cutting redesign).
+3. The fix is **verifiable in this environment** (browser-free), OR the
+   verification gap is explicitly carried into the PR as "needs human e2e."
+
+If any fails → do not resolve; return to `issue-assessment` (reply-only).
+
+---
+
+## Autonomy envelope (the action contract)
+
+Allowed autonomously:
+- ✅ Post one issue comment (status / reply to reporter).
+- ✅ Open a **draft** PR (push a `bugfix/`-prefixed branch off `develop`).
+- ✅ Run **browser-free / credit-free** verification (unit, lint, type, recording-verif, Gemini tool-path).
+
+Never (these require a human, regardless of pressure):
+- ❌ Spend Veo credits (no live video generation to "verify").
+- ❌ Mark a PR ready for review or merge it.
+- ❌ Push to `main` or `develop`.
+- ❌ State a fix is "verified" / "fixed" when it was not run on the affected surface.
+
+Red flags — if you catch yourself reasoning toward any of these, STOP:
+"just spend one credit to exercise the path", "it's obviously correct, merge it",
+"mark it ready to save the human time", "say it's verified so we can close it".
+Urgency does not make an unverified fix verified.
+
+---
+
+## Protocol
+
+### 1. Isolate
+Worktree off `origin/develop` on a `bugfix/<slug>` branch (use the
+`superpowers:using-git-worktrees` skill). Never work on `develop`/`main`.
+
+### 2. Gate high-stakes changes
+If the fix touches auth, a transport, selectors, or a schema → run
+`/gflow:predict` first; for edge-case coverage run `/gflow:scenario`. Otherwise
+proceed.
+
+### 3. Fix test-first (TDD)
+Use `superpowers:test-driven-development`. Write/confirm a **failing** test that
+reproduces the bug on the affected surface, then the minimal fix, then green.
+If the bug's surface can't be reached here, the test is the closest browser-free
+proxy and the PR flags the residual gap.
+
+### 4. Orchestrate (scales with complexity)
+For non-trivial fixes: Opus plans → delegates coding to a Sonnet subagent →
+Opus reviews the diff → loop until consensus. Gemini (`agy`) as an optional
+extra reviewer **if available** (soft dependency, never blocks). Trivial
+one-line fixes skip the loop.
+
+### 5. Check
+`/gflow:check` clean (ruff + pyright + tests) before the PR. Scope tests
+locally (full `pytest --cov` OOMs — memory `full-test-suite-ooms`); trust CI.
+
+### 6. Draft PR
+`gh pr create --draft --base develop`. Body is a **plain string** (never a
+heredoc — CLAUDE.md MCP rule). Include a **Verification status** section with
+checked/unchecked boxes; use `Refs #N` when a human must still verify,
+`Closes #N` only when fully verified here. Then `/gflow:pr-council-review`
+(or `/gflow:branch-review` pre-push). **STOP** — a human promotes and merges.
+
+---
+
+## Quick reference
+
+| Step | Tool |
+|---|---|
+| Worktree | `superpowers:using-git-worktrees` |
+| High-stakes gate | `/gflow:predict`, `/gflow:scenario` |
+| TDD | `superpowers:test-driven-development` |
+| Pre-commit | `/gflow:check` |
+| PR review | `/gflow:pr-council-review`, `/gflow:branch-review` |
+| Verify discipline | `superpowers:verification-before-completion` |
+
+(Re-derive tool names from `ls skills/` + `ls .claude/commands/gflow/` — don't trust a stale list.)
+
+---
+
+## Common mistakes
+
+- Working on `develop` instead of a `bugfix/` branch off it (memory: `develop-divergence-recovery`).
+- A non-draft PR that auto-merges (memory: `draft-pr-merge-trap` — `gh pr ready` is a human action).
+- Verifying on the wrong surface and calling it done (memory: `pr-must-verify-on-affected-surface`).
+- Heredoc in a PR body via an MCP tool (CLAUDE.md: plain string only).
+
+---
+
+## Provenance
+
+Designed 2026-06-29 (`docs/superpowers/specs/2026-06-29-issue-assessment-workflow-design.md`).
+Resolve-path validated by an injected pure-Python canary bug (off-by-one in
+`extension_from_magic`) fixed test-first to green on this host. Guardrails are
+the autonomous **action contract**, not discipline-rescue — baseline runs showed
+capable agents already refuse credit-spend / merge / false-verified under
+pressure; the envelope makes the policy explicit and machine-checkable.


### PR DESCRIPTION
## Summary

Adds a two-skill **issue triage + resolution** workflow (the gflow-cli *domain* layer of a planned hermes-ops autopilot):

- **`skills/issue-assessment/`** — read-only conductor: ingest a GitHub issue → verify against code/tests/docs/`KNOWN_ISSUES`/memory → assign one verdict (taxonomy) → **e2e-gate** (never claim a fix verified on an unverifiable surface) → reporter-reply artifact → graded hand-off.
- **`skills/issue-resolve/`** — mutating, gated: worktree off `develop` → predict/scenario gate → TDD → `/gflow:check` → **draft** PR with a verification-status section → council review → STOP for a human. Explicit autonomy envelope: never merges, spends credits, or claims unverified fixes.
- Command wrappers under `.claude/commands/gflow/`.
- Design spec under `docs/superpowers/specs/` (two-layer architecture; confirmed hermes-ops VPS/SOPS/blessing facts).

## How it was built (TDD for skills)

- 3 RED baselines (assess #222, resolve a canary, guardrail-pressure) all showed capable agents *already* comply with the project's discipline rules → skills authored **recipe-shaped**, not prohibition theater.
- GREEN-verified: `issue-assessment` on #222 (verdict `LIKELY-BUG/NEEDS-E2E`, correct e2e-gate; surfaced the `--password-store` root cause for #222), `issue-resolve` on an injected pure-Python canary (correct `bugfix/` branch, test-first, draft PR, STOP honored, no credits).

## Scope

Docs + skill markdown only — no source changes. `develop` and `main` untouched during development; canaries torn down.

## Test plan

- [x] `issue-assessment` GREEN on #222 from a one-line trigger
- [x] `issue-resolve` GREEN on injected canary (independently re-verified: 32 `test_paths.py` pass)
- [ ] Layer B (hermes-ops orchestration) — separate follow-up in the hermes-ops repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)