### PR TITLE
fix(api): keep --password-store=basic at generation to fix macOS 401 (#222)

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -333,10 +333,16 @@ class FlowApiClient:
             "locale": "en-US",
             "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
             "channel": channel_for_profile(self.profile_dir),
+            # Do NOT suppress Playwright's default --password-store=basic here.
+            # auth login (auth/real_chrome.py) seals the profile's cookies with
+            # the *basic* store; if generation lets Chrome fall back to the OS
+            # keychain (macOS "Chrome Safe Storage") the basic-sealed cookies
+            # can't be decrypted -> logged-out context -> 401 on createProject.
+            # Keeping the flag (via Playwright's default) makes both paths
+            # symmetric. See issue #222.
             "ignore_default_args": [
                 "--enable-automation",
                 "--no-sandbox",
-                "--password-store=basic",
             ],
             "args": ["--disable-blink-features=AutomationControlled", "--disable-dev-shm-usage"],
         }

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -31,8 +31,13 @@ def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
     assert kwargs["ignore_default_args"] == [
         "--enable-automation",
         "--no-sandbox",
-        "--password-store=basic",
     ]
+    # Regression for #222: generation must NOT suppress --password-store=basic.
+    # auth login seals the profile cookies with the *basic* store; if generation
+    # lets Chrome fall back to the macOS keychain, those cookies can't be
+    # decrypted -> logged-out -> 401 on createProject. (Unit-level proxy: the
+    # real failure only reproduces on a headed Chrome on macOS.)
+    assert "--password-store=basic" not in kwargs["ignore_default_args"]
     assert kwargs["args"] == [
         "--disable-blink-features=AutomationControlled",
         "--disable-dev-shm-usage",


### PR DESCRIPTION
## Summary

Fixes the macOS `401 AuthExpiredError` on `project.createProject` reported in #222, where `gflow image t2i` opened a logged-out browser despite a verified `auth login`.

**Root cause — a `--password-store` asymmetry between login and generation:**
- `auth login` (`auth/real_chrome.py:69`) launches Chrome **with** `--password-store=basic`, sealing the profile's cookies with Chrome's *basic* store (not the macOS Keychain).
- Generation (`api/client.py:_persistent_context_kwargs`) listed `--password-store=basic` in `ignore_default_args`, **stripping** the flag Playwright adds by default — so that Chrome used the macOS Keychain ("Chrome Safe Storage") to read the cookies.
- basic-sealed cookies read under the Keychain → decrypt failure → logged-out → `401`. macOS/Linux-only; Windows uses DPAPI and ignores the flag (why it never reproduced on Windows, and why `auth login`/`auth status` — which don't hit this path — succeeded).

**Fix:** stop suppressing `--password-store=basic` at generation so it is symmetric with login.

## ⚠️ Verification status — INCOMPLETE (needs macOS)
- [x] Unit: launch-kwargs pin test updated + regression assertion added (`tests/api/test_client_launch_kwargs.py`) — 2 passed
- [x] `ruff check` + `ruff format --check` clean; `pyright src/gflow_cli/api/client.py` 0 errors
- [ ] **Live `gflow image t2i` on macOS confirming the 401 is gone** — NOT DONE
- [ ] Confirm `auth login` (still basic) + generation (now basic) round-trip on macOS

This **cannot** be verified on CI (headless Linux) or on Windows — #222 is a macOS-Keychain-specific failure. Held as **draft** pending a maintainer macOS run. Auth-surface change — please review the symmetry argument before promoting.

`Refs #222` (not `Closes`) — do not auto-close until macOS-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)