### PR TITLE
fix(browser,image): co-land #219 — Chromium-only channel gate + T2I extra-image guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chrome channel on Chromium-only hosts**: `channel_for_profile()` now gates
+  Playwright's `channel="chrome"` on a new `_is_playwright_chrome_channel_available()`
+  check that probes only the exact Google-Chrome paths Playwright hardcodes, instead
+  of `is_chrome_available()` (which also accepts Chromium). On a host with only
+  Chromium installed, the CLI no longer requests `channel="chrome"` and fails with
+  `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`; it falls
+  back to bundled Chromium and logs an actionable warning (#219).
+- **Text-to-image extra-image billing**: the generation-settings trigger selector now
+  requires `button[aria-haspopup='menu']` (aliased to `MODE_SWITCH_TRIGGER_SELECTORS`),
+  preventing a mis-click on an icon-only aspect thumbnail that skipped the count panel
+  and left Flow's own default count (typically 2) in effect — billing extra generations
+  while the CLI saved only one (#219).
+- **Extra-image observability**: `generate_image()` now logs a
+  `client.generate_image_extra_returned` warning when the transport returns more images
+  than the requested `count=1`, so silent over-generation is surfaced to the user (#219).
+
 ## [0.22.0] — 2026-06-28
 
 ### Added

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -1316,6 +1316,12 @@ class FlowApiClient:
         constructing a :class:`GenerateImageRequest` with ``count>1`` and then
         invoking the single-image API still receive exactly one image (no
         silent discard).
+
+        When the transport returns more images than the requested ``count=1``
+        (typically because the generation-settings panel was not found and Flow
+        used its own default count, billing the account for the extra
+        generations), a ``client.generate_image_extra_returned`` warning is
+        logged so the caller can investigate.
         """
         req_one: GenerateImageRequest = _dc_replace(req, count=1)
         images = await self._drive_images_generation(
@@ -1323,6 +1329,20 @@ class FlowApiClient:
             req=req_one,
             recaptcha_action=recaptcha_action,
         )
+        if len(images) > 1:
+            logger.warning(
+                "client.generate_image_extra_returned",
+                requested=1,
+                returned=len(images),
+                extra_media_ids=[img.media_name for img in images[1:]],
+                hint=(
+                    "Flow generated more images than requested — the "
+                    "generation-settings panel selector may have missed and Flow "
+                    "used its own default count. The extra image(s) were billed "
+                    "to your account but not saved. Use `gflow image t2i -n 2` to "
+                    "request and save multiple images explicitly."
+                ),
+            )
         return images[0]
 
     async def generate_image(

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -387,15 +387,16 @@ WELCOME_SCREEN_SELECTORS = (
 )
 
 
-# Generation settings trigger — the button shows the current ratio icon.
-# All 5 ratio icon names are enumerated so the selector is ratio-invariant.
-GEN_SETTINGS_BUTTON_SELECTORS = (
-    "button:has(i.google-symbols:text('crop_16_9'))",
-    "button:has(i.google-symbols:text('crop_9_16'))",
-    "button:has(i.google-symbols:text('crop_square'))",
-    "button:has(i.google-symbols:text('crop_portrait'))",
-    "button:has(i.google-symbols:text('crop_landscape'))",
-)
+# Generation settings trigger — the SAME unified button as the mode-switch
+# dropdown: a ``button[aria-haspopup='menu']`` carrying the current ratio
+# ``crop_*`` icon. The ``aria-haspopup='menu'`` qualifier is REQUIRED — without
+# it any icon-only aspect thumbnail in the just-opened panel can match, causing
+# a click on the wrong element and a ``gen_settings_panel_not_found`` skip that
+# leaves Flow's own default count in effect (typically 2 concurrent requests
+# billed while the CLI downloads only 1). Aliased to
+# ``MODE_SWITCH_TRIGGER_SELECTORS`` so the two call sites stay a single source
+# of truth (see [[image-video-mode-switch-symmetry]]).
+GEN_SETTINGS_BUTTON_SELECTORS = MODE_SWITCH_TRIGGER_SELECTORS
 
 # CLI string → ordered list of candidate tab labels to try in the Flow gen
 # settings panel. Most ratios are labelled with their colon-numeric form

--- a/src/gflow_cli/browser_manager.py
+++ b/src/gflow_cli/browser_manager.py
@@ -168,8 +168,56 @@ def _find_chrome_binary() -> str:
     )
 
 
+def _is_playwright_chrome_channel_available() -> bool:
+    """Return True only when Playwright's ``channel="chrome"`` can find Chrome.
+
+    Playwright's ``launch_persistent_context(channel="chrome")`` looks for
+    **Google Chrome proper** at platform-specific hardcoded paths — it does NOT
+    accept a plain Chromium binary. This function replicates those paths so
+    :func:`channel_for_profile` can gate the ``channel="chrome"`` argument on a
+    binary that Playwright will actually find, avoiding the misleading
+    ``Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome``
+    error that occurs when only system Chromium is present.
+
+    The ``CHROME_BINARY`` env var override is honoured for parity with
+    :func:`_find_chrome_binary`.
+    """
+    env_override = os.environ.get("CHROME_BINARY")
+    if env_override:
+        return True
+
+    # Playwright's own resolution paths for channel="chrome". Derived from
+    # playwright/_impl/_browser_type.py executables(). channel="chrome" resolves
+    # ONLY to these exact Google-Chrome paths — a system Chromium does NOT
+    # satisfy it, so we must not list Chromium or distro chrome shims here.
+    if sys.platform == "win32":
+        local_app_data = os.environ.get("LOCALAPPDATA", "")
+        chrome_paths: list[Path] = [
+            Path("C:/Program Files/Google/Chrome/Application/chrome.exe"),
+            Path("C:/Program Files (x86)/Google/Chrome/Application/chrome.exe"),
+            Path(local_app_data or "") / "Google" / "Chrome" / "Application" / "chrome.exe",
+        ]
+    elif sys.platform == "darwin":
+        chrome_paths = [
+            Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+        ]
+    else:
+        # Linux — Playwright resolves channel="chrome" only to this path.
+        chrome_paths = [
+            Path("/opt/google/chrome/chrome"),
+        ]
+
+    return any(p.exists() for p in chrome_paths)
+
+
 def is_chrome_available() -> bool:
-    """Return True if a Google Chrome binary can be found on this system."""
+    """Return True if a Google Chrome (or Chromium fallback) binary can be found.
+
+    This is used for the auth login flow and CDP spawning. It intentionally
+    accepts Chromium as a fallback so the auth browser can open even when only
+    Chromium is installed. For deciding whether Playwright's ``channel="chrome"``
+    can be used, call :func:`_is_playwright_chrome_channel_available` instead.
+    """
     try:
         _find_chrome_binary()
         return True
@@ -182,14 +230,22 @@ def channel_for_profile(profile_dir: Path) -> str | None:
 
     Reads the ``.gflow_browser_strategy`` marker written by
     :class:`~gflow_cli.auth.real_chrome.RealChromeStrategy`. When the marker
-    is ``"chrome"`` and system Chrome is available, returns ``"chrome"`` so
-    callers can pass it to ``launch_persistent_context(channel=...)`` —
-    avoiding the downgrade-cleanup exit-33 that occurs when Playwright's
-    bundled Chromium opens a profile created by Chrome 130+.
+    is ``"chrome"`` and **Google Chrome proper** is available at the paths
+    Playwright expects, returns ``"chrome"`` so callers can pass it to
+    ``launch_persistent_context(channel=...)`` — avoiding the downgrade-cleanup
+    exit-33 that occurs when Playwright's bundled Chromium opens a profile
+    created by Chrome 130+.
+
+    Critically, this gate uses :func:`_is_playwright_chrome_channel_available`
+    (not :func:`is_chrome_available`) so that a system with only Chromium
+    installed does NOT request ``channel="chrome"`` — Playwright's
+    ``channel="chrome"`` resolves to hardcoded Google-Chrome paths and would
+    otherwise fail with
+    ``Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome``.
 
     Logs a warning when the marker requests Chrome but Chrome is no longer
-    available, as the resulting launch against bundled Chromium will likely
-    fail with the same exit-33 error.
+    available at the expected Playwright paths, as the resulting launch against
+    bundled Chromium will likely fail with the same exit-33 error.
     """
     import structlog as _structlog
 
@@ -200,13 +256,16 @@ def channel_for_profile(profile_dir: Path) -> str | None:
     strategy = marker.read_text(encoding="utf-8").strip()
     if strategy != "chrome":
         return None
-    if is_chrome_available():
+    if _is_playwright_chrome_channel_available():
         return "chrome"
     _log.warning(
         "browser_manager.chrome_marker_but_unavailable",
         profile_dir=str(profile_dir),
-        hint="Profile was captured with system Chrome but Chrome is not found. "
-        "Re-run `gflow auth login --browser chrome` after installing Chrome.",
+        hint="Profile was captured with system Chrome but Google Chrome is not "
+        "found at the paths Playwright expects (e.g. /opt/google/chrome/chrome). "
+        "Falling back to Playwright's bundled Chromium. "
+        "Re-run `gflow auth login --browser chrome` after installing Chrome if "
+        "you need the Chrome channel.",
     )
     return None
 

--- a/tests/api/test_client_image.py
+++ b/tests/api/test_client_image.py
@@ -15,12 +15,14 @@ a controllable _FakeTransport.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import inspect
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import structlog
 
 from gflow_cli.api.client import FlowApiClient, FlowApiError
 from gflow_cli.api.dto import GeneratedImage
@@ -151,6 +153,51 @@ class TestGenerateImage:
         result = await client.generate_image(project_id="proj-1", req=_make_req())
 
         assert isinstance(result, GeneratedImage)
+
+    async def test_generate_image_warns_when_transport_returns_extra(self, tmp_path: Path) -> None:
+        """count=1 but transport returns 2 → client.generate_image_extra_returned warning.
+
+        Guards the regression where a missed generation-settings panel let Flow
+        bill its own default count: the CLI still returns the first image, but
+        the over-generation must be surfaced via a structured warning naming the
+        extra media ids. A fresh LogCapture-wrapped logger is injected so no
+        cached structlog config from another test bleeds in
+        (see auto-memory: structlog cache-logger-off-for-tests).
+        """
+        cap = structlog.testing.LogCapture()
+        with patch(
+            "gflow_cli.api.client.logger",
+            structlog.wrap_logger(None, processors=[cap]),
+        ):
+            extra = dataclasses.replace(_FAKE_IMAGE, media_name="media-uuid-2")
+            transport = _FakeTransport(images=[_FAKE_IMAGE, extra])
+            client = _client_with_transport(tmp_path, transport)
+
+            result = await client.generate_image(project_id="proj-1", req=_make_req())
+
+        # The caller still receives exactly the first image (no silent discard surprise).
+        assert result.media_name == "media-uuid-1"
+
+        events = [e for e in cap.entries if e["event"] == "client.generate_image_extra_returned"]
+        assert len(events) == 1, f"expected one extra-returned warning, got {cap.entries}"
+        assert events[0]["log_level"] == "warning"
+        assert events[0]["requested"] == 1
+        assert events[0]["returned"] == 2
+        assert events[0]["extra_media_ids"] == ["media-uuid-2"]
+
+    async def test_generate_image_no_warning_on_single_image(self, tmp_path: Path) -> None:
+        """count=1 and transport returns 1 → no extra-returned warning (negative case)."""
+        cap = structlog.testing.LogCapture()
+        with patch(
+            "gflow_cli.api.client.logger",
+            structlog.wrap_logger(None, processors=[cap]),
+        ):
+            transport = _FakeTransport()  # default single image
+            client = _client_with_transport(tmp_path, transport)
+
+            await client.generate_image(project_id="proj-1", req=_make_req())
+
+        assert not [e for e in cap.entries if e["event"] == "client.generate_image_extra_returned"]
 
     async def test_generate_image_raises_content_policy_on_empty_media(
         self, tmp_path: Path

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -265,6 +265,38 @@ class TestPlaywrightChromeChannelAvailable:
         with patch.dict(os.environ, {"CHROME_BINARY": str(tmp_path / "chrome")}):
             assert _is_playwright_chrome_channel_available() is True
 
+    def test_win32_probes_program_files_chrome(self) -> None:
+        """On win32, the Program Files Google-Chrome path is probed → True when present."""
+        from gflow_cli.browser_manager import _is_playwright_chrome_channel_available
+
+        expected = "C:/Program Files/Google/Chrome/Application/chrome.exe"
+        env_without = {
+            k: v for k, v in os.environ.items() if k not in ("CHROME_BINARY", "LOCALAPPDATA")
+        }
+        env_without["LOCALAPPDATA"] = str(Path(tempfile.gettempdir()) / "nonexistent_la")
+
+        def path_exists_mock(self: Path) -> bool:
+            return str(self).replace("\\", "/") == expected
+
+        with (
+            patch.dict(os.environ, env_without, clear=True),
+            patch("sys.platform", "win32"),
+            patch.object(Path, "exists", path_exists_mock),
+        ):
+            assert _is_playwright_chrome_channel_available() is True
+
+    def test_darwin_probes_app_bundle(self) -> None:
+        """On darwin, the /Applications Google Chrome.app path is probed."""
+        from gflow_cli.browser_manager import _is_playwright_chrome_channel_available
+
+        env_without = {k: v for k, v in os.environ.items() if k != "CHROME_BINARY"}
+        with (
+            patch.dict(os.environ, env_without, clear=True),
+            patch("sys.platform", "darwin"),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert _is_playwright_chrome_channel_available() is True
+
 
 # ---------------------------------------------------------------------------
 # Port-range auto-increment

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -223,6 +223,49 @@ class TestChromeBinaryDetection:
         assert "chrome.exe" in result.lower() or "Chrome" in result
 
 
+class TestPlaywrightChromeChannelAvailable:
+    """Gate for Playwright's ``channel="chrome"`` — Chromium must NOT satisfy it.
+
+    ``launch_persistent_context(channel="chrome")`` resolves to hardcoded
+    Google-Chrome paths; a plain Chromium binary does not satisfy it. The gate
+    therefore must ignore ``shutil.which`` (which would find Chromium) and probe
+    only the exact Google-Chrome paths.
+    """
+
+    def test_chromium_only_host_returns_false(self) -> None:
+        """Chromium on PATH but no Google Chrome at Playwright's paths → False."""
+        from gflow_cli.browser_manager import _is_playwright_chrome_channel_available
+
+        env_without = {k: v for k, v in os.environ.items() if k != "CHROME_BINARY"}
+        with (
+            patch.dict(os.environ, env_without, clear=True),
+            patch("sys.platform", "linux"),
+            # Chromium IS discoverable, but the gate must ignore which() entirely.
+            patch("gflow_cli.browser_manager.shutil.which", return_value="/usr/bin/chromium"),
+            patch.object(Path, "exists", return_value=False),
+        ):
+            assert _is_playwright_chrome_channel_available() is False
+
+    def test_returns_true_when_google_chrome_present(self) -> None:
+        """Google Chrome at Playwright's expected path → True."""
+        from gflow_cli.browser_manager import _is_playwright_chrome_channel_available
+
+        env_without = {k: v for k, v in os.environ.items() if k != "CHROME_BINARY"}
+        with (
+            patch.dict(os.environ, env_without, clear=True),
+            patch("sys.platform", "linux"),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            assert _is_playwright_chrome_channel_available() is True
+
+    def test_env_override_returns_true(self, tmp_path: Path) -> None:
+        """CHROME_BINARY override is honoured for parity with _find_chrome_binary."""
+        from gflow_cli.browser_manager import _is_playwright_chrome_channel_available
+
+        with patch.dict(os.environ, {"CHROME_BINARY": str(tmp_path / "chrome")}):
+            assert _is_playwright_chrome_channel_available() is True
+
+
 # ---------------------------------------------------------------------------
 # Port-range auto-increment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Co-lands **#219** (by @C1ph3r404 — *resolve Chrome profile and T2I extra-image generation bugs*) onto current `develop`, with the council-required must-fixes folded in. #219 is behind `develop` (pre-dates the merged #225/#224) and could not be live-verified by the contributor (likely a Chromium-only host); this branch re-applies the three root-cause changes, addresses the review, and adds the missing tests. **Live-verified on a real-Chrome host** (see Test plan).

`Refs #219`. Not the #222 fix — #222 was resolved separately by #225 (`--password-store=basic` asymmetry). This fixes a distinct Chromium-only channel bug + a T2I over-generation bug.

## Changes (the 3 from #219)

1. **`browser_manager.py`** — new `_is_playwright_chrome_channel_available()` probing only the exact Google-Chrome paths Playwright hardcodes; `channel_for_profile()` now gates `channel="chrome"` on it instead of `is_chrome_available()` (which also accepts Chromium). Fixes the misleading `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome` on Chromium-only hosts — falls back to bundled Chromium with an actionable warning.
2. **`ui_automation.py`** — `GEN_SETTINGS_BUTTON_SELECTORS` now requires `button[aria-haspopup='menu']`, preventing a mis-click on an icon-only aspect thumbnail that skipped the count panel and left Flow's default count (~2) billing extra generations.
3. **`client.py`** — `generate_image()` logs `client.generate_image_extra_returned` when the transport returns more images than the requested `count=1`.

## Council must-fixes applied

1. **CHANGELOG** — added an `[Unreleased] ### Fixed` block for the three bugfixes.
2. **DRY selector** — `GEN_SETTINGS_BUTTON_SELECTORS = MODE_SWITCH_TRIGGER_SELECTORS` (single source of truth; they target the same button).
3. **Narrowed Linux probe** — `_is_playwright_chrome_channel_available()` checks only `/opt/google/chrome/chrome` on Linux; dropped the over-broad `/usr/bin/google-chrome*` paths that would re-trigger the very error being fixed.
4. **Tests** — extra-image warning fires on 2 images (+ negative case); `_is_playwright_chrome_channel_available()` Chromium-only → False (+ positive + env-override cases).

Also: client uses the module-level `logger` (no redundant local `import structlog`).

## Test plan

- [x] `/gflow:check`: hygiene ✅, ruff ✅, `pyright src` 0 errors ✅, scoped tests 908 passed / 7 skipped ✅ (incl. 5 new tests).
- [x] **Live-verify** (credit-free `image t2i`, headed, real Chrome, profile `denon82`): `image_mode_entered` ✅, gen-settings panel found (`panel_currently_visible: true`, **no** `gen_settings_panel_not_found`) ✅, count `desired=1 → final=1 success=true` ✅, **no** `generate_image_extra_returned` ✅, exactly 1 image saved, exit 0 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: C1ph3r404 <C1ph3r404@users.noreply.github.com>