### PR TITLE
docs(agents): add "Working discipline — verify before you act" rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,15 @@ Or invoke the wrapper: `/gflow:check`.
 - Run `/gflow:check` (or the Impeccable Routine) before every commit.
 - All releases require a signed annotated tag (`git tag -s vX.Y.Z`); CI rejects unsigned tags.
 
+## Working discipline — verify before you act
+
+These rules exist because docs alone don't bind under momentum: a "check open PRs first" rule was already written and still got skipped, and a PR was merged without seeing an entangled open one. Follow them on every task.
+
+- **Check what's already in flight before coding a fix, opening a PR, or merging.** Run `gh pr list` and `git ls-remote` first — another open PR may already touch the same issue or files. Reconcile against it; don't re-derive "the only thing left" from a stale handoff. (A `PreToolUse` hook also surfaces same-issue open PRs at `gh pr create`/`merge` time, but treat that as a backstop, not a substitute for looking.)
+- **Truth is the CLI and running the code — not IDE/LSP "reminder" diagnostics.** Editor / `pyright`-in-worktree warnings go stale for an entire session and throw false positives (especially across multiple worktrees). Confirm with `ruff` / `pyright` / `pytest` from the terminal — or trust the worktree's own venv — never an IDE squiggle.
+- **Verify third-party runtime behavior empirically before wiring it in.** Don't assume how an external library, API, or browser actually behaves — exercise it once and observe, then build on the observed contract.
+- **If a claim can't be verified in the current environment, it's LIKELY — not CONFIRMED.** Keep the issue open, reference it with `Refs #N` (not `Closes #N`), and ship diagnostics rather than a blind fix. When you can't reproduce it, hand the fix to whoever can.
+
 ## Skills reference (cross-tool)
 
 The `skills/` directory ships installable agent skill docs in plain Markdown with YAML frontmatter. Any agent can consume them directly:


### PR DESCRIPTION
## Summary

Adds a concise **Working discipline — verify before you act** section to `AGENTS.md` so the judgment rules are read up front by every coding agent (Claude Code, Cursor, Codex, Aider, …), not just hoped for.

Four rules:
- **Check what is already in flight** before coding a fix, opening a PR, or merging — `gh pr list` + `git ls-remote` first, reconcile against any open PR touching the same issue/files.
- **Truth is the CLI and running the code**, not stale IDE/LSP reminder diagnostics (which throw false positives for a whole session, especially across worktrees).
- **Verify third-party runtime behavior empirically** before wiring it in.
- **Unverifiable-in-this-environment ⇒ LIKELY, not CONFIRMED** — keep the issue open, use `Refs #N` (not `Closes #N`), ship diagnostics over a blind fix.

### Why
Docs alone do not bind under momentum: a "check open PRs first" rule already existed and still got skipped, merging a PR without seeing an entangled open one. This is the human-readable judgment layer; a new `gh pr` overlap `PreToolUse` hook is the deterministic backstop.

## Test plan
- [x] `scripts/ci/check_repo_hygiene.py` — 498 files, no violations
- [x] `scripts/ci/check_doc_links.py` — all links resolve across 23 files
- [x] Docs-only change (no code paths touched)