### PR TITLE
test(222): falsifiable /fx cookie-path regression for #230

### DIFF
--- a/tests/auth/test_cookies.py
+++ b/tests/auth/test_cookies.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gflow_cli.auth.cookies import _get_chrome_cookies3
+from gflow_cli.auth import cookies as cookies_mod
+from gflow_cli.auth.cookies import _get_chrome_cookies3, _get_chrome_cookies_playwright
 
 
 def _make_profile_with_cookies(tmp_path: Path) -> Path:
@@ -49,3 +51,57 @@ def test_get_chrome_cookies3_maps_browsercookieerror_to_permissionerror(
 
     with pytest.raises(PermissionError, match="decrypt"):
         _get_chrome_cookies3(profile)
+
+
+# --- issue #222 / #230: /fx-scoped session token must survive the cookie read ---
+
+
+@pytest.mark.asyncio
+async def test_playwright_read_keeps_fx_scoped_session_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #230: the Playwright cookie read must return the
+    ``/fx``-scoped ``__Secure-next-auth.session-token``.
+
+    Falsifiable by construction: the mocked context returns the session token
+    ONLY from the full jar (``ctx.cookies()``), NOT from the path-``/`` URL
+    filter (``ctx.cookies([url])``). The pre-#230 code read the URL-filtered
+    ``flow_cookies`` and would drop the token (this assertion fails); the fix
+    reads the full jar filtered by domain and keeps it (this assertion passes).
+    """
+    profile = tmp_path / "profile"
+    profile.mkdir()
+
+    full_jar = [
+        {"name": "SAPISID", "value": "g", "domain": ".google.com"},
+        {"name": "__Secure-next-auth.session-token", "value": "flow", "domain": "labs.google"},
+    ]
+    path_root_only = [{"name": "SAPISID", "value": "g", "domain": ".google.com"}]
+
+    async def _cookies(*args: object) -> list[dict[str, str]]:
+        # ctx.cookies([url]) → path=/ filtered (drops the /fx token);
+        # ctx.cookies() → the full jar.
+        return path_root_only if args and args[0] else full_jar
+
+    mock_ctx = MagicMock()
+    mock_ctx.cookies = AsyncMock(side_effect=_cookies)
+    mock_ctx.close = AsyncMock()
+
+    mock_pw = MagicMock()
+    mock_pw.chromium.launch_persistent_context = AsyncMock(return_value=mock_ctx)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_pw)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(
+        "gflow_cli.auth.strategies.async_playwright", MagicMock(return_value=mock_cm)
+    )
+    monkeypatch.setattr(cookies_mod, "channel_for_profile", lambda _pd: "chrome")
+
+    snapshot = await _get_chrome_cookies_playwright(profile)
+
+    assert "__Secure-next-auth.session-token" in snapshot.httpx_cookies
+    # SAPISID is a .google.com cookie — excluded by the labs.google domain filter.
+    assert "SAPISID" not in snapshot.httpx_cookies
+    # google_session is still derived from the full jar (SAPISID present there).
+    assert snapshot.google_session is True


### PR DESCRIPTION
## Summary

Adds the falsifiable regression test the #230 council review (D4) flagged as a coverage gap.

The #230 fix reads the full cookie jar filtered by domain instead of the path-`/` URL filter that silently dropped the `/fx`-scoped `__Secure-next-auth.session-token`. This test asserts the session token survives `_get_chrome_cookies_playwright`:
- the mocked context returns the token **only** from the full jar (`ctx.cookies()`), **not** from the URL-filtered read (`ctx.cookies([url])`)
- so it **FAILS on the pre-#230 form** and **PASSES on the fix** — verified by a temporary revert.

Test-only change; no production code touched.

## Test plan
- [x] `pytest tests/auth` — 57 passed
- [x] Falsifiability confirmed: reverting cookies.py to `_name_value_cookies(flow_cookies, flow_only=False)` makes the test fail; the fix makes it pass
- [x] ruff clean; `pyright src` 0 errors