### PR TITLE
feat(mcp): add project param to generate tools (CLI parity, #233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project instead of always creating a scratch project, matching `image t2i`/`i2i`.
   Lets programmatic callers (e.g. a multi-clip storyboard worker) share one project
   across several video generations instead of leaving one throwaway project per clip.
+- **`project` parameter on the MCP `gflow_generate_image` / `gflow_generate_video`
+  tools**: mirrors the CLI `--project` flag so MCP callers can also target an existing
+  Flow project (validated against the same id format). Completes `--project` parity
+  across the CLI and MCP surfaces.
 
 ## [0.23.0] — 2026-07-01
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -45,8 +45,8 @@ Both Click CLI (`src/gflow_cli/cli.py`) and MCP Server (`src/gflow_cli/mcp/`) ar
 The server registers three protocol surfaces:
 
 ### Tools (Executable actions)
-* `gflow_generate_image(prompt, model, aspect, count, seed, reference_images, tools, profile)`: Triggers text-to-image / image-to-image (Imagen / Nano Banana). `reference_images` switches to i2i.
-* `gflow_generate_video(prompt, mode, aspect, initial_frame, end_frame, reference_images, tools, profile)`: Triggers vertical or landscape video generation (Veo). `mode` is `t2v`/`i2v`/`r2v`; `i2v` requires `initial_frame`, `r2v` requires `reference_images`.
+* `gflow_generate_image(prompt, model, aspect, count, seed, reference_images, tools, profile, project)`: Triggers text-to-image / image-to-image (Imagen / Nano Banana). `reference_images` switches to i2i; `project` generates into an existing Flow project id (mirrors CLI `--project`).
+* `gflow_generate_video(prompt, mode, aspect, initial_frame, end_frame, reference_images, tools, profile, project)`: Triggers vertical or landscape video generation (Veo). `mode` is `t2v`/`i2v`/`r2v`; `i2v` requires `initial_frame`, `r2v` requires `reference_images`; `project` generates into an existing Flow project id (mirrors CLI `--project`).
 * `gflow_list_projects(profile, limit)`: Queries SQLite catalog for recent generation folders.
 * `gflow_list_characters(profile)`: Lists Flow Character entities (requires an active browser session).
 

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import structlog
 
+from gflow_cli._cli_helpers import _FLOW_ID_RE
 from gflow_cli.config import get_settings
 from gflow_cli.data.queries import list_projects
 from gflow_cli.data.repository import DataRepository
@@ -325,6 +326,19 @@ def _bad_param(title: str, detail: str) -> dict[str, Any]:
     }
 
 
+def _validate_project(project: str | None) -> dict[str, Any] | None:
+    """Return a bad-parameter error dict if ``project`` is set but not a valid
+    Flow project id, else ``None``. Reuses the CLI's ``_FLOW_ID_RE`` so the MCP
+    ``project`` arg is validated identically to the CLI ``--project`` flag.
+    """
+    if project is not None and not _FLOW_ID_RE.fullmatch(project):
+        return _bad_param(
+            "Invalid Project Id",
+            f"Project id '{project}' is not a valid Flow project id.",
+        )
+    return None
+
+
 def _resolve_image_path(
     raw: str, *, title: str, label: str
 ) -> tuple[str | None, dict[str, Any] | None]:
@@ -444,6 +458,7 @@ async def gflow_generate_image(
     reference_images: list[str] | None = None,
     tools: list[dict[str, Any]] | None = None,
     profile: str = "default",
+    project: str | None = None,
 ) -> dict[str, Any]:
     """Generate an image via Google Flow's Imagen.
 
@@ -466,11 +481,17 @@ async def gflow_generate_image(
             omit) to auto-resolve using the same precedence as the CLI:
             ``GFLOW_CLI_PROFILE`` env var → ``config.toml`` default →
             auto-select if exactly one profile exists.
+        project: Optional existing Flow project id to generate into (mirrors the
+            CLI ``--project`` flag). When omitted, a scratch project is created
+            as before.
 
     Returns:
         Dict with 'status', 'files' (list of local file paths), and metadata.
         On failure, 'status' is 'failed' or 'error' with an RFC 9457 'error' dict.
     """
+    if (proj_err := _validate_project(project)) is not None:
+        return proj_err
+
     if not await _rate_limiter.acquire():
         log.warning("mcp.tool.rate_limited", tool="gflow_generate_image")
         return {
@@ -510,6 +531,8 @@ async def gflow_generate_image(
         }
         if seed is not None:
             payload["seed"] = seed
+        if project is not None:
+            payload["project_id"] = project
 
         task_type = "t2i"
         if reference_images:
@@ -542,6 +565,7 @@ async def gflow_generate_image(
             "tool_specs": list(tool_specs),
             "profile": resolved_profile,
             "requested_profile": profile,
+            "project": project,
         }
         return result
 
@@ -564,6 +588,7 @@ async def gflow_generate_video(
     reference_images: list[str] | None = None,
     tools: list[dict[str, Any]] | None = None,
     profile: str = "default",
+    project: str | None = None,
 ) -> dict[str, Any]:
     """Generate a video via Google Flow's Veo.
 
@@ -585,11 +610,17 @@ async def gflow_generate_video(
             omit) to auto-resolve using the same precedence as the CLI:
             ``GFLOW_CLI_PROFILE`` env var → ``config.toml`` default →
             auto-select if exactly one profile exists.
+        project: Optional existing Flow project id to generate into (mirrors the
+            CLI ``--project`` flag on ``video t2v``/``i2v``/``r2v``). When
+            omitted, a scratch project is created as before.
 
     Returns:
         Dict with 'status', 'files' (list of local file paths), and metadata.
         On failure, 'status' is 'failed' or 'error' with an RFC 9457 'error' dict.
     """
+    if (proj_err := _validate_project(project)) is not None:
+        return proj_err
+
     if not await _rate_limiter.acquire():
         log.warning("mcp.tool.rate_limited", tool="gflow_generate_video")
         return {
@@ -638,6 +669,8 @@ async def gflow_generate_video(
 
         if tool_specs:
             payload["tool_specs"] = list(tool_specs)
+        if project is not None:
+            payload["project_id"] = project
 
         # task_type matches the mode ("t2v", "i2v", "r2v")
         result = await _run_generation_task(
@@ -658,6 +691,7 @@ async def gflow_generate_video(
             "tool_specs": list(tool_specs),
             "profile": resolved_profile,
             "requested_profile": profile,
+            "project": project,
         }
         return result
 

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -15,7 +15,23 @@ from gflow_cli.mcp.tools import (
     _build_video_media_inputs,
     _resolve_image_path,
     _resolve_image_references,
+    _validate_project,
 )
+
+
+def test_validate_project_none_is_ok() -> None:
+    assert _validate_project(None) is None
+
+
+def test_validate_project_valid_id_is_ok() -> None:
+    assert _validate_project("PROJ-123abc") is None
+
+
+def test_validate_project_rejects_bad_id() -> None:
+    err = _validate_project("bad/id")
+    assert err is not None
+    assert err["error"]["title"] == "Invalid Project Id"
+    assert err["error"]["status"] == 400
 
 
 def test_bad_param_envelope_shape() -> None:

--- a/tests/mcp/test_tools_wired.py
+++ b/tests/mcp/test_tools_wired.py
@@ -438,3 +438,97 @@ class TestRunGenerationTask:
 
         assert result["status"] == "error"
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# --project / project_id parity (mirrors the CLI --project flag)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectParam:
+    """The MCP `project` arg must thread through to the task payload as
+    `project_id` (which the worker already consumes), and reject a bad id."""
+
+    @pytest.mark.asyncio
+    async def test_image_project_threads_to_payload(self) -> None:
+        from gflow_cli.mcp import tools as tools_mod
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_run(*, profile: str, task_type: str, payload: dict[str, Any]):
+            captured["payload"] = payload
+            return {"status": "completed", "files": [], "flow_media_id": "m"}
+
+        with (
+            patch(
+                "gflow_cli.mcp.tools._rate_limiter",
+                tools_mod._TokenBucket(capacity=8, refill_rate=0.0),
+            ),
+            patch("gflow_cli.mcp.tools._resolve_and_validate_profile", return_value="default"),
+            patch.object(tools_mod, "_run_generation_task", _fake_run),
+        ):
+            result = await tools_mod.gflow_generate_image(prompt="a cat", project="PROJ123")
+
+        assert captured["payload"]["project_id"] == "PROJ123"
+        assert result["params"]["project"] == "PROJ123"
+
+    @pytest.mark.asyncio
+    async def test_video_project_threads_to_payload(self) -> None:
+        from gflow_cli.mcp import tools as tools_mod
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_run(*, profile: str, task_type: str, payload: dict[str, Any]):
+            captured["payload"] = payload
+            return {"status": "completed", "files": [], "flow_media_id": "m"}
+
+        with (
+            patch(
+                "gflow_cli.mcp.tools._rate_limiter",
+                tools_mod._TokenBucket(capacity=8, refill_rate=0.0),
+            ),
+            patch("gflow_cli.mcp.tools._resolve_and_validate_profile", return_value="default"),
+            patch.object(tools_mod, "_run_generation_task", _fake_run),
+        ):
+            result = await tools_mod.gflow_generate_video(prompt="a dog", project="PROJ123")
+
+        assert captured["payload"]["project_id"] == "PROJ123"
+        assert result["params"]["project"] == "PROJ123"
+
+    @pytest.mark.asyncio
+    async def test_image_omitted_project_has_no_project_id(self) -> None:
+        from gflow_cli.mcp import tools as tools_mod
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_run(*, profile: str, task_type: str, payload: dict[str, Any]):
+            captured["payload"] = payload
+            return {"status": "completed", "files": [], "flow_media_id": "m"}
+
+        with (
+            patch(
+                "gflow_cli.mcp.tools._rate_limiter",
+                tools_mod._TokenBucket(capacity=8, refill_rate=0.0),
+            ),
+            patch("gflow_cli.mcp.tools._resolve_and_validate_profile", return_value="default"),
+            patch.object(tools_mod, "_run_generation_task", _fake_run),
+        ):
+            await tools_mod.gflow_generate_image(prompt="a cat")
+
+        assert "project_id" not in captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_image_bad_project_rejected_before_worker(self) -> None:
+        from gflow_cli.mcp import tools as tools_mod
+
+        result = await tools_mod.gflow_generate_image(prompt="a cat", project="bad/id")
+        assert result["status"] == "error"
+        assert result["error"]["title"] == "Invalid Project Id"
+
+    @pytest.mark.asyncio
+    async def test_video_bad_project_rejected_before_worker(self) -> None:
+        from gflow_cli.mcp import tools as tools_mod
+
+        result = await tools_mod.gflow_generate_video(prompt="a dog", project="bad/id")
+        assert result["status"] == "error"
+        assert result["error"]["title"] == "Invalid Project Id"


### PR DESCRIPTION
## Summary
Completes the `--project` parity: the MCP `gflow_generate_image` / `gflow_generate_video` tools now accept a `project` arg mirroring the CLI `--project` flag (image + video), so MCP/agent callers can target an existing Flow project instead of a scratch one.

The worker/daemon already consumes `payload["project_id"]` (daemon.py:97/168) — this only surfaces + validates it at the MCP boundary, reusing the CLI's `_FLOW_ID_RE` so validation is identical.

## Test plan
- [x] `_validate_project` unit tests (none/valid/bad)
- [x] payload-threading tests: `project` reaches `project_id` in the enqueued payload (image + video); omitted → no `project_id`
- [x] bad id rejected at the boundary before the worker (image + video)
- [x] ruff + `pyright src` 0 errors; docs/MCP.md + CHANGELOG updated

Follow-up to #234 (CLI `--project` for video). Refs #233.