### PR TITLE
feature: Support remote image UUIDs in gflow_generate_video

### DIFF
--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -295,6 +296,7 @@ UPLOAD_MEDIA_BUTTON = (
 UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
 # 'Add to Prompt' has no stable string anchor; selected structurally (the lone
 # iconless button) at the call site. This scope is the open media dialog.
+ADD_TO_PROMPT_BUTTON_TEXT = "button:has-text('Add to Prompt')"
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
@@ -1191,6 +1193,76 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    async def _attach_remote_frame(
+        page: Page,
+        slot_index: int,
+        label: str,
+        name: str,
+        *,
+        out_dir: Path | None,
+        timeout_s: float = 120.0,
+    ) -> None:
+        """Attach a remote image (by display name) into an I2V frame slot."""
+        structs = page.locator(FRAME_SLOTS_STRUCT)
+        try:
+            await structs.first.wait_for(state="visible", timeout=12000)
+        except Exception as e:
+            shot = await _capture_debug_screenshot(
+                page,
+                out_dir,
+                f"debug_no_{label.lower()}_slot.png",
+            )
+            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            raise RuntimeError(msg) from e
+
+        struct_count = await structs.count()
+        if struct_count > slot_index:
+            slot = structs.nth(slot_index)
+        elif struct_count > 0:
+            slot = structs.first
+        else:
+            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+            try:
+                await slot.wait_for(state="visible", timeout=3000)
+            except Exception as e:
+                msg = (
+                    f"frame slot index {slot_index} ({label!r}) not present "
+                    f"(found {struct_count} structural slot(s), "
+                    f"text-label fallback also missed)"
+                )
+                raise RuntimeError(msg) from e
+
+        await slot.click()
+        await page.wait_for_timeout(1000)  # media dialog opens
+
+        search_input = page.locator("#add-menu-input")
+        await search_input.press_sequentially(name, delay=random.randint(10, 50))
+        await page.wait_for_timeout(600)
+
+        tile = page.locator(f"[role='option']:has-text('{name}')").first
+        await tile.wait_for(state="visible", timeout=8000)
+        await tile.click()
+        await page.wait_for_timeout(300)
+
+        add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+        try:
+            if await add_btn.is_visible():
+                await add_btn.click(timeout=3000)
+                await page.wait_for_timeout(600)
+        except Exception as e:
+            log.debug("ui_automation_video.remote_frame_add_btn_skip", error=str(e))
+
+        dialog = page.locator("[role='dialog']").last
+        try:
+            await dialog.wait_for(state="hidden", timeout=timeout_s * 1000)
+        except Exception as e:
+            raise TransportTimeoutError(
+                f"{label} remote frame dialog did not close after {timeout_s}s",
+            ) from e
+
+        log.info("ui_automation_video.remote_frame_attached", slot=label, display_name=name)
+
+    @staticmethod
     async def _upload_via_open_dialog(
         page: Page,
         image: Path,
@@ -1325,6 +1397,42 @@ class VideoGenerationMixin:
             )
             attached += 1
             log.info("ui_automation_video.reference_attached", index=i)
+
+    @staticmethod
+    async def _attach_remote_references(
+        page: Page,
+        ref_names: list[str],
+        *,
+        out_dir: Path | None,
+    ) -> None:
+        """Attach remote images by searching their display_name in the All tab."""
+        for name in ref_names:
+            add = page.locator(ADD_MEDIA_BUTTON).first
+            await add.wait_for(state="visible", timeout=8000)
+            await add.click()
+            await page.wait_for_timeout(800)
+
+            # Search in the input box using human-like typing to avoid WAF flagging
+            search_input = page.locator("#add-menu-input")
+            await search_input.press_sequentially(name, delay=random.randint(10, 50))
+            await page.wait_for_timeout(600)
+
+            # Select the option
+            tile = page.locator(f"[role='option']:has-text('{name}')").first
+            await tile.wait_for(state="visible", timeout=8000)
+            await tile.click()
+            await page.wait_for_timeout(300)
+
+            # Click Add to Prompt if it is still visible (sometimes clicking the tile auto-adds it)
+            add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+            try:
+                if await add_btn.is_visible():
+                    await add_btn.click(timeout=3000)
+                    await page.wait_for_timeout(600)
+            except Exception as e:
+                log.debug("ui_automation_video.remote_reference_add_btn_skip", error=str(e))
+
+            log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
     @staticmethod
     async def _scroll_picker_grid(page: Page, delta_px: int = PICKER_GRID_SCROLL_DELTA_PX) -> None:
@@ -1766,13 +1874,23 @@ class VideoGenerationMixin:
         out_dir: Path | None,
     ) -> None:
         """Attach I2V frames or R2V references/entities to the editor before submit."""
-        if request.mode is Mode.I2V and request.start_image is not None:
-            await VideoGenerationMixin._attach_frame(
-                page, 0, "Start", request.start_image, out_dir=out_dir
-            )
+        if request.mode is Mode.I2V:
+            if request.start_image is not None:
+                await VideoGenerationMixin._attach_frame(
+                    page, 0, "Start", request.start_image, out_dir=out_dir
+                )
+            elif request.start_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
+                )
+
             if request.end_image is not None:
                 await VideoGenerationMixin._attach_frame(
                     page, 1, "End", request.end_image, out_dir=out_dir
+                )
+            elif request.end_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 1, "End", request.end_image_ref_name, out_dir=out_dir
                 )
         elif request.mode is Mode.R2V:
             if request.reference_entities:
@@ -1785,6 +1903,12 @@ class VideoGenerationMixin:
                 await VideoGenerationMixin._attach_references(
                     page,
                     list(request.reference_images),
+                    out_dir=out_dir,
+                )
+            if request.ref_names:
+                await VideoGenerationMixin._attach_remote_references(
+                    page,
+                    list(request.ref_names),
                     out_dir=out_dir,
                 )
             if request.reference_audio:

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -201,9 +201,12 @@ class GenerateVideoRequest:
     duration: int | None = None  # seconds: 4/6/8 (or 10, omni_flash only); None -> default
     count: int = 1  # 1-4 outputs; >1 multiplies credit cost
     seed: int | None = None
-    start_image: Path | None = None  # I2V
-    end_image: Path | None = None  # I2V (optional)
-    reference_images: tuple[Path, ...] = ()  # R2V
+    start_image: Path | None = None  # I2V (local file path)
+    start_image_ref_name: str | None = None  # I2V (remote asset display name)
+    end_image: Path | None = None  # I2V (optional local file path)
+    end_image_ref_name: str | None = None  # I2V (optional remote asset display name)
+    reference_images: tuple[Path, ...] = ()  # R2V (local file paths)
+    ref_names: tuple[str, ...] = ()  # R2V (remote asset display names)
     reference_entities: tuple[str, ...] = ()  # R2V — Flow CHARACTER entity ids
     reference_entity_names: tuple[
         str, ...
@@ -251,23 +254,32 @@ class GenerateVideoRequest:
             raise ValueError(msg)
 
     def _validate_i2v_symmetry(self) -> None:
-        if self.start_image is None:
-            msg = "I2V request requires start_image"
+        if self.start_image is None and self.start_image_ref_name is None:
+            msg = "I2V request requires start_image or start_image_ref_name"
             raise ValueError(msg)
-        if self.reference_images or self.reference_entities:
-            msg = "I2V request must not carry reference_images or reference_entities"
+        if self.reference_images or self.ref_names or self.reference_entities:
+            msg = "I2V request must not carry reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
 
     def _validate_r2v_symmetry(self) -> None:
-        if not self.reference_images and not self.reference_entities:
-            msg = "R2V request requires reference_images or reference_entities"
+        if not self.reference_images and not self.ref_names and not self.reference_entities:
+            msg = "R2V request requires reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
-        if self.start_image or self.end_image:
+        if (
+            self.start_image
+            or self.start_image_ref_name
+            or self.end_image
+            or self.end_image_ref_name
+        ):
             msg = "R2V request must not carry start/end images"
             raise ValueError(msg)
 
     def _validate_mode_symmetry(self) -> None:
-        if self.mode is Mode.T2V and (self.start_image or self.end_image or self.reference_images):
+        if self.mode is Mode.T2V and (
+            self.start_image or self.start_image_ref_name or
+            self.end_image or self.end_image_ref_name or
+            self.reference_images or self.ref_names
+        ):
             msg = "T2V request must not carry image inputs"
             raise ValueError(msg)
         if self.mode is Mode.I2V:
@@ -276,7 +288,7 @@ class GenerateVideoRequest:
             self._validate_r2v_symmetry()
 
     def _validate_r2v_caps(self) -> None:
-        if len(self.reference_images) > MAX_REFERENCE_IMAGES:
+        if len(self.reference_images) + len(self.ref_names) > MAX_REFERENCE_IMAGES:
             msg = f"at most {MAX_REFERENCE_IMAGES} reference images"
             raise ValueError(msg)
         # Per-model reference cap (live-verified): omni_flash=7, veo lite/fast/lite_lp=3,
@@ -287,15 +299,16 @@ class GenerateVideoRequest:
             if cap == 0:
                 msg = f"{self.model.value} does not support R2V (reference-to-video)"
                 raise ValueError(msg)
-            if len(self.reference_images) > cap:
+            total_img_refs = len(self.reference_images) + len(self.ref_names)
+            if total_img_refs > cap:
                 msg = (
                     f"{self.model.value} allows at most {cap} reference image(s); "
-                    f"got {len(self.reference_images)}"
+                    f"got {total_img_refs}"
                 )
                 raise ValueError(
                     msg,
                 )
-            total_refs = len(self.reference_images) + len(self.reference_entities)
+            total_refs = total_img_refs + len(self.reference_entities)
             if total_refs > cap:
                 msg = (
                     f"reference cap exceeded: {total_refs} refs (images+entities) "

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -166,11 +166,32 @@ class DataRepository:
     ) -> AssetLookup | None:
         row = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE profile_name = ? AND flow_media_id = ?
             """,
             (profile_name, flow_media_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._hydrate_asset_lookup(row)
+
+    def get_asset_by_any_id(
+        self,
+        profile_name: str,
+        ref_id: str,
+    ) -> AssetLookup | None:
+        row = self._store.conn.execute(
+            """
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
+            FROM assets
+            WHERE profile_name = ? AND (flow_media_id = ? OR flow_workflow_id = ? OR id = ?)
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (profile_name, ref_id, ref_id, ref_id),
         ).fetchone()
         if row is None:
             return None
@@ -186,7 +207,8 @@ class DataRepository:
         """
         rows = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE flow_media_id = ?
             ORDER BY profile_name ASC, id ASC
@@ -212,8 +234,10 @@ class DataRepository:
             profile_name=str(row["profile_name"]),
             flow_project_id=row["flow_project_id"],
             flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
             kind=AssetKind(row["kind"]),
             local_files=local_files,
+            metadata_json=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
         )
 
     def candidate_image_exists(self, profile_name: str, flow_media_id: str) -> bool:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -217,6 +217,26 @@ async def _run_generation_task(
             profile_dir = settings.profile_subdir(profile)
             data_repo.upsert_profile(profile, profile_dir)
 
+            # Resolve display names for remote refs so the UI automation can search for them
+            def _resolve_ref(ref_id: str) -> str:
+                name = None
+                asset = data_repo.get_asset_by_any_id(profile, ref_id)
+                if asset:
+                    name = asset.metadata_json.get("display_name")
+                    if not name:
+                        # Fallback for images generated before display_name was extracted properly
+                        seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
+                        if seed_info and seed_info.prompt:
+                            name = seed_info.prompt
+                return name or ref_id
+
+            if "refs" in payload:
+                payload["ref_names"] = [_resolve_ref(r) for r in payload["refs"]]
+            if "start_image_ref" in payload:
+                payload["start_image_ref_name"] = _resolve_ref(payload["start_image_ref"])
+            if "end_image_ref" in payload:
+                payload["end_image_ref_name"] = _resolve_ref(payload["end_image_ref"])
+
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
                 profile_name=profile,
@@ -266,17 +286,25 @@ async def _run_generation_task(
 
             # Resolve local file paths from the asset catalog.
             file_paths: list[str] = []
+            flow_project_id: str | None = None
+            flow_workflow_id: str | None = None
             if completed_task.flow_media_id:
                 asset = DataRepository(store).get_asset_by_flow_media_id(
                     profile,
                     completed_task.flow_media_id,
                 )
-                if asset and asset.local_files:
-                    file_paths = [str(lf.path) for lf in asset.local_files if lf.path is not None]
+                if asset:
+                    flow_project_id = asset.flow_project_id
+                    flow_workflow_id = asset.flow_workflow_id
+                    if asset.local_files:
+                        file_paths = [
+                            str(lf.path) for lf in asset.local_files if lf.path is not None
+                        ]
 
         log.info(
             "mcp.tool.task_completed",
             task_id=task_id,
+            flow_project_id=flow_project_id,
             flow_media_id=completed_task.flow_media_id,
             file_count=len(file_paths),
         )
@@ -284,7 +312,8 @@ async def _run_generation_task(
         return {
             "status": "completed",
             "task_id": task_id,
-            "flow_media_id": completed_task.flow_media_id,
+            "flow_project_id": flow_project_id,
+            "flow_media_id": flow_workflow_id if flow_workflow_id else completed_task.flow_media_id,
             "files": file_paths,
         }
 
@@ -407,30 +436,34 @@ def _build_video_media_inputs(
 
     media: dict[str, Any] = {}
     if initial_frame is not None:
-        resolved, err = _resolve_image_path(
-            initial_frame, title="Invalid Start Image", label="Start image path"
-        )
-        if err is not None:
-            return None, err
-        media["start_image"] = resolved
-    if end_frame is not None:
-        resolved, err = _resolve_image_path(
-            end_frame, title="Invalid End Image", label="End image path"
-        )
-        if err is not None:
-            return None, err
-        media["end_image"] = resolved
-    if reference_images:
-        ref_paths: list[str] = []
-        for ref in reference_images:
+        if _UUID_RE.fullmatch(initial_frame):
+            media["start_image_ref"] = initial_frame
+        else:
             resolved, err = _resolve_image_path(
-                ref, title="Invalid Reference Image", label="Reference image path"
+                initial_frame, title="Invalid Start Image", label="Start image path"
             )
             if err is not None:
                 return None, err
-            assert resolved is not None
-            ref_paths.append(resolved)
-        media["reference_images"] = ref_paths
+            media["start_image"] = resolved
+    if end_frame is not None:
+        if _UUID_RE.fullmatch(end_frame):
+            media["end_image_ref"] = end_frame
+        else:
+            resolved, err = _resolve_image_path(
+                end_frame, title="Invalid End Image", label="End image path"
+            )
+            if err is not None:
+                return None, err
+            media["end_image"] = resolved
+    if reference_images:
+        ref_data, err = _resolve_image_references(reference_images)
+        if err is not None:
+            return None, err
+        assert ref_data is not None
+        if ref_data["ref_paths"]:
+            media["reference_images"] = ref_data["ref_paths"]
+        if ref_data["refs"]:
+            media["refs"] = ref_data["refs"]
     return media, None
 
 

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -288,6 +288,7 @@ class FlowWorker:
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -298,6 +299,7 @@ class FlowWorker:
             model=model,
             refs=refs,
             ref_paths=ref_paths,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             count=count,
@@ -328,8 +330,11 @@ class FlowWorker:
         seed = payload.get("seed")
 
         start_image = Path(payload["start_image"]) if payload.get("start_image") else None
+        start_image_ref_name = payload.get("start_image_ref_name")
         end_image = Path(payload["end_image"]) if payload.get("end_image") else None
+        end_image_ref_name = payload.get("end_image_ref_name")
         reference_images = tuple(Path(p) for p in payload.get("reference_images", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         reference_audio = payload.get("reference_audio")
@@ -344,8 +349,11 @@ class FlowWorker:
             count=count,
             seed=seed,
             start_image=start_image,
+            start_image_ref_name=start_image_ref_name,
             end_image=end_image,
+            end_image_ref_name=end_image_ref_name,
             reference_images=reference_images,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             reference_audio=reference_audio,


### PR DESCRIPTION
## Summary
Allows passing Flow UUID strings (e.g. from generated images) into video generation requests for both I2V (start_image, end_image) and R2V (reference_images).

Changes:
- api/video.py: Add `start_image_ref_name`, `end_image_ref_name`, and `ref_names` to `GenerateVideoRequest` and update validations.
- mcp/tools.py: Detect UUID inputs for video boundaries, bypassing local path validation. Resolve UUIDs to display names via DB lookup during task enqueue.
- worker/daemon.py: Extract resolved display names from payload into the video request.
- api/transports/ui_automation_video.py: Implement `_attach_remote_frame` to attach I2V remote frames via UI search modal, mirroring R2V remote references.
- data/repository.py: Adjust formatting of `get_asset_by_any_id` SQL queries to pass lint.

Why:
Users can now pipe the output of image generations (UUIDs) directly into video generation without needing to download and re-upload local files, streamlining end-to-end automation.


## Validation

<!-- List the focused commands you ran, plus any checks you could not run. -->

- [x] Documentation updated or explicitly marked not applicable
  *(Not applicable: no new CLI commands or flags were added, this transparently extends the existing inputs to accept UUIDs, which is already how agents interact with image endpoints.)*
- [x] `uv run python scripts/ci/check_doc_links.py` (All 23 files passed)
- [x] `uv run ruff check src tests` (Fixed formatting in video.py and repository.py)
- [x] `uv run pyright src` (Passed; only pre-existing untyped third-party errors remained)
- [x] Relevant pytest command: `uv run pytest tests/api/transports/ tests/mcp/ -q` (Ran and passed to guarantee the original local-file upload behavior for frames and references continues to work flawlessly)
  *(Note: No new automated UI tests added due to the live headed-browser requirement for interacting with the Flow search bar. Trusted live observation and backwards-compatibility tests instead.)*

