### PR TITLE
fix(config): remove shadowed duplicate daemon_token field definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Removed a shadowed duplicate `Settings.daemon_token` field definition (#243)**: the
+  class body defined `daemon_token` twice; Python silently kept only the second
+  (aliased) one, leaving the first as dead code that a future edit could touch without
+  effect. The surviving definition's contract (both `GFLOW_CLI_DAEMON_TOKEN` and
+  `GFLOW_DAEMON_TOKEN` accepted) is now pinned by tests, along with a guard that the
+  field is defined exactly once.
+
 - **`$GFLOW_CLI_HOME/.env` now loads as a dotenv fallback (#240)**: `config.py`'s own
   module docstring promised a `.env` fallback "from CWD or `$GFLOW_CLI_HOME/.env`", but
   the implementation only ever read the CWD file — a key placed in the home `.env` was

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -305,11 +305,6 @@ class Settings(BaseSettings):
             "Override via GFLOW_CLI_PREFER_CLASSIC."
         ),
     )
-    daemon_token: str | None = Field(
-        default=None,
-        description="Auth token required when binding the serve daemon to a non-localhost address.",
-    )
-
     # --- logging ----------------------------------------------------------
     log_level: LogLevel = LogLevel.INFO
     log_format: LogFormat = LogFormat.AUTO

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -410,6 +410,23 @@ class TestPreferClassic:
 
 
 class TestDaemonSettings:
+    def test_daemon_token_defined_exactly_once(self) -> None:
+        """A duplicated class-body field is silently shadowed by the later
+        definition (issue #243) — the dead duplicate must not return, or a
+        future edit to the wrong copy would be invisibly ignored."""
+        import inspect
+
+        source = inspect.getsource(Settings)
+        assert source.count("daemon_token: str | None") == 1
+
+    def test_daemon_token_keeps_both_env_aliases(self) -> None:
+        """Pin the SURVIVING definition's contract: both env var spellings
+        must stay accepted (the shadowed duplicate had no aliases)."""
+        field = Settings.model_fields["daemon_token"]
+        alias = field.validation_alias
+        assert alias is not None
+        assert getattr(alias, "choices", None) == ["GFLOW_CLI_DAEMON_TOKEN", "GFLOW_DAEMON_TOKEN"]
+
     def test_daemon_defaults(self, clean_env: None) -> None:
         s = Settings()
         assert s.daemon_token is None


### PR DESCRIPTION
## Summary

Fixes #243 — `Settings` defined `daemon_token` twice (plain at the old ~line 308, aliased at ~318); Python class-body semantics silently keep only the second, so the first was dead code that a future edit could touch with no effect. Deleted the shadowed definition; behavior is unchanged (the surviving definition is the intended aliased one).

TDD: a source-level guard test (`daemon_token` defined exactly once) was written first and watched fail on the duplicate; a second test pins the surviving contract (both `GFLOW_CLI_DAEMON_TOKEN` and `GFLOW_DAEMON_TOKEN` alias choices).

## Validation

- [x] Focused tests added or updated for behavior changes (2 new in `TestDaemonSettings`; 43 config tests green)
- [x] Documentation updated or explicitly marked not applicable — CHANGELOG `[Unreleased] > Fixed` entry; no operator-facing behavior change, so no doc text needed
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved
- [x] `uv run ruff check src tests` + `uv run ruff format --check src tests` — clean
- [x] `uv run pyright src` — 0 errors, 0 warnings
- [x] Relevant pytest command: `uv run python -m pytest -q -m "not live and not e2e and not smoke" --cov=gflow_cli` — **1969 passed, 16 skipped, coverage 89%**

## Contribution Checklist

- [x] This PR targets `develop`, unless it is a release or emergency fix
- [x] My commits use my real Git identity or GitHub noreply email
- [ ] External contribution commits include `Signed-off-by:` (n/a — maintainer repo)
- [x] I did not include secrets, cookies, account tokens, signed URLs, or private captured data
- [x] I reviewed any AI-assisted changes before submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)