### PR TITLE
fix(#237): remote image UUIDs in gflow_generate_video — hardened takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Remote image UUIDs in `gflow_generate_video` (#237)**: I2V (`initial_frame` /
+  `end_frame`) and R2V (`reference_images`) now accept a generated image's Flow UUID,
+  not just a local file path — pipe the output of an image generation straight into a
+  video generation with no download/re-upload round-trip. UUID inputs are resolved to
+  the asset's display name at enqueue time and attached via the resource picker; a UUID
+  that isn't in your asset catalog fails fast with a clear "Reference Not Found" error
+  instead of a long browser timeout. (Contributed by @C1ph3r404; hardened during
+  maintainer review — see below.)
+
 ### Fixed
 
 - **Removed a shadowed duplicate `Settings.daemon_token` field definition (#243)**: the

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1393,7 +1393,7 @@ class VideoGenerationMixin:
         if await add_btn.count():
             await add_btn.click()
         try:
-            await page.locator("[role='dialog']").last.wait_for(state="hidden", timeout=15_000)
+            await page.locator(DIALOG_ANY).last.wait_for(state="hidden", timeout=15_000)
         except Exception:
             log.warning("ui_automation_video.dialog_close_timeout", target=log_label)
         await page.wait_for_timeout(1500)
@@ -1477,7 +1477,7 @@ class VideoGenerationMixin:
         """Wheel-scroll the open resource picker down one step. The Tudo grid is
         virtualised, so off-screen tiles are absent from the DOM until scrolled
         into view. Hover the dialog first so the wheel targets the grid."""
-        dialog = page.locator("[role='dialog']").last
+        dialog = page.locator(DIALOG_ANY).last
         try:
             await dialog.hover(timeout=2000)
         except Exception:  # noqa: BLE001 - hover is best-effort; wheel still scrolls
@@ -1905,6 +1905,52 @@ class VideoGenerationMixin:
         return effective_model
 
     @staticmethod
+    async def _attach_i2v_frames(
+        page: Page, request: GenerateVideoRequest, *, out_dir: Path | None
+    ) -> None:
+        """Attach the Start (and optional End) I2V frame, local path or remote ref."""
+        if request.start_image is not None:
+            await VideoGenerationMixin._attach_frame(
+                page, 0, "Start", request.start_image, out_dir=out_dir
+            )
+        elif request.start_image_ref_name is not None:
+            await VideoGenerationMixin._attach_remote_frame(
+                page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
+            )
+        if request.end_image is not None:
+            await VideoGenerationMixin._attach_frame(
+                page, 1, "End", request.end_image, out_dir=out_dir
+            )
+        elif request.end_image_ref_name is not None:
+            await VideoGenerationMixin._attach_remote_frame(
+                page, 1, "End", request.end_image_ref_name, out_dir=out_dir
+            )
+
+    @staticmethod
+    async def _attach_r2v_references(
+        page: Page, request: GenerateVideoRequest, *, out_dir: Path | None
+    ) -> None:
+        """Attach R2V character entities, local reference images, remote refs, and audio."""
+        if request.reference_entities:
+            await VideoGenerationMixin._attach_character_entities(
+                page,
+                zip_entity_refs(request.reference_entities, request.reference_entity_names),
+                out_dir=out_dir,
+            )
+        if request.reference_images:
+            await VideoGenerationMixin._attach_references(
+                page, list(request.reference_images), out_dir=out_dir
+            )
+        if request.ref_names:
+            await VideoGenerationMixin._attach_remote_references(
+                page, list(request.ref_names), out_dir=out_dir
+            )
+        if request.reference_audio:
+            await VideoGenerationMixin._attach_reference_audio(
+                page, request.reference_audio, out_dir=out_dir
+            )
+
+    @staticmethod
     async def _attach_media_inputs(
         page: Page,
         request: GenerateVideoRequest,
@@ -1913,46 +1959,9 @@ class VideoGenerationMixin:
     ) -> None:
         """Attach I2V frames or R2V references/entities to the editor before submit."""
         if request.mode is Mode.I2V:
-            if request.start_image is not None:
-                await VideoGenerationMixin._attach_frame(
-                    page, 0, "Start", request.start_image, out_dir=out_dir
-                )
-            elif request.start_image_ref_name is not None:
-                await VideoGenerationMixin._attach_remote_frame(
-                    page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
-                )
-
-            if request.end_image is not None:
-                await VideoGenerationMixin._attach_frame(
-                    page, 1, "End", request.end_image, out_dir=out_dir
-                )
-            elif request.end_image_ref_name is not None:
-                await VideoGenerationMixin._attach_remote_frame(
-                    page, 1, "End", request.end_image_ref_name, out_dir=out_dir
-                )
+            await VideoGenerationMixin._attach_i2v_frames(page, request, out_dir=out_dir)
         elif request.mode is Mode.R2V:
-            if request.reference_entities:
-                await VideoGenerationMixin._attach_character_entities(
-                    page,
-                    zip_entity_refs(request.reference_entities, request.reference_entity_names),
-                    out_dir=out_dir,
-                )
-            if request.reference_images:
-                await VideoGenerationMixin._attach_references(
-                    page,
-                    list(request.reference_images),
-                    out_dir=out_dir,
-                )
-            if request.ref_names:
-                await VideoGenerationMixin._attach_remote_references(
-                    page,
-                    list(request.ref_names),
-                    out_dir=out_dir,
-                )
-            if request.reference_audio:
-                await VideoGenerationMixin._attach_reference_audio(
-                    page, request.reference_audio, out_dir=out_dir
-                )
+            await VideoGenerationMixin._attach_r2v_references(page, request, out_dir=out_dir)
 
     async def _submit_and_poll(
         self,

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -294,9 +294,9 @@ UPLOAD_MEDIA_BUTTON = (
 # This is exactly why the failure message tells the operator to set the Chrome
 # profile to English: it makes this fallback tier viable.
 UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
-# 'Add to Prompt' has no stable string anchor; selected structurally (the lone
-# iconless button) at the call site. This scope is the open media dialog.
-ADD_TO_PROMPT_BUTTON_TEXT = "button:has-text('Add to Prompt')"
+# 'Add to Prompt' has no stable string anchor; it is resolved via the tiered,
+# locale-safe PICKER_INCLUDE_BUTTON / _resolve_include_action pattern (a
+# hardcoded English string here previously hung non-English accounts — #170/#56).
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
@@ -1193,6 +1193,18 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    def _remote_option_tile(page: Page, name: str) -> Locator:
+        """Locate a picker result tile by its display name.
+
+        Uses ARIA role+name matching rather than
+        ``[role='option']:has-text('{name}')``: ``name`` is a stored
+        ``display_name`` or the original generation prompt, both of which
+        commonly contain an apostrophe or quote that would break a
+        single-quoted ``:has-text()`` CSS selector (PR #237 review).
+        """
+        return page.get_by_role("option", name=name)
+
+    @staticmethod
     async def _attach_remote_frame(
         page: Page,
         slot_index: int,
@@ -1239,18 +1251,22 @@ class VideoGenerationMixin:
         await search_input.press_sequentially(name, delay=random.randint(10, 50))
         await page.wait_for_timeout(600)
 
-        tile = page.locator(f"[role='option']:has-text('{name}')").first
+        tile = VideoGenerationMixin._remote_option_tile(page, name).first
         await tile.wait_for(state="visible", timeout=8000)
         await tile.click()
         await page.wait_for_timeout(300)
 
-        add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
-        try:
-            if await add_btn.is_visible():
-                await add_btn.click(timeout=3000)
-                await page.wait_for_timeout(600)
-        except Exception as e:
-            log.debug("ui_automation_video.remote_frame_add_btn_skip", error=str(e))
+        include = await VideoGenerationMixin._resolve_include_action(
+            page,
+            PICKER_INCLUDE_BUTTON,
+            _INCLUDE_BUTTON_TIER_NAMES,
+            surface="remote_frame_include",
+            detail=f"{label} remote frame",
+            out_dir=out_dir,
+            screenshot_name="remote_frame_include_missing.png",
+        )
+        await include.click(timeout=3000)
+        await page.wait_for_timeout(600)
 
         dialog = page.locator("[role='dialog']").last
         try:
@@ -1417,20 +1433,38 @@ class VideoGenerationMixin:
             await search_input.press_sequentially(name, delay=random.randint(10, 50))
             await page.wait_for_timeout(600)
 
-            # Select the option
-            tile = page.locator(f"[role='option']:has-text('{name}')").first
+            # Select the option (role+name match — apostrophes in the display
+            # name would break a `:has-text('{name}')` CSS selector).
+            tile = VideoGenerationMixin._remote_option_tile(page, name).first
             await tile.wait_for(state="visible", timeout=8000)
             await tile.click()
             await page.wait_for_timeout(300)
 
-            # Click Add to Prompt if it is still visible (sometimes clicking the tile auto-adds it)
-            add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+            # Include via the locale-safe tiered resolver (a hardcoded English
+            # "Add to Prompt" here previously hung on non-English accounts —
+            # issues #170/#56).
+            include = await VideoGenerationMixin._resolve_include_action(
+                page,
+                PICKER_INCLUDE_BUTTON,
+                _INCLUDE_BUTTON_TIER_NAMES,
+                surface="remote_reference_include",
+                detail="remote reference",
+                out_dir=out_dir,
+                screenshot_name="remote_reference_include_missing.png",
+            )
+            await include.click(timeout=3000)
+            await page.wait_for_timeout(600)
+
+            # Verify the picker actually closed — otherwise the include never
+            # fired and logging success would be a silent false positive.
+            dialog = page.locator("[role='dialog']").last
             try:
-                if await add_btn.is_visible():
-                    await add_btn.click(timeout=3000)
-                    await page.wait_for_timeout(600)
+                await dialog.wait_for(state="hidden", timeout=8000)
             except Exception as e:
-                log.debug("ui_automation_video.remote_reference_add_btn_skip", error=str(e))
+                raise TransportTimeoutError(
+                    f"remote reference {name!r} picker dialog did not close "
+                    "(the include action may not have registered)",
+                ) from e
 
             log.info("ui_automation_video.remote_reference_attached", display_name=name)
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -298,6 +298,9 @@ UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('
 # locale-safe PICKER_INCLUDE_BUTTON / _resolve_include_action pattern (a
 # hardcoded English string here previously hung non-English accounts — #170/#56).
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
+# Any open dialog (state-agnostic), used to confirm a picker closed after an
+# include action.
+DIALOG_ANY = "[role='dialog']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
 # the 'add_2' icon (its visible text 'Create' / 'Add Media' is unreliable — a
@@ -1193,6 +1196,58 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    async def _pick_option_and_include(
+        page: Page,
+        name: str,
+        *,
+        surface: str,
+        detail: str,
+        out_dir: Path | None,
+        dialog_timeout_s: float,
+    ) -> None:
+        """Shared picker flow: type ``name`` into the open resource picker,
+        select the matching result tile, fire the locale-safe include action,
+        and verify the picker dialog closed. Used by both the I2V frame and R2V
+        reference remote-attach paths (the picker is identical once open)."""
+        search_input = page.locator(PICKER_SEARCH_INPUT)
+        # Human-like typing jitter to dodge WAF bot heuristics — not a security
+        # context, so a plain PRNG is fine.
+        await search_input.press_sequentially(name, delay=random.randint(10, 50))  # NOSONAR
+        await page.wait_for_timeout(600)
+
+        # Role+name match — apostrophes in the display name would break a
+        # `:has-text('{name}')` CSS selector.
+        tile = VideoGenerationMixin._remote_option_tile(page, name).first
+        await tile.wait_for(state="visible", timeout=8000)
+        await tile.click()
+        await page.wait_for_timeout(300)
+
+        # Include via the tiered, locale-safe resolver (a hardcoded English
+        # "Add to Prompt" here previously hung non-English accounts — #170/#56).
+        include = await VideoGenerationMixin._resolve_include_action(
+            page,
+            PICKER_INCLUDE_BUTTON,
+            _INCLUDE_BUTTON_TIER_NAMES,
+            surface=surface,
+            detail=detail,
+            out_dir=out_dir,
+            screenshot_name=f"{surface}_missing.png",
+        )
+        await include.click(timeout=3000)
+        await page.wait_for_timeout(600)
+
+        # Confirm the picker closed — otherwise the include never registered and
+        # logging success would be a silent false positive.
+        dialog = page.locator(DIALOG_ANY).last
+        try:
+            await dialog.wait_for(state="hidden", timeout=dialog_timeout_s * 1000)
+        except Exception as e:
+            raise TransportTimeoutError(
+                f"{detail} picker dialog did not close after {dialog_timeout_s}s "
+                "(the include action may not have registered)",
+            ) from e
+
+    @staticmethod
     def _remote_option_tile(page: Page, name: str) -> Locator:
         """Locate a picker result tile by its display name.
 
@@ -1247,35 +1302,14 @@ class VideoGenerationMixin:
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
 
-        search_input = page.locator("#add-menu-input")
-        await search_input.press_sequentially(name, delay=random.randint(10, 50))
-        await page.wait_for_timeout(600)
-
-        tile = VideoGenerationMixin._remote_option_tile(page, name).first
-        await tile.wait_for(state="visible", timeout=8000)
-        await tile.click()
-        await page.wait_for_timeout(300)
-
-        include = await VideoGenerationMixin._resolve_include_action(
+        await VideoGenerationMixin._pick_option_and_include(
             page,
-            PICKER_INCLUDE_BUTTON,
-            _INCLUDE_BUTTON_TIER_NAMES,
+            name,
             surface="remote_frame_include",
             detail=f"{label} remote frame",
             out_dir=out_dir,
-            screenshot_name="remote_frame_include_missing.png",
+            dialog_timeout_s=timeout_s,
         )
-        await include.click(timeout=3000)
-        await page.wait_for_timeout(600)
-
-        dialog = page.locator("[role='dialog']").last
-        try:
-            await dialog.wait_for(state="hidden", timeout=timeout_s * 1000)
-        except Exception as e:
-            raise TransportTimeoutError(
-                f"{label} remote frame dialog did not close after {timeout_s}s",
-            ) from e
-
         log.info("ui_automation_video.remote_frame_attached", slot=label, display_name=name)
 
     @staticmethod
@@ -1428,44 +1462,14 @@ class VideoGenerationMixin:
             await add.click()
             await page.wait_for_timeout(800)
 
-            # Search in the input box using human-like typing to avoid WAF flagging
-            search_input = page.locator("#add-menu-input")
-            await search_input.press_sequentially(name, delay=random.randint(10, 50))
-            await page.wait_for_timeout(600)
-
-            # Select the option (role+name match — apostrophes in the display
-            # name would break a `:has-text('{name}')` CSS selector).
-            tile = VideoGenerationMixin._remote_option_tile(page, name).first
-            await tile.wait_for(state="visible", timeout=8000)
-            await tile.click()
-            await page.wait_for_timeout(300)
-
-            # Include via the locale-safe tiered resolver (a hardcoded English
-            # "Add to Prompt" here previously hung on non-English accounts —
-            # issues #170/#56).
-            include = await VideoGenerationMixin._resolve_include_action(
+            await VideoGenerationMixin._pick_option_and_include(
                 page,
-                PICKER_INCLUDE_BUTTON,
-                _INCLUDE_BUTTON_TIER_NAMES,
+                name,
                 surface="remote_reference_include",
-                detail="remote reference",
+                detail=f"remote reference {name!r}",
                 out_dir=out_dir,
-                screenshot_name="remote_reference_include_missing.png",
+                dialog_timeout_s=8.0,
             )
-            await include.click(timeout=3000)
-            await page.wait_for_timeout(600)
-
-            # Verify the picker actually closed — otherwise the include never
-            # fired and logging success would be a silent false positive.
-            dialog = page.locator("[role='dialog']").last
-            try:
-                await dialog.wait_for(state="hidden", timeout=8000)
-            except Exception as e:
-                raise TransportTimeoutError(
-                    f"remote reference {name!r} picker dialog did not close "
-                    "(the include action may not have registered)",
-                ) from e
-
             log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
     @staticmethod

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -295,6 +296,7 @@ UPLOAD_MEDIA_BUTTON = (
 UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
 # 'Add to Prompt' has no stable string anchor; selected structurally (the lone
 # iconless button) at the call site. This scope is the open media dialog.
+ADD_TO_PROMPT_BUTTON_TEXT = "button:has-text('Add to Prompt')"
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
@@ -1191,6 +1193,76 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    async def _attach_remote_frame(
+        page: Page,
+        slot_index: int,
+        label: str,
+        name: str,
+        *,
+        out_dir: Path | None,
+        timeout_s: float = 120.0,
+    ) -> None:
+        """Attach a remote image (by display name) into an I2V frame slot."""
+        structs = page.locator(FRAME_SLOTS_STRUCT)
+        try:
+            await structs.first.wait_for(state="visible", timeout=12000)
+        except Exception as e:
+            shot = await _capture_debug_screenshot(
+                page,
+                out_dir,
+                f"debug_no_{label.lower()}_slot.png",
+            )
+            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            raise RuntimeError(msg) from e
+
+        struct_count = await structs.count()
+        if struct_count > slot_index:
+            slot = structs.nth(slot_index)
+        elif struct_count > 0:
+            slot = structs.first
+        else:
+            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+            try:
+                await slot.wait_for(state="visible", timeout=3000)
+            except Exception as e:
+                msg = (
+                    f"frame slot index {slot_index} ({label!r}) not present "
+                    f"(found {struct_count} structural slot(s), "
+                    f"text-label fallback also missed)"
+                )
+                raise RuntimeError(msg) from e
+
+        await slot.click()
+        await page.wait_for_timeout(1000)  # media dialog opens
+
+        search_input = page.locator("#add-menu-input")
+        await search_input.press_sequentially(name, delay=random.randint(10, 50))
+        await page.wait_for_timeout(600)
+
+        tile = page.locator(f"[role='option']:has-text('{name}')").first
+        await tile.wait_for(state="visible", timeout=8000)
+        await tile.click()
+        await page.wait_for_timeout(300)
+
+        add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+        try:
+            if await add_btn.is_visible():
+                await add_btn.click(timeout=3000)
+                await page.wait_for_timeout(600)
+        except Exception as e:
+            log.debug("ui_automation_video.remote_frame_add_btn_skip", error=str(e))
+
+        dialog = page.locator("[role='dialog']").last
+        try:
+            await dialog.wait_for(state="hidden", timeout=timeout_s * 1000)
+        except Exception as e:
+            raise TransportTimeoutError(
+                f"{label} remote frame dialog did not close after {timeout_s}s",
+            ) from e
+
+        log.info("ui_automation_video.remote_frame_attached", slot=label, display_name=name)
+
+    @staticmethod
     async def _upload_via_open_dialog(
         page: Page,
         image: Path,
@@ -1325,6 +1397,42 @@ class VideoGenerationMixin:
             )
             attached += 1
             log.info("ui_automation_video.reference_attached", index=i)
+
+    @staticmethod
+    async def _attach_remote_references(
+        page: Page,
+        ref_names: list[str],
+        *,
+        out_dir: Path | None,
+    ) -> None:
+        """Attach remote images by searching their display_name in the All tab."""
+        for name in ref_names:
+            add = page.locator(ADD_MEDIA_BUTTON).first
+            await add.wait_for(state="visible", timeout=8000)
+            await add.click()
+            await page.wait_for_timeout(800)
+
+            # Search in the input box using human-like typing to avoid WAF flagging
+            search_input = page.locator("#add-menu-input")
+            await search_input.press_sequentially(name, delay=random.randint(10, 50))
+            await page.wait_for_timeout(600)
+
+            # Select the option
+            tile = page.locator(f"[role='option']:has-text('{name}')").first
+            await tile.wait_for(state="visible", timeout=8000)
+            await tile.click()
+            await page.wait_for_timeout(300)
+
+            # Click Add to Prompt if it is still visible (sometimes clicking the tile auto-adds it)
+            add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+            try:
+                if await add_btn.is_visible():
+                    await add_btn.click(timeout=3000)
+                    await page.wait_for_timeout(600)
+            except Exception as e:
+                log.debug("ui_automation_video.remote_reference_add_btn_skip", error=str(e))
+
+            log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
     @staticmethod
     async def _scroll_picker_grid(page: Page, delta_px: int = PICKER_GRID_SCROLL_DELTA_PX) -> None:
@@ -1766,13 +1874,23 @@ class VideoGenerationMixin:
         out_dir: Path | None,
     ) -> None:
         """Attach I2V frames or R2V references/entities to the editor before submit."""
-        if request.mode is Mode.I2V and request.start_image is not None:
-            await VideoGenerationMixin._attach_frame(
-                page, 0, "Start", request.start_image, out_dir=out_dir
-            )
+        if request.mode is Mode.I2V:
+            if request.start_image is not None:
+                await VideoGenerationMixin._attach_frame(
+                    page, 0, "Start", request.start_image, out_dir=out_dir
+                )
+            elif request.start_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
+                )
+
             if request.end_image is not None:
                 await VideoGenerationMixin._attach_frame(
                     page, 1, "End", request.end_image, out_dir=out_dir
+                )
+            elif request.end_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 1, "End", request.end_image_ref_name, out_dir=out_dir
                 )
         elif request.mode is Mode.R2V:
             if request.reference_entities:
@@ -1785,6 +1903,12 @@ class VideoGenerationMixin:
                 await VideoGenerationMixin._attach_references(
                     page,
                     list(request.reference_images),
+                    out_dir=out_dir,
+                )
+            if request.ref_names:
+                await VideoGenerationMixin._attach_remote_references(
+                    page,
+                    list(request.ref_names),
                     out_dir=out_dir,
                 )
             if request.reference_audio:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1132,58 +1132,13 @@ class VideoGenerationMixin:
             msg = f"frame image not found: {image}"
             raise FileNotFoundError(msg)
 
-        # Locate the slot structural-first (locale-free): the frame slots are the
-        # dialog-divs inside the swap_horiz container, indexed by position
-        # (0=start, 1=end).  FRAME_SLOT_BY_LABEL (has-text 'Start'/'End') is
-        # tried only as a fallback when the structural count is insufficient —
-        # it requires --lang=en-US / English Chrome profile to work.
-        #
-        # wait_for is short (1500 ms) because _wait_video_editor_ready already
+        # wait_ms is short (1500) because _wait_video_editor_ready already
         # guaranteed the editor SPA is mounted; the frame panel resolves in
-        # <10 ms (one CDP round-trip) on a pre-rendered page.  A shorter probe
-        # means a future swap_horiz rename surfaces as a fast, clear error
-        # instead of an 8-second dead wait on every I2V/R2V call.
-        structs = page.locator(FRAME_SLOTS_STRUCT)
-        try:
-            await structs.first.wait_for(state="visible", timeout=1500)
-        except Exception as e:
-            shot = await _capture_debug_screenshot(
-                page,
-                out_dir,
-                f"debug_no_{label.lower()}_slot.png",
-            )
-            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(
-                msg,
-            ) from e
-
-        struct_count = await structs.count()
-        if struct_count > slot_index:
-            # Both slots unfilled — pick by DOM order.
-            slot = structs.nth(slot_index)
-        elif struct_count > 0:
-            # Some slots already attached (typical: Start filled, End remaining).
-            # The DOM only keeps `div[type='button'][aria-haspopup='dialog']` on
-            # the unfilled slot(s) — once an image binds, the slot transitions
-            # away from that pattern. The next unfilled slot is therefore
-            # `.first` of the remaining matches, regardless of its original
-            # positional index. This case is hit on the End-frame call after
-            # Start was just attached.
-            slot = structs.first
-        else:
-            # Structural count was insufficient; fall back to text-label match.
-            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
-            try:
-                await slot.wait_for(state="visible", timeout=3000)
-            except Exception as e:
-                msg = (
-                    f"frame slot index {slot_index} ({label!r}) not present "
-                    f"(found {struct_count} structural slot(s), "
-                    f"text-label fallback also missed)"
-                )
-                raise RuntimeError(
-                    msg,
-                ) from e
+        # <10 ms on a pre-rendered page, so a future swap_horiz rename surfaces
+        # as a fast, clear error instead of an 8-second dead wait per call.
+        slot = await VideoGenerationMixin._resolve_frame_slot(
+            page, slot_index, label, out_dir=out_dir, wait_ms=1500
+        )
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
         await VideoGenerationMixin._upload_via_open_dialog(
@@ -1260,6 +1215,53 @@ class VideoGenerationMixin:
         return page.get_by_role("option", name=name)
 
     @staticmethod
+    async def _resolve_frame_slot(
+        page: Page,
+        slot_index: int,
+        label: str,
+        *,
+        out_dir: Path | None,
+        wait_ms: int,
+    ) -> Locator:
+        """Locate an I2V frame slot, structural-first with a text-label fallback.
+
+        Shared by the local-upload and remote-ref frame-attach paths. The frame
+        slots are the dialog-divs inside the swap_horiz container, indexed by
+        position (0=start, 1=end); FRAME_SLOT_BY_LABEL (has-text 'Start'/'End',
+        English-only) is the fallback when the structural count is insufficient.
+        Once an image binds, its slot leaves the structural pattern, so the next
+        unfilled slot is `.first` of the remaining matches regardless of index.
+        Returns the (unclicked) slot locator; raises RuntimeError with a debug
+        screenshot if none resolves.
+        """
+        structs = page.locator(FRAME_SLOTS_STRUCT)
+        try:
+            await structs.first.wait_for(state="visible", timeout=wait_ms)
+        except Exception as e:
+            shot = await _capture_debug_screenshot(
+                page, out_dir, f"debug_no_{label.lower()}_slot.png"
+            )
+            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            raise RuntimeError(msg) from e
+
+        struct_count = await structs.count()
+        if struct_count > slot_index:
+            return structs.nth(slot_index)
+        if struct_count > 0:
+            return structs.first
+        slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+        try:
+            await slot.wait_for(state="visible", timeout=3000)
+        except Exception as e:
+            msg = (
+                f"frame slot index {slot_index} ({label!r}) not present "
+                f"(found {struct_count} structural slot(s), "
+                f"text-label fallback also missed)"
+            )
+            raise RuntimeError(msg) from e
+        return slot
+
+    @staticmethod
     async def _attach_remote_frame(
         page: Page,
         slot_index: int,
@@ -1270,35 +1272,9 @@ class VideoGenerationMixin:
         timeout_s: float = 120.0,
     ) -> None:
         """Attach a remote image (by display name) into an I2V frame slot."""
-        structs = page.locator(FRAME_SLOTS_STRUCT)
-        try:
-            await structs.first.wait_for(state="visible", timeout=12000)
-        except Exception as e:
-            shot = await _capture_debug_screenshot(
-                page,
-                out_dir,
-                f"debug_no_{label.lower()}_slot.png",
-            )
-            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(msg) from e
-
-        struct_count = await structs.count()
-        if struct_count > slot_index:
-            slot = structs.nth(slot_index)
-        elif struct_count > 0:
-            slot = structs.first
-        else:
-            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
-            try:
-                await slot.wait_for(state="visible", timeout=3000)
-            except Exception as e:
-                msg = (
-                    f"frame slot index {slot_index} ({label!r}) not present "
-                    f"(found {struct_count} structural slot(s), "
-                    f"text-label fallback also missed)"
-                )
-                raise RuntimeError(msg) from e
-
+        slot = await VideoGenerationMixin._resolve_frame_slot(
+            page, slot_index, label, out_dir=out_dir, wait_ms=12000
+        )
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
 

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -276,9 +276,12 @@ class GenerateVideoRequest:
 
     def _validate_mode_symmetry(self) -> None:
         if self.mode is Mode.T2V and (
-            self.start_image or self.start_image_ref_name or
-            self.end_image or self.end_image_ref_name or
-            self.reference_images or self.ref_names
+            self.start_image
+            or self.start_image_ref_name
+            or self.end_image
+            or self.end_image_ref_name
+            or self.reference_images
+            or self.ref_names
         ):
             msg = "T2V request must not carry image inputs"
             raise ValueError(msg)

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -201,9 +201,12 @@ class GenerateVideoRequest:
     duration: int | None = None  # seconds: 4/6/8 (or 10, omni_flash only); None -> default
     count: int = 1  # 1-4 outputs; >1 multiplies credit cost
     seed: int | None = None
-    start_image: Path | None = None  # I2V
-    end_image: Path | None = None  # I2V (optional)
-    reference_images: tuple[Path, ...] = ()  # R2V
+    start_image: Path | None = None  # I2V (local file path)
+    start_image_ref_name: str | None = None  # I2V (remote asset display name)
+    end_image: Path | None = None  # I2V (optional local file path)
+    end_image_ref_name: str | None = None  # I2V (optional remote asset display name)
+    reference_images: tuple[Path, ...] = ()  # R2V (local file paths)
+    ref_names: tuple[str, ...] = ()  # R2V (remote asset display names)
     reference_entities: tuple[str, ...] = ()  # R2V — Flow CHARACTER entity ids
     reference_entity_names: tuple[
         str, ...
@@ -251,23 +254,32 @@ class GenerateVideoRequest:
             raise ValueError(msg)
 
     def _validate_i2v_symmetry(self) -> None:
-        if self.start_image is None:
-            msg = "I2V request requires start_image"
+        if self.start_image is None and self.start_image_ref_name is None:
+            msg = "I2V request requires start_image or start_image_ref_name"
             raise ValueError(msg)
-        if self.reference_images or self.reference_entities:
-            msg = "I2V request must not carry reference_images or reference_entities"
+        if self.reference_images or self.ref_names or self.reference_entities:
+            msg = "I2V request must not carry reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
 
     def _validate_r2v_symmetry(self) -> None:
-        if not self.reference_images and not self.reference_entities:
-            msg = "R2V request requires reference_images or reference_entities"
+        if not self.reference_images and not self.ref_names and not self.reference_entities:
+            msg = "R2V request requires reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
-        if self.start_image or self.end_image:
+        if (
+            self.start_image
+            or self.start_image_ref_name
+            or self.end_image
+            or self.end_image_ref_name
+        ):
             msg = "R2V request must not carry start/end images"
             raise ValueError(msg)
 
     def _validate_mode_symmetry(self) -> None:
-        if self.mode is Mode.T2V and (self.start_image or self.end_image or self.reference_images):
+        if self.mode is Mode.T2V and (
+            self.start_image or self.start_image_ref_name or
+            self.end_image or self.end_image_ref_name or
+            self.reference_images or self.ref_names
+        ):
             msg = "T2V request must not carry image inputs"
             raise ValueError(msg)
         if self.mode is Mode.I2V:
@@ -276,7 +288,7 @@ class GenerateVideoRequest:
             self._validate_r2v_symmetry()
 
     def _validate_r2v_caps(self) -> None:
-        if len(self.reference_images) > MAX_REFERENCE_IMAGES:
+        if len(self.reference_images) + len(self.ref_names) > MAX_REFERENCE_IMAGES:
             msg = f"at most {MAX_REFERENCE_IMAGES} reference images"
             raise ValueError(msg)
         # Per-model reference cap (live-verified): omni_flash=7, veo lite/fast/lite_lp=3,
@@ -287,15 +299,16 @@ class GenerateVideoRequest:
             if cap == 0:
                 msg = f"{self.model.value} does not support R2V (reference-to-video)"
                 raise ValueError(msg)
-            if len(self.reference_images) > cap:
+            total_img_refs = len(self.reference_images) + len(self.ref_names)
+            if total_img_refs > cap:
                 msg = (
                     f"{self.model.value} allows at most {cap} reference image(s); "
-                    f"got {len(self.reference_images)}"
+                    f"got {total_img_refs}"
                 )
                 raise ValueError(
                     msg,
                 )
-            total_refs = len(self.reference_images) + len(self.reference_entities)
+            total_refs = total_img_refs + len(self.reference_entities)
             if total_refs > cap:
                 msg = (
                     f"reference cap exceeded: {total_refs} refs (images+entities) "

--- a/src/gflow_cli/data/models.py
+++ b/src/gflow_cli/data/models.py
@@ -219,8 +219,10 @@ class AssetLookup:
     profile_name: str
     flow_project_id: str | None
     flow_media_id: str
+    flow_workflow_id: str | None
     kind: AssetKind
     local_files: list[LocalFileRecord]
+    metadata_json: JsonObject
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -5,7 +5,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from gflow_cli.data.models import (
     AssetKind,
@@ -709,25 +709,7 @@ class DataRepository:
             """,
             (OperationAssetRole.OUTPUT.value, profile_name, flow_media_id),
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def resolve_seed_image_by_path(self, profile_name: str, path: Path) -> SeedImage | None:
         row = self._store.conn.execute(
@@ -747,25 +729,7 @@ class DataRepository:
             """,
             (OperationAssetRole.OUTPUT.value, profile_name, str(path)),
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def resolve_latest_image(
         self,
@@ -806,25 +770,7 @@ class DataRepository:
             sql,
             [OperationAssetRole.OUTPUT.value, *params],
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def list_project_images(self, profile_name: str, flow_project_id: str) -> list[SeedImage]:
         rows = self._store.conn.execute(
@@ -923,6 +869,29 @@ class DataRepository:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _row_to_seed_image(self, row: Any) -> SeedImage | None:
+        """Hydrate a SeedImage from an assets+prompt row, or None if the row is
+        absent or lacks a flow_project_id. Shared by the resolve_* readers."""
+        if row is None:
+            return None
+        if row["flow_project_id"] is None:
+            return None
+        local_path = self._latest_local_path(str(row["id"]))
+        return SeedImage(
+            profile_name=str(row["profile_name"]),
+            flow_project_id=str(row["flow_project_id"]),
+            flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
+            local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=str(row["created_at"]),
+        )
 
     def _latest_local_path(self, asset_id: str) -> Path | None:
         row = self._store.conn.execute(

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -166,11 +166,32 @@ class DataRepository:
     ) -> AssetLookup | None:
         row = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE profile_name = ? AND flow_media_id = ?
             """,
             (profile_name, flow_media_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._hydrate_asset_lookup(row)
+
+    def get_asset_by_any_id(
+        self,
+        profile_name: str,
+        ref_id: str,
+    ) -> AssetLookup | None:
+        row = self._store.conn.execute(
+            """
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
+            FROM assets
+            WHERE profile_name = ? AND (flow_media_id = ? OR flow_workflow_id = ? OR id = ?)
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (profile_name, ref_id, ref_id, ref_id),
         ).fetchone()
         if row is None:
             return None
@@ -186,7 +207,8 @@ class DataRepository:
         """
         rows = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE flow_media_id = ?
             ORDER BY profile_name ASC, id ASC
@@ -212,8 +234,10 @@ class DataRepository:
             profile_name=str(row["profile_name"]),
             flow_project_id=row["flow_project_id"],
             flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
             kind=AssetKind(row["kind"]),
             local_files=local_files,
+            metadata_json=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
         )
 
     def candidate_image_exists(self, profile_name: str, flow_media_id: str) -> bool:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -217,6 +217,26 @@ async def _run_generation_task(
             profile_dir = settings.profile_subdir(profile)
             data_repo.upsert_profile(profile, profile_dir)
 
+            # Resolve display names for remote refs so the UI automation can search for them
+            def _resolve_ref(ref_id: str) -> str:
+                name = None
+                asset = data_repo.get_asset_by_any_id(profile, ref_id)
+                if asset:
+                    name = asset.metadata_json.get("display_name")
+                    if not name:
+                        # Fallback for images generated before display_name was extracted properly
+                        seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
+                        if seed_info and seed_info.prompt:
+                            name = seed_info.prompt
+                return name or ref_id
+
+            if "refs" in payload:
+                payload["ref_names"] = [_resolve_ref(r) for r in payload["refs"]]
+            if "start_image_ref" in payload:
+                payload["start_image_ref_name"] = _resolve_ref(payload["start_image_ref"])
+            if "end_image_ref" in payload:
+                payload["end_image_ref_name"] = _resolve_ref(payload["end_image_ref"])
+
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
                 profile_name=profile,
@@ -266,17 +286,25 @@ async def _run_generation_task(
 
             # Resolve local file paths from the asset catalog.
             file_paths: list[str] = []
+            flow_project_id: str | None = None
+            flow_workflow_id: str | None = None
             if completed_task.flow_media_id:
                 asset = DataRepository(store).get_asset_by_flow_media_id(
                     profile,
                     completed_task.flow_media_id,
                 )
-                if asset and asset.local_files:
-                    file_paths = [str(lf.path) for lf in asset.local_files if lf.path is not None]
+                if asset:
+                    flow_project_id = asset.flow_project_id
+                    flow_workflow_id = asset.flow_workflow_id
+                    if asset.local_files:
+                        file_paths = [
+                            str(lf.path) for lf in asset.local_files if lf.path is not None
+                        ]
 
         log.info(
             "mcp.tool.task_completed",
             task_id=task_id,
+            flow_project_id=flow_project_id,
             flow_media_id=completed_task.flow_media_id,
             file_count=len(file_paths),
         )
@@ -284,7 +312,8 @@ async def _run_generation_task(
         return {
             "status": "completed",
             "task_id": task_id,
-            "flow_media_id": completed_task.flow_media_id,
+            "flow_project_id": flow_project_id,
+            "flow_media_id": flow_workflow_id if flow_workflow_id else completed_task.flow_media_id,
             "files": file_paths,
         }
 
@@ -407,30 +436,34 @@ def _build_video_media_inputs(
 
     media: dict[str, Any] = {}
     if initial_frame is not None:
-        resolved, err = _resolve_image_path(
-            initial_frame, title="Invalid Start Image", label="Start image path"
-        )
-        if err is not None:
-            return None, err
-        media["start_image"] = resolved
-    if end_frame is not None:
-        resolved, err = _resolve_image_path(
-            end_frame, title="Invalid End Image", label="End image path"
-        )
-        if err is not None:
-            return None, err
-        media["end_image"] = resolved
-    if reference_images:
-        ref_paths: list[str] = []
-        for ref in reference_images:
+        if _UUID_RE.fullmatch(initial_frame):
+            media["start_image_ref"] = initial_frame
+        else:
             resolved, err = _resolve_image_path(
-                ref, title="Invalid Reference Image", label="Reference image path"
+                initial_frame, title="Invalid Start Image", label="Start image path"
             )
             if err is not None:
                 return None, err
-            assert resolved is not None
-            ref_paths.append(resolved)
-        media["reference_images"] = ref_paths
+            media["start_image"] = resolved
+    if end_frame is not None:
+        if _UUID_RE.fullmatch(end_frame):
+            media["end_image_ref"] = end_frame
+        else:
+            resolved, err = _resolve_image_path(
+                end_frame, title="Invalid End Image", label="End image path"
+            )
+            if err is not None:
+                return None, err
+            media["end_image"] = resolved
+    if reference_images:
+        ref_data, err = _resolve_image_references(reference_images)
+        if err is not None:
+            return None, err
+        assert ref_data is not None
+        if ref_data["ref_paths"]:
+            media["reference_images"] = ref_data["ref_paths"]
+        if ref_data["refs"]:
+            media["refs"] = ref_data["refs"]
     return media, None
 
 

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -217,25 +217,23 @@ async def _run_generation_task(
             profile_dir = settings.profile_subdir(profile)
             data_repo.upsert_profile(profile, profile_dir)
 
-            # Resolve display names for remote refs so the UI automation can search for them
-            def _resolve_ref(ref_id: str) -> str:
-                name = None
-                asset = data_repo.get_asset_by_any_id(profile, ref_id)
-                if asset:
-                    name = asset.metadata_json.get("display_name")
-                    if not name:
-                        # Fallback for images generated before display_name was extracted properly
-                        seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
-                        if seed_info and seed_info.prompt:
-                            name = seed_info.prompt
-                return name or ref_id
-
+            # Resolve remote-ref UUIDs to the display names the UI automation
+            # searches for; an unresolvable UUID fails fast here (see
+            # _resolve_ref_name) instead of timing out in the browser.
+            ref_names: list[str] = []
+            for ref in payload.get("refs", []):
+                name, err = _resolve_ref_name(data_repo, profile, ref)
+                if err is not None:
+                    return err
+                ref_names.append(name or ref)
             if "refs" in payload:
-                payload["ref_names"] = [_resolve_ref(r) for r in payload["refs"]]
-            if "start_image_ref" in payload:
-                payload["start_image_ref_name"] = _resolve_ref(payload["start_image_ref"])
-            if "end_image_ref" in payload:
-                payload["end_image_ref_name"] = _resolve_ref(payload["end_image_ref"])
+                payload["ref_names"] = ref_names
+            for key in ("start_image_ref", "end_image_ref"):
+                if key in payload:
+                    name, err = _resolve_ref_name(data_repo, profile, payload[key])
+                    if err is not None:
+                        return err
+                    payload[f"{key}_name"] = name
 
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
@@ -353,6 +351,37 @@ def _bad_param(title: str, detail: str) -> dict[str, Any]:
         "status": "error",
         "error": {"type": _BAD_PARAM_TYPE, "title": title, "status": 400, "detail": detail},
     }
+
+
+def _resolve_ref_name(
+    data_repo: DataRepository,
+    profile: str,
+    ref_id: str,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve a remote reference to the display name the UI automation searches.
+
+    Returns ``(name, None)`` or ``(None, error_envelope)``. A ``ref_id`` that is
+    UUID-shaped but absent from the asset catalog is a mistake worth catching at
+    enqueue time: passing the raw UUID downstream surfaced as a ~120s Playwright
+    timeout (PR #237 review). A non-UUID string is treated as a literal display
+    name the caller typed directly and passed through unchanged.
+    """
+    asset = data_repo.get_asset_by_any_id(profile, ref_id)
+    if asset is not None:
+        name = asset.metadata_json.get("display_name")
+        if not name:
+            # Fallback for images generated before display_name was extracted.
+            seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
+            if seed_info and seed_info.prompt:
+                name = seed_info.prompt
+        return name or ref_id, None
+    if _UUID_RE.fullmatch(ref_id):
+        return None, _bad_param(
+            "Reference Not Found",
+            f"'{ref_id}' was not found in your asset catalog for profile "
+            f"{profile!r}. Generate the image first, or pass its display name.",
+        )
+    return ref_id, None
 
 
 def _validate_project(project: str | None) -> dict[str, Any] | None:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -218,22 +218,11 @@ async def _run_generation_task(
             data_repo.upsert_profile(profile, profile_dir)
 
             # Resolve remote-ref UUIDs to the display names the UI automation
-            # searches for; an unresolvable UUID fails fast here (see
-            # _resolve_ref_name) instead of timing out in the browser.
-            ref_names: list[str] = []
-            for ref in payload.get("refs", []):
-                name, err = _resolve_ref_name(data_repo, profile, ref)
-                if err is not None:
-                    return err
-                ref_names.append(name or ref)
-            if "refs" in payload:
-                payload["ref_names"] = ref_names
-            for key in ("start_image_ref", "end_image_ref"):
-                if key in payload:
-                    name, err = _resolve_ref_name(data_repo, profile, payload[key])
-                    if err is not None:
-                        return err
-                    payload[f"{key}_name"] = name
+            # searches for; an unresolvable UUID fails fast here instead of
+            # timing out in the browser.
+            ref_err = _resolve_payload_ref_names(data_repo, profile, payload)
+            if ref_err is not None:
+                return ref_err
 
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
@@ -382,6 +371,34 @@ def _resolve_ref_name(
             f"{profile!r}. Generate the image first, or pass its display name.",
         )
     return ref_id, None
+
+
+def _resolve_payload_ref_names(
+    data_repo: DataRepository,
+    profile: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve every remote-ref field in ``payload`` to a display name in place.
+
+    Returns an error envelope on the first unresolvable UUID, else ``None``.
+    Keeps the UUID→name resolution out of the enqueue orchestrator so the
+    latter stays under the cognitive-complexity threshold.
+    """
+    if "refs" in payload:
+        ref_names: list[str] = []
+        for ref in payload["refs"]:
+            name, err = _resolve_ref_name(data_repo, profile, ref)
+            if err is not None:
+                return err
+            ref_names.append(name or ref)
+        payload["ref_names"] = ref_names
+    for key in ("start_image_ref", "end_image_ref"):
+        if key in payload:
+            name, err = _resolve_ref_name(data_repo, profile, payload[key])
+            if err is not None:
+                return err
+            payload[f"{key}_name"] = name
+    return None
 
 
 def _validate_project(project: str | None) -> dict[str, Any] | None:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -481,26 +481,21 @@ def _build_video_media_inputs(
         )
 
     media: dict[str, Any] = {}
-    if initial_frame is not None:
-        if _UUID_RE.fullmatch(initial_frame):
-            media["start_image_ref"] = initial_frame
-        else:
-            resolved, err = _resolve_image_path(
-                initial_frame, title="Invalid Start Image", label="Start image path"
-            )
-            if err is not None:
-                return None, err
-            media["start_image"] = resolved
-    if end_frame is not None:
-        if _UUID_RE.fullmatch(end_frame):
-            media["end_image_ref"] = end_frame
-        else:
-            resolved, err = _resolve_image_path(
-                end_frame, title="Invalid End Image", label="End image path"
-            )
-            if err is not None:
-                return None, err
-            media["end_image"] = resolved
+    for frame, ref_key, path_key, noun in (
+        (initial_frame, "start_image_ref", "start_image", "Start"),
+        (end_frame, "end_image_ref", "end_image", "End"),
+    ):
+        if frame is None:
+            continue
+        if _UUID_RE.fullmatch(frame):
+            media[ref_key] = frame
+            continue
+        resolved, err = _resolve_image_path(
+            frame, title=f"Invalid {noun} Image", label=f"{noun} image path"
+        )
+        if err is not None:
+            return None, err
+        media[path_key] = resolved
     if reference_images:
         ref_data, err = _resolve_image_references(reference_images)
         if err is not None:

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -293,6 +293,7 @@ class FlowWorker:
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -303,6 +304,7 @@ class FlowWorker:
             model=model,
             refs=refs,
             ref_paths=ref_paths,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             count=count,
@@ -333,8 +335,11 @@ class FlowWorker:
         seed = payload.get("seed")
 
         start_image = Path(payload["start_image"]) if payload.get("start_image") else None
+        start_image_ref_name = payload.get("start_image_ref_name")
         end_image = Path(payload["end_image"]) if payload.get("end_image") else None
+        end_image_ref_name = payload.get("end_image_ref_name")
         reference_images = tuple(Path(p) for p in payload.get("reference_images", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         reference_audio = payload.get("reference_audio")
@@ -349,8 +354,11 @@ class FlowWorker:
             count=count,
             seed=seed,
             start_image=start_image,
+            start_image_ref_name=start_image_ref_name,
             end_image=end_image,
+            end_image_ref_name=end_image_ref_name,
             reference_images=reference_images,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             reference_audio=reference_audio,

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -293,7 +293,10 @@ class FlowWorker:
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
-        ref_names = tuple(payload.get("ref_names", []))
+        # NOTE: the payload may carry "ref_names" (the MCP layer resolves them
+        # for the video request); the image transport attaches remote refs by
+        # media id, so GenerateImageRequest has no ref_names field and must
+        # not receive one.
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -304,7 +307,6 @@ class FlowWorker:
             model=model,
             refs=refs,
             ref_paths=ref_paths,
-            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             count=count,

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -154,7 +154,7 @@ class TestGenerateVideoRequest:
             )
 
     def test_r2v_requires_a_reference_image(self) -> None:
-        with pytest.raises(ValueError, match="reference_images or reference_entities"):
+        with pytest.raises(ValueError, match="reference_images, ref_names, or reference_entities"):
             GenerateVideoRequest(prompt="x", mode=Mode.R2V)
 
     def test_r2v_must_not_carry_start_end(self) -> None:

--- a/tests/api/test_video_request.py
+++ b/tests/api/test_video_request.py
@@ -29,10 +29,23 @@ def test_r2v_valid_with_audio() -> None:
 
 
 def test_r2v_requires_images_or_entities() -> None:
-    with pytest.raises(ValueError, match="reference_images or reference_entities"):
+    with pytest.raises(ValueError, match="reference_images, ref_names, or reference_entities"):
         GenerateVideoRequest(
             prompt="x", mode=Mode.R2V, aspect=Aspect.LANDSCAPE, model=VideoModel.VEO_3_1_LITE
         )
+
+
+def test_r2v_accepts_remote_ref_names_alone() -> None:
+    # PR #237: a UUID resolved to a remote display name (ref_names) is a valid
+    # R2V reference source on its own — no local reference_images required.
+    req = GenerateVideoRequest(
+        prompt="x",
+        mode=Mode.R2V,
+        aspect=Aspect.LANDSCAPE,
+        model=VideoModel.VEO_3_1_LITE,
+        ref_names=("A cozy cabin",),
+    )
+    assert req.ref_names == ("A cozy cabin",)
 
 
 def test_cap_budget_counts_entities_plus_images() -> None:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1309,3 +1309,64 @@ class TestAssertEntitiesAttached:
         assert "github.com/ffroliva/gflow-cli/issues/174" in err.remediation_hint
         assert err.to_problem_details().get("remediation_hint") == err.remediation_hint
         assert err.discovery == {"entity_attach_context": "video"}
+
+
+class TestRemoteRefTileLocator:
+    """PR #237: option tiles are matched by display_name / prompt text, which
+    commonly contains an apostrophe. The old `:has-text('{name}')` CSS selector
+    broke on those; `_remote_option_tile` must match by role name instead."""
+
+    def test_apostrophe_name_does_not_go_into_a_quoted_css_selector(self) -> None:
+        page = MagicMock()
+        VideoGenerationMixin._remote_option_tile(page, "Wren's cabin")
+        # role-based match: the raw name is passed as the accessible name,
+        # never interpolated into a `:has-text('...')` CSS string.
+        page.get_by_role.assert_called_once()
+        args, kwargs = page.get_by_role.call_args
+        assert args[0] == "option"
+        assert kwargs.get("name") == "Wren's cabin"
+        page.locator.assert_not_called()
+
+
+class TestRemoteReferencesDialogGuard:
+    """PR #237 review #4: _attach_remote_references logged success even when the
+    include action never fired (locale mismatch). It must verify the picker
+    dialog closed and raise TransportTimeoutError otherwise."""
+
+    @staticmethod
+    def _locator_mock() -> MagicMock:
+        loc = MagicMock()
+        loc.wait_for = AsyncMock()
+        loc.click = AsyncMock()
+        loc.press_sequentially = AsyncMock()
+        loc.first = loc
+        loc.last = loc
+        return loc
+
+    @pytest.mark.asyncio
+    async def test_raises_when_picker_dialog_stays_open(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        page = _mock_async_page()
+        dialog = self._locator_mock()
+        dialog.wait_for = AsyncMock(side_effect=Exception("dialog still open"))
+
+        def _locator(selector: str) -> MagicMock:
+            return dialog if selector == "[role='dialog']" else self._locator_mock()
+
+        page.locator = MagicMock(side_effect=_locator)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_remote_option_tile",
+            staticmethod(lambda p, n: self._locator_mock()),
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_resolve_include_action",
+            AsyncMock(return_value=self._locator_mock()),
+        )
+
+        with pytest.raises(TransportTimeoutError, match="did not close"):
+            await VideoGenerationMixin._attach_remote_references(
+                page, ["Wren's cabin"], out_dir=None
+            )

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -326,3 +326,51 @@ def test_seed_read_api_resolves_by_path_latest_project_and_candidate(tmp_path: P
         project_images = repo.list_project_images("default", "flow-project-1")
         assert [item.flow_media_id for item in project_images] == ["media-latest"]
         assert repo.candidate_image_exists("default", "media-latest") is True
+
+
+def test_get_asset_by_any_id_resolves_media_workflow_and_asset_ids(tmp_path: Path) -> None:
+    """PR #237: UUID→asset resolution must work for every id kind and hydrate
+    the fields the MCP display-name lookup relies on (flow_workflow_id,
+    metadata_json) — the original submission constructed AssetLookup with
+    fields the dataclass did not declare (TypeError)."""
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-any",
+                profile_name="default",
+                flow_project_id="flow-project-any",
+                title="t",
+                source="generated",
+            )
+        )
+        repo.upsert_asset(
+            AssetRecord(
+                id="asset-any",
+                profile_name="default",
+                flow_project_id="flow-project-any",
+                flow_media_id="media-any",
+                flow_workflow_id="workflow-any",
+                flow_media_generation_id="generation-any",
+                kind=AssetKind.IMAGE,
+                status="ready",
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                width=1024,
+                height=1792,
+                duration_seconds=None,
+                seed=1,
+                metadata_json={"display_name": "A cozy cabin"},
+            )
+        )
+
+        for ref in ("media-any", "workflow-any", "asset-any"):
+            found = repo.get_asset_by_any_id("default", ref)
+            assert found is not None, ref
+            assert found.flow_media_id == "media-any"
+            assert found.flow_workflow_id == "workflow-any"
+            assert found.metadata_json == {"display_name": "A cozy cabin"}
+
+        assert repo.get_asset_by_any_id("default", "nope") is None
+        assert repo.get_asset_by_any_id("other-profile", "media-any") is None

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -147,3 +147,73 @@ def test_video_media_i2v_bad_frame(tmp_path: Path) -> None:
     assert media is None
     assert err is not None
     assert err["error"]["title"] == "Invalid Start Image"
+
+
+class _FakeRepo:
+    """Minimal stand-in for DataRepository's two methods _resolve_ref_name uses."""
+
+    def __init__(self, asset=None, seed=None):
+        self._asset = asset
+        self._seed = seed
+
+    def get_asset_by_any_id(self, profile, ref_id):
+        return self._asset
+
+    def resolve_seed_image(self, profile, flow_media_id):
+        return self._seed
+
+
+class _Asset:
+    def __init__(self, metadata_json, flow_media_id="m"):
+        self.metadata_json = metadata_json
+        self.flow_media_id = flow_media_id
+
+
+class _Seed:
+    def __init__(self, prompt):
+        self.prompt = prompt
+
+
+_A_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_resolve_ref_name_uses_display_name() -> None:
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=_Asset({"display_name": "A cozy cabin"}))
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert err is None
+    assert name == "A cozy cabin"
+
+
+def test_resolve_ref_name_falls_back_to_seed_prompt() -> None:
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=_Asset({}), seed=_Seed("an old prompt"))
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert err is None
+    assert name == "an old prompt"
+
+
+def test_resolve_ref_name_unresolvable_uuid_returns_clear_error() -> None:
+    """PR #237 review #7: a UUID not in the catalog must fail fast with a clear
+    'not found' error instead of being passed downstream as a search term
+    (which surfaced as a ~120s Playwright timeout)."""
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=None)
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert name is None
+    assert err is not None
+    assert _A_UUID in str(err)
+    assert "catalog" in str(err).lower()
+
+
+def test_resolve_ref_name_passes_through_a_literal_display_name() -> None:
+    """A non-UUID string is a display name the user typed directly — keep it."""
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=None)
+    name, err = _resolve_ref_name(repo, "default", "A cozy cabin")
+    assert err is None
+    assert name == "A cozy cabin"


### PR DESCRIPTION
Takes over #237 (original author @C1ph3r404 went quiet) and resolves the 7 review findings that blocked it. The contributor's commit is preserved; a second commit applies the fixes. Closes #237.

## What the feature does
I2V (`initial_frame`/`end_frame`) and R2V (`reference_images`) now accept a generated image's Flow UUID, not just a local path — pipe an image generation's output straight into a video generation with no download/re-upload round-trip.

## Review findings closed (all had reproducing tests written first)
1. **`AssetLookup` TypeError** — added `flow_workflow_id` + `metadata_json` (the hydrate site constructed the dataclass with fields it never declared; every `get_asset_by_*` call raised).
2. **`GenerateImageRequest` TypeError** — dropped the `ref_names` kwarg wrongly forwarded on the image path (only `GenerateVideoRequest` gained the field).
3. **Playwright selector breakage** — picker tiles now match by ARIA role+name (`_remote_option_tile`) instead of `[role='option']:has-text('{name}')`; display names/prompts commonly contain an apostrophe.
4. **Locale regression** — remote frame + reference attach use the existing tiered, locale-safe `_resolve_include_action` (a hardcoded English "Add to Prompt" reintroduced the #170/#56 non-English hang) and now verify the picker dialog closed, so a locale miss raises instead of logging false success.
5/6. **Coverage + stale tests** — new tests for `get_asset_by_any_id`, `_resolve_ref_name`, R2V `ref_names` validation, the tile selector, and the dialog guard; the two stale regex-match tests updated for the new R2V error wording.
7. **Unresolvable UUID** — `_resolve_ref` extracted to a testable `_resolve_ref_name` that returns a clear "Reference Not Found" error at enqueue instead of a ~120s browser timeout; plus CHANGELOG entry and a `ruff format` pass (the format gate was red).

## Validation
- [x] Focused tests added for every behavior change
- [x] `ruff check` + `ruff format --check` clean; `pyright src` 0 errors
- [x] `check_repo_hygiene` / `check_doc_links` pass
- [x] `uv run python -m pytest -q -m "not live and not e2e and not smoke" --cov=gflow_cli` — **1977 passed, 16 skipped, coverage 89%**

## Not covered
Live headed-browser interaction with the Flow picker is not automatable in CI (same constraint the original PR noted); the new attach logic is covered by mocked-page unit tests for selector shape, locale-tier resolution, and the dialog-closed guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)