### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,8 @@
 # gflow-cli — example environment variables.
-# Copy to `.env` in the directory where you invoke `gflow` and uncomment what
-# you want to override. ($GFLOW_CLI_HOME is NOT a .env search path — only the
-# current working directory is loaded.)
+# Copy to `.env` in the directory where you invoke `gflow` (project-local
+# overrides) or to `$GFLOW_CLI_HOME/.env` (machine-wide defaults; used by
+# processes with arbitrary working directories, e.g. the MCP server) and
+# uncomment what you want to override. On conflicts the CWD `.env` wins.
 # All variables are OPTIONAL — defaults work out of the box for most users.
 # Lines below are commented to show the SHIPPED DEFAULT — uncomment to override.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`$GFLOW_CLI_HOME/.env` fallback now actually loads (#240)**: docs/CONFIGURATION.md
-  has always documented a `.env` fallback "from CWD or `$GFLOW_CLI_HOME/.env`", but the
-  implementation only ever read the CWD file — a key placed in the home `.env` was
+- **`$GFLOW_CLI_HOME/.env` now loads as a dotenv fallback (#240)**: `config.py`'s own
+  module docstring promised a `.env` fallback "from CWD or `$GFLOW_CLI_HOME/.env`", but
+  the implementation only ever read the CWD file — a key placed in the home `.env` was
   silently ignored (easy to miss under the prompt tools' never-fatal contract, and it
   bites any process whose CWD is not a project root: the MCP server launched by a
-  desktop client, a worker service, a scheduled task). Dotenv files are now resolved at
-  construction time via `settings_customise_sources`, honoring `GFLOW_CLI_HOME` from the
-  process env (falling back to the platform default home). Documented precedence is
-  preserved: process env vars beat both files, and a CWD `.env` beats `$GFLOW_CLI_HOME/.env`.
+  desktop client, a worker service, a scheduled task). `Settings` now defaults the
+  standard pydantic-settings `_env_file` init kwarg to `($GFLOW_CLI_HOME/.env, ./.env)`
+  per construction, so explicit `Settings(_env_file=...)` — including the disable idiom
+  `_env_file=None` — keeps working. Precedence: process env vars beat both files, and a
+  CWD `.env` beats `$GFLOW_CLI_HOME/.env`.
+  - **Home resolution is coherent across every channel**: the home used to locate the
+    home `.env` now matches what `Settings.home` reports when `GFLOW_CLI_HOME` comes
+    from the process env (case-insensitively, as the env source matches it), from a
+    `GFLOW_CLI_HOME` entry in the CWD `.env`, or is set-but-empty (treated as unset
+    rather than `Path('.')`). The home `.env` itself cannot relocate home (circular).
+  - **Docs reconciled**: `docs/CONFIGURATION.md` § ".env loading", `docs/SECURITY.md`
+    (Gemini-key locations) and `.env.template` previously documented CWD-only loading
+    and now describe the two-file behavior; the `gflow serve` token hint no longer
+    points at `.env.local`, which was never a loaded file.
+  - **Worker daemon**: `FlowApiClient` constructions in `process_task` now receive the
+    daemon's cached settings instead of re-reading `.env` files live per task, so a
+    mid-run edit to the home `.env` can no longer produce a task whose client config
+    disagrees with the parameters the task derived from `get_settings()`.
 
 ## [0.24.0] — 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Removed a shadowed duplicate `Settings.daemon_token` field definition (#243)**: the
+  class body defined `daemon_token` twice; Python silently kept only the second
+  (aliased) one, leaving the first as dead code that a future edit could touch without
+  effect. The surviving definition's contract (both `GFLOW_CLI_DAEMON_TOKEN` and
+  `GFLOW_DAEMON_TOKEN` accepted) is now pinned by tests, along with a guard that the
+  field is defined exactly once.
+
 - **`$GFLOW_CLI_HOME/.env` now loads as a dotenv fallback (#240)**: `config.py`'s own
   module docstring promised a `.env` fallback "from CWD or `$GFLOW_CLI_HOME/.env`", but
   the implementation only ever read the CWD file — a key placed in the home `.env` was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`$GFLOW_CLI_HOME/.env` fallback now actually loads (#240)**: docs/CONFIGURATION.md
+  has always documented a `.env` fallback "from CWD or `$GFLOW_CLI_HOME/.env`", but the
+  implementation only ever read the CWD file — a key placed in the home `.env` was
+  silently ignored (easy to miss under the prompt tools' never-fatal contract, and it
+  bites any process whose CWD is not a project root: the MCP server launched by a
+  desktop client, a worker service, a scheduled task). Dotenv files are now resolved at
+  construction time via `settings_customise_sources`, honoring `GFLOW_CLI_HOME` from the
+  process env (falling back to the platform default home). Documented precedence is
+  preserved: process env vars beat both files, and a CWD `.env` beats `$GFLOW_CLI_HOME/.env`.
+
 ## [0.24.0] — 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Remote image UUIDs in `gflow_generate_video` (#237)**: I2V (`initial_frame` /
+  `end_frame`) and R2V (`reference_images`) now accept a generated image's Flow UUID,
+  not just a local file path — pipe the output of an image generation straight into a
+  video generation with no download/re-upload round-trip. UUID inputs are resolved to
+  the asset's display name at enqueue time and attached via the resource picker; a UUID
+  that isn't in your asset catalog fails fast with a clear "Reference Not Found" error
+  instead of a long browser timeout. (Contributed by @C1ph3r404; hardened during
+  maintainer review — see below.)
+
 ### Fixed
 
 - **Removed a shadowed duplicate `Settings.daemon_token` field definition (#243)**: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-07-06
+
 ### Fixed
 
 - **Follow-up review fixes for remote image UUIDs (#237/#245)**: a post-merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Follow-up review fixes for remote image UUIDs (#237/#245)**: a post-merge
+  multi-angle review surfaced regressions and defects now corrected:
+  - Image `i2i` with a Flow media-id ref that isn't in the local catalog is no
+    longer rejected — UUID→display-name resolution is applied only to the video
+    paths (image refs attach by media id). Restores the `i2i` pass-through.
+  - The generation result envelope's `flow_media_id` again carries the real
+    media id (it was returning the asset's `flow_workflow_id`); the workflow id
+    is exposed under its own `flow_workflow_id` key.
+  - An in-catalog asset with no display name no longer returns its raw UUID as
+    the picker search term (which timed out); it fails fast with a clear error.
+  - Remote picker tiles match the display name exactly (`get_by_role(exact=True)`),
+    so a name that is a substring of another can't silently attach the wrong image.
+  - The R2V picker-close timeout matches the I2V budget (was a too-tight 8s that
+    aborted slow-but-successful attaches).
+  - `_attach_reference_audio` selects its tile by ARIA role+name instead of an
+    apostrophe-unsafe `:has-text()` selector.
+
 ### Added
 
 - **Remote image UUIDs in `gflow_generate_video` (#237)**: I2V (`initial_frame` /

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,9 +312,11 @@ predictable external storage keys, set the bucket prefix in
 
 ## .env loading
 
-`gflow-cli` (via [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)) loads a single `.env` from the **current working directory** at startup. There is no second load from `$GFLOW_CLI_HOME` — keep your `.env` next to where you invoke `gflow`.
+`gflow-cli` (via [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)) loads **two** `.env` files at startup: `$GFLOW_CLI_HOME/.env` (machine-wide defaults — useful for processes whose working directory is arbitrary, like the MCP server or a worker service) and a `.env` in the **current working directory** (project-local overrides). On conflicting keys the CWD file wins.
 
-Variables already set in the actual environment always beat any `.env` file. Anything explicitly passed on the CLI beats everything else.
+The home used for the first file is resolved from the `GFLOW_CLI_HOME` env var, else a `GFLOW_CLI_HOME` entry in the CWD `.env`, else the platform default — the same home `Settings.home` reports. (By construction the home `.env` cannot relocate home itself; set the env var or the CWD `.env` instead.)
+
+Variables already set in the actual environment always beat both `.env` files. Anything explicitly passed on the CLI beats everything else.
 
 Use [`.env.template`](../.env.template) as your starting point:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -46,7 +46,7 @@ The server registers three protocol surfaces:
 
 ### Tools (Executable actions)
 * `gflow_generate_image(prompt, model, aspect, count, seed, reference_images, tools, profile, project)`: Triggers text-to-image / image-to-image (Imagen / Nano Banana). `reference_images` switches to i2i; `project` generates into an existing Flow project id (mirrors CLI `--project`).
-* `gflow_generate_video(prompt, mode, aspect, initial_frame, end_frame, reference_images, tools, profile, project)`: Triggers vertical or landscape video generation (Veo). `mode` is `t2v`/`i2v`/`r2v`; `i2v` requires `initial_frame`, `r2v` requires `reference_images`; `project` generates into an existing Flow project id (mirrors CLI `--project`).
+* `gflow_generate_video(prompt, mode, aspect, initial_frame, end_frame, reference_images, tools, profile, project)`: Triggers vertical or landscape video generation (Veo). `mode` is `t2v`/`i2v`/`r2v`; `i2v` requires `initial_frame`, `r2v` requires `reference_images`; `project` generates into an existing Flow project id (mirrors CLI `--project`). `initial_frame`, `end_frame`, and `reference_images` each accept **either a local file path or the Flow image UUID of a generated asset** — pass a generated image's id straight in to chain image→video with no download/re-upload. A UUID that isn't in your local asset catalog is rejected up front with a clear "Reference Not Found" error.
 * `gflow_list_projects(profile, limit)`: Queries SQLite catalog for recent generation folders.
 * `gflow_list_characters(profile)`: Lists Flow Character entities (requires an active browser session).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,7 +39,7 @@
 
 Not used by v0.4.0a2's reverse-engineered Flow provider. Documented here in advance of `GFLOW_CLI_PROVIDER=official`.
 
-- **Location:** `$GFLOW_CLI_GEMINI_API_KEY` env var, optionally loaded from a `.env` file in the directory where you invoke `gflow` (CWD only — `$GFLOW_CLI_HOME` is not a `.env` search path; see [CONFIGURATION.md](CONFIGURATION.md)).
+- **Location:** `$GFLOW_CLI_GEMINI_API_KEY` env var, optionally loaded from a `.env` file in the directory where you invoke `gflow` or from `$GFLOW_CLI_HOME/.env` (CWD wins on conflicts; see [CONFIGURATION.md](CONFIGURATION.md#env-loading)). Treat BOTH locations as secret-bearing files: keep `$GFLOW_CLI_HOME/.env` user-readable only and out of shared images/backups.
 - **In memory:** Held only in the `Settings` dataclass, never logged.
 - **In transit:** Sent only to `generativelanguage.googleapis.com` over HTTPS.
 - **Rotate:** Set a new value in `.env`, restart the CLI. No persistence beyond the env var.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.24.0"
+version = "0.25.0"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1393,7 +1393,7 @@ class VideoGenerationMixin:
         if await add_btn.count():
             await add_btn.click()
         try:
-            await page.locator("[role='dialog']").last.wait_for(state="hidden", timeout=15_000)
+            await page.locator(DIALOG_ANY).last.wait_for(state="hidden", timeout=15_000)
         except Exception:
             log.warning("ui_automation_video.dialog_close_timeout", target=log_label)
         await page.wait_for_timeout(1500)
@@ -1477,7 +1477,7 @@ class VideoGenerationMixin:
         """Wheel-scroll the open resource picker down one step. The Tudo grid is
         virtualised, so off-screen tiles are absent from the DOM until scrolled
         into view. Hover the dialog first so the wheel targets the grid."""
-        dialog = page.locator("[role='dialog']").last
+        dialog = page.locator(DIALOG_ANY).last
         try:
             await dialog.hover(timeout=2000)
         except Exception:  # noqa: BLE001 - hover is best-effort; wheel still scrolls
@@ -1905,6 +1905,52 @@ class VideoGenerationMixin:
         return effective_model
 
     @staticmethod
+    async def _attach_i2v_frames(
+        page: Page, request: GenerateVideoRequest, *, out_dir: Path | None
+    ) -> None:
+        """Attach the Start (and optional End) I2V frame, local path or remote ref."""
+        if request.start_image is not None:
+            await VideoGenerationMixin._attach_frame(
+                page, 0, "Start", request.start_image, out_dir=out_dir
+            )
+        elif request.start_image_ref_name is not None:
+            await VideoGenerationMixin._attach_remote_frame(
+                page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
+            )
+        if request.end_image is not None:
+            await VideoGenerationMixin._attach_frame(
+                page, 1, "End", request.end_image, out_dir=out_dir
+            )
+        elif request.end_image_ref_name is not None:
+            await VideoGenerationMixin._attach_remote_frame(
+                page, 1, "End", request.end_image_ref_name, out_dir=out_dir
+            )
+
+    @staticmethod
+    async def _attach_r2v_references(
+        page: Page, request: GenerateVideoRequest, *, out_dir: Path | None
+    ) -> None:
+        """Attach R2V character entities, local reference images, remote refs, and audio."""
+        if request.reference_entities:
+            await VideoGenerationMixin._attach_character_entities(
+                page,
+                zip_entity_refs(request.reference_entities, request.reference_entity_names),
+                out_dir=out_dir,
+            )
+        if request.reference_images:
+            await VideoGenerationMixin._attach_references(
+                page, list(request.reference_images), out_dir=out_dir
+            )
+        if request.ref_names:
+            await VideoGenerationMixin._attach_remote_references(
+                page, list(request.ref_names), out_dir=out_dir
+            )
+        if request.reference_audio:
+            await VideoGenerationMixin._attach_reference_audio(
+                page, request.reference_audio, out_dir=out_dir
+            )
+
+    @staticmethod
     async def _attach_media_inputs(
         page: Page,
         request: GenerateVideoRequest,
@@ -1913,46 +1959,9 @@ class VideoGenerationMixin:
     ) -> None:
         """Attach I2V frames or R2V references/entities to the editor before submit."""
         if request.mode is Mode.I2V:
-            if request.start_image is not None:
-                await VideoGenerationMixin._attach_frame(
-                    page, 0, "Start", request.start_image, out_dir=out_dir
-                )
-            elif request.start_image_ref_name is not None:
-                await VideoGenerationMixin._attach_remote_frame(
-                    page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
-                )
-
-            if request.end_image is not None:
-                await VideoGenerationMixin._attach_frame(
-                    page, 1, "End", request.end_image, out_dir=out_dir
-                )
-            elif request.end_image_ref_name is not None:
-                await VideoGenerationMixin._attach_remote_frame(
-                    page, 1, "End", request.end_image_ref_name, out_dir=out_dir
-                )
+            await VideoGenerationMixin._attach_i2v_frames(page, request, out_dir=out_dir)
         elif request.mode is Mode.R2V:
-            if request.reference_entities:
-                await VideoGenerationMixin._attach_character_entities(
-                    page,
-                    zip_entity_refs(request.reference_entities, request.reference_entity_names),
-                    out_dir=out_dir,
-                )
-            if request.reference_images:
-                await VideoGenerationMixin._attach_references(
-                    page,
-                    list(request.reference_images),
-                    out_dir=out_dir,
-                )
-            if request.ref_names:
-                await VideoGenerationMixin._attach_remote_references(
-                    page,
-                    list(request.ref_names),
-                    out_dir=out_dir,
-                )
-            if request.reference_audio:
-                await VideoGenerationMixin._attach_reference_audio(
-                    page, request.reference_audio, out_dir=out_dir
-                )
+            await VideoGenerationMixin._attach_r2v_references(page, request, out_dir=out_dir)
 
     async def _submit_and_poll(
         self,

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -294,9 +294,9 @@ UPLOAD_MEDIA_BUTTON = (
 # This is exactly why the failure message tells the operator to set the Chrome
 # profile to English: it makes this fallback tier viable.
 UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
-# 'Add to Prompt' has no stable string anchor; selected structurally (the lone
-# iconless button) at the call site. This scope is the open media dialog.
-ADD_TO_PROMPT_BUTTON_TEXT = "button:has-text('Add to Prompt')"
+# 'Add to Prompt' has no stable string anchor; it is resolved via the tiered,
+# locale-safe PICKER_INCLUDE_BUTTON / _resolve_include_action pattern (a
+# hardcoded English string here previously hung non-English accounts — #170/#56).
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
@@ -1193,6 +1193,18 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    def _remote_option_tile(page: Page, name: str) -> Locator:
+        """Locate a picker result tile by its display name.
+
+        Uses ARIA role+name matching rather than
+        ``[role='option']:has-text('{name}')``: ``name`` is a stored
+        ``display_name`` or the original generation prompt, both of which
+        commonly contain an apostrophe or quote that would break a
+        single-quoted ``:has-text()`` CSS selector (PR #237 review).
+        """
+        return page.get_by_role("option", name=name)
+
+    @staticmethod
     async def _attach_remote_frame(
         page: Page,
         slot_index: int,
@@ -1239,18 +1251,22 @@ class VideoGenerationMixin:
         await search_input.press_sequentially(name, delay=random.randint(10, 50))
         await page.wait_for_timeout(600)
 
-        tile = page.locator(f"[role='option']:has-text('{name}')").first
+        tile = VideoGenerationMixin._remote_option_tile(page, name).first
         await tile.wait_for(state="visible", timeout=8000)
         await tile.click()
         await page.wait_for_timeout(300)
 
-        add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
-        try:
-            if await add_btn.is_visible():
-                await add_btn.click(timeout=3000)
-                await page.wait_for_timeout(600)
-        except Exception as e:
-            log.debug("ui_automation_video.remote_frame_add_btn_skip", error=str(e))
+        include = await VideoGenerationMixin._resolve_include_action(
+            page,
+            PICKER_INCLUDE_BUTTON,
+            _INCLUDE_BUTTON_TIER_NAMES,
+            surface="remote_frame_include",
+            detail=f"{label} remote frame",
+            out_dir=out_dir,
+            screenshot_name="remote_frame_include_missing.png",
+        )
+        await include.click(timeout=3000)
+        await page.wait_for_timeout(600)
 
         dialog = page.locator("[role='dialog']").last
         try:
@@ -1417,20 +1433,38 @@ class VideoGenerationMixin:
             await search_input.press_sequentially(name, delay=random.randint(10, 50))
             await page.wait_for_timeout(600)
 
-            # Select the option
-            tile = page.locator(f"[role='option']:has-text('{name}')").first
+            # Select the option (role+name match — apostrophes in the display
+            # name would break a `:has-text('{name}')` CSS selector).
+            tile = VideoGenerationMixin._remote_option_tile(page, name).first
             await tile.wait_for(state="visible", timeout=8000)
             await tile.click()
             await page.wait_for_timeout(300)
 
-            # Click Add to Prompt if it is still visible (sometimes clicking the tile auto-adds it)
-            add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+            # Include via the locale-safe tiered resolver (a hardcoded English
+            # "Add to Prompt" here previously hung on non-English accounts —
+            # issues #170/#56).
+            include = await VideoGenerationMixin._resolve_include_action(
+                page,
+                PICKER_INCLUDE_BUTTON,
+                _INCLUDE_BUTTON_TIER_NAMES,
+                surface="remote_reference_include",
+                detail="remote reference",
+                out_dir=out_dir,
+                screenshot_name="remote_reference_include_missing.png",
+            )
+            await include.click(timeout=3000)
+            await page.wait_for_timeout(600)
+
+            # Verify the picker actually closed — otherwise the include never
+            # fired and logging success would be a silent false positive.
+            dialog = page.locator("[role='dialog']").last
             try:
-                if await add_btn.is_visible():
-                    await add_btn.click(timeout=3000)
-                    await page.wait_for_timeout(600)
+                await dialog.wait_for(state="hidden", timeout=8000)
             except Exception as e:
-                log.debug("ui_automation_video.remote_reference_add_btn_skip", error=str(e))
+                raise TransportTimeoutError(
+                    f"remote reference {name!r} picker dialog did not close "
+                    "(the include action may not have registered)",
+                ) from e
 
             log.info("ui_automation_video.remote_reference_attached", display_name=name)
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -298,6 +298,9 @@ UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('
 # locale-safe PICKER_INCLUDE_BUTTON / _resolve_include_action pattern (a
 # hardcoded English string here previously hung non-English accounts — #170/#56).
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
+# Any open dialog (state-agnostic), used to confirm a picker closed after an
+# include action.
+DIALOG_ANY = "[role='dialog']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
 # the 'add_2' icon (its visible text 'Create' / 'Add Media' is unreliable — a
@@ -1193,6 +1196,58 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    async def _pick_option_and_include(
+        page: Page,
+        name: str,
+        *,
+        surface: str,
+        detail: str,
+        out_dir: Path | None,
+        dialog_timeout_s: float,
+    ) -> None:
+        """Shared picker flow: type ``name`` into the open resource picker,
+        select the matching result tile, fire the locale-safe include action,
+        and verify the picker dialog closed. Used by both the I2V frame and R2V
+        reference remote-attach paths (the picker is identical once open)."""
+        search_input = page.locator(PICKER_SEARCH_INPUT)
+        # Human-like typing jitter to dodge WAF bot heuristics — not a security
+        # context, so a plain PRNG is fine.
+        await search_input.press_sequentially(name, delay=random.randint(10, 50))  # NOSONAR
+        await page.wait_for_timeout(600)
+
+        # Role+name match — apostrophes in the display name would break a
+        # `:has-text('{name}')` CSS selector.
+        tile = VideoGenerationMixin._remote_option_tile(page, name).first
+        await tile.wait_for(state="visible", timeout=8000)
+        await tile.click()
+        await page.wait_for_timeout(300)
+
+        # Include via the tiered, locale-safe resolver (a hardcoded English
+        # "Add to Prompt" here previously hung non-English accounts — #170/#56).
+        include = await VideoGenerationMixin._resolve_include_action(
+            page,
+            PICKER_INCLUDE_BUTTON,
+            _INCLUDE_BUTTON_TIER_NAMES,
+            surface=surface,
+            detail=detail,
+            out_dir=out_dir,
+            screenshot_name=f"{surface}_missing.png",
+        )
+        await include.click(timeout=3000)
+        await page.wait_for_timeout(600)
+
+        # Confirm the picker closed — otherwise the include never registered and
+        # logging success would be a silent false positive.
+        dialog = page.locator(DIALOG_ANY).last
+        try:
+            await dialog.wait_for(state="hidden", timeout=dialog_timeout_s * 1000)
+        except Exception as e:
+            raise TransportTimeoutError(
+                f"{detail} picker dialog did not close after {dialog_timeout_s}s "
+                "(the include action may not have registered)",
+            ) from e
+
+    @staticmethod
     def _remote_option_tile(page: Page, name: str) -> Locator:
         """Locate a picker result tile by its display name.
 
@@ -1247,35 +1302,14 @@ class VideoGenerationMixin:
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
 
-        search_input = page.locator("#add-menu-input")
-        await search_input.press_sequentially(name, delay=random.randint(10, 50))
-        await page.wait_for_timeout(600)
-
-        tile = VideoGenerationMixin._remote_option_tile(page, name).first
-        await tile.wait_for(state="visible", timeout=8000)
-        await tile.click()
-        await page.wait_for_timeout(300)
-
-        include = await VideoGenerationMixin._resolve_include_action(
+        await VideoGenerationMixin._pick_option_and_include(
             page,
-            PICKER_INCLUDE_BUTTON,
-            _INCLUDE_BUTTON_TIER_NAMES,
+            name,
             surface="remote_frame_include",
             detail=f"{label} remote frame",
             out_dir=out_dir,
-            screenshot_name="remote_frame_include_missing.png",
+            dialog_timeout_s=timeout_s,
         )
-        await include.click(timeout=3000)
-        await page.wait_for_timeout(600)
-
-        dialog = page.locator("[role='dialog']").last
-        try:
-            await dialog.wait_for(state="hidden", timeout=timeout_s * 1000)
-        except Exception as e:
-            raise TransportTimeoutError(
-                f"{label} remote frame dialog did not close after {timeout_s}s",
-            ) from e
-
         log.info("ui_automation_video.remote_frame_attached", slot=label, display_name=name)
 
     @staticmethod
@@ -1428,44 +1462,14 @@ class VideoGenerationMixin:
             await add.click()
             await page.wait_for_timeout(800)
 
-            # Search in the input box using human-like typing to avoid WAF flagging
-            search_input = page.locator("#add-menu-input")
-            await search_input.press_sequentially(name, delay=random.randint(10, 50))
-            await page.wait_for_timeout(600)
-
-            # Select the option (role+name match — apostrophes in the display
-            # name would break a `:has-text('{name}')` CSS selector).
-            tile = VideoGenerationMixin._remote_option_tile(page, name).first
-            await tile.wait_for(state="visible", timeout=8000)
-            await tile.click()
-            await page.wait_for_timeout(300)
-
-            # Include via the locale-safe tiered resolver (a hardcoded English
-            # "Add to Prompt" here previously hung on non-English accounts —
-            # issues #170/#56).
-            include = await VideoGenerationMixin._resolve_include_action(
+            await VideoGenerationMixin._pick_option_and_include(
                 page,
-                PICKER_INCLUDE_BUTTON,
-                _INCLUDE_BUTTON_TIER_NAMES,
+                name,
                 surface="remote_reference_include",
-                detail="remote reference",
+                detail=f"remote reference {name!r}",
                 out_dir=out_dir,
-                screenshot_name="remote_reference_include_missing.png",
+                dialog_timeout_s=8.0,
             )
-            await include.click(timeout=3000)
-            await page.wait_for_timeout(600)
-
-            # Verify the picker actually closed — otherwise the include never
-            # fired and logging success would be a silent false positive.
-            dialog = page.locator("[role='dialog']").last
-            try:
-                await dialog.wait_for(state="hidden", timeout=8000)
-            except Exception as e:
-                raise TransportTimeoutError(
-                    f"remote reference {name!r} picker dialog did not close "
-                    "(the include action may not have registered)",
-                ) from e
-
             log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
     @staticmethod

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -295,6 +296,7 @@ UPLOAD_MEDIA_BUTTON = (
 UPLOAD_MEDIA_BUTTON_TEXT = "[role='dialog'][data-state='open'] button:has-text('Upload media')"
 # 'Add to Prompt' has no stable string anchor; selected structurally (the lone
 # iconless button) at the call site. This scope is the open media dialog.
+ADD_TO_PROMPT_BUTTON_TEXT = "button:has-text('Add to Prompt')"
 ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
@@ -1191,6 +1193,76 @@ class VideoGenerationMixin:
         log.info("ui_automation_video.frame_attached", slot=label)
 
     @staticmethod
+    async def _attach_remote_frame(
+        page: Page,
+        slot_index: int,
+        label: str,
+        name: str,
+        *,
+        out_dir: Path | None,
+        timeout_s: float = 120.0,
+    ) -> None:
+        """Attach a remote image (by display name) into an I2V frame slot."""
+        structs = page.locator(FRAME_SLOTS_STRUCT)
+        try:
+            await structs.first.wait_for(state="visible", timeout=12000)
+        except Exception as e:
+            shot = await _capture_debug_screenshot(
+                page,
+                out_dir,
+                f"debug_no_{label.lower()}_slot.png",
+            )
+            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            raise RuntimeError(msg) from e
+
+        struct_count = await structs.count()
+        if struct_count > slot_index:
+            slot = structs.nth(slot_index)
+        elif struct_count > 0:
+            slot = structs.first
+        else:
+            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+            try:
+                await slot.wait_for(state="visible", timeout=3000)
+            except Exception as e:
+                msg = (
+                    f"frame slot index {slot_index} ({label!r}) not present "
+                    f"(found {struct_count} structural slot(s), "
+                    f"text-label fallback also missed)"
+                )
+                raise RuntimeError(msg) from e
+
+        await slot.click()
+        await page.wait_for_timeout(1000)  # media dialog opens
+
+        search_input = page.locator("#add-menu-input")
+        await search_input.press_sequentially(name, delay=random.randint(10, 50))
+        await page.wait_for_timeout(600)
+
+        tile = page.locator(f"[role='option']:has-text('{name}')").first
+        await tile.wait_for(state="visible", timeout=8000)
+        await tile.click()
+        await page.wait_for_timeout(300)
+
+        add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+        try:
+            if await add_btn.is_visible():
+                await add_btn.click(timeout=3000)
+                await page.wait_for_timeout(600)
+        except Exception as e:
+            log.debug("ui_automation_video.remote_frame_add_btn_skip", error=str(e))
+
+        dialog = page.locator("[role='dialog']").last
+        try:
+            await dialog.wait_for(state="hidden", timeout=timeout_s * 1000)
+        except Exception as e:
+            raise TransportTimeoutError(
+                f"{label} remote frame dialog did not close after {timeout_s}s",
+            ) from e
+
+        log.info("ui_automation_video.remote_frame_attached", slot=label, display_name=name)
+
+    @staticmethod
     async def _upload_via_open_dialog(
         page: Page,
         image: Path,
@@ -1325,6 +1397,42 @@ class VideoGenerationMixin:
             )
             attached += 1
             log.info("ui_automation_video.reference_attached", index=i)
+
+    @staticmethod
+    async def _attach_remote_references(
+        page: Page,
+        ref_names: list[str],
+        *,
+        out_dir: Path | None,
+    ) -> None:
+        """Attach remote images by searching their display_name in the All tab."""
+        for name in ref_names:
+            add = page.locator(ADD_MEDIA_BUTTON).first
+            await add.wait_for(state="visible", timeout=8000)
+            await add.click()
+            await page.wait_for_timeout(800)
+
+            # Search in the input box using human-like typing to avoid WAF flagging
+            search_input = page.locator("#add-menu-input")
+            await search_input.press_sequentially(name, delay=random.randint(10, 50))
+            await page.wait_for_timeout(600)
+
+            # Select the option
+            tile = page.locator(f"[role='option']:has-text('{name}')").first
+            await tile.wait_for(state="visible", timeout=8000)
+            await tile.click()
+            await page.wait_for_timeout(300)
+
+            # Click Add to Prompt if it is still visible (sometimes clicking the tile auto-adds it)
+            add_btn = page.locator(ADD_TO_PROMPT_BUTTON_TEXT).first
+            try:
+                if await add_btn.is_visible():
+                    await add_btn.click(timeout=3000)
+                    await page.wait_for_timeout(600)
+            except Exception as e:
+                log.debug("ui_automation_video.remote_reference_add_btn_skip", error=str(e))
+
+            log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
     @staticmethod
     async def _scroll_picker_grid(page: Page, delta_px: int = PICKER_GRID_SCROLL_DELTA_PX) -> None:
@@ -1766,13 +1874,23 @@ class VideoGenerationMixin:
         out_dir: Path | None,
     ) -> None:
         """Attach I2V frames or R2V references/entities to the editor before submit."""
-        if request.mode is Mode.I2V and request.start_image is not None:
-            await VideoGenerationMixin._attach_frame(
-                page, 0, "Start", request.start_image, out_dir=out_dir
-            )
+        if request.mode is Mode.I2V:
+            if request.start_image is not None:
+                await VideoGenerationMixin._attach_frame(
+                    page, 0, "Start", request.start_image, out_dir=out_dir
+                )
+            elif request.start_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 0, "Start", request.start_image_ref_name, out_dir=out_dir
+                )
+
             if request.end_image is not None:
                 await VideoGenerationMixin._attach_frame(
                     page, 1, "End", request.end_image, out_dir=out_dir
+                )
+            elif request.end_image_ref_name is not None:
+                await VideoGenerationMixin._attach_remote_frame(
+                    page, 1, "End", request.end_image_ref_name, out_dir=out_dir
                 )
         elif request.mode is Mode.R2V:
             if request.reference_entities:
@@ -1785,6 +1903,12 @@ class VideoGenerationMixin:
                 await VideoGenerationMixin._attach_references(
                     page,
                     list(request.reference_images),
+                    out_dir=out_dir,
+                )
+            if request.ref_names:
+                await VideoGenerationMixin._attach_remote_references(
+                    page,
+                    list(request.ref_names),
                     out_dir=out_dir,
                 )
             if request.reference_audio:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1132,58 +1132,13 @@ class VideoGenerationMixin:
             msg = f"frame image not found: {image}"
             raise FileNotFoundError(msg)
 
-        # Locate the slot structural-first (locale-free): the frame slots are the
-        # dialog-divs inside the swap_horiz container, indexed by position
-        # (0=start, 1=end).  FRAME_SLOT_BY_LABEL (has-text 'Start'/'End') is
-        # tried only as a fallback when the structural count is insufficient —
-        # it requires --lang=en-US / English Chrome profile to work.
-        #
-        # wait_for is short (1500 ms) because _wait_video_editor_ready already
+        # wait_ms is short (1500) because _wait_video_editor_ready already
         # guaranteed the editor SPA is mounted; the frame panel resolves in
-        # <10 ms (one CDP round-trip) on a pre-rendered page.  A shorter probe
-        # means a future swap_horiz rename surfaces as a fast, clear error
-        # instead of an 8-second dead wait on every I2V/R2V call.
-        structs = page.locator(FRAME_SLOTS_STRUCT)
-        try:
-            await structs.first.wait_for(state="visible", timeout=1500)
-        except Exception as e:
-            shot = await _capture_debug_screenshot(
-                page,
-                out_dir,
-                f"debug_no_{label.lower()}_slot.png",
-            )
-            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(
-                msg,
-            ) from e
-
-        struct_count = await structs.count()
-        if struct_count > slot_index:
-            # Both slots unfilled — pick by DOM order.
-            slot = structs.nth(slot_index)
-        elif struct_count > 0:
-            # Some slots already attached (typical: Start filled, End remaining).
-            # The DOM only keeps `div[type='button'][aria-haspopup='dialog']` on
-            # the unfilled slot(s) — once an image binds, the slot transitions
-            # away from that pattern. The next unfilled slot is therefore
-            # `.first` of the remaining matches, regardless of its original
-            # positional index. This case is hit on the End-frame call after
-            # Start was just attached.
-            slot = structs.first
-        else:
-            # Structural count was insufficient; fall back to text-label match.
-            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
-            try:
-                await slot.wait_for(state="visible", timeout=3000)
-            except Exception as e:
-                msg = (
-                    f"frame slot index {slot_index} ({label!r}) not present "
-                    f"(found {struct_count} structural slot(s), "
-                    f"text-label fallback also missed)"
-                )
-                raise RuntimeError(
-                    msg,
-                ) from e
+        # <10 ms on a pre-rendered page, so a future swap_horiz rename surfaces
+        # as a fast, clear error instead of an 8-second dead wait per call.
+        slot = await VideoGenerationMixin._resolve_frame_slot(
+            page, slot_index, label, out_dir=out_dir, wait_ms=1500
+        )
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
         await VideoGenerationMixin._upload_via_open_dialog(
@@ -1260,6 +1215,53 @@ class VideoGenerationMixin:
         return page.get_by_role("option", name=name)
 
     @staticmethod
+    async def _resolve_frame_slot(
+        page: Page,
+        slot_index: int,
+        label: str,
+        *,
+        out_dir: Path | None,
+        wait_ms: int,
+    ) -> Locator:
+        """Locate an I2V frame slot, structural-first with a text-label fallback.
+
+        Shared by the local-upload and remote-ref frame-attach paths. The frame
+        slots are the dialog-divs inside the swap_horiz container, indexed by
+        position (0=start, 1=end); FRAME_SLOT_BY_LABEL (has-text 'Start'/'End',
+        English-only) is the fallback when the structural count is insufficient.
+        Once an image binds, its slot leaves the structural pattern, so the next
+        unfilled slot is `.first` of the remaining matches regardless of index.
+        Returns the (unclicked) slot locator; raises RuntimeError with a debug
+        screenshot if none resolves.
+        """
+        structs = page.locator(FRAME_SLOTS_STRUCT)
+        try:
+            await structs.first.wait_for(state="visible", timeout=wait_ms)
+        except Exception as e:
+            shot = await _capture_debug_screenshot(
+                page, out_dir, f"debug_no_{label.lower()}_slot.png"
+            )
+            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            raise RuntimeError(msg) from e
+
+        struct_count = await structs.count()
+        if struct_count > slot_index:
+            return structs.nth(slot_index)
+        if struct_count > 0:
+            return structs.first
+        slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
+        try:
+            await slot.wait_for(state="visible", timeout=3000)
+        except Exception as e:
+            msg = (
+                f"frame slot index {slot_index} ({label!r}) not present "
+                f"(found {struct_count} structural slot(s), "
+                f"text-label fallback also missed)"
+            )
+            raise RuntimeError(msg) from e
+        return slot
+
+    @staticmethod
     async def _attach_remote_frame(
         page: Page,
         slot_index: int,
@@ -1270,35 +1272,9 @@ class VideoGenerationMixin:
         timeout_s: float = 120.0,
     ) -> None:
         """Attach a remote image (by display name) into an I2V frame slot."""
-        structs = page.locator(FRAME_SLOTS_STRUCT)
-        try:
-            await structs.first.wait_for(state="visible", timeout=12000)
-        except Exception as e:
-            shot = await _capture_debug_screenshot(
-                page,
-                out_dir,
-                f"debug_no_{label.lower()}_slot.png",
-            )
-            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
-            raise RuntimeError(msg) from e
-
-        struct_count = await structs.count()
-        if struct_count > slot_index:
-            slot = structs.nth(slot_index)
-        elif struct_count > 0:
-            slot = structs.first
-        else:
-            slot = page.locator(FRAME_SLOT_BY_LABEL.format(label=label)).first
-            try:
-                await slot.wait_for(state="visible", timeout=3000)
-            except Exception as e:
-                msg = (
-                    f"frame slot index {slot_index} ({label!r}) not present "
-                    f"(found {struct_count} structural slot(s), "
-                    f"text-label fallback also missed)"
-                )
-                raise RuntimeError(msg) from e
-
+        slot = await VideoGenerationMixin._resolve_frame_slot(
+            page, slot_index, label, out_dir=out_dir, wait_ms=12000
+        )
         await slot.click()
         await page.wait_for_timeout(1000)  # media dialog opens
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -301,6 +301,10 @@ ADD_TO_PROMPT_DIALOG = "[role='dialog'][data-state='open']"
 # Any open dialog (state-agnostic), used to confirm a picker closed after an
 # include action.
 DIALOG_ANY = "[role='dialog']"
+# How long to wait for the resource picker to close after an include. Matched to
+# the I2V remote-frame budget (was an unexplained 8s for R2V, which spuriously
+# aborted slow-but-successful attaches on large/virtualised grids — #245 review).
+REMOTE_PICKER_CLOSE_TIMEOUT_S = 120.0
 # R2V references mode has NO Start/End slots — references are added via the
 # only button[aria-haspopup='dialog'] in the editor: a 'Create' button carrying
 # the 'add_2' icon (its visible text 'Create' / 'Add Media' is unreliable — a
@@ -1212,7 +1216,9 @@ class VideoGenerationMixin:
         commonly contain an apostrophe or quote that would break a
         single-quoted ``:has-text()`` CSS selector (PR #237 review).
         """
-        return page.get_by_role("option", name=name)
+        # exact=True: the default substring match would let 'cabin' select
+        # 'cabin at night' and .first attach the wrong image (PR #245 review).
+        return page.get_by_role("option", name=name, exact=True)
 
     @staticmethod
     async def _resolve_frame_slot(
@@ -1444,7 +1450,7 @@ class VideoGenerationMixin:
                 surface="remote_reference_include",
                 detail=f"remote reference {name!r}",
                 out_dir=out_dir,
-                dialog_timeout_s=8.0,
+                dialog_timeout_s=REMOTE_PICKER_CLOSE_TIMEOUT_S,
             )
             log.info("ui_automation_video.remote_reference_attached", display_name=name)
 
@@ -1600,9 +1606,13 @@ class VideoGenerationMixin:
         await page.wait_for_timeout(400)
         await page.locator(PICKER_SEARCH_INPUT).first.fill(voice_id)
         await page.wait_for_timeout(600)
-        tile = page.locator(
-            f"button:has-text('{voice_id}'), [role='option']:has-text('{voice_id}')"
-        ).first
+        # Role+name match (apostrophe-safe, mirroring _remote_option_tile) — a
+        # voice_id with a quote would break a single-quoted :has-text() selector.
+        tile = (
+            page.get_by_role("option", name=voice_id)
+            .or_(page.get_by_role("button", name=voice_id))
+            .first
+        )
         await tile.click()
         await page.wait_for_timeout(300)
         include = await VideoGenerationMixin._resolve_include_action(

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -276,9 +276,12 @@ class GenerateVideoRequest:
 
     def _validate_mode_symmetry(self) -> None:
         if self.mode is Mode.T2V and (
-            self.start_image or self.start_image_ref_name or
-            self.end_image or self.end_image_ref_name or
-            self.reference_images or self.ref_names
+            self.start_image
+            or self.start_image_ref_name
+            or self.end_image
+            or self.end_image_ref_name
+            or self.reference_images
+            or self.ref_names
         ):
             msg = "T2V request must not carry image inputs"
             raise ValueError(msg)

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -201,9 +201,12 @@ class GenerateVideoRequest:
     duration: int | None = None  # seconds: 4/6/8 (or 10, omni_flash only); None -> default
     count: int = 1  # 1-4 outputs; >1 multiplies credit cost
     seed: int | None = None
-    start_image: Path | None = None  # I2V
-    end_image: Path | None = None  # I2V (optional)
-    reference_images: tuple[Path, ...] = ()  # R2V
+    start_image: Path | None = None  # I2V (local file path)
+    start_image_ref_name: str | None = None  # I2V (remote asset display name)
+    end_image: Path | None = None  # I2V (optional local file path)
+    end_image_ref_name: str | None = None  # I2V (optional remote asset display name)
+    reference_images: tuple[Path, ...] = ()  # R2V (local file paths)
+    ref_names: tuple[str, ...] = ()  # R2V (remote asset display names)
     reference_entities: tuple[str, ...] = ()  # R2V — Flow CHARACTER entity ids
     reference_entity_names: tuple[
         str, ...
@@ -251,23 +254,32 @@ class GenerateVideoRequest:
             raise ValueError(msg)
 
     def _validate_i2v_symmetry(self) -> None:
-        if self.start_image is None:
-            msg = "I2V request requires start_image"
+        if self.start_image is None and self.start_image_ref_name is None:
+            msg = "I2V request requires start_image or start_image_ref_name"
             raise ValueError(msg)
-        if self.reference_images or self.reference_entities:
-            msg = "I2V request must not carry reference_images or reference_entities"
+        if self.reference_images or self.ref_names or self.reference_entities:
+            msg = "I2V request must not carry reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
 
     def _validate_r2v_symmetry(self) -> None:
-        if not self.reference_images and not self.reference_entities:
-            msg = "R2V request requires reference_images or reference_entities"
+        if not self.reference_images and not self.ref_names and not self.reference_entities:
+            msg = "R2V request requires reference_images, ref_names, or reference_entities"
             raise ValueError(msg)
-        if self.start_image or self.end_image:
+        if (
+            self.start_image
+            or self.start_image_ref_name
+            or self.end_image
+            or self.end_image_ref_name
+        ):
             msg = "R2V request must not carry start/end images"
             raise ValueError(msg)
 
     def _validate_mode_symmetry(self) -> None:
-        if self.mode is Mode.T2V and (self.start_image or self.end_image or self.reference_images):
+        if self.mode is Mode.T2V and (
+            self.start_image or self.start_image_ref_name or
+            self.end_image or self.end_image_ref_name or
+            self.reference_images or self.ref_names
+        ):
             msg = "T2V request must not carry image inputs"
             raise ValueError(msg)
         if self.mode is Mode.I2V:
@@ -276,7 +288,7 @@ class GenerateVideoRequest:
             self._validate_r2v_symmetry()
 
     def _validate_r2v_caps(self) -> None:
-        if len(self.reference_images) > MAX_REFERENCE_IMAGES:
+        if len(self.reference_images) + len(self.ref_names) > MAX_REFERENCE_IMAGES:
             msg = f"at most {MAX_REFERENCE_IMAGES} reference images"
             raise ValueError(msg)
         # Per-model reference cap (live-verified): omni_flash=7, veo lite/fast/lite_lp=3,
@@ -287,15 +299,16 @@ class GenerateVideoRequest:
             if cap == 0:
                 msg = f"{self.model.value} does not support R2V (reference-to-video)"
                 raise ValueError(msg)
-            if len(self.reference_images) > cap:
+            total_img_refs = len(self.reference_images) + len(self.ref_names)
+            if total_img_refs > cap:
                 msg = (
                     f"{self.model.value} allows at most {cap} reference image(s); "
-                    f"got {len(self.reference_images)}"
+                    f"got {total_img_refs}"
                 )
                 raise ValueError(
                     msg,
                 )
-            total_refs = len(self.reference_images) + len(self.reference_entities)
+            total_refs = total_img_refs + len(self.reference_entities)
             if total_refs > cap:
                 msg = (
                     f"reference cap exceeded: {total_refs} refs (images+entities) "

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -472,7 +472,7 @@ def serve(port: int, host: str, profile: str | None) -> None:
             console.print(
                 "[red]Error:[/red] Binding to a non-localhost address requires "
                 "[bold]GFLOW_DAEMON_TOKEN[/bold] to be set.\n"
-                "[dim]Set it in .env.local or as an environment variable.[/dim]"
+                "[dim]Set it in .env (CWD or $GFLOW_CLI_HOME) or as an environment variable.[/dim]"
             )
             sys.exit(11)
 

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -22,18 +22,15 @@ from __future__ import annotations
 
 import os
 import warnings
+from collections.abc import Mapping
 from enum import StrEnum
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 
+from dotenv import dotenv_values
 from pydantic import AliasChoices, Field, field_validator
-from pydantic_settings import (
-    BaseSettings,
-    DotEnvSettingsSource,
-    PydanticBaseSettingsSource,
-    SettingsConfigDict,
-)
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from gflow_cli import paths
 
@@ -65,18 +62,44 @@ def _migrate_legacy_env() -> None:
 _migrate_legacy_env()
 
 
-def _env_files() -> tuple[str, str]:
-    """Dotenv files for :class:`Settings`, in pydantic-settings order (later wins).
+_HOME_KEY = (_NEW_ENV_PREFIX + "HOME").lower()  # matched case-insensitively
 
-    Implements the documented fallback (docs/CONFIGURATION.md): a CWD ``.env``
-    takes precedence over ``$GFLOW_CLI_HOME/.env``. Home is resolved from the
-    process env var (the ``home`` field default isn't computed yet at this
-    point) falling back to :func:`gflow_cli.paths.default_home` — the same
-    resolution the field itself uses.
+
+def _home_key_value(mapping: Mapping[str, str | None]) -> Path | None:
+    """Non-empty ``GFLOW_CLI_HOME`` from ``mapping``, matched case-insensitively
+    (mirrors the env source's ``case_sensitive=False``); empty string = unset.
     """
-    home = os.environ.get(_NEW_ENV_PREFIX + "HOME")
-    home_dir = Path(home) if home else paths.default_home()
-    return (str(home_dir / ".env"), ".env")
+    for key, value in mapping.items():
+        if key.lower() == _HOME_KEY and value and value.strip():
+            return Path(value)
+    return None
+
+
+def _resolve_home() -> Path:
+    """The home directory, resolved BEFORE Settings exists (chicken-and-egg).
+
+    Mirrors the ``home`` field's own precedence: process env var, then the CWD
+    ``.env`` (the only dotenv file locatable without knowing home), then the
+    platform default. By construction the home ``.env`` cannot relocate home —
+    that would be circular; set the env var or the CWD ``.env`` instead.
+    """
+    from_env = _home_key_value(os.environ)
+    if from_env is not None:
+        return from_env
+    try:
+        from_cwd_env = _home_key_value(dotenv_values(".env"))
+    except OSError:
+        from_cwd_env = None
+    if from_cwd_env is not None:
+        return from_cwd_env
+    return paths.default_home()
+
+
+def _env_files() -> tuple[str, str]:
+    """Dotenv files for :class:`Settings`, in pydantic-settings order (later wins):
+    a CWD ``.env`` takes precedence over ``<home>/.env`` (docs/CONFIGURATION.md).
+    """
+    return (str(_resolve_home() / ".env"), ".env")
 
 
 class LogLevel(StrEnum):
@@ -116,41 +139,40 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="GFLOW_CLI_",
-        # env_file is intentionally absent: dotenv files are resolved per
-        # construction in `settings_customise_sources` so $GFLOW_CLI_HOME is
-        # honored at call time (issue #240).
+        # env_file is intentionally absent: the values in a static tuple here
+        # could not depend on the runtime environment, so __init__ below
+        # defaults `_env_file` to `_env_files()` per construction instead
+        # (issue #240). Re-adding env_file here would be silently ignored.
+        env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
     )
 
-    @classmethod
-    def settings_customise_sources(
-        cls,
-        settings_cls: type[BaseSettings],
-        init_settings: PydanticBaseSettingsSource,
-        env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
-        """Standard source order, with dotenv files resolved at call time.
-
-        A static ``model_config["env_file"]`` tuple is evaluated once at class
-        creation and cannot depend on the environment; this hook rebuilds the
-        dotenv source per construction so ``$GFLOW_CLI_HOME/.env`` is found
-        (docs/CONFIGURATION.md, issue #240).
-        """
-        dotenv = DotEnvSettingsSource(
-            settings_cls,
-            env_file=_env_files(),
-            env_file_encoding="utf-8",
-        )
-        return (init_settings, env_settings, dotenv, file_secret_settings)
+    if not TYPE_CHECKING:
+        # Runtime-only: defaulting the documented `_env_file` init kwarg keeps
+        # `Settings(_env_file=...)` / `_env_file=None` working exactly as in
+        # stock pydantic-settings. Hidden from type checkers so pyright keeps
+        # the synthesized field-typed constructor.
+        def __init__(self, **values: Any) -> None:
+            values.setdefault("_env_file", _env_files())
+            super().__init__(**values)
 
     # --- paths ------------------------------------------------------------
     home: Path = Field(
         default_factory=paths.default_home,
         description="Root for profiles, config.toml, etc.",
     )
+
+    @field_validator("home", mode="before")
+    @classmethod
+    def _empty_home_means_unset(cls, value: object) -> object:
+        """`GFLOW_CLI_HOME=` (set-but-empty, common in CI templates) means
+        "unset", not `Path('.')` — keeping the field coherent with
+        `_resolve_home()`, which treats empty the same way."""
+        if isinstance(value, str) and not value.strip():
+            return paths.default_home()
+        return value
+
     output_dir: Path = Field(
         default_factory=paths.default_output_dir,
         description="Where generated assets land (local storage).",

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -305,11 +305,6 @@ class Settings(BaseSettings):
             "Override via GFLOW_CLI_PREFER_CLASSIC."
         ),
     )
-    daemon_token: str | None = Field(
-        default=None,
-        description="Auth token required when binding the serve daemon to a non-localhost address.",
-    )
-
     # --- logging ----------------------------------------------------------
     log_level: LogLevel = LogLevel.INFO
     log_format: LogFormat = LogFormat.AUTO

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -28,7 +28,12 @@ from pathlib import Path
 from typing import Literal
 
 from pydantic import AliasChoices, Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    DotEnvSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 from gflow_cli import paths
 
@@ -58,6 +63,20 @@ def _migrate_legacy_env() -> None:
 
 
 _migrate_legacy_env()
+
+
+def _env_files() -> tuple[str, str]:
+    """Dotenv files for :class:`Settings`, in pydantic-settings order (later wins).
+
+    Implements the documented fallback (docs/CONFIGURATION.md): a CWD ``.env``
+    takes precedence over ``$GFLOW_CLI_HOME/.env``. Home is resolved from the
+    process env var (the ``home`` field default isn't computed yet at this
+    point) falling back to :func:`gflow_cli.paths.default_home` — the same
+    resolution the field itself uses.
+    """
+    home = os.environ.get(_NEW_ENV_PREFIX + "HOME")
+    home_dir = Path(home) if home else paths.default_home()
+    return (str(home_dir / ".env"), ".env")
 
 
 class LogLevel(StrEnum):
@@ -97,11 +116,35 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="GFLOW_CLI_",
-        env_file=(".env",),
-        env_file_encoding="utf-8",
+        # env_file is intentionally absent: dotenv files are resolved per
+        # construction in `settings_customise_sources` so $GFLOW_CLI_HOME is
+        # honored at call time (issue #240).
         case_sensitive=False,
         extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Standard source order, with dotenv files resolved at call time.
+
+        A static ``model_config["env_file"]`` tuple is evaluated once at class
+        creation and cannot depend on the environment; this hook rebuilds the
+        dotenv source per construction so ``$GFLOW_CLI_HOME/.env`` is found
+        (docs/CONFIGURATION.md, issue #240).
+        """
+        dotenv = DotEnvSettingsSource(
+            settings_cls,
+            env_file=_env_files(),
+            env_file_encoding="utf-8",
+        )
+        return (init_settings, env_settings, dotenv, file_secret_settings)
 
     # --- paths ------------------------------------------------------------
     home: Path = Field(

--- a/src/gflow_cli/data/models.py
+++ b/src/gflow_cli/data/models.py
@@ -219,8 +219,10 @@ class AssetLookup:
     profile_name: str
     flow_project_id: str | None
     flow_media_id: str
+    flow_workflow_id: str | None
     kind: AssetKind
     local_files: list[LocalFileRecord]
+    metadata_json: JsonObject
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -32,6 +32,11 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+_ASSET_LOOKUP_COLUMNS = (
+    "id, profile_name, flow_project_id, flow_media_id, flow_workflow_id, metadata_json, kind"
+)
+
+
 class DataRepository:
     def __init__(self, store: DataStore) -> None:
         self._store = store
@@ -165,9 +170,8 @@ class DataRepository:
         flow_media_id: str,
     ) -> AssetLookup | None:
         row = self._store.conn.execute(
-            """
-            SELECT id, profile_name, flow_project_id, flow_media_id,
-            flow_workflow_id, metadata_json, kind
+            f"""
+            SELECT {_ASSET_LOOKUP_COLUMNS}
             FROM assets
             WHERE profile_name = ? AND flow_media_id = ?
             """,
@@ -183,9 +187,8 @@ class DataRepository:
         ref_id: str,
     ) -> AssetLookup | None:
         row = self._store.conn.execute(
-            """
-            SELECT id, profile_name, flow_project_id, flow_media_id,
-            flow_workflow_id, metadata_json, kind
+            f"""
+            SELECT {_ASSET_LOOKUP_COLUMNS}
             FROM assets
             WHERE profile_name = ? AND (flow_media_id = ? OR flow_workflow_id = ? OR id = ?)
             ORDER BY created_at DESC
@@ -206,9 +209,8 @@ class DataRepository:
         Closes #87.
         """
         rows = self._store.conn.execute(
-            """
-            SELECT id, profile_name, flow_project_id, flow_media_id,
-            flow_workflow_id, metadata_json, kind
+            f"""
+            SELECT {_ASSET_LOOKUP_COLUMNS}
             FROM assets
             WHERE flow_media_id = ?
             ORDER BY profile_name ASC, id ASC

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -5,7 +5,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from gflow_cli.data.models import (
     AssetKind,
@@ -709,25 +709,7 @@ class DataRepository:
             """,
             (OperationAssetRole.OUTPUT.value, profile_name, flow_media_id),
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def resolve_seed_image_by_path(self, profile_name: str, path: Path) -> SeedImage | None:
         row = self._store.conn.execute(
@@ -747,25 +729,7 @@ class DataRepository:
             """,
             (OperationAssetRole.OUTPUT.value, profile_name, str(path)),
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def resolve_latest_image(
         self,
@@ -806,25 +770,7 @@ class DataRepository:
             sql,
             [OperationAssetRole.OUTPUT.value, *params],
         ).fetchone()
-        if row is None:
-            return None
-        if row["flow_project_id"] is None:
-            return None
-        local_path = self._latest_local_path(str(row["id"]))
-        return SeedImage(
-            profile_name=str(row["profile_name"]),
-            flow_project_id=str(row["flow_project_id"]),
-            flow_media_id=str(row["flow_media_id"]),
-            flow_workflow_id=row["flow_workflow_id"],
-            kind=AssetKind(row["kind"]),
-            width=row["width"],
-            height=row["height"],
-            local_path=local_path,
-            prompt=row["prompt"],
-            model=row["model"],
-            aspect_ratio=row["aspect_ratio"],
-            created_at=str(row["created_at"]),
-        )
+        return self._row_to_seed_image(row)
 
     def list_project_images(self, profile_name: str, flow_project_id: str) -> list[SeedImage]:
         rows = self._store.conn.execute(
@@ -923,6 +869,29 @@ class DataRepository:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _row_to_seed_image(self, row: Any) -> SeedImage | None:
+        """Hydrate a SeedImage from an assets+prompt row, or None if the row is
+        absent or lacks a flow_project_id. Shared by the resolve_* readers."""
+        if row is None:
+            return None
+        if row["flow_project_id"] is None:
+            return None
+        local_path = self._latest_local_path(str(row["id"]))
+        return SeedImage(
+            profile_name=str(row["profile_name"]),
+            flow_project_id=str(row["flow_project_id"]),
+            flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
+            kind=AssetKind(row["kind"]),
+            width=row["width"],
+            height=row["height"],
+            local_path=local_path,
+            prompt=row["prompt"],
+            model=row["model"],
+            aspect_ratio=row["aspect_ratio"],
+            created_at=str(row["created_at"]),
+        )
 
     def _latest_local_path(self, asset_id: str) -> Path | None:
         row = self._store.conn.execute(

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -166,11 +166,32 @@ class DataRepository:
     ) -> AssetLookup | None:
         row = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE profile_name = ? AND flow_media_id = ?
             """,
             (profile_name, flow_media_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._hydrate_asset_lookup(row)
+
+    def get_asset_by_any_id(
+        self,
+        profile_name: str,
+        ref_id: str,
+    ) -> AssetLookup | None:
+        row = self._store.conn.execute(
+            """
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
+            FROM assets
+            WHERE profile_name = ? AND (flow_media_id = ? OR flow_workflow_id = ? OR id = ?)
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (profile_name, ref_id, ref_id, ref_id),
         ).fetchone()
         if row is None:
             return None
@@ -186,7 +207,8 @@ class DataRepository:
         """
         rows = self._store.conn.execute(
             """
-            SELECT id, profile_name, flow_project_id, flow_media_id, kind
+            SELECT id, profile_name, flow_project_id, flow_media_id,
+            flow_workflow_id, metadata_json, kind
             FROM assets
             WHERE flow_media_id = ?
             ORDER BY profile_name ASC, id ASC
@@ -212,8 +234,10 @@ class DataRepository:
             profile_name=str(row["profile_name"]),
             flow_project_id=row["flow_project_id"],
             flow_media_id=str(row["flow_media_id"]),
+            flow_workflow_id=row["flow_workflow_id"],
             kind=AssetKind(row["kind"]),
             local_files=local_files,
+            metadata_json=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
         )
 
     def candidate_image_exists(self, profile_name: str, flow_media_id: str) -> bool:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -217,6 +217,26 @@ async def _run_generation_task(
             profile_dir = settings.profile_subdir(profile)
             data_repo.upsert_profile(profile, profile_dir)
 
+            # Resolve display names for remote refs so the UI automation can search for them
+            def _resolve_ref(ref_id: str) -> str:
+                name = None
+                asset = data_repo.get_asset_by_any_id(profile, ref_id)
+                if asset:
+                    name = asset.metadata_json.get("display_name")
+                    if not name:
+                        # Fallback for images generated before display_name was extracted properly
+                        seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
+                        if seed_info and seed_info.prompt:
+                            name = seed_info.prompt
+                return name or ref_id
+
+            if "refs" in payload:
+                payload["ref_names"] = [_resolve_ref(r) for r in payload["refs"]]
+            if "start_image_ref" in payload:
+                payload["start_image_ref_name"] = _resolve_ref(payload["start_image_ref"])
+            if "end_image_ref" in payload:
+                payload["end_image_ref_name"] = _resolve_ref(payload["end_image_ref"])
+
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
                 profile_name=profile,
@@ -266,17 +286,25 @@ async def _run_generation_task(
 
             # Resolve local file paths from the asset catalog.
             file_paths: list[str] = []
+            flow_project_id: str | None = None
+            flow_workflow_id: str | None = None
             if completed_task.flow_media_id:
                 asset = DataRepository(store).get_asset_by_flow_media_id(
                     profile,
                     completed_task.flow_media_id,
                 )
-                if asset and asset.local_files:
-                    file_paths = [str(lf.path) for lf in asset.local_files if lf.path is not None]
+                if asset:
+                    flow_project_id = asset.flow_project_id
+                    flow_workflow_id = asset.flow_workflow_id
+                    if asset.local_files:
+                        file_paths = [
+                            str(lf.path) for lf in asset.local_files if lf.path is not None
+                        ]
 
         log.info(
             "mcp.tool.task_completed",
             task_id=task_id,
+            flow_project_id=flow_project_id,
             flow_media_id=completed_task.flow_media_id,
             file_count=len(file_paths),
         )
@@ -284,7 +312,8 @@ async def _run_generation_task(
         return {
             "status": "completed",
             "task_id": task_id,
-            "flow_media_id": completed_task.flow_media_id,
+            "flow_project_id": flow_project_id,
+            "flow_media_id": flow_workflow_id if flow_workflow_id else completed_task.flow_media_id,
             "files": file_paths,
         }
 
@@ -407,30 +436,34 @@ def _build_video_media_inputs(
 
     media: dict[str, Any] = {}
     if initial_frame is not None:
-        resolved, err = _resolve_image_path(
-            initial_frame, title="Invalid Start Image", label="Start image path"
-        )
-        if err is not None:
-            return None, err
-        media["start_image"] = resolved
-    if end_frame is not None:
-        resolved, err = _resolve_image_path(
-            end_frame, title="Invalid End Image", label="End image path"
-        )
-        if err is not None:
-            return None, err
-        media["end_image"] = resolved
-    if reference_images:
-        ref_paths: list[str] = []
-        for ref in reference_images:
+        if _UUID_RE.fullmatch(initial_frame):
+            media["start_image_ref"] = initial_frame
+        else:
             resolved, err = _resolve_image_path(
-                ref, title="Invalid Reference Image", label="Reference image path"
+                initial_frame, title="Invalid Start Image", label="Start image path"
             )
             if err is not None:
                 return None, err
-            assert resolved is not None
-            ref_paths.append(resolved)
-        media["reference_images"] = ref_paths
+            media["start_image"] = resolved
+    if end_frame is not None:
+        if _UUID_RE.fullmatch(end_frame):
+            media["end_image_ref"] = end_frame
+        else:
+            resolved, err = _resolve_image_path(
+                end_frame, title="Invalid End Image", label="End image path"
+            )
+            if err is not None:
+                return None, err
+            media["end_image"] = resolved
+    if reference_images:
+        ref_data, err = _resolve_image_references(reference_images)
+        if err is not None:
+            return None, err
+        assert ref_data is not None
+        if ref_data["ref_paths"]:
+            media["reference_images"] = ref_data["ref_paths"]
+        if ref_data["refs"]:
+            media["refs"] = ref_data["refs"]
     return media, None
 
 

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -218,9 +218,9 @@ async def _run_generation_task(
             data_repo.upsert_profile(profile, profile_dir)
 
             # Resolve remote-ref UUIDs to the display names the UI automation
-            # searches for; an unresolvable UUID fails fast here instead of
-            # timing out in the browser.
-            ref_err = _resolve_payload_ref_names(data_repo, profile, payload)
+            # searches for (video paths only); an unresolvable UUID fails fast
+            # here instead of timing out in the browser.
+            ref_err = _resolve_payload_ref_names(data_repo, profile, payload, task_type)
             if ref_err is not None:
                 return ref_err
 
@@ -300,7 +300,8 @@ async def _run_generation_task(
             "status": "completed",
             "task_id": task_id,
             "flow_project_id": flow_project_id,
-            "flow_media_id": flow_workflow_id if flow_workflow_id else completed_task.flow_media_id,
+            "flow_media_id": completed_task.flow_media_id,
+            "flow_workflow_id": flow_workflow_id,
             "files": file_paths,
         }
 
@@ -363,7 +364,17 @@ def _resolve_ref_name(
             seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
             if seed_info and seed_info.prompt:
                 name = seed_info.prompt
-        return name or ref_id, None
+        if name:
+            return name, None
+        # Asset exists but has no searchable name: returning the raw UUID here
+        # would make the picker search for the UUID and time out (PR #245
+        # review). Fail fast with a clear error instead.
+        return None, _bad_param(
+            "Reference Has No Display Name",
+            f"'{ref_id}' exists in the catalog but has no display name to search "
+            "for in the Flow picker. Re-generate it so a display name is recorded, "
+            "or pass the display name directly.",
+        )
     if _UUID_RE.fullmatch(ref_id):
         return None, _bad_param(
             "Reference Not Found",
@@ -373,24 +384,37 @@ def _resolve_ref_name(
     return ref_id, None
 
 
+# Video task types whose remote refs the UI automation attaches by DISPLAY NAME
+# (searched in the Flow picker) and therefore need UUID→name resolution. Image
+# task types attach remote refs by raw media id and MUST NOT be resolved here —
+# gating on that was the PR #245 image-i2i regression.
+_VIDEO_TASK_TYPES = frozenset({"t2v", "i2v", "r2v"})
+
+
 def _resolve_payload_ref_names(
     data_repo: DataRepository,
     profile: str,
     payload: dict[str, Any],
+    task_type: str,
 ) -> dict[str, Any] | None:
     """Resolve every remote-ref field in ``payload`` to a display name in place.
 
-    Returns an error envelope on the first unresolvable UUID, else ``None``.
-    Keeps the UUID→name resolution out of the enqueue orchestrator so the
-    latter stays under the cognitive-complexity threshold.
+    Only the video task types need this (their refs are attached by display
+    name); image tasks attach remote refs by raw media id and are left
+    untouched. Returns an error envelope on the first unresolvable UUID, else
+    ``None``.
     """
+    if task_type not in _VIDEO_TASK_TYPES:
+        return None
     if "refs" in payload:
         ref_names: list[str] = []
         for ref in payload["refs"]:
             name, err = _resolve_ref_name(data_repo, profile, ref)
             if err is not None:
                 return err
-            ref_names.append(name or ref)
+            # name is never falsy when err is None (see _resolve_ref_name).
+            assert name is not None
+            ref_names.append(name)
         payload["ref_names"] = ref_names
     for key in ("start_image_ref", "end_image_ref"):
         if key in payload:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -217,25 +217,23 @@ async def _run_generation_task(
             profile_dir = settings.profile_subdir(profile)
             data_repo.upsert_profile(profile, profile_dir)
 
-            # Resolve display names for remote refs so the UI automation can search for them
-            def _resolve_ref(ref_id: str) -> str:
-                name = None
-                asset = data_repo.get_asset_by_any_id(profile, ref_id)
-                if asset:
-                    name = asset.metadata_json.get("display_name")
-                    if not name:
-                        # Fallback for images generated before display_name was extracted properly
-                        seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
-                        if seed_info and seed_info.prompt:
-                            name = seed_info.prompt
-                return name or ref_id
-
+            # Resolve remote-ref UUIDs to the display names the UI automation
+            # searches for; an unresolvable UUID fails fast here (see
+            # _resolve_ref_name) instead of timing out in the browser.
+            ref_names: list[str] = []
+            for ref in payload.get("refs", []):
+                name, err = _resolve_ref_name(data_repo, profile, ref)
+                if err is not None:
+                    return err
+                ref_names.append(name or ref)
             if "refs" in payload:
-                payload["ref_names"] = [_resolve_ref(r) for r in payload["refs"]]
-            if "start_image_ref" in payload:
-                payload["start_image_ref_name"] = _resolve_ref(payload["start_image_ref"])
-            if "end_image_ref" in payload:
-                payload["end_image_ref_name"] = _resolve_ref(payload["end_image_ref"])
+                payload["ref_names"] = ref_names
+            for key in ("start_image_ref", "end_image_ref"):
+                if key in payload:
+                    name, err = _resolve_ref_name(data_repo, profile, payload[key])
+                    if err is not None:
+                        return err
+                    payload[f"{key}_name"] = name
 
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
@@ -353,6 +351,37 @@ def _bad_param(title: str, detail: str) -> dict[str, Any]:
         "status": "error",
         "error": {"type": _BAD_PARAM_TYPE, "title": title, "status": 400, "detail": detail},
     }
+
+
+def _resolve_ref_name(
+    data_repo: DataRepository,
+    profile: str,
+    ref_id: str,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve a remote reference to the display name the UI automation searches.
+
+    Returns ``(name, None)`` or ``(None, error_envelope)``. A ``ref_id`` that is
+    UUID-shaped but absent from the asset catalog is a mistake worth catching at
+    enqueue time: passing the raw UUID downstream surfaced as a ~120s Playwright
+    timeout (PR #237 review). A non-UUID string is treated as a literal display
+    name the caller typed directly and passed through unchanged.
+    """
+    asset = data_repo.get_asset_by_any_id(profile, ref_id)
+    if asset is not None:
+        name = asset.metadata_json.get("display_name")
+        if not name:
+            # Fallback for images generated before display_name was extracted.
+            seed_info = data_repo.resolve_seed_image(profile, asset.flow_media_id)
+            if seed_info and seed_info.prompt:
+                name = seed_info.prompt
+        return name or ref_id, None
+    if _UUID_RE.fullmatch(ref_id):
+        return None, _bad_param(
+            "Reference Not Found",
+            f"'{ref_id}' was not found in your asset catalog for profile "
+            f"{profile!r}. Generate the image first, or pass its display name.",
+        )
+    return ref_id, None
 
 
 def _validate_project(project: str | None) -> dict[str, Any] | None:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -218,22 +218,11 @@ async def _run_generation_task(
             data_repo.upsert_profile(profile, profile_dir)
 
             # Resolve remote-ref UUIDs to the display names the UI automation
-            # searches for; an unresolvable UUID fails fast here (see
-            # _resolve_ref_name) instead of timing out in the browser.
-            ref_names: list[str] = []
-            for ref in payload.get("refs", []):
-                name, err = _resolve_ref_name(data_repo, profile, ref)
-                if err is not None:
-                    return err
-                ref_names.append(name or ref)
-            if "refs" in payload:
-                payload["ref_names"] = ref_names
-            for key in ("start_image_ref", "end_image_ref"):
-                if key in payload:
-                    name, err = _resolve_ref_name(data_repo, profile, payload[key])
-                    if err is not None:
-                        return err
-                    payload[f"{key}_name"] = name
+            # searches for; an unresolvable UUID fails fast here instead of
+            # timing out in the browser.
+            ref_err = _resolve_payload_ref_names(data_repo, profile, payload)
+            if ref_err is not None:
+                return ref_err
 
             task = QueueRepository(store).enqueue_task(
                 task_id=task_id,
@@ -382,6 +371,34 @@ def _resolve_ref_name(
             f"{profile!r}. Generate the image first, or pass its display name.",
         )
     return ref_id, None
+
+
+def _resolve_payload_ref_names(
+    data_repo: DataRepository,
+    profile: str,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve every remote-ref field in ``payload`` to a display name in place.
+
+    Returns an error envelope on the first unresolvable UUID, else ``None``.
+    Keeps the UUID→name resolution out of the enqueue orchestrator so the
+    latter stays under the cognitive-complexity threshold.
+    """
+    if "refs" in payload:
+        ref_names: list[str] = []
+        for ref in payload["refs"]:
+            name, err = _resolve_ref_name(data_repo, profile, ref)
+            if err is not None:
+                return err
+            ref_names.append(name or ref)
+        payload["ref_names"] = ref_names
+    for key in ("start_image_ref", "end_image_ref"):
+        if key in payload:
+            name, err = _resolve_ref_name(data_repo, profile, payload[key])
+            if err is not None:
+                return err
+            payload[f"{key}_name"] = name
+    return None
 
 
 def _validate_project(project: str | None) -> dict[str, Any] | None:

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -481,26 +481,21 @@ def _build_video_media_inputs(
         )
 
     media: dict[str, Any] = {}
-    if initial_frame is not None:
-        if _UUID_RE.fullmatch(initial_frame):
-            media["start_image_ref"] = initial_frame
-        else:
-            resolved, err = _resolve_image_path(
-                initial_frame, title="Invalid Start Image", label="Start image path"
-            )
-            if err is not None:
-                return None, err
-            media["start_image"] = resolved
-    if end_frame is not None:
-        if _UUID_RE.fullmatch(end_frame):
-            media["end_image_ref"] = end_frame
-        else:
-            resolved, err = _resolve_image_path(
-                end_frame, title="Invalid End Image", label="End image path"
-            )
-            if err is not None:
-                return None, err
-            media["end_image"] = resolved
+    for frame, ref_key, path_key, noun in (
+        (initial_frame, "start_image_ref", "start_image", "Start"),
+        (end_frame, "end_image_ref", "end_image", "End"),
+    ):
+        if frame is None:
+            continue
+        if _UUID_RE.fullmatch(frame):
+            media[ref_key] = frame
+            continue
+        resolved, err = _resolve_image_path(
+            frame, title=f"Invalid {noun} Image", label=f"{noun} image path"
+        )
+        if err is not None:
+            return None, err
+        media[path_key] = resolved
     if reference_images:
         ref_data, err = _resolve_image_references(reference_images)
         if err is not None:

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -105,6 +105,10 @@ class FlowWorker:
                         headless=headless,
                         transport=transport,
                         out_dir=out_dir,
+                        # Reuse the cached settings: a bare Settings() in the client
+                        # would re-read .env files live per task and could disagree
+                        # with the task parameters derived from get_settings().
+                        settings=settings,
                     ) as client:
                         project_title = task.payload.get("project_title", "gflow-cli images")
                         project_created = False
@@ -176,6 +180,7 @@ class FlowWorker:
                         headless=headless,
                         transport=transport,
                         out_dir=out_dir,
+                        settings=settings,  # same rationale as the image path above
                     ) as client:
 
                         def on_started(started: VideoStarted) -> None:

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -293,6 +293,7 @@ class FlowWorker:
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -303,6 +304,7 @@ class FlowWorker:
             model=model,
             refs=refs,
             ref_paths=ref_paths,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             count=count,
@@ -333,8 +335,11 @@ class FlowWorker:
         seed = payload.get("seed")
 
         start_image = Path(payload["start_image"]) if payload.get("start_image") else None
+        start_image_ref_name = payload.get("start_image_ref_name")
         end_image = Path(payload["end_image"]) if payload.get("end_image") else None
+        end_image_ref_name = payload.get("end_image_ref_name")
         reference_images = tuple(Path(p) for p in payload.get("reference_images", []))
+        ref_names = tuple(payload.get("ref_names", []))
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         reference_audio = payload.get("reference_audio")
@@ -349,8 +354,11 @@ class FlowWorker:
             count=count,
             seed=seed,
             start_image=start_image,
+            start_image_ref_name=start_image_ref_name,
             end_image=end_image,
+            end_image_ref_name=end_image_ref_name,
             reference_images=reference_images,
+            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             reference_audio=reference_audio,

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -293,7 +293,10 @@ class FlowWorker:
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
-        ref_names = tuple(payload.get("ref_names", []))
+        # NOTE: the payload may carry "ref_names" (the MCP layer resolves them
+        # for the video request); the image transport attaches remote refs by
+        # media id, so GenerateImageRequest has no ref_names field and must
+        # not receive one.
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -304,7 +307,6 @@ class FlowWorker:
             model=model,
             refs=refs,
             ref_paths=ref_paths,
-            ref_names=ref_names,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,
             count=count,

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -154,7 +154,7 @@ class TestGenerateVideoRequest:
             )
 
     def test_r2v_requires_a_reference_image(self) -> None:
-        with pytest.raises(ValueError, match="reference_images or reference_entities"):
+        with pytest.raises(ValueError, match="reference_images, ref_names, or reference_entities"):
             GenerateVideoRequest(prompt="x", mode=Mode.R2V)
 
     def test_r2v_must_not_carry_start_end(self) -> None:

--- a/tests/api/test_video_request.py
+++ b/tests/api/test_video_request.py
@@ -29,10 +29,23 @@ def test_r2v_valid_with_audio() -> None:
 
 
 def test_r2v_requires_images_or_entities() -> None:
-    with pytest.raises(ValueError, match="reference_images or reference_entities"):
+    with pytest.raises(ValueError, match="reference_images, ref_names, or reference_entities"):
         GenerateVideoRequest(
             prompt="x", mode=Mode.R2V, aspect=Aspect.LANDSCAPE, model=VideoModel.VEO_3_1_LITE
         )
+
+
+def test_r2v_accepts_remote_ref_names_alone() -> None:
+    # PR #237: a UUID resolved to a remote display name (ref_names) is a valid
+    # R2V reference source on its own — no local reference_images required.
+    req = GenerateVideoRequest(
+        prompt="x",
+        mode=Mode.R2V,
+        aspect=Aspect.LANDSCAPE,
+        model=VideoModel.VEO_3_1_LITE,
+        ref_names=("A cozy cabin",),
+    )
+    assert req.ref_names == ("A cozy cabin",)
 
 
 def test_cap_budget_counts_entities_plus_images() -> None:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1101,7 +1101,9 @@ class TestAttachCharacterEntities:
         loc.wait_for = AsyncMock()
         loc.scroll_into_view_if_needed = AsyncMock()
         loc.count = AsyncMock(return_value=1)
+        loc.or_ = MagicMock(return_value=loc)
         page.locator.return_value = loc
+        page.get_by_role.return_value = loc
         page.wait_for_timeout = AsyncMock()
         page.mouse = MagicMock()
         page.mouse.wheel = AsyncMock()
@@ -1326,6 +1328,15 @@ class TestRemoteRefTileLocator:
         assert args[0] == "option"
         assert kwargs.get("name") == "Wren's cabin"
         page.locator.assert_not_called()
+
+    def test_matches_exactly_so_a_substring_name_cannot_attach_the_wrong_tile(self) -> None:
+        # PR #245 review #4: without exact=True, get_by_role's default substring
+        # match makes 'cabin' also select 'cabin at night' → .first attaches the
+        # wrong image silently.
+        page = MagicMock()
+        VideoGenerationMixin._remote_option_tile(page, "cabin")
+        _, kwargs = page.get_by_role.call_args
+        assert kwargs.get("exact") is True
 
 
 class TestRemoteReferencesDialogGuard:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1309,3 +1309,64 @@ class TestAssertEntitiesAttached:
         assert "github.com/ffroliva/gflow-cli/issues/174" in err.remediation_hint
         assert err.to_problem_details().get("remediation_hint") == err.remediation_hint
         assert err.discovery == {"entity_attach_context": "video"}
+
+
+class TestRemoteRefTileLocator:
+    """PR #237: option tiles are matched by display_name / prompt text, which
+    commonly contains an apostrophe. The old `:has-text('{name}')` CSS selector
+    broke on those; `_remote_option_tile` must match by role name instead."""
+
+    def test_apostrophe_name_does_not_go_into_a_quoted_css_selector(self) -> None:
+        page = MagicMock()
+        VideoGenerationMixin._remote_option_tile(page, "Wren's cabin")
+        # role-based match: the raw name is passed as the accessible name,
+        # never interpolated into a `:has-text('...')` CSS string.
+        page.get_by_role.assert_called_once()
+        args, kwargs = page.get_by_role.call_args
+        assert args[0] == "option"
+        assert kwargs.get("name") == "Wren's cabin"
+        page.locator.assert_not_called()
+
+
+class TestRemoteReferencesDialogGuard:
+    """PR #237 review #4: _attach_remote_references logged success even when the
+    include action never fired (locale mismatch). It must verify the picker
+    dialog closed and raise TransportTimeoutError otherwise."""
+
+    @staticmethod
+    def _locator_mock() -> MagicMock:
+        loc = MagicMock()
+        loc.wait_for = AsyncMock()
+        loc.click = AsyncMock()
+        loc.press_sequentially = AsyncMock()
+        loc.first = loc
+        loc.last = loc
+        return loc
+
+    @pytest.mark.asyncio
+    async def test_raises_when_picker_dialog_stays_open(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        page = _mock_async_page()
+        dialog = self._locator_mock()
+        dialog.wait_for = AsyncMock(side_effect=Exception("dialog still open"))
+
+        def _locator(selector: str) -> MagicMock:
+            return dialog if selector == "[role='dialog']" else self._locator_mock()
+
+        page.locator = MagicMock(side_effect=_locator)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_remote_option_tile",
+            staticmethod(lambda p, n: self._locator_mock()),
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_resolve_include_action",
+            AsyncMock(return_value=self._locator_mock()),
+        )
+
+        with pytest.raises(TransportTimeoutError, match="did not close"):
+            await VideoGenerationMixin._attach_remote_references(
+                page, ["Wren's cabin"], out_dir=None
+            )

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -326,3 +326,51 @@ def test_seed_read_api_resolves_by_path_latest_project_and_candidate(tmp_path: P
         project_images = repo.list_project_images("default", "flow-project-1")
         assert [item.flow_media_id for item in project_images] == ["media-latest"]
         assert repo.candidate_image_exists("default", "media-latest") is True
+
+
+def test_get_asset_by_any_id_resolves_media_workflow_and_asset_ids(tmp_path: Path) -> None:
+    """PR #237: UUID→asset resolution must work for every id kind and hydrate
+    the fields the MCP display-name lookup relies on (flow_workflow_id,
+    metadata_json) — the original submission constructed AssetLookup with
+    fields the dataclass did not declare (TypeError)."""
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        repo.upsert_project(
+            ProjectRecord(
+                id="project-any",
+                profile_name="default",
+                flow_project_id="flow-project-any",
+                title="t",
+                source="generated",
+            )
+        )
+        repo.upsert_asset(
+            AssetRecord(
+                id="asset-any",
+                profile_name="default",
+                flow_project_id="flow-project-any",
+                flow_media_id="media-any",
+                flow_workflow_id="workflow-any",
+                flow_media_generation_id="generation-any",
+                kind=AssetKind.IMAGE,
+                status="ready",
+                model="NARWHAL",
+                aspect_ratio="IMAGE_ASPECT_RATIO_PORTRAIT",
+                width=1024,
+                height=1792,
+                duration_seconds=None,
+                seed=1,
+                metadata_json={"display_name": "A cozy cabin"},
+            )
+        )
+
+        for ref in ("media-any", "workflow-any", "asset-any"):
+            found = repo.get_asset_by_any_id("default", ref)
+            assert found is not None, ref
+            assert found.flow_media_id == "media-any"
+            assert found.flow_workflow_id == "workflow-any"
+            assert found.metadata_json == {"display_name": "A cozy cabin"}
+
+        assert repo.get_asset_by_any_id("default", "nope") is None
+        assert repo.get_asset_by_any_id("other-profile", "media-any") is None

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -62,10 +62,12 @@ def e2e_profile_dir(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
 
     from gflow_cli.config import Settings
 
-    # Resolve real home by bypassing the isolation env var
+    # Resolve real home by bypassing the isolation env var. _env_file=None
+    # also disables dotenv loading: a GFLOW_CLI_HOME line in a CWD or home
+    # .env must not redirect the "real user data dir" this fixture looks for.
     with monkeypatch.context() as m:
         m.delenv("GFLOW_CLI_HOME", raising=False)
-        real_settings = Settings()
+        real_settings = Settings(_env_file=None)  # pyright: ignore[reportCallIssue]
         candidate = real_settings.profile_subdir(name)
 
     if not candidate.exists():

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -147,3 +147,73 @@ def test_video_media_i2v_bad_frame(tmp_path: Path) -> None:
     assert media is None
     assert err is not None
     assert err["error"]["title"] == "Invalid Start Image"
+
+
+class _FakeRepo:
+    """Minimal stand-in for DataRepository's two methods _resolve_ref_name uses."""
+
+    def __init__(self, asset=None, seed=None):
+        self._asset = asset
+        self._seed = seed
+
+    def get_asset_by_any_id(self, profile, ref_id):
+        return self._asset
+
+    def resolve_seed_image(self, profile, flow_media_id):
+        return self._seed
+
+
+class _Asset:
+    def __init__(self, metadata_json, flow_media_id="m"):
+        self.metadata_json = metadata_json
+        self.flow_media_id = flow_media_id
+
+
+class _Seed:
+    def __init__(self, prompt):
+        self.prompt = prompt
+
+
+_A_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_resolve_ref_name_uses_display_name() -> None:
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=_Asset({"display_name": "A cozy cabin"}))
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert err is None
+    assert name == "A cozy cabin"
+
+
+def test_resolve_ref_name_falls_back_to_seed_prompt() -> None:
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=_Asset({}), seed=_Seed("an old prompt"))
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert err is None
+    assert name == "an old prompt"
+
+
+def test_resolve_ref_name_unresolvable_uuid_returns_clear_error() -> None:
+    """PR #237 review #7: a UUID not in the catalog must fail fast with a clear
+    'not found' error instead of being passed downstream as a search term
+    (which surfaced as a ~120s Playwright timeout)."""
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=None)
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert name is None
+    assert err is not None
+    assert _A_UUID in str(err)
+    assert "catalog" in str(err).lower()
+
+
+def test_resolve_ref_name_passes_through_a_literal_display_name() -> None:
+    """A non-UUID string is a display name the user typed directly — keep it."""
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=None)
+    name, err = _resolve_ref_name(repo, "default", "A cozy cabin")
+    assert err is None
+    assert name == "A cozy cabin"

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -217,3 +217,35 @@ def test_resolve_ref_name_passes_through_a_literal_display_name() -> None:
     name, err = _resolve_ref_name(repo, "default", "A cozy cabin")
     assert err is None
     assert name == "A cozy cabin"
+
+
+def test_resolve_ref_name_found_asset_without_name_errors_not_uuid_passthrough() -> None:
+    """PR #245 review #3: an in-catalog asset with no display_name and no seed
+    prompt must NOT return the raw UUID (which then times out in the picker) —
+    it must return a clear error."""
+    from gflow_cli.mcp.tools import _resolve_ref_name
+
+    repo = _FakeRepo(asset=_Asset({}), seed=None)  # found, but no name resolvable
+    name, err = _resolve_ref_name(repo, "default", _A_UUID)
+    assert name is None
+    assert err is not None
+    assert _A_UUID in str(err)
+
+
+def test_resolve_payload_ref_names_leaves_image_refs_untouched() -> None:
+    """PR #245 review #1: _resolve_payload_ref_names must only be applied to the
+    video path. Image 'refs' (media-id UUIDs) attach by id and must pass through
+    even when absent from the local catalog."""
+    from gflow_cli.mcp.tools import _resolve_payload_ref_names
+
+    repo = _FakeRepo(asset=None)  # UUID not in local catalog
+    payload = {"refs": [_A_UUID]}
+    # video task type: resolves (and would error on the missing UUID)
+    err_video = _resolve_payload_ref_names(repo, "default", dict(payload), task_type="r2v")
+    assert err_video is not None
+    # image task type: passes through untouched, no ref_names added, no error
+    p_image = dict(payload)
+    err_image = _resolve_payload_ref_names(repo, "default", p_image, task_type="i2i")
+    assert err_image is None
+    assert "ref_names" not in p_image
+    assert p_image["refs"] == [_A_UUID]

--- a/tests/mcp/test_tools_wired.py
+++ b/tests/mcp/test_tools_wired.py
@@ -414,6 +414,47 @@ class TestRunGenerationTask:
         assert "flow_media_id" in result
 
     @pytest.mark.asyncio
+    async def test_envelope_returns_media_id_not_workflow_id(
+        self, temp_db: DataStore, tmp_path: Path
+    ) -> None:
+        """PR #245 review #2: the 'flow_media_id' key must carry the real media
+        id, not the asset's flow_workflow_id, which is exposed separately."""
+        from gflow_cli.mcp.tools import _run_generation_task
+
+        with (
+            patch(
+                "gflow_cli.worker.daemon.FlowApiClient",
+                return_value=_FakeFlowApiClient(),
+            ),
+            patch(
+                "gflow_cli.mcp.tools.get_settings",
+                return_value=MagicMock(
+                    resolved_db_path=lambda: temp_db.path,
+                    profile_subdir=lambda _: tmp_path / "profile_default",
+                ),
+            ),
+            patch(
+                "gflow_cli.worker.daemon.get_settings",
+                return_value=MagicMock(
+                    profile_subdir=lambda _: tmp_path / "profile_default",
+                    headless=True,
+                    transport=None,
+                    output_dir=tmp_path / "out",
+                ),
+            ),
+        ):
+            result = await _run_generation_task(
+                profile="default",
+                task_type="t2i",
+                payload={"prompt": "envelope test", "aspect": "1:1", "count": 1},
+            )
+
+        assert result["status"] == "completed"
+        # The fake asset has flow_media_id="media-img-wired", flow_workflow_id="workflow-123".
+        assert result["flow_media_id"] == "media-img-wired"
+        assert result["flow_workflow_id"] == "workflow-123"
+
+    @pytest.mark.asyncio
     async def test_unknown_error_returns_error_status(
         self, temp_db: DataStore, tmp_path: Path
     ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -410,6 +410,23 @@ class TestPreferClassic:
 
 
 class TestDaemonSettings:
+    def test_daemon_token_defined_exactly_once(self) -> None:
+        """A duplicated class-body field is silently shadowed by the later
+        definition (issue #243) — the dead duplicate must not return, or a
+        future edit to the wrong copy would be invisibly ignored."""
+        import inspect
+
+        source = inspect.getsource(Settings)
+        assert source.count("daemon_token: str | None") == 1
+
+    def test_daemon_token_keeps_both_env_aliases(self) -> None:
+        """Pin the SURVIVING definition's contract: both env var spellings
+        must stay accepted (the shadowed duplicate had no aliases)."""
+        field = Settings.model_fields["daemon_token"]
+        alias = field.validation_alias
+        assert alias is not None
+        assert getattr(alias, "choices", None) == ["GFLOW_CLI_DAEMON_TOKEN", "GFLOW_DAEMON_TOKEN"]
+
     def test_daemon_defaults(self, clean_env: None) -> None:
         s = Settings()
         assert s.daemon_token is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,11 +24,44 @@ def _reset_cache() -> None:
 
 
 @pytest.fixture
-def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Strip every GFLOW_CLI_* and legacy FLOW_CLI_* env var to expose true defaults."""
+def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Strip every GFLOW_CLI_* / legacy FLOW_CLI_* env var AND fence the dotenv sweep.
+
+    Stripping alone removes the autouse tmp GFLOW_CLI_HOME (conftest
+    `_isolate_settings`), which would send the home-.env lookup to the
+    developer's REAL platform home; the CWD entry would read whatever
+    directory pytest was launched from. Both are re-fenced into tmp_path so
+    "defaults" tests never depend on real machine files. Tests that need a
+    different home/cwd simply set their own afterwards (later patches win).
+    """
     for key in list(__import__("os").environ):
         if key.startswith("GFLOW_CLI_") or key.startswith("FLOW_CLI_"):
             monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr("gflow_cli.config.paths.default_home", lambda: tmp_path / "clean-home")
+    clean_cwd = tmp_path / "clean-cwd"
+    clean_cwd.mkdir(exist_ok=True)
+    monkeypatch.chdir(clean_cwd)
+
+
+class TestCleanEnvHermeticity:
+    """`clean_env` must fence the dotenv sweep, not just strip env vars.
+
+    Stripping removes the autouse tmp GFLOW_CLI_HOME, which would otherwise
+    send the home-.env lookup to the developer's REAL platform home — a real
+    home .env (e.g. GFLOW_CLI_TIMEOUT_SECONDS=300) then fails the defaults
+    tests on that machine while CI stays green. Same for the CWD entry when
+    pytest is launched from a directory containing a .env (the repo root's
+    gitignored .env is the documented dev setup).
+    """
+
+    def test_dotenv_sweep_is_fenced_inside_the_test_tmp_dir(
+        self, clean_env: None, tmp_path: Path
+    ) -> None:
+        from gflow_cli import config as config_module
+
+        home_env_file, _cwd_env_file = config_module._env_files()
+        assert str(tmp_path) in home_env_file  # not the real platform home
+        assert str(tmp_path) in str(Path.cwd())  # not the pytest launch dir
 
 
 class TestDefaults:
@@ -246,6 +279,106 @@ class TestHomeEnvFileFallback:
         home.mkdir()
         monkeypatch.setenv("GFLOW_CLI_HOME", str(home))
         assert Settings().timeout_seconds == 600  # built-in default
+
+
+class TestHomeResolutionCoherence:
+    """#240 rework: the home used to locate the home ``.env`` must be the same
+    home the ``home`` field resolves to — for every channel that can set it.
+    """
+
+    @pytest.fixture
+    def isolated_cwd(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    def test_home_set_in_cwd_env_file_relocates_home_env_lookup(
+        self, clean_env: None, isolated_cwd: Path, tmp_path: Path
+    ) -> None:
+        new_home = tmp_path / "relocated-home"
+        new_home.mkdir()
+        (new_home / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=123\n", encoding="utf-8")
+        (isolated_cwd / ".env").write_text(f"GFLOW_CLI_HOME={new_home}\n", encoding="utf-8")
+        s = Settings()
+        assert s.home == new_home
+        assert s.timeout_seconds == 123  # the relocated home's .env was loaded
+
+    def test_empty_home_env_var_means_unset_for_field_and_env_lookup(
+        self,
+        clean_env: None,
+        isolated_cwd: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        default = tmp_path / "default-gflow-cli"
+        default.mkdir()
+        (default / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=321\n", encoding="utf-8")
+        monkeypatch.setattr("gflow_cli.config.paths.default_home", lambda: default)
+        monkeypatch.setenv("GFLOW_CLI_HOME", "")
+        s = Settings()
+        assert s.timeout_seconds == 321  # env lookup fell back to default home
+        assert s.home == default  # the field agrees — not Path('.')
+
+    def test_lowercase_home_env_var_honored_for_env_lookup(
+        self,
+        clean_env: None,
+        isolated_cwd: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Simulate a POSIX case-sensitive environment where only the lowercase
+        # key exists (valid for the field: case_sensitive=False).
+        import gflow_cli.config as config_module
+
+        home = tmp_path / "lower-home"
+        home.mkdir()
+        (home / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=222\n", encoding="utf-8")
+        monkeypatch.setattr(config_module.os, "environ", {"gflow_cli_home": str(home)})
+        s = Settings()
+        assert s.home == home
+        assert s.timeout_seconds == 222
+
+
+class TestEnvFileInitKwarg:
+    """The standard pydantic-settings ``_env_file`` init kwarg keeps working.
+
+    Regression for the #240 rework: the first implementation replaced the
+    framework dotenv source wholesale, silently ignoring
+    ``Settings(_env_file=...)`` including the disable idiom ``_env_file=None``.
+    """
+
+    @pytest.fixture
+    def isolated_cwd(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    @pytest.fixture
+    def home_with_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=123\n", encoding="utf-8")
+        monkeypatch.setenv("GFLOW_CLI_HOME", str(home))
+        return home
+
+    def test_env_file_none_disables_all_dotenv_loading(
+        self, clean_env: None, isolated_cwd: Path, home_with_env: Path
+    ) -> None:
+        (isolated_cwd / ".env").write_text("GFLOW_CLI_CONCURRENCY=3\n", encoding="utf-8")
+        s = Settings(_env_file=None)  # pyright: ignore[reportCallIssue]
+        assert s.timeout_seconds == 600  # home .env skipped
+        assert s.concurrency == 1  # CWD .env skipped
+
+    def test_explicit_env_file_replaces_both_defaults(
+        self, clean_env: None, isolated_cwd: Path, home_with_env: Path
+    ) -> None:
+        (isolated_cwd / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=456\n", encoding="utf-8")
+        other = isolated_cwd / "other.env"
+        other.write_text("GFLOW_CLI_TIMEOUT_SECONDS=999\n", encoding="utf-8")
+        s = Settings(_env_file=other)  # pyright: ignore[reportCallIssue]
+        assert s.timeout_seconds == 999
 
 
 class TestBrowserEngine:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,6 +169,85 @@ class TestLegacyEnvShim:
         assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
+class TestHomeEnvFileFallback:
+    """Issue #240: `.env` must also load from `$GFLOW_CLI_HOME/.env`.
+
+    docs/CONFIGURATION.md documents a home-`.env` fallback with CWD winning;
+    before the fix only the CWD `.env` was ever read.
+    """
+
+    @pytest.fixture
+    def isolated_cwd(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """Run the test from an empty directory so the repo's own `.env` never leaks in."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    @pytest.fixture
+    def home_with_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=123\n", encoding="utf-8")
+        monkeypatch.setenv("GFLOW_CLI_HOME", str(home))
+        return home
+
+    def test_home_env_file_is_loaded_without_cwd_env(
+        self, clean_env: None, isolated_cwd: Path, home_with_env: Path
+    ) -> None:
+        assert Settings().timeout_seconds == 123
+
+    def test_home_and_cwd_env_files_merge(
+        self, clean_env: None, isolated_cwd: Path, home_with_env: Path
+    ) -> None:
+        (isolated_cwd / ".env").write_text("GFLOW_CLI_CONCURRENCY=3\n", encoding="utf-8")
+        s = Settings()
+        assert s.timeout_seconds == 123  # from home .env
+        assert s.concurrency == 3  # from CWD .env
+
+    def test_cwd_env_file_wins_over_home_env_file(
+        self, clean_env: None, isolated_cwd: Path, home_with_env: Path
+    ) -> None:
+        (isolated_cwd / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=456\n", encoding="utf-8")
+        assert Settings().timeout_seconds == 456
+
+    def test_process_env_var_beats_both_env_files(
+        self,
+        clean_env: None,
+        isolated_cwd: Path,
+        home_with_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (isolated_cwd / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=456\n", encoding="utf-8")
+        monkeypatch.setenv("GFLOW_CLI_TIMEOUT_SECONDS", "789")
+        assert Settings().timeout_seconds == 789
+
+    def test_default_home_env_file_used_when_home_var_unset(
+        self,
+        clean_env: None,
+        isolated_cwd: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        home = tmp_path / "default-home"
+        home.mkdir()
+        (home / ".env").write_text("GFLOW_CLI_TIMEOUT_SECONDS=321\n", encoding="utf-8")
+        monkeypatch.setattr("gflow_cli.config.paths.default_home", lambda: home)
+        assert Settings().timeout_seconds == 321
+
+    def test_missing_home_env_file_is_harmless(
+        self,
+        clean_env: None,
+        isolated_cwd: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        home = tmp_path / "home-no-env"
+        home.mkdir()
+        monkeypatch.setenv("GFLOW_CLI_HOME", str(home))
+        assert Settings().timeout_seconds == 600  # built-in default
+
+
 class TestBrowserEngine:
     """GFLOW_CLI_BROWSER_ENGINE typed enum field (patchright opt-in)."""
 

--- a/tests/worker/test_daemon.py
+++ b/tests/worker/test_daemon.py
@@ -212,6 +212,60 @@ async def test_worker_process_t2v(temp_db: DataStore) -> None:
 
 
 @pytest.mark.asyncio
+async def test_worker_passes_cached_settings_to_image_client(temp_db: DataStore) -> None:
+    """The client must reuse the worker's cached settings object.
+
+    A bare ``Settings()`` inside FlowApiClient re-reads the .env files live per
+    task, so a mid-run edit to ``$GFLOW_CLI_HOME/.env`` yields a client whose
+    config disagrees with the headless/transport/out_dir the task derived from
+    ``get_settings()`` (#240 review finding).
+    """
+    from gflow_cli.config import get_settings
+
+    repo = QueueRepository(temp_db)
+    task = repo.enqueue_task(
+        task_id="task-t2i-settings",
+        profile_name="default",
+        task_type="t2i",
+        payload={"prompt": "scenic landscape", "aspect": "16:9", "count": 1},
+    )
+
+    worker = FlowWorker("default", str(temp_db.path))
+    fake_client = FakeFlowApiClient()
+    fake_client.create_project.return_value = MagicMock(project_id="p-1", title="T")
+    fake_client.generate_image.return_value = FakeGeneratedImage(media_name="media-img-s")
+
+    with patch("gflow_cli.worker.daemon.FlowApiClient", return_value=fake_client) as client_cls:
+        await worker.process_task(task)
+
+    assert client_cls.call_args.kwargs.get("settings") is get_settings()
+    worker.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_passes_cached_settings_to_video_client(temp_db: DataStore) -> None:
+    from gflow_cli.config import get_settings
+
+    repo = QueueRepository(temp_db)
+    task = repo.enqueue_task(
+        task_id="task-t2v-settings",
+        profile_name="default",
+        task_type="t2v",
+        payload={"prompt": "cinematic camera movement", "aspect": "16:9"},
+    )
+
+    worker = FlowWorker("default", str(temp_db.path))
+    fake_client = FakeFlowApiClient()
+    fake_client.generate_video.return_value = _completed_video_result("media-vid-s")
+
+    with patch("gflow_cli.worker.daemon.FlowApiClient", return_value=fake_client) as client_cls:
+        await worker.process_task(task)
+
+    assert client_cls.call_args.kwargs.get("settings") is get_settings()
+    worker.close()
+
+
+@pytest.mark.asyncio
 async def test_worker_t2v_recording_failure_does_not_fail_task(temp_db: DataStore) -> None:
     """A credit-spent video that succeeds must stay 'completed' even if the
     post-success data-layer recording raises — recording is best-effort."""


### PR DESCRIPTION
Release PR for **v0.25.0** → `main` (branch `chore/release-v0.25.0`, cut from `develop`).

Brings the full 0.25.0 line to main in one release: 24 files, +1171/-199.

## Bundled since 0.24.0
- **#240** `$GFLOW_CLI_HOME/.env` fallback now loads (minor bump — changes .env-loading behavior)
- **#243** removed a shadowed duplicate `Settings.daemon_token` field
- **#237** remote image UUIDs accepted in `gflow_generate_video`
- **#245 follow-ups** 3 HIGH + MED/LOW correctness fixes from the post-merge review

## Owner-only gates AFTER merge
1. **Live-verify** against live Flow → `docs/LIVE_VERIFICATION_v0.25.0.md` (RELEASE.md step 4, required).
2. **Signed annotated tag**: `git tag -s v0.25.0 -m v0.25.0 && git push origin v0.25.0` (triggers PyPI + GitHub Release).

Version bumped in `pyproject.toml` + `__init__.py`; CHANGELOG `[0.25.0] — 2026-07-06` dated.

Note: this supersedes the accidental no-op PR #248 (which merged a stale ancestor and brought no changes to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)