### PR TITLE
fix(i2i): properly resolve and attach remote UUID refs in UI automation

### DIFF
--- a/src/gflow_cli/api/dto.py
+++ b/src/gflow_cli/api/dto.py
@@ -128,6 +128,7 @@ class GeneratedImage:
     fife_url: str  # CDN URL — usually expires after ~6 hours
     dimensions: tuple[int, int]  # (width, height)
     media_generation_id: str | None = None
+    display_name: str | None = None
 
     @property
     def is_signed_url(self) -> bool:
@@ -172,8 +173,30 @@ class GeneratedImage:
         if not isinstance(media, list):
             msg = "unexpected batchGenerateImages response shape: media is not a list"
             raise ValueError(msg)
+        workflows = data.get("workflows", [])
+        workflow_map: dict[str, str] = {}
+        if isinstance(workflows, list):
+            for w in workflows:
+                if not isinstance(w, dict):
+                    continue
+                w_id = w.get("name")
+                if isinstance(w_id, str):
+                    metadata = w.get("metadata")
+                    if isinstance(metadata, dict):
+                        display_name = metadata.get("displayName")
+                        if isinstance(display_name, str):
+                            workflow_map[w_id] = display_name
+
         items = cast("list[dict[str, Any]]", media)
-        return [cls.from_response_item(item) for item in items]
+        result: list[GeneratedImage] = []
+        for item in items:
+            img = cls.from_response_item(item)
+            w_id = img.workflow_id
+            if w_id in workflow_map:
+                from dataclasses import replace
+                img = replace(img, display_name=workflow_map[w_id])
+            result.append(img)
+        return result
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -227,6 +227,9 @@ class GenerateImageRequest:
     aspect: Aspect = Aspect.PORTRAIT
     model: Model = Model.NARWHAL
     refs: tuple[ImageRef, ...] = ()
+    # Display names corresponding to the pre-uploaded UUID `refs`. Attached via the
+    # Flow UI picker by the ui_automation transport.
+    ref_names: tuple[str, ...] = ()
     # Local reference-image files for I2I — attached through the editor's media
     # dialog by the ui_automation transport (the REST uploadImage path 401s).
     # The common i2i case; `refs` (pre-uploaded UUIDs) would need library-select.

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -2110,6 +2110,15 @@ class UiAutomationTransport(VideoGenerationMixin):
         if request.ref_paths:
             await self._attach_references(page, list(request.ref_paths), out_dir=out_dir)
 
+        # Already-uploaded UUID references (ref_names) must be attached via the
+        # editor's media dialog using their display name, identical to video R2V.
+        if request.ref_names:
+            from gflow_cli.api.transports.ui_automation_video import VideoGenerationMixin
+
+            await VideoGenerationMixin._attach_remote_references(
+                page, list(request.ref_names), out_dir=out_dir
+            )
+
         # Entity references: attach locked CHARACTER entities via the Personagens
         # picker (inherited from the video transport). The entity must live in the
         # project we generate in (pass --project / project_id). Flow's JS then

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -245,6 +245,10 @@ class OperationRecorder:
         media_type = mimetypes.guess_type(saved_path.name)[0]
         asset_id = _new_id()
         width, height = image.dimensions
+        metadata = {"fife_url": image.fife_url}
+        if image.display_name:
+            metadata["display_name"] = image.display_name
+
         repo.upsert_asset(
             AssetRecord(
                 id=asset_id,
@@ -261,7 +265,7 @@ class OperationRecorder:
                 height=height,
                 duration_seconds=None,
                 seed=image.seed,
-                metadata_json=redact_metadata({"fife_url": image.fife_url}),
+                metadata_json=redact_metadata(metadata),
             ),
         )
         repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, i)

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -384,10 +384,6 @@ def _resolve_ref_name(
     return ref_id, None
 
 
-# Video task types whose remote refs the UI automation attaches by DISPLAY NAME
-# (searched in the Flow picker) and therefore need UUID→name resolution. Image
-# task types attach remote refs by raw media id and MUST NOT be resolved here —
-# gating on that was the PR #245 image-i2i regression.
 _VIDEO_TASK_TYPES = frozenset({"t2v", "i2v", "r2v"})
 
 
@@ -399,29 +395,38 @@ def _resolve_payload_ref_names(
 ) -> dict[str, Any] | None:
     """Resolve every remote-ref field in ``payload`` to a display name in place.
 
-    Only the video task types need this (their refs are attached by display
-    name); image tasks attach remote refs by raw media id and are left
-    untouched. Returns an error envelope on the first unresolvable UUID, else
-    ``None``.
+    Video task types require this (their refs are attached by display name in the
+    Flow picker). Image task types also resolve when possible to support the UI
+    automation transport, but fail gracefully (pass through) if the UUID is missing
+    from the local catalog to satisfy PR #245 image-i2i requirements.
+
+    Returns an error envelope on the first unresolvable UUID for video tasks,
+    else ``None``.
     """
-    if task_type not in _VIDEO_TASK_TYPES:
-        return None
+    is_video = task_type in _VIDEO_TASK_TYPES
     if "refs" in payload:
         ref_names: list[str] = []
         for ref in payload["refs"]:
             name, err = _resolve_ref_name(data_repo, profile, ref)
             if err is not None:
-                return err
+                if is_video:
+                    return err
+                # For image tasks, if missing from catalog, pass through silently
+                # to satisfy PR #245 image-i2i requirements.
+                continue
             # name is never falsy when err is None (see _resolve_ref_name).
             assert name is not None
             ref_names.append(name)
-        payload["ref_names"] = ref_names
-    for key in ("start_image_ref", "end_image_ref"):
-        if key in payload:
-            name, err = _resolve_ref_name(data_repo, profile, payload[key])
-            if err is not None:
-                return err
-            payload[f"{key}_name"] = name
+        if ref_names:
+            payload["ref_names"] = ref_names
+
+    if is_video:
+        for key in ("start_image_ref", "end_image_ref"):
+            if key in payload:
+                name, err = _resolve_ref_name(data_repo, profile, payload[key])
+                if err is not None:
+                    return err
+                payload[f"{key}_name"] = name
     return None
 
 

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -292,11 +292,8 @@ class FlowWorker:
         model = ImageModel.from_cli(model_val) if model_val else ImageModel.NARWHAL
 
         refs = tuple(ImageRef(r) for r in payload.get("refs", []))
+        ref_names = tuple(payload.get("ref_names", []))
         ref_paths = tuple(Path(p) for p in payload.get("ref_paths", []))
-        # NOTE: the payload may carry "ref_names" (the MCP layer resolves them
-        # for the video request); the image transport attaches remote refs by
-        # media id, so GenerateImageRequest has no ref_names field and must
-        # not receive one.
         reference_entities = tuple(payload.get("reference_entities", []))
         reference_entity_names = tuple(payload.get("reference_entity_names", []))
         count = payload.get("count", 1)
@@ -306,6 +303,7 @@ class FlowWorker:
             aspect=aspect,
             model=model,
             refs=refs,
+            ref_names=ref_names,
             ref_paths=ref_paths,
             reference_entities=reference_entities,
             reference_entity_names=reference_entity_names,

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -233,9 +233,10 @@ def test_resolve_ref_name_found_asset_without_name_errors_not_uuid_passthrough()
 
 
 def test_resolve_payload_ref_names_leaves_image_refs_untouched() -> None:
-    """PR #245 review #1: _resolve_payload_ref_names must only be applied to the
-    video path. Image 'refs' (media-id UUIDs) attach by id and must pass through
-    even when absent from the local catalog."""
+    """PR #245 review #1 (updated): image 'refs' (media-id UUIDs) must pass through
+    even when absent from the local catalog without erroring. The UI automation
+    transport will attempt to resolve them if found, but experimental REST transports
+    can still attempt to use the raw UUID."""
     from gflow_cli.mcp.tools import _resolve_payload_ref_names
 
     repo = _FakeRepo(asset=None)  # UUID not in local catalog
@@ -249,3 +250,17 @@ def test_resolve_payload_ref_names_leaves_image_refs_untouched() -> None:
     assert err_image is None
     assert "ref_names" not in p_image
     assert p_image["refs"] == [_A_UUID]
+
+
+def test_resolve_payload_ref_names_populates_ref_names_for_found_image_refs() -> None:
+    from gflow_cli.mcp.tools import _resolve_payload_ref_names
+
+    repo = _FakeRepo(asset=_Asset({"display_name": "My Found Image"}))
+    payload = {"refs": [_A_UUID]}
+
+    err = _resolve_payload_ref_names(repo, "default", payload, task_type="i2i")
+
+    assert err is None
+    assert "ref_names" in payload
+    assert payload["ref_names"] == ["My Found Image"]
+    assert payload["refs"] == [_A_UUID]


### PR DESCRIPTION
fix(i2i): properly resolve and attach remote UUID refs in UI automation

Fixes the regression where image tasks with remote UUID references were not
resolved to display names, causing the UI automation transport to ignore them
and submit standard text-to-image prompts.

- Updates _resolve_payload_ref_names to resolve image refs on a best-effort basis (satisfying PR #245).
- Adds ref_names to GenerateImageRequest.
- UI automation transport now properly searches and attaches UUID refs via the media dialog.

The display_name was previously ignored when parsing the batchGenerateImages response, causing the CLI to rely on the prompt text when searching for generated images in the remote UI picker.

Changes:
- api/dto.py: Extract the 'workflows' array from the response and map workflow IDs to their display names, injecting the 'display_name' into the GeneratedImage model.
- data/recorder.py: Save the extracted 'display_name' into the asset's metadata_json during database upsert.
