### PR TITLE
feat(dto): capture Flow display_name for generated images (foundation for image-UUID refs)

### DIFF
--- a/src/gflow_cli/api/dto.py
+++ b/src/gflow_cli/api/dto.py
@@ -8,7 +8,7 @@ KeyErrors leak.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
@@ -128,6 +128,10 @@ class GeneratedImage:
     fife_url: str  # CDN URL — usually expires after ~6 hours
     dimensions: tuple[int, int]  # (width, height)
     media_generation_id: str | None = None
+    # Flow-assigned display name (from the response's `workflows[]` array). This
+    # is the searchable label the media picker shows — recorded so a generated
+    # image can be referenced by name later. Original find by @C1ph3r404 (#253).
+    display_name: str | None = None
 
     @property
     def is_signed_url(self) -> bool:
@@ -172,8 +176,37 @@ class GeneratedImage:
         if not isinstance(media, list):
             msg = "unexpected batchGenerateImages response shape: media is not a list"
             raise ValueError(msg)
+        # Flow returns display names in a sibling `workflows[]` array keyed by
+        # workflow id (mirrors AssetInfo.from_upload_response). Build the lookup
+        # once and inject the name onto each parsed image. (Find by @C1ph3r404.)
+        workflow_names = cls._workflow_display_names(data.get("workflows"))
         items = cast("list[dict[str, Any]]", media)
-        return [cls.from_response_item(item) for item in items]
+        results: list[GeneratedImage] = []
+        for item in items:
+            img = cls.from_response_item(item)
+            name = workflow_names.get(img.workflow_id)
+            if name:
+                img = replace(img, display_name=name)
+            results.append(img)
+        return results
+
+    @staticmethod
+    def _workflow_display_names(workflows: object) -> dict[str, str]:
+        """Map workflow id → displayName from the response's ``workflows[]``."""
+        names: dict[str, str] = {}
+        if not isinstance(workflows, list):
+            return names
+        for w in cast("list[Any]", workflows):
+            if not isinstance(w, dict):
+                continue
+            entry = cast("dict[str, Any]", w)
+            w_id = entry.get("name")
+            metadata = entry.get("metadata")
+            if isinstance(w_id, str) and isinstance(metadata, dict):
+                display_name = cast("dict[str, Any]", metadata).get("displayName")
+                if isinstance(display_name, str) and display_name:
+                    names[w_id] = display_name
+        return names
 
 
 @dataclass(frozen=True)

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -245,6 +245,11 @@ class OperationRecorder:
         media_type = mimetypes.guess_type(saved_path.name)[0]
         asset_id = _new_id()
         width, height = image.dimensions
+        # Persist the Flow-assigned display name (when present) so a generated
+        # image can later be referenced by name — the picker's searchable label.
+        metadata: dict[str, str] = {"fife_url": image.fife_url}
+        if image.display_name:
+            metadata["display_name"] = image.display_name
         repo.upsert_asset(
             AssetRecord(
                 id=asset_id,
@@ -261,7 +266,7 @@ class OperationRecorder:
                 height=height,
                 duration_seconds=None,
                 seed=image.seed,
-                metadata_json=redact_metadata({"fife_url": image.fife_url}),
+                metadata_json=redact_metadata(metadata),
             ),
         )
         repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, i)

--- a/tests/api/test_image_dto.py
+++ b/tests/api/test_image_dto.py
@@ -68,6 +68,36 @@ class TestGeneratedImage:
         assert len(results) == 1
         assert results[0].seed == 646428
 
+    def test_from_response_dict_extracts_display_name_from_workflows(self) -> None:
+        """The Flow-assigned display name lives in the response's ``workflows[]``
+        array (keyed by workflow id), not in the media item — extract it onto
+        the GeneratedImage so the catalog records a searchable name. (Original
+        find by @C1ph3r404, PR #253.)"""
+        sample = _load("06_batchGenerateImages.json")
+        body = sample["response_body_parsed"]
+        results = GeneratedImage.from_response_dict(body)
+        assert results[0].display_name == "Warrior Zelda in dungeon"
+
+    def test_from_response_dict_display_name_none_when_no_workflows(self) -> None:
+        """A response without a matching workflow leaves display_name as None
+        (graceful — the field is optional)."""
+        item = {
+            "name": "m",
+            "workflowId": "w-1",
+            "image": {
+                "generatedImage": {
+                    "seed": "1",
+                    "prompt": "p",
+                    "modelNameType": "NARWHAL",
+                    "aspectRatio": "IMAGE_ASPECT_RATIO_PORTRAIT",
+                    "fifeUrl": "https://flow-content.google/image/x",
+                },
+                "dimensions": {"width": 1, "height": 1},
+            },
+        }
+        results = GeneratedImage.from_response_dict({"media": [item]})
+        assert results[0].display_name is None
+
     def test_parse_seeded_landscape_response(self) -> None:
         """Seeded I2I + 4:3 landscape capture parses to expected dimensions/aspect."""
         sample = _load("07_batchGenerateImages_seeded.json")

--- a/tests/mcp/test_tools_wired.py
+++ b/tests/mcp/test_tools_wired.py
@@ -51,6 +51,7 @@ class _FakeImage:
     aspect_ratio: str = "1:1"
     seed: int = 12345
     fife_url: str = "http://fake"
+    display_name: str | None = None  # mirrors GeneratedImage.display_name
 
 
 def _completed_video_result(media_id: str = "media-vid-wired") -> VideoResult:

--- a/tests/worker/test_daemon.py
+++ b/tests/worker/test_daemon.py
@@ -25,6 +25,7 @@ class FakeGeneratedImage:
     aspect_ratio: str = "1:1"
     seed: int = 12345
     fife_url: str = "http://fake"
+    display_name: str | None = None  # mirrors GeneratedImage.display_name
 
 
 def _completed_video_result(media_id: str = "media-vid-123") -> VideoResult:


### PR DESCRIPTION
## Summary
Extracts the Flow-assigned `display_name` for generated images from the `batchGenerateImages` response's `workflows[]` array (keyed by workflow id) and persists it in the asset catalog. Previously ignored, so catalogued images had no searchable name.

This is a **standalone catalog improvement** and the **foundation** for referencing an already-generated image by selecting its existing picker tile (instead of re-uploading a copy) — the image-i2i UUID-ref feature that builds on this next.

## Credit
Original find and approach by **@C1ph3r404** in #253 — he spotted that `displayName` was in the `workflows[]` array all along and the generated-image parser ignored it (mirrors the existing `AssetInfo.from_upload_response` extraction). Adapted here onto the reworked post-0.25.0 resolution path (his PR's video-path changes conflicted with the 0.25.0 local-upload rework; this lands the durable, non-conflicting core with credit).

## Changes
- `dto.py`: `GeneratedImage.display_name` + `_workflow_display_names` lookup in `from_response_dict`.
- `recorder.py`: persist `display_name` into the asset `metadata_json`.
- Tests: extraction against the real captured sample (`06_batchGenerateImages.json` → "Warrior Zelda in dungeon") + graceful None when absent.

## Not in this PR (follow-up)
The prefer-existing attach itself (locate the picker tile by the media UUID, local-upload fallback) — **live-verified** the image `add_2` picker surfaces generated media, so that path is viable; it'll land with a live e2e verification. Per the founder principle: UUID refs should **prefer selecting the existing Flow asset over uploading a duplicate**.

## Gates
`pyright src` 0 errors, ruff clean, dto + data suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)