### PR TITLE
feat(composition): global [style] block with named variants (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[style]` block and select it per-scene via `style_variant`, without repeating style text in
   every scene's action. Adds `prefix`/`suffix` fields to `[style]`, `[style.variants.*]`
   sub-tables, per-scene `style_variant` and `style_suffix` fields, deterministic composition
-  rule, `resume_hash()` for crash-recoverable resume, and `style_applied` per clip in the
-  handoff manifest.
+  rule, and `style_applied` (variant/prefix/suffix/scene_suffix) per clip in the handoff
+  manifest. `none` is a reserved variant name (opt-out keyword) and may not be defined.
+- **Prompt-aware resume for `movie run`:** completed scenes now persist a SHA-256 hash of
+  their composed prompt (`style_hash`); on resume, a scene whose prompt changed (style edit,
+  variant switch, action tweak) is regenerated instead of silently skipped. Unchanged scenes
+  still cost nothing. Old state files fall back to comparing the stored prompt text and are
+  never re-run on a guess. Dry-run shows the resolved style per scene and marks stale scenes
+  as `re-run (style changed)`.
 
 ## [0.26.0] — 2026-07-06
 
@@ -1822,7 +1828,9 @@ shell-script template that branches on these codes.
 
 First skeleton. Not functional end-to-end yet.
 
-[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/ffroliva/gflow-cli/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/ffroliva/gflow-cli/compare/v0.25.0...v0.26.0
+[0.25.0]: https://github.com/ffroliva/gflow-cli/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/ffroliva/gflow-cli/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/ffroliva/gflow-cli/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/ffroliva/gflow-cli/compare/v0.21.0...v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Global `[style]` block with named variants in `movie.toml` (Issue #239):** channel-format
+  videos can now express a visual style system (e.g. monochrome → warm color arc) once in the
+  `[style]` block and select it per-scene via `style_variant`, without repeating style text in
+  every scene's action. Adds `prefix`/`suffix` fields to `[style]`, `[style.variants.*]`
+  sub-tables, per-scene `style_variant` and `style_suffix` fields, deterministic composition
+  rule, `resume_hash()` for crash-recoverable resume, and `style_applied` per clip in the
+  handoff manifest.
+
 ## [0.26.0] — 2026-07-06
 
 ### Added

--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -101,6 +101,9 @@ Per-scene selection:
 | *(omitted)* | Uses the base `[style]` suffix. |
 | `style_suffix = "sunset light"` | Scene-specific text appended **after** the variant/base suffix. |
 
+`none` is a **reserved name**: defining `[style.variants.none]` is a
+configuration error, so the opt-out keyword can never shadow a real variant.
+
 **Composition rule** (deterministic, no LLM):
 
 ```
@@ -108,7 +111,15 @@ final_prompt = [prefix] + composed_scene_text + [variant.suffix | base.suffix] +
 ```
 
 The applied style is recorded per clip in `<manifest>-handoff.json` as
-`style_applied`, so downstream tools (Remotion, editors) can introspect it.
+`style_applied` (`variant`, `prefix`, `suffix`, `scene_suffix`), so downstream
+tools (Remotion, editors) can introspect it.
+
+**Resume:** each completed scene's state records a hash of its composed
+prompt. If you edit the style (or anything else that changes a scene's
+prompt) and re-run, only the affected scenes are regenerated — unchanged
+scenes are still skipped and cost no credits. State files written by older
+gflow-cli versions fall back to comparing the stored prompt text; scenes with
+no stored prompt are never re-run automatically.
 
 > **Consistency is best-effort, not pixel-exact.** gflow guarantees the *right
 > entity rides the wire* (`consistency_method = entity`); the final on-screen

--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -31,6 +31,18 @@ title = "E2E Stickman"
 project = "6ba50219-…"            # reusable Flow project id
 output_dir = "./out"
 
+[style]
+look = "cinematic, shallow depth of field"
+palette = "warm golden tones"
+negative = "no text, no watermark"
+suffix = "Black and white cinematic street photography, photorealistic, film grain."
+
+  [style.variants.warm]
+  suffix = "Warm golden-hour cinematic grade."
+
+  [style.variants.cool]
+  suffix = "Cool blue-toned cinematic grade."
+
 [[characters]]
 name = "Stickman"
 identity = "entity"               # reuse a Flow CHARACTER entity across scenes
@@ -47,12 +59,56 @@ line = "We finally made it to the top!"
 aspect = "9:16"
 model = "veo-lite"
 duration = 8
+
+[[scenes]]
+id = "close-up"
+action = "smiles with excitement"
+style_variant = "warm"            # selects [style.variants.warm]
+style_suffix = "golden hour light" # appended after the variant suffix
+aspect = "9:16"
+duration = 6
 ```
 
 On first run, characters with `identity = "entity"` are created once (image
 generation — **free**, no credits) and cached. Each scene then generates a clip
 that **reuses the same Flow CHARACTER entity** so the character drives every
 scene from one identity.
+
+### Style variants
+
+The `[style]` block defines a **global visual style** applied to every scene.
+For channel-format videos where the style changes across scenes (e.g. a
+monochrome → warm color arc), use **named variants**:
+
+```toml
+[style]
+prefix = ""           # optional, prepended before the composed scene text
+suffix = "Black and white cinematic street photography, photorealistic, film grain."
+
+  [style.variants.warm]
+  suffix = "Warm golden-hour cinematic grade."
+
+  [style.variants.cool]
+  suffix = "Cool blue-toned cinematic grade."
+```
+
+Per-scene selection:
+
+| Field | Effect |
+|---|---|
+| `style_variant = "warm"` | Selects `[style.variants.warm]` — its `suffix` replaces the base `suffix`. |
+| `style_variant = "none"` | Opts out of all style suffixes (base + variant). Prefix is still applied. |
+| *(omitted)* | Uses the base `[style]` suffix. |
+| `style_suffix = "sunset light"` | Scene-specific text appended **after** the variant/base suffix. |
+
+**Composition rule** (deterministic, no LLM):
+
+```
+final_prompt = [prefix] + composed_scene_text + [variant.suffix | base.suffix] + [scene.style_suffix]
+```
+
+The applied style is recorded per clip in `<manifest>-handoff.json` as
+`style_applied`, so downstream tools (Remotion, editors) can introspect it.
 
 > **Consistency is best-effort, not pixel-exact.** gflow guarantees the *right
 > entity rides the wire* (`consistency_method = entity`); the final on-screen

--- a/docs/schemas/movie-handoff.schema.json
+++ b/docs/schemas/movie-handoff.schema.json
@@ -50,6 +50,14 @@
           "dialogue": { "type": "array" },
           "prompt": { "type": ["string", "null"] },
           "status": { "enum": ["completed", "failed"] },
+          "style_applied": {
+            "type": "object",
+            "properties": {
+              "variant": { "type": ["string", "null"] },
+              "suffix": { "type": ["string", "null"] },
+              "scene_suffix": { "type": ["string", "null"] }
+            }
+          },
           "x_gflow": { "type": "object" }
         }
       }

--- a/docs/schemas/movie-handoff.schema.json
+++ b/docs/schemas/movie-handoff.schema.json
@@ -54,6 +54,7 @@
             "type": "object",
             "properties": {
               "variant": { "type": ["string", "null"] },
+              "prefix": { "type": ["string", "null"] },
               "suffix": { "type": ["string", "null"] },
               "scene_suffix": { "type": ["string", "null"] }
             }

--- a/docs/superpowers/plans/2026-07-07-style-variants/PLAN.md
+++ b/docs/superpowers/plans/2026-07-07-style-variants/PLAN.md
@@ -1,0 +1,255 @@
+# Style Variants Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature style-variants` to find the next
+> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** Allow `movie.toml` to express a global visual style system with named variants, so channel-format videos can define a style arc (e.g. monochrome → warm) once and apply it per-scene without repeating style text in every scene's action.
+
+**Architecture:** Three modules change: `composition.py` (StyleSpec gains prefix/suffix/variants, compose_prompt gains style resolution), `movie_manifest.py` (parser gains [style.variants.*] and per-scene style_variant/style_suffix), `cli_movie.py` (template + dry-run output shows resolved style). Handoff schema gains `style_applied` per clip. State file gains `style_hash` per scene for resume detection. No new modules. No transport or auth changes.
+
+**Predict verdict:** GO — confidence 8/10
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Prompt hash must include full composition (prefix + variant + scene suffix) | Hash the *resolved* prompt string, not just scene action |
+| High | `scene.style_variant` naming collision with existing `scene.variant` (character) | Use distinct field name `style_variant`; document clearly |
+| Medium | Old state files lack `style_hash` field | Default to None → always re-run (safe fallback) |
+
+---
+
+## File structure
+
+### New files
+```
+tests/composition/test_style_variants.py
+  Unit tests for style variant composition, validation, and handoff
+tests/cli/test_movie_manifest_style_variants.py
+  Unit tests for movie.toml parsing of [style.variants.*] and per-scene style fields
+```
+
+### Modified files
+```
+src/gflow_cli/composition.py
+  StyleSpec: add prefix, suffix, variants fields
+  Scene: add style_variant, style_suffix fields
+  compose_prompt: apply prefix/suffix/variant resolution
+  build_handoff: record style_applied per clip
+  New: resolve_style() helper, prompt_hash() helper
+
+src/gflow_cli/movie_manifest.py
+  _parse_style: parse prefix, suffix, variants sub-tables
+  _parse_scene: parse style_variant, style_suffix fields
+  SceneState: add style_hash field
+  MovieState: round-trip style_hash
+
+src/gflow_cli/cli_movie.py
+  Template: document [style.variants.*] usage
+  Dry-run output: show resolved style per scene
+
+docs/schemas/movie-handoff.schema.json
+  Add style_applied field to clip schema
+
+tests/composition/test_compose_prompt.py
+  Add tests for prefix/suffix/variant composition
+```
+
+---
+
+## Task 1 — Test scaffold (red tests)
+
+**What:** Write all failing tests for StyleSpec extensions, compose_prompt style resolution, movie.toml parsing, handoff style_applied, and prompt hash.
+
+**Files:**
+- `tests/composition/test_style_variants.py` — new file
+- `tests/cli/test_movie_manifest_style_variants.py` — new file
+- `tests/composition/test_compose_prompt.py` — extend with style variant tests
+
+**Steps:**
+- [ ] Create `tests/composition/test_style_variants.py` with tests for:
+  - StyleSpec with prefix/suffix/variants parses correctly
+  - compose_prompt applies prefix before and suffix after composed text
+  - compose_prompt applies variant.suffix when scene.style_variant matches
+  - compose_prompt falls back to base suffix when no variant specified
+  - compose_prompt applies scene.style_suffix after base/variant suffix
+  - compose_prompt with style_variant="none" skips all style suffixes
+  - prompt_hash changes when style suffix changes
+  - prompt_hash changes when prefix changes
+  - prompt_hash changes when scene.style_suffix changes
+  - build_handoff records style_applied per clip
+- [ ] Create `tests/cli/test_movie_manifest_style_variants.py` with tests for:
+  - movie.toml with [style] prefix and suffix parses correctly
+  - movie.toml with [style.variants.X] sub-tables parses correctly
+  - scene with style_variant = "name" parses correctly
+  - scene with style_suffix = "text" parses correctly
+  - scene with style_variant referencing unknown variant raises ConfigurationError
+  - scene with style_variant = "none" parses correctly
+  - old movie.toml without [style.variants] still works (backward compat)
+
+**Tests created (red):**
+- [ ] test_style_spec_prefix_suffix — StyleSpec with prefix/suffix
+- [ ] test_compose_prompt_prefix_before — prefix prepended
+- [ ] test_compose_prompt_suffix_after — suffix appended
+- [ ] test_compose_prompt_variant_suffix — variant suffix replaces base
+- [ ] test_compose_prompt_fallback_to_base — no variant → base suffix
+- [ ] test_compose_prompt_scene_style_suffix — scene suffix appended last
+- [ ] test_compose_prompt_style_none — style_variant="none" skips suffixes
+- [ ] test_prompt_hash_changes_on_suffix_edit — hash detects suffix change
+- [ ] test_prompt_hash_changes_on_prefix_edit — hash detects prefix change
+- [ ] test_handoff_style_applied — build_handoff records style_applied
+- [ ] test_parse_style_prefix_suffix — TOML parsing
+- [ ] test_parse_style_variants — TOML parsing of sub-tables
+- [ ] test_parse_scene_style_variant — per-scene field
+- [ ] test_parse_scene_style_suffix — per-scene field
+- [ ] test_unknown_style_variant_raises — ConfigurationError
+- [ ] test_style_variant_none_parses — "none" is valid
+
+---
+
+## Task 2 — StyleSpec model changes
+
+**What:** Add `prefix`, `suffix`, and `variants` fields to `StyleSpec` in `composition.py`.
+
+**Files:**
+- `src/gflow_cli/composition.py`
+
+**Steps:**
+- [ ] Add `prefix: str | None = None` to StyleSpec
+- [ ] Add `suffix: str | None = None` to StyleSpec
+- [ ] Add `variants: Mapping[str, str] = field(default_factory=dict)` to StyleSpec
+- [ ] Add `resolve_suffix(self, variant_name: str | None) -> str | None` method that returns variant.suffix if variant specified, else self.suffix
+- [ ] Verify tests from Task 1 pass for StyleSpec parsing
+
+---
+
+## Task 3 — Scene model changes
+
+**What:** Add `style_variant` and `style_suffix` fields to `Scene` in `composition.py`.
+
+**Files:**
+- `src/gflow_cli/composition.py`
+
+**Steps:**
+- [ ] Add `style_variant: str | None = None` to Scene
+- [ ] Add `style_suffix: str | None = None` to Scene
+- [ ] Verify Scene is still a frozen dataclass
+
+---
+
+## Task 4 — Composition rule implementation
+
+**What:** Implement the deterministic style composition in `compose_prompt` and add `prompt_hash` helper.
+
+**Files:**
+- `src/gflow_cli/composition.py`
+
+**Steps:**
+- [ ] Add `_resolve_style_suffix(style, scene)` helper: if scene.style_variant == "none" → None; elif scene.style_variant → style.resolve_suffix(scene.style_variant); else → style.suffix
+- [ ] Modify `compose_prompt` to prepend `style.prefix` (if set) before the composed parts
+- [ ] Modify `compose_prompt` to append resolved suffix + scene.style_suffix after the composed parts
+- [ ] Add `prompt_hash(prompt: str) -> str` function: SHA-256 hex digest of the composed prompt
+- [ ] Verify all tests from Task 1 pass
+
+---
+
+## Task 5 — Movie manifest parsing
+
+**What:** Extend `_parse_style` and `_parse_scene` to handle new fields.
+
+**Files:**
+- `src/gflow_cli/movie_manifest.py`
+
+**Steps:**
+- [ ] Extend `_parse_style` to read `prefix` (str) and `suffix` (str) from the [style] table
+- [ ] Add `_parse_style_variants(data)` to parse [style.variants.*] sub-tables into a dict[str, str]
+- [ ] Pass variants to StyleSpec constructor
+- [ ] Extend `_parse_scene` to read `style_variant` (str or None) and `style_suffix` (str or None)
+- [ ] Validate style_variant against defined variants (if not "none" and not None)
+- [ ] Verify all parsing tests from Task 1 pass
+
+---
+
+## Task 6 — Handoff schema update
+
+**What:** Add `style_applied` to the handoff manifest per clip.
+
+**Files:**
+- `src/gflow_cli/composition.py` (build_handoff)
+- `docs/schemas/movie-handoff.schema.json`
+
+**Steps:**
+- [ ] In `_build_handoff_clip`, compute `style_applied` from the resolved style + variant + suffix
+- [ ] Add `style_applied` field to clip dict: `{"variant": ..., "suffix": ..., "scene_suffix": ...}`
+- [ ] Update `movie-handoff.schema.json` to include `style_applied` in clip properties
+- [ ] Verify handoff tests pass
+
+---
+
+## Task 7 — State file style_hash
+
+**What:** Store prompt hash per scene in `-state.json` for resume detection.
+
+**Files:**
+- `src/gflow_cli/movie_manifest.py` (SceneState)
+- `src/gflow_cli/cli_movie.py` (runner)
+
+**Steps:**
+- [ ] Add `style_hash: str | None = None` to SceneState
+- [ ] Update SceneState.to_dict/from_dict to round-trip style_hash
+- [ ] In cli_movie.py runner, compute prompt_hash after compose_prompt and store in SceneState
+- [ ] On resume, compare stored style_hash with newly computed hash; re-run scene if different
+- [ ] Verify state round-trip tests pass
+
+---
+
+## Task 8 — CLI template and dry-run output
+
+**What:** Update the movie template and dry-run display to show style information.
+
+**Files:**
+- `src/gflow_cli/cli_movie.py`
+
+**Steps:**
+- [ ] Update `_TEMPLATE` to include example [style.variants.*] usage
+- [ ] In dry-run output, show resolved style variant and suffix per scene
+- [ ] Verify template renders correctly
+
+---
+
+## Task 9 — Documentation
+
+**What:** Update docs for the new style variant feature.
+
+**Files:**
+- `docs/MOVIE.md` (or USAGE.md movie section)
+- `CHANGELOG.md`
+
+**Steps:**
+- [ ] Document [style] prefix/suffix/variants in MOVIE.md
+- [ ] Document per-scene style_variant and style_suffix
+- [ ] Document composition order
+- [ ] Document resume behavior (prompt hash)
+- [ ] Add [Unreleased] entry to CHANGELOG.md
+
+---
+
+## Task 10 — Full gates + commit
+
+**What:** Run all quality gates, fix any issues, commit.
+
+**Steps:**
+- [ ] Run `/gflow:check` (ruff, format, pyright, pytest)
+- [ ] Fix any failures
+- [ ] Commit all changes
+- [ ] Verify CI green
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Docs updated (`MOVIE.md` style variants section)
+- [ ] BDD feature file covers all Critical + High scenarios from SCENARIO.md
+- [ ] No `# TODO` in diff without a tracked issue link

--- a/docs/superpowers/plans/2026-07-07-style-variants/SCENARIO.md
+++ b/docs/superpowers/plans/2026-07-07-style-variants/SCENARIO.md
@@ -1,0 +1,100 @@
+# Scenario: Global [style] Block with Named Variants
+
+## Coverage map
+
+| Dimension | Relevant? | Notes |
+|---|---|---|
+| D1 Auth & session | No | No auth changes |
+| D2 WAF / reCAPTCHA | No | No new API calls or token minting |
+| D3 Selector drift | No | No Playwright selectors |
+| D4 Batch manifest & resume | **Yes** | Prompt-hash resume is the core complexity |
+| D5 Concurrency & Page pool | No | Pure string composition |
+| D6 Data layer | No | No schema migration (state file format is additive) |
+| D7 Error propagation | **Yes** | New ConfigurationError paths for invalid style references |
+| D8 Cross-platform paths | Low | Style strings are text, not paths |
+| D9 Transport edge cases | No | No transport changes |
+| D10 Headless vs headed | No | No Playwright changes |
+| D11 Input validation | **Yes** | New fields need validation |
+| D12 Observability | Low | No new structlog events needed |
+
+## Scenario table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D4 Resume | User edits `[style]` after partial run; completed scenes keep old look | High | Prompt hash per scene detects change; only scenes with changed hash re-run | Unit |
+| 2 | D4 Resume | User adds a new variant and assigns it to a previously-completed scene | High | Hash changes → scene re-runs with new style | Unit |
+| 3 | D4 Resume | User deletes a variant that a completed scene references | Critical | ConfigurationError raised at manifest parse time (unknown variant) | Unit |
+| 4 | D4 Resume | State file from pre-style-variant version loads correctly | Medium | Missing `style_applied` field defaults gracefully; no crash | Unit |
+| 5 | D7 Error | Scene references `style = "nonexistent"` | High | ConfigurationError: "unknown style variant 'nonexistent'" | Unit |
+| 6 | D7 Error | `[style.variants.X]` has non-string `suffix` | High | ConfigurationError at parse time | Unit |
+| 7 | D11 Input | `style = "none"` on a scene opts out of all style | Medium | No prefix, no suffix, no variant suffix applied; composed prompt is bare | Unit |
+| 8 | D11 Input | `style_suffix` with empty string | Low | Treated as no suffix (same as omitting) | Unit |
+| 9 | D11 Input | `[style]` block with only `prefix`, no `suffix` | Low | Prefix applied, no suffix; valid configuration | Unit |
+| 10 | D11 Input | `style = "variant_name"` where variant exists but has empty suffix | Low | Variant selected but no suffix text appended; valid | Unit |
+| 11 | D4 Resume | Two runs with identical manifest produce identical hashes | Medium | No unnecessary re-runs | Unit |
+| 12 | D4 Resume | Hash includes prefix + variant suffix + scene suffix (full composition) | High | Changing any style element changes the hash | Unit |
+| 13 | D11 Input | Both `scene.variant` (character) and `scene.style_variant` (style) used together | Medium | Both resolve independently; no conflict | Unit |
+| 14 | D7 Error | `style_variant` references a character variant name (user confusion) | Low | Distinct error: "use scene.variant for character variants, scene.style_variant for style variants" | Unit |
+| 15 | D4 Resume | `-state.json` stores `style_hash` per scene alongside existing fields | Medium | Round-trips correctly; old state files without `style_hash` load as None (always re-run) | Unit |
+
+## Must-cover before merge (Critical + High)
+
+1. #1 — Prompt hash detects style changes on resume
+2. #2 — New variant assignment triggers re-run
+3. #3 — Deleted variant raises ConfigurationError
+4. #5 — Unknown style variant raises ConfigurationError
+5. #6 — Invalid variant field type raises ConfigurationError
+6. #12 — Hash includes full composition (prefix + variant + scene suffix)
+
+## Deferred (Medium + Low — log as issues, not blockers)
+
+7. #4 — Old state file backward compatibility
+8. #7 — `style = "none"` opt-out
+9. #8-10 — Edge cases with empty strings
+10. #13-14 — Character vs style variant naming clarity
+
+## Suggested BDD scenarios
+
+```gherkin
+Feature: Style Variants
+  Scenario: Compose prompt with base style suffix
+    Given a movie.toml with [style] suffix "Cinematic, photorealistic."
+    And a scene with action "walks on the beach"
+    When the prompt is composed
+    Then the prompt ends with "Cinematic, photorealistic."
+
+  Scenario: Compose prompt with named variant
+    Given a movie.toml with [style.variants.warm] suffix "Warm golden-hour grade."
+    And a scene with style_variant "warm"
+    When the prompt is composed
+    Then the prompt ends with "Warm golden-hour grade."
+
+  Scenario: Compose prompt with scene style_suffix
+    Given a movie.toml with [style] suffix "Photorealistic."
+    And a scene with style_suffix "sunset light"
+    When the prompt is composed
+    Then the prompt contains "Photorealistic."
+    And the prompt contains "sunset light"
+
+  Scenario: Style none opts out
+    Given a movie.toml with [style] suffix "Cinematic."
+    And a scene with style_variant "none"
+    When the prompt is composed
+    Then the prompt does not contain "Cinematic."
+
+  Scenario: Unknown style variant raises error
+    Given a movie.toml with no variants defined
+    And a scene with style_variant "nonexistent"
+    When the manifest is parsed
+    Then a ConfigurationError is raised
+
+  Scenario: Prompt hash changes when style suffix changes
+    Given a completed scene with prompt hash "abc123"
+    And the style suffix is changed from "A" to "B"
+    When the resume check runs
+    Then the scene is marked for re-run
+```
+
+## Known-issues cross-reference
+
+No existing KNOWN_ISSUES entries are affected by this feature.

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -68,6 +68,10 @@ output_dir = "./out/my-movie"  # optional
 look = "cinematic, shallow depth of field"
 palette = "warm golden tones"
 negative = "no text, no watermark"
+suffix = "Black and white cinematic street photography, photorealistic, film grain."
+
+  [style.variants.warm]
+  suffix = "Warm golden-hour cinematic grade."
 
 [[characters]]
 name = "Alice"
@@ -89,6 +93,7 @@ id = "arrival"
 action = "walks through a busy futuristic plaza, looking around with wonder"
 framing = "wide"
 characters = ["Alice"]
+style_variant = "warm"  # select [style.variants.warm]; omit for base style
 aspect = "16:9"
 duration = 8
 
@@ -99,6 +104,7 @@ framing = "close-up"
 characters = ["Alice"]
 speaker = "Alice"
 line = "We made it!"
+style_suffix = "golden hour light"  # appended after the variant/base suffix
 aspect = "16:9"
 duration = 6
 model = "veo-quality"

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -35,7 +35,14 @@ from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile, run_wit
 from gflow_cli.api.character import CharacterImageRequest
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.video import Aspect, GenerateVideoRequest, Mode, VideoModel, VideoStarted
-from gflow_cli.composition import Character, Scene, build_handoff, compose_prompt
+from gflow_cli.composition import (
+    Character,
+    Scene,
+    StyleSpec,
+    build_handoff,
+    compose_prompt,
+    resume_hash,
+)
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import ConfigurationError, DataStoreError, WireFormatError
@@ -263,15 +270,33 @@ def _print_header(manifest: MovieManifest, *, out_dir: Path, dry_run: bool) -> N
     console.print(f"  characters: {len(manifest.characters)}  scenes: {len(manifest.scenes)}")
 
 
-def _format_scene_line(s: Scene, done: bool, cost: int) -> str:
+def _style_tag(s: Scene, style: StyleSpec) -> str:
+    """Return the resolved-style fragment for the plan line, or ''."""
+    bits: list[str] = []
+    if s.style_variant:
+        bits.append(f"style={s.style_variant}")
+    elif style.suffix:
+        bits.append("style=base")
+    if s.style_suffix:
+        bits.append("+style_suffix")
+    return ("  " + " ".join(bits)) if bits else ""
+
+
+def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, cost: int) -> str:
     """Return the single-line plan summary for one scene."""
     mode = "r2v" if s.characters else "t2v"
     refs = f"  refs=[{', '.join(s.characters)}]" if s.characters else ""
     framing_tag = f"  {s.framing}" if s.framing else ""
     model_tag = f"  {s.model}" if s.model else ""
     dur_tag = f"  {s.duration}s" if s.duration else ""
-    status = "[dim]skip (done)[/dim]" if done else f"{cost} credit(s)"
-    return f"    [{mode}] {s.id!r}{framing_tag}{model_tag}{dur_tag}{refs}  {status}"
+    if done:
+        status = "[dim]skip (done)[/dim]"
+    elif stale:
+        status = f"re-run (style changed)  {cost} credit(s)"
+    else:
+        status = f"{cost} credit(s)"
+    style_tag = _style_tag(s, style)
+    return f"    [{mode}] {s.id!r}{framing_tag}{model_tag}{dur_tag}{refs}{style_tag}  {status}"
 
 
 def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
@@ -290,10 +315,14 @@ def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
     scene_credits = 0
     for s in manifest.scenes:
         done_state = state.scenes.get(s.id)
-        done = done_state is not None and done_state.status == "completed"
+        done = False
+        stale = False
+        if done_state is not None and done_state.status == "completed":
+            stale = done_state.is_stale_for(compose_prompt(manifest.style, s, manifest.characters))
+            done = not stale
         cost = 0 if done else 1
         scene_credits += cost
-        console.print(_format_scene_line(s, done, cost))
+        console.print(_format_scene_line(s, manifest.style, done=done, stale=stale, cost=cost))
 
     console.print(f"\n  Estimated credits: ~{scene_credits}")
 
@@ -370,6 +399,7 @@ async def _run_one_scene(
             status="completed",
             prompt=prompt,
             consistency_method="entity" if reference_entities else "text",
+            style_hash=resume_hash(prompt),
         )
         state.save(state_path)
         console.print(f"    saved: {video_result.local_path}")
@@ -396,6 +426,7 @@ async def _run_one_scene(
             status="failed",
             prompt=prompt,
             consistency_method=failed_method,
+            style_hash=resume_hash(prompt),
         )
         state.save(state_path)
         if continue_on_error:
@@ -474,11 +505,20 @@ async def _run_movie(
             for scene in manifest.scenes:
                 scene_state = state.scenes.get(scene.id)
                 if scene_state is not None and scene_state.status == "completed":
-                    console.print(f"  [dim]Scene {scene.id!r} — already generated, skipping.[/dim]")
-                    if scene_state.local_path:
-                        completed_local_paths.append(Path(scene_state.local_path))
-                    generated_any = True
-                    continue
+                    prompt_now = compose_prompt(manifest.style, scene, manifest.characters)
+                    if scene_state.is_stale_for(prompt_now):
+                        console.print(
+                            f"  Scene {scene.id!r} — prompt/style changed since last "
+                            "run; regenerating."
+                        )
+                    else:
+                        console.print(
+                            f"  [dim]Scene {scene.id!r} — already generated, skipping.[/dim]"
+                        )
+                        if scene_state.local_path:
+                            completed_local_paths.append(Path(scene_state.local_path))
+                        generated_any = True
+                        continue
 
                 console.print(f"\n  Generating scene [bold]{scene.id!r}[/bold]…")
                 local_path = await _run_one_scene(

--- a/src/gflow_cli/composition.py
+++ b/src/gflow_cli/composition.py
@@ -36,10 +36,17 @@ class StyleSpec:
     variants: Mapping[str, str] = field(default_factory=dict[str, str])
 
     def resolve_suffix(self, variant_name: str | None) -> str | None:
-        """Return the variant suffix if *variant_name* is given, else base suffix."""
-        if variant_name is not None:
-            return self.variants.get(variant_name)
-        return self.suffix
+        """Return the named variant's suffix, or the base suffix when ``None``.
+
+        Raises ValueError on an unknown variant name (mirrors
+        ``Character.resolve_variant``).
+        """
+        if variant_name is None:
+            return self.suffix
+        if variant_name not in self.variants:
+            msg = f"unknown style variant {variant_name!r}"
+            raise ValueError(msg)
+        return self.variants[variant_name]
 
 
 @dataclass(frozen=True)
@@ -181,19 +188,18 @@ def _framing_camera_block(scene: Scene, style: StyleSpec) -> str:
     return _sentence(framing_cam) if framing_cam else ""
 
 
-def _resolve_style_suffix(style: StyleSpec, scene: Scene) -> str | None:
+def resolve_style_suffix(style: StyleSpec, scene: Scene) -> str | None:
     """Resolve the effective style suffix for a scene.
 
     ``scene.style_variant = "none"`` → opt out of base and variant suffixes
-    (``scene.style_suffix`` is independent and still applied).
-    ``scene.style_variant = "<name>"`` → variant suffix.
-    Otherwise → base ``style.suffix``.
+    (``scene.style_suffix`` is independent and still applied); the manifest
+    parser rejects a variant literally named "none" so the sentinel cannot
+    shadow a real variant. Otherwise defer to :meth:`StyleSpec.resolve_suffix`
+    (variant suffix, or base ``style.suffix`` when no variant is set).
     """
     if scene.style_variant == "none":
         return None
-    if scene.style_variant is not None:
-        return style.resolve_suffix(scene.style_variant)
-    return style.suffix
+    return style.resolve_suffix(scene.style_variant)
 
 
 def compose_prompt(
@@ -209,6 +215,10 @@ def compose_prompt(
     global+scene.  ``prefix`` / ``suffix`` wrap the entire output.
     """
     parts: list[str] = []
+
+    # 0. PREFIX (raw — wraps the entire prompt)
+    if style.prefix:
+        parts.append(style.prefix)
 
     # 1. ACTION (required)
     parts.append(_sentence(scene.action))
@@ -254,26 +264,25 @@ def compose_prompt(
     if negs:
         parts.append(f"Avoid: {', '.join(negs)}.")
 
-    composed = " ".join(p for p in parts if p)
-
-    # 11. SUFFIX (variant or base)
-    suffix = _resolve_style_suffix(style, scene)
+    # 11. SUFFIX (variant or base — raw)
+    suffix = resolve_style_suffix(style, scene)
     if suffix:
-        composed = f"{composed} {suffix}" if composed else suffix
+        parts.append(suffix)
 
-    # 12. SCENE STYLE_SUFFIX
+    # 12. SCENE STYLE_SUFFIX (raw, always last)
     if scene.style_suffix:
-        composed = f"{composed} {scene.style_suffix}" if composed else scene.style_suffix
+        parts.append(scene.style_suffix)
 
-    # 13. PREFIX (prepended last so it's always first in output)
-    if style.prefix:
-        composed = f"{style.prefix} {composed}" if composed else style.prefix
-
-    return composed
+    return " ".join(p for p in parts if p)
 
 
 def resume_hash(prompt: str) -> str:
-    """Return SHA-256 hex digest of *prompt* for resume change detection."""
+    """Return the full SHA-256 hex digest of *prompt* for resume change detection.
+
+    Same digest as ``gflow_cli.data.redaction.prompt_fields`` computes for
+    observability; duplicated here because this module deliberately imports
+    nothing from the rest of the package (pure seam).
+    """
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
 
@@ -314,17 +323,18 @@ def _build_handoff_clip(
         stored = getattr(ss, "prompt", None) if ss else None
         prompt_val = stored or compose_prompt(manifest.style, scene, manifest.characters)
 
-    # Style applied — the resolved variant + suffix for this clip.
-    style_applied: dict[str, Any] = {}
-    variant_name = scene.style_variant
-    resolved_suffix = _resolve_style_suffix(manifest.style, scene)
-    scene_suffix = scene.style_suffix
-    if variant_name is not None or resolved_suffix or scene_suffix:
-        style_applied = {
-            "variant": variant_name,
-            "suffix": resolved_suffix,
-            "scene_suffix": scene_suffix,
-        }
+    # Style applied — the styling baked into this clip's prompt. Resolved from
+    # the current manifest; the resume check in cli_movie regenerates a scene
+    # whenever its composed prompt changes, so this stays consistent with the
+    # stored prompt for every clip that survives a run.
+    style_applied: dict[str, Any] = {
+        "variant": scene.style_variant,
+        "prefix": manifest.style.prefix,
+        "suffix": resolve_style_suffix(manifest.style, scene),
+        "scene_suffix": scene.style_suffix,
+    }
+    if all(v is None for v in style_applied.values()):
+        style_applied = {}
 
     return {
         "id": scene.id,

--- a/src/gflow_cli/composition.py
+++ b/src/gflow_cli/composition.py
@@ -184,7 +184,8 @@ def _framing_camera_block(scene: Scene, style: StyleSpec) -> str:
 def _resolve_style_suffix(style: StyleSpec, scene: Scene) -> str | None:
     """Resolve the effective style suffix for a scene.
 
-    ``scene.style_variant = "none"`` → opt out (no suffix at all).
+    ``scene.style_variant = "none"`` → opt out of base and variant suffixes
+    (``scene.style_suffix`` is independent and still applied).
     ``scene.style_variant = "<name>"`` → variant suffix.
     Otherwise → base ``style.suffix``.
     """
@@ -271,7 +272,7 @@ def compose_prompt(
     return composed
 
 
-def prompt_hash(prompt: str) -> str:
+def resume_hash(prompt: str) -> str:
     """Return SHA-256 hex digest of *prompt* for resume change detection."""
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
@@ -315,9 +316,9 @@ def _build_handoff_clip(
 
     # Style applied — the resolved variant + suffix for this clip.
     style_applied: dict[str, Any] = {}
-    variant_name = getattr(scene, "style_variant", None)
+    variant_name = scene.style_variant
     resolved_suffix = _resolve_style_suffix(manifest.style, scene)
-    scene_suffix = getattr(scene, "style_suffix", None)
+    scene_suffix = scene.style_suffix
     if variant_name is not None or resolved_suffix or scene_suffix:
         style_applied = {
             "variant": variant_name,

--- a/src/gflow_cli/composition.py
+++ b/src/gflow_cli/composition.py
@@ -8,6 +8,7 @@ the reusable seam a future second consumer (e.g. remotion) can import.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,7 +17,12 @@ from typing import Any, cast
 
 @dataclass(frozen=True)
 class StyleSpec:
-    """Global guiding prompt — every field optional, reused verbatim per scene."""
+    """Global guiding prompt — every field optional, reused verbatim per scene.
+
+    ``prefix`` / ``suffix`` are raw strings prepended / appended to the composed
+    prompt.  ``variants`` is a name → suffix mapping that lets a manifest express
+    a style arc (e.g. monochrome → warm) without repeating text in every scene.
+    """
 
     look: str | None = None
     palette: str | None = None
@@ -25,6 +31,15 @@ class StyleSpec:
     lighting: str | None = None
     mood: str | None = None
     negative: str | None = None
+    prefix: str | None = None
+    suffix: str | None = None
+    variants: Mapping[str, str] = field(default_factory=dict[str, str])
+
+    def resolve_suffix(self, variant_name: str | None) -> str | None:
+        """Return the variant suffix if *variant_name* is given, else base suffix."""
+        if variant_name is not None:
+            return self.variants.get(variant_name)
+        return self.suffix
 
 
 @dataclass(frozen=True)
@@ -100,6 +115,8 @@ class Scene:
     model: str | None = None
     aspect: str = "16:9"
     count: int = 1
+    style_variant: str | None = None
+    style_suffix: str | None = None
 
 
 def _sentence(text: str) -> str:
@@ -164,6 +181,20 @@ def _framing_camera_block(scene: Scene, style: StyleSpec) -> str:
     return _sentence(framing_cam) if framing_cam else ""
 
 
+def _resolve_style_suffix(style: StyleSpec, scene: Scene) -> str | None:
+    """Resolve the effective style suffix for a scene.
+
+    ``scene.style_variant = "none"`` → opt out (no suffix at all).
+    ``scene.style_variant = "<name>"`` → variant suffix.
+    Otherwise → base ``style.suffix``.
+    """
+    if scene.style_variant == "none":
+        return None
+    if scene.style_variant is not None:
+        return style.resolve_suffix(scene.style_variant)
+    return style.suffix
+
+
 def compose_prompt(
     style: StyleSpec,
     scene: Scene,
@@ -171,9 +202,10 @@ def compose_prompt(
 ) -> str:
     """Assemble the final Veo prompt deterministically (canonical order).
 
-    Order: action, subject(+variant), setting, look, palette, lighting,
-    framing+camera, mood, dialogue, negative. Each slot: scene override ->
-    global -> omit. `negative` MERGES global+scene.
+    Order: [prefix] + action + subject(+variant) + setting + look + palette +
+    lighting + framing+camera + mood + dialogue + negative + [suffix].
+    Each slot: scene override -> global -> omit.  ``negative`` MERGES
+    global+scene.  ``prefix`` / ``suffix`` wrap the entire output.
     """
     parts: list[str] = []
 
@@ -221,7 +253,27 @@ def compose_prompt(
     if negs:
         parts.append(f"Avoid: {', '.join(negs)}.")
 
-    return " ".join(p for p in parts if p)
+    composed = " ".join(p for p in parts if p)
+
+    # 11. SUFFIX (variant or base)
+    suffix = _resolve_style_suffix(style, scene)
+    if suffix:
+        composed = f"{composed} {suffix}" if composed else suffix
+
+    # 12. SCENE STYLE_SUFFIX
+    if scene.style_suffix:
+        composed = f"{composed} {scene.style_suffix}" if composed else scene.style_suffix
+
+    # 13. PREFIX (prepended last so it's always first in output)
+    if style.prefix:
+        composed = f"{style.prefix} {composed}" if composed else style.prefix
+
+    return composed
+
+
+def prompt_hash(prompt: str) -> str:
+    """Return SHA-256 hex digest of *prompt* for resume change detection."""
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
 
 def _build_handoff_characters(manifest: Any, state: Any) -> list[dict[str, Any]]:
@@ -261,6 +313,18 @@ def _build_handoff_clip(
         stored = getattr(ss, "prompt", None) if ss else None
         prompt_val = stored or compose_prompt(manifest.style, scene, manifest.characters)
 
+    # Style applied — the resolved variant + suffix for this clip.
+    style_applied: dict[str, Any] = {}
+    variant_name = getattr(scene, "style_variant", None)
+    resolved_suffix = _resolve_style_suffix(manifest.style, scene)
+    scene_suffix = getattr(scene, "style_suffix", None)
+    if variant_name is not None or resolved_suffix or scene_suffix:
+        style_applied = {
+            "variant": variant_name,
+            "suffix": resolved_suffix,
+            "scene_suffix": scene_suffix,
+        }
+
     return {
         "id": scene.id,
         "index": index,
@@ -274,6 +338,7 @@ def _build_handoff_clip(
         ],
         "prompt": prompt_val,
         "status": status,
+        "style_applied": style_applied,
         "x_gflow": {
             k: v
             for k, v in (

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -94,7 +94,7 @@ class MovieManifest:
         schema_version = _require_int(data, "schema_version", default=1)
         style = _parse_style(data.get("style"))
         characters = _parse_characters(data)
-        scenes = _parse_scenes(data, characters)
+        scenes = _parse_scenes(data, characters, style)
         continuity = _parse_continuity(data)
         assemble = _parse_assemble(data)
 
@@ -155,7 +155,11 @@ def _parse_characters(data: dict[str, object]) -> dict[str, Character]:
     return characters
 
 
-def _parse_scenes(data: dict[str, object], characters: dict[str, Character]) -> tuple[Scene, ...]:
+def _parse_scenes(
+    data: dict[str, object],
+    characters: dict[str, Character],
+    style: StyleSpec,
+) -> tuple[Scene, ...]:
     """Parse scenes from data."""
     scenes_raw = data.get("scenes", [])
     if not isinstance(scenes_raw, list):
@@ -164,7 +168,11 @@ def _parse_scenes(data: dict[str, object], characters: dict[str, Character]) -> 
         raise ConfigurationError("At least one [[scenes]] entry is required.")
     scenes_list = cast(_TomlList, scenes_raw)
     char_names = set(characters)
-    scenes = tuple(_parse_scene(s, i, char_names, characters) for i, s in enumerate(scenes_list))
+    style_variant_names = set(style.variants)
+    scenes = tuple(
+        _parse_scene(s, i, char_names, characters, style_variant_names)
+        for i, s in enumerate(scenes_list)
+    )
     scene_ids: set[str] = set()
     for s in scenes:
         if s.id in scene_ids:
@@ -409,6 +417,7 @@ def _parse_scene(
     idx: int,
     char_names: set[str],
     characters: dict[str, Character],
+    style_variant_names: set[str],
 ) -> Scene:
     if not isinstance(data, dict):
         raise ConfigurationError(f"scenes[{idx}] must be a TOML table.")
@@ -451,6 +460,16 @@ def _parse_scene(
     if style_variant_raw is not None and not isinstance(style_variant_raw, str):
         raise ConfigurationError(f"scenes[{idx}].style_variant must be a string.")
     style_variant = str(style_variant_raw).strip() if isinstance(style_variant_raw, str) else None
+
+    if (
+        style_variant is not None
+        and style_variant != "none"
+        and style_variant not in style_variant_names
+    ):
+        raise ConfigurationError(
+            f"scenes[{idx}].style_variant {style_variant!r} is not a defined "
+            f"style variant (defined: {sorted(style_variant_names)!r})."
+        )
 
     style_suffix_raw = d.get("style_suffix")
     if style_suffix_raw is not None and not isinstance(style_suffix_raw, str):

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -19,7 +19,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
-from gflow_cli.composition import FRAMING, Character, DialogueLine, Scene, StyleSpec
+from gflow_cli.composition import (
+    FRAMING,
+    Character,
+    DialogueLine,
+    Scene,
+    StyleSpec,
+    resume_hash,
+)
 from gflow_cli.errors import ConfigurationError
 
 __all__ = [
@@ -244,15 +251,22 @@ def _parse_style_variants(d: _TomlObj) -> dict[str, str]:
     if not isinstance(variants_raw, dict):
         raise ConfigurationError("[style.variants] must be a TOML table.")
     variants: dict[str, str] = {}
-    for name, val in cast(_TomlObj, variants_raw).items():
+    for raw_name, val in cast(_TomlObj, variants_raw).items():
+        name = str(raw_name).strip()
+        if not name:
+            raise ConfigurationError("[style.variants] names must be non-empty.")
+        if name == "none":
+            raise ConfigurationError(
+                '[style.variants.none] is not allowed: "none" is reserved for '
+                "scenes[].style_variant to opt out of the style suffix."
+            )
         if not isinstance(val, dict):
             raise ConfigurationError(f"[style.variants.{name}] must be a TOML table.")
         variant_d = cast(_TomlObj, val)
         suffix_val = variant_d.get("suffix")
-        if suffix_val is not None and not isinstance(suffix_val, str):
+        if not isinstance(suffix_val, str):
             raise ConfigurationError(f"style.variants.{name}.suffix must be a string.")
-        if isinstance(suffix_val, str):
-            variants[str(name)] = suffix_val.strip()
+        variants[name] = suffix_val.strip()
     return variants
 
 
@@ -269,6 +283,14 @@ def _character_opt_str(d: _TomlObj, key: str, idx: int) -> str | None:
     v = d.get(key)
     if v is not None and not isinstance(v, str):
         raise ConfigurationError(f"characters[{idx}].{key} must be a string.")
+    return v.strip() if isinstance(v, str) else None
+
+
+def _scene_opt_str(d: _TomlObj, key: str, idx: int) -> str | None:
+    """Read an optional string field from a scene dict; raise on wrong type."""
+    v = d.get(key)
+    if v is not None and not isinstance(v, str):
+        raise ConfigurationError(f"scenes[{idx}].{key} must be a string.")
     return v.strip() if isinstance(v, str) else None
 
 
@@ -456,11 +478,7 @@ def _parse_scene(
         v = d.get(key)
         return v.strip() if isinstance(v, str) else None
 
-    style_variant_raw = d.get("style_variant")
-    if style_variant_raw is not None and not isinstance(style_variant_raw, str):
-        raise ConfigurationError(f"scenes[{idx}].style_variant must be a string.")
-    style_variant = str(style_variant_raw).strip() if isinstance(style_variant_raw, str) else None
-
+    style_variant = _scene_opt_str(d, "style_variant", idx)
     if (
         style_variant is not None
         and style_variant != "none"
@@ -471,10 +489,7 @@ def _parse_scene(
             f"style variant (defined: {sorted(style_variant_names)!r})."
         )
 
-    style_suffix_raw = d.get("style_suffix")
-    if style_suffix_raw is not None and not isinstance(style_suffix_raw, str):
-        raise ConfigurationError(f"scenes[{idx}].style_suffix must be a string.")
-    style_suffix = str(style_suffix_raw).strip() if isinstance(style_suffix_raw, str) else None
+    style_suffix = _scene_opt_str(d, "style_suffix", idx)
 
     return Scene(
         id=sid.strip(),
@@ -538,6 +553,19 @@ class SceneState:
     prompt: str | None = None  # composed Veo prompt (for handoff projection)
     consistency_method: str = "text"  # "text" | "entity" | "degraded" (P2)
     style_hash: str | None = None  # SHA-256 of composed prompt for resume detection
+
+    def is_stale_for(self, prompt: str) -> bool:
+        """True when *prompt* no longer matches what this scene was generated with.
+
+        Prefers the persisted ``style_hash``; falls back to comparing the stored
+        prompt text (state files written before ``style_hash`` existed). With
+        neither record, assume not stale — never re-spend credits on a guess.
+        """
+        if self.style_hash is not None:
+            return self.style_hash != resume_hash(prompt)
+        if self.prompt is not None:
+            return self.prompt != prompt
+        return False
 
     def to_dict(self) -> dict[str, object]:
         return {

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -212,6 +212,8 @@ def _parse_style(data: object) -> StyleSpec:
             raise ConfigurationError(f"style.{key} must be a string.")
         return v.strip() if isinstance(v, str) else None
 
+    variants = _parse_style_variants(d)
+
     return StyleSpec(
         look=s("look"),
         palette=s("palette"),
@@ -220,7 +222,30 @@ def _parse_style(data: object) -> StyleSpec:
         lighting=s("lighting"),
         mood=s("mood"),
         negative=s("negative"),
+        prefix=s("prefix"),
+        suffix=s("suffix"),
+        variants=variants,
     )
+
+
+def _parse_style_variants(d: _TomlObj) -> dict[str, str]:
+    """Parse [style.variants.*] sub-tables into a name → suffix mapping."""
+    variants_raw = d.get("variants")
+    if variants_raw is None:
+        return {}
+    if not isinstance(variants_raw, dict):
+        raise ConfigurationError("[style.variants] must be a TOML table.")
+    variants: dict[str, str] = {}
+    for name, val in cast(_TomlObj, variants_raw).items():
+        if not isinstance(val, dict):
+            raise ConfigurationError(f"[style.variants.{name}] must be a TOML table.")
+        variant_d = cast(_TomlObj, val)
+        suffix_val = variant_d.get("suffix")
+        if suffix_val is not None and not isinstance(suffix_val, str):
+            raise ConfigurationError(f"style.variants.{name}.suffix must be a string.")
+        if isinstance(suffix_val, str):
+            variants[str(name)] = suffix_val.strip()
+    return variants
 
 
 def _parse_character_variants(d: _TomlObj, idx: int) -> dict[str, str]:
@@ -422,6 +447,16 @@ def _parse_scene(
         v = d.get(key)
         return v.strip() if isinstance(v, str) else None
 
+    style_variant_raw = d.get("style_variant")
+    if style_variant_raw is not None and not isinstance(style_variant_raw, str):
+        raise ConfigurationError(f"scenes[{idx}].style_variant must be a string.")
+    style_variant = str(style_variant_raw).strip() if isinstance(style_variant_raw, str) else None
+
+    style_suffix_raw = d.get("style_suffix")
+    if style_suffix_raw is not None and not isinstance(style_suffix_raw, str):
+        raise ConfigurationError(f"scenes[{idx}].style_suffix must be a string.")
+    style_suffix = str(style_suffix_raw).strip() if isinstance(style_suffix_raw, str) else None
+
     return Scene(
         id=sid.strip(),
         action=action.strip(),
@@ -439,6 +474,8 @@ def _parse_scene(
         model=model if isinstance(model, str) else None,
         aspect=aspect,
         count=1,
+        style_variant=style_variant,
+        style_suffix=style_suffix,
     )
 
 
@@ -481,6 +518,7 @@ class SceneState:
     status: str  # "completed" | "failed"
     prompt: str | None = None  # composed Veo prompt (for handoff projection)
     consistency_method: str = "text"  # "text" | "entity" | "degraded" (P2)
+    style_hash: str | None = None  # SHA-256 of composed prompt for resume detection
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -490,6 +528,7 @@ class SceneState:
             "status": self.status,
             "prompt": self.prompt,
             "consistency_method": self.consistency_method,
+            "style_hash": self.style_hash,
         }
 
     @classmethod
@@ -498,6 +537,7 @@ class SceneState:
         raw_path = d.get("local_path")
         raw_prompt = d.get("prompt")
         raw_method = d.get("consistency_method", "text")
+        raw_hash = d.get("style_hash")
         return cls(
             media_id=str(d.get("media_id") or ""),
             flow_operation_id=str(raw_op_id) if isinstance(raw_op_id, str) else None,
@@ -505,6 +545,7 @@ class SceneState:
             status=str(d.get("status") or "completed"),
             prompt=str(raw_prompt) if isinstance(raw_prompt, str) else None,
             consistency_method=str(raw_method) if isinstance(raw_method, str) else "text",
+            style_hash=str(raw_hash) if isinstance(raw_hash, str) else None,
         )
 
 

--- a/tests/cli/test_movie_manifest_style_variants.py
+++ b/tests/cli/test_movie_manifest_style_variants.py
@@ -1,0 +1,366 @@
+"""Tests for movie.toml parsing of [style.variants.*] and per-scene style fields (Issue #239)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.errors import ConfigurationError
+from gflow_cli.movie_manifest import MovieManifest
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "movie.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# [style] prefix / suffix
+# ---------------------------------------------------------------------------
+
+
+class TestStylePrefixSuffix:
+    def test_prefix_and_suffix_parse(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+
+[style]
+prefix = "SCENE 1:"
+suffix = "Cinematic, photorealistic."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.prefix == "SCENE 1:"
+        assert m.style.suffix == "Cinematic, photorealistic."
+
+    def test_prefix_and_suffix_default_to_none(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+look = "ink"
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.prefix is None
+        assert m.style.suffix is None
+
+
+# ---------------------------------------------------------------------------
+# [style.variants.*]
+# ---------------------------------------------------------------------------
+
+
+class TestStyleVariants:
+    def test_variants_parse(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+
+[style]
+suffix = "Base."
+
+[style.variants.warm]
+suffix = "Warm golden-hour grade."
+
+[style.variants.cool]
+suffix = "Cool blue grade."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.variants == {"warm": "Warm golden-hour grade.", "cool": "Cool blue grade."}
+
+    def test_empty_variants_table(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+suffix = "Base."
+[style.variants]
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.variants == {}
+
+    def test_variant_with_empty_suffix(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+suffix = "Base."
+[style.variants.minimal]
+suffix = ""
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.variants.get("minimal") == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-scene style_variant / style_suffix
+# ---------------------------------------------------------------------------
+
+
+class TestSceneStyleFields:
+    def test_style_variant_parses(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+suffix = "Base."
+[style.variants.warm]
+suffix = "Warm."
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "warm"
+""",
+            )
+        )
+        assert m.scenes[0].style_variant == "warm"
+
+    def test_style_suffix_parses(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[[scenes]]
+id = "s1"
+action = "walks"
+style_suffix = "sunset light"
+""",
+            )
+        )
+        assert m.scenes[0].style_suffix == "sunset light"
+
+    def test_style_variant_none_parses(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+suffix = "Cinematic."
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "none"
+""",
+            )
+        )
+        assert m.scenes[0].style_variant == "none"
+
+    def test_style_fields_default_to_none(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.scenes[0].style_variant is None
+        assert m.scenes[0].style_suffix is None
+
+    def test_both_style_variant_and_style_suffix(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+suffix = "Base."
+[style.variants.warm]
+suffix = "Warm."
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "warm"
+style_suffix = "golden hour"
+""",
+            )
+        )
+        assert m.scenes[0].style_variant == "warm"
+        assert m.scenes[0].style_suffix == "golden hour"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestStyleValidation:
+    def test_invalid_prefix_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="style.prefix"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style]
+prefix = 42
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
+    def test_invalid_suffix_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="style.suffix"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style]
+suffix = true
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
+    def test_variant_suffix_non_string_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="variants.*suffix"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style.variants.warm]
+suffix = 123
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
+    def test_variant_not_table_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="variants.*table"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style.variants]
+warm = "not a table"
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
+    def test_invalid_style_variant_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="style_variant"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = 42
+""",
+                )
+            )
+
+    def test_invalid_style_suffix_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="style_suffix"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[[scenes]]
+id = "s1"
+action = "walks"
+style_suffix = true
+""",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_old_manifest_without_variants_still_works(self, tmp_path: Path) -> None:
+        m = MovieManifest.from_toml_path(
+            _write_toml(
+                tmp_path,
+                """
+title = "T"
+project = "p"
+[style]
+look = "ink"
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+            )
+        )
+        assert m.style.look == "ink"
+        assert m.style.prefix is None
+        assert m.style.suffix is None
+        assert m.style.variants == {}
+        assert m.scenes[0].style_variant is None
+        assert m.scenes[0].style_suffix is None

--- a/tests/cli/test_movie_manifest_style_variants.py
+++ b/tests/cli/test_movie_manifest_style_variants.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from gflow_cli.composition import resume_hash
 from gflow_cli.errors import ConfigurationError
-from gflow_cli.movie_manifest import MovieManifest
+from gflow_cli.movie_manifest import MovieManifest, SceneState
 
 
 def _write_toml(tmp_path: Path, content: str) -> Path:
@@ -336,6 +337,40 @@ style_suffix = true
                 )
             )
 
+    def test_variant_named_none_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="reserved"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style.variants.none]
+suffix = "Grainy archival look."
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
+    def test_variant_without_suffix_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="variants.warm.suffix"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style.variants.warm]
+lighting = "not a suffix"
+[[scenes]]
+id = "s1"
+action = "walks"
+""",
+                )
+            )
+
     def test_unknown_style_variant_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="style_variant.*wram"):
             MovieManifest.from_toml_path(
@@ -384,3 +419,37 @@ action = "walks"
         assert m.style.variants == {}
         assert m.scenes[0].style_variant is None
         assert m.scenes[0].style_suffix is None
+
+
+# ---------------------------------------------------------------------------
+# Resume staleness — SceneState.is_stale_for
+# ---------------------------------------------------------------------------
+
+
+def _completed_state(**kwargs: object) -> SceneState:
+    return SceneState(
+        media_id="m",
+        flow_operation_id="op",
+        local_path="/out/s1.mp4",
+        status="completed",
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+class TestSceneStateStaleness:
+    def test_matching_style_hash_is_not_stale(self) -> None:
+        ss = _completed_state(style_hash=resume_hash("Walks."))
+        assert not ss.is_stale_for("Walks.")
+
+    def test_changed_style_hash_is_stale(self) -> None:
+        ss = _completed_state(style_hash=resume_hash("Walks. Old suffix."))
+        assert ss.is_stale_for("Walks. New suffix.")
+
+    def test_no_hash_falls_back_to_stored_prompt(self) -> None:
+        ss = _completed_state(prompt="Walks. Old suffix.")
+        assert ss.is_stale_for("Walks. New suffix.")
+        assert not ss.is_stale_for("Walks. Old suffix.")
+
+    def test_no_hash_and_no_prompt_is_never_stale(self) -> None:
+        ss = _completed_state()
+        assert not ss.is_stale_for("Anything at all.")

--- a/tests/cli/test_movie_manifest_style_variants.py
+++ b/tests/cli/test_movie_manifest_style_variants.py
@@ -336,6 +336,26 @@ style_suffix = true
                 )
             )
 
+    def test_unknown_style_variant_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="style_variant.*wram"):
+            MovieManifest.from_toml_path(
+                _write_toml(
+                    tmp_path,
+                    """
+title = "T"
+project = "p"
+[style]
+suffix = "Base."
+[style.variants.warm]
+suffix = "Warm."
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "wram"
+""",
+                )
+            )
+
 
 # ---------------------------------------------------------------------------
 # Backward compatibility

--- a/tests/composition/test_style_variants.py
+++ b/tests/composition/test_style_variants.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 from gflow_cli.composition import (
     Character,
@@ -42,9 +43,10 @@ class TestStyleSpecExtensions:
         s = StyleSpec(suffix="Base suffix.")
         assert s.resolve_suffix(None) == "Base suffix."
 
-    def test_resolve_suffix_returns_none_for_unknown_variant(self) -> None:
+    def test_resolve_suffix_raises_for_unknown_variant(self) -> None:
         s = StyleSpec(variants={"warm": "X"})
-        assert s.resolve_suffix("nope") is None
+        with pytest.raises(ValueError, match="nope"):
+            s.resolve_suffix("nope")
 
     def test_resolve_suffix_returns_none_when_no_suffix(self) -> None:
         s = StyleSpec()
@@ -227,6 +229,25 @@ def test_handoff_style_applied_scene_suffix() -> None:
     clip = next(c for c in h["clips"] if c["id"] == "s4")
     assert clip["style_applied"]["scene_suffix"] == "golden hour"
     assert clip["style_applied"]["suffix"] == "Cinematic."
+
+
+def test_handoff_style_applied_records_prefix() -> None:
+    class _PrefixManifest:
+        title = "T"
+        project = "p"
+        style = StyleSpec(prefix="SCENE:")
+        characters: dict[str, Character] = {}
+        scenes = (Scene(id="s1", action="walks"),)
+
+    st = MovieState(title="T", project="p")
+    st.scenes["s1"] = SceneState(
+        media_id="m", flow_operation_id="op", local_path="/out/s1.mp4", status="completed"
+    )
+    h = build_handoff(_PrefixManifest(), st, out_dir=Path("/out"))
+    applied = h["clips"][0]["style_applied"]
+    assert applied["prefix"] == "SCENE:"
+    assert applied["variant"] is None
+    assert applied["suffix"] is None
 
 
 def test_handoff_validates_against_schema() -> None:

--- a/tests/composition/test_style_variants.py
+++ b/tests/composition/test_style_variants.py
@@ -1,0 +1,244 @@
+"""Tests for style variant composition, resolution, and handoff (Issue #239)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from gflow_cli.composition import (
+    Character,
+    Scene,
+    StyleSpec,
+    build_handoff,
+    compose_prompt,
+    prompt_hash,
+)
+from gflow_cli.movie_manifest import MovieState, SceneState
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "schemas" / "movie-handoff.schema.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# StyleSpec extensions
+# ---------------------------------------------------------------------------
+
+
+class TestStyleSpecExtensions:
+    def test_prefix_and_suffix_fields(self) -> None:
+        s = StyleSpec(prefix="PRE:", suffix="SUF.")
+        assert s.prefix == "PRE:"
+        assert s.suffix == "SUF."
+
+    def test_variants_mapping(self) -> None:
+        s = StyleSpec(variants={"warm": "Warm grade.", "cool": "Cool grade."})
+        assert s.resolve_suffix("warm") == "Warm grade."
+        assert s.resolve_suffix("cool") == "Cool grade."
+
+    def test_resolve_suffix_returns_base_when_no_variant(self) -> None:
+        s = StyleSpec(suffix="Base suffix.")
+        assert s.resolve_suffix(None) == "Base suffix."
+
+    def test_resolve_suffix_returns_none_for_unknown_variant(self) -> None:
+        s = StyleSpec(variants={"warm": "X"})
+        assert s.resolve_suffix("nope") is None
+
+    def test_resolve_suffix_returns_none_when_no_suffix(self) -> None:
+        s = StyleSpec()
+        assert s.resolve_suffix(None) is None
+
+
+# ---------------------------------------------------------------------------
+# compose_prompt — prefix / suffix / variant
+# ---------------------------------------------------------------------------
+
+
+class TestComposePromptStyleVariants:
+    def test_suffix_appended(self) -> None:
+        style = StyleSpec(suffix="Cinematic, photorealistic.")
+        out = compose_prompt(style, Scene(id="s", action="walks"), {})
+        assert out.endswith("Cinematic, photorealistic.")
+        assert "Walks." in out
+
+    def test_prefix_prepended(self) -> None:
+        style = StyleSpec(prefix="SCENE 1:")
+        out = compose_prompt(style, Scene(id="s", action="walks"), {})
+        assert out.startswith("SCENE 1:")
+        assert "Walks." in out
+
+    def test_prefix_and_suffix_together(self) -> None:
+        style = StyleSpec(prefix="PRE:", suffix="SUF.")
+        out = compose_prompt(style, Scene(id="s", action="go"), {})
+        assert out == "PRE: Go. SUF."
+
+    def test_variant_suffix_replaces_base(self) -> None:
+        style = StyleSpec(suffix="Base.", variants={"warm": "Warm grade."})
+        scene = Scene(id="s", action="walks", style_variant="warm")
+        out = compose_prompt(style, scene, {})
+        assert "Warm grade." in out
+        assert "Base." not in out
+
+    def test_fallback_to_base_when_no_variant(self) -> None:
+        style = StyleSpec(suffix="Base.", variants={"warm": "Warm."})
+        scene = Scene(id="s", action="walks")
+        out = compose_prompt(style, scene, {})
+        assert "Base." in out
+
+    def test_style_none_skips_all_suffixes(self) -> None:
+        style = StyleSpec(suffix="Cinematic.", prefix="PRE:")
+        scene = Scene(id="s", action="walks", style_variant="none")
+        out = compose_prompt(style, scene, {})
+        assert "Cinematic." not in out
+        assert out.startswith("PRE:")
+        assert "Walks." in out
+
+    def test_scene_style_suffix_appended_last(self) -> None:
+        style = StyleSpec(suffix="Base.")
+        scene = Scene(id="s", action="walks", style_suffix="sunset light")
+        out = compose_prompt(style, scene, {})
+        assert out.endswith("sunset light")
+        assert "Base." in out
+
+    def test_prefix_composes_with_suffix_and_scene_suffix(self) -> None:
+        style = StyleSpec(prefix="P:", suffix="S.", variants={"w": "W."})
+        scene = Scene(id="s", action="go", style_variant="w", style_suffix="extra")
+        out = compose_prompt(style, scene, {})
+        assert out == "P: Go. W. extra"
+
+    def test_empty_action_with_prefix_only(self) -> None:
+        style = StyleSpec(prefix="SCENE:")
+        out = compose_prompt(style, Scene(id="s", action=""), {})
+        assert out == "SCENE:"
+
+
+# ---------------------------------------------------------------------------
+# prompt_hash
+# ---------------------------------------------------------------------------
+
+
+class TestPromptHash:
+    def test_hash_is_sha256_hex(self) -> None:
+        h = prompt_hash("hello")
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_same_input_same_hash(self) -> None:
+        assert prompt_hash("abc") == prompt_hash("abc")
+
+    def test_different_input_different_hash(self) -> None:
+        assert prompt_hash("abc") != prompt_hash("xyz")
+
+    def test_hash_changes_when_suffix_changes(self) -> None:
+        s1 = StyleSpec(suffix="A")
+        s2 = StyleSpec(suffix="B")
+        scene = Scene(id="s", action="walks")
+        h1 = prompt_hash(compose_prompt(s1, scene, {}))
+        h2 = prompt_hash(compose_prompt(s2, scene, {}))
+        assert h1 != h2
+
+    def test_hash_changes_when_prefix_changes(self) -> None:
+        s1 = StyleSpec(prefix="A")
+        s2 = StyleSpec(prefix="B")
+        scene = Scene(id="s", action="walks")
+        h1 = prompt_hash(compose_prompt(s1, scene, {}))
+        h2 = prompt_hash(compose_prompt(s2, scene, {}))
+        assert h1 != h2
+
+    def test_hash_changes_when_scene_suffix_changes(self) -> None:
+        s = StyleSpec(suffix="Base.")
+        s1 = Scene(id="s", action="walks", style_suffix="X")
+        s2 = Scene(id="s", action="walks", style_suffix="Y")
+        h1 = prompt_hash(compose_prompt(s, s1, {}))
+        h2 = prompt_hash(compose_prompt(s, s2, {}))
+        assert h1 != h2
+
+    def test_hash_changes_when_variant_changes(self) -> None:
+        s = StyleSpec(variants={"a": "A.", "b": "B."})
+        s1 = Scene(id="s", action="walks", style_variant="a")
+        s2 = Scene(id="s", action="walks", style_variant="b")
+        h1 = prompt_hash(compose_prompt(s, s1, {}))
+        h2 = prompt_hash(compose_prompt(s, s2, {}))
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# build_handoff — style_applied
+# ---------------------------------------------------------------------------
+
+
+class _FakeManifest:
+    title = "T"
+    project = "p"
+    style = StyleSpec(suffix="Cinematic.", variants={"warm": "Warm grade."})
+    characters: dict[str, Character] = {}
+    scenes = (
+        Scene(id="s1", action="walks", style_variant="warm"),
+        Scene(id="s2", action="runs"),
+        Scene(id="s3", action="jumps", style_variant="none"),
+        Scene(id="s4", action="flies", style_suffix="golden hour"),
+    )
+
+
+def _fake_state() -> MovieState:
+    st = MovieState(title="T", project="p")
+    for sid in ("s1", "s2", "s3", "s4"):
+        st.scenes[sid] = SceneState(
+            media_id=f"m-{sid}",
+            flow_operation_id=f"op-{sid}",
+            local_path=f"/out/{sid}.mp4",
+            status="completed",
+        )
+    return st
+
+
+def test_handoff_style_applied_variant() -> None:
+    h = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out"))
+    clip = next(c for c in h["clips"] if c["id"] == "s1")
+    assert clip["style_applied"]["variant"] == "warm"
+    assert clip["style_applied"]["suffix"] == "Warm grade."
+
+
+def test_handoff_style_applied_base_suffix() -> None:
+    h = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out"))
+    clip = next(c for c in h["clips"] if c["id"] == "s2")
+    assert clip["style_applied"]["variant"] is None
+    assert clip["style_applied"]["suffix"] == "Cinematic."
+
+
+def test_handoff_style_applied_none_variant() -> None:
+    h = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out"))
+    clip = next(c for c in h["clips"] if c["id"] == "s3")
+    assert clip["style_applied"]["variant"] == "none"
+    assert clip["style_applied"]["suffix"] is None
+
+
+def test_handoff_style_applied_scene_suffix() -> None:
+    h = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out"))
+    clip = next(c for c in h["clips"] if c["id"] == "s4")
+    assert clip["style_applied"]["scene_suffix"] == "golden hour"
+    assert clip["style_applied"]["suffix"] == "Cinematic."
+
+
+def test_handoff_validates_against_schema() -> None:
+    h = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out"))
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(h, schema)
+
+
+def test_handoff_empty_style_applied_when_no_style_fields() -> None:
+    class _PlainManifest:
+        title = "T"
+        project = "p"
+        style = StyleSpec()
+        characters: dict[str, Character] = {}
+        scenes = (Scene(id="s1", action="walks"),)
+
+    st = MovieState(title="T", project="p")
+    st.scenes["s1"] = SceneState(
+        media_id="m", flow_operation_id="op", local_path="/out/s1.mp4", status="completed"
+    )
+    h = build_handoff(_PlainManifest(), st, out_dir=Path("/out"))
+    assert h["clips"][0]["style_applied"] == {}

--- a/tests/composition/test_style_variants.py
+++ b/tests/composition/test_style_variants.py
@@ -13,7 +13,7 @@ from gflow_cli.composition import (
     StyleSpec,
     build_handoff,
     compose_prompt,
-    prompt_hash,
+    resume_hash,
 )
 from gflow_cli.movie_manifest import MovieState, SceneState
 
@@ -95,6 +95,13 @@ class TestComposePromptStyleVariants:
         assert out.startswith("PRE:")
         assert "Walks." in out
 
+    def test_style_none_with_scene_suffix_still_applies(self) -> None:
+        style = StyleSpec(suffix="Cinematic.")
+        scene = Scene(id="s", action="walks", style_variant="none", style_suffix="extra")
+        out = compose_prompt(style, scene, {})
+        assert "Cinematic." not in out
+        assert out.endswith("extra")
+
     def test_scene_style_suffix_appended_last(self) -> None:
         style = StyleSpec(suffix="Base.")
         scene = Scene(id="s", action="walks", style_suffix="sunset light")
@@ -121,46 +128,46 @@ class TestComposePromptStyleVariants:
 
 class TestPromptHash:
     def test_hash_is_sha256_hex(self) -> None:
-        h = prompt_hash("hello")
+        h = resume_hash("hello")
         assert len(h) == 64
         assert all(c in "0123456789abcdef" for c in h)
 
     def test_same_input_same_hash(self) -> None:
-        assert prompt_hash("abc") == prompt_hash("abc")
+        assert resume_hash("abc") == resume_hash("abc")
 
     def test_different_input_different_hash(self) -> None:
-        assert prompt_hash("abc") != prompt_hash("xyz")
+        assert resume_hash("abc") != resume_hash("xyz")
 
     def test_hash_changes_when_suffix_changes(self) -> None:
         s1 = StyleSpec(suffix="A")
         s2 = StyleSpec(suffix="B")
         scene = Scene(id="s", action="walks")
-        h1 = prompt_hash(compose_prompt(s1, scene, {}))
-        h2 = prompt_hash(compose_prompt(s2, scene, {}))
+        h1 = resume_hash(compose_prompt(s1, scene, {}))
+        h2 = resume_hash(compose_prompt(s2, scene, {}))
         assert h1 != h2
 
     def test_hash_changes_when_prefix_changes(self) -> None:
         s1 = StyleSpec(prefix="A")
         s2 = StyleSpec(prefix="B")
         scene = Scene(id="s", action="walks")
-        h1 = prompt_hash(compose_prompt(s1, scene, {}))
-        h2 = prompt_hash(compose_prompt(s2, scene, {}))
+        h1 = resume_hash(compose_prompt(s1, scene, {}))
+        h2 = resume_hash(compose_prompt(s2, scene, {}))
         assert h1 != h2
 
     def test_hash_changes_when_scene_suffix_changes(self) -> None:
         s = StyleSpec(suffix="Base.")
         s1 = Scene(id="s", action="walks", style_suffix="X")
         s2 = Scene(id="s", action="walks", style_suffix="Y")
-        h1 = prompt_hash(compose_prompt(s, s1, {}))
-        h2 = prompt_hash(compose_prompt(s, s2, {}))
+        h1 = resume_hash(compose_prompt(s, s1, {}))
+        h2 = resume_hash(compose_prompt(s, s2, {}))
         assert h1 != h2
 
     def test_hash_changes_when_variant_changes(self) -> None:
         s = StyleSpec(variants={"a": "A.", "b": "B."})
         s1 = Scene(id="s", action="walks", style_variant="a")
         s2 = Scene(id="s", action="walks", style_variant="b")
-        h1 = prompt_hash(compose_prompt(s, s1, {}))
-        h2 = prompt_hash(compose_prompt(s, s2, {}))
+        h1 = resume_hash(compose_prompt(s, s1, {}))
+        h2 = resume_hash(compose_prompt(s, s2, {}))
         assert h1 != h2
 
 

--- a/tests/composition/test_style_variants_e2e.py
+++ b/tests/composition/test_style_variants_e2e.py
@@ -1,0 +1,305 @@
+"""End-to-end integration tests for style variants (Issue #239).
+
+Exercises the full pipeline: TOML parse → MovieManifest → compose_prompt →
+resume_hash → build_handoff, verifying all pieces work together correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from gflow_cli.composition import (
+    build_handoff,
+    compose_prompt,
+    resume_hash,
+)
+from gflow_cli.movie_manifest import (
+    MovieManifest,
+    MovieState,
+    SceneState,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "schemas" / "movie-handoff.schema.json"
+)
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    p = tmp_path / "movie.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: TOML → manifest → compose → hash → handoff
+# ---------------------------------------------------------------------------
+
+
+class TestStyleVariantsE2E:
+    """End-to-end tests that parse a real TOML, compose prompts, hash them,
+    build a handoff, and validate the handoff against the JSON schema."""
+
+    def test_arc_manifest_parses_and_composes(self, tmp_path: Path) -> None:
+        """A monochrome-to-warm arc: 3 scenes with different style selections."""
+        toml = """\
+title = "Arc Test"
+project = "proj-arc"
+
+[style]
+suffix = "Black and white cinematic."
+
+[style.variants.warm]
+suffix = "Warm golden-hour grade."
+
+[style.variants.cool]
+suffix = "Cool blue grade."
+
+[[scenes]]
+id = "s1"
+action = "walks in the rain"
+style_variant = "cool"
+
+[[scenes]]
+id = "s2"
+action = "stands at a crossroads"
+
+[[scenes]]
+id = "s3"
+action = "smiles in sunlight"
+style_variant = "warm"
+style_suffix = "lens flare"
+"""
+        m = MovieManifest.from_toml_path(_write_toml(tmp_path, toml))
+
+        # Verify manifest parsed correctly
+        assert m.style.suffix == "Black and white cinematic."
+        assert m.style.variants == {"warm": "Warm golden-hour grade.", "cool": "Cool blue grade."}
+        assert len(m.scenes) == 3
+        assert m.scenes[0].style_variant == "cool"
+        assert m.scenes[1].style_variant is None
+        assert m.scenes[2].style_variant == "warm"
+        assert m.scenes[2].style_suffix == "lens flare"
+
+        # Compose prompts for each scene
+        prompts = [compose_prompt(m.style, s, m.characters) for s in m.scenes]
+
+        # s1: cool variant suffix
+        assert prompts[0].endswith("Cool blue grade.")
+        assert "Black and white" not in prompts[0]
+
+        # s2: base suffix (no variant)
+        assert prompts[1].endswith("Black and white cinematic.")
+
+        # s3: warm variant + scene suffix
+        assert prompts[2].endswith("Warm golden-hour grade. lens flare")
+        assert "Black and white" not in prompts[2]
+
+        # Hashes are all different (different styles)
+        hashes = [resume_hash(p) for p in prompts]
+        assert len(set(hashes)) == 3
+
+    def test_arc_handoff_records_style_applied(self, tmp_path: Path) -> None:
+        """Build handoff from the arc manifest; verify style_applied per clip."""
+        toml = """\
+title = "Arc"
+project = "p"
+
+[style]
+suffix = "Base."
+
+[style.variants.warm]
+suffix = "Warm."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "warm"
+
+[[scenes]]
+id = "s2"
+action = "runs"
+
+[[scenes]]
+id = "s3"
+action = "jumps"
+style_variant = "none"
+style_suffix = "sunset"
+"""
+        m = MovieManifest.from_toml_path(_write_toml(tmp_path, toml))
+
+        state = MovieState(title="Arc", project="p")
+        for sid in ("s1", "s2", "s3"):
+            state.scenes[sid] = SceneState(
+                media_id=f"m-{sid}",
+                flow_operation_id=f"op-{sid}",
+                local_path=f"/out/{sid}.mp4",
+                status="completed",
+            )
+
+        h = build_handoff(m, state, out_dir=Path("/out"))
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(h, schema)
+
+        clips = {c["id"]: c for c in h["clips"]}
+
+        # s1: warm variant
+        assert clips["s1"]["style_applied"]["variant"] == "warm"
+        assert clips["s1"]["style_applied"]["suffix"] == "Warm."
+
+        # s2: base suffix
+        assert clips["s2"]["style_applied"]["variant"] is None
+        assert clips["s2"]["style_applied"]["suffix"] == "Base."
+
+        # s3: none + scene suffix
+        assert clips["s3"]["style_applied"]["variant"] == "none"
+        assert clips["s3"]["style_applied"]["suffix"] is None
+        assert clips["s3"]["style_applied"]["scene_suffix"] == "sunset"
+
+    def test_resume_hash_detects_style_change(self, tmp_path: Path) -> None:
+        """Simulate: run with style A, change to style B, verify hash mismatch."""
+        base_toml = """\
+title = "T"
+project = "p"
+
+[style]
+suffix = "Original."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+"""
+        m1 = MovieManifest.from_toml_path(_write_toml(tmp_path, base_toml))
+        prompt1 = compose_prompt(m1.style, m1.scenes[0], m1.characters)
+        hash1 = resume_hash(prompt1)
+
+        # Simulate editing the suffix
+        changed_toml = """\
+title = "T"
+project = "p"
+
+[style]
+suffix = "Changed."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+"""
+        m2 = MovieManifest.from_toml_path(_write_toml(tmp_path / "v2", changed_toml))
+        prompt2 = compose_prompt(m2.style, m2.scenes[0], m2.characters)
+        hash2 = resume_hash(prompt2)
+
+        # Hashes differ → resume would re-run this scene
+        assert hash1 != hash2
+
+        # Same manifest → same hash (idempotent)
+        prompt1b = compose_prompt(m1.style, m1.scenes[0], m1.characters)
+        assert resume_hash(prompt1b) == hash1
+
+    def test_state_round_trip_with_style_hash(self, tmp_path: Path) -> None:
+        """SceneState with style_hash round-trips through save/load."""
+        from gflow_cli.movie_manifest import MovieState
+
+        state = MovieState(title="T", project="p")
+        state.scenes["s1"] = SceneState(
+            media_id="m1",
+            flow_operation_id="op1",
+            local_path="/out/s1.mp4",
+            status="completed",
+            style_hash="abc123def456",
+        )
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        loaded = MovieState.load(state_path, title="T", project="p")
+        assert loaded.scenes["s1"].style_hash == "abc123def456"
+
+    def test_style_variant_validation_rejects_unknown(self, tmp_path: Path) -> None:
+        """Unknown style_variant raises ConfigurationError with the name and defined set."""
+        from gflow_cli.errors import ConfigurationError
+
+        toml = """\
+title = "T"
+project = "p"
+
+[style]
+suffix = "Base."
+
+[style.variants.warm]
+suffix = "Warm."
+
+[[scenes]]
+id = "s1"
+action = "walks"
+style_variant = "typo_variant"
+"""
+        with pytest.raises(ConfigurationError, match="style_variant.*typo_variant"):
+            MovieManifest.from_toml_path(_write_toml(tmp_path, toml))
+
+    def test_full_manifest_with_characters_and_style(self, tmp_path: Path) -> None:
+        """Full manifest: characters + style variants + dialogue + style fields."""
+        toml = """\
+title = "Full"
+project = "p"
+
+[style]
+look = "cinematic"
+suffix = "Photorealistic."
+
+[style.variants.dream]
+suffix = "Dreamy soft-focus."
+
+[[characters]]
+name = "Alice"
+appearance = "red hair"
+voice = "alnilam"
+  [characters.variants]
+  formal = "wearing a suit"
+
+[[scenes]]
+id = "s1"
+action = "Alice walks"
+characters = ["Alice"]
+variant = "formal"
+style_variant = "dream"
+speaker = "Alice"
+line = "Hello world"
+aspect = "9:16"
+duration = 8
+
+[[scenes]]
+id = "s2"
+action = "Alice runs"
+characters = ["Alice"]
+style_suffix = "golden hour"
+"""
+        m = MovieManifest.from_toml_path(_write_toml(tmp_path, toml))
+
+        # Compose both scenes
+        p1 = compose_prompt(m.style, m.scenes[0], m.characters)
+        p2 = compose_prompt(m.style, m.scenes[1], m.characters)
+
+        # s1: character variant "formal" + style variant "dream"
+        assert "wearing a suit" in p1
+        assert p1.endswith("Dreamy soft-focus.")
+        assert "Photorealistic." not in p1
+
+        # s2: base style + scene suffix
+        assert p2.endswith("Photorealistic. golden hour")
+
+        # Handoff validates
+        state = MovieState(title="Full", project="p")
+        for sid in ("s1", "s2"):
+            state.scenes[sid] = SceneState(
+                media_id=f"m-{sid}",
+                flow_operation_id=f"op-{sid}",
+                local_path=f"/out/{sid}.mp4",
+                status="completed",
+            )
+        h = build_handoff(m, state, out_dir=Path("/out"))
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(h, schema)


### PR DESCRIPTION
## Summary

- Add [style] block with prefix/suffix and [style.variants.*] sub-tables to movie.toml so channel-format videos can express a visual style arc (e.g. monochrome to warm) once and select it per-scene
- Per-scene style_variant selects a named variant (or none to opt out); style_suffix adds scene-specific text
- Deterministic composition rule: prefix + composed_prompt + (variant.suffix | base.suffix) + scene_suffix
- Handoff manifest records style_applied per clip; prompt hash enables resume change detection
- Fully backward compatible - existing manifests without [style.variants] work unchanged

## Test plan

- [x] 44 new unit tests: composition, parsing, validation, handoff, prompt hash
- [x] All 120 affected tests pass (44 new + 76 existing)
- [x] ruff check + format clean
- [x] pyright strict clean
- [x] Handoff schema validated against movie-handoff.schema.json

## Files changed

| File | Change |
|---|---|
| src/gflow_cli/composition.py | StyleSpec (prefix/suffix/variants), Scene (style_variant/style_suffix), compose_prompt, prompt_hash, build_handoff |
| src/gflow_cli/movie_manifest.py | Parser (prefix/suffix/variants, style_variant/style_suffix), SceneState (style_hash) |
| docs/schemas/movie-handoff.schema.json | Added style_applied to clip schema |
| tests/composition/test_style_variants.py | 28 new tests |
| tests/cli/test_movie_manifest_style_variants.py | 16 new tests |
| docs/superpowers/plans/2026-07-07-style-variants/ | Plan + scenario docs |

Closes #239
