### PR TITLE
bugfix: address v0.27.0 release follow-ups

### DIFF
--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -101,8 +101,12 @@ Per-scene selection:
 | *(omitted)* | Uses the base `[style]` suffix. |
 | `style_suffix = "sunset light"` | Scene-specific text appended **after** the variant/base suffix. |
 
-`none` is a **reserved name**: defining `[style.variants.none]` is a
-configuration error, so the opt-out keyword can never shadow a real variant.
+<a name="style-configuration-errors"></a>
+### Style Configuration Errors
+
+There are two style configuration errors that will raise a `ConfigurationError`:
+* **Reserved `none` name:** Defining `[style.variants.none]` is a configuration error, so the opt-out keyword can never shadow a real variant.
+* **Unknown variant name:** Specifying a `style_variant` in a scene that does not exist in `[style.variants]` (and is not `"none"`) is a configuration error.
 
 **Composition rule** (deterministic, no LLM):
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1044,6 +1044,84 @@ GFLOW_EXAMPLE_PROFILE=<your-profile> python examples/batch_from_config.py
 
 The bundled `examples/sample_config.json` produces three images at three aspect ratios in `gflow-output/example-batch/`. Copy and edit for your own scenes.
 
+## `gflow movie`
+
+Sequential TOML-described multi-scene AI movie generation. New in v0.14.0.
+
+### `gflow movie template`
+
+Writes a starter `movie.toml` template.
+
+```text
+gflow movie template [OUTPUT] [--force]
+```
+
+* `OUTPUT`: The destination path for the template file (defaults to `./movie.toml`).
+* `--force`: Overwrite the destination file if it already exists.
+
+### `gflow movie run`
+
+Generates individual video clips sequentially from a single TOML manifest file, maintaining crash-recoverable state in a local state JSON file.
+
+```text
+gflow movie run MANIFEST [--out-dir DIR] [--profile NAME] [--continue-on-error|--fail-fast] [--dry-run] [--stitch]
+```
+
+Refer to the complete [Movie Manifests Guide](MOVIE.md) for detailed syntax, character entity creation, and style consistency features.
+
+### Parameters
+
+* `MANIFEST`: Path to your `movie.toml` manifest file (required positional argument).
+* `--out-dir DIR`: Output directory for generated video clips and the handoff file. Defaults to `out/` or `GFLOW_CLI_OUTPUT_DIR`.
+* `--profile NAME`: Specify Google Flow profile to use.
+* `--continue-on-error`: Skip failed scenes and continue generating subsequent scenes (default).
+* `--fail-fast`: Terminate immediately on the first failed scene generation.
+* `--dry-run`: Parse the manifest, estimate credits, and print the generation plan without calling Google Flow.
+* `--stitch`: Run a post-generation preview stitch using ffmpeg to concatenate clips into a single video file.
+
+### Manifest structure (movie.toml)
+
+```toml
+title = "My Cinematic Film"
+project = "Cinematics"
+
+[style]
+look = "3d animation"
+mood = "mysterious"
+negative = "text, watermark"
+prefix = "Cinematic film still, high detail."
+suffix = "Shot on IMAX 70mm, unreal engine 5 render."
+
+[style.variants.warm]
+suffix = "Golden hour light, warm color grading."
+
+[[characters]]
+name = "Stickman"
+identity = "text"
+voice = "alnilam"
+
+[[scenes]]
+id = "scene_01"
+action = "A mysterious stickman walks slowly through a dark forest."
+framing = "wide"
+duration = 5
+characters = ["Stickman"]
+
+[[scenes]]
+id = "scene_02"
+action = "Close up of the stickman looking back in shock."
+framing = "close-up"
+duration = 5
+characters = ["Stickman"]
+style_variant = "warm"
+```
+
+### Outputs
+
+1. **Clip Files:** Individual video files saved under `<out_dir>/scene_<id>.mp4` (or other formats).
+2. **State File:** A `<stem>-state.json` file recording completed operations, seeds, and metadata, allowing a run to resume without wasting credits.
+3. **Handoff Manifest:** A `<stem>-handoff.json` file that projects the run's metadata and clip paths, designed for downstream assemblers.
+
 ## Recipes
 
 ### Burn through a directory of inputs

--- a/scripts/ci/check_doc_links.py
+++ b/scripts/ci/check_doc_links.py
@@ -40,6 +40,7 @@ FILES: tuple[str, ...] = (
     "docs/USER_GUIDE.md",
     "docs/LIVE_VERIFICATION_v0.8.1.md",
     "docs/CHARACTER.md",
+    "docs/MOVIE.md",
 )
 
 # [text](target) — non-greedy text, balanced target (no nested parens).

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -285,7 +285,7 @@ def _style_tag(s: Scene, style: StyleSpec) -> str:
 def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, cost: int) -> str:
     """Return the single-line plan summary for one scene."""
     mode = "r2v" if s.characters else "t2v"
-    refs = f"  refs=[{', '.join(s.characters)}]" if s.characters else ""
+    refs = f"  refs=\\[{', '.join(s.characters)}]" if s.characters else ""
     framing_tag = f"  {s.framing}" if s.framing else ""
     model_tag = f"  {s.model}" if s.model else ""
     dur_tag = f"  {s.duration}s" if s.duration else ""
@@ -296,7 +296,7 @@ def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, c
     else:
         status = f"{cost} credit(s)"
     style_tag = _style_tag(s, style)
-    return f"    [{mode}] {s.id!r}{framing_tag}{model_tag}{dur_tag}{refs}{style_tag}  {status}"
+    return f"    \\[{mode}] {s.id!r}{framing_tag}{model_tag}{dur_tag}{refs}{style_tag}  {status}"
 
 
 def _print_plan(manifest: MovieManifest, state: MovieState) -> None:

--- a/src/gflow_cli/composition.py
+++ b/src/gflow_cli/composition.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
+from gflow_cli import __version__
+
 
 @dataclass(frozen=True)
 class StyleSpec:
@@ -367,7 +369,7 @@ def build_handoff(
     state: Any,
     *,
     out_dir: Path,
-    version: str = "0.14.0",
+    version: str = __version__,
     include_prompts: bool = True,
 ) -> dict[str, Any]:
     """Project a completed/partial movie run into the versioned handoff manifest.

--- a/src/gflow_cli/mcp/resources.py
+++ b/src/gflow_cli/mcp/resources.py
@@ -58,6 +58,9 @@ Browse the local project catalog.
 ### gflow_list_characters
 Browse reusable Flow Character entities.
 
+### gflow_list_tools
+List available gflow prompt tools (name, title, description, category).
+
 ## Important Rules
 1. **Use tools, not shell commands.** Do NOT run `gflow image t2i ...` via the terminal.
 2. **One generation at a time.** The rate limiter allows bursts of 8 but throttles sustained use.

--- a/src/gflow_cli/mcp/server.py
+++ b/src/gflow_cli/mcp/server.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 import structlog
 from mcp.server.fastmcp import FastMCP
 
+from gflow_cli import __version__
+
 if TYPE_CHECKING:
     pass
 
@@ -27,11 +29,14 @@ log = structlog.get_logger()
 # ---------------------------------------------------------------------------
 
 _SERVER_NAME = "gflow-cli"
-_SERVER_VERSION = "0.21.0"
+_SERVER_VERSION = __version__
 
 server = FastMCP(
     name=_SERVER_NAME,
 )
+# FastMCP does not expose a public API to configure the server version.
+# As a workaround, we assign it directly to the underlying Server instance.
+server._mcp_server.version = _SERVER_VERSION  # pyright: ignore[reportPrivateUsage]
 
 # ---------------------------------------------------------------------------
 # Stdout isolation

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -904,3 +904,21 @@ class TestEntityIdentity:
         assert create_mock.call_args.kwargs["body"] is not None
         # Entity id was persisted to state for downstream scene resolution.
         assert state.characters["Hero"].entity_id == "ent-new"
+
+
+class TestFormatSceneLine:
+    def test_format_scene_line_escapes_brackets_for_rich(self) -> None:
+        from gflow_cli.cli_movie import _format_scene_line
+        from gflow_cli.composition import Scene, StyleSpec
+
+        # T2V scene (no characters)
+        s1 = Scene(id="s1", action="A", framing="medium", duration=4)
+        line = _format_scene_line(s1, StyleSpec(), done=False, stale=False, cost=2)
+        assert "\\[t2v]" in line
+        assert "refs=" not in line
+
+        # R2V scene (with characters)
+        s2 = Scene(id="s2", action="B", framing="wide", duration=8, characters=("Hero",))
+        line2 = _format_scene_line(s2, StyleSpec(), done=False, stale=False, cost=2)
+        assert "\\[r2v]" in line2
+        assert "refs=\\[Hero]" in line2

--- a/tests/composition/test_handoff.py
+++ b/tests/composition/test_handoff.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import jsonschema
 
+from gflow_cli import __version__
 from gflow_cli.composition import Character, Scene, StyleSpec, build_handoff
 from gflow_cli.movie_manifest import CharacterState, MovieState, SceneState
 
@@ -38,6 +39,8 @@ def _fake_state() -> MovieState:
 def test_build_handoff_shape_and_schema(tmp_path: Path) -> None:
     handoff = build_handoff(_FakeManifest(), _fake_state(), out_dir=Path("/out/x"))
     assert handoff["schema_version"] == 1
+    assert handoff["generator"]["name"] == "gflow-cli"
+    assert handoff["generator"]["version"] == __version__
     assert handoff["clips"][0]["index"] == 0
     assert handoff["clips"][0]["id"] == "s1"
     # relative POSIX path, no backslashes, no signed-url leak


### PR DESCRIPTION
Addresses the deferred follow-ups from the v0.27.0 release:

1. **Version Wiring:** Imported `__version__` in `composition.py` and used it as the default version in `build_handoff()`, and updated handoff tests.
2. **Rich Markup Escaping:** Escaped brackets in `_format_scene_line` in `cli_movie.py` to prevent Rich console from swallowing `[t2v]`/`[r2v]` and `refs=[...]`, and added unit tests.
3. **MCP Server Sync:** Added `gflow_list_tools` to MCP agent guide, mapped `__version__` to `FastMCP`'s inner server version, and suppressed private usage typecheck warnings.
4. **Style Error Anchors:** Added a new section with HTML anchor `<a name="style-configuration-errors"></a>` in `MOVIE.md`, and added `MOVIE.md` to link check.
5. **`gflow movie` USAGE:** Added command, manifest format, parameters, and output description sections to `USAGE.md`.
