### PR TITLE
test: isolate tools no-key test from developer .env (#264)

### DIFF
--- a/tests/cli/test_cli_tools.py
+++ b/tests/cli/test_cli_tools.py
@@ -27,6 +27,12 @@ def test_tools_run_json_without_key_falls_back(
     install_log_capture: object,  # noqa: ARG001 — configures structlog LogCapture before invoke
 ) -> None:
     monkeypatch.delenv("GFLOW_CLI_GEMINI_API_KEY", raising=False)
+    # Isolate from any developer `.env` (issue #264): `delenv` only clears the
+    # process env, but Settings re-reads the key from a CWD/home `.env` on the
+    # next build — so on a machine that has GFLOW_CLI_GEMINI_API_KEY in `.env`
+    # the tool WOULD expand and this "no key" assertion fails. Neutralize the
+    # dotenv sources so the deleted env var actually means "no key".
+    monkeypatch.setattr("gflow_cli.config._env_files", tuple)
     # Prevent main() from overriding the LogCapture structlog config with a
     # PrintLogger that would route the "no key" warning into result.output.
     monkeypatch.setattr("gflow_cli.cli.configure_logging", lambda *_a, **_kw: None)


### PR DESCRIPTION
## Summary

Fixes #264. `test_tools_run_json_without_key_falls_back` deleted `GFLOW_CLI_GEMINI_API_KEY` from the process env but `Settings` re-read it from a CWD/home `.env` on the next build — so on any machine with a Gemini key in `.env`, the tool expanded the prompt and the "no key → graceful fallback" assertion failed (`was_expanded` True). Green only in CI, which has no `.env`.

## Fix

Neutralize the dotenv sources for this test via `monkeypatch.setattr("gflow_cli.config._env_files", tuple)` (returns `()` → no env files loaded), so the deleted env var genuinely means "no key". One-line, test-only change.

## Test plan

- [x] Reproduced the failure locally (machine has the key in `.env`).
- [x] `test_tools_run_json_without_key_falls_back` now passes; full `test_cli_tools.py` green (3 passed).
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)