### PR TITLE
fix(agentic): reliable agentic binding when -i instructions are used (#267)

### DIFF
--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -212,6 +212,14 @@ AGENT_FORCE_ENV_VAR = "GFLOW_CLI_FORCE_AGENT_UI"
 AGENT_TUNE_INDICATOR_SELECTOR = "i.google-symbols:text-is('tune')"
 AGENT_EXPAND_BUTTON_SELECTOR = "button:has(i.google-symbols:text-is('expand_content'))"
 
+# _force_agent_mode: after clicking the Agent toggle, POLL for the ``tune``
+# indicator instead of a single fixed sleep — the agentic composer renders a
+# beat after the click and a fixed-delay check races that render, so the probe
+# bound classic ~50% of the time and instructions silently no-op'd (#267).
+_AGENT_ACTIVATE_TIMEOUT_S = 6.0
+_AGENT_ACTIVATE_POLL_MS = 300
+_AGENT_FORCE_MAX_CLICKS = 2
+
 # Self-contained, locale-independent triptych instruction for body generation.
 # Live-verified 2026-06-02: produces a consistent front/side/back body image in ONE
 # generation, seeded by the auto-attached face reference. We replace Flow's own
@@ -1062,19 +1070,39 @@ class UiAutomationTransport(VideoGenerationMixin):
         except Exception:
             log.warning("ui_automation.agent_toggle_not_found")
             return False
-        await toggle.click(force=True)
-        await page.wait_for_timeout(1200)
-        # Best-effort: open the agent side panel via the expand button.
-        try:
-            expand = page.locator(AGENT_EXPAND_BUTTON_SELECTOR).first
-            if await expand.count() > 0:
-                await expand.click(force=True)
-                await page.wait_for_timeout(800)
-        except Exception as e:
-            log.debug("ui_automation.agent_expand_failed", error=str(e)[:80])
-        activated = await page.locator(AGENT_TUNE_INDICATOR_SELECTOR).count() > 0
-        log.info("ui_automation.agent_mode_forced", activated=activated)
-        return activated
+        # Click the toggle, then POLL for the ``tune`` indicator up to
+        # ``_AGENT_ACTIVATE_TIMEOUT_S`` (the render lags the click); re-click once
+        # if the first attempt doesn't take. Replaces the old single 1.2s wait
+        # that raced the render and bound classic ~50% of the time (#267).
+        for attempt in range(_AGENT_FORCE_MAX_CLICKS):
+            await toggle.click(force=True)
+            if await UiAutomationTransport._wait_selector_present(
+                page, AGENT_TUNE_INDICATOR_SELECTOR, timeout_s=_AGENT_ACTIVATE_TIMEOUT_S
+            ):
+                # Best-effort: open the agent side panel via the expand button.
+                try:
+                    expand = page.locator(AGENT_EXPAND_BUTTON_SELECTOR).first
+                    if await expand.count() > 0:
+                        await expand.click(force=True)
+                        await page.wait_for_timeout(800)
+                except Exception as e:
+                    log.debug("ui_automation.agent_expand_failed", error=str(e)[:80])
+                log.info("ui_automation.agent_mode_forced", activated=True, attempt=attempt)
+                return True
+            log.debug("ui_automation.agent_mode_force_retry", attempt=attempt)
+        log.warning("ui_automation.agent_mode_force_failed")
+        return False
+
+    @staticmethod
+    async def _wait_selector_present(page: Page, selector: str, *, timeout_s: float) -> bool:
+        """Poll until ``selector`` matches ≥1 node, or ``timeout_s`` elapses."""
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while True:
+            if await page.locator(selector).count() > 0:
+                return True
+            if asyncio.get_event_loop().time() >= deadline:
+                return False
+            await page.wait_for_timeout(_AGENT_ACTIVATE_POLL_MS)
 
     @staticmethod
     async def _switch_to_image_mode(page: Page, *, out_dir: Path | None = None) -> None:
@@ -2071,11 +2099,27 @@ class UiAutomationTransport(VideoGenerationMixin):
         # of the editor before we click into settings / submit (#26).
         await self._dismiss_blocking_overlays(page, out_dir)
 
-        # Opt-in (GFLOW_CLI_FORCE_AGENT_UI): force the agentic composer so the
-        # agentic path can be exercised deterministically (the A/B cohort can't
-        # be forced server-side). The probe below then binds the agentic driver.
-        if os.getenv(AGENT_FORCE_ENV_VAR):
-            await self._force_agent_mode(page)
+        # Force the agentic composer when it's needed or explicitly requested:
+        #  - ``request.instructions`` present → instruction cards are an
+        #    agentic-only surface, so a classic bind would silently drop them
+        #    (#267). Switching the composer to agentic first makes ``-i``
+        #    dependable instead of ~50/50.
+        #  - ``GFLOW_CLI_FORCE_AGENT_UI`` set → opt-in to exercise the agentic
+        #    path deterministically (the A/B cohort can't be forced server-side).
+        # ``_force_agent_mode`` is idempotent (no-op when already agentic) and
+        # polls for the render, so the probe below reliably binds agentic.
+        if os.getenv(AGENT_FORCE_ENV_VAR) or request.instructions:
+            forced = await self._force_agent_mode(page)
+            if not forced and request.instructions:
+                log.warning(
+                    "ui_automation.agent_force_failed_with_instructions",
+                    instruction_count=len(request.instructions),
+                    detail=(
+                        "Could not switch this session to the agentic composer; "
+                        "instruction cards (-i) may not be applied. This account "
+                        "may not offer Agent mode."
+                    ),
+                )
 
         # Probe the DOM for the active UI cohort AFTER _enter_editor so the
         # project page is fully rendered.  The cohort flaps per page load so

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2956,6 +2956,9 @@ async def test_instructions_on_classic_cohort_emit_warning(
     # Reach the cohort branch, then stop before the real classic capture path.
     monkeypatch.setattr(t, "_enter_editor", AsyncMock())
     monkeypatch.setattr(t, "_dismiss_blocking_overlays", AsyncMock())
+    # Instructions present → the transport tries to force agentic first; here it
+    # fails (account has no Agent mode), so the probe binds classic.
+    monkeypatch.setattr(t, "_force_agent_mode", AsyncMock(return_value=False))
     classic_driver = MagicMock()
     classic_driver.name = "classic"
     classic_driver.switch_to_image_mode = AsyncMock(side_effect=_StopFlowError)
@@ -2986,8 +2989,13 @@ async def test_instructions_on_agentic_cohort_emit_no_classic_warning(
     t._page = MagicMock()  # noqa: SLF001
     t._out_dir = None  # noqa: SLF001
 
+    # No force-env flag → the force below can only be driven by `instructions`.
+    monkeypatch.delenv("GFLOW_CLI_FORCE_AGENT_UI", raising=False)
     monkeypatch.setattr(t, "_enter_editor", AsyncMock())
     monkeypatch.setattr(t, "_dismiss_blocking_overlays", AsyncMock())
+    # Instructions present → force agentic succeeds, so the probe binds agentic.
+    force_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(t, "_force_agent_mode", force_mock)
     agentic_driver = MagicMock()
     agentic_driver.name = "agentic"
     agentic_driver.switch_to_image_mode = AsyncMock(side_effect=_StopFlowError)
@@ -3001,5 +3009,80 @@ async def test_instructions_on_agentic_cohort_emit_no_classic_warning(
     with structlog.testing.capture_logs() as caps, pytest.raises(_StopFlowError):
         await t._generate_images_locked(req)  # noqa: SLF001
 
+    # Instructions alone (no env flag) must drive the agentic force.
+    force_mock.assert_awaited()
     events = [c.get("event") for c in caps]
     assert "ui_automation.instructions_ignored_classic_cohort" not in events
+
+
+def _force_agent_page(
+    tune_counts: list[int], *, toggle_raises: bool = False, expand_count: int = 0
+) -> tuple[MagicMock, MagicMock]:
+    """Page mock for _force_agent_mode: the ``tune`` indicator count is consumed
+    from ``tune_counts`` per query (last value repeats); toggle + expand are
+    AsyncMock-driven. Returns (page, toggle_first_locator)."""
+    idx = {"i": 0}
+
+    async def _tune_count() -> int:
+        i = idx["i"]
+        idx["i"] = i + 1
+        return tune_counts[i] if i < len(tune_counts) else tune_counts[-1]
+
+    tune_loc = MagicMock()
+    tune_loc.count = _tune_count
+    toggle_first = MagicMock()
+    toggle_first.wait_for = AsyncMock(
+        side_effect=RuntimeError("not found") if toggle_raises else None
+    )
+    toggle_first.click = AsyncMock()
+    toggle_loc = MagicMock(first=toggle_first)
+    expand_first = MagicMock()
+    expand_first.count = AsyncMock(return_value=expand_count)
+    expand_first.click = AsyncMock()
+    expand_loc = MagicMock(first=expand_first)
+
+    def _locator(sel: str) -> MagicMock:
+        if "tune" in sel:
+            return tune_loc
+        if "expand_content" in sel:
+            return expand_loc
+        return toggle_loc
+
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=_locator)
+    page.wait_for_timeout = AsyncMock()
+    return page, toggle_first
+
+
+@pytest.mark.asyncio
+async def test_force_agent_mode_already_active_no_click() -> None:
+    """Already agentic (tune present) → returns True without clicking the toggle."""
+    page, toggle = _force_agent_page([1])
+    assert await UiAutomationTransport._force_agent_mode(page) is True  # noqa: SLF001
+    toggle.click.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_agent_mode_succeeds_after_render_poll() -> None:
+    """The tune indicator renders a beat after the click — polling catches it."""
+    # [already-active check=0, poll#1=0, poll#2=1]
+    page, toggle = _force_agent_page([0, 0, 1])
+    assert await UiAutomationTransport._force_agent_mode(page) is True  # noqa: SLF001
+    toggle.click.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_force_agent_mode_retries_then_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never activates → re-clicks up to the max, then returns False."""
+    monkeypatch.setattr("gflow_cli.api.transports.ui_automation._AGENT_ACTIVATE_TIMEOUT_S", 0.05)
+    page, toggle = _force_agent_page([0])  # always 0
+    assert await UiAutomationTransport._force_agent_mode(page) is False  # noqa: SLF001
+    assert toggle.click.await_count == 2  # noqa: PLR2004 — _AGENT_FORCE_MAX_CLICKS
+
+
+@pytest.mark.asyncio
+async def test_force_agent_mode_returns_false_when_toggle_missing() -> None:
+    """Toggle never becomes visible → returns False without clicking."""
+    page, toggle = _force_agent_page([0], toggle_raises=True)
+    assert await UiAutomationTransport._force_agent_mode(page) is False  # noqa: SLF001
+    toggle.click.assert_not_awaited()


### PR DESCRIPTION
Closes #267. **Held for 0.29.0** (draft until live-verified).

## Problem
Instruction cards (`-i`) are an agentic-only surface, but binding was ~50/50 on fresh projects: `_force_agent_mode` clicked the Agent toggle then checked the `tune` indicator after a single fixed 1.2s wait, racing the render → the probe often bound classic and `-i` silently no-op'd (found during the v0.28.0 spike).

## Fix
- **`_force_agent_mode`** now polls for the `tune` indicator up to a real timeout and re-clicks once if it doesn't take (`_wait_selector_present`), returning an accurate result.
- **`_generate_images_locked`** forces the agentic composer whenever `request.instructions` is present (not only under `GFLOW_CLI_FORCE_AGENT_UI`), and warns if the force fails so instructions never silently vanish (idempotent no-op when already agentic).

## Tests
Unit: poll-succeeds-after-render, retry-then-fail, already-active-no-click, toggle-missing; cohort tests updated to drive the new force path. `ruff` / `pyright` / `test_ui_automation.py` (164) all green.

## Pending before un-draft / 0.29.0
- **Live determinism verification** (`scratch/probe_binding_267.py`, credit-free — create → force → probe cohort, repeated): confirm it binds agentic every run. Blocked right now on an expired auth session; will run after re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)