### PR TITLE
chore(skills): make /gflow:check and the council CI-faithful (D0 gate)

### DIFF
--- a/.claude/commands/gflow/check.md
+++ b/.claude/commands/gflow/check.md
@@ -8,10 +8,13 @@ Run in order. Stop and report if a step fails after the fix pass.
 
 ## Steps
 
-**1. Repo hygiene** (read-only — checks tmp/ output rule, secret files, etc.)
+These steps mirror the CI `test` job in `.github/workflows/ci.yml` **in the same order**. Any command that CI runs as a *verify* (`--check`) is run here as a verify too — see step 4.
+
+**1. Repo hygiene + doc links** (read-only — CI runs both; a broken doc link fails CI)
 
 ```bash
 PYTHONUTF8=1 uv run python scripts/ci/check_repo_hygiene.py
+PYTHONUTF8=1 uv run python scripts/ci/check_doc_links.py
 ```
 
 **2. Auto-fix lint and formatting** (rewrites files in place)
@@ -21,15 +24,26 @@ uv run ruff check --fix src tests
 uv run ruff format src tests
 ```
 
-Report which files were modified. Do NOT stage or commit — leave the diff for review.
+Report which files were modified. **If this rewrote anything, those files are part of the change — stage them.** CI does not run the auto-fix; it runs the `--check` verify in step 4 against the *committed* tree, so an uncommitted reformat is a red CI build.
 
-**3. Type check** (report only — cannot auto-fix)
+**3. Repeat lint/format ONLY on the files you touched? No — always run repo-wide.** The whole-tree `src tests` scope in step 2/4 is deliberate: a latent format failure in a file your change merely imports (e.g. a BDD step module) will fail CI even if your own edits are clean. Never narrow the scope to "just my files."
+
+**4. Verify — the EXACT CI gate (non-mutating; must be clean before you commit/push)**
+
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+```
+
+These are byte-for-byte what CI runs (`ci.yml` "Lint" + "Format check"). If `--check` exits non-zero here, step 2's rewrites are **uncommitted** — stage them and re-run. **Never push while this is red:** the test job dies at the format step *before* pytest, which also makes SonarCloud report `new_coverage=0%` (no coverage XML is produced). A green `/gflow:check` that skips this verify is how PR #269 shipped a format failure past an 8-agent council.
+
+**5. Type check** (report only — cannot auto-fix)
 
 ```bash
 uv run pyright src
 ```
 
-**4. Tests + coverage** (report only)
+**6. Tests + coverage** (report only)
 
 ```bash
 uv run python -m pytest -q --cov=gflow_cli --cov-fail-under=80
@@ -38,6 +52,7 @@ uv run python -m pytest -q --cov=gflow_cli --cov-fail-under=80
 ## Output
 
 - List files changed by the fix pass (empty = nothing needed fixing)
+- **Step 4 verify result — `ruff check` + `ruff format --check` both clean (this is the CI gate; a non-zero here is a blocking finding, not a warning)**
 - All pyright errors with `file:line` references
 - Pytest summary line and coverage percentage
 - Final verdict: all gates pass / which gates failed
@@ -54,6 +69,10 @@ credit-spending gates and must be requested with a separate `-m e2e` / `-m live`
 **Windows agent sessions:** `uv run pytest` is unreliable — invoke
 `.venv/Scripts/python.exe -m pytest` directly, and prefix Python invocations with
 `PYTHONUTF8=1` when output contains non-ASCII. The unscoped full-coverage sweep
-(step 4) can OOM locally (exit 137 / SIGKILL): run the suites scoped to the dirs you
+(step 6) can OOM locally (exit 137 / SIGKILL): run the suites scoped to the dirs you
 touched and trust CI for the full coverage gate — **a green full-suite CI run on the
-same tree (e.g. the just-merged PR) satisfies step 4 for release purposes.**
+same tree (e.g. the just-merged PR) satisfies step 6 for release purposes.**
+
+The OOM allowance applies to step 6 (coverage) ONLY. Step 4 (`ruff check` + `ruff
+format --check src tests`) is cheap, never OOMs, and must ALWAYS be run repo-wide
+against the exact tree you are about to push — no scoping, no skipping.

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -21,7 +21,7 @@ Treat **YELLOW as soft block** (per memory `[[llm-council-data-layer-fixes]]`).
 
 ## 0 · Pre-flight
 
-**All five checks are mandatory. Any failure halts before Phase 1/2.**
+**All six checks are mandatory. Any failure (except step 6, which records a finding) halts before Phase 1/2.**
 
 1. **`gh` authenticated** — run `gh auth status`. Non-zero exit → stop with: *"`gh` is not authenticated. Run `gh auth login` and re-invoke."*
 2. **Inside the repo** — assert `AGENTS.md` AND `CLAUDE.md` exist in the working directory.
@@ -30,6 +30,21 @@ Treat **YELLOW as soft block** (per memory `[[llm-council-data-layer-fixes]]`).
    - **PR number** → validate with `gh pr view <N> --json number`. If error → stop with the error verbatim.
 4. **Draft check** (PR# mode only) — if `gh pr view <N> --json isDraft` returns `true`, surface a banner citing memory `[[draft-pr-merge-trap]]`: *"PR #N is DRAFT. Reviewing is fine, but do NOT merge a draft (the merge API can close it + delete the head ref). Run `gh pr ready N` first if you intend to merge. Continue review? (yes/no)"*. Ask the user before dispatching.
 5. **Capture PR head ref + SHA (pin the review)** — `head_branch=$(gh pr view <N> --json headRefName --jq '.headRefName')` and `head_sha=$(gh pr view <N> --json headRefOid --jq '.headRefOid')`. **Pin both to a `REVIEWED_SHA` variable** and pass to every dispatched agent so the council's verdict is anchored to one commit. The local working tree is NOT on the PR head; all file reads must go through `git show $REVIEWED_SHA:<path>` (or `git show origin/$head_branch:<path>` if you fetched first). If the author pushes new commits during the review, the council still reports against `REVIEWED_SHA`; the synthesizer notes any divergence in Phase 5 step 5.
+6. **Mechanical CI gate (D0 — non-LLM, runs BEFORE dispatch).** The LLM dimensions reason about the diff; none of them run the repo's actual lint/format/link gates, so a whole-tree failure sails past the council (this happened on PR #269 — a latent `ruff format` failure in a file the diff only *touched* went green through 8 agents, then reddened CI and dragged SonarCloud `new_coverage` to 0). Run the **exact CI gate commands** (`.github/workflows/ci.yml` → Lint / Format check / Documentation links / Repo hygiene) against the reviewed tree:
+   ```bash
+   # Prefer running at REVIEWED_SHA. If HEAD is already there (reviewing your own
+   # just-pushed PR, or branch-review mode), run in place:
+   if [ "$(git rev-parse HEAD)" = "$REVIEWED_SHA" ]; then dir=.; else \
+     dir=$(mktemp -d); git worktree add --detach "$dir" "$REVIEWED_SHA"; fi
+   ( cd "$dir" && uv run ruff check src tests \
+       && uv run ruff format --check src tests \
+       && uv run python scripts/ci/check_doc_links.py \
+       && uv run python scripts/ci/check_repo_hygiene.py )
+   # if a worktree was created: git worktree remove --force "$dir" (Windows: prune later if locked)
+   ```
+   - **Any non-zero → record a `D0 — CI-mechanical` RED.** This is a hard blocker regardless of the LLM dimensions' verdicts; surface the failing command + output verbatim in the report and do NOT call the PR merge-ready. (Mirrors the SonarCloud-gate rule in the wrapper: the council must not bless a tree CI will reject.)
+   - If running the gate is impractical (no `uv`, worktree add fails), fall back to `gh pr checks <N>` and inspect the `test` job's Lint/Format steps; if they are **pending or failing**, flag D0 as `UNVERIFIED — must be confirmed green before merge`, never as GREEN.
+   - Unlike steps 1–5, a D0 failure does **not** halt — dispatch the LLM council anyway so its findings are gathered in one pass, then fold D0 into the Phase 5 verdict.
 
 ---
 
@@ -174,6 +189,15 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 
 ### Dimension → mandatory memory slugs table
 
+> **⚠️ Slug names are conceptual anchors, not filenames.** The auto-memory store uses
+> descriptive filenames (`feedback_*.md`, `project_*.md`, `reference_*.md`, plus
+> `MEMORY.md`), **not** files named after these `[[kebab-slug]]`s. To consult a slug:
+> read `MEMORY.md` and open the file whose topic matches (e.g. `[[rest-transports-drop-ui-fields]]`
+> → whichever `project_*`/`feedback_*` entry covers transport field-drop). **If no memory
+> entry matches a referenced slug, state that explicitly in your report and move on — do
+> NOT fabricate its contents.** (Backlog: reconcile this table with the real filenames, or
+> alias memory files to their slugs, so citations resolve directly.)
+
 | Dim | Mandatory memory slugs |
 |---|---|
 | D1 | `[[pr-must-verify-on-affected-surface]]` |
@@ -222,9 +246,10 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 1. **Tally verdicts** per dimension.
 2. **Handle missing agents:** any dimension that failed → mark `UNKNOWN`, downgrade consensus by one step (GREEN→YELLOW, YELLOW→YELLOW, RED→RED). Never wait indefinitely.
 3. **Consensus rule:**
+   - **`D0` (mechanical CI gate, Pre-flight step 6) RED or UNVERIFIED → the overall verdict cannot be GREEN.** A D0 RED forces **RED** even if every LLM dimension is GREEN — CI will reject the tree. A D0 UNVERIFIED caps the verdict at **YELLOW** with an explicit "confirm CI green before merge" action.
    - Any RED → **RED** (block merge).
    - Any YELLOW → **YELLOW** (soft block per `[[llm-council-data-layer-fixes]]`).
-   - All GREEN → **GREEN** (mergeable).
+   - All GREEN (including D0) → **GREEN** (mergeable).
 4. **Deduplicate must-fix AND confirmed-good** — same finding from two dimensions = list once + credit both.
 5. **False-positive filter + SHA divergence check (NEW v2, refined v2.1):**
    - **Spot-check 2-3 file-state claims** via `git show <REVIEWED_SHA>:<path>` (NOT `git show origin/<head>:<path>` — the remote may have moved since dispatch). If any agent claim contradicts `<REVIEWED_SHA>`, mark it FALSE POSITIVE in the report — do not silently drop, so accuracy is auditable.


### PR DESCRIPTION
## Summary

Closes the gate gap surfaced by PR #269: it passed local `/gflow:check` **and** an 8-agent `/gflow:pr-council-review`, then went RED on CI because a repo-wide `ruff format --check src tests` caught a latent format failure in a file the diff only *touched* — which also dragged SonarCloud `new_coverage` to 0% (the test job dies at the format step before pytest produces coverage).

Root cause: our local gates ran the **mutating** `ruff format` (exits 0 after rewriting files), and the council ran **no** mechanical lint/format at all — so neither mirrored CI's non-mutating `--check` verify.

## Changes

- **`.claude/commands/gflow/check.md`** — add a non-mutating **"Verify — the EXACT CI gate"** step (`ruff check src tests` + `ruff format --check src tests`), add the missing `check_doc_links.py` gate, and make explicit that auto-fix rewrites must be committed or CI's `--check` reddens.
- **`skills/pr-council-review/SKILL.md`** — add Pre-flight step 6 **"D0 — mechanical CI gate"**: runs the exact CI commands against `REVIEWED_SHA` (in place when HEAD is already there, else via a throwaway `git worktree`); a **D0 RED hard-blocks** the verdict regardless of the LLM dimensions, mirroring the existing SonarCloud-gate rule. Wired into the §5 consensus rule.
- **`skills/pr-council-review/SKILL.md`** — note that `[[slug]]` memory citations are conceptual anchors, not filenames; map them to the real `feedback_*`/`project_*` entries and never fabricate a missing entry.

## Test plan
- [x] `check_doc_links.py` clean (docs-only change).
- [x] Both files are Markdown skill/command docs — no code paths affected.

## Follow-ups (from the same skills audit, not in this PR)
- MCP↔CLI parity: the `gflow instructions` CRUD + `movie` groups have no MCP tools; add a parity-assertion test + the missing tools.
- Transport sync: consolidate the triplicated agentic-indicator selectors and add an image/video/REST symmetry test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
