### PR TITLE
refactor(transports): consolidate agentic-indicator selectors onto drivers/factory

### DIFF
--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -14,10 +14,11 @@ rule, validated by live capture:
 The cohort flaps per page load, so callers must re-probe **per generation** —
 never cache a driver across navigations.
 
-This module is the detection source of truth; the selector probes mirror
-``ui_automation_video.{MODE_SWITCH_TRIGGER_SELECTORS, AGENTIC_UI_INDICATORS}``,
-which Task 2 consolidates onto these (the transport depends on ``drivers``, not
-the reverse).
+This module is the detection source of truth: ``AGENTIC_INDICATOR_SELECTORS``
+and ``AGENT_TUNE_INDICATOR_SELECTOR`` are canonical here, and the UI transports
+(``ui_automation``, ``ui_automation_video``) import them rather than redefining
+them (the transport depends on ``drivers``, not the reverse —
+``tests/api/transports/test_selector_symmetry.py`` locks this).
 """
 
 from __future__ import annotations
@@ -53,9 +54,12 @@ _CLASSIC_CROP_SELECTORS: tuple[str, ...] = (
 
 # Agentic cohort indicators — Material Symbols ligatures unique to the chat UI.
 # Locale-invariant (icon names, not UI text). Only consulted when no ``crop_*``
-# trigger is present.
-_AGENTIC_INDICATOR_SELECTORS: tuple[str, ...] = (
-    "i.google-symbols:text-is('tune')",
+# trigger is present. Canonical: the UI transports derive their agentic probes
+# from this tuple instead of carrying their own copies.
+AGENT_TUNE_INDICATOR_SELECTOR = "i.google-symbols:text-is('tune')"
+
+AGENTIC_INDICATOR_SELECTORS: tuple[str, ...] = (
+    AGENT_TUNE_INDICATOR_SELECTOR,
     "i.google-symbols:text-is('apps_spark_2')",
     "i.google-symbols:text-is('article_spark')",
     "i.google-symbols:text-is('edit_square')",
@@ -112,7 +116,7 @@ async def detect_ui_mode(
     while True:
         if await _any_present(page, _CLASSIC_CROP_SELECTORS):
             return "classic"
-        if await _any_present(page, _AGENTIC_INDICATOR_SELECTORS):
+        if await _any_present(page, AGENTIC_INDICATOR_SELECTORS):
             return "agentic"
         if asyncio.get_event_loop().time() >= deadline:
             return "classic"

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -29,6 +29,7 @@ from gflow_cli.api.character import CHARACTER_MODELS, CharacterImageRequest
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports._common import extract_project_id
+from gflow_cli.api.transports.drivers.factory import AGENT_TUNE_INDICATOR_SELECTOR
 from gflow_cli.api.transports.ui_automation_video import (
     COMPOSER_AGENT_TOGGLE_SELECTOR,
     ENTITY_ATTACH_DRIFT_HINT,
@@ -209,7 +210,6 @@ SUBMIT_BUTTON_SELECTORS = (
 # drive the agentic path regardless of the server-assigned A/B cohort (which has
 # no client-readable flag and cannot otherwise be forced).
 AGENT_FORCE_ENV_VAR = "GFLOW_CLI_FORCE_AGENT_UI"
-AGENT_TUNE_INDICATOR_SELECTOR = "i.google-symbols:text-is('tune')"
 AGENT_EXPAND_BUTTON_SELECTOR = "button:has(i.google-symbols:text-is('expand_content'))"
 
 # _force_agent_mode: after clicking the Agent toggle, POLL for the ``tune``

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -24,6 +24,7 @@ import structlog
 
 from gflow_cli.api import routes
 from gflow_cli.api.transports._common import extract_project_id
+from gflow_cli.api.transports.drivers.factory import AGENTIC_INDICATOR_SELECTORS
 from gflow_cli.api.video import (
     I2V_DEFAULT_MODEL,
     Aspect,
@@ -157,12 +158,12 @@ AGENT_CHAT_PANEL_CLOSE_SELECTOR = (
 )
 
 # Selectors unique to the new Agentic UI cohort. If crop settings are absent
-# and any of these are present, we are in the forced Agentic UI cohort.
+# and any of these are present, we are in the forced Agentic UI cohort. The
+# ligature probes are canonical in ``drivers/factory.py`` (detection source of
+# truth); this tuple extends them with the composer pill + chat-panel close,
+# which only the exit-loop cares about.
 AGENTIC_UI_INDICATORS = (
-    "i.google-symbols:text-is('tune')",
-    "i.google-symbols:text-is('apps_spark_2')",
-    "i.google-symbols:text-is('article_spark')",
-    "i.google-symbols:text-is('edit_square')",
+    *AGENTIC_INDICATOR_SELECTORS,
     COMPOSER_AGENT_TOGGLE_SELECTOR,
     AGENT_CHAT_PANEL_CLOSE_SELECTOR,
 )

--- a/tests/api/transports/drivers/test_factory.py
+++ b/tests/api/transports/drivers/test_factory.py
@@ -22,14 +22,14 @@ from gflow_cli.api.transports.drivers.agentic import AgenticFlowUiDriver
 from gflow_cli.api.transports.drivers.base import FlowUiDriver
 from gflow_cli.api.transports.drivers.classic import ClassicFlowUiDriver
 from gflow_cli.api.transports.drivers.factory import (
-    _AGENTIC_INDICATOR_SELECTORS,
     _CLASSIC_CROP_SELECTORS,
+    AGENTIC_INDICATOR_SELECTORS,
     detect_ui_mode,
     get_ui_driver,
 )
 
 _CROP = _CLASSIC_CROP_SELECTORS[0]
-_TUNE = _AGENTIC_INDICATOR_SELECTORS[0]
+_TUNE = AGENTIC_INDICATOR_SELECTORS[0]
 
 
 def _fake_page(present: set[str], *, raising: set[str] | None = None) -> MagicMock:

--- a/tests/api/transports/test_selector_symmetry.py
+++ b/tests/api/transports/test_selector_symmetry.py
@@ -1,0 +1,42 @@
+"""Agentic-indicator selector symmetry — factory.py is the single source of truth.
+
+The 4 core agentic ligature probes (``tune`` / ``apps_spark_2`` / ``article_spark``
+/ ``edit_square``) were historically triplicated across ``drivers/factory.py``,
+``ui_automation_video.AGENTIC_UI_INDICATORS`` and
+``ui_automation.AGENT_TUNE_INDICATOR_SELECTOR`` — and had already drifted apart
+once. These tests lock the consolidation: both transports must derive their
+selectors from the canonical tuple in ``drivers/factory.py`` (the detection
+source of truth), never redefine them.
+"""
+
+from __future__ import annotations
+
+from gflow_cli.api.transports import ui_automation, ui_automation_video
+from gflow_cli.api.transports.drivers.factory import (
+    AGENT_TUNE_INDICATOR_SELECTOR,
+    AGENTIC_INDICATOR_SELECTORS,
+)
+
+
+def test_canonical_indicators_are_subset_of_video_ui_indicators() -> None:
+    # ui_automation_video extends the canonical tuple (composer pill + chat-panel
+    # close) but must never drop or diverge from a canonical entry.
+    assert set(AGENTIC_INDICATOR_SELECTORS) <= set(ui_automation_video.AGENTIC_UI_INDICATORS)
+
+
+def test_video_extends_canonical_with_exactly_pill_and_panel_close() -> None:
+    extras = set(ui_automation_video.AGENTIC_UI_INDICATORS) - set(AGENTIC_INDICATOR_SELECTORS)
+    assert extras == {
+        ui_automation_video.COMPOSER_AGENT_TOGGLE_SELECTOR,
+        ui_automation_video.AGENT_CHAT_PANEL_CLOSE_SELECTOR,
+    }
+
+
+def test_tune_selector_is_a_canonical_indicator() -> None:
+    assert AGENT_TUNE_INDICATOR_SELECTOR in AGENTIC_INDICATOR_SELECTORS
+
+
+def test_ui_automation_reuses_factory_tune_selector() -> None:
+    # ``is`` (not ``==``): ui_automation must import the factory constant, not
+    # carry an equal-looking local copy that can silently drift.
+    assert ui_automation.AGENT_TUNE_INDICATOR_SELECTOR is AGENT_TUNE_INDICATOR_SELECTOR


### PR DESCRIPTION
## Summary

Task 5 of the 2026-07-09 skills-audit council hardening roadmap.

The 4 core agentic ligature probes (`tune` / `apps_spark_2` / `article_spark` / `edit_square`) were triplicated across `drivers/factory.py`, `ui_automation_video.AGENTIC_UI_INDICATORS`, and `ui_automation.AGENT_TUNE_INDICATOR_SELECTOR` — and had already drifted once. `factory.py` is the declared detection source of truth; this PR finishes the consolidation its docstring promised ('Task 2 consolidates onto these').

- **factory.py**: `_AGENTIC_INDICATOR_SELECTORS` made public as `AGENTIC_INDICATOR_SELECTORS`; `AGENT_TUNE_INDICATOR_SELECTOR` defined once and exported.
- **ui_automation_video.py**: `AGENTIC_UI_INDICATORS` now extends the canonical tuple with its two extra selectors (composer pill + chat-panel close).
- **ui_automation.py**: local `tune` selector deleted; imports the factory constant.
- **New `tests/api/transports/test_selector_symmetry.py`**: 4 tests locking the consolidation against future drift (subset, exact-extras, tune-in-canonical, identity of the shared constant).

Cycle-safe: `drivers/{classic,agentic,base}` import only `gflow_cli.errors` at module level; `factory` imports `ui_automation_video` only lazily inside functions.

## Test plan
- [x] TDD: symmetry test written first, watched fail (ImportError on missing public names), then consolidation applied
- [x] `ruff check src tests` / `ruff format --check src tests` / `pyright src` — clean
- [x] `check_repo_hygiene.py` + `check_doc_links.py` — clean
- [x] Full suite: 2088 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)