### PR TITLE
fix(spike): clean expired-session handling in the WAF harness

### DIFF
--- a/scripts/spike_waf_camoufox.py
+++ b/scripts/spike_waf_camoufox.py
@@ -318,7 +318,21 @@ def main() -> int:
         step("abort", "not confirmed — nothing generated.")
         return 0
 
-    result = asyncio.run(_run(args, profile_dir))
+    # A 401 during session setup (create_project) lands here, OUTSIDE the
+    # per-attempt loop. Surface it as a clean re-auth prompt, never a traceback —
+    # a locally-present cookie is not a live server session. No credits are spent
+    # on this path (it dies before the first generation).
+    from gflow_cli.errors import AuthExpiredError
+
+    try:
+        result = asyncio.run(_run(args, profile_dir))
+    except AuthExpiredError:
+        step(
+            "auth",
+            f"session for profile '{args.profile_name}' is expired (HTTP 401) — no credits "
+            f"spent. Re-auth with `gflow auth login --profile {args.profile_name}` and re-run.",
+        )
+        return 4
 
     out_path = Path(args.out) if args.out else default_out_path("waf_spike", ".json")
     out_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Found by running the Phase 2 baseline: the profile's Flow session had expired, and the 401 at `create_project` — which happens *before* the per-attempt classify-and-continue loop — crashed the harness with a traceback.

Catches `AuthExpiredError` around the run and exits 4 with a `gflow auth login --profile <name>` re-auth hint. A locally-present cookie is not a live server session; the expiry only surfaces on the first real REST call. **No credits are spent on this path** (it dies before the first generation).

## Test plan
- [x] ruff check / format clean; parses.
- [x] The failing path that produced this fix: baseline run died at `create_project` with `AuthExpiredError: HTTP 401`, zero credits spent — now surfaces as a clean re-auth message + exit 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)