### PR TITLE
docs(camoufox): Phase 2 WAF baseline = 0% — STOP the roadmap (ADR-13 gate)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -653,6 +653,8 @@ Records image, batch, T2V, I2V, and R2V provenance in a local SQLite catalog. Re
 
 **Status:** NOT implemented. Parked until the stealth-flag fix (`--disable-blink-features=AutomationControlled` + init script) is confirmed insufficient, or until a contributor picks it up.
 
+**2026-07-09 verification — the current stealth fix is CONFIRMED SUFFICIENT (so this stays parked).** A 20-generation baseline on a live authed profile through the default stealth stack produced a **0.0% WAF 403 rate** (19/20 success; the one miss was a UI-scrape timeout, not a WAF block). This met ADR-13's "must verify before implementing" gate and closed the [Camoufox adoption roadmap](superpowers/plans/2026-07-09-camoufox-adoption/PLAN.md) at Phase 2 — the Camoufox engine was NOT built. Evidence: [superpowers/spikes/2026-07-09-camoufox-waf-403.md](superpowers/spikes/2026-07-09-camoufox-waf-403.md). Re-run `scripts/spike_waf_camoufox.py` if a repeatable WAF-403 is later observed; a materially non-zero rate would reopen CDP-Attach / Camoufox.
+
 ---
 
 ### Phase 8 — Pluggable storage backend — BACKLOG
@@ -699,7 +701,7 @@ Today the CLI writes media to `$GFLOW_CLI_OUTPUT_DIR` on the local filesystem. P
 | 10 | Both `gflow` and `flow` binary names installed | `flow` is friendlier; `gflow` avoids conflicts with Facebook Flow / MS Power Automate |
 | 11 | LF-only line endings via `.gitattributes` | Single repo source of truth; cross-platform contributors don't think about it |
 | 12 | `Provider` indirection (legacy `providers/`) removed | Superseded by `api.FlowApiClient`. Re-introduce when we add `OfficialVeoProvider` (planned v0.5+) |
-| 13 | CDP attach transport deferred | Must first confirm whether CDP-attached Chrome still sets `navigator.webdriver=true` (which would negate any reCAPTCHA advantage over the current stealth fix). See CDP Attach backlog entry. |
+| 13 | CDP attach / stealth-engine alternatives deferred; **current stealth fix confirmed sufficient 2026-07-09** | Gate met: a 20-gen live baseline through the default stealth stack showed a **0.0% WAF 403 rate**, so the "confirm insufficient before implementing" bar is unmet — CDP-Attach and the Camoufox engine stay parked (Camoufox roadmap closed at Phase 2). Evidence: [superpowers/spikes/2026-07-09-camoufox-waf-403.md](superpowers/spikes/2026-07-09-camoufox-waf-403.md). |
 | 14 | HTTP status path (`get_video_status`) retired alongside `generate_video` | It is the same 401-dead path and would collide with the new `api/video.py:VideoStatus` value object — retiring both together keeps the domain clean. |
 
 ---

--- a/docs/superpowers/plans/2026-07-09-camoufox-adoption/PLAN.md
+++ b/docs/superpowers/plans/2026-07-09-camoufox-adoption/PLAN.md
@@ -5,6 +5,11 @@
 > This plan supersedes PR #258 (closed) — it re-expresses that contributor work as a
 > gated, decomposed series. Preserve `Co-authored-by: C1ph3r404 <C1ph3r404@users.noreply.github.com>`
 > on every commit that carries their code.
+>
+> **STATUS (2026-07-09): Phase 1 shipped (PR #273); Phase 2 verdict = STOP — the Camoufox
+> engine (Phase 3) is NOT built because the current stealth fix showed a 0.0% WAF 403 rate.
+> See Phase 2 below + `docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md`. Phase 4 items
+> remain independent backlog.**
 
 **Goal:** Adopt Camoufox as an optional, evidence-justified stealth browser engine for
 WAF-blocked users — without regressing the default (playwright) path — landing the
@@ -179,23 +184,31 @@ by the package).
       dilutes the 403 rate), `RateLimitError`→429; `--delay` between attempts avoids self-inflicted 429s.
 - [x] Ruff clean; dry-run + both guard exit codes verified without spending.
 
-## Task 2.2 — Run the baseline + record the evidence (owner-gated — spends credits)
+## Task 2.2 — Run the baseline + record the evidence — ✅ DONE (STOP verdict)
 
-**What:** Run the baseline arm, then write `docs/superpowers/spikes/<date>-camoufox-waf-403.md`
-with the numbers and a GO/NO-GO for Phase 3. **This is the ADR-13 artifact.**
+**What:** Ran the baseline arm; wrote the ADR-13 evidence artifact.
 
-**Steps:**
-- [ ] `uv run python scripts/spike_waf_camoufox.py --engine playwright -n 20 --profile <name>`
-      (≈20 Imagen credits). Optionally also `--engine patchright` for a second baseline point.
-- [ ] Record raw JSON + the 403 rate; if a session 401s mid-run, re-auth and re-run.
-- [ ] **Verdict:** ~0% baseline 403 → **STOP**: update ADR-13 (Decision Log #13) with the
-      evidence, keep Phase 1 shipped, close the roadmap at Phase 2. Materially non-zero →
-      proceed to Phase 3 and re-run the harness with `--engine camoufox` as the A/B comparison,
-      citing the delta in `docs/LIVE_VERIFICATION_camoufox.md`.
+**Result (2026-07-09):** 20-gen baseline on `ffroliva` through the default stealth stack →
+**0.0% WAF 403 rate** (19/20 success; the one miss was a `TransportTimeoutError` UI-scrape
+flake, not a WAF block). Evidence: [../../spikes/2026-07-09-camoufox-waf-403.md](../../spikes/2026-07-09-camoufox-waf-403.md).
+
+**Verdict: STOP.** The current stealth fix is confirmed sufficient — ADR-13's "confirm
+insufficient before implementing" gate is unmet. ADR-13 (PLAN.md Decision Log #13) updated
+with the evidence. Phase 1 stays shipped; **Phase 3 is NOT built.**
+
+- [x] Baseline run (≈20 Imagen credits; a first attempt aborted at 0 credits on an expired
+      session, which validated the harness's clean expired-session handling).
+- [x] Recorded raw JSON + the 403 rate.
+- [x] Verdict applied: ~0% → STOP; ADR-13 updated; roadmap closed at Phase 2.
 
 ---
 
-# PHASE 3 — Camoufox engine adoption (only if Phase 2 = GO)
+# PHASE 3 — Camoufox engine adoption — ❌ NOT PROCEEDING (Phase 2 = STOP)
+
+**Gate closed 2026-07-09.** The Phase 2 baseline showed a 0.0% WAF 403 rate, so per ADR-13 the
+Camoufox engine is **not built**. The tasks below are retained only as the design of record in
+case a future, repeatable WAF-403 reopens the gate (re-run `scripts/spike_waf_camoufox.py`;
+a materially non-zero rate would revive this phase). Until then, none of it is implemented.
 
 Re-expressed from PR #258 through the widened abstraction so engine logic lives in one place.
 Own branch `feature/camoufox-engine → develop`, contributor-credited.

--- a/docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md
+++ b/docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md
@@ -1,0 +1,75 @@
+# Spike evidence — Camoufox WAF 403 baseline (ADR-13 gate)
+
+**Date:** 2026-07-09 · **Verdict: STOP — do not build the Camoufox engine (roadmap Phase 3).**
+
+This is the ADR-13 evidence artifact for the
+[camoufox-adoption roadmap](../plans/2026-07-09-camoufox-adoption/PLAN.md). ADR-13
+(PLAN.md Decision Log #13 + the CDP-Attach backlog) parks every stealth-engine
+alternative "until the stealth-flag fix is **confirmed insufficient** — this must be
+verified before implementing anything." This spike ran that verification and the current
+stealth stack is **confirmed sufficient**: zero WAF rejections over a real 20-generation
+baseline. The premise for adopting Camoufox is therefore unmet.
+
+## Method
+
+`scripts/spike_waf_camoufox.py --engine playwright -n 20 --profile ffroliva` — 20 real
+Imagen image generations against live Flow on one authenticated profile, through the
+**default** stealth stack (Playwright + system Chrome `channel=chrome` +
+`--disable-blink-features=AutomationControlled` + the `navigator.webdriver` init script).
+Each attempt is classified: `success` / `waf_403` (`WafRejectionError`, the WAF/reCAPTCHA
+wall) / `auth_401` / `rate_limited_429` / `other_error`.
+
+- **Engine:** `playwright` (the baseline / default). Camoufox was **not** run — it is not a
+  drivable engine on develop (it *is* Phase 3, gated on this spike), and the baseline result
+  makes a Camoufox comparison moot.
+- **Profile:** `ffroliva` (re-authenticated immediately before the run — a first attempt
+  aborted cleanly at 0 credits on an expired session, which validated the harness's
+  expired-session handling).
+- **Model/aspect:** `narwhal` / `1:1`. **Window:** 2026-07-09 20:07–20:14 UTC (442.9s).
+- **Raw evidence:** `scripts/dev/_spike_out/waf_spike_20260709_211430.json` (gitignored;
+  per-attempt records + summary).
+
+## Result
+
+| Outcome | Count |
+|---|---|
+| success | 19 |
+| **WAF 403 (`WafRejectionError`)** | **0** |
+| auth 401 | 0 |
+| rate-limit 429 | 0 |
+| other error | 1 |
+| **WAF 403 rate** | **0.0%** |
+| success rate | 95.0% |
+
+Success latency: n=19, avg 10.5s (min 3.4s, max 34.6s).
+
+The single non-success (attempt #3) was a `TransportTimeoutError` — "Agentic DOM scraping
+timed out after 180s: 0/1 distinct media UUIDs appeared". That is a UI-cohort scraping
+flake (the session bound the agentic cohort on that attempt), **not** a WAF block. It is
+orthogonal to the stealth question and does not count toward the 403 rate.
+
+## Interpretation
+
+The historical 403 (`PUBLIC_ERROR_UNUSUAL_ACTIVITY`) that motivated the CDP-Attach / stealth
+backlog was observed before the current stealth flags landed, when `navigator.webdriver=true`
+let reCAPTCHA-Enterprise detect automation. This run — on the current stealth stack — produced
+**zero** WAF rejections in 20 consecutive real generations. The stealth fix works; the WAF is
+not a material problem for this configuration today.
+
+**Sample-size honesty:** 0/20 is strong evidence that the WAF is *not currently* a material
+blocker, not a proof of 0% under all conditions (WAF scoring varies with profile age, IP
+reputation, request volume, and time). But the ADR-13 gate does not ask for a universal
+guarantee — it asks whether the current fix is *insufficient*. This run decisively fails to
+reproduce insufficiency. If a real, repeatable WAF-403 problem is later observed on the
+default stack, re-run this spike to quantify it; a materially non-zero rate would reopen the
+Camoufox question with the A/B arm.
+
+## Decision
+
+- **STOP the Camoufox adoption roadmap at Phase 2.** Do not build the engine (Phase 3).
+- **Phase 1 stays shipped** (PR #273 — MCP video param parity; unrelated to the engine).
+- **ADR-13 updated** (PLAN.md Decision Log #13) with this evidence: the stealth-flag fix is
+  confirmed sufficient as of 2026-07-09; CDP-Attach and Camoufox remain parked.
+- **Phase 4 items** (transport-side UI-first create_project, `mcp_warmup`, the i2i `ref_names`
+  invariant, the MCP `_SessionManager` idle-reaper concurrency fix) were always independent of
+  the engine and remain as their own backlog — each needs its own predict if picked up.


### PR DESCRIPTION
## Summary

The ADR-13 evidence run is complete. A **20-generation live baseline** on `ffroliva` through the default stealth stack (Playwright + system Chrome + `--disable-blink-features=AutomationControlled` + the `navigator.webdriver` init script) produced a **0.0% WAF 403 rate** (19/20 success; the one miss was a `TransportTimeoutError` UI-scrape flake, not a WAF block).

ADR-13 parks every stealth-engine alternative until the current fix is *"confirmed insufficient."* This decisively confirms it **sufficient** — so:

- **The camoufox-adoption roadmap is closed at Phase 2. The Camoufox engine (Phase 3) is NOT built.**
- Phase 1 stays shipped (PR #273 — MCP video param parity, unrelated to the engine).
- Phase 4 items remain independent backlog.

## Changes
- **New evidence artifact:** `docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md` (method, result table, latency, the honest sample-size caveat, decision).
- **ADR-13 updated** — PLAN.md Decision Log #13 + the CDP-Attach backlog now record the 0% baseline; CDP-Attach and Camoufox stay parked.
- **Roadmap PLAN.md** marked Phase 2 done (STOP verdict), Phase 3 NOT PROCEEDING.

Re-run `scripts/spike_waf_camoufox.py` if a repeatable WAF-403 is later observed; a materially non-zero rate reopens the engine question with the `--engine camoufox` A/B arm.

## Test plan
- [x] Baseline run: `scripts/dev/_spike_out/waf_spike_20260709_211430.json` (0/20 WAF 403).
- [x] doc-links + repo-hygiene pass.

Docs-only; closes out the decomposed takeover of #258 on an evidence-based STOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)