### PR TITLE
docs(i2i): correct stale UUID-ref comment (Phase 4.3 investigation: not a bug)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-camoufox-adoption/PLAN.md
+++ b/docs/superpowers/plans/2026-07-09-camoufox-adoption/PLAN.md
@@ -313,12 +313,16 @@ silently dropped. **Do not bundle these into Phases 1–3.**
 - **4.2 — `mcp_warmup` redesign or removal.** As-is it automates Google Search on a logged-in
   account (account-level risk). If any warmup is needed: direct `labs.google` navigation, own
   env flag defaulted OFF, rate-limited, hard-stop (not swallow) on a Google captcha.
-- **4.3 — i2i remote-UUID refs / `ref_names` invariant reversal** (PR #258 `b94302c`). The PR's
-  only i2i change reverses the PR #245 image-i2i guard on the default path (adds `ref_names` to
-  `GenerateImageRequest`, routes image refs through R2V `_attach_remote_references`). This was
-  originally mis-scoped into Phase 1 as a "safe fix" — it is not. Needs its own predict + tests +
-  a decision on whether the PR #245 invariant should stand. Verify first whether i2i with a bare
-  UUID ref is genuinely broken on develop today (the contributor's premise).
+- **4.3 — i2i remote-UUID refs / `ref_names` invariant reversal** (PR #258 `b94302c`) —
+  **INVESTIGATED 2026-07-09: NOT A BUG on develop. Closed, no change needed.** The contributor's
+  premise ("i2i with a bare UUID ref is ignored → plain t2i submitted") does not reproduce:
+  develop attaches UUID refs via the v0.26.0 select-in-place path (`ui_automation.py:2175`
+  `if request.refs → _attach_image_uuid_refs`), which selects the existing Flow asset in the
+  picker, falls back to local-file upload, and **fails loud** if neither works — never a silent
+  drop. The PR's `ref_names` change would have added a SECOND, parallel R2V attach path on top,
+  likely double-attaching — good that it wasn't merged. Root cause of the false premise: a stale
+  `cli_image.py` comment claiming UUID binding was "not wired yet" (fixed). The PR #245 invariant
+  stands.
 - **4.4 — MCP `_SessionManager` client caching + idle reaper.** The idle monitor can close a
   client mid-generation. Needs in-use refcounting in the worker/service layer before any
   session-caching lands.

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -1414,8 +1414,11 @@ async def _run_i2i(
 
             # Local-file refs are attached through the editor's media dialog by the
             # ui_automation transport (the REST uploadImage path 401s — see #15/#39).
-            # Already-uploaded UUID refs go on `refs` (best-effort; binding a library
-            # asset by UUID via the UI is not wired yet — local files are the path).
+            # Already-uploaded UUID refs go on `refs`: the transport binds them by
+            # SELECTING the existing Flow asset in the reference picker (no duplicate
+            # upload — v0.26.0, `_attach_image_uuid_refs`), falling back to uploading
+            # the asset's local file, and failing loud if neither is possible. A UUID
+            # ref is never silently dropped.
             uuid_refs = tuple(r for r in params.classified_refs if isinstance(r, ImageRef))
             local_ref_paths = tuple(r for r in params.classified_refs if isinstance(r, Path))
             req = GenerateImageRequest(


### PR DESCRIPTION
## Summary

Investigated the PR #258 Phase-4.3 premise — that `gflow image i2i --ref <UUID>` silently drops the reference and submits a plain text-to-image. **It is not a bug on develop.**

The transport attaches UUID refs via the v0.26.0 select-in-place path (`ui_automation.py:2175` → `_attach_image_uuid_refs`): it selects the existing Flow asset in the reference picker (no duplicate upload), falls back to uploading the local file, and **fails loud** if neither works — a UUID ref is never silently dropped. The contributor's premise described an earlier state; their branch predated this work.

The false premise traced to a **stale comment** in `_run_i2i` claiming UUID binding was "not wired yet" — the exact opposite of the real behavior, and very likely what led the contributor to build the redundant `ref_names` R2V attach path (which we correctly did not merge; it would have double-attached on top of the existing path). This corrects the comment so nobody re-derives the same wrong conclusion.

No behavior change — comment + roadmap Phase-4.3 note only. The PR #245 image-i2i invariant stands.

## Test plan
- [x] ruff check / format clean; doc-links pass. Comment-only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)