### PR TITLE
fix(agentic): idempotent character recorder + quiet prefer_classic on agentic cohort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP `gflow_generate_video` model/duration/count parameters (CLI↔MCP parity):** agents can now select the Veo model (`veo_lite`/`veo_fast`/`veo_quality`/`omni_flash`, aliases accepted), clip duration, and batch count through MCP, matching the CLI `gflow video` flags. An unknown model is rejected up front with a 400 instead of failing deep in the worker; an omitted model still lets the transport apply its i2v veo-lite default (issue #125). Co-authored-by C1ph3r404 (from the closed PR #258). Note: the pre-existing transport-level i2v veo-lite default already protected the MCP path, so this is parity + agent control, not a new credit guard.
 
+### Fixed
+
+- **Character-create recorder no longer crashes on a duplicated `flow_media_id`.** Under the agentic cohort the classic character-editor slot-add control is absent, so the body prompt lands in the still-active face slot and both slots report the same `flow_media_id`; `_record_character_local_files` minted a fresh asset `id` per slot and the second slot violated `UNIQUE(profile_name, flow_media_id)` → `DataIntegrityError`. The recorder now reuses the existing asset id (mirroring `record_completed_video`), making character local-file recording idempotent on the business key. Regression test in `tests/data/test_recorder_character.py`.
+- **`prefer_classic` no longer logs a misleading `WARNING` on the agentic cohort.** The server-gated agentic (`tune`) cohort cannot be exited client-side, and `prefer_classic` is best-effort by contract, so `get_ui_driver` now logs that expected fall-through at `INFO` (`ui_driver.prefer_classic.cohort_natively_agentic`) and reserves `WARNING` for genuinely unexpected exit failures.
+
 ## [0.29.0] — 2026-07-09
 
 ### Added

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -139,10 +139,16 @@ async def get_ui_driver(
         from gflow_cli.api.transports.ui_automation_video import (
             VideoGenerationMixin,
         )
+        from gflow_cli.errors import FlowAgentUiError
 
         try:
             log.info("ui_driver.prefer_classic.attempt_exit_agent")
             await VideoGenerationMixin._exit_agent_mode(page)  # type: ignore[reportPrivateUsage]
+        except FlowAgentUiError as exc:
+            # Expected: the server-gated agentic ("tune") cohort cannot be exited
+            # client-side. prefer_classic is best-effort (see config docstring), so
+            # falling through to the agentic driver is normal, not a fault.
+            log.info("ui_driver.prefer_classic.cohort_natively_agentic", detail=str(exc))
         except Exception as exc:
             log.warning("ui_driver.prefer_classic.exit_agent_failed", error=str(exc))
 

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -858,7 +858,15 @@ class OperationRecorder:
             workflow_id = workflow_ids[slot] if slot < len(workflow_ids) else None
             path = _Path(path_str)
             media_type = mimetypes.guess_type(path.name)[0] or "image/png"
-            asset_id = _new_id()
+            # Idempotent on the (profile_name, flow_media_id) business key: under the
+            # agentic cohort the classic slot-add control is absent, so two slots can
+            # report the SAME flow_media_id. Reuse the existing asset id (mirrors
+            # record_completed_video) so upsert_asset UPDATEs instead of violating
+            # UNIQUE(profile_name, flow_media_id). See spike 2026-07-09.
+            existing_asset = (
+                repo.get_asset_by_flow_media_id(profile_name, media_id) if media_id else None
+            )
+            asset_id = existing_asset.id if existing_asset is not None else _new_id()
             repo.upsert_asset(
                 AssetRecord(
                     id=asset_id,

--- a/tests/data/test_recorder_character.py
+++ b/tests/data/test_recorder_character.py
@@ -252,3 +252,51 @@ def test_signed_url_stripped_from_media_metadata(tmp_path: Path) -> None:
         # The safe field should still be present
         meta = json.loads(meta_str)
         assert meta.get("media_metadata", {}).get("display_name") == "character.png"
+
+
+# ---------------------------------------------------------------------------
+# Regression — duplicate flow_media_id across slots (agentic slot-add fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_record_character_completed_duplicate_media_id_is_idempotent(tmp_path: Path) -> None:
+    """Two slots sharing one flow_media_id must not crash the recorder.
+
+    Under the agentic cohort the classic character-editor slot-add control is
+    absent, so the body prompt is submitted to the still-active face slot and
+    both slots report the SAME ``flow_media_id``.  ``_record_character_local_files``
+    minted a fresh ``id`` per slot, so the second slot violated
+    ``UNIQUE(profile_name, flow_media_id)`` -> ``DataIntegrityError``.  The recorder
+    must reuse the existing asset id (mirroring ``record_completed_video``).
+    See spike 2026-07-09.
+    """
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+
+        row_id = recorder.record_character_started(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project_id="flow-project-dup",
+            entity_id="entity-dup-1",
+            name="Dup Character",
+        )
+
+        face = tmp_path / "face.png"
+        face.write_bytes(b"\x89PNG\r\n\x1a\nface-bytes")
+        body = tmp_path / "body.png"
+        body.write_bytes(b"\x89PNG\r\n\x1a\nbody-bytes")
+
+        # Both slots carry the SAME media id (the agentic fallback bug).
+        recorder.record_character_completed(
+            row_id=row_id,
+            workflow_ids=["wf-dup", "wf-dup"],
+            primary_media_ids=["dup-media", "dup-media"],
+            image_paths=[str(face), str(body)],
+        )
+
+        # Must not raise; exactly ONE asset row for the duplicated media id.
+        n = store.conn.execute(
+            "SELECT COUNT(*) AS n FROM assets WHERE profile_name = ? AND flow_media_id = ?",
+            ("default", "dup-media"),
+        ).fetchone()["n"]
+        assert n == 1, "duplicate flow_media_id must upsert to a single asset row"


### PR DESCRIPTION
## Summary

Two agentic-cohort bugs surfaced by the 2026-07-09 parable image-consistency spike. Both are in-scope, root-caused, and unit-tested. No behavior change to the image/video happy paths.

- **Recorder crash (DataIntegrityError).** `character create` under the agentic cohort lacks the classic slot-add control, so both slots report one `flow_media_id`; `_record_character_local_files` minted a fresh asset `id` per slot and violated `UNIQUE(profile_name, flow_media_id)`. Now reuses the existing asset id via `get_asset_by_flow_media_id` (mirrors `record_completed_video`) → idempotent on the business key.
- **`prefer_classic` misleading WARNING.** The server-gated agentic (`tune`) cohort cannot be exited client-side, and `prefer_classic` is best-effort by contract, so `get_ui_driver` now logs that expected fall-through at INFO (`ui_driver.prefer_classic.cohort_natively_agentic`) and reserves WARNING for genuine exit failures.

Out of scope (documented, not fixed here): agentic entity *creation* is classic-only (#174); referencing (`--ref` / `--reference-entity`) already works under agentic.

## Test plan
- [x] New regression test `tests/data/test_recorder_character.py::test_record_character_completed_duplicate_media_id_is_idempotent` (RED→GREEN).
- [x] `pytest tests/api/transports/drivers/ tests/data/` green (63 passed).
- [x] `ruff check` + `ruff format --check` clean.

CHANGELOG entries under `[Unreleased] → Fixed` (no version bump — for the coordinated 0.30.0 cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)