### PR TITLE
fix: #283 follow-ups — picker off-by-one, await_images stable-break, phantom screenshots, UUID consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Picker grid scroll no longer misses a tile rendered by the final scroll (#283 off-by-one).** `_select_existing_asset` checked the tile count only *before* each scroll, so an asset the last scroll brought into the virtualised grid was never re-checked and the picker gave up with the tile on screen. A post-loop re-check closes it (`_find_picker_entity_tile` shares the loop shape but returns the locator unconditionally, so it was unaffected — now documented).
+- **Agentic `await_images` no longer trusts a single exact-count scrape (#283 hardening of the #281 race).** The poll loop breaks only when the new-UUID set is identical across two consecutive scrapes at the expected count (~one extra 0.5s poll); a set that transiently hits the exact count and then grows surfaces as the #281 `MediaAttributionError` instead of being returned as "the" generated media.
+- **Debug screenshots that fail to capture are no longer reported as if they existed.** `_capture_debug_screenshot` returned the target path even when `page.screenshot` raised (observed live 2026-07-11: an error message pointed at a file that was never written). It now returns `None` on capture failure and every error message appends its `Screenshot:` clause conditionally (new `screenshot_clause` helper) (#283).
+
+### Changed
+
+- **UUID-shape validation consolidated onto `gflow_cli.api.video.is_media_uuid`.** The four per-module private `_UUID_RE` copies (cli_image, cli_instructions, image_upscale, mcp/tools) now delegate to the public helper introduced in #290; no behavior change. `MediaAttributionError` raises in the recorder now carry `route=` provenance, the agentic ambiguity raise no longer duplicates the class remediation text, `image i2i --ref` help uses the same "media UUID" vocabulary as `video i2v`, and a bad value passed via the deprecated `--end-image` alias names `--end-image` (not `--end-frame`) in its usage error (#283).
+
 ## [0.32.0] — 2026-07-11
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -798,8 +798,13 @@ through all three layers: wrong file on disk, exit 0. Mitigations until this
 is closed: run generations in a dedicated, low-asset project (fewer
 pre-existing tiles means a smaller lazy-render population to collide with),
 and visually verify anchor/canonical images before referencing them
-downstream in `i2i`. Follow-up hardening (a break condition stable across
-two consecutive scrapes, not one) is tracked upstream against this issue.
+downstream in `i2i`. The stable-break hardening shipped post-v0.32.0 (#283 /
+PR #292): the loop now requires the SAME new-UUID set on two consecutive
+scrapes at the expected count before trusting it, which narrows this window
+to a pre-existing tile that lazy-renders AND holds stable across two 0.5s
+scrapes at exactly the expected count (or first hits the count on the final
+poll before the 180s deadline). Narrowed, not closed — the dedicated-project
+mitigation still applies.
 
 **Known gap: the shell multi-prompt path records no history at all.**
 `gflow run --config <file>` and `gflow image t2i` with multiple prompts
@@ -815,7 +820,8 @@ collision escalation) both depend on local history via
 neither guard exists on this path — this is a pre-existing gap, not a
 regression from this fix. `gflow image batch` (the manifest path, via
 `run_manifest_image_batch`) already threads a recorder through and is covered
-by all three layers. Follow-up tracked in #283.
+by all three layers. Accepted low-risk gap (#283 closed with this noted as
+un-shipped remainder; re-file if it bites in practice).
 
 **Workaround (pre-fix):** none — on an affected version, manually verify the
 downloaded file matches the prompt before trusting a `t2i`/`i2i` result.

--- a/src/gflow_cli/api/image_upscale.py
+++ b/src/gflow_cli/api/image_upscale.py
@@ -19,11 +19,12 @@ Wire facts (reverse-engineered, see ``docs/IMAGE_UPSCALE_RECON.md``)::
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Any
+
+from gflow_cli.api.video import is_media_uuid
 
 __all__ = [
     "DEFAULT_PAYGATE_TIER",
@@ -45,10 +46,6 @@ DEFAULT_PAYGATE_TIER = "PAYGATE_TIER_ONE"
 # Strict UUID allowlist for the source mediaId and the owning projectId. Both
 # are interpolated into the request body (not a URL path), but validating up
 # front rejects malformed input before any reCAPTCHA mint or network call fires
-# (scenario #9). Flow media + project ids are both 8-4-4-4-12 hex UUIDs.
-_UUID_RE = re.compile(
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-)
 
 
 class TargetResolution(StrEnum):
@@ -114,13 +111,13 @@ class UpsampleImageRequest:
     recaptcha_token: str = field(default="")
 
     def __post_init__(self) -> None:
-        if not _UUID_RE.fullmatch(self.media_id):
+        if not is_media_uuid(self.media_id):
             msg = (
                 f"UpsampleImageRequest.media_id must be a bare UUID "
                 f"(8-4-4-4-12 hex, no whitespace); got {self.media_id!r}"
             )
             raise ValueError(msg)
-        if not _UUID_RE.fullmatch(self.project_id):
+        if not is_media_uuid(self.project_id):
             msg = (
                 f"UpsampleImageRequest.project_id must be a bare UUID "
                 f"(8-4-4-4-12 hex, no whitespace); got {self.project_id!r}"

--- a/src/gflow_cli/api/transports/drivers/agentic.py
+++ b/src/gflow_cli/api/transports/drivers/agentic.py
@@ -503,6 +503,7 @@ class AgenticFlowUiDriver:
 
         deadline = asyncio.get_event_loop().time() + _AWAIT_TIMEOUT_S
         new_uuids: set[str] = set()
+        prev_new_uuids: set[str] | None = None
 
         while asyncio.get_event_loop().time() < deadline:
             await asyncio.sleep(_POLL_INTERVAL_S)
@@ -522,8 +523,14 @@ class AgenticFlowUiDriver:
             current_uuids = _extract_uuids(current_srcs)
             new_uuids = current_uuids - baseline_uuids
 
-            if len(new_uuids) >= expected_count:
+            if len(new_uuids) > expected_count:
+                break  # ambiguity — fail fast below (#281)
+            # Stable-break (#283): exact-count on a single scrape can still be
+            # a lazy-render race; require the SAME set on two consecutive
+            # scrapes (~one extra poll interval) before trusting it.
+            if len(new_uuids) == expected_count and new_uuids == prev_new_uuids:
                 break
+            prev_new_uuids = set(new_uuids)
 
         if len(new_uuids) < expected_count:
             if new_uuids:
@@ -543,9 +550,7 @@ class AgenticFlowUiDriver:
             raise MediaAttributionError(
                 detail=(
                     f"Cannot attribute the generation among {len(candidates)} candidate "
-                    f"media UUIDs (expected {expected_count}): {candidates}. Re-run the "
-                    "generation; a dedicated project with fewer pre-existing assets "
-                    "avoids lazy-render ambiguity."
+                    f"media UUIDs (expected {expected_count}): {candidates}."
                 ),
                 route="agentic:await_images",
             )

--- a/src/gflow_cli/api/transports/drivers/agentic.py
+++ b/src/gflow_cli/api/transports/drivers/agentic.py
@@ -478,6 +478,14 @@ class AgenticFlowUiDriver:
         interval of wall time up front; the total poll timeout budget
         (``_AWAIT_TIMEOUT_S``) is unchanged.
 
+        **Stable break (issue #283):** reaching ``expected_count`` on a single
+        scrape is not trusted — a lazily-rendered pre-existing tile can
+        transiently hit the exact count. The loop breaks only when the same
+        new-UUID set holds across two consecutive scrapes (~one extra 0.5s
+        poll). Deliberate fall-through: a set that first reaches the exact
+        count on the final poll before the deadline is returned unconfirmed —
+        better a last-second success than a spurious timeout.
+
         **Ambiguity fail-fast (issue #281):** if more new UUIDs appear than
         were requested, there is no reliable way to tell which ones belong to
         this generation. Rather than arbitrarily slice the unordered set (the

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1041,8 +1041,8 @@ class UiAutomationTransport(VideoGenerationMixin):
 
         shot_path = await _capture_debug_screenshot(page, out_dir, "debug_new_project.png")
         msg = (
-            f"Could not find 'New project' CTA on Flow gallery. URL: {page.url}. "
-            f"Screenshot: {shot_path}"
+            f"Could not find 'New project' CTA on Flow gallery. "
+            f"URL: {page.url}.{screenshot_clause(shot_path)}"
         )
         raise RuntimeError(
             msg,
@@ -1184,7 +1184,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                 continue
 
         shot_path = await _capture_debug_screenshot(page, out_dir, "debug_prompt_not_found.png")
-        msg = f"Prompt input not found in Flow UI. URL: {page.url}. Screenshot: {shot_path}"
+        msg = f"Prompt input not found in Flow UI. URL: {page.url}.{screenshot_clause(shot_path)}"
         raise RuntimeError(msg)
 
     async def _click_submit(self, page: Page) -> None:

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -35,6 +35,7 @@ from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
     VideoGenerationMixin,
+    screenshot_clause,
     selector_drift_detail,
     zip_entity_refs,
 )
@@ -178,6 +179,7 @@ async def _capture_debug_screenshot(
         )
     except Exception as e:
         log.debug("ui_automation.screenshot_capture_failed", error=str(e))
+        return None  # never report a path that was not written (#283)
     return shot_path
 
 
@@ -2767,7 +2769,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             )
             msg = (
                 f"Character editor not ready: prompt textbox not visible "
-                f"within 20 s. URL: {page.url}. Screenshot: {shot}"
+                f"within 20 s. URL: {page.url}.{screenshot_clause(shot)}"
             )
             raise RuntimeError(msg) from exc
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1430,12 +1430,13 @@ class VideoGenerationMixin:
                 msg = (
                     f"Neither the icon nor the text 'Upload media' selector opened a file "
                     f"chooser for {log_label!r} — Google likely changed the media dialog "
-                    f"(issue #56).{screenshot_clause(shot)} Workaround: set the CHROME BROWSER "
+                    f"(issue #56). Workaround: set the CHROME BROWSER "
                     f"PROFILE's language to English (chrome://settings/languages). NOTE: "
                     f"this is the Chrome PROFILE language, NOT the Google ACCOUNT language "
                     f"— changing only the Google account language does NOT work, because "
                     f"Flow follows the Chrome profile locale (and the --lang=en-US launch "
                     f"arg cannot override an already-configured profile)."
+                    f"{screenshot_clause(shot)}"
                 )
                 raise RuntimeError(
                     msg,

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -423,7 +423,14 @@ async def _capture_debug_screenshot(page: Any, out_dir: Path | None, filename: s
         )
     except Exception as e:
         log.debug("ui_automation_video.screenshot_capture_failed", error=str(e))
+        return None  # never report a path that was not written (#283)
     return shot_path
+
+
+def screenshot_clause(shot: Path | None) -> str:
+    """' Screenshot: <path>' when one was captured, else '' — a capture
+    failure must not put a phantom path (or 'None') in the error text."""
+    return f" Screenshot: {shot}" if shot is not None else ""
 
 
 def selector_drift_detail(probe: str, what: str, shot: Path | None) -> str:
@@ -1050,7 +1057,7 @@ class VideoGenerationMixin:
                 msg = (
                     f"model picker trigger not found; cannot select {model.value!r} "
                     f"for i2v. Refusing to proceed (Flow's default would drop the "
-                    f"frames to T2V — issue #125). Screenshot: {shot}"
+                    f"frames to T2V — issue #125).{screenshot_clause(shot)}"
                 )
                 raise VideoModelSelectionError(detail=msg, route="model_picker_trigger")
             return
@@ -1092,7 +1099,7 @@ class VideoGenerationMixin:
                 f"could not select video model {model.value!r} for i2v after 2 "
                 f"attempts. Refusing to proceed — Flow's default model "
                 f"({VideoModel.OMNI_FLASH.value}) silently drops the start/end "
-                f"frames and routes to T2V (issue #125). Screenshot: {shot}"
+                f"frames and routes to T2V (issue #125).{screenshot_clause(shot)}"
             )
             raise VideoModelSelectionError(detail=msg, route="model_option")
 
@@ -1280,7 +1287,7 @@ class VideoGenerationMixin:
             shot = await _capture_debug_screenshot(
                 page, out_dir, f"debug_no_{label.lower()}_slot.png"
             )
-            msg = f"frame slot {label!r} not found on the Flow editor. Screenshot: {shot}"
+            msg = f"frame slot {label!r} not found on the Flow editor.{screenshot_clause(shot)}"
             raise RuntimeError(msg) from e
 
         struct_count = await structs.count()
@@ -1423,7 +1430,7 @@ class VideoGenerationMixin:
                 msg = (
                     f"Neither the icon nor the text 'Upload media' selector opened a file "
                     f"chooser for {log_label!r} — Google likely changed the media dialog "
-                    f"(issue #56). Screenshot: {shot}. Workaround: set the CHROME BROWSER "
+                    f"(issue #56).{screenshot_clause(shot)} Workaround: set the CHROME BROWSER "
                     f"PROFILE's language to English (chrome://settings/languages). NOTE: "
                     f"this is the Chrome PROFILE language, NOT the Google ACCOUNT language "
                     f"— changing only the Google account language does NOT work, because "
@@ -1488,7 +1495,8 @@ class VideoGenerationMixin:
             except Exception as e:
                 if i == 0:
                     shot = await _capture_debug_screenshot(page, out_dir, "debug_no_add_media.png")
-                    msg = f"'Add Media' button not found for first reference. Screenshot: {shot}"
+                    clause = screenshot_clause(shot)
+                    msg = f"'Add Media' button not found for first reference.{clause}"
                     raise RuntimeError(
                         msg,
                     ) from e
@@ -1611,6 +1619,10 @@ class VideoGenerationMixin:
                     visible = True
                     break
                 await VideoGenerationMixin._scroll_picker_grid(page)
+            # Final re-check (#283 off-by-one): the count runs BEFORE each
+            # scroll, so a tile rendered by the LAST scroll was never seen.
+            if not visible and await tile.count():
+                visible = True
             if visible:
                 try:
                     await tile.wait_for(state="visible", timeout=4000)
@@ -1728,7 +1740,9 @@ class VideoGenerationMixin:
         """Locate the Personagens-tab tile for a character entity. Each tile is
         keyed by the entity id as `data-tile-id="fe_id_<entityId>"` (exact — no
         display-name ambiguity). Scroll the grid until it renders, then return
-        the locator (the caller still waits for visibility)."""
+        the locator (the caller still waits for visibility — which also covers
+        a tile rendered by the final scroll, so the #283 off-by-one fixed in
+        `_select_existing_asset` has no effect here)."""
         tile = page.locator(f"[data-tile-id='fe_id_{entity_id}']").first
         for _ in range(PICKER_GRID_SCROLL_ATTEMPTS):
             if await tile.count():
@@ -1781,7 +1795,7 @@ class VideoGenerationMixin:
         await page.keyboard.press("Escape")
         raise TransportTimeoutError(
             f"{detail} include action did not appear (no selector tier "
-            f"matched on surface {surface!r}). Screenshot: {shot}",
+            f"matched on surface {surface!r}).{screenshot_clause(shot)}",
             remediation_hint=(
                 "Flow's resource picker may have changed, or your account's "
                 "UI language is not yet covered by the selector fallbacks. "

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -15,7 +15,6 @@ in :mod:`gflow_cli._cli_helpers` since T4b — a negative AST-based test in
 from __future__ import annotations
 
 import asyncio
-import re
 import sys
 from dataclasses import dataclass
 from datetime import date
@@ -50,6 +49,7 @@ from gflow_cli.api.image import (
 )
 from gflow_cli.api.image_upscale import TargetResolution, UpsampleImageRequest
 from gflow_cli.api.transports import transport_choices
+from gflow_cli.api.video import is_media_uuid
 from gflow_cli.config import get_settings
 from gflow_cli.data.recorder import OperationRecorder, escalate_asset_collision
 from gflow_cli.data.repository import DataRepository
@@ -106,14 +106,9 @@ if TYPE_CHECKING:
 
 _CmdFn = TypeVar("_CmdFn", bound="Callable[..., object]")
 
-# Case-insensitive 8-4-4-4-12 hex with hyphens — Flow's media UUIDs.
-# When a `--ref` value matches this regex it's treated as an already-uploaded
-# asset and passed through verbatim; anything else is treated as a local path
-# that needs to be uploaded first.
-_UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-    re.IGNORECASE,
-)
+# A `--ref` value shaped like a Flow media UUID (see `is_media_uuid`) is an
+# already-uploaded asset passed through verbatim; anything else is a local
+# path that needs to be uploaded first.
 
 _CREATING_PROJECT_MSG = "  Creating project..."
 _T2I_PROJECT_TITLE = "gflow-cli t2i"
@@ -220,7 +215,7 @@ def _classify_ref(ref: str) -> ImageRef | Path:
     Raises:
         click.UsageError: if *ref* is neither a UUID nor an existing path.
     """
-    if _UUID_RE.fullmatch(ref):
+    if is_media_uuid(ref):
         return ImageRef(name=ref)
     try:
         return Path(ref).resolve(strict=True)
@@ -451,7 +446,7 @@ def upscale(
         resolution = TargetResolution.from_cli(scale)
     except ValueError as exc:
         raise click.BadParameter(str(exc), param_hint="--scale") from exc
-    if not _UUID_RE.fullmatch(media_id):
+    if not is_media_uuid(media_id):
         raise click.BadParameter(
             "MEDIA_ID must be a bare UUID (8-4-4-4-12 hex).", param_hint="MEDIA_ID"
         )
@@ -1245,7 +1240,7 @@ class _I2IParams:
     help=(
         "Image-to-image generation: blend a text prompt with one or more "
         "reference images. Each --ref is either a local image path (auto-uploaded) "
-        "or an already-uploaded asset UUID (from a prior `gflow image upload`).\n\n"
+        "or the media UUID of an already-uploaded asset (from a prior `gflow image upload`).\n\n"
         "\b\n"
         "Examples:\n"
         '  gflow image i2i "make it cinematic" --ref hero.png\n'
@@ -1262,8 +1257,8 @@ class _I2IParams:
     multiple=True,
     required=True,
     help=(
-        "Reference image: either a local path (auto-uploaded) or an already-uploaded "
-        "asset UUID. Repeat to pass multiple refs (order is preserved). "
+        "Reference image: either a local path (auto-uploaded) or the media UUID of an "
+        "already-uploaded asset. Repeat to pass multiple refs (order is preserved). "
         "For text-only generation, use `gflow image t2i` instead."
     ),
 )

--- a/src/gflow_cli/cli_instructions.py
+++ b/src/gflow_cli/cli_instructions.py
@@ -15,7 +15,6 @@ See ``docs/INSTRUCTIONS.md`` for the approved spec this module implements.
 from __future__ import annotations
 
 import json
-import re
 import tomllib
 from dataclasses import replace
 from pathlib import Path
@@ -35,6 +34,7 @@ from gflow_cli._cli_helpers import (
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.image import AgentInstruction
 from gflow_cli.api.transports import transport_choices
+from gflow_cli.api.video import is_media_uuid
 from gflow_cli.config import get_settings
 
 if TYPE_CHECKING:
@@ -47,13 +47,7 @@ console = Console()
 # Case-insensitive 8-4-4-4-12 hex — Flow's media/generated-asset UUIDs. A bare
 # UUID `--ref` is an already-uploaded/generated asset (routed to
 # imageReferenceMediaIds); anything else is a local image path (uploaded first)
-# or a character id/name. Same shape used by cli_image._UUID_RE /
-# image_upscale._UUID_RE — each call-site module keeps its own copy per repo
-# convention rather than cross-importing a private name.
-_UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-    re.IGNORECASE,
-)
+# or a character id/name (UUID shape check: `api.video.is_media_uuid`).
 
 _TRANSPORT_HELP = (
     "Override transport strategy. Falls back to GFLOW_CLI_TRANSPORT env var "
@@ -161,7 +155,7 @@ async def classify_refs(
     image_ids: list[str] = []
     char_ids: list[str] = []
     for ref in refs:
-        if _UUID_RE.fullmatch(ref):
+        if is_media_uuid(ref):
             image_ids.append(ref)
             continue
         try:

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -1020,6 +1020,7 @@ def i2v(  # NOSONAR
     """Generate a video from an initial frame + motion PROMPT."""
     resolved_image, resolved_prompt = _resolve_i2v_args(image, prompt, initial_frame)
 
+    end_hint = "'--end-frame'"
     if end_image_deprecated is not None:
         warnings.warn(
             "--end-image is deprecated and will be removed in a future release;"
@@ -1029,9 +1030,10 @@ def i2v(  # NOSONAR
         )
         if end_frame is None:
             end_frame = end_image_deprecated
+            end_hint = "'--end-image'"  # name the flag the user actually typed
 
     start_path, start_ref_id = _classify_frame(resolved_image, "'IMAGE' / '--initial-frame'")
-    end_path, end_ref_id = _classify_frame(end_frame, "'--end-frame'")
+    end_path, end_ref_id = _classify_frame(end_frame, end_hint)
 
     profile_name = _resolve_profile(profile)
     provider_dir = _make_provider_dir(profile_name)

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -118,7 +118,7 @@ def escalate_asset_collision(
         f"[{media_ids}], local_path is one of [{paths}]. Earlier images in "
         "this batch/operation may already have been recorded."
     )
-    raise MediaAttributionError(msg) from exc
+    raise MediaAttributionError(msg, route="data.escalate_asset_collision") from exc
 
 
 class OperationRecorder:
@@ -191,7 +191,7 @@ class OperationRecorder:
                 "batch — wrong-media attribution (#281); nothing was downloaded: "
                 f"{', '.join(intra_batch_duplicates)}"
             )
-            raise MediaAttributionError(msg)
+            raise MediaAttributionError(msg, route="data.verify_media_attribution")
 
         already_recorded = [
             img.media_name
@@ -204,7 +204,7 @@ class OperationRecorder:
                 "wrong-media attribution (#281); nothing was downloaded: "
                 f"{', '.join(already_recorded)}"
             )
-            raise MediaAttributionError(msg)
+            raise MediaAttributionError(msg, route="data.verify_media_attribution")
 
     def _resolve_prompts(
         self,

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -15,7 +15,6 @@ to prevent Playwright browser-context collisions.
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -28,6 +27,7 @@ import structlog
 from gflow_cli._cli_helpers import _FLOW_ID_RE
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.image import AgentInstruction
+from gflow_cli.api.video import is_media_uuid
 from gflow_cli.cli_instructions import classify_refs
 from gflow_cli.config import get_settings
 from gflow_cli.data.queries import list_projects
@@ -338,10 +338,6 @@ async def _run_generation_task(
 _BAD_PARAM_TYPE = "https://gflow-cli.dev/errors/bad-parameter"
 
 # UUID (Flow media id) vs on-disk path discriminator for image references.
-_UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-    re.IGNORECASE,
-)
 
 
 def _bad_param(title: str, detail: str) -> dict[str, Any]:
@@ -518,7 +514,7 @@ def _resolve_image_references(
     refs: list[str] = []
     ref_paths: list[str] = []
     for ref in reference_images:
-        if _UUID_RE.fullmatch(ref):
+        if is_media_uuid(ref):
             refs.append(ref)
             continue
         resolved, err = _resolve_image_path(
@@ -567,7 +563,7 @@ def _build_video_media_inputs(
     ):
         if frame is None:
             continue
-        if _UUID_RE.fullmatch(frame):
+        if is_media_uuid(frame):
             media[ref_key] = frame
             continue
         resolved, err = _resolve_image_path(

--- a/tests/api/transports/drivers/test_agentic.py
+++ b/tests/api/transports/drivers/test_agentic.py
@@ -825,3 +825,34 @@ async def test_await_images_breaks_after_two_stable_scrapes() -> None:
     page = _fake_page_poll_sequence([[_SRC_A], [_SRC_A]])
     images = await driver.await_images(page, expected_count=1)
     assert [img.media_name for img in images] == ["aaaaaaaa-1111-4111-8111-111111111111"]
+
+
+@pytest.mark.asyncio
+async def test_await_images_oscillation_needs_two_consecutive_identical_scrapes() -> None:
+    """{x} -> {} -> {x} -> {x}: the shrink resets stability; only the final
+    consecutive pair may break the loop."""
+    driver = AgenticFlowUiDriver()
+    page = _fake_page_poll_sequence([[_SRC_A], [], [_SRC_A], [_SRC_A]])
+    images = await driver.await_images(page, expected_count=1)
+    assert [img.media_name for img in images] == ["aaaaaaaa-1111-4111-8111-111111111111"]
+
+
+@pytest.mark.asyncio
+async def test_await_images_deadline_exit_returns_last_exact_count_unconfirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Documented fall-through: exact count first reached on the final poll
+    before the deadline is returned WITHOUT the two-scrape confirmation —
+    better a last-second success than a spurious timeout."""
+    from gflow_cli.api.transports.drivers import agentic as mod
+
+    monkeypatch.setattr(mod, "_AWAIT_TIMEOUT_S", mod._POLL_INTERVAL_S * 3.5)
+    # never stable: each poll alternates, deadline lands while set == {A}
+    page = _fake_page_poll_sequence([[], [_SRC_A]])
+    images = await driver_await(page)
+    assert [img.media_name for img in images] == ["aaaaaaaa-1111-4111-8111-111111111111"]
+
+
+async def driver_await(page: MagicMock) -> list:
+    driver = AgenticFlowUiDriver()
+    return await driver.await_images(page, expected_count=1)

--- a/tests/api/transports/drivers/test_agentic.py
+++ b/tests/api/transports/drivers/test_agentic.py
@@ -772,3 +772,56 @@ async def test_driver_reconcile_dispatches_patch_payload() -> None:
     assert card["description"] == "Daytime Cinematic"
     assert card["enabled"] is True
     assert card["imageReferenceMediaIds"] == ["media-uuid-1"]
+
+
+# ---------------------------------------------------------------------------
+# await_images — stable-break condition (#283 hardening of the #281 race)
+# ---------------------------------------------------------------------------
+
+
+def _fake_page_poll_sequence(poll_srcs: list[list[str]]) -> MagicMock:
+    """Page whose img scrapes return: [] for both baseline passes, then each
+    entry of `poll_srcs` in order (last entry repeats). Policy scan: clean."""
+    img_calls = 0
+
+    async def _eval_on_selector_all(selector: str, expr: str) -> list[str]:
+        nonlocal img_calls
+        if selector == "img":
+            img_calls += 1
+            if img_calls <= 2:
+                return []
+            idx = min(img_calls - 3, len(poll_srcs) - 1)
+            return poll_srcs[idx]
+        return []
+
+    page = MagicMock()
+    page.eval_on_selector_all = _eval_on_selector_all
+    count_mock = AsyncMock(return_value=0)
+    locator_mock = MagicMock()
+    locator_mock.count = count_mock
+    page.locator = MagicMock(return_value=locator_mock)
+    return page
+
+
+_SRC_A = "https://lh3.googleusercontent.com/x?name=aaaaaaaa-1111-4111-8111-111111111111"
+_SRC_B = "https://lh3.googleusercontent.com/x?name=bbbbbbbb-2222-4222-8222-222222222222"
+
+
+@pytest.mark.asyncio
+async def test_await_images_does_not_break_on_first_unstable_sighting() -> None:
+    """#283 stable-break: reaching expected_count on ONE scrape is not enough —
+    a lazily-rendered pre-existing tile can transiently hit the exact count.
+    Here the set grows past expected on the next scrape, which must surface as
+    the #281 ambiguity error, NOT be returned as 'the' generated image."""
+    driver = AgenticFlowUiDriver()
+    page = _fake_page_poll_sequence([[_SRC_A], [_SRC_A, _SRC_B]])
+    with pytest.raises(MediaAttributionError):
+        await driver.await_images(page, expected_count=1)
+
+
+@pytest.mark.asyncio
+async def test_await_images_breaks_after_two_stable_scrapes() -> None:
+    driver = AgenticFlowUiDriver()
+    page = _fake_page_poll_sequence([[_SRC_A], [_SRC_A]])
+    images = await driver.await_images(page, expected_count=1)
+    assert [img.media_name for img in images] == ["aaaaaaaa-1111-4111-8111-111111111111"]

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1869,3 +1869,15 @@ class TestCaptureDebugScreenshotFailure:
         shot = await _capture_debug_screenshot(page, tmp_path, "nope.png")
         assert shot is None
         assert not (tmp_path / "nope.png").exists()
+
+    @pytest.mark.asyncio
+    async def test_image_module_copy_also_returns_none_on_failure(self, tmp_path: Path) -> None:
+        # The function is duplicated in ui_automation.py (circular-import
+        # discipline) — the failure-path fix must hold in BOTH copies.
+        from gflow_cli.api.transports.ui_automation import (
+            _capture_debug_screenshot as ua_capture,
+        )
+
+        page = MagicMock()
+        page.screenshot = AsyncMock(side_effect=RuntimeError("target closed"))
+        assert await ua_capture(page, tmp_path, "nope.png") is None

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1511,6 +1511,24 @@ class TestSelectExistingAssetPickerScroll:
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
 
     @pytest.mark.asyncio
+    async def test_tile_rendered_by_final_scroll_is_still_found(self) -> None:
+        """#283 off-by-one: the loop checked tile.count() BEFORE each scroll,
+        so a tile rendered into the DOM by the LAST scroll was never seen and
+        the picker gave up with the asset on screen."""
+        # count: 0 for every pre-scroll check; 1 only on the post-loop re-check.
+        tile = self._tile_mock(
+            wait_for_side_effect=[TimeoutError("not in initial viewport"), None],
+            count_side_effect=[0] * PICKER_GRID_SCROLL_ATTEMPTS + [1],
+        )
+        page = self._page_with_tile(tile)
+
+        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
+
+        assert result is True, "tile rendered by the final scroll must be found"
+        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
+        tile.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_failed_display_name_search_is_cleared_before_scrolling(self) -> None:
         """A FAILED display-name search leaves the picker grid filtered on
         that term; scrolling a still-filtered grid can never surface a tile
@@ -1836,3 +1854,18 @@ class TestUploadRejectionTypedError:
                 page, image, log_label="Start", out_dir=None
             )
         page.remove_listener.assert_called_once()  # finally-detach on the raise path
+
+
+class TestCaptureDebugScreenshotFailure:
+    @pytest.mark.asyncio
+    async def test_capture_failure_returns_none_not_a_phantom_path(self, tmp_path: Path) -> None:
+        """#283 follow-up (observed live 2026-07-11): when page.screenshot
+        raises, the function reported a path that was never written — error
+        messages then pointed users at a nonexistent file."""
+        from gflow_cli.api.transports.ui_automation_video import _capture_debug_screenshot
+
+        page = MagicMock()
+        page.screenshot = AsyncMock(side_effect=RuntimeError("target closed"))
+        shot = await _capture_debug_screenshot(page, tmp_path, "nope.png")
+        assert shot is None
+        assert not (tmp_path / "nope.png").exists()

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -1128,3 +1128,14 @@ class TestI2VAssetRef:
             )
         assert result.exit_code == 0, result.output  # type: ignore[attr-defined]
         assert captured["request"].end_image_ref_id == _ASSET_UUID  # type: ignore[attr-defined]
+
+    def test_deprecated_end_image_bad_value_names_end_image(self, tmp_path: Path) -> None:
+        """#283 follow-up: the error must name the flag the user typed."""
+        start = tmp_path / "hero.png"
+        start.write_bytes(b"\x89PNG\r\n\x1a\n")
+        with pytest.warns(DeprecationWarning):
+            result, _ = self._invoke(
+                tmp_path, ["i2v", str(start), "prompt", "--end-image", "no/such/file.png"]
+            )
+        assert result.exit_code == 2  # type: ignore[attr-defined]
+        assert "--end-image" in result.output  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Closes the actionable remainder of #283 (verified item-by-item against develop before starting — see the issue comment trail):

- **F — picker scroll off-by-one (real latent bug):** `_select_existing_asset` checked `tile.count()` only BEFORE each scroll, so a tile rendered into the virtualised grid by the final scroll was never re-checked. Post-loop re-check added; `_find_picker_entity_tile` shares the loop shape but returns the locator unconditionally (caller waits for visibility), so it was unaffected — now documented in its docstring.
- **A — `await_images` stable-break (#281 residual race):** break only when the new-UUID set is identical across two consecutive scrapes at `expected_count`; a transient exact-count that then grows now raises the #281 `MediaAttributionError` instead of returning wrong media. Cost: ~one extra 0.5s poll per generation, as the issue estimated.
- **Phantom screenshot paths (live-observed 2026-07-11):** `_capture_debug_screenshot` (both copies) now returns `None` when capture fails; new `screenshot_clause()` helper; all 9 `Screenshot: {shot}` interpolation sites append conditionally — error messages can no longer point at files that were never written.
- **C — `route=`** on the recorder's three `MediaAttributionError` raises; **D — remediation dedupe** (agentic raise site relies on the class default).
- **UUID consolidation:** the four private `_UUID_RE` copies (cli_image, cli_instructions, image_upscale, mcp/tools) now delegate to `api.video.is_media_uuid` (#290's public helper). Pure refactor, no behavior change.
- **UX crumbs:** i2i/i2v share the 'media UUID' vocabulary; a bad value via the deprecated `--end-image` alias names `--end-image` in its usage error.

## Deliberately not done (with reasons)

- **E — bulk `is_media_recorded`:** the issue itself gates it on batch limits growing past ~50; they haven't.
- **I — upscale attribution guard:** issue marks it 'noted for completeness, low risk' (the user names the source asset explicitly).
- **H:** superseded — v0.31.0 inverted the behavior it asked to document (continue-on-error now honors collisions; documented at image_batch.py:876).
- **Error-path browser teardown leak** (Chrome lingers holding the profile after error exits; observed 3× live on 2026-07-11): needs its own investigation of the client teardown path — scoped out rather than blind-fixed; tracked in the closing comment.

## Verification status

- [x] TDD: three failing tests written first (picker final-scroll, stable-break ambiguity, phantom screenshot), then fixes to green
- [x] 667 passed across transports/cli-video/cli-image/recorder/mcp; instructions + upscale suites green after consolidation; ruff + format + doc links + hygiene + pyright 0 errors
- [x] The stable-break and picker paths are browser-free logic — the unit tests ARE the affected surface; no live gap
- [ ] Optional live spot-check: any picker-based flow (e.g. `i2i --ref <uuid>`) exercising the new final-scroll path — behavior-preserving on the happy path, so not release-gating

Refs #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)