### PR TITLE
feat(site): GitHub Pages site — landing + Material for MkDocs docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy site to GitHub Pages
+
+# Publishes the marketing landing (index.html) at the site root and the
+# Material for MkDocs docs portal (website/) at /docs. One site, two parts.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "index.html"
+      - "website/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel an in-progress deploy; queue instead.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install MkDocs Material
+        run: pip install "mkdocs-material>=9,<10"
+      - name: Build docs portal
+        working-directory: website
+        run: mkdocs build
+      - name: Assemble site (landing at /, docs at /docs)
+        run: |
+          mkdir -p _site
+          cp index.html _site/
+          cp -r website/site _site/docs
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ worktrees/
 
 # Subagent-driven-development scratch (ledger + task reports)
 .superpowers/
+
+# MkDocs build output
+website/site/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="gflow-cli — an unofficial, alpha CLI and MCP server that drives Google Flow (Veo + Imagen) from the terminal, or lets your AI assistant drive it.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22%3E%F0%9F%8E%AC%3C/text%3E%3C/svg%3E">
+<title>gflow-cli — drive Google Flow from your terminal</title>
+<style>
+  :root{
+    --ground:#0e1014; --surface:#161a21; --raised:#1c212a; --hair:#272d38;
+    --ink:#ecebe5; --muted:#8c939d; --faint:#5c636e;
+    --accent:#ffb03a; --accent-dim:#c9852c; --accent-ghost:rgba(255,176,58,.12);
+    --risk:#e5674f; --risk-ghost:rgba(229,103,79,.10);
+    --mono:ui-monospace,"Cascadia Code","SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,Roboto,Helvetica,Arial,sans-serif;
+    --maxw:74ch;
+  }
+  @media (prefers-color-scheme: light){
+    :root{
+      --ground:#f6f3ec; --surface:#fffefa; --raised:#fbf8f1; --hair:#e5e0d4;
+      --ink:#1b1d22; --muted:#6a7079; --faint:#9aa0a7;
+      --accent:#b9740f; --accent-dim:#9c610b; --accent-ghost:rgba(185,116,15,.10);
+      --risk:#c4442c; --risk-ghost:rgba(196,68,44,.08);
+    }
+  }
+  :root[data-theme="dark"]{
+    --ground:#0e1014; --surface:#161a21; --raised:#1c212a; --hair:#272d38;
+    --ink:#ecebe5; --muted:#8c939d; --faint:#5c636e;
+    --accent:#ffb03a; --accent-dim:#c9852c; --accent-ghost:rgba(255,176,58,.12);
+    --risk:#e5674f; --risk-ghost:rgba(229,103,79,.10);
+  }
+  :root[data-theme="light"]{
+    --ground:#f6f3ec; --surface:#fffefa; --raised:#fbf8f1; --hair:#e5e0d4;
+    --ink:#1b1d22; --muted:#6a7079; --faint:#9aa0a7;
+    --accent:#b9740f; --accent-dim:#9c610b; --accent-ghost:rgba(185,116,15,.10);
+    --risk:#c4442c; --risk-ghost:rgba(196,68,44,.08);
+  }
+  *{box-sizing:border-box}
+  html{-webkit-text-size-adjust:100%}
+  body{
+    margin:0; background:var(--ground); color:var(--ink);
+    font-family:var(--sans); font-size:17px; line-height:1.65;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+    overflow-x:hidden;
+  }
+  .wrap{max-width:1080px; margin:0 auto; padding:0 24px}
+  .col{max-width:var(--maxw)}
+  a{color:var(--accent); text-decoration:none}
+  a:hover{text-decoration:underline; text-underline-offset:3px}
+  :focus-visible{outline:2px solid var(--accent); outline-offset:3px; border-radius:3px}
+  h1,h2,h3{font-family:var(--mono); font-weight:600; letter-spacing:-.01em; text-wrap:balance; line-height:1.15; margin:0}
+  .eyebrow{font-family:var(--mono); font-size:12.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--accent-dim); margin:0 0 18px}
+  .muted{color:var(--muted)}
+
+  /* top bar */
+  header{position:sticky; top:0; z-index:20; background:color-mix(in srgb,var(--ground) 88%, transparent); backdrop-filter:blur(8px); border-bottom:1px solid var(--hair)}
+  .bar{display:flex; align-items:center; gap:20px; height:60px}
+  .brand{font-family:var(--mono); font-weight:600; font-size:16px; letter-spacing:-.02em; color:var(--ink); white-space:nowrap}
+  .brand .caret{color:var(--accent)}
+  .bar nav{display:flex; gap:22px; margin-left:auto; font-size:14px; font-family:var(--mono)}
+  .bar nav a{color:var(--muted)}
+  .bar nav a:hover{color:var(--ink); text-decoration:none}
+  .ghost-btn{font-family:var(--mono); font-size:13.5px; padding:8px 14px; border:1px solid var(--hair); border-radius:8px; color:var(--ink); white-space:nowrap}
+  .ghost-btn:hover{border-color:var(--accent); text-decoration:none}
+  @media(max-width:720px){ .bar nav{display:none} }
+
+  /* hero */
+  .hero{padding:76px 0 34px}
+  .hero h1{font-size:clamp(30px,5.4vw,52px)}
+  .hero h1 .amber{color:var(--accent)}
+  .lede{font-size:clamp(17px,2.2vw,20px); color:var(--muted); margin:22px 0 0; max-width:60ch; line-height:1.55}
+
+  /* terminal */
+  .term{margin:34px 0 0; background:var(--surface); border:1px solid var(--hair); border-radius:12px; overflow:hidden; box-shadow:0 24px 60px -30px rgba(0,0,0,.6)}
+  .term-bar{display:flex; align-items:center; gap:8px; padding:12px 15px; border-bottom:1px solid var(--hair); background:var(--raised)}
+  .dot{width:11px; height:11px; border-radius:50%; background:var(--faint); opacity:.5}
+  .term-title{font-family:var(--mono); font-size:12px; color:var(--faint); margin-left:8px}
+  .term-body{padding:20px 20px 24px; font-family:var(--mono); font-size:14.5px; line-height:1.85; overflow-x:auto}
+  .term-body .ln{white-space:pre; display:block}
+  .prompt{color:var(--accent)}
+  .cmd{color:var(--ink)}
+  .out{color:var(--muted)}
+  .ok{color:var(--accent)}
+  .cursor{display:inline-block; width:8px; height:1.05em; background:var(--accent); vertical-align:-2px; margin-left:2px; animation:blink 1.1s steps(1) infinite}
+  @keyframes blink{50%{opacity:0}}
+
+  .cta-row{display:flex; flex-wrap:wrap; gap:12px; align-items:center; margin:30px 0 0}
+  .install{display:inline-flex; align-items:center; gap:12px; font-family:var(--mono); font-size:15px; background:var(--surface); border:1px solid var(--hair); border-radius:10px; padding:12px 14px}
+  .install .p{color:var(--accent)}
+  .install button{font-family:var(--mono); font-size:12px; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); background:transparent; border:1px solid var(--hair); border-radius:6px; padding:5px 9px; cursor:pointer}
+  .install button:hover{color:var(--ink); border-color:var(--accent)}
+  .btn{display:inline-flex; align-items:center; gap:9px; font-family:var(--mono); font-size:14.5px; font-weight:600; padding:12px 18px; border-radius:10px; cursor:pointer; border:1px solid transparent}
+  .btn.primary{background:var(--accent); color:#0e1014}
+  .btn.primary:hover{background:var(--accent-dim); text-decoration:none}
+  .btn.line{border-color:var(--hair); color:var(--ink)}
+  .btn.line:hover{border-color:var(--accent); text-decoration:none}
+
+  /* sections */
+  section{padding:64px 0; border-top:1px solid var(--hair)}
+  .sec-head{max-width:60ch}
+  .sec-head h2{font-size:clamp(23px,3.2vw,30px)}
+  .sec-head p{color:var(--muted); margin:16px 0 0; font-size:17px}
+
+  /* drive-it split */
+  .drive{display:grid; grid-template-columns:1.05fr .95fr; gap:44px; align-items:center}
+  @media(max-width:820px){ .drive{grid-template-columns:1fr; gap:30px} }
+  .drive .steps{list-style:none; margin:26px 0 0; padding:0; display:flex; flex-direction:column; gap:18px}
+  .drive .steps li{display:flex; gap:14px; align-items:flex-start}
+  .drive .steps .n{font-family:var(--mono); font-size:13px; color:var(--accent); border:1px solid var(--hair); border-radius:7px; padding:3px 8px; margin-top:2px; flex:none}
+  .drive .steps b{font-family:var(--mono); font-weight:600; font-size:15.5px}
+  .drive .steps span{color:var(--muted); font-size:15px}
+
+  /* feature grid */
+  .grid{display:grid; grid-template-columns:repeat(2,1fr); gap:1px; background:var(--hair); border:1px solid var(--hair); border-radius:14px; overflow:hidden; margin-top:34px}
+  @media(max-width:720px){ .grid{grid-template-columns:1fr} }
+  .cell{background:var(--surface); padding:26px 24px}
+  .cell code{font-family:var(--mono); font-size:13.5px; color:var(--accent); background:var(--accent-ghost); padding:2px 7px; border-radius:6px}
+  .cell h3{font-size:16px; margin:14px 0 8px}
+  .cell p{color:var(--muted); font-size:15px; margin:0; line-height:1.6}
+
+  /* honest band */
+  .honest{background:var(--risk-ghost); border-top:1px solid var(--hair); border-bottom:1px solid var(--hair)}
+  .honest .eyebrow{color:var(--risk)}
+  .honest ul{list-style:none; margin:22px 0 0; padding:0; display:grid; grid-template-columns:repeat(2,1fr); gap:14px 34px}
+  @media(max-width:720px){ .honest ul{grid-template-columns:1fr} }
+  .honest li{display:flex; gap:11px; font-size:15px; color:var(--ink); align-items:flex-start}
+  .honest li::before{content:"—"; color:var(--risk); font-family:var(--mono); flex:none}
+  .honest strong{font-family:var(--mono); font-weight:600}
+
+  /* demo */
+  .demo-card{display:flex; align-items:center; gap:20px; flex-wrap:wrap; background:var(--surface); border:1px solid var(--hair); border-radius:14px; padding:24px; margin-top:28px}
+  .play{width:52px; height:52px; border-radius:50%; background:var(--accent); color:#0e1014; display:grid; place-items:center; flex:none; font-size:18px}
+  .demo-card .t{flex:1; min-width:220px}
+  .demo-card .t b{font-family:var(--mono)}
+  .demo-card .t p{margin:4px 0 0; color:var(--muted); font-size:15px}
+
+  footer{border-top:1px solid var(--hair); padding:46px 0 60px}
+  .foot{display:flex; flex-wrap:wrap; gap:18px 40px; align-items:baseline}
+  .foot .brand{font-size:15px}
+  .foot nav{display:flex; gap:22px; font-family:var(--mono); font-size:14px}
+  .foot nav a{color:var(--muted)}
+  .foot .fine{width:100%; color:var(--faint); font-size:13px; font-family:var(--mono); margin-top:6px}
+
+  @media (prefers-reduced-motion: reduce){ .cursor{animation:none} *{animation-duration:.001ms !important; transition:none !important} }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap bar">
+    <span class="brand"><span class="caret">›</span> gflow-cli</span>
+    <nav>
+      <a href="#drive">Agent-driven</a>
+      <a href="#features">Features</a>
+      <a href="docs/">Docs</a>
+      <a href="https://github.com/ffroliva/gflow-cli">GitHub ↗</a>
+    </nav>
+    <a class="ghost-btn" href="https://github.com/ffroliva/gflow-cli">★ Star on GitHub</a>
+  </div>
+</header>
+
+<main>
+  <div class="wrap hero">
+    <p class="eyebrow">Unofficial · Alpha · MCP-native</p>
+    <h1>Drive Google Flow from your terminal.<br><span class="amber">Or let your AI assistant drive it.</span></h1>
+    <p class="lede">A command-line tool and MCP server for Google Flow — script Veo video and Imagen stills instead of clicking through the web UI. Point Claude, Cursor, or Copilot at it and the agent picks the models, prompt tooling, and settings for you.</p>
+
+    <div class="term" role="img" aria-label="Terminal: an agent runs gflow to generate a Veo clip">
+      <div class="term-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="term-title">claude — gflow mcp</span></div>
+      <div class="term-body" id="term">
+        <span class="ln"><span class="out"># you, to your assistant:</span></span>
+        <span class="ln"><span class="cmd">"make a 9:16 clip of a lighthouse in a storm, moody, slow push-in"</span></span>
+        <span class="ln" id="typed"><span class="prompt">gflow&nbsp;›</span> <span class="cmd" id="typetarget"></span><span class="cursor" id="cur"></span></span>
+        <span class="ln reveal" style="display:none"><span class="out">  ↳ tool: creative-director  ·  model: veo-3  ·  aspect: 9:16</span></span>
+        <span class="ln reveal" style="display:none"><span class="out">  ↳ paced batch · reusing project · no re-upload</span></span>
+        <span class="ln reveal" style="display:none"><span class="ok">  ✓ lighthouse_storm.mp4  ·  8s  ·  1080×1920</span></span>
+      </div>
+    </div>
+
+    <div class="cta-row">
+      <span class="install"><span><span class="p">$</span> uv tool install gflow-cli</span><button id="copy" aria-label="Copy install command">Copy</button></span>
+      <a class="btn primary" href="docs/">Get started →</a>
+      <a class="btn line" href="https://www.youtube.com/shorts/SyJb2jfLMrw">▶ Watch the demo</a>
+    </div>
+  </div>
+
+  <section id="drive">
+    <div class="wrap">
+      <div class="drive">
+        <div class="sec-head">
+          <p class="eyebrow">The agent-native part</p>
+          <h2>You describe it. The agent runs it.</h2>
+          <p>gflow-cli ships an MCP server, so an AI assistant connects to it natively — no pasting docs, no copying commands back and forth. CLI-to-MCP parity is enforced in CI: anything the terminal can do, your assistant can do.</p>
+          <ol class="steps">
+            <li><span class="n">01</span><div><b>gflow mcp run</b><br><span>Claude / Cursor / Copilot connects over MCP.</span></div></li>
+            <li><span class="n">02</span><div><b>Ask in plain language</b><br><span>The agent picks the Veo/Imagen model, aspect, and prompt tooling.</span></div></li>
+            <li><span class="n">03</span><div><b>Get files back</b><br><span>It runs the generation on your own Flow session and hands you the output.</span></div></li>
+          </ol>
+        </div>
+        <div class="term" aria-hidden="true">
+          <div class="term-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="term-title">~/.config — AGENTS.md</span></div>
+          <div class="term-body">
+<span class="ln"><span class="out">$</span> <span class="cmd">gflow mcp run</span></span>
+<span class="ln"><span class="out">  serving 2 tools over stdio:</span></span>
+<span class="ln"><span class="ok">  • gflow_generate_image</span></span>
+<span class="ln"><span class="ok">  • gflow_generate_video</span></span>
+<span class="ln"><span class="out">  ready — your assistant can drive Flow.</span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="features">
+    <div class="wrap">
+      <div class="sec-head">
+        <p class="eyebrow">What it handles for you</p>
+        <h2>Built for real runs, not just a demo.</h2>
+        <p>The knobs an agent (or you) leans on, plus the reliability work that keeps batch jobs and big projects from falling over.</p>
+      </div>
+      <div class="grid">
+        <div class="cell"><code>--tool creative-director</code><h3>Prompt-crafting, built in</h3><p>Rewrites a terse line with Google's 5-component formula before a single credit is spent.</p></div>
+        <div class="cell"><code>gflow instructions</code><h3>Instruction cards</h3><p>Persistent, credit-free brief cards that steer look and tone across every generation.</p></div>
+        <div class="cell"><code>reuse by UUID</code><h3>Reference an asset, don't re-upload</h3><p>Chain a still into a video by its id — no duplicate uploads, no shuffling files.</p></div>
+        <div class="cell"><code>--ui-mode</code><h3>Fail fast, before credits</h3><p>Aborts up front when Flow's UI cohort isn't what the command needs — instead of burning a generation.</p></div>
+        <div class="cell"><code>GFLOW_CLI_JITTER_RANGE</code><h3>Configurable batch pacing</h3><p>Tunable jitter between submissions so multi-prompt runs stop tripping rate limits.</p></div>
+        <div class="cell"><code>movie.toml</code><h3>Multi-scene pipeline</h3><p>Direct a whole sequence from one manifest — chain clips, compose scenes, render.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="honest" id="honest">
+    <div class="wrap">
+      <p class="eyebrow">Read this before you install</p>
+      <h2 class="sec-head" style="font-size:clamp(22px,3vw,28px)">Unofficial, alpha, and honest about it.</h2>
+      <ul>
+        <li><span><strong>Not affiliated with Google.</strong> gflow-cli is an independent, unofficial project. Flow, Veo, and Imagen are Google's.</span></li>
+        <li><span><strong>Reverse-engineered &amp; alpha.</strong> It drives Flow's private API; things break and change.</span></li>
+        <li><span><strong>Runs a headed browser on your own Flow session.</strong> Treat it as your own account risk.</span></li>
+        <li><span><strong>Needs Google AI Ultra or Pro</strong> with Flow access. Every generation bills your own account.</span></li>
+      </ul>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <div class="sec-head">
+        <p class="eyebrow">See it move</p>
+        <h2>A short made entirely with it.</h2>
+      </div>
+      <a class="demo-card" href="https://www.youtube.com/shorts/SyJb2jfLMrw">
+        <span class="play" aria-hidden="true">▶</span>
+        <span class="t"><b>Watch the 100-second demo</b><p>Generated end to end through gflow-cli — YouTube Shorts.</p></span>
+        <span class="btn line" aria-hidden="true">Open ↗</span>
+      </a>
+      <div class="cta-row" style="margin-top:34px">
+        <span class="install"><span><span class="p">$</span> uv tool install gflow-cli</span><button id="copy2" aria-label="Copy install command">Copy</button></span>
+        <a class="btn primary" href="docs/">Read the docs →</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap foot">
+    <span class="brand"><span class="caret">›</span> gflow-cli</span>
+    <nav>
+      <a href="docs/">Docs</a>
+      <a href="https://github.com/ffroliva/gflow-cli">GitHub</a>
+      <a href="https://www.youtube.com/shorts/SyJb2jfLMrw">Demo</a>
+      <a href="https://github.com/ffroliva/gflow-cli/issues">Issues</a>
+    </nav>
+    <p class="fine">Unofficial · not affiliated with Google · MIT-licensed · your credits, your account, your risk.</p>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var target = document.getElementById('typetarget');
+  var cur = document.getElementById('cur');
+  var reveals = document.querySelectorAll('.reveal');
+  var text = 'video i2v --tool creative-director --aspect 9:16';
+  function showAll(){ target.textContent = text; reveals.forEach(function(r){ r.style.display=''; }); if(cur) cur.style.display='none'; }
+  if(reduce){ showAll(); }
+  else{
+    var i=0;
+    function tick(){
+      if(i<=text.length){ target.textContent = text.slice(0,i); i++; setTimeout(tick, 34 + Math.random()*40); }
+      else{ var d=380; reveals.forEach(function(r){ setTimeout(function(){ r.style.display=''; }, d); d+=340; }); if(cur) setTimeout(function(){cur.style.display='none';}, d); }
+    }
+    setTimeout(tick, 650);
+  }
+  function wireCopy(id){
+    var b=document.getElementById(id); if(!b) return;
+    b.addEventListener('click', function(){
+      var t='uv tool install gflow-cli';
+      if(navigator.clipboard){ navigator.clipboard.writeText(t).then(function(){ var o=b.textContent; b.textContent='Copied'; setTimeout(function(){b.textContent=o;},1400); }); }
+    });
+  }
+  wireCopy('copy'); wireCopy('copy2');
+})();
+</script>
+</body>
+</html>

--- a/website/docs/agents.md
+++ b/website/docs/agents.md
@@ -1,0 +1,43 @@
+# Let your assistant drive it
+
+gflow-cli is built to be driven by an AI assistant. It ships an **MCP server**, so Claude, Cursor, or Copilot connects to it natively — no pasting docs, no copying commands back and forth. CLI-to-MCP parity is enforced in CI: anything the terminal can do, your assistant can do.
+
+## Start the server
+
+```bash
+gflow mcp run
+#   serving over stdio:
+#   • gflow_generate_image
+#   • gflow_generate_video
+#   ready — your assistant can drive Flow.
+```
+
+`gflow mcp run` speaks MCP over stdio; `gflow serve` exposes an HTTP/SSE endpoint if you'd rather connect over the network. `gflow mcp setup` helps wire it into a client.
+
+## Point your agent at it
+
+The repo ships the files an agent reads to understand the tool:
+
+| File | Purpose | Use with |
+| --- | --- | --- |
+| `AGENTS.md` | Universal agent onboarding | Cursor, Codex, Aider, Claude Code |
+| `llms.txt` | LLM-readable command reference | Paste into ChatGPT / Claude / Gemini |
+| `CLAUDE.md` | Claude Code memory hub | Claude Code specifically |
+
+Once connected, describe what you want in plain language:
+
+> "Make a 9:16 clip of a lighthouse in a storm, moody, slow push-in."
+
+The agent picks the Veo model, aspect, and prompt tooling, runs the generation on your own Flow session, and hands you the files.
+
+## What the agent leans on
+
+- **`--tool creative-director`** — expands a terse prompt with Google's 5-component formula before spending credits.
+- **`gflow instructions`** — persistent, credit-free brief cards that steer look and tone across generations.
+- **Asset reuse by UUID** — chain a still into a video by its id, no re-upload.
+- **`--ui-mode`** — aborts up front when Flow's UI cohort isn't what the command needs, instead of burning a generation.
+
+!!! note "It runs on your account"
+    Even when an agent drives it, gflow-cli still uses your own headed Flow session and bills your own credits. The same alpha/account-risk caveats apply.
+
+Next: [**Known issues →**](known-issues.md).

--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -1,0 +1,29 @@
+# Authentication
+
+gflow-cli authenticates by saving a real browser session against **your own** Google Flow account. There are no API keys — the tool drives Flow the way you would, in a headed Chrome window.
+
+## One-time login
+
+```bash
+gflow auth login --browser chrome
+```
+
+The `--browser chrome` flag is **mandatory**; the CLI fails fast on any other strategy. A Chrome window opens for you to sign in — including 2FA. Once you're in, the session is saved and reused on every subsequent run.
+
+!!! warning "Your account, your risk"
+    The saved session drives Flow as you. gflow-cli is unofficial and reverse-engineered — treat the whole thing as your own account risk. Not affiliated with Google.
+
+## reCAPTCHA & the WAF
+
+Google's auth path and Flow's WAF are the two things most likely to interrupt a run:
+
+- **reCAPTCHA** can appear during login or token refresh. Complete it in the headed window.
+- **The WAF (403)** reacts to cumulative request cadence. Bursty, unpaced generation trips it. Pace batch runs with `--jitter MIN-MAX` or `GFLOW_CLI_JITTER_RANGE`, and give a blocked account a cooldown before retrying. See [Known issues](known-issues.md) for the field notes.
+
+## Sessions & profiles
+
+- The saved session persists between runs — you don't log in every time.
+- If a run starts failing with auth or 403 errors that a fresh login fixes, re-run `gflow auth login --browser chrome`.
+- Live/E2E test flows opt in via their own environment variables (`GFLOW_LIVE=1`, `GFLOW_CLI_E2E_PROFILE`).
+
+Next: [**Let your assistant drive it →**](agents.md).

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,49 @@
+# Introduction
+
+**gflow-cli** is an unofficial CLI and MCP server for [Google Flow](https://labs.google/fx/tools/flow) — it scripts **Veo** video and **Imagen** image generation from the terminal instead of clicking through the web UI. And because it ships an MCP server, you can point an AI assistant at it and let the agent drive the generations for you.
+
+!!! warning "Read this before you install"
+    gflow-cli is **unofficial, alpha, and reverse-engineered**. It drives a headed browser on *your own* Google Flow session, so treat it as your own account risk. It requires a Google AI **Ultra or Pro** subscription with Flow access, and every generation bills your account. **Not affiliated with Google.**
+
+## Why it exists
+
+Flow's web UI is fine for one-off clips. It's slow for real work — batches, character consistency across shots, reusing assets, or driving generation from a script or an agent. gflow-cli gives you the terminal surface for all of that, and an MCP server so your assistant can do it on your behalf.
+
+## The two ways to use it
+
+<div class="grid cards" markdown>
+
+-   __Drive it yourself__
+
+    ---
+
+    Script Veo and Imagen from the terminal: `gflow image`, `gflow video`, `gflow character`, `gflow movie`, `gflow batch`.
+
+    [:octicons-arrow-right-24: Quickstart](quickstart.md)
+
+-   __Let your assistant drive it__
+
+    ---
+
+    Run `gflow mcp run` and point Claude, Cursor, or Copilot at it. The agent picks the models, prompt tooling, and settings.
+
+    [:octicons-arrow-right-24: Agent-driven](agents.md)
+
+</div>
+
+## What it handles for you
+
+- **`--tool creative-director`** — rewrites a terse prompt with Google's 5-component formula before a single credit is spent.
+- **`gflow instructions`** — persistent, credit-free brief cards that steer look and tone across generations.
+- **Asset reuse by UUID** — reference an already-generated still in a video without re-uploading it.
+- **`--ui-mode`** — fails fast, *before* spending credits, when Flow's UI cohort isn't what the command needs.
+- **`GFLOW_CLI_JITTER_RANGE`** — configurable pacing so batch runs stop tripping rate limits.
+- **`movie.toml`** — direct a multi-scene sequence from one manifest.
+
+## Requirements
+
+- A Google AI **Ultra or Pro** subscription with Flow access.
+- `uv` (to install the tool) and a Chromium the browser transport can drive.
+- A display for the one-time browser login.
+
+Ready? [**Start with the Quickstart →**](quickstart.md)

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -1,0 +1,45 @@
+# Installation
+
+## Requirements
+
+- A Google AI **Ultra or Pro** subscription with Flow access — every generation bills your own account.
+- [`uv`](https://docs.astral.sh/uv/) to install the tool.
+- A Chromium the browser transport can drive (installed via Playwright, below).
+- A display for the one-time browser login (headless CI without a prerecorded profile won't work — see [Known issues](known-issues.md)).
+
+## Install the CLI
+
+```bash
+uv tool install gflow-cli
+```
+
+This puts `gflow` on your `PATH`. Verify:
+
+```bash
+gflow --version
+```
+
+## Install the browser engine
+
+gflow-cli drives Flow through a real Chrome session managed by Playwright. Install Chromium once:
+
+```bash
+uv tool run --from gflow-cli playwright install chromium
+```
+
+!!! note "Why a browser at all?"
+    Google's auth + reCAPTCHA stack rejects Playwright's bundled Chromium in most headless setups, so gflow-cli uses a headed browser transport (`ui_automation`). This is the project's defining trade-off — it works end-to-end against live Ultra/Pro accounts, but needs a saved profile and a display for the first login. See [Known issues](known-issues.md).
+
+## Configuration
+
+- **Output directory** — CLI outputs default to `./out/`; override with `GFLOW_CLI_OUTPUT_DIR`. Scripts/tests write to `./tmp/`.
+- **Batch pacing** — `GFLOW_CLI_JITTER_RANGE` (or `--jitter MIN-MAX`) tunes the delay between batch submissions.
+- **Environment** — copy the project's `.env.template` to `.env.local` for the full list of variables; never commit it.
+
+## Upgrade
+
+```bash
+uv tool upgrade gflow-cli
+```
+
+Next: [**Authentication →**](authentication.md).

--- a/website/docs/known-issues.md
+++ b/website/docs/known-issues.md
@@ -1,0 +1,29 @@
+# Known issues
+
+gflow-cli is alpha and reverse-engineered. These are the current sharp edges. For the authoritative, up-to-date list, see [`KNOWN_ISSUES.md`](https://github.com/ffroliva/gflow-cli/blob/develop/KNOWN_ISSUES.md) and the [issue tracker](https://github.com/ffroliva/gflow-cli/issues) in the repo.
+
+## Headed-browser dependency
+
+gflow-cli drives Flow via a real Chrome session managed by Playwright (`ui_automation` transport). Google's auth + reCAPTCHA stack rejects bundled Chromium and most headless approaches. This means:
+
+- It needs a saved Chrome profile and a display for the one-time login.
+- It can't run on serverless / headless CI workers without transplanting a prerecorded profile.
+- Per-account concurrency is capped by what one warm browser can drive.
+
+If you can help unblock a pure HTTP transport (especially for video generation, where HTTP 401 + reCAPTCHA mints currently block it), please [open an issue](https://github.com/ffroliva/gflow-cli/issues).
+
+## WAF / 403 pacing
+
+Flow's WAF reacts to cumulative submission cadence. Bursty, unpaced runs trip a `403` ("blocked by WAF or fingerprint check").
+
+- Pace batch runs with `--jitter MIN-MAX` or `GFLOW_CLI_JITTER_RANGE`. Defaults are deliberately small; widen only when you actually hit 403s, then dial back.
+- After a 403, give the account a cooldown (30–60 min) and probe with a single small generation before batching again.
+
+## Credit safety
+
+- Use `--ui-mode` where available — it fails fast *before* spending credits when Flow's UI cohort isn't what the command needs.
+- Generation always bills your own Google account. There is no dry-run that produces media for free.
+
+## Reporting
+
+Found something? An [issue](https://github.com/ffroliva/gflow-cli/issues) with the command, the traceback, and your OS helps a lot. If you drive gflow-cli through an agent, include what you asked it to do.

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+From install to your first Veo clip in about five minutes — or hand the whole thing to your AI assistant.
+
+!!! warning "Before you begin"
+    gflow-cli is **unofficial, alpha, and reverse-engineered**. It drives a headed browser on *your own* Google Flow session — treat it as your own account risk. It requires a Google AI **Ultra or Pro** subscription with Flow access, and every generation bills your account. Not affiliated with Google.
+
+## 1. Install
+
+gflow-cli installs as a standalone tool with `uv` — no global Python environment to manage.
+
+```bash
+# install the CLI
+uv tool install gflow-cli
+
+# one-time: the browser transport needs Chromium
+uv tool run --from gflow-cli playwright install chromium
+```
+
+## 2. Authenticate
+
+A one-time login saves a browser session against your own Flow account. The `--browser chrome` flag is **mandatory** — the CLI fails fast on any other strategy.
+
+```bash
+gflow auth login --browser chrome
+```
+
+!!! note
+    A Chrome window opens once for you to sign in (2FA included). The session persists after that — you won't log in every run.
+
+## 3. Your first generation
+
+The shortest happy path is one text-to-image call. Output lands in `./out/` (or `$GFLOW_CLI_OUTPUT_DIR`).
+
+```bash
+gflow image t2i "a lighthouse in a storm, moody, cinematic" --tool creative-director
+#   ↳ creative-director expanded the prompt (Google's 5-component formula)
+#   ✓ out/lighthouse_storm.png
+```
+
+Turn that still into an 8-second Veo clip with image-to-video:
+
+```bash
+gflow video i2v out/lighthouse_storm.png --aspect 9:16
+```
+
+## 4. Let your assistant drive it
+
+Everything above, an agent can do for you. Start the MCP server and point Claude, Cursor, or Copilot at it — CLI-to-MCP parity is enforced in CI, so any command is reachable as a tool.
+
+```bash
+gflow mcp run
+#   serving over stdio:
+#   • gflow_generate_image   • gflow_generate_video
+```
+
+Then just ask, in plain language — the agent picks the model, aspect, and prompt tooling and hands you the files. See [Agent-driven](agents.md) for the full setup.
+
+## Where to next
+
+- [**Authentication →**](authentication.md) — profiles, reCAPTCHA, and the headed-browser transport in depth.
+- [**Let your assistant drive it →**](agents.md) — wire gflow-cli into your agent via MCP.
+- [**Known issues →**](known-issues.md) — WAF/403 pacing, credit traps, and current limitations.

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -1,0 +1,86 @@
+/* gflow-cli docs — amber-on-ink identity layered over Material for MkDocs.
+   Overrides Material's CSS custom properties so both light and dark schemes
+   carry the terminal-cinema look (amber accent, cool ink ground, mono display). */
+
+:root {
+  --gf-mono: ui-monospace, "Cascadia Code", "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --gf-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, Roboto, Helvetica, Arial, sans-serif;
+  --md-text-font-family: var(--gf-sans);
+  --md-code-font-family: var(--gf-mono);
+}
+
+/* ---- light scheme (default) ---- */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        #b9740f;
+  --md-primary-fg-color--light: #c9852c;
+  --md-primary-fg-color--dark:  #9c610b;
+  --md-accent-fg-color:         #9c610b;
+  --md-default-bg-color:        #fdfcf9;
+  --md-default-fg-color:        #1b1d22;
+  --md-default-fg-color--light: #4a5058;
+  --md-typeset-a-color:         #b9740f;
+  --md-code-bg-color:           #1b1f27;
+  --md-code-fg-color:           #d7dae0;
+}
+
+/* ---- dark scheme (slate) ---- */
+[data-md-color-scheme="slate"] {
+  --md-hue: 220;
+  --md-primary-fg-color:        #ffb03a;
+  --md-primary-fg-color--light: #ffbf5e;
+  --md-primary-fg-color--dark:  #c9852c;
+  --md-accent-fg-color:         #ffb03a;
+  --md-default-bg-color:        #0e1014;
+  --md-default-fg-color:        #eceae4;
+  --md-default-fg-color--light: #b7bdc6;
+  --md-default-fg-color--lighter:#8b929c;
+  --md-typeset-a-color:         #ffb03a;
+  --md-code-bg-color:           #0b0d12;
+  --md-code-fg-color:           #d7dae0;
+  --md-footer-bg-color:         #0b0d12;
+}
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-tabs {
+  background-color: #0b0d12;
+}
+/* keep the header text legible on the dark ground instead of amber-on-amber */
+[data-md-color-scheme="slate"] .md-header {
+  color: var(--md-default-fg-color);
+  border-bottom: 1px solid #242a34;
+}
+
+/* mono display voice for headings + brand */
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-header__title {
+  font-family: var(--gf-mono);
+  letter-spacing: -0.01em;
+  font-weight: 600;
+}
+.md-typeset h1 { letter-spacing: -0.02em; }
+
+/* inline code as an amber chip */
+.md-typeset code {
+  font-family: var(--gf-mono);
+}
+[data-md-color-scheme="slate"] .md-typeset :not(pre) > code {
+  background-color: rgba(255, 176, 58, 0.12);
+  color: #ffb03a;
+}
+[data-md-color-scheme="default"] .md-typeset :not(pre) > code {
+  background-color: rgba(185, 116, 15, 0.10);
+  color: #9c610b;
+}
+
+/* code-copy + admonition accents stay on-brand */
+.md-typeset .admonition.warning,
+.md-typeset details.warning {
+  border-color: #e5674f;
+}
+
+/* subtle amber focus ring, consistent with the landing */
+:focus-visible {
+  outline: 2px solid var(--md-primary-fg-color);
+  outline-offset: 2px;
+}

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,0 +1,80 @@
+site_name: gflow-cli
+site_description: >-
+  Unofficial CLI and MCP server for Google Flow — script Veo video and Imagen
+  stills from the terminal, or let your AI assistant drive it.
+site_url: https://ffroliva.github.io/gflow-cli/docs/
+repo_url: https://github.com/ffroliva/gflow-cli
+repo_name: ffroliva/gflow-cli
+copyright: >-
+  Unofficial · not affiliated with Google · MIT-licensed · your credits, your account, your risk.
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  # System fonts only — no Google Fonts fetch (matches the site identity, works offline).
+  font: false
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+
+nav:
+  - Home ↗: https://ffroliva.github.io/gflow-cli/
+  - Getting started:
+      - Introduction: index.md
+      - Quickstart: quickstart.md
+      - Installation: installation.md
+      - Authentication: authentication.md
+  - Agent-driven:
+      - Let your assistant drive it: agents.md
+  - Reference:
+      - Known issues: known-issues.md
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ffroliva/gflow-cli
+    - icon: fontawesome/brands/youtube
+      link: https://www.youtube.com/shorts/SyJb2jfLMrw


### PR DESCRIPTION
## Summary

A public site for gflow-cli: a marketing **landing** at the root and a themed **docs portal** at `/docs`, cross-linked both ways — the lovable.dev ↔ docs.lovable.dev pattern the owner asked for.

- **`index.html`** — self-contained landing (terminal-cinema identity, amber-on-ink, light+dark, honest alpha / not-affiliated band, agent-native hero). Relative links to `/docs`.
- **`website/`** — Material for MkDocs, built from Markdown, themed to the same identity via `stylesheets/extra.css` (system fonts, no Google Fonts fetch). Starter pages: Introduction, Quickstart, Installation, Authentication, Let-your-assistant-drive-it, Known issues. Nav "Home" links back to the landing.
- **`.github/workflows/pages.yml`** — builds MkDocs, assembles landing at `/` + docs at `/docs`, deploys to Pages on push to `develop`.

## Design previews (the approved direction)
- Landing: https://claude.ai/code/artifact/f27867b2-f20c-4920-b754-fc7e09e7c1f7
- Docs: https://claude.ai/code/artifact/0b8e4bf9-742b-45b3-8a4b-469586e8845f

## Verification
- [x] `mkdocs build` succeeds locally, 0 errors; all pages render; `extra.css` bundled; **no external font fetches** (`font: false`)
- [x] Landing HTML well-formed (doctype, closed `<style>`, body, script); cross-links resolve to relative `/docs`
- [ ] First deploy runs on merge → **https://ffroliva.github.io/gflow-cli/**

## Notes
- Deploys from `develop` (the default/integration branch) so docs stay current; `workflow_dispatch` also enabled.
- Content is a curated starter set; more of the existing `docs/*.md` can be mapped into the nav over time.
- The repo's stale homepage URL (`github.com/ffroliva/flow-cli`) should point at the new Pages URL once live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)