### PR TITLE
feat: HAR capture + debug traceback diagnostic knobs (closes #316)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -261,6 +261,31 @@ GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
 **When to set it:** capturing locale-invariant DOM via `scripts/dev/capture_locale_invariants.py`, or live-verifying a generation under a non-EN account language.
 **Important:** Chrome's *UI* language is independently forced to `en-US` via the `--lang=en-US` launch arg (so Flow keeps serving `/fx/tools/flow/` and the editor's localized text selectors keep working). This env var only affects request headers — not the editor UI you see. See [KNOWN_ISSUES § issue #24](../KNOWN_ISSUES.md) for the path to dropping `--lang=en-US`.
 
+### `GFLOW_CLI_HAR_PATH`
+
+**What:** Captures full Playwright network traffic (requests, responses, headers, cookies) to a HAR file for the session — useful for diagnosing wire-format surprises or WAF rejections.
+**Default:** unset (no capture).
+**Override examples:**
+```bash
+export GFLOW_CLI_HAR_PATH=/tmp/gflow-debug/session.har       # POSIX
+$env:GFLOW_CLI_HAR_PATH = "C:\gflow-debug\session.har"      # PowerShell
+```
+
+**SECURITY:** a HAR file contains live auth cookies and bearer tokens — never share one publicly. The file is chmod'd `0o600` on POSIX after Playwright writes it (best-effort; no-op on Windows). Two concurrent `gflow` processes pointed at the same path will overwrite each other's HAR (last-writer-wins, no error) — use a distinct path per run if running more than one profile/command at once.
+
+### `GFLOW_CLI_DEBUG_TRACEBACK`
+
+**What:** Prints the real exception message + full traceback for unhandled (non-typed) errors — to the console, and under `--json`, into the payload's `error.detail` / `error.traceback` fields — instead of the default generic "Unexpected error" placeholder. This CLI's structured telemetry event is always SHA-256-hashed regardless of this setting; this flag only changes what you see, not what's logged.
+**Values:** `true` | `false`
+**Default:** `false`
+**Override examples:**
+```bash
+GFLOW_CLI_DEBUG_TRACEBACK=1 gflow image t2i "a cat" --profile dev   # POSIX
+$env:GFLOW_CLI_DEBUG_TRACEBACK = "1"                                # PowerShell
+```
+
+**SECURITY:** the real error text may contain tokens/cookies present in exception state — for local debugging only. `--json` output under this flag is a materially higher-risk surface than the interactive console: a human watches the console live and can react to the yellow warning, but `--json` output is designed to be piped into CI logs, log aggregators, and webhooks that persist or forward it unreviewed. **Never pipe `--json` output under this flag to a shared or persistent system without redacting it first.**
+
 ## Output paths
 
 The default output scheme keeps generated assets sortable, dated, and grouped by job:

--- a/docs/superpowers/plans/2026-07-15-har-debug-traceback-plan.md
+++ b/docs/superpowers/plans/2026-07-15-har-debug-traceback-plan.md
@@ -1,0 +1,589 @@
+# HAR Capture + Debug Traceback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two opt-in, env-var-driven debug knobs to gflow-cli — `GFLOW_CLI_HAR_PATH` (Playwright HAR network-traffic capture) and `GFLOW_CLI_DEBUG_TRACEBACK` (bypass the SHA-256 hash redaction on unhandled exceptions, in both console and `--json` output) — closing GitHub issue #316.
+
+**Architecture:** Two independent `Settings` fields feed two independent code paths: `har_path` is consumed once, at the single production browser-launch site (`FlowApiClient._persistent_context_kwargs()`), plus a permission-hardening step at context close; `debug_traceback` is consumed at the two `_cli_helpers.py` exception-boundary call sites (console + `--json`), which already hold the live exception object and build their own raw output directly — `observability.emit_unhandled_event()` is untouched and keeps hashing unconditionally forever.
+
+**Tech Stack:** Python 3.11+, pydantic-settings, Playwright (`record_har_path`), Click, structlog, Rich console, pytest.
+
+## Global Constraints
+
+- Python 3.11+ (repo `requires-python = ">=3.11"`) — `traceback.format_exception(exc)` single-arg form is valid.
+- No new dependencies — everything here uses stdlib (`os`, `traceback`) or already-installed packages (Playwright, pydantic).
+- Env vars are `GFLOW_CLI_*`-prefixed, resolved automatically by `Settings.model_config.env_prefix` — no manual aliasing needed.
+- Type annotations on every new/modified signature (project convention, CLAUDE.md).
+- Comments explain WHY, not WHAT — no restating obvious code.
+- structlog event names follow the existing `<module>.<event>` dotted convention seen throughout `client.py` (e.g. `client.chrome_strategy_downgraded`).
+- On Windows, run tests via `.venv/Scripts/python.exe -m pytest` (bare `uv run pytest` is broken in this environment per project convention) — scope pytest invocations to the specific test file/function being worked on, never the full suite (OOMs unscoped).
+- Run `ruff check` / `ruff format` on every touched file before each commit (matches CI's `Lint` / `Format check` jobs).
+
+---
+
+### Task 1: `har_path` + `debug_traceback` Settings fields, HAR capture wiring
+
+**Files:**
+- Modify: `src/gflow_cli/config.py:452` (insert new `# --- debugging ---` section, right before the existing `# --- logging ---` section)
+- Modify: `src/gflow_cli/api/client.py:333-370` (`_persistent_context_kwargs`) and `:678-707` (`_close_browser_resources`)
+- Test: `tests/api/test_client_launch_kwargs.py`
+
+**Interfaces:**
+- Produces: `Settings.har_path: Path | None` (default `None`), `Settings.debug_traceback: bool` (default `False`) — consumed by Task 2 and Task 3.
+- Produces: `FlowApiClient._persistent_context_kwargs()` includes `"record_har_path"` key when `self.settings.har_path` is set (unchanged shape otherwise) — no other task depends on this directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/api/test_client_launch_kwargs.py`, right after `test_persistent_context_kwargs_are_unchanged` (after line 57):
+
+```python
+def test_persistent_context_kwargs_omits_har_path_when_unset(tmp_path: Path) -> None:
+    """No GFLOW_CLI_HAR_PATH -> no record_har_path key at all (not just None)."""
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert "record_har_path" not in kwargs
+
+
+def test_persistent_context_kwargs_includes_har_path_when_set(tmp_path: Path) -> None:
+    """har_path set -> record_har_path passed through + parent dir created."""
+    from gflow_cli.config import Settings
+
+    har_path = tmp_path / "captures" / "session.har"
+    settings = Settings(har_path=har_path)
+    client = FlowApiClient(profile_dir=tmp_path, headless=True, settings=settings)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert kwargs["record_har_path"] == str(har_path)
+    assert har_path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_close_browser_resources_chmods_har_file(tmp_path: Path) -> None:
+    """After context close, an existing HAR file is hardened to 0o600 on POSIX.
+
+    Windows has no POSIX permission bits, so the assertion is skipped there —
+    the chmod call itself is still exercised (must not raise on Windows).
+    """
+    import stat
+    import sys
+
+    from gflow_cli.config import Settings
+
+    har_path = tmp_path / "session.har"
+    har_path.write_bytes(b"{}")  # simulate Playwright having already written it
+    settings = Settings(har_path=har_path)
+    client = FlowApiClient(profile_dir=tmp_path, headless=True, settings=settings)
+    # _close_browser_resources only enters its close-block (where the chmod
+    # lives) when self._context is not None — a fresh client that never
+    # entered __aenter__ has _context=None, so a fake context is required
+    # here, matching the _client_with_cookies pattern used elsewhere in this
+    # file (e.g. test_context_cookie_state_present_and_unexpired).
+    client._context = MagicMock()  # noqa: SLF001
+    with patch("gflow_cli.api.client.close_context_bounded", AsyncMock()):
+        await client._close_browser_resources()  # noqa: SLF001
+    if sys.platform != "win32":
+        assert stat.S_IMODE(har_path.stat().st_mode) == 0o600
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/api/test_client_launch_kwargs.py -v -k "har_path or chmods_har"`
+Expected: 3 FAIL — `Settings(har_path=...)` raises (unknown field), and `record_har_path` never appears in kwargs.
+
+- [ ] **Step 3: Add the two Settings fields**
+
+In `src/gflow_cli/config.py`, insert immediately before line 453 (`    # --- logging ----------------------------------------------------------`):
+
+```python
+    # --- debugging ---------------------------------------------------------
+    har_path: Path | None = Field(
+        default=None,
+        description=(
+            "When set, captures full Playwright network traffic (requests, "
+            "responses, headers, cookies) to this HAR file for the session. "
+            "SECURITY: HAR files can contain auth cookies and bearer tokens — "
+            "never share one publicly; the file is chmod 0o600 on POSIX. "
+            "Concurrent gflow processes pointed at the same path will overwrite "
+            "each other's HAR (last-writer-wins) — use a distinct path per run. "
+            "Override via GFLOW_CLI_HAR_PATH."
+        ),
+    )
+    debug_traceback: bool = Field(
+        default=False,
+        description=(
+            "Bypasses hash redaction for unhandled (non-GFlowError) exceptions: "
+            "prints the real message + traceback to the console and, under "
+            "--json, into the payload's error.traceback field, instead of "
+            "SHA-256 hashes. SECURITY: may leak tokens/cookies present in "
+            "exception text — for local debugging only. Never pipe --json "
+            "output under this flag to a shared/persistent system (CI logs, "
+            "log aggregators, webhooks) without redacting it first. "
+            "Override via GFLOW_CLI_DEBUG_TRACEBACK."
+        ),
+    )
+```
+
+- [ ] **Step 4: Restructure `_persistent_context_kwargs` and add the chmod step**
+
+In `src/gflow_cli/api/client.py`, replace the entire method — signature, docstring, and the `return { ... }` literal body (lines 333-370) — with:
+
+```python
+    def _persistent_context_kwargs(self) -> JsonObject:
+        """Keyword arguments for the persistent browser-context launch.
+
+        Extracted as an overridable seam so out-of-core tooling (e.g. a
+        dev-scoped recording subclass that adds ``record_video_dir``) can
+        augment the launch without any recording/test concern living in this
+        core path. The returned dict is identical to the previous inline call,
+        plus an optional ``record_har_path`` when ``GFLOW_CLI_HAR_PATH`` is set.
+        """
+        kwargs: JsonObject = {
+            "user_data_dir": str(self.profile_dir),
+            "headless": self.headless,
+            "viewport": {"width": 1280, "height": 720},
+            "locale": "en-US",
+            "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
+            "channel": channel_for_profile(self.profile_dir),
+            "ignore_default_args": [
+                "--enable-automation",
+                "--no-sandbox",
+            ],
+            # Pass --password-store=basic EXPLICITLY (issue #222). auth login
+            # (auth/real_chrome.py:69) and verification (auth/verification.py:246)
+            # seal and read the profile's cookies with Chrome's *basic* store —
+            # as does every other launch site in the codebase (auth/cookies.py,
+            # auth/internal_chromium.py, browser_manager.py, ui_automation.py).
+            # This shared generation context was the ONE path that omitted the
+            # flag and merely relied on Playwright's internal default; on macOS
+            # that let Chrome read cookies via the OS Keychain ("Chrome Safe
+            # Storage"), which cannot decrypt the basic-sealed cookies -> a
+            # logged-out context -> HTTP 401 at project.createProject. #225 added
+            # a comment but never the flag here. Passing it explicitly keeps all
+            # paths symmetric regardless of Playwright's defaults.
+            "args": [
+                "--password-store=basic",
+                "--disable-blink-features=AutomationControlled",
+                "--disable-dev-shm-usage",
+            ],
+        }
+        if self.settings.har_path is not None:
+            self.settings.har_path.parent.mkdir(parents=True, exist_ok=True)
+            kwargs["record_har_path"] = str(self.settings.har_path)
+            logger.warning(
+                "client.har_capture_enabled",
+                har_path=str(self.settings.har_path),
+                hint="HAR file will contain full request/response bodies, headers, "
+                "and cookies — do not share it publicly or attach it to a public "
+                "bug report.",
+            )
+        return kwargs
+```
+
+- [ ] **Step 5: Add the post-close chmod hardening**
+
+In `src/gflow_cli/api/client.py`, in `_close_browser_resources` (currently lines 678-707), change the context-close block from:
+
+```python
+        try:
+            if self._context is not None:
+                # Bounded close + force-close fallback (issue #293) — shared
+                # with the transports' own-context teardowns via _engine.
+                await close_context_bounded(self._context, owner="client")
+```
+
+to:
+
+```python
+        try:
+            if self._context is not None:
+                # Bounded close + force-close fallback (issue #293) — shared
+                # with the transports' own-context teardowns via _engine.
+                await close_context_bounded(self._context, owner="client")
+                # HAR files hold live auth cookies/bearer tokens — higher
+                # sensitivity than the CDP lockfile _write_lock already hardens
+                # in browser_manager.py. Playwright writes the HAR lazily on
+                # this close, so this is the earliest point the file exists;
+                # best-effort only (never fail teardown over a permission tweak).
+                if self.settings.har_path is not None:
+                    try:
+                        os.chmod(self.settings.har_path, 0o600)
+                    except OSError:
+                        logger.warning("client.har_chmod_failed", exc_info=True)
+```
+
+(the rest of the method — the `if self._pw is not None:` block and the `finally:` — is unchanged.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/api/test_client_launch_kwargs.py -v`
+Expected: all PASS (including the 8 pre-existing tests in this file — confirms no regression).
+
+- [ ] **Step 7: Lint + format**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/gflow_cli/config.py src/gflow_cli/api/client.py tests/api/test_client_launch_kwargs.py && .venv/Scripts/python.exe -m ruff format --check src/gflow_cli/config.py src/gflow_cli/api/client.py tests/api/test_client_launch_kwargs.py`
+Expected: clean (no findings). If `ruff format` reports changes needed, run without `--check` to apply, then re-run tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gflow_cli/config.py src/gflow_cli/api/client.py tests/api/test_client_launch_kwargs.py
+git commit -m "feat(config): add GFLOW_CLI_HAR_PATH capture + 0600 hardening (#316)"
+```
+
+---
+
+### Task 2: `GFLOW_CLI_DEBUG_TRACEBACK` — console path
+
+**Files:**
+- Modify: `src/gflow_cli/_cli_helpers.py:257-266` (`_handle_unhandled_error`)
+- Test: `tests/cli/test_error_handling.py`
+
+**Interfaces:**
+- Consumes: `Settings.debug_traceback: bool` (Task 1).
+- Produces: no new public interface — `_handle_unhandled_error`'s console output changes based on the setting; its signature (`(exc: BaseException, *, cli_command: str) -> int`) is unchanged, so Task 3 and any other caller are unaffected.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/cli/test_error_handling.py`, right after `test_cli_unhandled_exception_exits_1_and_emits_unhandled_event` (after line 218):
+
+```python
+def test_cli_unhandled_exception_debug_traceback_prints_real_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """GFLOW_CLI_DEBUG_TRACEBACK=1 -> console shows the real message + traceback,
+    with a yellow leak-risk warning, instead of the generic 'Unexpected error.'"""
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_DEBUG_TRACEBACK", "1")
+    reset_settings()
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt"])
+    assert result.exit_code == 1
+    assert "bad input" in result.output
+    assert "ValueError" in result.output
+    assert "GFLOW_CLI_DEBUG_TRACEBACK" in result.output  # the leak-risk warning
+    assert "Unexpected error." not in result.output
+
+
+def test_cli_unhandled_exception_default_hides_real_error_from_console(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """Default (GFLOW_CLI_DEBUG_TRACEBACK unset) -> console never shows the raw
+    message, and the hint now points at the real env var, not the misleading
+    --verbose claim."""
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt"])
+    assert result.exit_code == 1
+    assert "bad input" not in result.output
+    assert "GFLOW_CLI_DEBUG_TRACEBACK=1" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/cli/test_error_handling.py -v -k debug_traceback`
+Expected: both FAIL — today's code always prints the generic message and mentions `--verbose`, never `GFLOW_CLI_DEBUG_TRACEBACK`.
+
+- [ ] **Step 3: Implement**
+
+Add near the top of `src/gflow_cli/_cli_helpers.py`, in the import block (after `import sys` at line 39):
+
+```python
+import traceback
+```
+
+Add to the `from gflow_cli...` import group (after the `from gflow_cli import auth as auth_mod` line, i.e. after line 47):
+
+```python
+from gflow_cli.config import get_settings
+```
+
+Replace `_handle_unhandled_error` (lines 257-266) with:
+
+```python
+def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
+    """Catch-all for non-:class:`GFlowError`. Privacy-safe by default: hashes
+    message + stack, never prints the raw payload. Set
+    GFLOW_CLI_DEBUG_TRACEBACK=1 to print the real exception + traceback
+    instead (local debugging only — the output may contain tokens/cookies).
+    Always returns exit code 1.
+    """
+    emit_unhandled_event(_logger, exc, cli_command=cli_command)
+    if get_settings().debug_traceback:
+        _console.print(
+            "[yellow]GFLOW_CLI_DEBUG_TRACEBACK is set — the output below may "
+            "contain tokens/cookies. Do not share it publicly.[/yellow]"
+        )
+        _console.print("".join(traceback.format_exception(exc)))
+    else:
+        _console.print(
+            "[red]Unexpected error.[/red] Re-run with GFLOW_CLI_DEBUG_TRACEBACK=1 "
+            "to see the real error. If this persists, file a bug at "
+            "https://github.com/ffroliva/gflow-cli/issues.",
+        )
+    return 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/cli/test_error_handling.py -v`
+Expected: all PASS (including every pre-existing test in this file — confirms no regression to the GFlowError path or other exit codes).
+
+- [ ] **Step 5: Lint + format**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/gflow_cli/_cli_helpers.py tests/cli/test_error_handling.py && .venv/Scripts/python.exe -m ruff format --check src/gflow_cli/_cli_helpers.py tests/cli/test_error_handling.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/_cli_helpers.py tests/cli/test_error_handling.py
+git commit -m "feat(cli): GFLOW_CLI_DEBUG_TRACEBACK console path (#316)"
+```
+
+---
+
+### Task 3: `GFLOW_CLI_DEBUG_TRACEBACK` — `--json` path
+
+**Files:**
+- Modify: `src/gflow_cli/json_output.py:93-107` (`unexpected_payload`)
+- Modify: `src/gflow_cli/_cli_helpers.py:316-321` (`run_with_handlers`'s `as_json` branch)
+- Test: `tests/test_json_output.py`, `tests/cli/test_error_handling.py`
+
+**Interfaces:**
+- Consumes: `Settings.debug_traceback: bool` (Task 1); `get_settings` already imported in `_cli_helpers.py` (Task 2).
+- Produces: `json_output.unexpected_payload(debug: BaseException | None = None) -> dict[str, Any]` — the default (`debug=None`) return shape is byte-identical to today's zero-arg call, so no other caller needs to change.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_json_output.py`, replace `test_unexpected_is_privacy_safe` (lines 142-148) with:
+
+```python
+    def test_unexpected_is_privacy_safe_by_default(self) -> None:
+        payload = json_output.unexpected_payload()
+        assert payload["error"]["class"] == "UnexpectedError"
+        assert payload["error"]["retryable"] is False
+        assert payload["error"]["exit_code"] == 1
+        # The raw exception message/stack must never leak into the payload
+        # unless the caller explicitly opts in via debug=.
+        assert "detail" not in payload["error"]
+        assert "traceback" not in payload["error"]
+
+    def test_unexpected_with_debug_includes_detail_and_traceback(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            payload = json_output.unexpected_payload(debug=exc)
+        assert payload["error"]["detail"] == "boom"
+        assert "ValueError" in payload["error"]["traceback"]
+        assert "boom" in payload["error"]["traceback"]
+        # Non-debug fields stay identical to the default shape.
+        assert payload["error"]["class"] == "UnexpectedError"
+        assert payload["error"]["exit_code"] == 1
+```
+
+Add to `tests/cli/test_error_handling.py`, right after `test_cli_unhandled_exception_default_hides_real_error_from_console` (the test added in Task 2):
+
+```python
+def test_cli_json_unhandled_exception_debug_traceback_includes_raw_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """--json + GFLOW_CLI_DEBUG_TRACEBACK=1 -> the JSON payload's error.detail /
+    error.traceback carry the real exception, same observability as console."""
+    import json as json_mod
+
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_DEBUG_TRACEBACK", "1")
+    reset_settings()
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt", "--json"])
+    assert result.exit_code == 1
+    payload = json_mod.loads(result.output)
+    assert payload["error"]["detail"] == "bad input"
+    assert "ValueError" in payload["error"]["traceback"]
+
+
+def test_cli_json_unhandled_exception_default_stays_privacy_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """--json without the debug flag -> no detail/traceback fields, same as today."""
+    import json as json_mod
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt", "--json"])
+    assert result.exit_code == 1
+    payload = json_mod.loads(result.output)
+    assert "detail" not in payload["error"]
+    assert "traceback" not in payload["error"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_json_output.py tests/cli/test_error_handling.py -v -k "debug or unexpected_with"`
+Expected: FAIL — `unexpected_payload()` doesn't accept a `debug` kwarg yet, so the JSON payload never carries `detail`/`traceback`.
+
+- [ ] **Step 3: Implement**
+
+Add to the top of `src/gflow_cli/json_output.py` (after `import json` at line 15):
+
+```python
+import traceback
+```
+
+Replace `unexpected_payload` (lines 93-107) with:
+
+```python
+def unexpected_payload(debug: BaseException | None = None) -> dict[str, Any]:
+    """Privacy-safe payload for a non-:class:`GFlowError`, by default.
+
+    Mirrors ``_handle_unhandled_error``: never leaks the raw message or stack —
+    only the fact that an unclassified error occurred — unless ``debug`` is
+    passed (the caller has already confirmed GFLOW_CLI_DEBUG_TRACEBACK=1), in
+    which case ``detail``/``traceback`` carry the real exception. Always exit
+    code 1.
+    """
+    error: dict[str, Any] = {
+        "class": "UnexpectedError",
+        "title": "Unexpected error",
+        "exit_code": 1,
+        "retryable": False,
+    }
+    if debug is not None:
+        error["detail"] = str(debug)
+        error["traceback"] = "".join(traceback.format_exception(debug))
+    return {"status": "fail", "error": error}
+```
+
+In `src/gflow_cli/_cli_helpers.py`, replace the `as_json` branch inside `run_with_handlers`'s final `except BaseException as e:` block (lines 316-321):
+
+```python
+    except BaseException as e:
+        if as_json:
+            emit_unhandled_event(_logger, e, cli_command=cli_command)
+            json_output.emit(json_output.unexpected_payload())
+            sys.exit(1)
+        sys.exit(_handle_unhandled_error(e, cli_command=cli_command))
+```
+
+with:
+
+```python
+    except BaseException as e:
+        if as_json:
+            emit_unhandled_event(_logger, e, cli_command=cli_command)
+            debug_exc = e if get_settings().debug_traceback else None
+            json_output.emit(json_output.unexpected_payload(debug=debug_exc))
+            sys.exit(1)
+        sys.exit(_handle_unhandled_error(e, cli_command=cli_command))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_json_output.py tests/cli/test_error_handling.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint + format**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/gflow_cli/json_output.py src/gflow_cli/_cli_helpers.py tests/test_json_output.py tests/cli/test_error_handling.py && .venv/Scripts/python.exe -m ruff format --check src/gflow_cli/json_output.py src/gflow_cli/_cli_helpers.py tests/test_json_output.py tests/cli/test_error_handling.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gflow_cli/json_output.py src/gflow_cli/_cli_helpers.py tests/test_json_output.py tests/cli/test_error_handling.py
+git commit -m "feat(json): GFLOW_CLI_DEBUG_TRACEBACK --json path (#316)"
+```
+
+---
+
+### Task 4: Docs — `docs/CONFIGURATION.md`
+
+**Files:**
+- Modify: `docs/CONFIGURATION.md:262-264` (insert two new `###` entries between the end of `GFLOW_CLI_LOCALE` and the `## Output paths` heading)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (pure documentation of the settings Task 1 already implemented).
+- Produces: nothing consumed by other tasks — this is the terminal task.
+
+- [ ] **Step 1: Insert the two entries**
+
+In `docs/CONFIGURATION.md`, insert immediately after line 262 (the last line of the `GFLOW_CLI_LOCALE` entry) and before line 264 (`## Output paths`):
+
+```markdown
+
+### `GFLOW_CLI_HAR_PATH`
+
+**What:** Captures full Playwright network traffic (requests, responses, headers, cookies) to a HAR file for the session — useful for diagnosing wire-format surprises or WAF rejections.
+**Default:** unset (no capture).
+**Override examples:**
+```bash
+export GFLOW_CLI_HAR_PATH=/tmp/gflow-debug/session.har       # POSIX
+$env:GFLOW_CLI_HAR_PATH = "C:\gflow-debug\session.har"      # PowerShell
+```
+
+**SECURITY:** a HAR file contains live auth cookies and bearer tokens — never share one publicly. The file is chmod'd `0o600` on POSIX after Playwright writes it (best-effort; no-op on Windows). Two concurrent `gflow` processes pointed at the same path will overwrite each other's HAR (last-writer-wins, no error) — use a distinct path per run if running more than one profile/command at once.
+
+### `GFLOW_CLI_DEBUG_TRACEBACK`
+
+**What:** Bypasses this CLI's default privacy-safe hash redaction for unhandled (non-typed) errors — prints the real exception message + full traceback to the console, and under `--json`, into the payload's `error.detail` / `error.traceback` fields, instead of SHA-256 hashes.
+**Values:** `true` | `false`
+**Default:** `false`
+**Override examples:**
+```bash
+GFLOW_CLI_DEBUG_TRACEBACK=1 gflow image t2i "a cat" --profile dev   # POSIX
+$env:GFLOW_CLI_DEBUG_TRACEBACK = "1"                                # PowerShell
+```
+
+**SECURITY:** the real error text may contain tokens/cookies present in exception state — for local debugging only. `--json` output under this flag is a materially higher-risk surface than the interactive console: a human watches the console live and can react to the yellow warning, but `--json` output is designed to be piped into CI logs, log aggregators, and webhooks that persist or forward it unreviewed. **Never pipe `--json` output under this flag to a shared or persistent system without redacting it first.**
+```
+
+- [ ] **Step 2: Verify the doc-links checker still passes**
+
+Run: `.venv/Scripts/python.exe scripts/ci/check_doc_links.py`
+Expected: exits 0, no broken links reported (this change adds no links, but the checker also validates overall markdown structure — confirms the insertion didn't break heading nesting).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/CONFIGURATION.md
+git commit -m "docs(config): document GFLOW_CLI_HAR_PATH + GFLOW_CLI_DEBUG_TRACEBACK (#316)"
+```
+
+---
+
+## Post-plan cleanup (not a task — housekeeping only)
+
+After all 4 tasks land and the PR is merged, delete `docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md` and this plan file per `[[release-spec-plan-memory-consolidation]]`, and add the memory entry D5 flagged during council review: `FlowApiClient._persistent_context_kwargs()` (`api/client.py`) is the sole production browser-launch site — `UiAutomationTransport.setup()`'s standalone `launch_persistent_context` branch only fires when `page=None`, which happens only in dev/e2e scripts. Any future production browser-launch kwarg belongs in `_persistent_context_kwargs()`, not `ui_automation.py`.

--- a/docs/superpowers/plans/2026-07-15-har-debug-traceback-plan.md
+++ b/docs/superpowers/plans/2026-07-15-har-debug-traceback-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add two opt-in, env-var-driven debug knobs to gflow-cli — `GFLOW_CLI_HAR_PATH` (Playwright HAR network-traffic capture) and `GFLOW_CLI_DEBUG_TRACEBACK` (bypass the SHA-256 hash redaction on unhandled exceptions, in both console and `--json` output) — closing GitHub issue #316.
+**Goal:** Add two opt-in, env-var-driven debug knobs to gflow-cli — `GFLOW_CLI_HAR_PATH` (Playwright HAR network-traffic capture) and `GFLOW_CLI_DEBUG_TRACEBACK` (print the real message + traceback for unhandled exceptions, in both console and `--json` output, instead of today's generic placeholder) — closing GitHub issue #316. Note: only the structured telemetry event (`observability.emit_unhandled_event`) currently hashes anything; the console and `--json` surfaces already show nothing but a generic message today, so `debug_traceback` doesn't "bypass a hash" on those two paths — it replaces a placeholder with the real content. Telemetry stays hashed unconditionally either way (see Task 2/3).
 
 **Architecture:** Two independent `Settings` fields feed two independent code paths: `har_path` is consumed once, at the single production browser-launch site (`FlowApiClient._persistent_context_kwargs()`), plus a permission-hardening step at context close; `debug_traceback` is consumed at the two `_cli_helpers.py` exception-boundary call sites (console + `--json`), which already hold the live exception object and build their own raw output directly — `observability.emit_unhandled_event()` is untouched and keeps hashing unconditionally forever.
 
@@ -82,12 +82,30 @@ async def test_close_browser_resources_chmods_har_file(tmp_path: Path) -> None:
         await client._close_browser_resources()  # noqa: SLF001
     if sys.platform != "win32":
         assert stat.S_IMODE(har_path.stat().st_mode) == 0o600
+
+
+def test_har_path_resolves_from_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """GFLOW_CLI_HAR_PATH (not just constructor injection) actually parses into
+    Settings.har_path — the other tests in this file inject har_path directly via
+    the constructor, which proves the consuming code works but never proves the
+    advertised env var name/wiring does."""
+    from gflow_cli.config import Settings, reset_settings
+
+    har_path = tmp_path / "env.har"
+    monkeypatch.setenv("GFLOW_CLI_HAR_PATH", str(har_path))
+    reset_settings()
+    assert Settings().har_path == har_path
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `.venv/Scripts/python.exe -m pytest tests/api/test_client_launch_kwargs.py -v -k "har_path or chmods_har"`
-Expected: 3 FAIL — `Settings(har_path=...)` raises (unknown field), and `record_har_path` never appears in kwargs.
+
+Expected — 2 of the 4 new tests genuinely fail pre-implementation; the other 2 pass trivially and are regression guards, not red steps (worth knowing going in, not a plan defect — `Settings.model_config` has `extra="ignore"`, so an unrecognized `har_path=...` constructor kwarg is silently dropped rather than raising):
+- `test_persistent_context_kwargs_omits_har_path_when_unset` — PASSES already (no `har_path` involved either way).
+- `test_persistent_context_kwargs_includes_har_path_when_set` — FAILS (the field doesn't exist yet, so it's silently dropped and `record_har_path` never appears in `kwargs`).
+- `test_close_browser_resources_chmods_har_file` — FAILS on POSIX (the chmod code doesn't exist yet, so the file keeps its default `write_bytes` permissions, not `0o600`); passes **trivially** on Windows today, since the whole assertion is skipped there — the chmod code path still needs Step 5 to exist, this test just can't catch its absence on Windows.
+- `test_har_path_resolves_from_env_var` — FAILS (`Settings().har_path` doesn't exist as an attribute yet).
 
 - [ ] **Step 3: Add the two Settings fields**
 
@@ -110,14 +128,15 @@ In `src/gflow_cli/config.py`, insert immediately before line 453 (`    # --- log
     debug_traceback: bool = Field(
         default=False,
         description=(
-            "Bypasses hash redaction for unhandled (non-GFlowError) exceptions: "
-            "prints the real message + traceback to the console and, under "
-            "--json, into the payload's error.traceback field, instead of "
-            "SHA-256 hashes. SECURITY: may leak tokens/cookies present in "
-            "exception text — for local debugging only. Never pipe --json "
-            "output under this flag to a shared/persistent system (CI logs, "
-            "log aggregators, webhooks) without redacting it first. "
-            "Override via GFLOW_CLI_DEBUG_TRACEBACK."
+            "Prints the real message + traceback for unhandled (non-GFlowError) "
+            "exceptions to the console and, under --json, into the payload's "
+            "error.traceback field, instead of the generic placeholder. The "
+            "structured telemetry event stays hashed either way — this only "
+            "affects what the operator/caller sees. SECURITY: may leak "
+            "tokens/cookies present in exception text — for local debugging "
+            "only. Never pipe --json output under this flag to a "
+            "shared/persistent system (CI logs, log aggregators, webhooks) "
+            "without redacting it first. Override via GFLOW_CLI_DEBUG_TRACEBACK."
         ),
     )
 ```
@@ -156,9 +175,10 @@ In `src/gflow_cli/api/client.py`, replace the entire method — signature, docst
             # flag and merely relied on Playwright's internal default; on macOS
             # that let Chrome read cookies via the OS Keychain ("Chrome Safe
             # Storage"), which cannot decrypt the basic-sealed cookies -> a
-            # logged-out context -> HTTP 401 at project.createProject. #225 added
-            # a comment but never the flag here. Passing it explicitly keeps all
-            # paths symmetric regardless of Playwright's defaults.
+            # logged-out context -> HTTP 401 at project.createProject (login and
+            # verify succeed, generation fails). #225 added a comment but never
+            # the flag here. Passing it explicitly keeps all paths symmetric
+            # regardless of Playwright's defaults.
             "args": [
                 "--password-store=basic",
                 "--disable-blink-features=AutomationControlled",
@@ -205,17 +225,17 @@ to:
                 # best-effort only (never fail teardown over a permission tweak).
                 if self.settings.har_path is not None:
                     try:
-                        os.chmod(self.settings.har_path, 0o600)
+                        self.settings.har_path.chmod(0o600)
                     except OSError:
                         logger.warning("client.har_chmod_failed", exc_info=True)
 ```
 
-(the rest of the method — the `if self._pw is not None:` block and the `finally:` — is unchanged.)
+(the rest of the method — the `if self._pw is not None:` block and the `finally:` — is unchanged. `Path.chmod()` matches the existing precedent for hardening a token-bearing file in `src/gflow_cli/api/transports/experimental/bearer.py:102` — same effect as `os.chmod(path, mode)`, method style. `close_context_bounded` never re-raises a plain `Exception` internally — on a graceful-close failure it force-closes instead — so this chmod call is reached whichever of those two paths `close_context_bounded` took; the `try/except OSError` around it only needs to cover the file not existing or being unwritable.)
 
 - [ ] **Step 6: Run tests to verify they pass**
 
 Run: `.venv/Scripts/python.exe -m pytest tests/api/test_client_launch_kwargs.py -v`
-Expected: all PASS (including the 8 pre-existing tests in this file — confirms no regression).
+Expected: all 20 PASS (16 pre-existing + 4 new — confirms no regression to the pre-existing 16).
 
 - [ ] **Step 7: Lint + format**
 
@@ -280,7 +300,17 @@ def test_cli_unhandled_exception_default_hides_real_error_from_console(
 ) -> None:
     """Default (GFLOW_CLI_DEBUG_TRACEBACK unset) -> console never shows the raw
     message, and the hint now points at the real env var, not the misleading
-    --verbose claim."""
+    --verbose claim.
+
+    Explicitly clears GFLOW_CLI_DEBUG_TRACEBACK: the autouse _isolate_settings
+    fixture (tests/conftest.py) only pins GFLOW_CLI_HOME/GFLOW_CLI_DB_PATH, so
+    a developer's shell or .env.local exporting this var would otherwise leak
+    into "default" behavior and make this test flaky outside CI.
+    """
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_DEBUG_TRACEBACK", raising=False)
+    reset_settings()
     _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
     monkeypatch.setattr(
         "gflow_cli.cli_image._run_t2i",
@@ -307,7 +337,7 @@ Add near the top of `src/gflow_cli/_cli_helpers.py`, in the import block (after 
 import traceback
 ```
 
-Add to the `from gflow_cli...` import group (after the `from gflow_cli import auth as auth_mod` line, i.e. after line 47):
+Add to the `from gflow_cli...` import group — **after** `from gflow_cli import json_output, profile_store` (line 48), **before** `from gflow_cli.errors import (` (line 49). Ruff's isort rule (`I001`) sorts `gflow_cli.config` after the two plain `gflow_cli`/`gflow_cli as X` import lines, not between them:
 
 ```python
 from gflow_cli.config import get_settings
@@ -317,11 +347,12 @@ Replace `_handle_unhandled_error` (lines 257-266) with:
 
 ```python
 def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
-    """Catch-all for non-:class:`GFlowError`. Privacy-safe by default: hashes
-    message + stack, never prints the raw payload. Set
-    GFLOW_CLI_DEBUG_TRACEBACK=1 to print the real exception + traceback
-    instead (local debugging only — the output may contain tokens/cookies).
-    Always returns exit code 1.
+    """Catch-all for non-:class:`GFlowError`. Privacy-safe by default: the
+    console shows only a generic message (the structured telemetry event is
+    always SHA-256-hashed regardless of this setting — see
+    ``emit_unhandled_event``). Set GFLOW_CLI_DEBUG_TRACEBACK=1 to print the
+    real exception + traceback to the console instead (local debugging only —
+    the output may contain tokens/cookies). Always returns exit code 1.
     """
     emit_unhandled_event(_logger, exc, cli_command=cli_command)
     if get_settings().debug_traceback:
@@ -433,9 +464,19 @@ def test_cli_json_unhandled_exception_default_stays_privacy_safe(
     tmp_path: Path,
     install_log_capture: structlog.testing.LogCapture,
 ) -> None:
-    """--json without the debug flag -> no detail/traceback fields, same as today."""
+    """--json without the debug flag -> no detail/traceback fields, same as today.
+
+    Explicitly clears GFLOW_CLI_DEBUG_TRACEBACK for the same reason as
+    test_cli_unhandled_exception_default_hides_real_error_from_console (Task 2)
+    — the autouse fixture doesn't isolate this var, so a developer's shell
+    exporting it would otherwise make this test environment-dependent.
+    """
     import json as json_mod
 
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_DEBUG_TRACEBACK", raising=False)
+    reset_settings()
     _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
     monkeypatch.setattr(
         "gflow_cli.cli_image._run_t2i",
@@ -540,9 +581,9 @@ git commit -m "feat(json): GFLOW_CLI_DEBUG_TRACEBACK --json path (#316)"
 
 - [ ] **Step 1: Insert the two entries**
 
-In `docs/CONFIGURATION.md`, insert immediately after line 262 (the last line of the `GFLOW_CLI_LOCALE` entry) and before line 264 (`## Output paths`):
+In `docs/CONFIGURATION.md`, insert immediately after line 262 (the last line of the `GFLOW_CLI_LOCALE` entry) and before line 264 (`## Output paths`). The block below is wrapped in a 4-backtick fence purely so it renders correctly in THIS plan document — the nested ```bash examples inside it are real content to paste verbatim into `CONFIGURATION.md`, not part of the fence syntax itself:
 
-```markdown
+````markdown
 
 ### `GFLOW_CLI_HAR_PATH`
 
@@ -558,7 +599,7 @@ $env:GFLOW_CLI_HAR_PATH = "C:\gflow-debug\session.har"      # PowerShell
 
 ### `GFLOW_CLI_DEBUG_TRACEBACK`
 
-**What:** Bypasses this CLI's default privacy-safe hash redaction for unhandled (non-typed) errors — prints the real exception message + full traceback to the console, and under `--json`, into the payload's `error.detail` / `error.traceback` fields, instead of SHA-256 hashes.
+**What:** Prints the real exception message + full traceback for unhandled (non-typed) errors — to the console, and under `--json`, into the payload's `error.detail` / `error.traceback` fields — instead of the default generic "Unexpected error" placeholder. This CLI's structured telemetry event is always SHA-256-hashed regardless of this setting; this flag only changes what you see, not what's logged.
 **Values:** `true` | `false`
 **Default:** `false`
 **Override examples:**
@@ -568,12 +609,12 @@ $env:GFLOW_CLI_DEBUG_TRACEBACK = "1"                                # PowerShell
 ```
 
 **SECURITY:** the real error text may contain tokens/cookies present in exception state — for local debugging only. `--json` output under this flag is a materially higher-risk surface than the interactive console: a human watches the console live and can react to the yellow warning, but `--json` output is designed to be piped into CI logs, log aggregators, and webhooks that persist or forward it unreviewed. **Never pipe `--json` output under this flag to a shared or persistent system without redacting it first.**
-```
+````
 
 - [ ] **Step 2: Verify the doc-links checker still passes**
 
 Run: `.venv/Scripts/python.exe scripts/ci/check_doc_links.py`
-Expected: exits 0, no broken links reported (this change adds no links, but the checker also validates overall markdown structure — confirms the insertion didn't break heading nesting).
+Expected: exits 0, no broken links reported. Note this only validates relative-link targets, NOT general markdown structure — it will not catch a malformed fence or broken heading nesting. Manually confirm the two new `###` entries render correctly (e.g. preview the file, or diff against the `GFLOW_CLI_LOCALE` entry immediately above them for matching structure) before committing.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
+++ b/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
@@ -30,16 +30,22 @@ har_path: Path | None = Field(
         "When set, captures full Playwright network traffic (requests, "
         "responses, headers, cookies) to this HAR file for the session. "
         "SECURITY: HAR files can contain auth cookies and bearer tokens — "
-        "never share one publicly. Override via GFLOW_CLI_HAR_PATH."
+        "never share one publicly; the file is chmod 0o600 on POSIX. "
+        "Concurrent gflow processes pointed at the same path will overwrite "
+        "each other's HAR (last-writer-wins) — use a distinct path per run. "
+        "Override via GFLOW_CLI_HAR_PATH."
     ),
 )
 debug_traceback: bool = Field(
     default=False,
     description=(
         "Bypasses hash redaction for unhandled (non-GFlowError) exceptions: "
-        "prints the real message + traceback to the console and JSON output "
-        "instead of SHA-256 hashes. SECURITY: may leak tokens/cookies present "
-        "in exception text — for local debugging only. "
+        "prints the real message + traceback to the console and, under "
+        "--json, into the payload's error.traceback field, instead of "
+        "SHA-256 hashes. SECURITY: may leak tokens/cookies present in "
+        "exception text — for local debugging only. Never pipe --json "
+        "output under this flag to a shared/persistent system (CI logs, "
+        "log aggregators, webhooks) without redacting it first. "
         "Override via GFLOW_CLI_DEBUG_TRACEBACK."
     ),
 )
@@ -49,52 +55,44 @@ No CLI flags, no validators needed — both are plain env-var-driven settings, r
 
 ### 2. HAR capture (`src/gflow_cli/api/client.py`)
 
-`FlowApiClient._persistent_context_kwargs()` (the single production browser-launch site — confirmed `UiAutomationTransport.setup()` always takes the shared-page branch in production and never opens its own context; its standalone-launch branch is exercised only by dev/e2e scripts) adds `record_har_path` when set:
+`FlowApiClient._persistent_context_kwargs()` (the single production browser-launch site — confirmed `UiAutomationTransport.setup()` always takes the shared-page branch in production and never opens its own context; its standalone-launch branch is exercised only by dev/e2e scripts) adds `record_har_path` when set. **Note:** the method today is a single `return {...}` dict literal (`client.py:333-370`, no local variable) — this is a small restructuring of its shape, not a pure insertion:
 
 ```python
-if self.settings.har_path is not None:
-    self.settings.har_path.parent.mkdir(parents=True, exist_ok=True)
-    kwargs["record_har_path"] = str(self.settings.har_path)
-    logger.warning(
-        "client.har_capture_enabled",
-        har_path=str(self.settings.har_path),
-        hint="HAR file will contain full request/response bodies, headers, "
-        "and cookies — do not share it publicly or attach it to a public bug report.",
-    )
+def _persistent_context_kwargs(self) -> JsonObject:
+    kwargs: JsonObject = {
+        "user_data_dir": str(self.profile_dir),
+        # ... existing fields unchanged ...
+    }
+    if self.settings.har_path is not None:
+        self.settings.har_path.parent.mkdir(parents=True, exist_ok=True)
+        kwargs["record_har_path"] = str(self.settings.har_path)
+        logger.warning(
+            "client.har_capture_enabled",
+            har_path=str(self.settings.har_path),
+            hint="HAR file will contain full request/response bodies, headers, "
+            "and cookies — do not share it publicly or attach it to a public bug report.",
+        )
+    return kwargs
 ```
 
-Playwright writes the HAR on context close; no other lifecycle changes needed. Default `record_har_mode`/`record_har_content` (full capture, embedded content) are left as Playwright's own defaults — that's the useful mode for this use case and there's no reason to expose a second knob for it.
+Playwright writes the HAR lazily on context close (`_close_browser_resources` → `close_context_bounded(self._context, owner="client")`, `client.py:692`). Default `record_har_mode`/`record_har_content` (full capture, embedded content) are left as Playwright's own defaults — that's the useful mode for this use case and there's no reason to expose a second knob for it.
+
+**File permissions (D3 must-fix):** a HAR file holds live auth cookies and bearer tokens — higher sensitivity than the CDP lockfile this codebase already hardens (`browser_manager.py::_write_lock`, `mode=0o600`, "not world-readable on multi-user POSIX boxes"). After the context close in `_close_browser_resources` succeeds and `self.settings.har_path` is set, best-effort `os.chmod(self.settings.har_path, 0o600)` (POSIX; no-op on Windows, wrapped in `try/except OSError` — never fail teardown over a permissions tweak).
+
+**Known caveat, not fixed (documented, per D1):** `GFLOW_CLI_HAR_PATH` is env-scoped, so two concurrent `gflow` processes (or a daemon serving multiple profiles) pointed at the same path would each write their own HAR on context close — last-writer-wins, silent overwrite, no error. Acceptable for an opt-in single-operator debug tool; call this out in the `Field` description so a user pointing multiple concurrent runs at one path isn't surprised.
 
 ### 3. Debug tracebacks
 
-**`src/gflow_cli/observability.py`** — `emit_unhandled_event` gains a `debug: bool = False` kwarg:
+**`src/gflow_cli/observability.py` stays untouched (D14 cut).** Both `_cli_helpers.py` call sites already have the live `exc`/`e` object in scope — there's no need to route the raw message/traceback *through* `emit_unhandled_event` to reach them, and nothing in this codebase consumes the structured `error_unhandled` log event today (no aggregator, no tailer). Threading a `debug` kwarg through it would be a third redundant surface for zero additional consumers, and it would also weaken `emit_unhandled_event`'s module docstring guarantee ("NEVER includes the raw exception message or formatted traceback") from absolute to conditional for no practical gain. So: `emit_unhandled_event` keeps hashing unconditionally, always, regardless of `debug_traceback` — the structured log event stays privacy-safe by construction, permanently.
 
-```python
-def emit_unhandled_event(
-    logger: FilteringBoundLogger,
-    exc: BaseException,
-    *,
-    cli_command: str,
-    debug: bool = False,
-) -> None:
-    if debug:
-        logger.error(
-            "error_unhandled",
-            exception_class=type(exc).__name__,
-            message=str(exc),
-            traceback="".join(traceback.format_exception(exc)),
-            cli_command=cli_command,
-        )
-        return
-    # ... existing hash path unchanged
-```
+**`src/gflow_cli/_cli_helpers.py`** — both call sites read `get_settings().debug_traceback` and build their own raw output directly from the exception already in scope, independent of `emit_unhandled_event`:
 
-**`src/gflow_cli/_cli_helpers.py`** — both call sites read `get_settings().debug_traceback` and pass it through:
+- `_handle_unhandled_error` (console path): still calls `emit_unhandled_event(...)` unchanged (hashed log line). Additionally, when `debug_traceback` is set, print the real exception + full traceback (`traceback.format_exception(exc)`) instead of the generic message, prefixed with a `[yellow]` one-line warning that the output may contain sensitive tokens/cookies.
+- `run_with_handlers`'s `as_json` branch: still calls `emit_unhandled_event(...)` unchanged. `json_output.unexpected_payload()` gains an optional `debug: BaseException | None = None` param; when passed, the payload's `error` dict gets `detail` (the message) and `traceback` fields instead of staying generic. Exit code stays 1 either way — this only changes payload content, not control flow.
 
-- `_handle_unhandled_error` (console path): when `debug_traceback` is set, print the real exception + full traceback (via `traceback.format_exception`) instead of the generic message, prefixed with a `[yellow]` one-line warning that the output may contain sensitive tokens/cookies.
-- `run_with_handlers`'s `as_json` branch: `json_output.unexpected_payload()` gains an optional `debug: BaseException | None = None` param; when passed, the payload's `error` dict gets `detail` (the message) and `traceback` fields instead of staying generic. Exit code stays 1 either way — this only changes payload content, not control flow.
+  **Security caveat (D3 must-fix) — JSON is a materially different risk surface than the console line.** A human watches the interactive console live and can react to the yellow warning; `--json` output is designed to be piped into CI logs, log aggregators, and webhooks that persist or forward it unreviewed. The `debug_traceback` `Field` description and `docs/CONFIGURATION.md` entry must carry an explicit, JSON-specific line: *"Under `--json`, the raw traceback lands in the JSON payload's `error.traceback` field — never pipe `--json` output under this flag to a shared or persistent system (CI logs, log aggregators, chat webhooks) without redacting it first."*
 
-Both call sites already have `exc`/`e` in scope, so this is a straight pass-through — no new exception plumbing.
+Net effect: 4 files touched (`config.py`, `client.py`, `_cli_helpers.py`, `docs/CONFIGURATION.md`) instead of 5 — `observability.py` drops out of the diff entirely.
 
 ### Non-goals
 
@@ -107,10 +105,11 @@ Both call sites already have `exc`/`e` in scope, so this is a straight pass-thro
 
 Extends existing test files rather than adding new ones:
 
-- `tests/api/test_client_launch_kwargs.py` — `record_har_path` present when `har_path` set, absent when `None`; parent directory created.
-- `tests/test_observability.py` — `emit_unhandled_event(debug=True)` logs raw message/traceback instead of hashes; `debug=False` (default) unchanged, covering the existing `test_emit_unhandled_event_hashes_message_and_stack`.
-- `tests/cli/test_error_handling.py` — console output switches between generic message and real traceback based on `debug_traceback`; JSON payload gains `detail`/`traceback` fields under the same setting.
+- `tests/api/test_client_launch_kwargs.py` — `record_har_path` present when `har_path` set, absent when `None`; parent directory created; file chmod 0o600 after close on POSIX (skip the permission assertion on Windows).
+- `tests/test_observability.py` — unchanged; `emit_unhandled_event` keeps its existing `test_emit_unhandled_event_hashes_message_and_stack` behavior, always hashed regardless of `debug_traceback` (no new param).
+- `tests/cli/test_error_handling.py` — console output switches between generic message and real traceback based on `debug_traceback`.
+- `tests/test_json_output.py` — extends the existing `TestErrorPayload`/`test_unexpected_is_privacy_safe` coverage of `unexpected_payload()`: default (`debug=None`) stays privacy-safe and unchanged; passing an exception adds `detail`/`traceback` to the `error` dict. This is the precise, low-indirection place to pin the new optional param, one level closer than the CLI-integration test in `test_error_handling.py`.
 
 ## Docs
 
-`docs/CONFIGURATION.md` gets both new env vars added to its reference table, each with the same security caveat as in the `Field` descriptions above.
+`docs/CONFIGURATION.md` gets both new env vars added as `### GFLOW_CLI_HAR_PATH` / `### GFLOW_CLI_DEBUG_TRACEBACK` entries (the file's existing reference format is per-variable `###` subsections with bolded `**What:**`/`**Default:**` fields, not a literal table), each carrying the same security caveats as the `Field` descriptions above, including the JSON-specific warning.

--- a/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
+++ b/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
@@ -1,0 +1,116 @@
+# Diagnostic visibility: HAR capture + debug tracebacks — design
+
+**Issue:** [#316](https://github.com/ffroliva/gflow-cli/issues/316) — "Add --har option and GFLOW_CLI_DEBUG_TRACEBACK env var for diagnostic visibility." Consolidated from #311 (Item 6), a production debugging session where the operator had no way to capture raw network traffic or see a real traceback — every unclassified error collapses to `"Unexpected error."` plus a SHA-256 hash.
+
+## Problem
+
+Two independent gaps when diagnosing a gflow-cli failure live:
+
+1. **No network capture.** There's no way to see the actual request/response bodies Flow's frontend exchanged (submit payloads, wire-format surprises, WAF responses). The only visibility is whatever a given transport chooses to log.
+2. **Errors are opaque by design.** `observability.emit_unhandled_event()` intentionally hashes the message and traceback of any non-`GFlowError` exception (`message_hash`, `stack_hash`) so aggregated logs never leak PII/tokens. Correct for telemetry, but it also means a developer chasing a real bug locally gets nothing to go on beyond "Unexpected error. Re-run with --verbose to capture details" — a hint that is currently false: `--verbose` only lowers the structlog level, it does not touch the hash.
+
+Both are opt-in, explicit-consent debug knobs — never default-on, because both can capture sensitive material (auth cookies, bearer tokens, session identifiers).
+
+## Decisions (from brainstorming)
+
+- **HAR capture is env-var only — no `--har` CLI flag.** This codebase has no shared Click option decorator; every flag (`--profile`, `--headless`, ...) is hand-copied into each of the ~15 generation command functions. Adding `--har` to all of them is a lot of surface for a debug-only feature. `GFLOW_CLI_HAR_PATH` gives the same capability with a one-line settings field and matches how other debug toggles in this codebase already work (`CHROME_BINARY`, `GFLOW_CLI_TRANSPORT`).
+- **`GFLOW_CLI_DEBUG_TRACEBACK` affects console output, not just logs.** The point is live debugging, so the real message + traceback must print to the terminal, not only end up in a structured log event nobody is tailing.
+- **JSON mode gets the same visibility.** Per the user: "most robust and safe approach giving the most observability possible." `--json` output must carry the same raw detail as the Rich console path when the flag is set — no diminished mode for scripted callers.
+
+## Design
+
+### 1. Settings (`src/gflow_cli/config.py`)
+
+Two new fields on `Settings`, following the existing `db_path: Path | None` / boolean-flag patterns:
+
+```python
+har_path: Path | None = Field(
+    default=None,
+    description=(
+        "When set, captures full Playwright network traffic (requests, "
+        "responses, headers, cookies) to this HAR file for the session. "
+        "SECURITY: HAR files can contain auth cookies and bearer tokens — "
+        "never share one publicly. Override via GFLOW_CLI_HAR_PATH."
+    ),
+)
+debug_traceback: bool = Field(
+    default=False,
+    description=(
+        "Bypasses hash redaction for unhandled (non-GFlowError) exceptions: "
+        "prints the real message + traceback to the console and JSON output "
+        "instead of SHA-256 hashes. SECURITY: may leak tokens/cookies present "
+        "in exception text — for local debugging only. "
+        "Override via GFLOW_CLI_DEBUG_TRACEBACK."
+    ),
+)
+```
+
+No CLI flags, no validators needed — both are plain env-var-driven settings, resolved the same way every other `GFLOW_CLI_*` knob is.
+
+### 2. HAR capture (`src/gflow_cli/api/client.py`)
+
+`FlowApiClient._persistent_context_kwargs()` (the single production browser-launch site — confirmed `UiAutomationTransport.setup()` always takes the shared-page branch in production and never opens its own context; its standalone-launch branch is exercised only by dev/e2e scripts) adds `record_har_path` when set:
+
+```python
+if self.settings.har_path is not None:
+    self.settings.har_path.parent.mkdir(parents=True, exist_ok=True)
+    kwargs["record_har_path"] = str(self.settings.har_path)
+    logger.warning(
+        "client.har_capture_enabled",
+        har_path=str(self.settings.har_path),
+        hint="HAR file will contain full request/response bodies, headers, "
+        "and cookies — do not share it publicly or attach it to a public bug report.",
+    )
+```
+
+Playwright writes the HAR on context close; no other lifecycle changes needed. Default `record_har_mode`/`record_har_content` (full capture, embedded content) are left as Playwright's own defaults — that's the useful mode for this use case and there's no reason to expose a second knob for it.
+
+### 3. Debug tracebacks
+
+**`src/gflow_cli/observability.py`** — `emit_unhandled_event` gains a `debug: bool = False` kwarg:
+
+```python
+def emit_unhandled_event(
+    logger: FilteringBoundLogger,
+    exc: BaseException,
+    *,
+    cli_command: str,
+    debug: bool = False,
+) -> None:
+    if debug:
+        logger.error(
+            "error_unhandled",
+            exception_class=type(exc).__name__,
+            message=str(exc),
+            traceback="".join(traceback.format_exception(exc)),
+            cli_command=cli_command,
+        )
+        return
+    # ... existing hash path unchanged
+```
+
+**`src/gflow_cli/_cli_helpers.py`** — both call sites read `get_settings().debug_traceback` and pass it through:
+
+- `_handle_unhandled_error` (console path): when `debug_traceback` is set, print the real exception + full traceback (via `traceback.format_exception`) instead of the generic message, prefixed with a `[yellow]` one-line warning that the output may contain sensitive tokens/cookies.
+- `run_with_handlers`'s `as_json` branch: `json_output.unexpected_payload()` gains an optional `debug: BaseException | None = None` param; when passed, the payload's `error` dict gets `detail` (the message) and `traceback` fields instead of staying generic. Exit code stays 1 either way — this only changes payload content, not control flow.
+
+Both call sites already have `exc`/`e` in scope, so this is a straight pass-through — no new exception plumbing.
+
+### Non-goals
+
+- No per-command `--har` flag (see Decisions).
+- No new redaction/scrubbing layer on top of the raw traceback — the whole point of the flag is "give me the truth," gated by an explicit opt-in and a warning, matching how `GFLOW_CLI_HAR_PATH` is handled.
+- No change to the `GFlowError` path (`_handle_gflow_error` / `error_payload`) — those already print full `detail`/`remediation_hint` unredacted; only the *unhandled* exception path is hashed today.
+- No change to `--verbose`'s existing log-level behavior — it stays orthogonal to `debug_traceback`. (Its console hint text should get corrected to mention `GFLOW_CLI_DEBUG_TRACEBACK` instead of implying `--verbose` alone reveals detail — small copy fix bundled into the same PR.)
+
+## Testing
+
+Extends existing test files rather than adding new ones:
+
+- `tests/api/test_client_launch_kwargs.py` — `record_har_path` present when `har_path` set, absent when `None`; parent directory created.
+- `tests/test_observability.py` — `emit_unhandled_event(debug=True)` logs raw message/traceback instead of hashes; `debug=False` (default) unchanged, covering the existing `test_emit_unhandled_event_hashes_message_and_stack`.
+- `tests/cli/test_error_handling.py` — console output switches between generic message and real traceback based on `debug_traceback`; JSON payload gains `detail`/`traceback` fields under the same setting.
+
+## Docs
+
+`docs/CONFIGURATION.md` gets both new env vars added to its reference table, each with the same security caveat as in the `Field` descriptions above.

--- a/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
+++ b/docs/superpowers/specs/2026-07-15-har-debug-traceback-design.md
@@ -92,7 +92,7 @@ Playwright writes the HAR lazily on context close (`_close_browser_resources` �
 
   **Security caveat (D3 must-fix) — JSON is a materially different risk surface than the console line.** A human watches the interactive console live and can react to the yellow warning; `--json` output is designed to be piped into CI logs, log aggregators, and webhooks that persist or forward it unreviewed. The `debug_traceback` `Field` description and `docs/CONFIGURATION.md` entry must carry an explicit, JSON-specific line: *"Under `--json`, the raw traceback lands in the JSON payload's `error.traceback` field — never pipe `--json` output under this flag to a shared or persistent system (CI logs, log aggregators, chat webhooks) without redacting it first."*
 
-Net effect: 4 files touched (`config.py`, `client.py`, `_cli_helpers.py`, `docs/CONFIGURATION.md`) instead of 5 — `observability.py` drops out of the diff entirely.
+Net effect: still 5 files touched, but `observability.py` swaps out for `json_output.py` (`config.py`, `client.py`, `_cli_helpers.py`, `json_output.py`, `docs/CONFIGURATION.md`) — the D14 cut removes a redundant *surface*, not a file, since `unexpected_payload()`'s new optional `debug` param already lived in the plan as part of the JSON-output change.
 
 ### Non-goals
 

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -330,7 +330,8 @@ def run_with_handlers(
     except BaseException as e:
         if as_json:
             emit_unhandled_event(_logger, e, cli_command=cli_command)
-            json_output.emit(json_output.unexpected_payload())
+            debug_exc = e if get_settings().debug_traceback else None
+            json_output.emit(json_output.unexpected_payload(debug=debug_exc))
             sys.exit(1)
         sys.exit(_handle_unhandled_error(e, cli_command=cli_command))
 

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -270,7 +270,7 @@ def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
             "[yellow]GFLOW_CLI_DEBUG_TRACEBACK is set — the output below may "
             "contain tokens/cookies. Do not share it publicly.[/yellow]"
         )
-        _console.print("".join(traceback.format_exception(exc)))
+        _console.print("".join(traceback.format_exception(exc)), markup=False)
     else:
         _console.print(
             "[red]Unexpected error.[/red] Re-run with GFLOW_CLI_DEBUG_TRACEBACK=1 "

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import re
 import sys
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -46,6 +47,7 @@ from rich.console import Console
 
 from gflow_cli import auth as auth_mod
 from gflow_cli import json_output, profile_store
+from gflow_cli.config import get_settings
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
     GFlowError,
@@ -255,14 +257,26 @@ def _handle_gflow_error(exc: GFlowError, *, cli_command: str) -> int:
 
 
 def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
-    """Catch-all for non-:class:`GFlowError`. Privacy-safe: hashes message + stack,
-    never logs raw payload. Always returns exit code 1.
+    """Catch-all for non-:class:`GFlowError`. Privacy-safe by default: the
+    console shows only a generic message (the structured telemetry event is
+    always SHA-256-hashed regardless of this setting — see
+    ``emit_unhandled_event``). Set GFLOW_CLI_DEBUG_TRACEBACK=1 to print the
+    real exception + traceback to the console instead (local debugging only —
+    the output may contain tokens/cookies). Always returns exit code 1.
     """
     emit_unhandled_event(_logger, exc, cli_command=cli_command)
-    _console.print(
-        "[red]Unexpected error.[/red] Re-run with --verbose to capture details. "
-        "If this persists, file a bug at https://github.com/ffroliva/gflow-cli/issues.",
-    )
+    if get_settings().debug_traceback:
+        _console.print(
+            "[yellow]GFLOW_CLI_DEBUG_TRACEBACK is set — the output below may "
+            "contain tokens/cookies. Do not share it publicly.[/yellow]"
+        )
+        _console.print("".join(traceback.format_exception(exc)))
+    else:
+        _console.print(
+            "[red]Unexpected error.[/red] Re-run with GFLOW_CLI_DEBUG_TRACEBACK=1 "
+            "to see the real error. If this persists, file a bug at "
+            "https://github.com/ffroliva/gflow-cli/issues.",
+        )
     return 1
 
 

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -336,9 +336,10 @@ class FlowApiClient:
         Extracted as an overridable seam so out-of-core tooling (e.g. a
         dev-scoped recording subclass that adds ``record_video_dir``) can
         augment the launch without any recording/test concern living in this
-        core path. The returned dict is identical to the previous inline call.
+        core path. The returned dict is identical to the previous inline call,
+        plus an optional ``record_har_path`` when ``GFLOW_CLI_HAR_PATH`` is set.
         """
-        return {
+        kwargs: JsonObject = {
             "user_data_dir": str(self.profile_dir),
             "headless": self.headless,
             "viewport": {"width": 1280, "height": 720},
@@ -368,6 +369,17 @@ class FlowApiClient:
                 "--disable-dev-shm-usage",
             ],
         }
+        if self.settings.har_path is not None:
+            self.settings.har_path.parent.mkdir(parents=True, exist_ok=True)
+            kwargs["record_har_path"] = str(self.settings.har_path)
+            logger.warning(
+                "client.har_capture_enabled",
+                har_path=str(self.settings.har_path),
+                hint="HAR file will contain full request/response bodies, headers, "
+                "and cookies — do not share it publicly or attach it to a public "
+                "bug report.",
+            )
+        return kwargs
 
     def _log_and_guard_launch(self, kwargs: dict[str, Any]) -> None:
         """Log the resolved browser-launch identity and fail loud on a silent
@@ -690,6 +702,16 @@ class FlowApiClient:
                 # Bounded close + force-close fallback (issue #293) — shared
                 # with the transports' own-context teardowns via _engine.
                 await close_context_bounded(self._context, owner="client")
+                # HAR files hold live auth cookies/bearer tokens — higher
+                # sensitivity than the CDP lockfile _write_lock already hardens
+                # in browser_manager.py. Playwright writes the HAR lazily on
+                # this close, so this is the earliest point the file exists;
+                # best-effort only (never fail teardown over a permission tweak).
+                if self.settings.har_path is not None:
+                    try:
+                        self.settings.har_path.chmod(0o600)
+                    except OSError:
+                        logger.warning("client.har_chmod_failed", exc_info=True)
             if self._pw is not None:
                 try:
                     # pw.stop() awaits the Node driver's exit with no deadline

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -450,6 +450,34 @@ class Settings(BaseSettings):
         parse_jitter_range(value)
         return value
 
+    # --- debugging ---------------------------------------------------------
+    har_path: Path | None = Field(
+        default=None,
+        description=(
+            "When set, captures full Playwright network traffic (requests, "
+            "responses, headers, cookies) to this HAR file for the session. "
+            "SECURITY: HAR files can contain auth cookies and bearer tokens — "
+            "never share one publicly; the file is chmod 0o600 on POSIX. "
+            "Concurrent gflow processes pointed at the same path will overwrite "
+            "each other's HAR (last-writer-wins) — use a distinct path per run. "
+            "Override via GFLOW_CLI_HAR_PATH."
+        ),
+    )
+    debug_traceback: bool = Field(
+        default=False,
+        description=(
+            "Prints the real message + traceback for unhandled (non-GFlowError) "
+            "exceptions to the console and, under --json, into the payload's "
+            "error.traceback field, instead of the generic placeholder. The "
+            "structured telemetry event stays hashed either way — this only "
+            "affects what the operator/caller sees. SECURITY: may leak "
+            "tokens/cookies present in exception text — for local debugging "
+            "only. Never pipe --json output under this flag to a "
+            "shared/persistent system (CI logs, log aggregators, webhooks) "
+            "without redacting it first. Override via GFLOW_CLI_DEBUG_TRACEBACK."
+        ),
+    )
+
     # --- logging ----------------------------------------------------------
     log_level: LogLevel = LogLevel.INFO
     log_format: LogFormat = LogFormat.AUTO

--- a/src/gflow_cli/json_output.py
+++ b/src/gflow_cli/json_output.py
@@ -13,6 +13,7 @@ that shells out to ``gflow``) parses instead of scraping the Rich tables.
 from __future__ import annotations
 
 import json
+import traceback
 from typing import TYPE_CHECKING, Any
 
 from gflow_cli.errors import (
@@ -90,21 +91,25 @@ def error_payload(exc: GFlowError) -> dict[str, Any]:
     }
 
 
-def unexpected_payload() -> dict[str, Any]:
-    """Privacy-safe payload for a non-:class:`GFlowError`.
+def unexpected_payload(debug: BaseException | None = None) -> dict[str, Any]:
+    """Privacy-safe payload for a non-:class:`GFlowError`, by default.
 
     Mirrors ``_handle_unhandled_error``: never leaks the raw message or stack —
-    only the fact that an unclassified error occurred. Always exit code 1.
+    only the fact that an unclassified error occurred — unless ``debug`` is
+    passed (the caller has already confirmed GFLOW_CLI_DEBUG_TRACEBACK=1), in
+    which case ``detail``/``traceback`` carry the real exception. Always exit
+    code 1.
     """
-    return {
-        "status": "fail",
-        "error": {
-            "class": "UnexpectedError",
-            "title": "Unexpected error",
-            "exit_code": 1,
-            "retryable": False,
-        },
+    error: dict[str, Any] = {
+        "class": "UnexpectedError",
+        "title": "Unexpected error",
+        "exit_code": 1,
+        "retryable": False,
     }
+    if debug is not None:
+        error["detail"] = str(debug)
+        error["traceback"] = "".join(traceback.format_exception(debug))
+    return {"status": "fail", "error": error}
 
 
 def image_result(

--- a/tests/api/test_client_launch_kwargs.py
+++ b/tests/api/test_client_launch_kwargs.py
@@ -56,6 +56,66 @@ def test_persistent_context_kwargs_are_unchanged(tmp_path: Path) -> None:
     assert kwargs["channel"] is None
 
 
+def test_persistent_context_kwargs_omits_har_path_when_unset(tmp_path: Path) -> None:
+    """No GFLOW_CLI_HAR_PATH -> no record_har_path key at all (not just None)."""
+    client = FlowApiClient(profile_dir=tmp_path, headless=True)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert "record_har_path" not in kwargs
+
+
+def test_persistent_context_kwargs_includes_har_path_when_set(tmp_path: Path) -> None:
+    """har_path set -> record_har_path passed through + parent dir created."""
+    from gflow_cli.config import Settings
+
+    har_path = tmp_path / "captures" / "session.har"
+    settings = Settings(har_path=har_path)
+    client = FlowApiClient(profile_dir=tmp_path, headless=True, settings=settings)
+    kwargs = client._persistent_context_kwargs()  # noqa: SLF001
+    assert kwargs["record_har_path"] == str(har_path)
+    assert har_path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_close_browser_resources_chmods_har_file(tmp_path: Path) -> None:
+    """After context close, an existing HAR file is hardened to 0o600 on POSIX.
+
+    Windows has no POSIX permission bits, so the assertion is skipped there —
+    the chmod call itself is still exercised (must not raise on Windows).
+    """
+    import stat
+    import sys
+
+    from gflow_cli.config import Settings
+
+    har_path = tmp_path / "session.har"
+    har_path.write_bytes(b"{}")  # simulate Playwright having already written it
+    settings = Settings(har_path=har_path)
+    client = FlowApiClient(profile_dir=tmp_path, headless=True, settings=settings)
+    # _close_browser_resources only enters its close-block (where the chmod
+    # lives) when self._context is not None — a fresh client that never
+    # entered __aenter__ has _context=None, so a fake context is required
+    # here, matching the _client_with_cookies pattern used elsewhere in this
+    # file (e.g. test_context_cookie_state_present_and_unexpired).
+    client._context = MagicMock()  # noqa: SLF001
+    with patch("gflow_cli.api.client.close_context_bounded", AsyncMock()):
+        await client._close_browser_resources()  # noqa: SLF001
+    if sys.platform != "win32":
+        assert stat.S_IMODE(har_path.stat().st_mode) == 0o600
+
+
+def test_har_path_resolves_from_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """GFLOW_CLI_HAR_PATH (not just constructor injection) actually parses into
+    Settings.har_path — the other tests in this file inject har_path directly via
+    the constructor, which proves the consuming code works but never proves the
+    advertised env var name/wiring does."""
+    from gflow_cli.config import Settings, reset_settings
+
+    har_path = tmp_path / "env.har"
+    monkeypatch.setenv("GFLOW_CLI_HAR_PATH", str(har_path))
+    reset_settings()
+    assert Settings().har_path == har_path
+
+
 @pytest.mark.asyncio
 async def test_ui_automation_setup_passes_disable_dev_shm_usage(tmp_path: Path) -> None:
     """setup() must pass --disable-dev-shm-usage in args to launch_persistent_context."""

--- a/tests/cli/test_error_handling.py
+++ b/tests/cli/test_error_handling.py
@@ -245,6 +245,34 @@ def test_cli_unhandled_exception_debug_traceback_prints_real_error(
     assert "Unexpected error." not in result.output
 
 
+def test_cli_unhandled_exception_debug_traceback_disables_markup_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """A raw exception message containing Rich-markup-like brackets (e.g. a
+    Playwright locator string) must NOT crash the catch-all handler with
+    rich.errors.MarkupError, and must be printed verbatim -- not stripped or
+    mangled by Rich's markup parser. Regression test for the ``markup=False``
+    fix on the raw-traceback print in `_handle_unhandled_error`."""
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_DEBUG_TRACEBACK", "1")
+    reset_settings()
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    bracketed = 'selector not found: [data-testid="foo"]'
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError(bracketed)),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt"])
+    assert result.exit_code == 1, result.output
+    assert bracketed in result.output
+
+
 def test_cli_unhandled_exception_default_hides_real_error_from_console(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/cli/test_error_handling.py
+++ b/tests/cli/test_error_handling.py
@@ -304,6 +304,66 @@ def test_cli_unhandled_exception_default_hides_real_error_from_console(
     assert "GFLOW_CLI_DEBUG_TRACEBACK=1" in result.output
 
 
+def test_cli_json_unhandled_exception_debug_traceback_includes_raw_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """--json + GFLOW_CLI_DEBUG_TRACEBACK=1 -> the JSON payload's error.detail /
+    error.traceback carry the real exception, same observability as console."""
+    import json as json_mod
+
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_DEBUG_TRACEBACK", "1")
+    reset_settings()
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt", "--json"])
+    assert result.exit_code == 1
+    payload = json_mod.loads(result.output)
+    assert payload["error"]["detail"] == "bad input"
+    assert "ValueError" in payload["error"]["traceback"]
+
+
+def test_cli_json_unhandled_exception_default_stays_privacy_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """--json without the debug flag -> no detail/traceback fields, same as today.
+
+    Explicitly clears GFLOW_CLI_DEBUG_TRACEBACK for the same reason as
+    test_cli_unhandled_exception_default_hides_real_error_from_console (Task 2)
+    — the autouse fixture doesn't isolate this var, so a developer's shell
+    exporting it would otherwise make this test environment-dependent.
+    """
+    import json as json_mod
+
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_DEBUG_TRACEBACK", raising=False)
+    reset_settings()
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt", "--json"])
+    assert result.exit_code == 1
+    payload = json_mod.loads(result.output)
+    assert "detail" not in payload["error"]
+    assert "traceback" not in payload["error"]
+
+
 def test_cli_gflow_error_emits_error_raised_event_with_correlation_id(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/cli/test_error_handling.py
+++ b/tests/cli/test_error_handling.py
@@ -218,6 +218,64 @@ def test_cli_unhandled_exception_exits_1_and_emits_unhandled_event(
     assert "bad input" not in str(e)
 
 
+def test_cli_unhandled_exception_debug_traceback_prints_real_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """GFLOW_CLI_DEBUG_TRACEBACK=1 -> console shows the real message + traceback,
+    with a yellow leak-risk warning, instead of the generic 'Unexpected error.'"""
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_DEBUG_TRACEBACK", "1")
+    reset_settings()
+
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt"])
+    assert result.exit_code == 1
+    assert "bad input" in result.output
+    assert "ValueError" in result.output
+    assert "GFLOW_CLI_DEBUG_TRACEBACK" in result.output  # the leak-risk warning
+    assert "Unexpected error." not in result.output
+
+
+def test_cli_unhandled_exception_default_hides_real_error_from_console(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """Default (GFLOW_CLI_DEBUG_TRACEBACK unset) -> console never shows the raw
+    message, and the hint now points at the real env var, not the misleading
+    --verbose claim.
+
+    Explicitly clears GFLOW_CLI_DEBUG_TRACEBACK: the autouse _isolate_settings
+    fixture (tests/conftest.py) only pins GFLOW_CLI_HOME/GFLOW_CLI_DB_PATH, so
+    a developer's shell or .env.local exporting this var would otherwise leak
+    into "default" behavior and make this test flaky outside CI.
+    """
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_DEBUG_TRACEBACK", raising=False)
+    reset_settings()
+    _patch_profile_resolution(monkeypatch, tmp_path, "gflow_cli.cli_image")
+    monkeypatch.setattr(
+        "gflow_cli.cli_image._run_t2i",
+        _make_raiser(ValueError("bad input")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["image", "t2i", "test prompt"])
+    assert result.exit_code == 1
+    assert "bad input" not in result.output
+    assert "GFLOW_CLI_DEBUG_TRACEBACK=1" in result.output
+
+
 def test_cli_gflow_error_emits_error_raised_event_with_correlation_id(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -139,10 +139,24 @@ class TestErrorPayload:
         assert payload["error"]["retryable"] is False
         assert payload["error"]["exit_code"] == 5
 
-    def test_unexpected_is_privacy_safe(self) -> None:
+    def test_unexpected_is_privacy_safe_by_default(self) -> None:
         payload = json_output.unexpected_payload()
         assert payload["error"]["class"] == "UnexpectedError"
         assert payload["error"]["retryable"] is False
         assert payload["error"]["exit_code"] == 1
-        # The raw exception message/stack must never leak into the payload.
+        # The raw exception message/stack must never leak into the payload
+        # unless the caller explicitly opts in via debug=.
         assert "detail" not in payload["error"]
+        assert "traceback" not in payload["error"]
+
+    def test_unexpected_with_debug_includes_detail_and_traceback(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            payload = json_output.unexpected_payload(debug=exc)
+        assert payload["error"]["detail"] == "boom"
+        assert "ValueError" in payload["error"]["traceback"]
+        assert "boom" in payload["error"]["traceback"]
+        # Non-debug fields stay identical to the default shape.
+        assert payload["error"]["class"] == "UnexpectedError"
+        assert payload["error"]["exit_code"] == 1


### PR DESCRIPTION
## Summary
- `GFLOW_CLI_HAR_PATH` — captures full Playwright network traffic to a HAR file at the single production browser-launch site, with 0600 permission hardening after the file is written (best-effort, POSIX).
- `GFLOW_CLI_DEBUG_TRACEBACK` — prints the real exception message + traceback for unhandled errors, to the console and under `--json`, instead of the generic placeholder. Structured telemetry stays SHA-256-hashed unconditionally either way — this only changes what the operator/caller sees.
- Both are opt-in, env-var only (no new CLI flags — this codebase has no shared Click option decorator, adding a flag to all ~15 generation commands wasn't worth it for a debug-only feature).
- Fixes a pre-existing misleading hint: the old catch-all message told users to "re-run with --verbose", which doesn't actually reveal anything.
- `docs/CONFIGURATION.md` documents both new env vars.

Closes #316.

## Process

Design spec → 3 rounds of multi-agent council review (6 internal Claude dimensions + one external `codex` pass, which caught 6 real issues the internal rounds missed — wording accuracy, a wrong test count, a Windows-only test-triviality nuance, a test-isolation gap, a missing test, a malformed markdown fence) → implementation plan, also council-reviewed → 4 tasks implemented via fresh subagents, each with an independent task-level spec+quality review → final whole-branch review on the most capable available model.

The task-review loop caught one real Important bug implementation-level council review couldn't have (it doesn't exist until there's code): printing raw exception text through Rich's `Console()` at its default `markup=True` can crash (`MarkupError`) on bracketed content or silently mangle it — this codebase's own Playwright selector strings (e.g. `[data-testid="foo"]") are a realistic example of exactly that shape. Fixed with `markup=False` on that one print call, plus a regression test using that exact bracket shape.

## Test plan
- [x] All 4 tasks individually implemented with TDD (RED/GREEN evidence in each task's commit), each independently reviewed (spec compliance + code quality)
- [x] Scoped regression run across every touched file: `tests/api/test_client_launch_kwargs.py`, `tests/cli/test_error_handling.py`, `tests/test_json_output.py`, `tests/test_config.py` — 97 passed
- [x] `ruff check` / `ruff format --check` clean on every touched file
- [x] `scripts/ci/check_doc_links.py` exits 0
- [x] Final whole-branch review (Opus): Ready to merge — Yes, no Critical/Important findings
- [ ] CI (will run on this PR)