### PR TITLE
feat(ci): fall back to local SonarQube when SonarCloud is unreachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,26 @@ jobs:
           name: coverage-xml
         continue-on-error: true  # graceful if coverage upload was skipped
 
+      # SonarCloud is a third-party service; it does have outages (seen live
+      # 2026-07-16, ~504s across its whole API including the unauthenticated
+      # /api/system/status endpoint). Reassessed fresh on every run — no manual
+      # flag to remember to flip back once it recovers. A skip here still lets
+      # the job COMPLETE (green), it just doesn't run the scan step; local
+      # coverage during an outage comes from the shared SonarQube instance
+      # (scripts/dev/sonar-local-scan.sh) — see docs/GITHUB.md § SonarCloud
+      # outage handling.
+      - name: Check SonarCloud availability
+        id: sonarcloud_health
+        run: |
+          if curl -sf -m 10 "https://sonarcloud.io/api/system/status" | grep -q '"status":"UP"'; then
+            echo "up=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SonarCloud is unreachable or degraded — skipping the scan for this run (not a code quality failure). Verify locally with scripts/dev/sonar-local-scan.sh before merging if this persists, and re-run this job once SonarCloud recovers."
+          fi
+
       - name: SonarCloud scan
+        if: steps.sonarcloud_health.outputs.up == 'true'
         uses: SonarSource/sonarcloud-github-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR decoration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 # Pre-commit hooks for gflow-cli
-# Install: pip install pre-commit && pre-commit install
+# Install (commit-time hooks): pip install pre-commit && pre-commit install
+# Install (pre-push hook too):  pre-commit install --hook-type pre-push
 # Run manually: pre-commit run --all-files
 #
-# Gates enforced:
+# Gates enforced on commit:
 #   1. ruff lint + format (fast, catches import order / style / unused imports)
 #   2. repo-hygiene (blocks tracked images, CDP lock files, hardcoded Windows paths)
 #
@@ -10,6 +11,14 @@
 #   - generated output artefacts (*.jpg, *.jpeg, test_assets/smoke_*/, test_assets/debug_*/)
 #   - CDP lock files (.gflow-cdp.lock) that contain browser session metadata
 #   - hardcoded machine-specific paths in scripts/ (C:\Users\<name>\...)
+#
+# Gate enforced on push:
+#   3. sonar-outage-fallback — SonarCloud (CI's primary gate) is reachable in
+#      the overwhelming majority of pushes, so this SKIPS in that case (CI
+#      does the real enforcement); it only runs a local SonarQube scan when
+#      SonarCloud itself is unreachable, so a push isn't silently unassessed
+#      during an outage. Gracefully skips (never blocks) if the optional
+#      local Sonar infra isn't set up -- most contributors won't have it.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -28,6 +37,14 @@ repos:
         pass_filenames: false
         always_run: true
         additional_dependencies: []
+
+      - id: sonar-outage-fallback
+        name: Sonar (SonarCloud primary; local fallback only on outage)
+        language: system
+        entry: bash scripts/dev/sonar-pre-push-gate.sh
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -130,6 +130,26 @@ Open the PR Summary at `sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli&pul
   `cast(T, ...)  # pyright: ignore[reportUnnecessaryCast]` pattern that satisfies
   S5655/S5890 (removing those casts reintroduces the finding).
 
+### SonarCloud outage handling
+
+SonarCloud is a third-party service and does have outages (seen live
+2026-07-16 — a ~504 across its whole API, including the unauthenticated
+`/api/system/status` endpoint). The `sonar` job's `Check SonarCloud
+availability` step probes that endpoint fresh on every run and skips the
+`SonarCloud scan` step (job stays green) when it's down — no manual flag to
+remember to flip back once it recovers.
+
+During an outage there's still local coverage: `git push` runs
+`scripts/dev/sonar-pre-push-gate.sh` (wired via `.pre-commit-config.yaml`'s
+`pre-push` stage — install with `pre-commit install --hook-type pre-push`).
+It re-checks SonarCloud itself and only falls back to a scan against the
+shared local SonarQube instance
+(`../shared-infra/sonarqube`, via `scripts/dev/sonar-local-scan.sh`) when
+SonarCloud is unreachable. Both scripts skip gracefully (exit 0) if that
+optional local infra isn't checked out — most contributors won't have it,
+and that must never block a push. If the outage persists past your push,
+re-run the `sonar` job once SonarCloud recovers before merging.
+
 ## If Sonar Did Not Run
 
 For small PRs, merge to `develop` after review when tests and gitleaks are

--- a/scripts/dev/sonar-local-scan.sh
+++ b/scripts/dev/sonar-local-scan.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# sonar-local-scan.sh — run the shared SonarQube Community Edition scan against
+# gflow-cli's own sonar-project.properties, for use when SonarCloud (the CI
+# primary — this project is open-source and gets free SonarCloud coverage) is
+# unreachable. NOT wired into CI: the local SonarQube CE server (docker, on
+# this machine / shared-infra) is never reachable from GitHub-hosted runners.
+# This is a manual/local pre-flight, or what the pre-push hook falls back to.
+#
+# gflow-cli-specific wrapper around shared-infra/sonarqube/sonar-gate.sh: this
+# repo's coverage command must be the Windows-safe form (`uv run pytest` is
+# broken on Windows for this project — see memory windows-dev-quirks), which
+# the shared gate's own auto-default does not know.
+#
+# Usage (from repo root):
+#   bash scripts/dev/sonar-local-scan.sh
+#
+# Env:
+#   SHARED_INFRA_DIR   default ../shared-infra (sibling checkout)
+#   SONAR_HOST_URL      default http://localhost:9000
+#   SONAR_TOKEN         required — SonarQube > My Account > Security > Generate Tokens
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SHARED="${SHARED_INFRA_DIR:-$ROOT/../shared-infra}"
+GATE="$SHARED/sonarqube/sonar-gate.sh"
+
+# Graceful skip (exit 0), not a hard failure: most contributors won't have
+# shared-infra checked out, and that must never block anything -- matches
+# sonar-gate.sh's own "never block on missing optional infra" convention.
+if [ ! -f "$GATE" ]; then
+  echo "[sonar-local] SKIP: shared-infra not found at $SHARED (set SHARED_INFRA_DIR to enable)."
+  exit 0
+fi
+
+echo "[sonar-local] scanning gflow-cli against the local SonarQube instance ..."
+echo "[sonar-local] (start it first if needed: bash $SHARED/sonarqube/start.sh)"
+
+SONAR_COVERAGE_CMD="${SONAR_COVERAGE_CMD:-.venv/Scripts/python.exe -m pytest --cov=src --cov-report=xml -q}" \
+  bash "$GATE"

--- a/scripts/dev/sonar-pre-push-gate.sh
+++ b/scripts/dev/sonar-pre-push-gate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# sonar-pre-push-gate.sh — SonarCloud health-check + local-Sonar fallback,
+# run at git pre-push (wired via pre-commit's `stages: [pre-push]`).
+#
+# SonarCloud is the PRIMARY gate for gflow-cli (this project is open-source
+# and gets free SonarCloud coverage), and CI already enforces it on every
+# push/PR. This hook exists only so a push isn't silently left unassessed
+# during a SonarCloud outage (seen live 2026-07-16):
+#   - SonarCloud reachable -> CI will do the real enforcement; skip here so
+#     pushes stay fast (no local Docker scan on every push).
+#   - SonarCloud unreachable -> fall back to the shared local SonarQube
+#     instance (scripts/dev/sonar-local-scan.sh) so there's still a real
+#     quality-gate signal before the code ships. Gracefully skips (never
+#     blocks a push) if the local infra isn't set up either -- most
+#     contributors won't have it, and that must never be a blocker.
+set -uo pipefail
+
+if curl -sf -m 8 "https://sonarcloud.io/api/system/status" 2>/dev/null | grep -q '"status":"UP"'; then
+  echo "[sonar] SonarCloud is UP -- CI will enforce the gate on push, skipping local scan."
+  exit 0
+fi
+
+echo "[sonar] SonarCloud unreachable -- falling back to local SonarQube for this push."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/sonar-local-scan.sh"
+rc=$?
+# sonar-local-scan.sh exits 0 for both "gate passed" and "infra unavailable,
+# gracefully skipped" -- a non-zero here is always a genuine Quality Gate
+# failure, never a missing-infra false alarm.
+if [ "$rc" -ne 0 ]; then
+  echo "[sonar] local Sonar Quality Gate FAILED -- push blocked. Fix the issues above."
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary
- SonarCloud had a live outage on 2026-07-16 (~504 across its whole API, including the unauthenticated `/api/system/status` endpoint) that blocked the v0.36.0 release PR with a false-negative check.
- The `sonar` CI job now health-checks SonarCloud before scanning and skips the scan step gracefully (job stays green) when it's unreachable — reassessed fresh on every run, no manual flag to remember to flip back.
- New pre-push git hook (`scripts/dev/sonar-pre-push-gate.sh`, wired via `.pre-commit-config.yaml`'s `pre-push` stage) does the same health check locally: if SonarCloud is up, it skips (CI already enforces the gate); if SonarCloud is down, it falls back to a scan against the shared local SonarQube CE instance (`scripts/dev/sonar-local-scan.sh`, wraps `shared-infra/sonarqube/sonar-gate.sh`) so a push isn't silently left unassessed during an outage.
- Both new scripts skip gracefully (exit 0) if the optional local SonarQube infra isn't checked out — most contributors won't have it, and that must never block a push.
- `docs/GITHUB.md` documents the new outage-handling behavior under a new "SonarCloud outage handling" subsection.

## Test plan
- [x] `bash -n` syntax check on both new scripts
- [x] YAML validation of `.github/workflows/ci.yml` (parses clean; pre-existing unrelated YAML escape bug in `.pre-commit-config.yaml`'s `detect-secrets` exclude regex confirmed present on `develop` before this change, out of scope)
- [x] `scripts/ci/check_doc_links.py` — all links resolved
- [x] `scripts/ci/check_repo_hygiene.py` — no violations
- [x] `ruff check` / `ruff format --check` — clean (no Python source touched)
- [x] Manually exercised both branches of `sonar-pre-push-gate.sh`: SonarCloud UP → skip; local infra unavailable → graceful skip
- [ ] CI green on this PR (SonarCloud scan itself, since SonarCloud is back online as of this PR)