### PR TITLE
fix(agentic): enforce image count via Agent settings panel (#313)

### DIFF
--- a/docs/AGENT_UI_RECON.md
+++ b/docs/AGENT_UI_RECON.md
@@ -137,10 +137,16 @@ duration** (4/6/8/10 s), and likely **aspect ratio** and **model** — can be ex
 the agent resolves the selection itself.
 
 Implications for `AgenticFlowUiDriver`:
-- **`configure_settings` becomes optional.** Encoding settings as a directive prompt
-  avoids driving the fragile `tune` → Radix-popover dropdowns — the most drift-prone
-  surface on a volatile A/B UI. Prefer prompt-encoding; treat popover automation as a
-  fallback only if prompt-steering proves unreliable.
+- **`configure_settings` drives count as a fallback (2026-07-16, issue #313).**
+  Prompt-encoding alone proved unreliable: Agent mode's `tune` panel has a
+  STICKY "Image generation default" count that silently overrode the
+  natural-language directive when stale. `AgenticFlowUiDriver` now sets that
+  control to match the request (best-effort, never raises — falls through to
+  prompt-only on any selector miss) in addition to the natural-language
+  phrasing. Aspect/model are NOT automated via this panel — count only, to
+  keep the newly-added surface area minimal. See
+  `flow-agent-settings-panel-sticky-defaults` project memory for the full
+  selector write-up.
 - **The agent *interprets* the request → verify, don't trust.** It may produce a
   different count or ignore a duration. This is precisely why scrape-and-dedup-by-UUID
   is load-bearing: request N → poll until N distinct new media UUIDs → if the produced

--- a/docs/superpowers/plans/2026-07-16-agentic-count-enforcement/PLAN.md
+++ b/docs/superpowers/plans/2026-07-16-agentic-count-enforcement/PLAN.md
@@ -1,0 +1,482 @@
+# Agentic Image Count Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Flow's Agent-mode composer from silently overriding gflow-cli's requested image count, which currently causes issue #313 (the `MediaAttributionError` ambiguity guard fires *after* a full generation attempt, wasting the run).
+
+**Architecture:** `AgenticFlowUiDriver.configure_image_settings` currently only encodes count/aspect into a natural-language prompt directive (`_compose_directive`). Live investigation (2026-07-16, issue #313 comment) found that Agent mode also has a `tune` "Agent settings" panel with a **sticky** "Image generation default" count control (`1x`/`x2`/`x3`/`x4`) that is never touched by gflow-cli — a stale value there can override the natural-language phrasing. This plan adds a best-effort step that drives that panel to match the requested count, keeping the natural-language phrasing as reinforcement and the existing `MediaAttributionError` fail-fast guard as a backstop.
+
+This is the fallback path `docs/AGENT_UI_RECON.md` § "Settings via prompt, not the `tune` popover" already anticipated: *"treat popover automation as a fallback only if prompt-steering proves unreliable"* — issue #313 is that proof.
+
+**Tech Stack:** Python 3.11+, Playwright async API, pytest + pytest-asyncio, existing `AgenticFlowUiDriver` mock-page test conventions.
+
+## Global Constraints
+
+- Selectors must be **locale-invariant**: Material Symbol ligatures + DOM structure only, never text content, never hashed CSS-module class names (`sc-xxxxxxx-N`) as the sole anchor — see memory `flow-locale-leak-icon-ligatures` and this repo's existing `MODE_SWITCH_TRIGGER_SELECTORS` pattern.
+- The new behavior must be **best-effort and never raise**: if any selector step fails (panel not found, button not found, different UI cohort), log a warning and fall through to the existing natural-language-only behavior. This must never turn a working generation into a hard failure — the whole point is to *reduce* failures, not add a new failure mode.
+- Count is already validated to the range 1–4 by `GenerateImageRequest.__post_init__` (`src/gflow_cli/api/image.py:443-444`) — the four settings-panel count buttons (`1x`/`x2`/`x3`/`x4`) cover the full range; no clamping/fallback-for-out-of-range logic is needed.
+- All existing tests in `tests/api/transports/drivers/test_agentic.py` that call `configure_image_settings` with a `MagicMock()` page must keep passing — the new page-interaction code path must be safely no-op-able against a bare `MagicMock()` (a `MagicMock().locator(...).count()` returns a `MagicMock`, which is truthy in a boolean context in the WRONG way for `await ... > 0` comparisons unless tests are updated to configure the mock explicitly; the task must either update those 3 existing tests to configure the new mock behavior, or ensure the code path degrades safely and add `AsyncMock`-based assertions).
+- Do not touch aspect-ratio or model automation via this panel — stay scoped to count only, matching issue #313 as filed.
+
+---
+
+### Task 1: Drive Agent settings panel's Image count control from `configure_image_settings`
+
+**Files:**
+- Modify: `src/gflow_cli/api/transports/drivers/agentic.py`
+- Modify: `tests/api/transports/drivers/test_agentic.py`
+- Modify: `docs/AGENT_UI_RECON.md` (mark the fallback as implemented)
+
+**Interfaces:**
+- Consumes: `GenerateImageRequest.count` (already validated 1–4, `src/gflow_cli/api/image.py:443-444`); `AgenticFlowUiDriver.configure_image_settings(page, request, *, out_dir=None, prompt_idx=None)` (existing signature, unchanged).
+- Produces: `AgenticFlowUiDriver._enforce_image_count_via_settings_panel(page: Page, count: int) -> None` — new private async method, best-effort, never raises. Called from `configure_image_settings`.
+
+- [ ] **Step 1: Read the current `configure_image_settings` and module header for context**
+
+Read `src/gflow_cli/api/transports/drivers/agentic.py` lines 1-120 (module docstring + constants) and lines 222-260 (`configure_image_settings`) before editing, so the new constants and method land in the same style as the existing code (structlog `log.debug`/`log.warning` with snake_case event names prefixed `agentic_driver.`, late imports only where the module docstring requires them).
+
+- [ ] **Step 2: Add the new module-level selector constants**
+
+Add these near the existing `_SLATE_COMPOSER_SELECTOR` constant (around line 60), after it:
+
+```python
+# Agent settings panel (issue #313) — driven as a best-effort FALLBACK only,
+# because prompt-encoding is the primary mechanism and this popover is the
+# most drift-prone surface on Flow's UI (docs/AGENT_UI_RECON.md § "Settings
+# via prompt, not the tune popover"). A sticky prior value in this panel can
+# silently override the natural-language directive's requested count — that
+# mismatch is issue #313's root cause. This enforcement makes the panel match
+# the request so the natural-language phrasing and the UI setting agree.
+_TUNE_BUTTON_SELECTOR = "button:has(i.google-symbols:text-is('tune'))"
+
+# The image count control is the FIRST [role='tablist'] in DOM order that
+# contains both '1x' and 'x2' buttons — Flow always renders the "Image
+# generation default" section before "Video generation default" (verified
+# live 2026-07-16, both en and pt-BR locales; count labels are numeric
+# multipliers, not translated text, so this is locale-safe).
+_IMAGE_COUNT_TABLIST_SELECTOR = (
+    "[role='tablist']:has(button:text-is('1x')):has(button:text-is('x2'))"
+)
+
+# request.count is validated to 1-4 by GenerateImageRequest.__post_init__
+# (api/image.py) — this covers the settings panel's full button range.
+_COUNT_BUTTON_TEXT: dict[int, str] = {1: "1x", 2: "x2", 3: "x3", 4: "x4"}
+
+# The panel's "Save" button has no icon ligature, no data-* attribute, no
+# type="submit", and its text ("Salvar"/"Save"/etc.) is locale-dependent —
+# per memory flow-locale-leak-icon-ligatures this cannot be text-matched.
+# Locate it structurally instead: walk up from the panel's arrow_back header
+# icon to the nearest ancestor that ALSO contains the count tablist (i.e.
+# the panel root), then take the last visible <button> in that scope — that
+# button is Save in every live-verified capture (2026-07-16). Tags the match
+# with a data attribute so Playwright can locate it without re-running the
+# walk in a second round-trip.
+_FIND_SAVE_BUTTON_JS = """
+() => {
+  const backBtn = [...document.querySelectorAll('button')].find((b) => {
+    const i = b.querySelector('i.google-symbols');
+    return i && (i.textContent || '').trim() === 'arrow_back';
+  });
+  if (!backBtn) return false;
+  let node = backBtn.parentElement;
+  for (let i = 0; i < 8 && node; i++) {
+    const hasCountTablist = [...node.querySelectorAll("[role='tablist']")].some((t) => {
+      const texts = [...t.querySelectorAll('button')].map((b) => (b.textContent || '').trim());
+      return texts.includes('1x') && texts.includes('x2');
+    });
+    if (hasCountTablist) {
+      const visible = [...node.querySelectorAll('button')].filter((b) => {
+        const r = b.getBoundingClientRect();
+        return r.width > 0 && r.height > 0;
+      });
+      const save = visible[visible.length - 1];
+      if (!save) return false;
+      save.setAttribute('data-gflow-save-target', '1');
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+"""
+```
+
+- [ ] **Step 2 verify: run ruff on the file so far**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/gflow_cli/api/transports/drivers/agentic.py`
+Expected: `All checks passed!` (constants only, no logic yet — this just catches typos before the method lands)
+
+- [ ] **Step 3: Add `_enforce_image_count_via_settings_panel` to `AgenticFlowUiDriver`**
+
+Add this method immediately after `configure_image_settings` (after its closing, before `_reconcile_instructions` — or after `_reconcile_instructions`, whichever keeps `configure_image_settings` and its direct helpers adjacent; place it directly below `configure_image_settings`):
+
+```python
+    async def _enforce_image_count_via_settings_panel(self, page: Page, count: int) -> None:
+        """Best-effort: set Agent mode's sticky "Image generation default"
+        count to match ``count`` via the ``tune`` Settings panel.
+
+        Fallback mechanism for issue #313 — see the module-level selector
+        comments for why this is scoped to count-only and driven only as a
+        secondary signal alongside the natural-language directive.
+
+        **Never raises.** Any selector miss (older UI cohort with no ``tune``
+        panel at all, a future Flow redesign, a transient render delay) is
+        logged and swallowed — the natural-language directive alone is the
+        pre-existing behavior, so failing to enforce here must never turn a
+        previously-working generation into a hard failure.
+        """
+        try:
+            tune_btn = page.locator(_TUNE_BUTTON_SELECTOR).first
+            if await tune_btn.count() == 0:
+                log.debug("agentic_driver.settings_panel.tune_not_found")
+                return
+            await tune_btn.click(timeout=5_000)
+
+            count_tablist = page.locator(_IMAGE_COUNT_TABLIST_SELECTOR).first
+            target_label = _COUNT_BUTTON_TEXT[count]
+            target_btn = count_tablist.locator(f"button:text-is('{target_label}')").first
+            if await target_btn.count() == 0:
+                log.warning(
+                    "agentic_driver.settings_panel.count_button_not_found",
+                    count=count,
+                )
+                return
+            await target_btn.click(timeout=5_000)
+
+            found_save = await page.evaluate(_FIND_SAVE_BUTTON_JS)
+            if not found_save:
+                log.warning("agentic_driver.settings_panel.save_button_not_found")
+                return
+            await page.locator("[data-gflow-save-target='1']").first.click(timeout=5_000)
+            log.debug("agentic_driver.settings_panel.count_enforced", count=count)
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "agentic_driver.settings_panel.enforce_count_failed",
+                error=str(e)[:120],
+            )
+```
+
+- [ ] **Step 4: Call the new method from `configure_image_settings`**
+
+In `configure_image_settings` (around line 222-251 currently), add the call after the existing instructions-reconciliation block. The method becomes:
+
+```python
+    async def configure_image_settings(  # NOSONAR
+        self,
+        page: Page,  # NOSONAR
+        request: GenerateImageRequest,
+        *,
+        out_dir: Path | None = None,  # NOSONAR
+        prompt_idx: int | None = None,
+    ) -> None:
+        """Encode settings on the instance for prompt-directive composition,
+        and best-effort enforce the count via the Agent settings panel.
+
+        Does NOT drive the ``tune`` popover for aspect/model — only count,
+        as a fallback for issue #313 (a stale sticky default there can
+        override the natural-language directive). See
+        ``_enforce_image_count_via_settings_panel``.
+        """
+        # request.model / request.aspect are non-optional StrEnums — str() yields
+        # the wire value ("NARWHAL", "IMAGE_ASPECT_RATIO_PORTRAIT", …).
+        self._pending_count = request.count
+        self._pending_model = str(request.model)
+        self._pending_aspect = _ASPECT_PROMPT_LABEL.get(str(request.aspect))
+        log.debug(
+            "agentic_driver.configure_image_settings.stored",
+            count=self._pending_count,
+            aspect=self._pending_aspect,
+            model=self._pending_model,
+            prompt_idx=prompt_idx,
+        )
+
+        if request.instructions is not None:
+            await self._reconcile_instructions(page, request.instructions)
+
+        await self._enforce_image_count_via_settings_panel(page, request.count)
+```
+
+(Only the new final line and the docstring differ from the current implementation — the stored-value logic and instructions reconciliation call are unchanged.)
+
+- [ ] **Step 5: Update the 3 existing `configure_image_settings` tests that pass a bare `MagicMock()` page**
+
+These three existing tests in `tests/api/transports/drivers/test_agentic.py` currently pass `MagicMock()` or `page` (also a bare `MagicMock()`) as the page argument: `test_configure_image_settings_stores_count_and_aspect` (line 163), `test_configure_image_settings_portrait_aspect` (line 172), `test_configure_image_settings_square_aspect` (line 180). A bare `MagicMock()`'s `.locator(...).count()` returns a `MagicMock` (not an int), and `await mock_result` on a non-awaitable `MagicMock` raises `TypeError` — so these will now fail with `TypeError: object MagicMock can't be used in 'await' expression` once Step 4 lands, because `_enforce_image_count_via_settings_panel` calls `await tune_btn.count()`.
+
+Add a shared helper at the top of the file (near `_make_image_request`, after it) and use it in all three tests:
+
+```python
+def _mock_page_no_settings_panel() -> MagicMock:
+    """Page where the Agent settings panel's tune button is absent (count 0) —
+    exercises the graceful-skip path so configure_image_settings tests don't
+    need to model the full settings-panel click sequence."""
+    page = MagicMock()
+    locator_mock = MagicMock()
+    locator_mock.first = locator_mock
+    locator_mock.count = AsyncMock(return_value=0)
+    page.locator = MagicMock(return_value=locator_mock)
+    return page
+```
+
+Replace the page argument in all three tests:
+
+```python
+@pytest.mark.asyncio
+async def test_configure_image_settings_stores_count_and_aspect() -> None:
+    driver = AgenticFlowUiDriver()
+    page = _mock_page_no_settings_panel()
+    req = _make_image_request(count=4, aspect=Aspect.LANDSCAPE)
+    await driver.configure_image_settings(page, req)
+    assert driver._pending_count == 4  # noqa: SLF001
+    assert driver._pending_aspect == "16:9"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_configure_image_settings_portrait_aspect() -> None:
+    driver = AgenticFlowUiDriver()
+    req = _make_image_request(count=1, aspect=Aspect.PORTRAIT)
+    await driver.configure_image_settings(_mock_page_no_settings_panel(), req)
+    assert driver._pending_aspect == "9:16"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_configure_image_settings_square_aspect() -> None:
+    driver = AgenticFlowUiDriver()
+    req = _make_image_request(count=2, aspect=Aspect.SQUARE)
+    await driver.configure_image_settings(_mock_page_no_settings_panel(), req)
+    assert driver._pending_aspect == "1:1"  # noqa: SLF001
+```
+
+Two more call sites pass `configure_image_settings` a page at lines 641 and 761 of the same test file (both already read and checked against the new code path):
+
+**`test_reconcile_instructions_no_op_when_none`** (line 636-642) — **must be edited**, its `page.locator.assert_not_called()` assertion breaks because the new count-enforcement step calls `page.locator(_TUNE_BUTTON_SELECTOR)` unconditionally, even though `instructions=None` correctly skips `_reconcile_instructions` itself. Replace the whole test body:
+
+```python
+@pytest.mark.asyncio
+async def test_reconcile_instructions_no_op_when_none() -> None:
+    driver = AgenticFlowUiDriver()
+    page = _mock_page_no_settings_panel()
+    req = GenerateImageRequest(prompt="a cat", instructions=None)
+    await driver.configure_image_settings(page, req)
+    # instructions=None means _reconcile_instructions's REST PATCH path must
+    # not run. The settings-panel count-enforcement step (unrelated) DOES
+    # call page.locator now, so the original "locator never called"
+    # assertion no longer holds — assert the instructions-specific behavior
+    # instead.
+    assert not page.request.patch.called
+```
+
+**`test_driver_reconcile_dispatches_patch_payload`** (line 735-773) — **no change needed**. Its `page` is a bare `MagicMock()` with only `page.request.get`/`page.request.patch` configured, `page.locator` is left auto-mocked. The new count-enforcement step will call `page.locator(...).first` (auto-mocked, no error) then `await tune_btn.count()`, which raises `TypeError` because a bare `MagicMock` (not `AsyncMock`) isn't awaitable — but `_enforce_image_count_via_settings_panel`'s `except Exception` (Step 3) catches and logs that `TypeError` before it can propagate, and it happens *after* `_reconcile_instructions` already ran and called `page.request.patch`. So `mock_patch.assert_called_once()` and every other assertion in this test still pass unmodified. Run it after Step 4 lands to confirm — do not edit it speculatively.
+
+- [ ] **Step 6: Run the existing test file to confirm nothing regressed**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/api/transports/drivers/test_agentic.py -v`
+Expected: all tests PASS (the 3+ updated tests, plus everything else unaffected)
+
+- [ ] **Step 7: Write new unit tests for `_enforce_image_count_via_settings_panel`**
+
+Add a new test section (after the `configure_image_settings` section, before `switch_to_image_mode`) in `tests/api/transports/drivers/test_agentic.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# _enforce_image_count_via_settings_panel — issue #313 fallback
+# ---------------------------------------------------------------------------
+
+
+def _mock_page_with_settings_panel(*, already_selected: str = "x2") -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Page where the tune button, count tablist, and Save button are all
+    present. Returns (page, target_btn_mock, tune_btn_mock) so tests can
+    assert on click() call counts for specific elements.
+
+    ``already_selected`` is unused by the mock itself (the production code
+    always clicks the target button unconditionally — see Step 3) but is
+    kept as a documented parameter for readability at call sites that care
+    about the pre-click state being irrelevant to the assertion.
+    """
+    del already_selected  # documented no-op — see docstring
+
+    tune_btn = MagicMock()
+    tune_btn.count = AsyncMock(return_value=1)
+    tune_btn.click = AsyncMock()
+
+    target_btn = MagicMock()
+    target_btn.count = AsyncMock(return_value=1)
+    target_btn.click = AsyncMock()
+
+    count_tablist = MagicMock()
+    count_tablist.locator = MagicMock(return_value=target_btn)
+
+    save_btn = MagicMock()
+    save_btn.click = AsyncMock()
+
+    def _locator(selector: str) -> MagicMock:
+        result = MagicMock()
+        if selector == _TUNE_BUTTON_SELECTOR:
+            result.first = tune_btn
+        elif selector == _IMAGE_COUNT_TABLIST_SELECTOR:
+            result.first = count_tablist
+        elif selector == "[data-gflow-save-target='1']":
+            result.first = save_btn
+        else:
+            result.first = MagicMock()
+        return result
+
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=_locator)
+    page.evaluate = AsyncMock(return_value=True)
+
+    return page, target_btn, tune_btn
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_clicks_matching_button_and_saves() -> None:
+    driver = AgenticFlowUiDriver()
+    page, target_btn, tune_btn = _mock_page_with_settings_panel()
+    await driver._enforce_image_count_via_settings_panel(page, 3)  # noqa: SLF001
+    tune_btn.click.assert_awaited_once()
+    target_btn.click.assert_awaited_once()
+    page.evaluate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_maps_all_valid_counts_to_button_labels() -> None:
+    """1..4 must each resolve to a locator call for the matching '<n>x' label
+    (or '1x' for count=1) — a regression here means a future count silently
+    clicks the wrong tab."""
+    for count, expected_label in agentic_mod._COUNT_BUTTON_TEXT.items():
+        driver = AgenticFlowUiDriver()
+        page, target_btn, _ = _mock_page_with_settings_panel()
+        await driver._enforce_image_count_via_settings_panel(page, count)  # noqa: SLF001
+        count_tablist_locator = page.locator(agentic_mod._IMAGE_COUNT_TABLIST_SELECTOR).first
+        count_tablist_locator.locator.assert_any_call(f"button:text-is('{expected_label}')")
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_gracefully_when_tune_button_absent() -> None:
+    """Older UI cohort / no settings panel at all — must return quietly, not raise."""
+    driver = AgenticFlowUiDriver()
+    page = MagicMock()
+    absent = MagicMock()
+    absent.count = AsyncMock(return_value=0)
+    page.locator = MagicMock(return_value=absent)
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    # No exception raised is the assertion; nothing else to check.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_gracefully_when_count_button_absent() -> None:
+    driver = AgenticFlowUiDriver()
+    tune_btn = MagicMock()
+    tune_btn.count = AsyncMock(return_value=1)
+    tune_btn.click = AsyncMock()
+
+    absent_target = MagicMock()
+    absent_target.count = AsyncMock(return_value=0)
+
+    count_tablist = MagicMock()
+    count_tablist.locator = MagicMock(return_value=absent_target)
+
+    def _locator(selector: str) -> MagicMock:
+        result = MagicMock()
+        if selector == _TUNE_BUTTON_SELECTOR:
+            result.first = tune_btn
+        elif selector == _IMAGE_COUNT_TABLIST_SELECTOR:
+            result.first = count_tablist
+        else:
+            result.first = MagicMock()
+        return result
+
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=_locator)
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    # No exception — graceful skip.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_save_click_when_save_button_not_found() -> None:
+    driver = AgenticFlowUiDriver()
+    page, target_btn, tune_btn = _mock_page_with_settings_panel()
+    page.evaluate = AsyncMock(return_value=False)  # _FIND_SAVE_BUTTON_JS found nothing
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    tune_btn.click.assert_awaited_once()
+    target_btn.click.assert_awaited_once()
+    # No exception, and no attempt to click a nonexistent save button.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_swallows_exceptions_and_never_raises() -> None:
+    driver = AgenticFlowUiDriver()
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=RuntimeError("boom"))
+    # Must not raise.
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+```
+
+Add the two new selector-constant imports to the existing import block at the top of the file:
+
+```python
+from gflow_cli.api.transports.drivers.agentic import (
+    _IMAGE_COUNT_TABLIST_SELECTOR,
+    _MEDIA_REDIRECT_BASE,
+    _TUNE_BUTTON_SELECTOR,
+    AgenticFlowUiDriver,
+    _extract_uuids,
+)
+```
+
+- [ ] **Step 8: Run the full test file again**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/api/transports/drivers/test_agentic.py -v`
+Expected: all tests PASS, including the 6 new tests from Step 7
+
+- [ ] **Step 9: Update `docs/AGENT_UI_RECON.md` to reflect the now-implemented fallback**
+
+In the "Settings via prompt, not the `tune` popover (agentic acts MCP-like)" section (starts around line 131), the bullet:
+
+```
+- **`configure_settings` becomes optional.** Encoding settings as a directive prompt
+  avoids driving the fragile `tune` → Radix-popover dropdowns — the most drift-prone
+  surface on a volatile A/B UI. Prefer prompt-encoding; treat popover automation as a
+  fallback only if prompt-steering proves unreliable.
+```
+
+becomes:
+
+```
+- **`configure_settings` drives count as a fallback (2026-07-16, issue #313).**
+  Prompt-encoding alone proved unreliable: Agent mode's `tune` panel has a
+  STICKY "Image generation default" count that silently overrode the
+  natural-language directive when stale. `AgenticFlowUiDriver` now sets that
+  control to match the request (best-effort, never raises — falls through to
+  prompt-only on any selector miss) in addition to the natural-language
+  phrasing. Aspect/model are NOT automated via this panel — count only, to
+  keep the newly-added surface area minimal. See
+  `flow-agent-settings-panel-sticky-defaults` project memory for the full
+  selector write-up.
+```
+
+- [ ] **Step 10: Run ruff + pyright on the changed files**
+
+Run: `.venv/Scripts/python.exe -m ruff check src/gflow_cli/api/transports/drivers/agentic.py tests/api/transports/drivers/test_agentic.py`
+Run: `.venv/Scripts/python.exe -m ruff format --check src/gflow_cli/api/transports/drivers/agentic.py tests/api/transports/drivers/test_agentic.py`
+Run: `.venv/Scripts/python.exe -m pyright src/gflow_cli/api/transports/drivers/agentic.py`
+Expected: all clean. Fix any issues before committing.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/gflow_cli/api/transports/drivers/agentic.py tests/api/transports/drivers/test_agentic.py docs/AGENT_UI_RECON.md
+git commit -m "fix(agentic): enforce image count via Agent settings panel (#313)
+
+Agent mode's tune Settings panel has a sticky 'Image generation default'
+count that can silently override the natural-language directive when
+stale, causing the MediaAttributionError ambiguity guard to fire after a
+wasted generation attempt. configure_image_settings now best-effort drives
+that panel's count control to match the request, keeping the existing
+natural-language phrasing and ambiguity guard as reinforcement/backstop."
+```
+
+---
+
+## Post-implementation verification (controller, not a subagent task)
+
+Image generation is credit-free (memory `flow-credits-videos-only`), so after this task's review passes, the controller should run a real live generation via `gflow image` in Agent mode against a project with a known-stale count default (e.g. the `denon82` profile / project `580a6bbf-d433-4153-80b9-1842b5a560ea` used during the spike, after manually setting its Agent settings count back to something other than the requested count) and confirm the generation returns the requested count without raising `MediaAttributionError`. This is the actual DoD signal (memory `feature-dod-full-e2e`, `done-means-e2e-verified`) — the unit tests above only prove the selector logic in isolation against mocks.

--- a/scripts/dev/spike_issue313_agent_mode_controls.py
+++ b/scripts/dev/spike_issue313_agent_mode_controls.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+r"""Issue #313 recon — Agent mode's "tune" Settings panel and its sticky
+count defaults (0 credits).
+
+A 33-day-old memory (PR #124/#138) documented Agent mode removing the whole
+media-generation settings panel from the DOM. That was true when written —
+but Flow's UI has since added a NEW settings surface: a `tune` icon on the
+Agent composer that opens a full "Agent settings" panel (not a small popover
+like classic mode's `crop_*` menu) with STICKY count/aspect/model defaults
+for image and video generation separately. This spike proves that mechanism
+live and validates the selectors + click mechanics needed to drive it —
+see memory `flow-agent-settings-panel-sticky-defaults` for the write-up.
+
+Navigation only — no prompt is submitted, no generate route is hit, 0 credits.
+
+Usage (headed, supervised):
+
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_issue313_agent_mode_controls.py \
+        --profile denon82 --project 580a6bbf-d433-4153-80b9-1842b5a560ea
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+    VideoGenerationMixin,
+)
+
+_TUNE_BUTTON_SELECTOR = "button:has(i.google-symbols:text-is('tune'))"
+_COMPOSER_SELECTOR = "div[role='textbox'][data-slate-editor='true']"
+# The image count control is the FIRST [role='tablist'] in DOM order that
+# contains both '1x' and 'x2' buttons — the image section always renders
+# before the video section (verified live, both en and pt-BR locales).
+_IMAGE_COUNT_TABLIST_SELECTOR = (
+    "[role='tablist']:has(button:text-is('1x')):has(button:text-is('x2'))"
+)
+
+# Scoped, locale-invariant "Save" lookup: the button has no icon ligature, no
+# data-* attribute, no type=submit, and its text ("Salvar"/"Save") is
+# locale-dependent. Walk up from the arrow_back header icon to the nearest
+# ancestor that also contains the count tablist (the panel root), then take
+# the last visible button in that scope.
+_FIND_SAVE_BUTTON_JS = """
+() => {
+  const backBtn = [...document.querySelectorAll('button')].find((b) => {
+    const i = b.querySelector('i.google-symbols');
+    return i && (i.textContent || '').trim() === 'arrow_back';
+  });
+  if (!backBtn) return null;
+  let node = backBtn.parentElement;
+  for (let i = 0; i < 8 && node; i++) {
+    const hasCountTablist = [...node.querySelectorAll("[role='tablist']")].some((t) => {
+      const texts = [...t.querySelectorAll('button')].map((b) => (b.textContent || '').trim());
+      return texts.includes('1x') && texts.includes('x2');
+    });
+    if (hasCountTablist) {
+      const visible = [...node.querySelectorAll('button')].filter((b) => {
+        const r = b.getBoundingClientRect();
+        return r.width > 0 && r.height > 0;
+      });
+      const save = visible[visible.length - 1];
+      save?.setAttribute('data-spike-save-target', '1');
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+"""
+
+
+async def _run(*, profile_dir: Path, project_id: str, locale: str, out_path: Path) -> int:
+    out_dir = out_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Any] = {
+        "spike": "issue313-agent-mode-controls",
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "project": project_id,
+        "locale": locale,
+    }
+
+    async with build_client(profile_dir, headless=False) as client:
+        page = await client._checkout_page()  # noqa: SLF001
+        try:
+            editor_url = routes.project_editor_url(locale, project_id)
+            step("1", f"goto {editor_url}", prefix="313")
+            await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
+            await page.wait_for_timeout(4_000)
+            await page.keyboard.press("Escape")
+
+            media_present = await VideoGenerationMixin._media_panel_present(page)  # noqa: SLF001
+            result["mediaPanelPresent_onLoad"] = media_present
+            if media_present:
+                # Toggle into Agent mode (binary pill) if we loaded into classic.
+                pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
+                if await pill.count() > 0:
+                    await pill.click(force=True, timeout=5_000)
+                    await page.wait_for_timeout(1_000)
+            step("1", f"in Agent mode = {not media_present}", prefix="313")
+            await page.screenshot(path=str(out_dir / "1_agent_mode.png"))
+
+            tune_btn = page.locator(_TUNE_BUTTON_SELECTOR).first
+            if await tune_btn.count() == 0:
+                result["error"] = "no tune button found"
+                return 1
+
+            step("2", "opening Agent settings panel (tune icon)", prefix="313")
+            await tune_btn.click(timeout=5_000)
+            await page.wait_for_timeout(1_000)
+            await page.screenshot(path=str(out_dir / "2_settings_panel.png"))
+
+            image_count_tablist = page.locator(_IMAGE_COUNT_TABLIST_SELECTOR).first
+            before = await image_count_tablist.locator(
+                "button[aria-selected='true']"
+            ).text_content()
+            result["countBeforeChange"] = (before or "").strip()
+
+            step("3", "setting image count default to 1x", prefix="313")
+            one_x_btn = image_count_tablist.locator("button:text-is('1x')").first
+            await one_x_btn.click(timeout=5_000)
+            await page.wait_for_timeout(300)
+            result["ariaSelectedAfterClick"] = await one_x_btn.get_attribute("aria-selected")
+
+            step("4", "saving via scoped, locale-invariant Save selector", prefix="313")
+            found_save = await page.evaluate(_FIND_SAVE_BUTTON_JS)
+            result["saveButtonFound"] = bool(found_save)
+            if found_save:
+                save_btn = page.locator("[data-spike-save-target='1']").first
+                await save_btn.click(timeout=5_000)
+                await page.wait_for_timeout(500)
+
+            composer = page.locator(_COMPOSER_SELECTOR).first
+            result["composerVisibleAfterSave"] = (
+                await composer.count() > 0 and await composer.is_visible()
+            )
+            await page.screenshot(path=str(out_dir / "3_after_save.png"))
+            step(
+                "5",
+                f"composer visible after Save = {result['composerVisibleAfterSave']}",
+                prefix="313",
+            )
+
+            # Reopen to confirm the change persisted (not just an optimistic UI flip).
+            await tune_btn.click(timeout=5_000)
+            await page.wait_for_timeout(800)
+            reselected = await image_count_tablist.locator(
+                "button[aria-selected='true']"
+            ).text_content()
+            result["countAfterReopen"] = (reselected or "").strip()
+            await page.screenshot(path=str(out_dir / "4_reopened.png"))
+        finally:
+            client._checkin_page(page)  # noqa: SLF001
+            out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(f"\n[313] json -> {out_path}", flush=True)
+    print(f"[313] countBeforeChange = {result.get('countBeforeChange')}", flush=True)
+    print(f"[313] countAfterReopen  = {result.get('countAfterReopen')}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Issue #313: drive Agent mode's settings-panel count control (0 credits)"
+    )
+    p.add_argument("--profile", default=os.environ.get("GFLOW_CLI_PROFILE", "denon82"))
+    p.add_argument(
+        "--project",
+        default=os.environ.get("GFLOW_CLI_PROJECT"),
+        required="GFLOW_CLI_PROJECT" not in os.environ,
+    )
+    p.add_argument("--locale", default=os.environ.get("GFLOW_CLI_LOCALE", "en"))
+    p.add_argument("--out", default=None)
+    args = p.parse_args(argv)
+
+    profile_dir = resolve_profile_dir(args.profile)
+    out_path = (
+        Path(args.out) if args.out else default_out_path("spike_issue313_agent_mode", ".json")
+    )
+    step("--", f"profile={args.profile} project={args.project}", prefix="313")
+    try:
+        return asyncio.run(
+            _run(
+                profile_dir=profile_dir,
+                project_id=args.project,
+                locale=args.locale,
+                out_path=out_path,
+            )
+        )
+    except KeyboardInterrupt:
+        print("[313] aborted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/drivers/agentic.py
+++ b/src/gflow_cli/api/transports/drivers/agentic.py
@@ -59,6 +59,66 @@ _MEDIA_UUID_RE = re.compile(r"[?&]name=([0-9a-fA-F-]+)")
 # from any secondary contenteditable nodes that may exist in the page.
 _SLATE_COMPOSER_SELECTOR = 'div[role="textbox"][data-slate-editor="true"]'
 
+# Agent settings panel (issue #313) — driven as a best-effort FALLBACK only,
+# because prompt-encoding is the primary mechanism and this popover is the
+# most drift-prone surface on Flow's UI (docs/AGENT_UI_RECON.md § "Settings
+# via prompt, not the tune popover"). A sticky prior value in this panel can
+# silently override the natural-language directive's requested count — that
+# mismatch is issue #313's root cause. This enforcement makes the panel match
+# the request so the natural-language phrasing and the UI setting agree.
+_TUNE_BUTTON_SELECTOR = "button:has(i.google-symbols:text-is('tune'))"
+
+# The image count control is the FIRST [role='tablist'] in DOM order that
+# contains both '1x' and 'x2' buttons — Flow always renders the "Image
+# generation default" section before "Video generation default" (verified
+# live 2026-07-16, both en and pt-BR locales; count labels are numeric
+# multipliers, not translated text, so this is locale-safe).
+_IMAGE_COUNT_TABLIST_SELECTOR = (
+    "[role='tablist']:has(button:text-is('1x')):has(button:text-is('x2'))"
+)
+
+# request.count is validated to 1-4 by GenerateImageRequest.__post_init__
+# (api/image.py) — this covers the settings panel's full button range.
+_COUNT_BUTTON_TEXT: dict[int, str] = {1: "1x", 2: "x2", 3: "x3", 4: "x4"}
+
+# The panel's "Save" button has no icon ligature, no data-* attribute, no
+# type="submit", and its text ("Salvar"/"Save"/etc.) is locale-dependent —
+# per memory flow-locale-leak-icon-ligatures this cannot be text-matched.
+# Locate it structurally instead: walk up from the panel's arrow_back header
+# icon to the nearest ancestor that ALSO contains the count tablist (i.e.
+# the panel root), then take the last visible <button> in that scope — that
+# button is Save in every live-verified capture (2026-07-16). Tags the match
+# with a data attribute so Playwright can locate it without re-running the
+# walk in a second round-trip.
+_FIND_SAVE_BUTTON_JS = """
+() => {
+  const backBtn = [...document.querySelectorAll('button')].find((b) => {
+    const i = b.querySelector('i.google-symbols');
+    return i && (i.textContent || '').trim() === 'arrow_back';
+  });
+  if (!backBtn) return false;
+  let node = backBtn.parentElement;
+  for (let i = 0; i < 8 && node; i++) {
+    const hasCountTablist = [...node.querySelectorAll("[role='tablist']")].some((t) => {
+      const texts = [...t.querySelectorAll('button')].map((b) => (b.textContent || '').trim());
+      return texts.includes('1x') && texts.includes('x2');
+    });
+    if (hasCountTablist) {
+      const visible = [...node.querySelectorAll('button')].filter((b) => {
+        const r = b.getBoundingClientRect();
+        return r.width > 0 && r.height > 0;
+      });
+      const save = visible[visible.length - 1];
+      if (!save) return false;
+      save.setAttribute('data-gflow-save-target', '1');
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+"""
+
 # DOM polling defaults — match the classic transport's _await_captured cadence.
 _POLL_INTERVAL_S = 0.5
 _AWAIT_TIMEOUT_S = 180.0
@@ -227,12 +287,13 @@ class AgenticFlowUiDriver:
         out_dir: Path | None = None,  # NOSONAR
         prompt_idx: int | None = None,
     ) -> None:
-        """Encode settings on the instance for prompt-directive composition.
+        """Encode settings on the instance for prompt-directive composition,
+        and best-effort enforce the count via the Agent settings panel.
 
-        Does NOT drive the ``tune`` popover — the agentic UI resolves count,
-        aspect, and model from natural language in the prompt. Storing the
-        values here lets ``send_prompt`` compose the directive from a single
-        place.
+        Does NOT drive the ``tune`` popover for aspect/model — only count,
+        as a fallback for issue #313 (a stale sticky default there can
+        override the natural-language directive). See
+        ``_enforce_image_count_via_settings_panel``.
         """
         # request.model / request.aspect are non-optional StrEnums — str() yields
         # the wire value ("NARWHAL", "IMAGE_ASPECT_RATIO_PORTRAIT", …).
@@ -249,6 +310,52 @@ class AgenticFlowUiDriver:
 
         if request.instructions is not None:
             await self._reconcile_instructions(page, request.instructions)
+
+        await self._enforce_image_count_via_settings_panel(page, request.count)
+
+    async def _enforce_image_count_via_settings_panel(self, page: Page, count: int) -> None:
+        """Best-effort: set Agent mode's sticky "Image generation default"
+        count to match ``count`` via the ``tune`` Settings panel.
+
+        Fallback mechanism for issue #313 — see the module-level selector
+        comments for why this is scoped to count-only and driven only as a
+        secondary signal alongside the natural-language directive.
+
+        **Never raises.** Any selector miss (older UI cohort with no ``tune``
+        panel at all, a future Flow redesign, a transient render delay) is
+        logged and swallowed — the natural-language directive alone is the
+        pre-existing behavior, so failing to enforce here must never turn a
+        previously-working generation into a hard failure.
+        """
+        try:
+            tune_btn = page.locator(_TUNE_BUTTON_SELECTOR).first
+            if await tune_btn.count() == 0:
+                log.debug("agentic_driver.settings_panel.tune_not_found")
+                return
+            await tune_btn.click(timeout=5_000)
+
+            count_tablist = page.locator(_IMAGE_COUNT_TABLIST_SELECTOR).first
+            target_label = _COUNT_BUTTON_TEXT[count]
+            target_btn = count_tablist.locator(f"button:text-is('{target_label}')").first
+            if await target_btn.count() == 0:
+                log.warning(
+                    "agentic_driver.settings_panel.count_button_not_found",
+                    count=count,
+                )
+                return
+            await target_btn.click(timeout=5_000)
+
+            found_save = await page.evaluate(_FIND_SAVE_BUTTON_JS)
+            if not found_save:
+                log.warning("agentic_driver.settings_panel.save_button_not_found")
+                return
+            await page.locator("[data-gflow-save-target='1']").first.click(timeout=5_000)
+            log.debug("agentic_driver.settings_panel.count_enforced", count=count)
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "agentic_driver.settings_panel.enforce_count_failed",
+                error=str(e)[:120],
+            )
 
     async def _reconcile_instructions(
         self,

--- a/tests/api/transports/drivers/test_agentic.py
+++ b/tests/api/transports/drivers/test_agentic.py
@@ -17,7 +17,9 @@ import pytest
 from gflow_cli.api.image import AgentInstruction, Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports.drivers import agentic as agentic_mod
 from gflow_cli.api.transports.drivers.agentic import (
+    _IMAGE_COUNT_TABLIST_SELECTOR,
     _MEDIA_REDIRECT_BASE,
+    _TUNE_BUTTON_SELECTOR,
     AgenticFlowUiDriver,
     _extract_uuids,
 )
@@ -57,6 +59,18 @@ def _make_image_request(
     model: Model = Model.NARWHAL,
 ) -> GenerateImageRequest:
     return GenerateImageRequest(prompt="a cat", count=count, aspect=aspect, model=model)
+
+
+def _mock_page_no_settings_panel() -> MagicMock:
+    """Page where the Agent settings panel's tune button is absent (count 0) —
+    exercises the graceful-skip path so configure_image_settings tests don't
+    need to model the full settings-panel click sequence."""
+    page = MagicMock()
+    locator_mock = MagicMock()
+    locator_mock.first = locator_mock
+    locator_mock.count = AsyncMock(return_value=0)
+    page.locator = MagicMock(return_value=locator_mock)
+    return page
 
 
 def _fake_page_no_policy(
@@ -162,7 +176,7 @@ def test_compose_directive_plural_singular() -> None:
 @pytest.mark.asyncio
 async def test_configure_image_settings_stores_count_and_aspect() -> None:
     driver = AgenticFlowUiDriver()
-    page = MagicMock()
+    page = _mock_page_no_settings_panel()
     req = _make_image_request(count=4, aspect=Aspect.LANDSCAPE)
     await driver.configure_image_settings(page, req)
     assert driver._pending_count == 4  # noqa: SLF001
@@ -173,7 +187,7 @@ async def test_configure_image_settings_stores_count_and_aspect() -> None:
 async def test_configure_image_settings_portrait_aspect() -> None:
     driver = AgenticFlowUiDriver()
     req = _make_image_request(count=1, aspect=Aspect.PORTRAIT)
-    await driver.configure_image_settings(MagicMock(), req)
+    await driver.configure_image_settings(_mock_page_no_settings_panel(), req)
     assert driver._pending_aspect == "9:16"  # noqa: SLF001
 
 
@@ -181,8 +195,146 @@ async def test_configure_image_settings_portrait_aspect() -> None:
 async def test_configure_image_settings_square_aspect() -> None:
     driver = AgenticFlowUiDriver()
     req = _make_image_request(count=2, aspect=Aspect.SQUARE)
-    await driver.configure_image_settings(MagicMock(), req)
+    await driver.configure_image_settings(_mock_page_no_settings_panel(), req)
     assert driver._pending_aspect == "1:1"  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# _enforce_image_count_via_settings_panel — issue #313 fallback
+# ---------------------------------------------------------------------------
+
+
+def _mock_page_with_settings_panel(
+    *, already_selected: str = "x2"
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Page where the tune button, count tablist, and Save button are all
+    present. Returns (page, target_btn_mock, tune_btn_mock) so tests can
+    assert on click() call counts for specific elements.
+
+    ``already_selected`` is unused by the mock itself (the production code
+    always clicks the target button unconditionally — see Step 3) but is
+    kept as a documented parameter for readability at call sites that care
+    about the pre-click state being irrelevant to the assertion.
+    """
+    del already_selected  # documented no-op — see docstring
+
+    tune_btn = MagicMock()
+    tune_btn.count = AsyncMock(return_value=1)
+    tune_btn.click = AsyncMock()
+
+    target_btn = MagicMock()
+    target_btn.first = target_btn  # production does count_tablist.locator(...).first
+    target_btn.count = AsyncMock(return_value=1)
+    target_btn.click = AsyncMock()
+
+    count_tablist = MagicMock()
+    count_tablist.locator = MagicMock(return_value=target_btn)
+
+    save_btn = MagicMock()
+    save_btn.click = AsyncMock()
+
+    def _locator(selector: str) -> MagicMock:
+        result = MagicMock()
+        if selector == _TUNE_BUTTON_SELECTOR:
+            result.first = tune_btn
+        elif selector == _IMAGE_COUNT_TABLIST_SELECTOR:
+            result.first = count_tablist
+        elif selector == "[data-gflow-save-target='1']":
+            result.first = save_btn
+        else:
+            result.first = MagicMock()
+        return result
+
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=_locator)
+    page.evaluate = AsyncMock(return_value=True)
+
+    return page, target_btn, tune_btn
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_clicks_matching_button_and_saves() -> None:
+    driver = AgenticFlowUiDriver()
+    page, target_btn, tune_btn = _mock_page_with_settings_panel()
+    await driver._enforce_image_count_via_settings_panel(page, 3)  # noqa: SLF001
+    tune_btn.click.assert_awaited_once()
+    target_btn.click.assert_awaited_once()
+    page.evaluate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_maps_all_valid_counts_to_button_labels() -> None:
+    """1..4 must each resolve to a locator call for the matching '<n>x' label
+    (or '1x' for count=1) — a regression here means a future count silently
+    clicks the wrong tab."""
+    for count, expected_label in agentic_mod._COUNT_BUTTON_TEXT.items():
+        driver = AgenticFlowUiDriver()
+        page, target_btn, _ = _mock_page_with_settings_panel()
+        await driver._enforce_image_count_via_settings_panel(page, count)  # noqa: SLF001
+        count_tablist_locator = page.locator(agentic_mod._IMAGE_COUNT_TABLIST_SELECTOR).first
+        count_tablist_locator.locator.assert_any_call(f"button:text-is('{expected_label}')")
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_gracefully_when_tune_button_absent() -> None:
+    """Older UI cohort / no settings panel at all — must return quietly, not raise."""
+    driver = AgenticFlowUiDriver()
+    page = MagicMock()
+    absent = MagicMock()
+    absent.count = AsyncMock(return_value=0)
+    page.locator = MagicMock(return_value=absent)
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    # No exception raised is the assertion; nothing else to check.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_gracefully_when_count_button_absent() -> None:
+    driver = AgenticFlowUiDriver()
+    tune_btn = MagicMock()
+    tune_btn.count = AsyncMock(return_value=1)
+    tune_btn.click = AsyncMock()
+
+    absent_target = MagicMock()
+    absent_target.first = absent_target  # production does count_tablist.locator(...).first
+    absent_target.count = AsyncMock(return_value=0)
+
+    count_tablist = MagicMock()
+    count_tablist.locator = MagicMock(return_value=absent_target)
+
+    def _locator(selector: str) -> MagicMock:
+        result = MagicMock()
+        if selector == _TUNE_BUTTON_SELECTOR:
+            result.first = tune_btn
+        elif selector == _IMAGE_COUNT_TABLIST_SELECTOR:
+            result.first = count_tablist
+        else:
+            result.first = MagicMock()
+        return result
+
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=_locator)
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    # No exception — graceful skip.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_skips_save_click_when_save_button_not_found() -> None:
+    driver = AgenticFlowUiDriver()
+    page, target_btn, tune_btn = _mock_page_with_settings_panel()
+    page.evaluate = AsyncMock(return_value=False)  # _FIND_SAVE_BUTTON_JS found nothing
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
+    tune_btn.click.assert_awaited_once()
+    target_btn.click.assert_awaited_once()
+    # No exception, and no attempt to click a nonexistent save button.
+
+
+@pytest.mark.asyncio
+async def test_enforce_count_swallows_exceptions_and_never_raises() -> None:
+    driver = AgenticFlowUiDriver()
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=RuntimeError("boom"))
+    # Must not raise.
+    await driver._enforce_image_count_via_settings_panel(page, 1)  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
@@ -636,10 +788,15 @@ async def test_await_images_synthesised_fields() -> None:
 @pytest.mark.asyncio
 async def test_reconcile_instructions_no_op_when_none() -> None:
     driver = AgenticFlowUiDriver()
-    page = MagicMock()
+    page = _mock_page_no_settings_panel()
     req = GenerateImageRequest(prompt="a cat", instructions=None)
     await driver.configure_image_settings(page, req)
-    page.locator.assert_not_called()
+    # instructions=None means _reconcile_instructions's REST PATCH path must
+    # not run. The settings-panel count-enforcement step (unrelated) DOES
+    # call page.locator now, so the original "locator never called"
+    # assertion no longer holds — assert the instructions-specific behavior
+    # instead.
+    assert not page.request.patch.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #313 — Flow's Agent-mode composer has a `tune` Settings panel with a **sticky** "Image generation default" count control (`1x`/`x2`/`x3`/`x4`) that gflow-cli's automation never touched. A stale value there could silently override the natural-language count phrasing already sent in the prompt directive, causing the `MediaAttributionError` ambiguity guard to fire *after* a full (wasted) generation attempt.

Both fixes originally proposed in the issue turned out to be non-viable on investigation (no UI count control was known to exist at the time; download-and-pick breaks an exact-count invariant elsewhere). Live investigation against a real Flow account found the actual mechanism — a previously-undocumented settings panel — and validated a fix: `configure_image_settings` now best-effort drives that panel's count control to match the request, on top of (not instead of) the existing natural-language phrasing. Full root-cause writeup: [issue #313 comment](https://github.com/ffroliva/gflow-cli/issues/313#issuecomment-4992276806).

This is the fallback path `docs/AGENT_UI_RECON.md` already anticipated (*"treat popover automation as a fallback only if prompt-steering proves unreliable"*) — issue #313 is that proof, not a reversal of the original design intent.

- `src/gflow_cli/api/transports/drivers/agentic.py` — new locale-invariant selectors + `_enforce_image_count_via_settings_panel`, best-effort and never-raising (falls through to prior natural-language-only behavior on any selector miss — older UI cohort, future redesign, transient render delay).
- `tests/api/transports/drivers/test_agentic.py` — 6 new unit tests + 4 updated existing tests (mock-page based, no live browser).
- `docs/AGENT_UI_RECON.md` — marks the fallback as implemented.
- `scripts/dev/spike_issue313_agent_mode_controls.py` — credit-free recon spike documenting the discovery, kept for future Agent-settings-panel work.
- `docs/superpowers/plans/2026-07-16-agentic-count-enforcement/PLAN.md` — full implementation plan.

## Test plan

- [x] Unit tests: `pytest tests/api/transports/drivers/test_agentic.py -v` — 45 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pyright src` (whole tree) — 0 errors, 0 warnings
- [x] `check_doc_links.py` / `check_repo_hygiene.py` — clean
- [x] **Live e2e verification** (image generation is credit-free): deliberately set a real Flow project's sticky count default to `x3` (mismatched), then ran `gflow image t2i ... -n 1` against it — got exactly 1 image back, no `MediaAttributionError`, confirming the panel was correctly driven back to `1x` before generation. Verified the output file: valid JPEG, correct dimensions, single file.