### PR TITLE
feat(ui-automation): enlarge viewport to 1920×1080 (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **UI-automation viewport enlarged to 1920×1080** (from 1280×800) to reduce the static browser-fingerprint signal with the most common real desktop resolution. Only the `UiAutomationTransport` context is affected; the `FlowApiClient` REST context (1280×720, selector-irrelevant) is unchanged. Enlarging stays within Flow's desktop layout, so selectors are unaffected. Timing/click humanization from #315 remains out of scope — parked under ADR-13 (the current stealth stack already measures a 0.0% WAF-403 rate). (#315)
+
 ## [0.36.0] — 2026-07-16
 
 ### Added

--- a/docs/superpowers/specs/2026-07-16-issue-315-viewport-1080p.md
+++ b/docs/superpowers/specs/2026-07-16-issue-315-viewport-1080p.md
@@ -1,0 +1,62 @@
+# Spec — Enlarge UI-automation viewport to 1920×1080 (#315, verifiable slice)
+
+**Date:** 2026-07-16 · **Issue:** [#315](https://github.com/ffroliva/gflow-cli/issues/315)
+· **Branch:** `feature/315-ui-viewport-1080p` · **Status:** in progress
+
+## Problem
+
+The `UiAutomationTransport` launches its persistent browser context at a fixed
+`1280×800` (`ui_automation.py:113` `_VIEWPORT`, used at `:777`). This is a static,
+slightly uncommon fingerprint — the most common real desktop resolution is `1920×1080`.
+A fixed, unusual viewport is one weak signal reCAPTCHA-Enterprise can score, and it is
+the one anti-detection axis we can change **without** touching the selector-stability
+contract that pins locale (`?hl=en`) — enlarging *within* the desktop layout range.
+
+## Scope (deliberately narrow)
+
+**In:** change the UI-automation `_VIEWPORT` to `1920×1080`; update its test assertion.
+
+**Out (explicitly):**
+- The `FlowApiClient` REST context viewport (`client.py:345`, `1280×720`) — selector-
+  irrelevant there; left untouched. These are two independent contexts, not a drift bug.
+- Timing/click **humanization** (mouse movement, jittered pacing) — **PARKED under
+  ADR-13**: the WAF-403 spike (`docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md`)
+  measured a 0.0% rejection rate on the current stealth stack, so the stealth motivation
+  is unmet. See memory `issue-315-humanization-adr13-gated`.
+- The interaction-seam (`PageInteractor`/`settle`) refactor — belongs with #299's driver
+  hardening (same call sites), not this change.
+
+## Why bigger, not smaller, and why 1920×1080
+
+Flow is a responsive web app; below ~1024px it collapses toolbars/labels into overflow
+menus and reflows the count-tabs — the elements the selectors target. **Larger** stays
+in the desktop layout the selectors were validated against; **smaller** is what breaks
+them. `1920×1080` is the single most common real desktop resolution — maximally human
+and firmly in desktop-layout territory.
+
+## Acceptance criteria
+
+1. `_VIEWPORT == {"width": 1920, "height": 1080}` and the UI-automation context launches
+   at it.
+2. `FlowApiClient` REST viewport unchanged (`1280×720`).
+3. All unit/type/lint gates green (`/gflow:check`), including the updated
+   `test_ui_automation.py:215` assertion.
+4. **Headed e2e — the ship gate:** on a credited profile (`ffroliva`), at 1920×1080:
+   - `gflow image t2i` completes end-to-end (mode-switch trigger, prompt box, count
+     tabs, submit selectors all resolve; an image is produced).
+   - a video generation completes end-to-end (the video-path selectors hold).
+5. No new `UiSelectorDriftError` (exit 23) or selector-not-found in the e2e runs.
+
+## Risks & mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Flow reflows toolbars/count-tabs at 1920 → selector drift (same surface as #183/#174) | **Headed e2e is the gate.** If any selector drifts, HOLD — do not ship; report which selector + screenshot. |
+| CG-Worker (sibling `compiled-growth` repo) assumes 1280×800 | Out of this repo's boundary; flag in PR for owner to reconcile CG-Worker viewport. |
+| Test locks old value | Update assertion as part of TDD (red→green). |
+
+## Verification plan
+
+Browser-free: `/gflow:check` + scoped pytest. Headed: background e2e (image then video)
+per the `background-e2e-pytest-pattern`, screenshots on failure, evidence pasted into the
+PR body. Ship to `develop` only if criterion 4 passes cleanly.

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -109,8 +109,13 @@ IMAGE_TAB_IN_MENU_SELECTORS = (
     "[role='menu'] [role='tab']:has(i:text('image'))",
 )
 
-# Browser viewport — matches the validated smoke (also matches the CG Worker).
-_VIEWPORT = {"width": 1280, "height": 800}
+# Browser viewport — 1920×1080, the most common real desktop resolution (#315).
+# Enlarged from 1280×800 to reduce the static-fingerprint signal; bigger stays in
+# Flow's desktop layout (smaller would cross the responsive breakpoint and drift the
+# selectors). NOTE: the sibling CG Worker assumes the old size — reconcile there
+# separately. The REST client's own viewport
+# (client.py, 1280×720) is an independent, selector-irrelevant context and is unchanged.
+_VIEWPORT = {"width": 1920, "height": 1080}
 
 # Hosts allowed when downloading generated PNGs. Flow's fifeUrl currently
 # resolves to lh3.googleusercontent.com; the broader allow-list covers

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -212,7 +212,7 @@ class TestSetup:
         call_args = fake_pw.chromium.launch_persistent_context.call_args.args
         assert call_args[0] == str(tmp_path)
         assert call_kwargs.get("headless") is False
-        assert call_kwargs.get("viewport") == {"width": 1280, "height": 800}
+        assert call_kwargs.get("viewport") == {"width": 1920, "height": 1080}
         assert call_kwargs.get("locale") == "en-US"
         assert t._owns_playwright is True  # type: ignore[attr-defined]
         assert t._setup_done is True  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Enlarges the `UiAutomationTransport` persistent-context viewport from **1280×800 → 1920×1080** — the most common real desktop resolution — to reduce the static browser-fingerprint signal. This is the **verifiable slice** of #315; the timing/click humanization proposed in that issue stays **parked under ADR-13** (the current stealth stack already measures a **0.0% WAF-403 rate** — see `docs/superpowers/spikes/2026-07-09-camoufox-waf-403.md`).

Enlarging (not shrinking) is deliberate: bigger stays inside Flow's desktop layout, whereas smaller would cross the responsive breakpoint and drift the selectors. Locale stays pinned (`?hl=en`) for selector stability.

## Scope (deliberately narrow)

- **In:** `_VIEWPORT` in `ui_automation.py` + its test assertion.
- **Out:** the `FlowApiClient` REST context (`client.py`, 1280×720, selector-irrelevant) — **unchanged**. It's an independent context, not a drift bug.
- **Out:** the auth contexts (`internal_chromium.py`, `real_chrome.py`, 1280×800) — separate future-harmonization concern, flagged for follow-up.
- **Out / parked:** timing/click humanization + the `PageInteractor`/`settle` seam — the seam belongs with #299's driver hardening (same call sites); humanization is ADR-13-gated.

## Test plan / evidence

Full ritual: spec → plan → TDD (red→green) → `/gflow:check` → code-review → ponytail-review → **headed e2e** → ship.

- `/gflow:check`: repo hygiene + doc links clean; ruff check + `format --check` clean (CI gate); **pyright src: 0 errors, 0 warnings**; 185 scoped tests pass.
- Code-review (independent): clean — complete constant change, honest comment, REST untouched.
- Ponytail-review: clean — no abstraction/flag/file added beyond the constant + test + spec.

**Headed live e2e on `ffroliva` at 1920×1080 (real Chrome, real credits):**

| Path | Cohort | Result | Artifact |
|---|---|---|---|
| `image t2i` | agentic | ✅ `status: ok` | 865 KB JPEG |
| `video t2v` (veo-fast) | classic | ✅ `MEDIA_GENERATION_STATUS_SUCCESSFUL` | 6.4 MB MP4 (valid `ftyp`) |

**Every** selector resolved at 1080p across both cohorts — including `mode_switch_trigger` (the `crop_*` probe #183 fails on), the video mode/model/aspect/count tabs, the Slate prompt box, and submit. No `UiSelectorDriftError`, no selector-not-found.

> One initial `video t2v` attempt (omni-flash) failed with `PUBLIC_ERROR_VIDEO_GENERATION_TIMED_OUT` — a **Flow backend** generation timeout *after* a successful submit (HTTP 200); all UI selectors had already matched. The veo-fast retry completed cleanly, confirming it was a transient server-side flake, not a viewport/selector regression.

## Follow-ups (not this PR)

- **CG Worker** (sibling `compiled-growth` repo) assumes the old 1280×800 — reconcile there (out of this repo's boundary).
- Auth-context viewport harmonization (1280×800) — optional, separate.
- The interaction seam (`PageInteractor`/`settle`) + humanization — track under **#299** / ADR-13.

Closes the viewport portion of #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)