### PR TITLE
chore(auth): harmonize login viewports to 1920×1080 (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **UI-automation viewport enlarged to 1920×1080** (from 1280×800) to reduce the static browser-fingerprint signal with the most common real desktop resolution. Only the `UiAutomationTransport` context is affected; the `FlowApiClient` REST context (1280×720, selector-irrelevant) is unchanged. Enlarging stays within Flow's desktop layout, so selectors are unaffected. Timing/click humanization from #315 remains out of scope — parked under ADR-13 (the current stealth stack already measures a 0.0% WAF-403 rate). (#315)
+- **Auth-login viewports harmonized to 1920×1080** so a profile logs in at the same size it later generates with — `internal_chromium` (Playwright viewport) and `real_chrome` (`--window-size`). Login-window only, not selector-bound. (#315)
 
 ## [0.36.0] — 2026-07-16
 

--- a/docs/superpowers/specs/2026-07-16-auth-viewport-1080p.md
+++ b/docs/superpowers/specs/2026-07-16-auth-viewport-1080p.md
@@ -1,0 +1,50 @@
+# Spec — Harmonize auth-context viewports to 1920×1080 (#315 follow-up)
+
+**Date:** 2026-07-16 · **Branch:** `chore/auth-viewport-1080p` · **Follows:** PR #327
+(generation viewport → 1920×1080) · **Status:** in progress
+
+## Problem
+
+After #327 moved the `UiAutomationTransport` generation viewport to 1920×1080, the two
+**auth-login** contexts still open at the old `1280×800`:
+
+- `internal_chromium.py:151` — Playwright `viewport={"width": 1280, "height": 800}` in the
+  internal-Chromium login `launch_persistent_context`.
+- `real_chrome.py:68` — `"--window-size=1280,800"` Chrome CLI arg for the real-Chrome login.
+
+This is a cosmetic inconsistency: the browser a profile logs in with is a different size
+than the browser it later generates with.
+
+## Scope
+
+**In:** change both auth viewports to `1920×1080` (Playwright dict + `--window-size` string).
+
+**Out:** the `FlowApiClient` REST context (`client.py`, 1280×720) — independent,
+selector-irrelevant, unchanged. No shared-constant abstraction (the three viewports are
+independent knobs of different purpose/format — coupling them would be over-engineering).
+
+## Why this is low-risk (verification bar)
+
+Both are **login-window size only**, NOT selector-sensitive:
+- `internal_chromium.login()` navigates to the Google sign-in page; the **user** signs in
+  manually while gflow polls the **session token** (`_poll_session_until_authenticated`) —
+  gflow never drives login-page selectors.
+- `real_chrome` launches the real Chrome the user logs into.
+
+So there is no generation-selector surface to break. A headed login e2e is both
+**impractical** (interactive Google sign-in can't be automated overnight) and
+**unnecessary** (no selector path). Verification = unit tests asserting the new size in
+each launch path + `/gflow:check`.
+
+## Acceptance criteria
+
+1. `internal_chromium.py` launch viewport == `{"width": 1920, "height": 1080}`.
+2. `real_chrome.py` args contain `--window-size=1920,1080`.
+3. Unit tests assert both (added/updated); all gates green (`/gflow:check`).
+4. No other 1280×800 auth references remain.
+
+## Value / caveat
+
+Small consistency tidy-up. The fingerprint gain is marginal (login and generation are
+different session moments), so this is primarily code/behavior consistency, not a stealth
+measure — stealth humanization stays parked under ADR-13.

--- a/src/gflow_cli/auth/internal_chromium.py
+++ b/src/gflow_cli/auth/internal_chromium.py
@@ -148,7 +148,9 @@ class InternalChromiumStrategy(AuthStrategy):
             ctx = await pw.chromium.launch_persistent_context(
                 user_data_dir=str(profile_dir),
                 headless=headless,
-                viewport={"width": 1280, "height": 800},
+                # Match the generation viewport (#315) so a profile logs in at the
+                # same size it later generates with; login-window only, not selector-bound.
+                viewport={"width": 1920, "height": 1080},
                 args=["--password-store=basic"],
             )
             try:

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -65,7 +65,7 @@ def _build_chrome_args(chrome_exe: str, profile_dir: Path, headless: bool) -> li
         f"--user-data-dir={profile_dir}",
         "--no-first-run",
         "--no-default-browser-check",
-        "--window-size=1280,800",
+        "--window-size=1920,1080",  # match the generation viewport (#315 consistency)
         "--password-store=basic",
         # No --remote-debugging-port: zero automation surface.
         GEMINI_URL,  # open straight on the Flow sign-in page

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -72,6 +72,8 @@ class TestRealChromeStrategy:
         assert "--enable-automation" not in args_list
         assert not any("--remote-debugging-port" in a for a in args_list)
         assert GEMINI_URL in args_list  # Chrome opens directly on the Flow page
+        # Login window matches the generation viewport (#315 consistency).
+        assert "--window-size=1920,1080" in args_list
 
     @pytest.mark.asyncio
     async def test_real_chrome_success_writes_marker(self, tmp_path: Path) -> None:
@@ -299,6 +301,8 @@ class TestInternalChromiumStrategy:
         _, kwargs = mock_launch_pctx.call_args
         assert "channel" not in kwargs or kwargs["channel"] != "chrome"
         assert "--disable-blink-features=AutomationControlled" not in kwargs.get("args", [])
+        # Login viewport matches the generation viewport (#315 consistency).
+        assert kwargs.get("viewport") == {"width": 1920, "height": 1080}
         mock_page.request.get.assert_awaited()
         account_file = profile_dir / ".gflow_account"
         assert account_file.exists(), ".gflow_account must be written on successful login"


### PR DESCRIPTION
## Summary

Follow-up to #327. Harmonizes the two **auth-login** browser viewports to `1920×1080` so a profile logs in at the same size it later generates with:

- `internal_chromium.py` — Playwright `viewport` dict `1280×800 → 1920×1080`
- `real_chrome.py` — `--window-size=1280,800 → 1920,1080`

## Why it's low-risk

Both are **login-window size only**, not selector-bound: `internal_chromium.login()` navigates to the Google sign-in page, the **user** signs in manually, and gflow polls the **session token** (`_poll_session_until_authenticated`) — it never drives login-page selectors. `real_chrome` launches the real Chrome the user logs into. Confirmed the only callers are the auth `factory` (login), no generation/selector path.

## Scope

- **In:** the two auth viewport constants + unit assertions.
- **Out:** `FlowApiClient` REST context (1280×720) unchanged; no shared-constant abstraction (three independent viewports of different purpose/format).

## Test plan

Full ritual: spec → plan → TDD (red→green) → `/gflow:check` → code-review → ponytail-review (ultra).

- `/gflow:check`: hygiene (577 files) + doc-links clean; ruff check + `format --check` clean; **pyright src 0/0/0**; 57 auth tests pass.
- TDD: added assertions in `test_strategies.py` for both launch paths (`launch_persistent_context` viewport + subprocess `--window-size`), red→green.
- Code-review (independent): clean — no findings across correctness, tests, comment honesty, scope, regression risk.
- Ponytail-review (ultra): `net: -0 lines. Lean already. Ship.`

No headed e2e: interactive Google sign-in isn't automatable overnight and isn't needed — these contexts drive no selectors (see spec § "Why this is low-risk").

## Note

Marginal fingerprint value (login and generation are different session moments) — primarily a consistency tidy-up. Stealth humanization stays parked under ADR-13.

Spec: `docs/superpowers/specs/2026-07-16-auth-viewport-1080p.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)