### PR TITLE
chore: production-readiness hardening + safe Sonar cleanups

### DIFF
--- a/docs/superpowers/spikes/2026-07-17-production-readiness-assessment.md
+++ b/docs/superpowers/spikes/2026-07-17-production-readiness-assessment.md
@@ -1,0 +1,73 @@
+# Production-Readiness Assessment — gflow-cli
+
+**Date:** 2026-07-17 · **Commit base:** `develop` (post #327/#328) · **Assessor:** autonomous run
+
+## Executive summary
+
+**The codebase is in strong production-ready shape.** Every automated gate is green,
+the full test suite passes with zero failures, dependencies have no known
+vulnerabilities, and the SonarCloud quality gate is **OK**. There were **no errors to
+fix** — no failing tests, no type errors, no lint violations. The work this pass
+delivers is therefore *hardening + code-smell cleanup*, not defect repair.
+
+## Gate results
+
+| Gate | Result |
+|---|---|
+| **Full test suite** | ✅ **2357 passed, 7 skipped, 0 failed** (255s) |
+| **pyright `src`** (CI type gate) | ✅ 0 errors, 0 warnings, 0 informations |
+| **ruff check + format** (CI lint gate) | ✅ clean |
+| **repo hygiene + doc links** | ✅ 578 files, all links resolved |
+| **SonarCloud quality gate** | ✅ **OK** (new-code conditions pass) |
+| **SonarCloud hotspots** | ✅ 0 to review |
+| **pip-audit** (dependency CVEs) | ✅ no known vulnerabilities |
+
+## Security scan (bandit — advisory, not a CI gate)
+
+| ID | Sev | Location | Verdict |
+|---|---|---|---|
+| **B324** SHA-1 for security | HIGH | `api/_sapisidhash.py:14` | **FIXED** — added `usedforsecurity=False`. SHA-1 is *mandated* by Google's SAPISIDHASH scheme (not a chosen primitive); the flag marks it a protocol hash **and** makes it FIPS-mode-safe (previously would raise on FIPS Python). |
+| **B113** httpx `timeout=None` | MED (low-conf) | `transports/experimental/sapisidhash.py:319` | **Accept (false-positive)** — deliberate: the docstring documents that `asyncio.wait_for` in `_call_once` is the single wall-clock guard (HIGH #7). Adding a client timeout would double-guard. |
+| B311 non-crypto `random` | LOW | jitter/pacing sites | Accept — already `# noqa: S311`, pacing not crypto. |
+| B101 `assert` | LOW | various | Accept — asserts in non-security paths; stripped under `-O` but not used for control flow at trust boundaries. |
+| B105 hardcoded "password" | LOW | `--password-store=basic`, empty strings | Accept — false positives (flag/field names, not secrets). |
+| B112 try/except/continue | LOW | best-effort loops | Accept — intentional best-effort continues, logged. |
+
+Net security action: **one real hardening fix** (B324); the rest are justified accepts.
+
+## SonarCloud issues — 29 open (all CODE_SMELL; gate stays OK because none are new-code)
+
+Triaged into three buckets:
+
+### Fixed this pass (6 — safe, clear value)
+- `python:S5655` `mcp/tools.py` — `_card_dict(replace(...))` type lost by Sonar → wrapped in `cast(...)` per the repo's `sonar-dataclasses-replace` pattern.
+- `python:S1192` `drivers/agentic.py` — `"agentic:await_images"` ×3 → module constant `_ROUTE_AWAIT_IMAGES`.
+- `python:S7500` `tools/invocation.py` — dict comprehension → `dict(self.params)`.
+- `python:S108` `mcp/server.py` — removed the empty `if TYPE_CHECKING: pass` block + now-unused import.
+- `python:S1186` `ui/app.py` — added the explanatory comment to the intentional no-op `AlreadySentResponse.__call__`.
+- (`python:S324` was the same SHA-1 site — covered by the B324 hardening fix.)
+
+### False-positives / not safely fixable (3 — recommend "Won't Fix" in Sonar with justification)
+- `python:S1192` `ui_automation_video.py:2194` — the duplicated literal is the **type string** `"dict[str, object]"` inside `cast(...)`; extracting it to a variable breaks pyright (cast needs a literal type). Keep.
+- `python:S7503` `ui/app.py:115` — `wrapped_receive` **must** be `async` (ASGI receive-callable contract); Sonar's "remove async" is wrong here.
+- `python:S7632` ×3 (`factory.py:173`, `image_batch.py:537`, `cli_video.py:257`) — flags the `# noqa: <code> - reason` suppression syntax. These are **ruff** suppressions that ruff parses correctly; reformatting risks breaking the suppression. Low value, high fiddle-risk. Recommend accept.
+
+### Deferred — risky refactors, NOT done autonomously (19)
+**15× `python:S3776` cognitive complexity** + **4× `python:S107` too-many-parameters**. These are on **verified, hard-to-unit-test** surfaces:
+- Highest complexity is live browser-automation and the daemon: `ui_automation_video.py` (CC **62**, 36, 26, 23, 21), `worker/daemon.py` (CC **45**), `browser_manager.py`, `client.py`, `mcp/tools.py`.
+- The S107 cases are **Click CLI command signatures** (`t2i` 18 params, `i2i`/`i2v` 15) — the "parameters" *are* the CLI options; bundling them into a params object also touches CLI→MCP parity (`cli-param-changes-need-mcp-parity`).
+
+**Why deferred:** restructuring a CC-62 live-automation function (or the daemon) to satisfy a metric changes control flow that only **live e2e** can verify. Doing that in an unattended overnight batch and auto-merging is a **net production-readiness risk** — the likely outcome is a subtle regression in exactly the selector/flow paths that unit tests can't cover. The responsible path is **individually-reviewed, e2e-verified refactor PRs** (or accept-with-justification for the inherently-complex automation ones). Recommend one dedicated PR per hotspot, each with a live e2e run — not a blind sweep.
+
+## Recommendations
+
+1. **Ship** the 6 safe fixes + B324 hardening (this pass — PR to `develop`).
+2. **Mark the 3 false-positives "Won't Fix"** in SonarCloud (dashboard action; keeps the count honest without unsafe edits).
+3. **Schedule the 19 refactors** as individual reviewed PRs, prioritising the pure-logic, well-tested ones (`expander.py`, `movie_manifest.py`, `_cli_helpers.py`, `client.py:549`) and treating the live-automation/daemon ones as accept-or-carefully-refactor-with-e2e.
+4. The interaction-seam / `SettleKind` work (issue #315 follow-up) folds naturally into #299 and would *reduce* several of these complexity scores as a side effect — another reason to do it there, with e2e, rather than as isolated metric-chasing.
+
+## Bottom line
+
+No production blockers. One real hardening fix shipped (FIPS-safe SHA-1). Code-smell count
+is maintainability debt concentrated in known-complex automation code, best paid down with
+reviewed, e2e-verified refactors rather than an unattended sweep.

--- a/src/gflow_cli/api/_sapisidhash.py
+++ b/src/gflow_cli/api/_sapisidhash.py
@@ -11,5 +11,7 @@ def compute_sapisidhash(*, timestamp: int, sapisid: str, origin: str) -> str:
     Google's first-party web-app authentication scheme for its private APIs.
     """
     payload = f"{timestamp} {sapisid} {origin}".encode()
-    digest = hashlib.sha1(payload).hexdigest()  # noqa: S324 — Google's scheme mandates SHA-1
+    # Google's scheme mandates SHA-1; usedforsecurity=False marks it a protocol hash
+    # (not a security primitive) so it also works under FIPS-mode Python.
+    digest = hashlib.sha1(payload, usedforsecurity=False).hexdigest()  # noqa: S324
     return f"{timestamp}_{digest}"

--- a/src/gflow_cli/api/transports/drivers/agentic.py
+++ b/src/gflow_cli/api/transports/drivers/agentic.py
@@ -60,6 +60,8 @@ _MEDIA_UUID_RE = re.compile(r"[?&]name=([0-9a-fA-F-]+)")
 # The ``data-slate-editor="true"`` attribute distinguishes the primary input
 # from any secondary contenteditable nodes that may exist in the page.
 _SLATE_COMPOSER_SELECTOR = 'div[role="textbox"][data-slate-editor="true"]'
+# structlog route tag for the await-images generation wait (used in 3 error paths).
+_ROUTE_AWAIT_IMAGES = "agentic:await_images"
 
 # Agent settings panel (issue #313, reworked 2026-07-16 after code review) —
 # driven as a best-effort FALLBACK only, because prompt-encoding is the
@@ -764,7 +766,7 @@ class AgenticFlowUiDriver:
                         "(explicit text or block symbol detected). "
                         "Prompt may violate Flow's content policy."
                     ),
-                    route="agentic:await_images",
+                    route=_ROUTE_AWAIT_IMAGES,
                 )
 
             current_srcs = await _scrape_img_srcs(page)
@@ -791,7 +793,7 @@ class AgenticFlowUiDriver:
                     f"Agentic DOM scraping timed out after {_AWAIT_TIMEOUT_S:.0f}s: "
                     f"0/{expected_count} distinct media UUIDs appeared"
                 )
-            raise TransportTimeoutError(detail=detail, route="agentic:await_images")
+            raise TransportTimeoutError(detail=detail, route=_ROUTE_AWAIT_IMAGES)
 
         if len(new_uuids) > expected_count:
             candidates = sorted(new_uuids)
@@ -800,7 +802,7 @@ class AgenticFlowUiDriver:
                     f"Cannot attribute the generation among {len(candidates)} candidate "
                     f"media UUIDs (expected {expected_count}): {candidates}."
                 ),
-                route="agentic:await_images",
+                route=_ROUTE_AWAIT_IMAGES,
             )
 
         return _build_generated_images(

--- a/src/gflow_cli/mcp/server.py
+++ b/src/gflow_cli/mcp/server.py
@@ -12,15 +12,11 @@ from __future__ import annotations
 import asyncio
 import io
 import sys
-from typing import TYPE_CHECKING
 
 import structlog
 from mcp.server.fastmcp import FastMCP
 
 from gflow_cli import __version__
-
-if TYPE_CHECKING:
-    pass
 
 log = structlog.get_logger()
 

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -1238,7 +1238,8 @@ async def gflow_instructions_set_enabled(
         brief = await client.get_agent_info(project)
         card = brief.find(title=title) if card_id is None else brief.find(card_id=card_id)
         # Replace the target in place (preserving its id) and PATCH the FULL set.
-        updated = replace(card, enabled=enabled)
+        # cast: replace() loses the concrete type for Sonar S5655 (see sonar-dataclasses-replace).
+        updated = cast("AgentInstruction", replace(card, enabled=enabled))  # pyright: ignore[reportUnnecessaryCast]
         new_cards = tuple(updated if c is card else c for c in brief.cards)
         await client.patch_agent_info(project, enabled=True, cards=new_cards)
         return _ok_payload(project, card=_card_dict(updated))

--- a/src/gflow_cli/tools/invocation.py
+++ b/src/gflow_cli/tools/invocation.py
@@ -35,7 +35,7 @@ class AppliedTool:
     params: tuple[tuple[str, str], ...] = ()
 
     def params_dict(self) -> dict[str, str]:
-        return {k: v for k, v in self.params}
+        return dict(self.params)
 
 
 def config_hash(config: ToolConfig) -> str:

--- a/src/gflow_cli/ui/app.py
+++ b/src/gflow_cli/ui/app.py
@@ -132,7 +132,9 @@ class AlreadySentResponse(Response):
     """Response that does nothing; used when response was already written to ASGI send."""
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        pass
+        # Intentional no-op: the response was already written directly to the ASGI
+        # `send` upstream, so this placeholder must not emit anything further.
+        return
 
 
 @app.post("/mcp/message")


### PR DESCRIPTION
## Summary

Output of a production-readiness assessment (full report in `docs/superpowers/spikes/2026-07-17-production-readiness-assessment.md`). **The tree was already production-healthy** — 2357 tests pass, pyright/ruff clean, Sonar gate OK, no dependency CVEs — so this PR is *hardening + safe code-smell cleanup*, not defect repair.

### Hardening (1 real security fix)
- **`_sapisidhash`**: `hashlib.sha1(payload, usedforsecurity=False)` — Google's SAPISIDHASH scheme *mandates* SHA-1; the flag marks it a protocol hash (not a security primitive) and makes it **FIPS-mode safe** (previously would raise on FIPS Python). **Digest is byte-identical** — verified the auth value is unchanged. (bandit B324)

### Safe Sonar fixes (5, all semantics-preserving)
- `S5655` `mcp/tools.py` — `cast(AgentInstruction, replace(...))` per the repo's `sonar-dataclasses-replace` pattern.
- `S1192` `drivers/agentic.py` — `"agentic:await_images"` ×3 → `_ROUTE_AWAIT_IMAGES` constant.
- `S7500` `tools/invocation.py` — `dict(self.params)` instead of a comprehension.
- `S108` `mcp/server.py` — removed empty `if TYPE_CHECKING: pass` + now-unused import.
- `S1186` `ui/app.py` — documented the intentional no-op `AlreadySentResponse.__call__`.

## Deliberately NOT in this PR

The other 19 Sonar issues are **cognitive-complexity (S3776, up to CC 62 on live video-automation and CC 45 on the daemon)** and **CLI param-count (S107)** on verified, hard-to-unit-test surfaces. Restructuring them to satisfy a metric changes control flow that only **live e2e** can verify — an unattended auto-merged sweep there is a net production-readiness *risk*. They're documented in the assessment as individually-reviewed, e2e-verified follow-up PRs. 3 further Sonar items are false-positives (type-cast literal, ASGI async contract, ruff-noqa syntax) recommended for "Won't Fix".

## Test plan

- `/gflow:check`: hygiene (578 files) + doc-links clean · ruff verify gate clean · **pyright src 0/0/0**.
- Full suite pre-change: **2357 passed, 0 failed**. Touched-module suite post-change: **1145 passed, 0 failed**.
- SHA-1 digest verified byte-identical (auth unchanged).
- Code-review (independent): clean — all 6 changes semantics-preserving, no missed refs/imports.
- Ponytail-review (ultra): net-simplifying — empty block + import removed, comprehension shrunk. "Lean. Ship."
- bandit: B324 fixed; remaining findings triaged as justified accepts. pip-audit: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)