### PR TITLE
refactor: reduce cognitive complexity of 5 functions (Sonar S3776)

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -562,8 +562,52 @@ class FlowApiClient:
         await self._preread_flow_session_cookies()
         kwargs = self._persistent_context_kwargs()
         self._log_and_guard_launch(kwargs)
+        self._context = await self._launch_persistent_context(kwargs)
+        # Hide the automation flag so reCAPTCHA Enterprise doesn't score
+        # the session as a bot — navigator.webdriver=true causes low-score
+        # tokens and HTTP 403 on batchGenerateImages.
+        await self._context.add_init_script(
+            "Object.defineProperty(navigator,'webdriver',{get:()=>undefined})",
+        )
+        # issue #222: log whether the headed context loaded the Flow session
+        # cookie and, if not (macOS can't decrypt the on-disk store), seed it
+        # from the pre-launch snapshot.
+        await self._ensure_context_session_cookie()
+        # Open ``Settings.concurrency`` Pages inside the one persistent
+        # BrowserContext. ``launch_persistent_context`` opens one Page by
+        # default; reuse it as slot 0 to avoid an unused N+1 Page.
+        n = max(1, self.settings.concurrency)
+        self._pages = await self._open_page_pool(n)
+        # asyncio.Queue gives FIFO checkout/checkin with no manual locking.
+        # ``maxsize=n`` makes the upper bound STRUCTURAL — a double-checkin
+        # (bug in a future caller) raises QueueFull rather than silently
+        # corrupting the pool. The generic parameter satisfies pyright strict.
+        self._page_queue = asyncio.Queue[Page](maxsize=n)
+        for p in self._pages:
+            self._page_queue.put_nowait(p)
+        # Back-compat alias for callers that still touch ``self._page``
+        # directly. T3 removes the field entirely.
+        self._page = self._pages[0]
+        # Bootstrap navigation so cookies + JS context are loaded before any
+        # API call. Many endpoints 401 if you POST cold without an active page.
+        # (Phase 3 deferred ``_new_session_id`` flake is addressed in T3 by
+        # re-minting reCAPTCHA inside each retry loop on the worker's own
+        # Page; no session-id work happens in T2.)
+        await self._page.goto(
+            routes.EDITOR_BOOTSTRAP_URL,
+            wait_until="domcontentloaded",
+            timeout=60_000,
+        )
+
+        # --- Step 2: Resolve and set up transport, passing the live Page so
+        # S1 can share this context rather than opening its own.
+        await self._setup_transport()
+
+    async def _launch_persistent_context(self, kwargs: JsonObject) -> BrowserContext:
+        """Launch the persistent context; translate a launch-time crash into ProfileLockedError."""
+        assert self._pw is not None
         try:
-            self._context = await self._pw.chromium.launch_persistent_context(**kwargs)
+            return await self._pw.chromium.launch_persistent_context(**kwargs)
         except Exception as exc:
             if _is_target_closed(exc):
                 # A TargetClosedError at LAUNCH usually means the profile dir
@@ -590,55 +634,28 @@ class FlowApiClient:
                     ),
                 ) from exc
             raise
-        # Hide the automation flag so reCAPTCHA Enterprise doesn't score
-        # the session as a bot — navigator.webdriver=true causes low-score
-        # tokens and HTTP 403 on batchGenerateImages.
-        await self._context.add_init_script(
-            "Object.defineProperty(navigator,'webdriver',{get:()=>undefined})",
-        )
-        # issue #222: log whether the headed context loaded the Flow session
-        # cookie and, if not (macOS can't decrypt the on-disk store), seed it
-        # from the pre-launch snapshot.
-        await self._ensure_context_session_cookie()
-        # Open ``Settings.concurrency`` Pages inside the one persistent
-        # BrowserContext. ``launch_persistent_context`` opens one Page by
-        # default; reuse it as slot 0 to avoid an unused N+1 Page.
-        n = max(1, self.settings.concurrency)
-        self._pages = []
+
+    async def _open_page_pool(self, n: int) -> list[Page]:
+        """Open ``n`` Pages in the context, reusing the default Page as slot 0."""
+        assert self._context is not None
+        pages: list[Page] = []
         if self._context.pages:
-            self._pages.append(self._context.pages[0])
+            pages.append(self._context.pages[0])
             for _ in range(n - 1):
-                self._pages.append(await self._context.new_page())
+                pages.append(await self._context.new_page())
         else:
             for _ in range(n):
-                self._pages.append(await self._context.new_page())
-        # asyncio.Queue gives FIFO checkout/checkin with no manual locking.
-        # ``maxsize=n`` makes the upper bound STRUCTURAL — a double-checkin
-        # (bug in a future caller) raises QueueFull rather than silently
-        # corrupting the pool. The generic parameter satisfies pyright strict.
-        self._page_queue = asyncio.Queue[Page](maxsize=n)
-        for p in self._pages:
-            self._page_queue.put_nowait(p)
-        # Back-compat alias for callers that still touch ``self._page``
-        # directly. T3 removes the field entirely.
-        self._page = self._pages[0]
-        # Bootstrap navigation so cookies + JS context are loaded before any
-        # API call. Many endpoints 401 if you POST cold without an active page.
-        # (Phase 3 deferred ``_new_session_id`` flake is addressed in T3 by
-        # re-minting reCAPTCHA inside each retry loop on the worker's own
-        # Page; no session-id work happens in T2.)
-        await self._page.goto(
-            routes.EDITOR_BOOTSTRAP_URL,
-            wait_until="domcontentloaded",
-            timeout=60_000,
-        )
+                pages.append(await self._context.new_page())
+        return pages
 
-        # --- Step 2: Resolve and set up transport, passing the live Page so
-        # S1 can share this context rather than opening its own.
-        # Branch on the discriminating types (str, None) so pyright narrows
-        # the else-branch to FlowTransportStrategy. We deliberately avoid
-        # `@runtime_checkable` on the Protocol — that would freeze its
-        # public surface and constrain future evolution.
+    async def _setup_transport(self) -> None:
+        """Resolve and set up ``self.transport``, passing the live Page so S1 can share it.
+
+        Branch on the discriminating types (str, None) so pyright narrows
+        the else-branch to FlowTransportStrategy. We deliberately avoid
+        `@runtime_checkable` on the Protocol — that would freeze its
+        public surface and constrain future evolution.
+        """
         inp = self._transport_input
         if inp is None or isinstance(inp, str):
             # Client-owned: resolve from factory, run full lifecycle.

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -30,6 +30,7 @@ from gflow_cli.api.image import AgentInstruction
 from gflow_cli.api.video import is_media_uuid
 from gflow_cli.cli_instructions import classify_refs
 from gflow_cli.config import UiMode, get_settings
+from gflow_cli.data.models import AssetLookup
 from gflow_cli.data.queries import list_projects
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
@@ -419,22 +420,28 @@ def _enrich_image_refs(
         asset = data_repo.get_asset_by_any_id(profile, ref)
         if asset is None:
             continue
-        entry: dict[str, str] = {}
-        name = asset.metadata_json.get("display_name")
-        if isinstance(name, str) and name:
-            entry["display_name"] = name
-        for local_file in asset.local_files:
-            if (
-                local_file.storage_provider is None
-                and local_file.path is not None
-                and local_file.path.is_file()
-            ):
-                entry["local_path"] = str(local_file.path)
-                break
+        entry = _ref_meta_entry(asset)
         if entry:
             meta[ref] = entry
     if meta:
         payload["ref_meta"] = meta
+
+
+def _ref_meta_entry(asset: AssetLookup) -> dict[str, str]:
+    """Build the ``display_name``/``local_path`` metadata entry for one catalog asset."""
+    entry: dict[str, str] = {}
+    name = asset.metadata_json.get("display_name")
+    if isinstance(name, str) and name:
+        entry["display_name"] = name
+    for local_file in asset.local_files:
+        if (
+            local_file.storage_provider is None
+            and local_file.path is not None
+            and local_file.path.is_file()
+        ):
+            entry["local_path"] = str(local_file.path)
+            break
+    return entry
 
 
 def _resolve_payload_refs(

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -520,6 +520,41 @@ def _parse_scene_numeric_fields(d: _TomlObj, idx: int) -> tuple[str, object]:
     return str(aspect), duration
 
 
+def _validate_scene_framing(framing: object, idx: int) -> None:
+    """Validate that scene framing, if given, is one of the allowed values."""
+    if framing is not None and framing not in FRAMING:
+        raise ConfigurationError(
+            f"scenes[{idx}].framing must be one of {sorted(FRAMING)} (got {framing!r})."
+        )
+
+
+def _validate_scene_model(model: object, idx: int) -> None:
+    """Validate that scene model, if given, is a string."""
+    if model is not None and not isinstance(model, str):
+        raise ConfigurationError(f"scenes[{idx}].model must be a string.")
+
+
+def _validate_scene_style_variant(
+    style_variant: str | None, idx: int, style_variant_names: set[str]
+) -> None:
+    """Validate that style_variant, if given, is 'none' or a defined style variant."""
+    if (
+        style_variant is not None
+        and style_variant != "none"
+        and style_variant not in style_variant_names
+    ):
+        raise ConfigurationError(
+            f"scenes[{idx}].style_variant {style_variant!r} is not a defined "
+            f"style variant (defined: {sorted(style_variant_names)!r})."
+        )
+
+
+def _scene_opt_field(d: _TomlObj, key: str) -> str | None:
+    """Read an optional string field from a scene dict, stripped; non-str values become None."""
+    v = d.get(key)
+    return v.strip() if isinstance(v, str) else None
+
+
 def _parse_scene(
     data: object,
     idx: int,
@@ -540,10 +575,7 @@ def _parse_scene(
         raise ConfigurationError(f"scenes[{idx}].action must be a non-empty string.")
 
     framing = d.get("framing")
-    if framing is not None and framing not in FRAMING:
-        raise ConfigurationError(
-            f"scenes[{idx}].framing must be one of {sorted(FRAMING)} (got {framing!r})."
-        )
+    _validate_scene_framing(framing, idx)
 
     chars = _parse_scene_chars(d, idx, char_names)
 
@@ -557,23 +589,10 @@ def _parse_scene(
     aspect, duration = _parse_scene_numeric_fields(d, idx)
 
     model = d.get("model")
-    if model is not None and not isinstance(model, str):
-        raise ConfigurationError(f"scenes[{idx}].model must be a string.")
-
-    def opt(key: str) -> str | None:
-        v = d.get(key)
-        return v.strip() if isinstance(v, str) else None
+    _validate_scene_model(model, idx)
 
     style_variant = _scene_opt_str(d, "style_variant", idx)
-    if (
-        style_variant is not None
-        and style_variant != "none"
-        and style_variant not in style_variant_names
-    ):
-        raise ConfigurationError(
-            f"scenes[{idx}].style_variant {style_variant!r} is not a defined "
-            f"style variant (defined: {sorted(style_variant_names)!r})."
-        )
+    _validate_scene_style_variant(style_variant, idx, style_variant_names)
 
     style_suffix = _scene_opt_str(d, "style_suffix", idx)
     instructions = _parse_scene_instructions(d.get("instructions"), idx)
@@ -581,13 +600,13 @@ def _parse_scene(
     return Scene(
         id=sid.strip(),
         action=action.strip(),
-        title=opt("title"),
-        setting=opt("setting"),
+        title=_scene_opt_field(d, "title"),
+        setting=_scene_opt_field(d, "setting"),
         framing=str(framing) if framing else None,
-        camera=opt("camera"),
-        lighting=opt("lighting"),
-        mood=opt("mood"),
-        negative=opt("negative"),
+        camera=_scene_opt_field(d, "camera"),
+        lighting=_scene_opt_field(d, "lighting"),
+        mood=_scene_opt_field(d, "mood"),
+        negative=_scene_opt_field(d, "negative"),
         characters=tuple(chars),
         variant=str(variant) if isinstance(variant, str) else None,
         dialogue=tuple(dialogue),

--- a/src/gflow_cli/tools/expander.py
+++ b/src/gflow_cli/tools/expander.py
@@ -213,22 +213,10 @@ class PromptExpander:
                 data = self._transport(url, payload, attempt_timeout)
             except GeminiHttpError as exc:
                 if exc.status in _RETRYABLE_STATUS and attempt < self._max_retries:
-                    if (self._clock() - start) + delay >= self._max_total_seconds:
-                        # No budget left to sleep + run another attempt — fall back
-                        # now instead of sleeping into a guaranteed-skipped retry.
-                        log.warning(
-                            "prompt_expander_budget_exhausted",
-                            max_total_seconds=self._max_total_seconds,
-                        )
+                    next_delay = self._retry_after_gemini_error(exc, attempt, start, delay)
+                    if next_delay is None:
                         return None
-                    log.warning(
-                        "prompt_expander_retry",
-                        status=exc.status,
-                        attempt=attempt + 1,
-                        max_retries=self._max_retries,
-                    )
-                    self._sleep(delay)
-                    delay *= 2
+                    delay = next_delay
                     continue
                 log.warning("prompt_expander_failed", status=exc.status, detail=exc.detail)
                 return None
@@ -244,6 +232,31 @@ class PromptExpander:
             return expanded
 
         return None  # pragma: no cover
+
+    def _retry_after_gemini_error(
+        self, exc: GeminiHttpError, attempt: int, start: float, delay: float
+    ) -> float | None:
+        """Sleep and return the next backoff delay for a retryable error, or None to abort.
+
+        Caller has already confirmed the error is retry-eligible
+        (``exc.status in _RETRYABLE_STATUS and attempt < self._max_retries``).
+        """
+        if (self._clock() - start) + delay >= self._max_total_seconds:
+            # No budget left to sleep + run another attempt — fall back
+            # now instead of sleeping into a guaranteed-skipped retry.
+            log.warning(
+                "prompt_expander_budget_exhausted",
+                max_total_seconds=self._max_total_seconds,
+            )
+            return None
+        log.warning(
+            "prompt_expander_retry",
+            status=exc.status,
+            attempt=attempt + 1,
+            max_retries=self._max_retries,
+        )
+        self._sleep(delay)
+        return delay * 2
 
     def expand(self, prompt: str) -> ExpansionResult:
         """Return an :class:`ExpansionResult`. Never raises for API/network faults."""

--- a/src/gflow_cli/ui/app.py
+++ b/src/gflow_cli/ui/app.py
@@ -90,39 +90,49 @@ class LogMcpRequestsMiddleware:
         path = scope.get("path", "")
         if path.startswith("/mcp"):
             if path in ("/mcp/message", "/mcp/messages"):
-                try:
-                    # Read all body chunks safely
-                    body_bytes = b""
-                    more_body = True
-                    chunks: list[bytes] = []
-                    while more_body:
-                        message = await receive()
-                        chunks.append(message.get("body", b""))
-                        more_body = message.get("more_body", False)
-                    body_bytes = b"".join(chunks)
-
-                    if body_bytes:
-                        try:
-                            body_json = json.loads(body_bytes)
-                            redacted = redact_metadata(body_json)
-                            logger.info("Incoming MCP request payload", path=path, payload=redacted)
-                        except Exception:
-                            logger.info(
-                                "Incoming MCP request raw payload", path=path, size=len(body_bytes)
-                            )
-
-                    # Reconstruct receive so downstream handlers can read it
-                    async def wrapped_receive() -> dict[str, Any]:
-                        return {"type": "http.request", "body": body_bytes, "more_body": False}
-
-                    await self.app(scope, wrapped_receive, send)
+                if await self._forward_logged_mcp_message(scope, receive, send, path):
                     return
-                except Exception as exc:
-                    logger.warning("Failed to parse request body in middleware", exc_info=exc)
             else:
                 logger.info("Incoming MCP request", path=path)
 
         await self.app(scope, receive, send)
+
+    def _log_mcp_payload(self, path: str, body_bytes: bytes) -> None:
+        """Log the decoded MCP request payload (redacted), or raw bytes if not JSON."""
+        try:
+            body_json = json.loads(body_bytes)
+            redacted = redact_metadata(body_json)
+            logger.info("Incoming MCP request payload", path=path, payload=redacted)
+        except Exception:
+            logger.info("Incoming MCP request raw payload", path=path, size=len(body_bytes))
+
+    async def _forward_logged_mcp_message(
+        self, scope: Scope, receive: Receive, send: Send, path: str
+    ) -> bool:
+        """Read+log the body of an /mcp/message(s) POST, then forward it; True if forwarded."""
+        try:
+            # Read all body chunks safely
+            body_bytes = b""
+            more_body = True
+            chunks: list[bytes] = []
+            while more_body:
+                message = await receive()
+                chunks.append(message.get("body", b""))
+                more_body = message.get("more_body", False)
+            body_bytes = b"".join(chunks)
+
+            if body_bytes:
+                self._log_mcp_payload(path, body_bytes)
+
+            # Reconstruct receive so downstream handlers can read it
+            async def wrapped_receive() -> dict[str, Any]:
+                return {"type": "http.request", "body": body_bytes, "more_body": False}
+
+            await self.app(scope, wrapped_receive, send)
+            return True
+        except Exception as exc:
+            logger.warning("Failed to parse request body in middleware", exc_info=exc)
+            return False
 
 
 app.add_middleware(LogMcpRequestsMiddleware)


### PR DESCRIPTION
## Summary

Closes the SonarCloud cognitive-complexity debt from the 2026-07-17 production-readiness assessment. **Pure refactor — zero behavior change.**

- **5 functions refactored** by extracting cohesive private helpers (pure-logic, well-tested, CC 16-18): `mcp/tools` (`_ref_meta_entry`), `api/client` (`_launch_persistent_context`/`_open_page_pool`/`_setup_transport`), `tools/expander` (`_retry_after_gemini_error`), `movie_manifest` (`_validate_scene_*` + `_scene_opt_field`), `ui/app` middleware (`_log_mcp_payload`/`_forward_logged_mcp_message`).
- **14 issues accepted in SonarCloud** with justification (not touched): live video-automation (CC 62/36/26/23/21), daemon (CC 45), stateful browser-manager, moderate orchestration helpers, and 4× Click CLI param-count (S107) — refactoring verified/essential-complexity code for a metric is net-negative.

Result: SonarCloud open issues → **0** (5 fixed here + 14 accepted).

## Verification (zero behavior change)

- **pyright src 0/0/0**, ruff check + format clean.
- **1202 scoped tests pass** (0 failed) across the touched modules; all 5 modules import cleanly.
- **Independent behavior-diff review:** clean — every extraction verbatim (`_scene_opt_field` byte-identical to the old `opt` closure, no stale references, control flows and log events preserved, client.py `assert` guards never fire because callers already narrow).
- **Ponytail-review:** cohesive nesting-reducing extractions, no gratuitous abstraction. Ship.

No runtime surface changed, so no live e2e needed — but the release e2e for 0.37.0 already exercised the image/video paths that touch `client.py`/`mcp/tools` on this same develop base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)