### PR TITLE
feat(ui-automation): robust aria-pressed agentic→classic mode control

### DIFF
--- a/scripts/dev/spike_mode_roundtrip.py
+++ b/scripts/dev/spike_mode_roundtrip.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+r"""Mode-switch round-trip validation (#299) — drive classic -> agentic -> back,
+asserting the real selectors at each step (0 credits, navigation only).
+
+Confirmed from live DOM (2026-07-17, PT locale):
+- The "Agente" toggle is `button[aria-pressed]` containing `span.content`
+  (aria-pressed=false => classic, true => agent on). Locale-invariant.
+- Turning it on reveals an `expand_content` button; clicking that opens the
+  right chat sidebar (classic composer gone), closed via the `close` (X) button.
+- `apps_spark_2` is the "Tools" nav item, NOT an agentic signal.
+
+This maps the state machine empirically and validates the selectors the robust
+ModeController will use.
+
+Usage:
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_mode_roundtrip.py \
+        --profile ffroliva --project <project-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+
+# Candidate locale-invariant selectors (to validate).
+AGENT_TOGGLE = "button[aria-pressed]:has(span.content)"
+EXPAND_BTN = "button:has(i.google-symbols:text-is('expand_content'))"
+SIDEBAR_CLOSE = (
+    "div:has(button:has(i.google-symbols:text-is('edit_square'))) "
+    "button:has(i.google-symbols:text-is('close'))"
+)
+CROP = (
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_16_9')), "
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_9_16'))"
+)
+
+
+async def _state(page: Any) -> dict[str, Any]:
+    toggle = page.locator(AGENT_TOGGLE)
+    n = await toggle.count()
+    pressed = None
+    text = None
+    if n:
+        pressed = await toggle.first.get_attribute("aria-pressed")
+        text = (await toggle.first.inner_text() or "").strip()[:20]
+    return {
+        "agent_toggle_count": n,
+        "agent_pressed": pressed,
+        "agent_text": text,
+        "crop_present": await page.locator(CROP).count() > 0,
+        "expand_present": await page.locator(EXPAND_BTN).count() > 0,
+        "sidebar_close_present": await page.locator(SIDEBAR_CLOSE).count() > 0,
+        "slate_present": await page.locator(
+            'div[role="textbox"][data-slate-editor="true"]'
+        ).count()
+        > 0,
+    }
+
+
+async def _wait_editor(page: Any) -> bool:
+    for _ in range(30):
+        if (
+            await page.locator('div[role="textbox"][data-slate-editor="true"]').count() > 0
+            or await page.locator("button").count() > 8
+        ):
+            return True
+        await page.wait_for_timeout(1000)
+    return False
+
+
+async def _run(profile: str, project: str) -> dict[str, Any]:
+    out_dir = default_out_path("mode_roundtrip", ".json").parent
+    result: dict[str, Any] = {"profile": profile, "project": project, "trace": []}
+
+    async def snap(page: Any, label: str) -> dict[str, Any]:
+        s = await _state(page)
+        s["label"] = label
+        result["trace"].append(s)
+        await page.screenshot(path=str(out_dir / f"rt_{label}.png"))
+        return s
+
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        step("A", f"goto project {project}", prefix="rt")
+        await page.goto(routes.project_editor_url("en", project), wait_until="domcontentloaded", timeout=60_000)
+        result["editor_ready"] = await _wait_editor(page)
+        await page.wait_for_timeout(1500)
+        await snap(page, "00_initial")
+
+        # 1. Turn Agente ON (if a toggle exists and reads not-pressed).
+        toggle = page.locator(AGENT_TOGGLE).first
+        if await toggle.count() > 0:
+            step("B", "click Agente toggle -> agent ON", prefix="rt")
+            await toggle.click(force=True, timeout=4000)
+            await page.wait_for_timeout(1500)
+            await snap(page, "01_agent_on")
+
+            # 2. Expand to the sidebar, if the expand button appeared.
+            exp = page.locator(EXPAND_BTN).first
+            if await exp.count() > 0:
+                step("C", "click expand_content -> sidebar", prefix="rt")
+                await exp.click(force=True, timeout=4000)
+                await page.wait_for_timeout(1500)
+                await snap(page, "02_sidebar")
+
+                # 3. Close the sidebar via X.
+                x = page.locator(SIDEBAR_CLOSE).first
+                if await x.count() > 0:
+                    step("D", "click sidebar X (close) -> back to composer", prefix="rt")
+                    await x.click(force=True, timeout=4000)
+                    await page.wait_for_timeout(1500)
+                    await snap(page, "03_after_close")
+
+            # 4. Ensure classic: toggle Agente off if still pressed.
+            t2 = page.locator(AGENT_TOGGLE).first
+            if await t2.count() > 0 and (await t2.get_attribute("aria-pressed")) == "true":
+                step("E", "toggle Agente OFF -> classic", prefix="rt")
+                await t2.click(force=True, timeout=4000)
+                await page.wait_for_timeout(1500)
+            await snap(page, "04_final_classic")
+
+        out_file = out_dir / "mode_roundtrip.json"
+        out_file.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        result["_out_file"] = str(out_file)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args(argv)
+    res = asyncio.run(_run(args.profile, args.project))
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/spike_mode_switch_agentic_to_classic.py
+++ b/scripts/dev/spike_mode_switch_agentic_to_classic.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+r"""Mode-switch recon (#299 core) — can we click the Agent toggle to get back
+to CLASSIC media mode on a forced-agentic account? (0 credits, navigation only.)
+
+The current `_exit_agent_mode` clicks the in-composer pill AT MOST ONCE and, if
+the classic `crop_*` media panel doesn't return while a forced-agentic indicator
+is present, gives up ("not recoverable"). This spike is exploratory: it dumps
+EVERY agent/mode affordance in the DOM, then systematically clicks candidate
+toggles (dismiss chat panel, click the Agent pill, and a broad text/ligature
+scan for any 'Agent'-like button), re-checking for the classic `crop_*` trigger
+after each action. Goal: find the reliable click sequence that restores classic,
+so it can be built into a clean, robust ModeController component.
+
+Usage (headed, supervised):
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_mode_switch_agentic_to_classic.py \
+        --profile ffroliva --project <project-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    AGENT_CHAT_PANEL_CLOSE_SELECTOR,
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+    MODE_SWITCH_TRIGGER_SELECTORS,
+    VideoGenerationMixin,
+)
+
+# Forced-agentic indicator ligatures (factory.py doc).
+_AGENTIC_INDICATORS = {
+    "apps_spark_2": "i.google-symbols:text-is('apps_spark_2')",
+    "article_spark": "i.google-symbols:text-is('article_spark')",
+    "edit_square": "i.google-symbols:text-is('edit_square')",
+    "tune": "i.google-symbols:text-is('tune')",
+}
+_CLASSIC = MODE_SWITCH_TRIGGER_SELECTORS  # crop_* trigger present == classic panel back
+
+# Broad scan: any button whose text/ligature hints at an Agent/mode toggle.
+_BUTTON_SCAN_JS = r"""
+() => {
+  const btns = Array.from(document.querySelectorAll('button'));
+  return btns.map((b, i) => {
+    const lig = b.querySelector('i.google-symbols');
+    const span = b.querySelector('span');
+    const t = (b.innerText || '').trim().slice(0, 40);
+    return {
+      i, text: t,
+      ligature: lig ? lig.textContent.trim() : null,
+      spanText: span ? (span.textContent || '').trim().slice(0, 40) : null,
+      ariaLabel: b.getAttribute('aria-label'),
+    };
+  }).filter(x => {
+    const hay = `${x.text} ${x.ligature} ${x.spanText} ${x.ariaLabel}`.toLowerCase();
+    return /agent|spark|classic|mode|image|video|crop/.test(hay);
+  }).slice(0, 25);
+}
+"""
+
+
+async def _classic_present(page: Any) -> bool:
+    for sel in _CLASSIC:
+        if await page.locator(sel).count() > 0:
+            return True
+    return False
+
+
+async def _snapshot(page: Any) -> dict[str, Any]:
+    snap: dict[str, Any] = {"classic_crop_present": await _classic_present(page)}
+    snap["media_panel_present"] = await VideoGenerationMixin._media_panel_present(page)  # noqa: SLF001
+    snap["agent_pill_present"] = await page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first.count() > 0
+    snap["chat_close_present"] = await page.locator(AGENT_CHAT_PANEL_CLOSE_SELECTOR).first.count() > 0
+    ind: dict[str, int] = {}
+    for name, sel in _AGENTIC_INDICATORS.items():
+        ind[name] = await page.locator(sel).count()
+    snap["agentic_indicators"] = ind
+    return snap
+
+
+async def _run(profile: str, project: str) -> dict[str, Any]:
+    out_dir = default_out_path("mode_switch", ".json").parent
+    result: dict[str, Any] = {"profile": profile, "project": project, "steps": []}
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        url = routes.project_editor_url("en", project)
+        step("A", f"goto {url}", prefix="mode")
+        await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+        # Flow is a heavy SPA — poll until the editor actually renders (the Slate
+        # prompt box is present in BOTH cohorts) before snapshotting, else the DOM
+        # is empty and every selector reads 0.
+        step("A2", "wait for editor to render", prefix="mode")
+        editor_ready = False
+        for _ in range(30):  # ~30 s max
+            box = await page.locator('div[role="textbox"][data-slate-editor="true"]').count()
+            btns = await page.locator("button").count()
+            if box > 0 or btns > 8:
+                editor_ready = True
+                break
+            await page.wait_for_timeout(1000)
+        result["editor_ready"] = editor_ready
+        result["url_after_load"] = page.url
+        await page.wait_for_timeout(1500)
+
+        step("B", "initial snapshot + candidate-button scan", prefix="mode")
+        result["initial"] = await _snapshot(page)
+        result["candidate_buttons"] = await page.evaluate(_BUTTON_SCAN_JS)
+        await page.screenshot(path=str(out_dir / "mode_00_initial.png"))
+
+        # Systematic attempts: dismiss chat panel, then click the Agent pill,
+        # re-checking classic after each — up to 4 actions (not once).
+        actions = [
+            ("dismiss_chat_panel", AGENT_CHAT_PANEL_CLOSE_SELECTOR),
+            ("click_agent_pill", COMPOSER_AGENT_TOGGLE_SELECTOR),
+            ("click_agent_pill_2", COMPOSER_AGENT_TOGGLE_SELECTOR),
+            ("dismiss_chat_panel_2", AGENT_CHAT_PANEL_CLOSE_SELECTOR),
+        ]
+        for n, (label, sel) in enumerate(actions, 1):
+            loc = page.locator(sel).first
+            present = await loc.count() > 0
+            entry: dict[str, Any] = {"action": label, "present": present}
+            if present:
+                try:
+                    await loc.click(force=True, timeout=4000)
+                    await page.wait_for_timeout(1500)
+                    entry["clicked"] = True
+                except Exception as e:  # noqa: BLE001
+                    entry["clicked"] = False
+                    entry["error"] = f"{type(e).__name__}: {e}"
+            entry["classic_after"] = await _classic_present(page)
+            result["steps"].append(entry)
+            await page.screenshot(path=str(out_dir / f"mode_{n:02d}_{label}.png"))
+            if entry["classic_after"]:
+                result["classic_restored_by"] = label
+                break
+
+        result["final"] = await _snapshot(page)
+        out_file = out_dir / "mode_switch_recon.json"
+        out_file.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        result["_out_file"] = str(out_file)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args(argv)
+    res = asyncio.run(_run(args.profile, args.project))
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/mode_control.py
+++ b/src/gflow_cli/api/transports/mode_control.py
@@ -1,0 +1,123 @@
+"""Robust agentic↔classic composer mode control.
+
+Flow's composer carries an **Agent toggle** — a ``button[aria-pressed]`` whose
+child ``span.content`` holds the (localised) label. ``aria-pressed`` is the
+source of truth for the mode:
+
+* ``aria-pressed="false"`` → **classic media mode** — the ``crop_*`` settings
+  trigger (:data:`MODE_SWITCH_TRIGGER_SELECTORS`) is present.
+* ``aria-pressed="true"``  → **agent mode** — the media panel is gone; an
+  ``expand_content`` button appears, and expanding it opens a right-side chat
+  sidebar (the classic composer disappears), closed via its ``close`` (X).
+
+This module reads and drives that state in a **locale-invariant** way (via
+``aria-pressed`` + the stable ``span.content`` class and Material-Symbols
+ligatures — never UI text). It deliberately does **not** consult the ``tune`` /
+``apps_spark_2`` ligatures: ``apps_spark_2`` is the "Tools" nav item, present in
+BOTH modes, so treating it as an agentic signal is a false positive (the cause
+of spurious "forced agentic — not recoverable" aborts).
+
+Validated live 2026-07-17 (``scripts/dev/spike_mode_roundtrip.py``): a full
+classic → agent-on → sidebar → close → toggle-off → classic round-trip, with
+``aria-pressed`` and ``crop_*`` asserted at every step.
+
+Leaf module: imports only stdlib + structlog (+ Playwright ``Page`` under
+``TYPE_CHECKING``), so every transport/driver can reuse it without import cycles.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+
+log = structlog.get_logger(__name__)
+
+# The Agent toggle. ``aria-pressed`` = the mode; ``span.content`` is the stable
+# label wrapper (the class is semantic, not a hashed styled-components name).
+AGENT_TOGGLE_SELECTOR = "button[aria-pressed]:has(span.content)"
+
+# Classic media panel indicator — the ``crop_*`` mode-switch trigger.
+_CROP_SELECTORS: tuple[str, ...] = (
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_16_9'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_9_16'))",
+)
+
+# The expanded chat sidebar's close (X), scoped to the sidebar (which also
+# carries the ``edit_square`` "new session" affordance) so it never matches an
+# unrelated close button elsewhere on the page.
+SIDEBAR_CLOSE_SELECTOR = (
+    "div:has(button:has(i.google-symbols:text-is('edit_square'))) "
+    "button:has(i.google-symbols:text-is('close'))"
+)
+
+Mode = Literal["media", "agent", "unknown"]
+
+_SETTLE_MS = 1200
+_MAX_STEPS = 4
+_CLICK_TIMEOUT_MS = 4000
+
+
+async def _crop_present(page: Page) -> bool:
+    for sel in _CROP_SELECTORS:
+        if await page.locator(sel).count() > 0:
+            return True
+    return False
+
+
+async def read_mode(page: Page) -> Mode:
+    """Return the current composer mode.
+
+    ``crop_*`` present → ``"media"``. Otherwise the Agent toggle's
+    ``aria-pressed`` decides (``true`` → ``"agent"``, ``false`` → ``"media"``).
+    ``"unknown"`` only when neither signal is available (e.g. the editor has not
+    rendered yet — callers should wait for render before trusting this).
+    """
+    if await _crop_present(page):
+        return "media"
+    toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
+    if await toggle.count() > 0:
+        pressed = await toggle.get_attribute("aria-pressed")
+        if pressed == "true":
+            return "agent"
+        if pressed == "false":
+            return "media"
+    return "unknown"
+
+
+async def ensure_media_mode(page: Page) -> bool:
+    """Ensure the composer is in classic media mode; return ``True`` if it acted.
+
+    State-aware and idempotent (a no-op when already in media mode). Closes the
+    expanded chat sidebar (X) if open, then toggles the Agent pill OFF **only
+    when** ``aria-pressed`` reads ``"true"`` — never a blind click. Bounded loop
+    (sidebar → toggle → re-check). Best-effort: logs and returns if the media
+    panel never returns, leaving the caller's own probe to fail loudly.
+    """
+    acted = False
+    for _ in range(_MAX_STEPS):
+        if await _crop_present(page):
+            return acted
+        # The expanded sidebar suppresses the in-composer toggle → close it first.
+        sidebar_x = page.locator(SIDEBAR_CLOSE_SELECTOR).first
+        if await sidebar_x.count() > 0:
+            await sidebar_x.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+            await page.wait_for_timeout(_SETTLE_MS)
+            acted = True
+            continue
+        toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
+        if await toggle.count() > 0 and await toggle.get_attribute("aria-pressed") == "true":
+            await toggle.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+            await page.wait_for_timeout(_SETTLE_MS)
+            acted = True
+            continue
+        break  # nothing actionable and no crop_* — give up (caller probe fails loudly)
+    if not await _crop_present(page):
+        log.warning(
+            "mode_control.ensure_media_incomplete",
+            note="classic media panel not restored after mode-control attempts",
+        )
+    return acted

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -171,16 +171,6 @@ AGENTIC_UI_INDICATORS = (
     AGENT_CHAT_PANEL_CLOSE_SELECTOR,
 )
 
-# Timing for the Agent-exit loop. The clicks are force=True (immediate), so the
-# click timeout is only a safety cap, not a wait we expect to spend. The settle
-# pause lets Flow re-render the composer (pill → media panel, or panel-close →
-# pill) before the loop re-checks ``crop_*``.
-_AGENT_CLICK_TIMEOUT_MS = 1500
-_AGENT_SETTLE_MS = 500
-# Iteration cap for the Agent-exit loop. At most a couple of transitions are
-# expected (chat-panel close → pill reveal → pill click); the cap is a backstop
-# against a pathological flip-flop, not a value tuned to a specific shape.
-_AGENT_EXIT_MAX_ITERS = 3
 # Output-count + duration tabs are selected by aria-label text in
 # `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
 # tab '-trigger-4' and the duration tab '-trigger-4' (4s) share a suffix, so an
@@ -1155,39 +1145,21 @@ class VideoGenerationMixin:
 
     @staticmethod
     async def _dismiss_agent_affordances(page: Page) -> bool:
-        """Run a bounded loop to dismiss Agent-mode affordances until the media panel returns.
+        """Bring the composer back to classic media mode; return True if it acted.
 
-        Returns ``(acted, panel_restored)`` encoded as a single bool: True when
-        the media panel is back after at least one click, False when nothing was
-        clicked or the panel never re-mounted. Raises ``FlowAgentUiError`` if a
-        forced Agentic UI indicator is detected.
+        Delegates to the robust :func:`mode_control.ensure_media_mode`, which is
+        **state-aware**: it reads the Agent toggle's ``aria-pressed`` (the
+        locale-invariant source of truth) and clicks it OFF only when actually
+        on, and closes the expanded chat sidebar (X) first — replacing the older
+        blind single pill-click that gave up on a still-open composer. Does not
+        raise; the caller (:meth:`_exit_agent_mode`) re-checks the media panel
+        and escalates via :meth:`_check_forced_agentic_ui` only if it never
+        returned.
         """
-        acted = False
-        clicked_pill = False
-        for _ in range(_AGENT_EXIT_MAX_ITERS):
-            if await VideoGenerationMixin._media_panel_present(page):
-                break
-            # Shape 2 first: the chat side-panel suppresses the pill entirely,
-            # so it must go before the pill can be found.
-            chat_close = page.locator(AGENT_CHAT_PANEL_CLOSE_SELECTOR).first
-            if await chat_close.count() > 0:
-                await chat_close.click(force=True, timeout=_AGENT_CLICK_TIMEOUT_MS)
-                await page.wait_for_timeout(_AGENT_SETTLE_MS)
-                acted = True
-                continue
-            # Shape 1: the in-composer pill — click AT MOST ONCE (binary toggle).
-            if clicked_pill:
-                break
-            pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
-            if await pill.count() > 0:
-                await pill.click(force=True, timeout=_AGENT_CLICK_TIMEOUT_MS)
-                await page.wait_for_timeout(_AGENT_SETTLE_MS)
-                acted = True
-                clicked_pill = True
-                continue
-            # Neither affordance present — nothing more to do.
-            break
-        return acted
+        # Local import keeps mode_control a leaf and avoids any import cycle.
+        from gflow_cli.api.transports import mode_control
+
+        return await mode_control.ensure_media_mode(page)
 
     @staticmethod
     async def _check_forced_agentic_ui(page: Page, out_dir: Path | None) -> None:

--- a/tests/api/transports/test_mode_control.py
+++ b/tests/api/transports/test_mode_control.py
@@ -1,0 +1,123 @@
+"""Unit tests for the robust agentic↔classic mode-control component.
+
+A tiny fake composer state machine (media / agent / sidebar) drives the same
+transitions the live round-trip proved, so the switch logic is verified without
+a browser: aria-pressed is the source of truth, apps_spark_2 is never consulted,
+and clicks are state-aware (never blind).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.api.transports import mode_control as mc
+
+
+class _FakeLocator:
+    def __init__(self, page: _FakePage, sel: str) -> None:
+        self._page = page
+        self._sel = sel
+
+    @property
+    def first(self) -> _FakeLocator:
+        return self
+
+    async def count(self) -> int:
+        return self._page.count(self._sel)
+
+    async def get_attribute(self, name: str) -> str | None:
+        return self._page.attr(self._sel, name)
+
+    async def click(self, **_kw: object) -> None:
+        self._page.click(self._sel)
+
+
+class _FakePage:
+    """Models Flow's composer: state in {media, agent, sidebar}.
+
+    - media:  crop_* present; toggle present with aria-pressed=false.
+    - agent:  no crop; toggle present with aria-pressed=true; expand available.
+    - sidebar: no crop; no in-composer toggle; the sidebar X (close) present.
+    """
+
+    def __init__(self, state: str = "media") -> None:
+        self.state = state
+        self.clicks: list[str] = []
+
+    def locator(self, sel: str) -> _FakeLocator:
+        return _FakeLocator(self, sel)
+
+    async def wait_for_timeout(self, _ms: int) -> None:
+        return None
+
+    def count(self, sel: str) -> int:
+        if sel in mc._CROP_SELECTORS:
+            return 1 if self.state == "media" else 0
+        if sel == mc.AGENT_TOGGLE_SELECTOR:
+            return 1 if self.state in ("media", "agent") else 0
+        if sel == mc.SIDEBAR_CLOSE_SELECTOR:
+            return 1 if self.state == "sidebar" else 0
+        return 0
+
+    def attr(self, sel: str, name: str) -> str | None:
+        if sel == mc.AGENT_TOGGLE_SELECTOR and name == "aria-pressed":
+            if self.state == "agent":
+                return "true"
+            if self.state == "media":
+                return "false"
+        return None
+
+    def click(self, sel: str) -> None:
+        self.clicks.append(sel)
+        if sel == mc.AGENT_TOGGLE_SELECTOR:
+            self.state = "agent" if self.state == "media" else "media"
+        elif sel == mc.SIDEBAR_CLOSE_SELECTOR:
+            # Closing the sidebar returns to the composer, still agent-on
+            # (aria-pressed=true) — matches the live round-trip (03_after_close).
+            self.state = "agent"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [("media", "media"), ("agent", "agent"), ("stuck", "unknown")],
+)
+async def test_read_mode(state: str, expected: str) -> None:
+    page = _FakePage(state)
+    assert await mc.read_mode(page) == expected  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_ensure_media_noop_when_already_media() -> None:
+    page = _FakePage("media")
+    acted = await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert acted is False
+    assert page.clicks == []  # no blind click
+    assert page.state == "media"
+
+
+@pytest.mark.asyncio
+async def test_ensure_media_from_agent_toggles_off() -> None:
+    page = _FakePage("agent")
+    acted = await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert acted is True
+    assert page.clicks == [mc.AGENT_TOGGLE_SELECTOR]
+    assert page.state == "media"
+
+
+@pytest.mark.asyncio
+async def test_ensure_media_from_sidebar_closes_then_toggles() -> None:
+    page = _FakePage("sidebar")
+    acted = await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert acted is True
+    # X first (sidebar → agent), then toggle off (agent → media).
+    assert page.clicks == [mc.SIDEBAR_CLOSE_SELECTOR, mc.AGENT_TOGGLE_SELECTOR]
+    assert page.state == "media"
+
+
+@pytest.mark.asyncio
+async def test_ensure_media_gives_up_when_nothing_actionable() -> None:
+    page = _FakePage("stuck")
+    acted = await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert acted is False
+    assert page.clicks == []

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2594,8 +2594,8 @@ def _exit_agent_page(initial: dict) -> tuple[MagicMock, dict]:
     ``(page, state)`` so a test can assert final counts + click tallies (the
     state dict also accrues ``pill_clicks`` / ``chat_clicks``).
     """
+    from gflow_cli.api.transports import mode_control
     from gflow_cli.api.transports.ui_automation_video import (
-        AGENT_CHAT_PANEL_CLOSE_SELECTOR,
         COMPOSER_AGENT_TOGGLE_SELECTOR,
     )
 
@@ -2608,11 +2608,15 @@ def _exit_agent_page(initial: dict) -> tuple[MagicMock, dict]:
         "crop_after_pill": 1,
         "pill_after_chat": 1,
         "chat_after_chat": 0,
+        # The Agent toggle's aria-pressed (the mode-control source of truth).
+        # "true" = agent-on; a pill click flips it to "false" (binary toggle).
+        "agent_pressed": "true",
         **initial,
     }
 
     async def _pill_click(*_a, **_k) -> None:
         state["pill_clicks"] += 1
+        state["agent_pressed"] = "false"  # binary toggle flips off
         state["crop"] = state["crop_after_pill"]
 
     async def _chat_click(*_a, **_k) -> None:
@@ -2620,22 +2624,32 @@ def _exit_agent_page(initial: dict) -> tuple[MagicMock, dict]:
         state["chat"] = state["chat_after_chat"]
         state["pill"] = state["pill_after_chat"]
 
-    def _loc(key: str, on_click=None) -> MagicMock:
+    def _loc(key: str, on_click=None, aria_key: str | None = None) -> MagicMock:
         loc = MagicMock()
         loc.first = loc
         loc.count = AsyncMock(side_effect=lambda: state[key])
         loc.click = AsyncMock(side_effect=on_click) if on_click else AsyncMock()
+        loc.get_attribute = AsyncMock(
+            side_effect=lambda name: (
+                state[aria_key] if aria_key and name == "aria-pressed" else None
+            )
+        )
         return loc
 
     def locator(sel: str) -> MagicMock:
-        if sel == COMPOSER_AGENT_TOGGLE_SELECTOR:
-            return _loc("pill", _pill_click)
-        if sel == AGENT_CHAT_PANEL_CLOSE_SELECTOR:
+        if sel == mode_control.AGENT_TOGGLE_SELECTOR:
+            return _loc("pill", _pill_click, aria_key="agent_pressed")
+        if sel == mode_control.SIDEBAR_CLOSE_SELECTOR:
             return _loc("chat", _chat_click)
+        # The legacy pill selector is still a "still-stuck" indicator consulted by
+        # _check_forced_agentic_ui (AGENTIC_UI_INDICATORS) — map it to the pill so
+        # the forced-agentic escalation fires when recovery leaves the pill up.
+        if sel == COMPOSER_AGENT_TOGGLE_SELECTOR:
+            return _loc("pill")
         for k in state:
-            if k in sel:
+            if isinstance(state[k], int) and k in sel:
                 return _loc(k)
-        return _loc("crop")  # any MODE_SWITCH_TRIGGER_SELECTORS probe
+        return _loc("crop")  # any crop_* MODE_SWITCH_TRIGGER probe
 
     page = AsyncMock()
     page.locator = MagicMock(side_effect=locator)


### PR DESCRIPTION
## Summary

Fixes the root cause behind the spurious "forced agentic — classic media panel not recoverable" aborts (blocking #299/#314/#183/#174): the recovery clicked the Agent pill **once, blindly**, and treated `apps_spark_2` (the always-present **Tools** nav icon) as proof of an unrecoverable agentic cohort.

**New leaf component `mode_control`** — `read_mode` + `ensure_media_mode`. Flow's Agent toggle is `button[aria-pressed]:has(span.content)`; its **`aria-pressed`** *is* the mode (`false`=classic, `true`=agent) — locale-invariant. `ensure_media_mode` closes the expanded chat sidebar (X) first, then toggles OFF **only when actually on** — never a blind click, idempotent, bounded. `_dismiss_agent_affordances` delegates to it, so every caller (image + video mode-switch, driver detection) gets robust recovery. The classic→agentic direction already has the robust `_force_agent_mode`.

## Evidence (owner-provided live DOM + validation)

The mechanism was confirmed from owner-provided agentic-mode DOM/screenshots (PT locale) and then **live-validated end-to-end** by `scripts/dev/spike_mode_roundtrip.py`, which drove a full **classic → agent-on → sidebar → close → toggle-off → classic** cycle on real Flow, asserting `aria-pressed` and `crop_*` at every step:

| step | aria-pressed | crop_* | sidebar-X |
|---|---|---|---|
| initial | false | ✅ | – |
| toggle on | true | – | – |
| expand | (gone) | – | ✅ |
| close X | true | – | – |
| toggle off | **false** | ✅ | – |

## Test plan

- `mode_control` unit tests (state-machine fake: noop / agent→media / sidebar→agent→media / stuck).
- Updated `_exit_agent_mode` integration tests (fake now models `aria-pressed`; the stuck case still escalates to `FlowAgentUiError`).
- `/gflow:check`: ruff clean, **pyright src 0/0/0**, hygiene + doc-links clean; 257 transport/driver tests pass.
- Independent code-review: clean (no correctness issues). Ponytail-review: dropped the redundant `ensure_agent_mode` (duplicated the superior `_force_agent_mode`); kept the cohesive `read_mode`+`ensure_media_mode` pair.

## Follow-up (documented, not in this PR)

Adopt `read_mode` in `factory.detect_ui_mode` and drop `apps_spark_2`/`tune` from `AGENTIC_UI_INDICATORS` (still used as a last-resort escalation signal today; the robust recovery now handles the common case first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)