### PR TITLE
feat(image): dedup i2i refs via picker filename search (#314)

### DIFF
--- a/scripts/dev/spike_issue314_picker_filename_search.py
+++ b/scripts/dev/spike_issue314_picker_filename_search.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+r"""Issue #314 recon — does the image i2i reference picker's search match an
+uploaded file's FILENAME? (0 credits — navigation + picker only.)
+
+The "select existing asset instead of re-upload" machinery already exists
+(_select_existing_asset, keyed on media UUID). #314 wants a FILENAME-keyed
+variant so dedup works without trusting UUIDs across runs. The load-bearing
+unknown: does typing a filename into the picker search (#add-menu-input)
+filter to the matching library asset, and what do result tiles expose?
+
+This spike opens the Add-media picker in image mode, dumps the first tiles'
+structure (thumbnail URL → UUID, plus any name/alt/title/aria text), then
+types a token derived from the first tile's own visible text and checks
+whether the tile count drops (search filters by that displayed name). No
+prompt is submitted, no generate route is hit.
+
+Usage (headed, supervised):
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_issue314_picker_filename_search.py \
+        --profile ffroliva --project <project-id> [--term son]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    ADD_MEDIA_BUTTON,
+    PICKER_SEARCH_INPUT,
+)
+
+_ADD_MEDIA_FALLBACK = "button:has(i.google-symbols:text-is('add_2'))"
+_TILE = "[role='option']"
+
+_DUMP_JS = r"""
+() => {
+  const tiles = Array.from(document.querySelectorAll("[role='option']")).slice(0, 8);
+  return tiles.map(t => {
+    const img = t.querySelector('img');
+    return {
+      text: (t.innerText || '').trim().slice(0, 120),
+      ariaLabel: t.getAttribute('aria-label'),
+      title: t.getAttribute('title'),
+      dataTileId: t.getAttribute('data-tile-id'),
+      imgSrc: img ? img.getAttribute('src') : null,
+      imgAlt: img ? img.getAttribute('alt') : null,
+      imgTitle: img ? img.getAttribute('title') : null,
+    };
+  });
+}
+"""
+
+
+async def _open_picker(page: Any) -> None:
+    add = page.locator(ADD_MEDIA_BUTTON).first
+    if await add.count() == 0:
+        add = page.locator(_ADD_MEDIA_FALLBACK).first
+    await add.wait_for(state="visible", timeout=8000)
+    await add.click()
+    await page.wait_for_timeout(1000)
+
+
+async def _enter_image_mode(page: Any) -> bool:
+    try:
+        await UiAutomationTransport._switch_to_image_mode(page)  # noqa: SLF001
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def _run(profile: str, project: str, term: str | None) -> dict[str, Any]:
+    out_dir = default_out_path("issue314_picker", ".json").parent
+    result: dict[str, Any] = {"profile": profile, "project": project}
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001  # spike: drive the persistent context's page
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        url = routes.project_editor_url("en", project)
+        step("A", f"goto {url}", prefix="314")
+        await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+        await page.wait_for_timeout(2500)
+
+        step("B", "enter image mode", prefix="314")
+        result["image_mode_entered"] = await _enter_image_mode(page)
+
+        step("C", "open Add-media picker", prefix="314")
+        await _open_picker(page)
+        await page.screenshot(path=str(out_dir / "issue314_picker_open.png"))
+
+        step("D", "dump first tiles (structure + what they expose)", prefix="314")
+        tiles_before = await page.evaluate(_DUMP_JS)
+        result["tiles_before"] = tiles_before
+        result["tile_count_before"] = await page.locator(_TILE).count()
+
+        # Derive a search token: explicit --term, else the first tile's first word.
+        token = term
+        if not token and tiles_before:
+            txt = (tiles_before[0].get("text") or tiles_before[0].get("ariaLabel") or "").strip()
+            token = txt.split()[0] if txt else None
+        result["search_token"] = token
+
+        if token:
+            step("E", f"type {token!r} into picker search #add-menu-input", prefix="314")
+            search = page.locator(PICKER_SEARCH_INPUT).first
+            if await search.count() == 0:
+                result["search_input_present"] = False
+            else:
+                result["search_input_present"] = True
+                await search.click()
+                await search.press_sequentially(token, delay=30)
+                await page.wait_for_timeout(1500)
+                result["tile_count_after"] = await page.locator(_TILE).count()
+                result["tiles_after"] = await page.evaluate(_DUMP_JS)
+                await page.screenshot(path=str(out_dir / "issue314_picker_searched.png"))
+
+        out_file = out_dir / "issue314_picker_recon.json"
+        out_file.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        result["_out_file"] = str(out_file)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--term", default=None, help="explicit search token (else first tile's first word)")
+    args = ap.parse_args(argv)
+    res = asyncio.run(_run(args.profile, args.project, args.term))
+    print(json.dumps({k: v for k, v in res.items() if not k.startswith("tiles")}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -2148,7 +2148,12 @@ class UiAutomationTransport(VideoGenerationMixin):
         # The REST uploadImage path 401s, and passive capture needs the refs IN
         # the UI (not just a wire body), so we attach + let Flow's JS include them.
         if request.ref_paths:
-            await self._attach_references(page, list(request.ref_paths), out_dir=out_dir)
+            # prefer_existing: dedup a repeated local ref by selecting the
+            # already-uploaded library asset (named by its filename) instead of
+            # re-uploading it (#314). Image i2i only; R2V keeps upload-every-time.
+            await self._attach_references(
+                page, list(request.ref_paths), out_dir=out_dir, prefer_existing=True
+            )
 
         # Pre-generated image UUID refs: attach by selecting the EXISTING Flow
         # asset in the reference picker (no duplicate upload — founder principle),

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1808,10 +1808,19 @@ class VideoGenerationMixin:
         *,
         out_dir: Path | None,
         timeout_s: float = 120.0,
+        prefer_existing: bool = False,
     ) -> None:
         """R2V: attach up to MAX_REFERENCE_IMAGES reference images. References
         have no Start/End slots — each is added via the 'Add Media' button, which
-        opens the same media dialog. Must run with the settings panel closed."""
+        opens the same media dialog. Must run with the settings panel closed.
+
+        When ``prefer_existing`` is set (image i2i), each ref is first looked up
+        in the open picker by its filename before uploading: Flow names an
+        uploaded file by its exact filename, so a repeated local ref is DEDUPED —
+        selected in place — instead of re-uploaded, avoiding the duplicate
+        library entries of #314. Upload stays the fallback when no library match
+        exists (fresh file, or a picker cohort without a search box). Off by
+        default so the R2V video path keeps its upload-every-time behaviour."""
         missing = [str(p) for p in images if not p.exists()]
         if missing:
             msg = f"reference image(s) not found: {missing}"
@@ -1842,6 +1851,12 @@ class VideoGenerationMixin:
                 break
             await add_media.click()
             await page.wait_for_timeout(1000)
+            if prefer_existing and await VideoGenerationMixin._try_select_existing_by_filename(
+                page, img.name, out_dir=out_dir
+            ):
+                attached += 1
+                log.info("ui_automation_video.reference_attached", index=i, deduped=True)
+                continue
             await VideoGenerationMixin._upload_via_open_dialog(
                 page,
                 img,
@@ -1851,6 +1866,71 @@ class VideoGenerationMixin:
             )
             attached += 1
             log.info("ui_automation_video.reference_attached", index=i)
+
+    @staticmethod
+    async def _try_select_existing_by_filename(
+        page: Page, filename: str, *, out_dir: Path | None
+    ) -> bool:
+        """In the OPEN reference picker, try to select an existing library asset
+        whose display name equals ``filename`` — dedup instead of re-upload (#314).
+
+        Flow names an uploaded file by its exact filename (live-verified: an
+        upload of ``zzdedupprobe.png`` surfaces as a picker option named
+        ``zzdedupprobe.png``), and the picker search filters on that name. So a
+        repeated local ref can be attached by selecting the existing tile rather
+        than uploading a duplicate — without persisting or trusting any media
+        UUID across runs.
+
+        Soft by design: a quick presence check (no long actionability wait), and
+        it clears the search filter on a miss so the caller's upload path starts
+        from a clean grid. Returns ``True`` when a matching asset was attached,
+        ``False`` when none matched (caller uploads).
+        """
+        # The picker library has its OWN active project (#287) — align it to the
+        # editor's project so the search sees this project's media, where the
+        # duplicate uploads accumulate.
+        await VideoGenerationMixin._sync_picker_project(page, out_dir=out_dir)
+
+        search = page.locator(PICKER_SEARCH_INPUT).first
+        if not await search.count():
+            return False  # no search box (older / #174 full-page cohort) → upload
+        await search.fill("")
+        # Human-like typing jitter to dodge WAF heuristics — not security.
+        await search.press_sequentially(filename, delay=random.randint(10, 50))  # NOSONAR
+        await page.wait_for_timeout(600)
+
+        # Match the tile by its image ALT (= the exact filename, locale-invariant).
+        # The option's accessible NAME also carries a localised media-type suffix
+        # ("Image"/"Imagem"), so an exact name match would miss; the img alt is
+        # exactly the filename. get_by_alt_text avoids CSS-quoting a filename.
+        tile = (
+            page.get_by_role("option").filter(has=page.get_by_alt_text(filename, exact=True)).first
+        )
+        if not await tile.count():
+            await search.fill("")  # clear the filter for the upload fallback
+            return False
+
+        await tile.click()
+        await page.wait_for_timeout(400)
+        # The image picker attaches on tile-click and auto-closes; if the dialog
+        # is still open (video-style picker), fire the locale-safe include.
+        dialog = page.locator(DIALOG_ANY).last
+        try:
+            await dialog.wait_for(state="hidden", timeout=2500)
+        except Exception:  # noqa: BLE001 - still open → needs explicit include
+            include = await VideoGenerationMixin._resolve_include_action(
+                page,
+                PICKER_INCLUDE_BUTTON,
+                _INCLUDE_BUTTON_TIER_NAMES,
+                surface="filename_ref_include",
+                detail=f"filename ref {filename!r}",
+                out_dir=out_dir,
+                screenshot_name="filename_ref_include_missing.png",
+            )
+            await include.click(timeout=3000)
+            await page.wait_for_timeout(600)
+        log.info("ui_automation_video.reference_deduped_by_filename", filename=filename)
+        return True
 
     @staticmethod
     async def _attach_remote_references(

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -3038,3 +3038,139 @@ class TestCaptureDebugScreenshotFailure:
         page = MagicMock()
         page.screenshot = AsyncMock(side_effect=RuntimeError("target closed"))
         assert await ua_capture(page, tmp_path, "nope.png") is None
+
+
+class TestAttachReferencesDedup:
+    """#314: image i2i dedups a repeated local ref by selecting the existing
+    library asset (Flow names uploads by their exact filename) instead of
+    re-uploading a duplicate. R2V video keeps upload-every-time (default)."""
+
+    @staticmethod
+    def _picker(*, search_present: bool = True, tile_present: bool = True) -> tuple:
+        page = MagicMock()
+        search = MagicMock()
+        search.first = search
+        search.count = AsyncMock(return_value=1 if search_present else 0)
+        search.fill = AsyncMock()
+        search.press_sequentially = AsyncMock()
+        tile = MagicMock()
+        tile.first = tile
+        tile.count = AsyncMock(return_value=1 if tile_present else 0)
+        tile.click = AsyncMock()
+        role_loc = MagicMock()
+        role_loc.filter = MagicMock(return_value=tile)  # get_by_role("option").filter(...)
+        dialog = MagicMock()
+        dialog.last = dialog
+        dialog.wait_for = AsyncMock()  # goes hidden → image auto-attach on click
+
+        def _locator(sel: str) -> MagicMock:
+            return dialog if sel == DIALOG_ANY else search
+
+        page.locator = MagicMock(side_effect=_locator)
+        page.get_by_role = MagicMock(return_value=role_loc)
+        page.get_by_alt_text = MagicMock(return_value=MagicMock())
+        page.wait_for_timeout = AsyncMock()
+        return page, search, tile
+
+    @pytest.mark.asyncio
+    async def test_selects_existing_when_filename_matches(self, monkeypatch) -> None:
+        monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", AsyncMock())
+        page, search, tile = self._picker(tile_present=True)
+
+        got = await VideoGenerationMixin._try_select_existing_by_filename(
+            page, "zzdedupprobe.png", out_dir=None
+        )
+
+        assert got is True
+        tile.click.assert_awaited()
+        # Matched by the img ALT = the EXACT filename (locale-invariant; the
+        # option's accessible name also carries a localised "Image" suffix).
+        assert page.get_by_alt_text.call_args.args[0] == "zzdedupprobe.png"
+        assert page.get_by_alt_text.call_args.kwargs.get("exact") is True
+        search.press_sequentially.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_and_clears_search_on_no_match(self, monkeypatch) -> None:
+        monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", AsyncMock())
+        page, search, tile = self._picker(tile_present=False)
+
+        got = await VideoGenerationMixin._try_select_existing_by_filename(
+            page, "novel.png", out_dir=None
+        )
+
+        assert got is False
+        tile.click.assert_not_awaited()
+        # Cleared the filter so the upload fallback starts from a clean grid.
+        assert search.fill.await_args_list[-1].args == ("",)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_search_box(self, monkeypatch) -> None:
+        monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", AsyncMock())
+        page, _search, tile = self._picker(search_present=False)
+
+        got = await VideoGenerationMixin._try_select_existing_by_filename(
+            page, "x.png", out_dir=None
+        )
+
+        assert got is False
+        tile.click.assert_not_awaited()
+
+    @staticmethod
+    def _attach_page() -> MagicMock:
+        page = MagicMock()
+        add = MagicMock()
+        add.first = add
+        add.wait_for = AsyncMock()
+        add.click = AsyncMock()
+        page.locator = MagicMock(return_value=add)
+        page.wait_for_timeout = AsyncMock()
+        return page
+
+    @pytest.mark.asyncio
+    async def test_prefer_existing_selects_and_skips_upload(self, monkeypatch, tmp_path) -> None:
+        ref = tmp_path / "son.jpg"
+        ref.write_bytes(b"x")
+        select = AsyncMock(return_value=True)
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_try_select_existing_by_filename", select)
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+
+        await VideoGenerationMixin._attach_references(
+            self._attach_page(), [ref], out_dir=None, prefer_existing=True
+        )
+
+        select.assert_awaited_once()
+        upload.assert_not_awaited()  # deduped → no re-upload
+
+    @pytest.mark.asyncio
+    async def test_prefer_existing_uploads_when_no_match(self, monkeypatch, tmp_path) -> None:
+        ref = tmp_path / "fresh.jpg"
+        ref.write_bytes(b"x")
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_try_select_existing_by_filename",
+            AsyncMock(return_value=False),
+        )
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+
+        await VideoGenerationMixin._attach_references(
+            self._attach_page(), [ref], out_dir=None, prefer_existing=True
+        )
+
+        upload.assert_awaited_once()  # fallback upload for a fresh file
+
+    @pytest.mark.asyncio
+    async def test_default_never_dedups_video_path(self, monkeypatch, tmp_path) -> None:
+        ref = tmp_path / "frame.jpg"
+        ref.write_bytes(b"x")
+        select = AsyncMock(return_value=True)
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_try_select_existing_by_filename", select)
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+
+        # prefer_existing defaults False → R2V video path is unchanged.
+        await VideoGenerationMixin._attach_references(self._attach_page(), [ref], out_dir=None)
+
+        select.assert_not_awaited()
+        upload.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #314: image i2i re-uploaded every local reference, piling up **duplicate library entries** (the reporter's 8× `son.jpg`). Flow names an uploaded file by its **exact filename** and the picker search filters on that name — so a repeated ref is now attached by **selecting the existing tile** instead of re-uploading, without persisting or trusting any media UUID across runs.

New soft helper **`_try_select_existing_by_filename`**: syncs the picker to the editor's project (the library is project-scoped, #287), searches the filename, and matches the tile by its **image `alt`** (= the exact filename, locale-invariant — the option's *accessible name* also carries a localized "Image"/"Imagem" suffix, so an exact name match misses). Match → select + include; miss → clear the filter, return False → caller uploads. Wired via an opt-in **`prefer_existing`** flag: image i2i opts in; **R2V video keeps upload-only** (zero video-side change).

## Live verification (the deciding evidence)

On `ffroliva`, project `9d5b9a86` (credit-free), a **2nd i2i of the same ref**:

| run | mode | dedup fired | re-uploaded | result |
|---|---|---|---|---|
| pre-fix | classic | ❌ (accessible-name+suffix miss) | ✅ | led to the `alt`-match fix |
| post-fix | **agentic** | ✅ `reference_deduped_by_filename` | **0** | dedup works cross-cohort (gen then hit the known agentic scrape-timeout — orthogonal) |
| post-fix | **classic** (forced) | ✅ | **0** | `status: ok`, real 54 KB JPEG — **clean end-to-end** |

So the dedup fires in **both** cohorts and does **not** break generation (classic clean success). The agentic run's `TransportTimeoutError` is the cohort's pre-existing DOM-scrape flake (#281/#299), not caused by this change.

## Test plan

- 6 unit tests (`TestAttachReferencesDedup`): match→select-no-upload, miss→clear+upload, no-search-box→upload, prefer_existing routing both ways, default→video-path-unchanged.
- `/gflow:check`: ruff clean, **pyright src 0/0/0**, hygiene + doc-links clean, 305 transport tests pass.
- Independent code-review: clean (no correctness issues). Ponytail-review: reuses existing machinery, `prefer_existing` is justified branching — ship.
- Recon/validation spike: `scripts/dev/spike_issue314_picker_filename_search.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)