### PR TITLE
docs(readme): expand trust-boundary warning — account risk, billing, failure cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 [![Tests: TDD](https://img.shields.io/badge/tests-TDD-brightgreen.svg)](CONTRIBUTING.md)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli)
 
-> ⚠️ **Unofficial, reverse-engineered, not affiliated with Google.** Endpoints can change without notice. Read the full [DISCLAIMER](DISCLAIMER.md).
+> ⚠️ **Read this before you install.** gflow-cli is **unofficial, alpha, and reverse-engineered — not affiliated with Google**. It drives a headed browser on *your own* Google Flow session, so treat it as your own account risk: automation is subject to Google's ToS, and endpoints or UI can change without notice. It requires a Google AI **Ultra or Pro** subscription with Flow access, and every generation bills your account. Read the full [DISCLAIMER](DISCLAIMER.md).
+>
+> 💳 **What failure costs you.** Credits are only spent on Veo *video* generation — images and composition ops are free, so most breakage costs nothing. When Flow's UI drifts mid-run, the CLI fails fast and loudly with distinct exit codes (e.g. selector drift = exit 23) instead of resubmitting, and batch items are recorded locally *before* submission so a broken run never silently burns credits on a stale state. See [KNOWN_ISSUES](KNOWN_ISSUES.md) for the current risk list.
 >
 > 🌐 **Headed browser today.** gflow drives Flow through a persistent Playwright Chromium profile, because Google's auth and reCAPTCHA gates require it. The [Architecture](#architecture--current-limitations) section shows where you can help.
 


### PR DESCRIPTION
## Summary

Two independent r/SideProject commenters converged on the same ask: state the trust boundary up front. The README's top warning block now carries the substance:

- **Read this before you install** — unofficial/alpha/reverse-engineered, your-own-account risk, ToS caveat, Ultra/Pro requirement, generations bill your account (mirrors the docs site's warning box).
- **What failure costs you** — credits only spent on Veo video; images/composition free; fail-fast distinct exit codes on UI drift; batch items recorded locally before submission (no silent credit burn on a stale state); pointer to KNOWN_ISSUES.

Docs-only, 1 file, +3/−1.

## Test plan
- [x] check_doc_links.py — all links resolved
- [x] check_repo_hygiene.py — no violations
- [ ] PR CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)