### PR TITLE
fix(mode-control): opt-in reload rescue for server-pinned agentic arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1] — 2026-07-17
+
+### Fixed
+
+- **Agentic-pin recovery: opt-in reload after a real toggle-off** (#338): when a REAL
+  (actionability-checked, unforced) Agent-toggle click lands but the classic media panel
+  never mounts in place (the 2026-07-17 both-accounts pin), `ensure_media_mode` can now
+  reload the page once and re-run its loop — a fresh load both re-rolls the server's
+  per-load cohort arm and mounts the server-persisted `isAgentModeToggled=false`
+  preference (`docs/superpowers/spikes/2026-07-12-ui-cohort-backend-config.md`). The
+  reload is **opt-in** (`allow_reload`, threaded via `_exit_agent_mode`) and sanctioned
+  only from `get_ui_driver`'s pre-bind CLASSIC path, which re-verifies the cohort after
+  any navigation — mid-flow image/video mode switches keep strict no-navigation
+  semantics (their bound driver's cohort must not be re-rolled underneath them).
+  Robustness details from the review pass: a slow in-place panel mount gets a 4s grace
+  poll before any reload (parity with the callers' old trigger-probe tolerance); after
+  the reload a composer-readiness poll (up to 8s) replaces the fixed settle so the SPA
+  re-mount is never probed as a blank shell; the toggle click is unforced-first (a
+  forced click can flip the DOM without firing the React handler that persists the
+  setting), and the force fallback re-reads `aria-pressed` before clicking — Playwright
+  can raise AFTER the events dispatched, and a blind second click would re-enable agent
+  mode. A force-fallback click never arms the reload (nothing was persisted).
+- **Crop-selector drift between the mode controller and the cohort detector**: `mode_control`
+  probed only 2 of the 6 `crop_*` ratio icons while `drivers/factory` probed all 6 — the
+  canonical 6-icon tuple now lives in `mode_control` (the leaf module) and `factory` imports
+  it; `test_selector_symmetry.py` locks the identity.
+
 ## [0.38.0] — 2026-07-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gflow-cli"
-version = "0.38.0"
+version = "0.38.1"
 description = "Unofficial CLI for Google Flow — drive Veo image-to-video generations from the terminal."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gflow_cli/__init__.py
+++ b/src/gflow_cli/__init__.py
@@ -1,3 +1,3 @@
 """gflow-cli — unofficial CLI for Google Flow."""
 
-__version__ = "0.38.0"
+__version__ = "0.38.1"

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -14,11 +14,14 @@ rule, validated by live capture:
 The cohort flaps per page load, so callers must re-probe **per generation** —
 never cache a driver across navigations.
 
-This module is the detection source of truth: ``AGENTIC_INDICATOR_SELECTORS``
-and ``AGENT_TUNE_INDICATOR_SELECTOR`` are canonical here, and the UI transports
-(``ui_automation``, ``ui_automation_video``) import them rather than redefining
-them (the transport depends on ``drivers``, not the reverse —
-``tests/api/transports/test_selector_symmetry.py`` locks this).
+This module is the detection source of truth for the AGENTIC indicators:
+``AGENTIC_INDICATOR_SELECTORS`` and ``AGENT_TUNE_INDICATOR_SELECTOR`` are
+canonical here, and the UI transports (``ui_automation``,
+``ui_automation_video``) import them rather than redefining them. The CLASSIC
+crop tuple is the one exception: its canonical home is ``mode_control`` (the
+leaf module — it may import nothing from ``drivers``, so the dependency points
+factory→mode_control for that tuple only).
+``tests/api/transports/test_selector_symmetry.py`` locks both directions.
 """
 
 from __future__ import annotations
@@ -30,6 +33,7 @@ import structlog
 
 from gflow_cli.api.transports.drivers.agentic import AgenticFlowUiDriver
 from gflow_cli.api.transports.drivers.classic import ClassicFlowUiDriver
+from gflow_cli.api.transports.mode_control import CROP_SELECTORS
 from gflow_cli.config import UiMode
 
 if TYPE_CHECKING:
@@ -41,17 +45,11 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
-# Classic media panel — the locale-stable ``crop_*`` aspect/mode trigger. Its
-# presence means the composer is in classic media mode (all 6 ratio icons are
-# enumerated so the probe is ratio-invariant).
-_CLASSIC_CROP_SELECTORS: tuple[str, ...] = (
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_16_9'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_9_16'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_square'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_portrait'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_landscape'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_original'))",
-)
+# Classic media panel — the locale-stable ``crop_*`` aspect/mode trigger (all 6
+# ratio icons, ratio-invariant). Canonical tuple lives in ``mode_control`` (the
+# leaf module) so both this detector and the mode controller probe the SAME
+# panel — they had drifted (2 vs 6 icons) before the 2026-07-17 pin incident.
+_CLASSIC_CROP_SELECTORS: tuple[str, ...] = CROP_SELECTORS
 
 # Agentic cohort indicators — Material Symbols ligatures unique to the chat UI.
 # Locale-invariant (icon names, not UI text). Only consulted when no ``crop_*``
@@ -157,7 +155,12 @@ async def get_ui_driver(
 
         try:
             log.info("ui_driver.ui_mode.attempt_exit_agent")
-            await VideoGenerationMixin._exit_agent_mode(page)  # type: ignore[reportPrivateUsage]
+            # allow_reload: this is the ONE sanctioned reload site — it runs
+            # BEFORE any driver is bound and the re-probe below re-verifies the
+            # cohort after any navigation (mode_control docstring caveat).
+            await VideoGenerationMixin._exit_agent_mode(  # type: ignore[reportPrivateUsage]
+                page, allow_reload=True
+            )
         except FlowAgentUiError as exc:
             # Expected: a server-pinned agentic cohort cannot be exited
             # client-side. The verify check below turns this into a clean abort.

--- a/src/gflow_cli/api/transports/mode_control.py
+++ b/src/gflow_cli/api/transports/mode_control.py
@@ -32,7 +32,9 @@ from typing import TYPE_CHECKING, Literal
 import structlog
 
 if TYPE_CHECKING:
-    from playwright.async_api import Page
+    from collections.abc import Awaitable, Callable
+
+    from playwright.async_api import Locator, Page
 
 log = structlog.get_logger(__name__)
 
@@ -102,7 +104,9 @@ async def _composer_present(page: Page) -> bool:
     return False
 
 
-async def _wait_until(page: Page, probe, timeout_ms: int) -> bool:  # type: ignore[no-untyped-def]
+async def _wait_until(
+    page: Page, probe: Callable[[Page], Awaitable[bool]], timeout_ms: int
+) -> bool:
     """Poll ``probe(page)`` until true or ``timeout_ms`` elapses (logical time).
 
     Uses ``page.wait_for_timeout`` for the pacing so test fakes stay
@@ -163,57 +167,83 @@ async def ensure_media_mode(page: Page, *, allow_reload: bool = False) -> bool:
     acted = False
     persisted_off = False  # a REAL (unforced) toggle click succeeded → server pref persisted
     for round_no in range(2):
-        for _ in range(_MAX_STEPS):
-            if await _crop_present(page):
-                return acted
-            # The expanded sidebar suppresses the in-composer toggle → close it first.
-            sidebar_x = page.locator(SIDEBAR_CLOSE_SELECTOR).first
-            if await sidebar_x.count() > 0:
-                await sidebar_x.click(force=True, timeout=_CLICK_TIMEOUT_MS)
-                await page.wait_for_timeout(_SETTLE_MS)
-                acted = True
-                continue
-            toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
-            if await toggle.count() > 0 and await toggle.get_attribute("aria-pressed") == "true":
-                # A REAL click (actionability-checked), never force-first: a forced
-                # click can flip the DOM node without firing the React handler that
-                # persists ``isAgentModeToggled=false`` server-side (the 2026-07-17
-                # both-accounts pin) — force remains only as a last-resort fallback.
-                try:
-                    await toggle.click(timeout=_CLICK_TIMEOUT_MS)
-                    persisted_off = True
-                except Exception as exc:  # noqa: BLE001 - fall back, verified below
-                    log.warning("mode_control.toggle_click_fallback_force", error=str(exc))
-                    # Playwright can raise AFTER the click events dispatched
-                    # (post-click instability). Re-read the pill state first: a
-                    # blind force click on a now-OFF toggle re-enables agent
-                    # mode and re-persists it server-side.
-                    if await toggle.get_attribute("aria-pressed") == "true":
-                        await toggle.click(force=True, timeout=_CLICK_TIMEOUT_MS)
-                await page.wait_for_timeout(_SETTLE_MS)
-                acted = True
-                continue
-            break  # nothing actionable and no crop_* — give up (caller probe fails loudly)
+        stepped, persisted = await _run_dismiss_steps(page)
+        acted = acted or stepped
+        persisted_off = persisted_off or persisted
+        if await _crop_present(page):
+            return acted
         # Absorb a slow in-place mount before giving up or navigating (the old
         # code delegated this tolerance to the callers' 4s trigger probes).
         if acted and await _wait_until(page, _crop_present, _CROP_GRACE_TIMEOUT_MS):
             return acted
         if round_no == 0 and allow_reload and persisted_off:
-            # Real toggle click landed but the classic panel never mounted in
-            # place: reload. A fresh load both re-rolls the server's per-load
-            # arm AND mounts the now-persisted ``isAgentModeToggled=false``
-            # preference. Opt-in only (see the docstring's navigation caveat).
-            log.info("mode_control.reload_retry", note="toggle clicked, panel absent — reloading")
-            await page.reload()
-            # SPA re-mount: wait for a composer signal (either arm) so the
-            # round-2 probes and the caller's cohort re-detect see a settled
-            # page, not the post-``load`` shell.
-            await _wait_until(page, _composer_present, _COMPOSER_READY_TIMEOUT_MS)
+            await _reload_for_persisted_pref(page)
         else:
             break  # no reload sanctioned — keep the old single-round give-up
-    if not await _crop_present(page):
-        log.warning(
-            "mode_control.ensure_media_incomplete",
-            note="classic media panel not restored after mode-control attempts",
-        )
+    log.warning(
+        "mode_control.ensure_media_incomplete",
+        note="classic media panel not restored after mode-control attempts",
+    )
     return acted
+
+
+async def _run_dismiss_steps(page: Page) -> tuple[bool, bool]:
+    """One bounded pass of (sidebar → toggle → re-check) steps.
+
+    Returns ``(acted, persisted_off)``: whether anything was clicked, and
+    whether a REAL (unforced) toggle click landed (→ server pref persisted).
+    """
+    acted = False
+    persisted_off = False
+    for _ in range(_MAX_STEPS):
+        if await _crop_present(page):
+            break
+        # The expanded sidebar suppresses the in-composer toggle → close it first.
+        sidebar_x = page.locator(SIDEBAR_CLOSE_SELECTOR).first
+        if await sidebar_x.count() > 0:
+            await sidebar_x.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+            await page.wait_for_timeout(_SETTLE_MS)
+            acted = True
+            continue
+        toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
+        if await toggle.count() > 0 and await toggle.get_attribute("aria-pressed") == "true":
+            persisted_off = await _click_toggle_off(toggle) or persisted_off
+            await page.wait_for_timeout(_SETTLE_MS)
+            acted = True
+            continue
+        break  # nothing actionable and no crop_* — give up (caller probe fails loudly)
+    return acted, persisted_off
+
+
+async def _click_toggle_off(toggle: Locator) -> bool:
+    """Click the Agent pill OFF; return ``True`` only for a REAL (unforced) click.
+
+    A REAL click (actionability-checked), never force-first: a forced click can
+    flip the DOM node without firing the React handler that persists
+    ``isAgentModeToggled=false`` server-side (the 2026-07-17 both-accounts pin)
+    — force remains only as a last-resort fallback, and only after re-reading
+    ``aria-pressed``: Playwright can raise AFTER the click events dispatched
+    (post-click instability), and a blind force click on a now-OFF toggle
+    re-enables agent mode and re-persists it server-side.
+    """
+    try:
+        await toggle.click(timeout=_CLICK_TIMEOUT_MS)
+    except Exception as exc:  # noqa: BLE001  # NOSONAR
+        log.warning("mode_control.toggle_click_fallback_force", error=str(exc))
+        if await toggle.get_attribute("aria-pressed") == "true":
+            await toggle.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+        return False
+    return True
+
+
+async def _reload_for_persisted_pref(page: Page) -> None:
+    """Reload once after a real toggle-off failed to mount the classic panel.
+
+    A fresh load both re-rolls the server's per-load arm AND mounts the
+    now-persisted ``isAgentModeToggled=false`` preference; afterwards wait for a
+    composer signal (either arm) so the next probes and the caller's cohort
+    re-detect see a settled page, not the post-``load`` shell.
+    """
+    log.info("mode_control.reload_retry", note="toggle clicked, panel absent — reloading")
+    await page.reload()
+    await _wait_until(page, _composer_present, _COMPOSER_READY_TIMEOUT_MS)

--- a/src/gflow_cli/api/transports/mode_control.py
+++ b/src/gflow_cli/api/transports/mode_control.py
@@ -40,10 +40,17 @@ log = structlog.get_logger(__name__)
 # label wrapper (the class is semantic, not a hashed styled-components name).
 AGENT_TOGGLE_SELECTOR = "button[aria-pressed]:has(span.content)"
 
-# Classic media panel indicator — the ``crop_*`` mode-switch trigger.
-_CROP_SELECTORS: tuple[str, ...] = (
-    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_16_9'))",
-    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('crop_9_16'))",
+# Classic media panel indicator — the ``crop_*`` mode-switch trigger. Canonical
+# for the whole codebase (all 6 ratio icons, ratio-invariant): ``drivers/factory``
+# imports THIS tuple — this module stays a leaf, so the dependency points here.
+# ``tests/api/transports/test_selector_symmetry.py`` locks the identity.
+CROP_SELECTORS: tuple[str, ...] = (
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_16_9'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_9_16'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_square'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_portrait'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_landscape'))",
+    "button[aria-haspopup='menu']:has(i.google-symbols:text('crop_original'))",
 )
 
 # The expanded chat sidebar's close (X), scoped to the sidebar (which also
@@ -59,13 +66,56 @@ Mode = Literal["media", "agent", "unknown"]
 _SETTLE_MS = 1200
 _MAX_STEPS = 4
 _CLICK_TIMEOUT_MS = 4000
+# Slow in-place panel mounts were historically absorbed by the CALLERS' own
+# 4s trigger-probe cascade — the pre-reload grace keeps that tolerance so a
+# panel that mounts in 1.3-4s never triggers a needless navigation.
+_CROP_GRACE_TIMEOUT_MS = 4000
+# Post-reload the SPA mounts the composer well after ``load`` (the agentic
+# indicator was observed ~1.25s after navigation; slow loads take longer) —
+# poll for ANY composer signal instead of trusting a fixed settle.
+_COMPOSER_READY_TIMEOUT_MS = 8000
+_POLL_INTERVAL_MS = 250
 
 
 async def _crop_present(page: Page) -> bool:
-    for sel in _CROP_SELECTORS:
-        if await page.locator(sel).count() > 0:
-            return True
+    for sel in CROP_SELECTORS:
+        # Best-effort probe (parity with the factory detector): a transient
+        # locator error on one selector must not abort the whole probe.
+        try:
+            if await page.locator(sel).count() > 0:
+                return True
+        except Exception:  # noqa: BLE001  # NOSONAR
+            continue
     return False
+
+
+async def _composer_present(page: Page) -> bool:
+    """Any composer signal — crop panel (classic), Agent toggle, or sidebar."""
+    if await _crop_present(page):
+        return True
+    for sel in (AGENT_TOGGLE_SELECTOR, SIDEBAR_CLOSE_SELECTOR):
+        try:
+            if await page.locator(sel).count() > 0:
+                return True
+        except Exception:  # noqa: BLE001  # NOSONAR
+            continue
+    return False
+
+
+async def _wait_until(page: Page, probe, timeout_ms: int) -> bool:  # type: ignore[no-untyped-def]
+    """Poll ``probe(page)`` until true or ``timeout_ms`` elapses (logical time).
+
+    Uses ``page.wait_for_timeout`` for the pacing so test fakes stay
+    deterministic (their no-op wait makes the loop spin through instantly).
+    """
+    waited = 0
+    while True:
+        if await probe(page):
+            return True
+        if waited >= timeout_ms:
+            return False
+        await page.wait_for_timeout(_POLL_INTERVAL_MS)
+        waited += _POLL_INTERVAL_MS
 
 
 async def read_mode(page: Page) -> Mode:
@@ -88,33 +138,79 @@ async def read_mode(page: Page) -> Mode:
     return "unknown"
 
 
-async def ensure_media_mode(page: Page) -> bool:
+async def ensure_media_mode(page: Page, *, allow_reload: bool = False) -> bool:
     """Ensure the composer is in classic media mode; return ``True`` if it acted.
 
     State-aware and idempotent (a no-op when already in media mode). Closes the
     expanded chat sidebar (X) if open, then toggles the Agent pill OFF **only
     when** ``aria-pressed`` reads ``"true"`` — never a blind click. Bounded loop
-    (sidebar → toggle → re-check). Best-effort: logs and returns if the media
-    panel never returns, leaving the caller's own probe to fail loudly.
+    (sidebar → toggle → re-check), plus a grace poll for slow in-place panel
+    mounts. Best-effort: logs and returns if the media panel never returns,
+    leaving the caller's own probe to fail loudly.
+
+    ``allow_reload=True`` additionally sanctions ONE ``page.reload()`` when a
+    real (unforced) toggle click landed but the panel never mounted — the
+    2026-07-17 pinned-arm shape: the click persists ``isAgentModeToggled=false``
+    server-side and the fresh load both re-rolls the per-load cohort arm and
+    mounts the persisted preference. **A reload is a navigation with page-wide
+    side effects** (it can re-roll the arm and resurface dismissed overlays), so
+    only callers that re-verify the cohort AFTER this returns may opt in — in
+    practice ``drivers/factory.get_ui_driver``, which owns the switch→verify
+    cycle and runs BEFORE a driver is bound. Mid-flow callers (image/video mode
+    switches after driver binding) must keep the default: their cohort is bound
+    for the flow's lifetime and must not be re-rolled underneath them.
     """
     acted = False
-    for _ in range(_MAX_STEPS):
-        if await _crop_present(page):
+    persisted_off = False  # a REAL (unforced) toggle click succeeded → server pref persisted
+    for round_no in range(2):
+        for _ in range(_MAX_STEPS):
+            if await _crop_present(page):
+                return acted
+            # The expanded sidebar suppresses the in-composer toggle → close it first.
+            sidebar_x = page.locator(SIDEBAR_CLOSE_SELECTOR).first
+            if await sidebar_x.count() > 0:
+                await sidebar_x.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+                await page.wait_for_timeout(_SETTLE_MS)
+                acted = True
+                continue
+            toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
+            if await toggle.count() > 0 and await toggle.get_attribute("aria-pressed") == "true":
+                # A REAL click (actionability-checked), never force-first: a forced
+                # click can flip the DOM node without firing the React handler that
+                # persists ``isAgentModeToggled=false`` server-side (the 2026-07-17
+                # both-accounts pin) — force remains only as a last-resort fallback.
+                try:
+                    await toggle.click(timeout=_CLICK_TIMEOUT_MS)
+                    persisted_off = True
+                except Exception as exc:  # noqa: BLE001 - fall back, verified below
+                    log.warning("mode_control.toggle_click_fallback_force", error=str(exc))
+                    # Playwright can raise AFTER the click events dispatched
+                    # (post-click instability). Re-read the pill state first: a
+                    # blind force click on a now-OFF toggle re-enables agent
+                    # mode and re-persists it server-side.
+                    if await toggle.get_attribute("aria-pressed") == "true":
+                        await toggle.click(force=True, timeout=_CLICK_TIMEOUT_MS)
+                await page.wait_for_timeout(_SETTLE_MS)
+                acted = True
+                continue
+            break  # nothing actionable and no crop_* — give up (caller probe fails loudly)
+        # Absorb a slow in-place mount before giving up or navigating (the old
+        # code delegated this tolerance to the callers' 4s trigger probes).
+        if acted and await _wait_until(page, _crop_present, _CROP_GRACE_TIMEOUT_MS):
             return acted
-        # The expanded sidebar suppresses the in-composer toggle → close it first.
-        sidebar_x = page.locator(SIDEBAR_CLOSE_SELECTOR).first
-        if await sidebar_x.count() > 0:
-            await sidebar_x.click(force=True, timeout=_CLICK_TIMEOUT_MS)
-            await page.wait_for_timeout(_SETTLE_MS)
-            acted = True
-            continue
-        toggle = page.locator(AGENT_TOGGLE_SELECTOR).first
-        if await toggle.count() > 0 and await toggle.get_attribute("aria-pressed") == "true":
-            await toggle.click(force=True, timeout=_CLICK_TIMEOUT_MS)
-            await page.wait_for_timeout(_SETTLE_MS)
-            acted = True
-            continue
-        break  # nothing actionable and no crop_* — give up (caller probe fails loudly)
+        if round_no == 0 and allow_reload and persisted_off:
+            # Real toggle click landed but the classic panel never mounted in
+            # place: reload. A fresh load both re-rolls the server's per-load
+            # arm AND mounts the now-persisted ``isAgentModeToggled=false``
+            # preference. Opt-in only (see the docstring's navigation caveat).
+            log.info("mode_control.reload_retry", note="toggle clicked, panel absent — reloading")
+            await page.reload()
+            # SPA re-mount: wait for a composer signal (either arm) so the
+            # round-2 probes and the caller's cohort re-detect see a settled
+            # page, not the post-``load`` shell.
+            await _wait_until(page, _composer_present, _COMPOSER_READY_TIMEOUT_MS)
+        else:
+            break  # no reload sanctioned — keep the old single-round give-up
     if not await _crop_present(page):
         log.warning(
             "mode_control.ensure_media_incomplete",

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1144,7 +1144,7 @@ class VideoGenerationMixin:
         return False
 
     @staticmethod
-    async def _dismiss_agent_affordances(page: Page) -> bool:
+    async def _dismiss_agent_affordances(page: Page, *, allow_reload: bool = False) -> bool:
         """Bring the composer back to classic media mode; return True if it acted.
 
         Delegates to the robust :func:`mode_control.ensure_media_mode`, which is
@@ -1155,11 +1155,15 @@ class VideoGenerationMixin:
         raise; the caller (:meth:`_exit_agent_mode`) re-checks the media panel
         and escalates via :meth:`_check_forced_agentic_ui` only if it never
         returned.
+
+        ``allow_reload`` passes through to ``ensure_media_mode``'s pinned-arm
+        reload rescue — only the pre-bind ``get_ui_driver`` path may set it (a
+        reload re-rolls the cohort arm; see the mode_control docstring).
         """
         # Local import keeps mode_control a leaf and avoids any import cycle.
         from gflow_cli.api.transports import mode_control
 
-        return await mode_control.ensure_media_mode(page)
+        return await mode_control.ensure_media_mode(page, allow_reload=allow_reload)
 
     @staticmethod
     async def _check_forced_agentic_ui(page: Page, out_dir: Path | None) -> None:
@@ -1182,7 +1186,9 @@ class VideoGenerationMixin:
                 )
 
     @staticmethod
-    async def _exit_agent_mode(page: Page, *, out_dir: Path | None = None) -> bool:
+    async def _exit_agent_mode(
+        page: Page, *, out_dir: Path | None = None, allow_reload: bool = False
+    ) -> bool:
         """Ensure the composer is in media (Image/Video) mode, not Agent mode.
 
         Flow's "Agent" mode hides the media-generation panel — the ``crop_*``
@@ -1217,7 +1223,9 @@ class VideoGenerationMixin:
             if await VideoGenerationMixin._media_panel_present(page):
                 return False
 
-            acted = await VideoGenerationMixin._dismiss_agent_affordances(page)
+            acted = await VideoGenerationMixin._dismiss_agent_affordances(
+                page, allow_reload=allow_reload
+            )
 
             if await VideoGenerationMixin._media_panel_present(page):
                 if acted:

--- a/tests/api/transports/test_mode_control.py
+++ b/tests/api/transports/test_mode_control.py
@@ -28,21 +28,37 @@ class _FakeLocator:
     async def get_attribute(self, name: str) -> str | None:
         return self._page.attr(self._sel, name)
 
-    async def click(self, **_kw: object) -> None:
-        self._page.click(self._sel)
+    async def click(self, **kw: object) -> None:
+        mode = self._page.raise_unforced_click
+        if mode and not kw.get("force") and self._sel == mc.AGENT_TOGGLE_SELECTOR:
+            self._page.raise_unforced_click = None  # raise once
+            if mode == "after":
+                self._page.click(self._sel, kw)
+            raise RuntimeError(f"click failed ({mode}-dispatch)")
+        self._page.click(self._sel, kw)
 
 
 class _FakePage:
-    """Models Flow's composer: state in {media, agent, sidebar}.
+    """Models Flow's composer: state in {media, agent, sidebar, pinned, stuck}.
 
     - media:  crop_* present; toggle present with aria-pressed=false.
     - agent:  no crop; toggle present with aria-pressed=true; expand available.
     - sidebar: no crop; no in-composer toggle; the sidebar X (close) present.
+    - pinned: server-pinned agentic arm — toggle present (aria-pressed=true),
+      clicking flips aria to false BUT the crop panel never mounts in place
+      (state → pinned_off); only a reload after the persisted toggle-off
+      brings classic back (pinned_off → media). Models the 2026-07-17 incident.
     """
 
-    def __init__(self, state: str = "media") -> None:
+    def __init__(self, state: str = "media", raise_unforced_click: str | None = None) -> None:
         self.state = state
         self.clicks: list[str] = []
+        self.click_kwargs: list[dict[str, object]] = []
+        self.reloads = 0
+        # "before": unforced toggle click raises WITHOUT dispatching;
+        # "after": dispatches the state change, THEN raises (post-click
+        # instability — Playwright can raise after the events fired).
+        self.raise_unforced_click = raise_unforced_click
 
     def locator(self, sel: str) -> _FakeLocator:
         return _FakeLocator(self, sel)
@@ -50,27 +66,38 @@ class _FakePage:
     async def wait_for_timeout(self, _ms: int) -> None:
         return None
 
+    async def reload(self, **_kw: object) -> None:
+        self.reloads += 1
+        if self.state == "pinned_off":
+            # The toggle click persisted isAgentModeToggled=false server-side;
+            # the fresh load mounts the classic composer.
+            self.state = "media"
+
     def count(self, sel: str) -> int:
-        if sel in mc._CROP_SELECTORS:
+        if sel in mc.CROP_SELECTORS:
             return 1 if self.state == "media" else 0
         if sel == mc.AGENT_TOGGLE_SELECTOR:
-            return 1 if self.state in ("media", "agent") else 0
+            return 1 if self.state in ("media", "agent", "pinned", "pinned_off") else 0
         if sel == mc.SIDEBAR_CLOSE_SELECTOR:
             return 1 if self.state == "sidebar" else 0
         return 0
 
     def attr(self, sel: str, name: str) -> str | None:
         if sel == mc.AGENT_TOGGLE_SELECTOR and name == "aria-pressed":
-            if self.state == "agent":
+            if self.state in ("agent", "pinned"):
                 return "true"
-            if self.state == "media":
+            if self.state in ("media", "pinned_off"):
                 return "false"
         return None
 
-    def click(self, sel: str) -> None:
+    def click(self, sel: str, kw: dict[str, object] | None = None) -> None:
         self.clicks.append(sel)
+        self.click_kwargs.append(kw or {})
         if sel == mc.AGENT_TOGGLE_SELECTOR:
-            self.state = "agent" if self.state == "media" else "media"
+            if self.state == "pinned":
+                self.state = "pinned_off"
+            else:
+                self.state = "agent" if self.state == "media" else "media"
         elif sel == mc.SIDEBAR_CLOSE_SELECTOR:
             # Closing the sidebar returns to the composer, still agent-on
             # (aria-pressed=true) — matches the live round-trip (03_after_close).
@@ -121,3 +148,74 @@ async def test_ensure_media_gives_up_when_nothing_actionable() -> None:
     acted = await mc.ensure_media_mode(page)  # type: ignore[arg-type]
     assert acted is False
     assert page.clicks == []
+    # No toggle was clicked, so the reload rescue must not fire either.
+    assert page.reloads == 0
+
+
+@pytest.mark.asyncio
+async def test_pinned_arm_recovers_via_reload() -> None:
+    # 2026-07-17 incident shape: the toggle flips aria-pressed but the classic
+    # panel never mounts in place — only a reload (which re-rolls the arm AND
+    # mounts the server-persisted isAgentModeToggled=false) restores classic.
+    page = _FakePage("pinned")
+    acted = await mc.ensure_media_mode(page, allow_reload=True)  # type: ignore[arg-type]
+    assert acted is True
+    assert page.reloads == 1
+    assert page.state == "media"
+    assert mc.AGENT_TOGGLE_SELECTOR in page.clicks
+
+
+@pytest.mark.asyncio
+async def test_reload_requires_opt_in() -> None:
+    # Mid-flow callers (image/video mode switches after driver binding) must
+    # NEVER get a surprise navigation — reload is opt-in for the pre-bind
+    # get_ui_driver path only.
+    page = _FakePage("pinned")
+    await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert page.reloads == 0
+    assert page.state == "pinned_off"  # toggle still clicked (old semantics)
+
+
+@pytest.mark.asyncio
+async def test_clean_toggle_does_not_reload() -> None:
+    page = _FakePage("agent")
+    await mc.ensure_media_mode(page, allow_reload=True)  # type: ignore[arg-type]
+    assert page.reloads == 0
+
+
+@pytest.mark.asyncio
+async def test_force_fallback_does_not_arm_reload() -> None:
+    # Unforced click fails WITHOUT dispatching → force fallback lands the DOM
+    # flip, but nothing was persisted server-side — the reload premise is
+    # false, so no navigation may fire even with allow_reload=True.
+    page = _FakePage("pinned", raise_unforced_click="before")
+    await mc.ensure_media_mode(page, allow_reload=True)  # type: ignore[arg-type]
+    assert any(kw.get("force") for kw in page.click_kwargs)  # fallback used
+    assert page.reloads == 0
+    assert page.state == "pinned_off"
+
+
+@pytest.mark.asyncio
+async def test_post_dispatch_click_failure_never_double_clicks() -> None:
+    # Playwright can raise AFTER the click events dispatched. A blind force
+    # fallback would click the now-OFF toggle and re-enable agent mode; the
+    # fallback must re-read aria-pressed first.
+    page = _FakePage("agent", raise_unforced_click="after")
+    await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    assert page.state == "media"
+    assert page.clicks == [mc.AGENT_TOGGLE_SELECTOR]  # exactly one dispatch
+    assert not any(kw.get("force") for kw in page.click_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_toggle_click_is_unforced() -> None:
+    # force=True bypasses actionability AND can skip the React handler that
+    # fires the persisting tRPC mutation — the toggle must get a real click.
+    page = _FakePage("agent")
+    await mc.ensure_media_mode(page)  # type: ignore[arg-type]
+    toggle_kwargs = [
+        kw
+        for sel, kw in zip(page.clicks, page.click_kwargs, strict=True)
+        if sel == mc.AGENT_TOGGLE_SELECTOR
+    ]
+    assert toggle_kwargs and all(not kw.get("force") for kw in toggle_kwargs)

--- a/tests/api/transports/test_selector_symmetry.py
+++ b/tests/api/transports/test_selector_symmetry.py
@@ -40,3 +40,14 @@ def test_ui_automation_reuses_factory_tune_selector() -> None:
     # ``is`` (not ``==``): ui_automation must import the factory constant, not
     # carry an equal-looking local copy that can silently drift.
     assert ui_automation.AGENT_TUNE_INDICATOR_SELECTOR is AGENT_TUNE_INDICATOR_SELECTOR
+
+
+def test_factory_crop_detector_is_mode_control_canonical() -> None:
+    # The crop tuples had drifted (mode_control probed 2 icons, factory 6) —
+    # the 2026-07-17 pin incident's controller/verify asymmetry. Canonical lives
+    # in mode_control (the leaf); factory must import it, never redefine.
+    from gflow_cli.api.transports import mode_control
+    from gflow_cli.api.transports.drivers import factory
+
+    assert factory._CLASSIC_CROP_SELECTORS is mode_control.CROP_SELECTORS  # noqa: SLF001
+    assert len(mode_control.CROP_SELECTORS) == 6

--- a/uv.lock
+++ b/uv.lock
@@ -787,7 +787,7 @@ wheels = [
 
 [[package]]
 name = "gflow-cli"
-version = "0.38.0"
+version = "0.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Problem

2026-07-17: both accounts were served the agentic arm on every page load for 2+ hours. The #332 controller pressed the Agent toggle honestly but the classic panel never mounted (`mode_control.ensure_media_incomplete`) — stills production fully blocked.

Per `docs/superpowers/spikes/2026-07-12-ui-cohort-backend-config.md`, the effective arm is `experiment_override ?? user_setting(isAgentModeToggled)` — server-persisted per user. A REAL toggle click persists `isAgentModeToggled=false`; a fresh page load then mounts the persisted preference (and re-rolls the per-load arm besides).

## Fix

- `ensure_media_mode(page, allow_reload=False)`: after a real (unforced) toggle click that fails to restore the panel, ONE `page.reload()` + second recovery round. **Opt-in**: only `get_ui_driver`'s pre-bind CLASSIC path sanctions it (it re-verifies the cohort after any navigation); mid-flow image/video mode switches keep strict no-navigation semantics — their bound driver's cohort must not be re-rolled underneath them.
- 4s grace poll before any reload (slow in-place mounts were previously absorbed by callers' 4s trigger probes — no needless navigations).
- Composer-readiness poll (8s) after the reload replaces the fixed 1.2s settle — the SPA mounts the composer well after `load`; without it the rescue defeats itself and `detect_ui_mode` can misclassify a half-rendered page.
- Unforced-first toggle click: `force=True` can flip the DOM node without firing the React handler that persists the setting. Force fallback re-reads `aria-pressed` first (Playwright can raise AFTER dispatch; a blind second click re-enables agent mode) and never arms the reload.
- Crop-selector canonicalization: `mode_control` probed 2 of 6 `crop_*` icons vs factory's 6 — the canonical 6-icon tuple now lives in `mode_control` (the leaf) and factory imports it; `test_selector_symmetry` locks the identity.

## Docs

CHANGELOG 0.38.1 entry; `ensure_media_mode` + factory docstrings updated (navigation caveat, dependency-direction rule). Known accepted caveat documented: a reload can resurface the issue-#26 overlay (reachable only on the previously-hard-blocked path).

## Tests

9 mode-control unit tests (pinned-arm reload, opt-in gating, force-fallback no-reload, post-dispatch no-double-click, unforced click) + crop symmetry lock. Full transports suite: 549 passed. Impeccable Routine green (hygiene, doc-links, ruff, pyright, pytest).