### PR TITLE
feat(data): persist failed generations — error tracking as a first-class DB citizen (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Failed generations are now persisted to the local catalog** ([#341]):
+  every paid-generation path (`video t2v/i2v/r2v`, `video chain`,
+  `image t2i/i2i`, multi-prompt t2i, `gflow run`, `image batch`, `movie run`,
+  and the async worker) records a terminal `status="failed"` operation row —
+  with a stable `error_type` derived from the exception's RFC 9457
+  `problem_type` (`waf-rejection`, `content-policy`, `auth-expired`, ...) and
+  a redacted `error_detail` — before the error propagates. WAF-403 block
+  onset, duration, and recovery windows are now measurable instead of
+  reconstructed from memory.
+- New `gflow data list errors [--profile] [--limit] [--offset] [--json]`
+  subcommand: browse failed operations newest-first (Rich table on a TTY,
+  JSONL otherwise).
+
+### Security
+
+- `error_detail` values are scrubbed before persistence
+  (`Bearer`/`SAPISIDHASH` tokens, auth-cookie pairs, signed URLs; 500-char
+  cap) and non-`GFlowError` messages are stored only as SHA-256 hashes.
+  Prompts on failed rows honor `GFLOW_CLI_HISTORY_PROMPTS`; note `store` mode
+  therefore also stores prompts of content-policy-rejected generations.
+- The experimental REST transports (`bearer`, `sapisidhash`,
+  `evaluate_fetch`) now redact response bodies BEFORE truncating them into
+  exception messages, closing a partial-secret leak into logs and (new) the
+  catalog DB.
+
+[#341]: https://github.com/ffroliva/gflow-cli/issues/341
+
 ## [0.38.1] — 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `gflow data list errors [--profile] [--limit] [--offset] [--json]`
   subcommand: browse failed operations newest-first (Rich table on a TTY,
   JSONL otherwise).
+- Videos whose poll completes with a Flow-reported failure
+  (`succeeded=false`, e.g. `PUBLIC_ERROR_UNSAFE_GENERATION`) are now recorded
+  as `failed` with `error_type=generation-failed` — previously they were
+  recorded as `succeeded` (all paths: CLI, chain, movie, worker).
 
 ### Security
 
@@ -33,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `evaluate_fetch`) now redact response bodies BEFORE truncating them into
   exception messages, closing a partial-secret leak into logs and (new) the
   catalog DB.
+- The worker queue's `generation_queue.error_json` now applies the same
+  redaction: `GFlowError` details are scrubbed and non-`GFlowError` messages
+  are stored as SHA-256 hashes instead of raw text.
 
 [#341]: https://github.com/ffroliva/gflow-cli/issues/341
 

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -133,6 +133,31 @@ For T2V the sequence is split: `record_started_video(...)` fires the moment the 
 
 For batches, each row is recorded individually in a per-row `try/except DataStoreError`, so one row's persistence failure does not stop the rest of the batch.
 
+### Failure recording (#341, v0.39.0+)
+
+Failed generations are first-class catalog citizens: every paid-generation
+orchestrator records a terminal `status="failed"` operation row before
+re-raising the error. The funnel covers `video t2v/i2v/r2v`, `video chain`
+(per-link, via the `on_link_failed` hook), `image t2i/i2i`, multi-prompt
+t2i / `gflow run` / `image batch` manifest rows, `movie run` scenes, and the
+async worker (which mirrors its `generation_queue.error_json` failure into
+`operations` — the operations table owns terminal truth).
+
+- `error_type` is the last segment of the exception's RFC 9457 `problem_type`
+  URI (`waf-rejection`, `content-policy`, `auth-expired`,
+  `transport-timeout`, ...) — the taxonomy is declared per `GFlowError`
+  subclass, never hand-mapped. Non-`GFlowError` exceptions store the class
+  name, with `error_detail` reduced to a SHA-256 hash of the message (never
+  the text — it may carry tokens).
+- Video failures UPDATE the `on_started` STARTED row to `failed` (mirroring
+  `record_completed_video`); failures before `on_started`, and all image
+  failures, INSERT a fresh row with full request metadata.
+- The write itself is best-effort: `record_failed_operation_safe` wraps it in
+  a broad warn-only guard (`failure_record_skipped` structlog event) so a
+  data-layer fault can never mask the generation error or change the exit code.
+- The character-create saga deliberately keeps its STARTED rows for resume —
+  it is excluded from the failure funnel by design.
+
 ---
 
 ## Persistence-failure handling
@@ -179,6 +204,20 @@ The hash is always stored so you can correlate without the plaintext.
 
 This means the recorder OWNS redaction — call sites cannot leak signed URLs into the DB even by accident, because `OperationRecorder` always pipes metadata through `redact_metadata` before writing.
 
+### `error_detail` redaction (#341)
+
+Failure rows persist the exception's Problem-Details `detail` string through
+[`redact_error_detail`](../src/gflow_cli/data/redaction.py): free-text
+`Bearer …` / `SAPISIDHASH …` tokens and auth-cookie pairs become
+`<redacted:secret>`, URLs carrying signed-query markers become
+`<redacted:url>`, and the result is truncated to 500 chars post-redaction as
+defense-in-depth. The experimental REST transports also redact response bodies
+BEFORE truncating them into exception messages, so a clipped secret can't
+reach the DB. Non-`GFlowError` details are stored only as SHA-256 hashes.
+Prompts on FAILED rows honor `GFLOW_CLI_HISTORY_PROMPTS` exactly like success
+rows — note that in `store` mode this includes prompts of content-policy
+REJECTED generations (the same opt-in that stores successful prompts).
+
 ### What the DB still contains
 
 Even with `redacted` mode and metadata stripping, the DB stores: profile names, Flow project/media/workflow/operation IDs, local file paths or cloud URIs, asset dimensions/seeds/timestamps, model and aspect choices, and prompt hashes. If your threat model requires hiding even profile-level activity, exclude `<GFLOW_CLI_HOME>/gflow.db` from backups or set `GFLOW_CLI_DB_PATH` to a per-task ephemeral location.
@@ -189,7 +228,7 @@ See [`SECURITY.md`](SECURITY.md) for the broader threat model.
 
 ## Querying the data layer
 
-### `gflow data list {projects,images,videos,profiles}` — browse the catalog (v0.9.0+)
+### `gflow data list {projects,images,videos,profiles,errors}` — browse the catalog (v0.9.0+)
 
 ```bash
 # Newest 20 projects across all profiles
@@ -206,9 +245,14 @@ gflow data list videos --json | jq '.media_id'
 
 # Profiles with at least one recorded generation
 gflow data list profiles
+
+# Failed generations, newest first (#341): when, which command/mode/model,
+# stable error_type (waf-rejection, content-policy, ...) + redacted detail.
+# The dataset for WAF-cadence and reliability analysis.
+gflow data list errors --profile denon82 --json | jq '{started_at, error_type}'
 ```
 
-Flags shared by all four subcommands:
+Flags shared by all five subcommands:
 
 | Flag | Default | Notes |
 |---|---|---|
@@ -391,6 +435,13 @@ All three errors map to **exit code 16**:
 All three are subclasses of `GFlowError` and re-exported through `gflow_cli.exceptions`. They follow the project's RFC 9457 Problem Details pattern.
 
 See [`errors.py::EXIT_CODE_MAP`](../src/gflow_cli/errors.py) for the complete exit-code mapping.
+
+Distinct from the above (which are errors OF the data layer), the
+`operations.error_type` column stores the taxonomy of RECORDED generation
+failures — the last segment of each exception's `problem_type` URI. Common
+values: `waf-rejection` (HTTP 403 / WAF), `content-policy`, `auth-expired`,
+`transport-timeout`, `wire-format`, `rate-limit`, `ui-mode-unavailable`
+(cohort pin), `media-attribution`. Query them with `gflow data list errors`.
 
 ---
 

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -149,9 +149,13 @@ async worker (which mirrors its `generation_queue.error_json` failure into
   subclass, never hand-mapped. Non-`GFlowError` exceptions store the class
   name, with `error_detail` reduced to a SHA-256 hash of the message (never
   the text — it may carry tokens).
-- Video failures UPDATE the `on_started` STARTED row to `failed` (mirroring
-  `record_completed_video`); failures before `on_started`, and all image
-  failures, INSERT a fresh row with full request metadata.
+- Video failures UPDATE every `on_started` STARTED row to `failed` (a
+  `count>1` request fires the callback per output — no sibling row is
+  stranded); failures before `on_started`, and all image failures, INSERT a
+  fresh row with full request metadata.
+- A poll that COMPLETES with a Flow-reported failure (`succeeded=false`) is
+  recorded as `failed` with `error_type=generation-failed` and the
+  `failure_reasons` as detail — not as a success.
 - The write itself is best-effort: `record_failed_operation_safe` wraps it in
   a broad warn-only guard (`failure_record_skipped` structlog event) so a
   data-layer fault can never mask the generation error or change the exit code.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -888,6 +888,7 @@ gflow data list projects   [--profile NAME] [--limit N] [--offset N] [--json]
 gflow data list images     [--profile NAME] [--limit N] [--offset N] [--json] [--all-copies]
 gflow data list videos     [--profile NAME] [--limit N] [--offset N] [--json] [--all-copies]
 gflow data list profiles                    [--limit N] [--offset N] [--json]
+gflow data list errors     [--profile NAME] [--limit N] [--offset N] [--json]
 
 Options:
   --profile NAME        Filter to one profile (not available on `profiles`).
@@ -925,7 +926,18 @@ gflow data list videos --json | jq '.media_id'
 
 # Profiles with at least one recorded generation
 gflow data list profiles
+
+# Failed generations, newest first (v0.39.0+, #341): started_at, command, mode,
+# model, profile, error_type (waf-rejection, content-policy, ...), redacted detail
+gflow data list errors --profile denon82 --json | jq '{started_at, error_type}'
 ```
+
+`errors` lists terminal `status="failed"` operation rows — every paid
+generation that raised (WAF 403, content policy, cohort pin, timeout, auth)
+is recorded before the CLI exits, so block onset/recovery windows are
+measurable. `error_detail` is redacted before persistence (no tokens, cookies,
+or signed URLs). See
+[`DATA_LAYER.md § Failure recording`](DATA_LAYER.md#failure-recording-341-v0390).
 
 > **`data list profiles` vs `gflow auth list`** — `data list profiles` shows profiles that have **recorded generations** in the catalog; `gflow auth list` shows profiles that have ever **logged in** via `gflow auth login`. A profile that logged in but never generated anything will appear in `auth list` but not in `data list profiles`.
 

--- a/docs/superpowers/plans/2026-07-18-issue-341-error-tracking/PLAN.md
+++ b/docs/superpowers/plans/2026-07-18-issue-341-error-tracking/PLAN.md
@@ -1,0 +1,68 @@
+# PLAN — Issue #341: persist failed generations (error tracking as a first-class DB citizen)
+
+**Date:** 2026-07-18 · **Branch:** `feature/issue-341-error-tracking` · **Base:** `develop`
+**Predict verdict:** GO-with-conditions (council: Architect GO 7, Security CAUTION 8, Perf/UX GO 8, Devil's Advocate CAUTION 8)
+
+## Goal
+
+Every failed paid generation writes a terminal `FAILED` row to the `operations` table
+(`error_type` + redacted `error_detail`), queryable via `gflow data list errors`, so WAF-403
+cadence, cohort pins, and policy rejections become measurable instead of folkloric.
+
+## Council-locked design decisions
+
+- **Taxonomy = existing RFC 9457 `problem_type`.** `error_type` is the last URI segment of
+  `exc.problem_type` (`waf-rejection`, `content-policy`, `auth-expired`, …). Non-`GFlowError`
+  → `error_type = type(exc).__name__`, `error_detail` = SHA-256 hash (never `str(exc)`).
+  No hand-rolled slug map (drift risk).
+- **Record-on-catch at the orchestrator choke points, then re-raise.** No STARTED-first
+  rewrite of the image hot path. FAILED write guarded by `try/except DataStoreError` →
+  warn-only (existing idiom), so failure-recording can never mask the generation error.
+- **Video**: STARTED row may exist (via `on_started`) — mirror `record_completed_video`:
+  `get_operation_for_output_asset` → `update_operation_status(FAILED)`; else INSERT.
+  Early failures (before `on_started`) INSERT a fresh FAILED row.
+- **Images/batch/movie**: no pre-existing row — always INSERT with full request metadata.
+- **Character saga excluded** — `services/character_create.py` deliberately keeps STARTED
+  rows for resume; do NOT wire FAILED there.
+- **Redaction (testable requirements):** `error_detail` passes through a new free-text scrub
+  (`Bearer …`, `SAPISIDHASH …`, session-token/SAPISID cookie pairs, signed-URL query keys)
+  then truncates to 500 chars; prompts on FAILED rows go through the same
+  `_resolve_prompts`/`prompt_fields(mode=…)` path as success rows; the Rich table escapes
+  markup; the read path only ever reads the persisted column. Fix the pre-existing
+  unredacted `text[:200]` interpolation in `api/transports/_common.py::interpret_response`
+  in the same PR (issue #341 upgrades its blast radius to a durable queryable row).
+- **Surface = `gflow data list errors`** (consistent with `list projects/images/videos/profiles`,
+  same `_PROFILE_OPT/_LIMIT_OPT/_OFFSET_OPT/_JSON_OPT/@_guard/_emit` conventions). The issue's
+  `gflow data errors` example is satisfied by the `list` subgroup placement. MCP parity via
+  `_MCP_EXEMPT` entry in `tests/mcp/test_cli_parity.py` (merge gate).
+- **No schema migration** (columns exist), **no status index** (~400 rows), **deferred**:
+  retention/export, structured external failure events, `attempt_index`/`waf_recovery_seconds`/
+  `retryable` columns, `image upscale` path. Documented in PR as explicit descopes.
+
+## Verified paid-generation funnel coverage (Devil's Advocate audit)
+
+| Path | Site of FAILED write |
+|---|---|
+| `video t2v/i2v/r2v` | `cli_video.py::_generate_and_report` |
+| `video chain` | `cli_video.py` chain `ChainPartialError`/failure handler (NOT `chain.py`) |
+| `image t2i` / `i2i` (single) | `cli_image.py::_run_t2i` / `_run_i2i` |
+| `image t2i` multi-prompt + `gflow run` | `image_batch.py` per-prompt failure path |
+| `image batch <manifest>` | `image_batch.py` manifest failed-row path |
+| `movie run` scene | `cli_movie.py` scene failure handler |
+| MCP generate (queue) | `worker/daemon.py::process_task` except block |
+| `scene create`, `character`, `upscale` | excluded (credit-free / saga / descoped) |
+
+## Tasks
+
+- [ ] T1 Redaction: `redact_error_detail()` in `data/redaction.py` + tests (Bearer/SAPISIDHASH/
+      cookie/signed-URL scrub, 500-char truncate)
+- [ ] T2 Recorder: `OperationRecorder.record_failed_operation(...)` + tests (GFlowError slug,
+      non-GFlowError hash, prompt-mode honored, video UPDATE-vs-INSERT, warn-only wrapper helper)
+- [ ] T3 Transport hardening: redact-before-truncate in `api/transports/_common.py::interpret_response`
+      + test (Bearer token in response body never reaches exception detail)
+- [ ] T4 Read path: `queries.list_errors()` + `OperationErrorRow` + tests
+- [ ] T5 CLI: `gflow data list errors` + `_emit_errors_table` (markup-escaped) + tests + `_MCP_EXEMPT`
+- [ ] T6 Wire call sites: video, chain, t2i, i2i, image_batch (×2), movie, worker daemon + per-family tests
+- [ ] T7 Docs: DATA_LAYER.md (recording flow, querying, redaction incl. store-mode covers refused
+      prompts), USAGE.md (`data list errors`), CHANGELOG `[Unreleased]`
+- [ ] T8 Gates: `/gflow:check` + council branch-review + ponytail review + PR (Refs #341)

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -81,21 +81,20 @@ def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
     """
     status: int = resp.status_code
     text: str = resp.text or ""
-    # Redact BEFORE truncating (same rationale as client._build_wire_format_discovery,
-    # audit gap #11): a token clipped at char 200 is still a partial secret, and
-    # since #341 these messages persist to the catalog DB as `error_detail`.
-    snippet = redact_error_detail(text)[:200]
 
     if status == 200:
         try:
             payload = json.loads(text)
         except json.JSONDecodeError as exc:
-            msg = f"{strategy_name}: non-JSON response body: {snippet}"
+            msg = f"{strategy_name}: non-JSON response body: {_redacted_snippet(text)}"
             raise WireFormatError(msg) from exc
 
         media = payload.get("media")
         if not isinstance(media, list):
-            msg = f"{strategy_name}: missing or invalid 'media' list in response: {snippet}"
+            msg = (
+                f"{strategy_name}: missing or invalid 'media' list in response: "
+                f"{_redacted_snippet(text)}"
+            )
             raise WireFormatError(
                 msg,
             )
@@ -108,16 +107,31 @@ def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
         msg = f"{strategy_name}: HTTP 401 from Flow API — session expired"
         raise AuthExpiredError(msg)
     if status == 403:
-        msg = f"{strategy_name}: HTTP 403 — likely WAF/fingerprint mismatch: {snippet}"
+        msg = (
+            f"{strategy_name}: HTTP 403 — likely WAF/fingerprint mismatch: "
+            f"{_redacted_snippet(text)}"
+        )
         raise WafRejectionError(
             msg,
         )
     if status == 429:
-        msg = f"{strategy_name}: HTTP 429 — rate limit hit: {snippet}"
+        msg = f"{strategy_name}: HTTP 429 — rate limit hit: {_redacted_snippet(text)}"
         raise RateLimitError(msg)
     if status >= 500:
-        msg = f"{strategy_name}: HTTP {status} server error: {snippet}"
+        msg = f"{strategy_name}: HTTP {status} server error: {_redacted_snippet(text)}"
         raise NetworkError(msg)
 
-    msg = f"{strategy_name}: unexpected HTTP status {status}: {snippet}"
+    msg = f"{strategy_name}: unexpected HTTP status {status}: {_redacted_snippet(text)}"
     raise WireFormatError(msg)
+
+
+def _redacted_snippet(text: str) -> str:
+    """Redact-then-truncate a response body for an exception message.
+
+    Redaction runs BEFORE truncation (same rationale as
+    ``client._build_wire_format_discovery``, audit gap #11): a token clipped at
+    char 200 is still a partial secret, and since #341 these messages persist
+    to the catalog DB as ``error_detail``. Called only at raise sites so the
+    success path pays nothing.
+    """
+    return redact_error_detail(text)[:200]

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -16,6 +16,7 @@ import uuid
 from typing import Any
 
 from gflow_cli.api.dto import GeneratedImage
+from gflow_cli.data.redaction import redact_error_detail
 from gflow_cli.errors import (
     AuthExpiredError,
     ContentPolicyError,
@@ -80,17 +81,21 @@ def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
     """
     status: int = resp.status_code
     text: str = resp.text or ""
+    # Redact BEFORE truncating (same rationale as client._build_wire_format_discovery,
+    # audit gap #11): a token clipped at char 200 is still a partial secret, and
+    # since #341 these messages persist to the catalog DB as `error_detail`.
+    snippet = redact_error_detail(text)[:200]
 
     if status == 200:
         try:
             payload = json.loads(text)
         except json.JSONDecodeError as exc:
-            msg = f"{strategy_name}: non-JSON response body: {text[:200]}"
+            msg = f"{strategy_name}: non-JSON response body: {snippet}"
             raise WireFormatError(msg) from exc
 
         media = payload.get("media")
         if not isinstance(media, list):
-            msg = f"{strategy_name}: missing or invalid 'media' list in response: {text[:200]}"
+            msg = f"{strategy_name}: missing or invalid 'media' list in response: {snippet}"
             raise WireFormatError(
                 msg,
             )
@@ -103,16 +108,16 @@ def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
         msg = f"{strategy_name}: HTTP 401 from Flow API — session expired"
         raise AuthExpiredError(msg)
     if status == 403:
-        msg = f"{strategy_name}: HTTP 403 — likely WAF/fingerprint mismatch: {text[:200]}"
+        msg = f"{strategy_name}: HTTP 403 — likely WAF/fingerprint mismatch: {snippet}"
         raise WafRejectionError(
             msg,
         )
     if status == 429:
-        msg = f"{strategy_name}: HTTP 429 — rate limit hit: {text[:200]}"
+        msg = f"{strategy_name}: HTTP 429 — rate limit hit: {snippet}"
         raise RateLimitError(msg)
     if status >= 500:
-        msg = f"{strategy_name}: HTTP {status} server error: {text[:200]}"
+        msg = f"{strategy_name}: HTTP {status} server error: {snippet}"
         raise NetworkError(msg)
 
-    msg = f"{strategy_name}: unexpected HTTP status {status}: {text[:200]}"
+    msg = f"{strategy_name}: unexpected HTTP status {status}: {snippet}"
     raise WireFormatError(msg)

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -64,6 +64,7 @@ __all__ = [
     "ChainRecorder",
     "FrameExtractor",
     "LinkCompletedHook",
+    "LinkFailedHook",
     "LinkStartedHook",
     "run_chain",
 ]
@@ -157,6 +158,19 @@ class LinkCompletedHook(Protocol):
     def __call__(self, request: GenerateVideoRequest, result: VideoResult) -> None: ...
 
 
+class LinkFailedHook(Protocol):
+    """Hook called when a link's ``generate_video`` raises (#341).
+
+    Receives the link's own request + the exception BEFORE the orchestrator
+    wraps/re-raises it, so the CLI can persist a FAILED catalog row with full
+    request context. The implementation MUST absorb its own persistence
+    failures — it runs on the error path and must never mask the original
+    exception; the orchestrator does not guard the call.
+    """
+
+    def __call__(self, request: GenerateVideoRequest, exc: BaseException) -> None: ...
+
+
 def _build_link_request(
     *,
     spec: ChainLinkSpec,
@@ -187,12 +201,17 @@ async def _generate_link(
     index: int,
     completed_paths: list[Path],
     on_link_started: LinkStartedHook | None,
+    on_link_failed: LinkFailedHook | None,
 ) -> VideoResult:
     """Call generate_video for one link; raise ChainPartialError on abort."""
     link_on_started = on_link_started(req) if on_link_started is not None else None
     try:
         return await client.generate_video(req=req, on_started=link_on_started)
-    except (WireFormatError, WafRejectionError) as exc:
+    except Exception as exc:
+        if on_link_failed is not None:
+            on_link_failed(req, exc)
+        if not isinstance(exc, WireFormatError | WafRejectionError):
+            raise
         _log.warning(
             "chain_link_aborted",
             index=index,
@@ -238,6 +257,7 @@ async def run_chain(
     recorder: ChainRecorder | None = None,
     on_link_started: LinkStartedHook | None = None,
     on_link_completed: LinkCompletedHook | None = None,
+    on_link_failed: LinkFailedHook | None = None,
     aspect: Aspect = Aspect.PORTRAIT,
     seed_offset_ms: int = 0,
     jitter: float = 0.0,
@@ -306,6 +326,7 @@ async def run_chain(
             index=index,
             completed_paths=completed_paths,
             on_link_started=on_link_started,
+            on_link_failed=on_link_failed,
         )
 
         if result.local_path is None:

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -208,8 +208,7 @@ async def _generate_link(
     try:
         return await client.generate_video(req=req, on_started=link_on_started)
     except Exception as exc:
-        if on_link_failed is not None:
-            on_link_failed(req, exc)
+        _notify_link_failed(on_link_failed, req, exc)
         if not isinstance(exc, WireFormatError | WafRejectionError):
             raise
         _log.warning(
@@ -223,6 +222,26 @@ async def _generate_link(
             partial_results=list(completed_paths),
             cause=exc,
         ) from exc
+
+
+def _notify_link_failed(
+    hook: LinkFailedHook | None,
+    req: GenerateVideoRequest,
+    exc: BaseException,
+) -> None:
+    """Invoke the failure hook, absorbing ITS failures (#341 review finding).
+
+    The hook runs on the error path; letting a hook exception propagate would
+    replace the original error and skip the ChainPartialError partial-results
+    contract, so the orchestrator enforces the absorb rule at the seam instead
+    of trusting every hook implementer.
+    """
+    if hook is None:
+        return
+    try:
+        hook(req, exc)
+    except Exception as hook_exc:  # noqa: BLE001 — double-fault guard, see docstring
+        _log.warning("chain_link_failed_hook_error", error=str(hook_exc))
 
 
 def _build_link_result(
@@ -331,7 +350,12 @@ async def run_chain(
 
         if result.local_path is None:
             msg = f"link {index} returned no local_path (download failed)"
-            raise ChainPartialError(detail=msg, partial_results=list(completed_paths))
+            exc = ChainPartialError(detail=msg, partial_results=list(completed_paths))
+            # #341: this abort path must also reach the failure hook, else the
+            # link's STARTED catalog row is stranded and the abort is invisible
+            # to `gflow data list errors`.
+            _notify_link_failed(on_link_failed, req, exc)
+            raise exc
 
         is_last = index == len(links) - 1
 

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -18,9 +18,11 @@ from gflow_cli.config import get_settings
 from gflow_cli.data.models import AssetLookup
 from gflow_cli.data.queries import (
     ImageRow,
+    OperationErrorRow,
     ProfileRow,
     ProjectRow,
     VideoRow,
+    list_errors,
     list_images,
     list_profiles,
     list_projects,
@@ -148,6 +150,28 @@ def _emit_videos_table(rows: list[VideoRow]) -> None:
             r.created_at.strftime("%Y-%m-%d %H:%M"),
             str(r.copy_count),
             r.local_path or "",
+        )
+    Console().print(tbl)
+
+
+def _emit_errors_table(rows: list[OperationErrorRow]) -> None:
+    # error_type / error_detail / command originate from exception text —
+    # escape so bracketed content can't be parsed as Rich markup (#341,
+    # prior Console(markup=True) incident class).
+    from rich.markup import escape
+
+    tbl = Table(show_header=True, header_style="bold")
+    for col in ("STARTED", "COMMAND", "MODE", "MODEL", "PROFILE", "ERROR_TYPE", "ERROR_DETAIL"):
+        tbl.add_column(col)
+    for r in rows:
+        tbl.add_row(
+            r.started_at.strftime("%Y-%m-%d %H:%M"),
+            escape(r.command or ""),
+            r.mode,
+            r.model or "",
+            r.profile,
+            escape(r.error_type or ""),
+            escape(_truncate(r.error_detail)),
         )
     Console().print(tbl)
 
@@ -391,6 +415,23 @@ def list_videos_cmd(
         all_copies=all_copies,
     )
     _emit(rows, as_json, _emit_videos_table, "No videos recorded.")
+
+
+@list_group.command(name="errors")
+@_PROFILE_OPT
+@_LIMIT_OPT
+@_OFFSET_OPT
+@_JSON_OPT
+@_guard
+def list_errors_cmd(profile: str | None, limit: int, offset: int, as_json: bool) -> None:
+    """List failed generation operations newest-first (#341).
+
+    Shows when each failure happened, which command/mode/model it hit, and the
+    stable error_type (waf-rejection, content-policy, ...) plus redacted
+    detail — the dataset for WAF-cadence and reliability analysis.
+    """
+    rows = list_errors(db_path=_db_path(), profile=profile, limit=limit, offset=offset)
+    _emit(rows, as_json, _emit_errors_table, "No failed operations recorded.")
 
 
 @list_group.command(name="profiles")

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from gflow_cli._cli_helpers import run_with_handlers, safe_path_text
@@ -155,11 +156,6 @@ def _emit_videos_table(rows: list[VideoRow]) -> None:
 
 
 def _emit_errors_table(rows: list[OperationErrorRow]) -> None:
-    # error_type / error_detail / command originate from exception text —
-    # escape so bracketed content can't be parsed as Rich markup (#341,
-    # prior Console(markup=True) incident class).
-    from rich.markup import escape
-
     tbl = Table(show_header=True, header_style="bold")
     for col in ("STARTED", "COMMAND", "MODE", "MODEL", "PROFILE", "ERROR_TYPE", "ERROR_DETAIL"):
         tbl.add_column(col)

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -164,12 +164,14 @@ def _emit_errors_table(rows: list[OperationErrorRow]) -> None:
     for col in ("STARTED", "COMMAND", "MODE", "MODEL", "PROFILE", "ERROR_TYPE", "ERROR_DETAIL"):
         tbl.add_column(col)
     for r in rows:
+        # Every column comes from the persisted DB, not live enums — escape
+        # them all so bracketed content can't be parsed as Rich markup.
         tbl.add_row(
             r.started_at.strftime("%Y-%m-%d %H:%M"),
             escape(r.command or ""),
-            r.mode,
-            r.model or "",
-            r.profile,
+            escape(r.mode),
+            escape(r.model or ""),
+            escape(r.profile),
             escape(r.error_type or ""),
             escape(_truncate(r.error_detail)),
         )

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -51,7 +51,12 @@ from gflow_cli.api.image_upscale import TargetResolution, UpsampleImageRequest
 from gflow_cli.api.transports import transport_choices
 from gflow_cli.api.video import is_media_uuid
 from gflow_cli.config import UiMode, get_settings, parse_jitter_range
-from gflow_cli.data.recorder import OperationRecorder, escalate_asset_collision
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.recorder import (
+    OperationRecorder,
+    escalate_asset_collision,
+    record_failed_operation_safe,
+)
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import (
@@ -1104,6 +1109,20 @@ async def _run_t2i(
                 input_media_ids=[],
                 operation_kind="t2i",
             )
+    except Exception as exc:
+        # #341: persist the failure before re-raising (images have no STARTED
+        # pre-insert, so this is always a fresh FAILED row).
+        record_failed_operation_safe(
+            recorder,
+            logger=logger,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=exc,
+            request=req,
+        )
+        raise
     finally:
         recorder.close()
 
@@ -1483,6 +1502,7 @@ async def _run_i2i(
 ) -> None:
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
+    req: GenerateImageRequest | None = None
     try:
         async with FlowApiClient(
             profile_dir=profile_dir,
@@ -1569,6 +1589,20 @@ async def _run_i2i(
                 input_media_ids=[ref.name for ref in uuid_refs],
                 operation_kind="i2i",
             )
+    except Exception as exc:
+        # #341: persist the failure before re-raising. ``req`` is None when the
+        # failure predates request construction (e.g. project resolution).
+        record_failed_operation_safe(
+            recorder,
+            logger=logger,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command="image i2i",
+            mode=OperationKind.I2I,
+            exc=exc,
+            request=req,
+        )
+        raise
     finally:
         recorder.close()
 

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -923,6 +923,7 @@ def _execute_t2i_batch(
                 jitter_range=jitter_range,
                 _profile_name=profile_name,
                 _recorder=recorder,
+                _command="image t2i",
             ),
         )
     finally:

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -884,7 +884,7 @@ async def _generate_scene(
             exc=exc,
             request=request,
             flow_project_id=project_id,
-            flow_media_id=started_media_ids[-1] if started_media_ids else None,
+            flow_media_ids=started_media_ids,
         )
         raise
 

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -48,7 +48,8 @@ from gflow_cli.composition import (
     resume_hash,
 )
 from gflow_cli.config import get_settings
-from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.recorder import OperationRecorder, record_failed_operation_safe
 from gflow_cli.errors import ConfigurationError, DataStoreError, WireFormatError
 from gflow_cli.movie_manifest import (
     CharacterState,
@@ -848,7 +849,10 @@ async def _generate_scene(
         reference_entity_names=reference_entity_names,
     )
 
+    started_media_ids: list[str] = []
+
     def on_started(started: VideoStarted) -> None:
+        started_media_ids.append(started.media_id)
         try:
             recorder.record_started_video(
                 profile_name=profile_name,
@@ -859,13 +863,30 @@ async def _generate_scene(
         except DataStoreError as exc:
             log.warning("movie.persistence_failed_on_start", error=str(exc))
 
-    result = await client.generate_video(
-        req=request,
-        project_id=project_id,
-        out_dir=out_dir,
-        download=True,
-        on_started=on_started,
-    )
+    try:
+        result = await client.generate_video(
+            req=request,
+            project_id=project_id,
+            out_dir=out_dir,
+            download=True,
+            on_started=on_started,
+        )
+    except Exception as exc:
+        # #341: persist the scene failure before the per-scene handler in
+        # `_run_one_scene` decides continue-vs-abort.
+        record_failed_operation_safe(
+            recorder,
+            logger=log,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command="movie run",
+            mode=OperationKind(mode.value),
+            exc=exc,
+            request=request,
+            flow_project_id=project_id,
+            flow_media_id=started_media_ids[-1] if started_media_ids else None,
+        )
+        raise
 
     try:
         recorder.record_completed_video(

--- a/src/gflow_cli/cli_run.py
+++ b/src/gflow_cli/cli_run.py
@@ -26,6 +26,7 @@ from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.transports import EXPERIMENTAL_TRANSPORTS
 from gflow_cli.config import get_settings
+from gflow_cli.data.recorder import OperationRecorder
 from gflow_cli.errors import ConfigurationError
 from gflow_cli.image_batch import (
     MAX_PROMPTS,
@@ -180,6 +181,8 @@ async def _run_batch(
     prompts: tuple[BatchPromptItem, ...],
     output_dir: Path,
     continue_on_error: bool,
+    profile_name: str | None = None,
+    recorder: OperationRecorder | None = None,
 ) -> list[BatchOutcome]:
     """Run ``prompts`` sequentially through ONE FlowApiClient session.
 
@@ -197,6 +200,9 @@ async def _run_batch(
         continue_on_error=continue_on_error,
         project_title="gflow-cli run",
         client_factory=FlowApiClient,
+        _profile_name=profile_name,
+        _recorder=recorder,
+        _command="run",
     )
     return outcomes
 
@@ -267,16 +273,22 @@ def run(
     if not continue_on_error:
         console.print("  mode: [yellow]fail-fast[/yellow]")
 
-    outcomes = asyncio.run(
-        _run_batch(
-            profile_dir=provider_dir,
-            headless=settings.headless,
-            transport=cfg.transport,
-            prompts=cfg.prompts,
-            output_dir=output_dir,
-            continue_on_error=continue_on_error,
-        ),
-    )
+    recorder = OperationRecorder.open(settings)
+    try:
+        outcomes = asyncio.run(
+            _run_batch(
+                profile_dir=provider_dir,
+                headless=settings.headless,
+                transport=cfg.transport,
+                prompts=cfg.prompts,
+                output_dir=output_dir,
+                continue_on_error=continue_on_error,
+                profile_name=profile_name,
+                recorder=recorder,
+            ),
+        )
+    finally:
+        recorder.close()
     exit_code = render_image_batch_summary(outcomes, title="gflow run")
     if exit_code != 0:
         sys.exit(exit_code)

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -154,7 +154,7 @@ async def _generate_and_report(
             mode=OperationKind(request.mode.value),
             exc=exc,
             request=request,
-            flow_media_id=started_media_ids[-1] if started_media_ids else None,
+            flow_media_ids=started_media_ids,
         )
         raise
     finally:
@@ -523,13 +523,17 @@ async def _execute_chain_links(
     from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStarted
     from gflow_cli.errors import ChainPartialError
 
-    started_media_by_req: dict[int, str] = {}
+    # (request, media_id) pairs — matched by object IDENTITY in _on_link_failed.
+    # A dict keyed by id(request) would hold no reference to the request, so a
+    # GC'd earlier link's address could be reused by a later link (review
+    # finding); keeping the object itself in the pair removes the hazard.
+    started_media_pairs: list[tuple[GenerateVideoRequest, str]] = []
 
     def _on_link_started(request: GenerateVideoRequest) -> Any:
         """Build the per-link ``on_started`` forwarded into ``generate_video``."""
 
         def on_started(started: VideoStarted) -> None:
-            started_media_by_req[id(request)] = started.media_id
+            started_media_pairs.append((request, started.media_id))
             try:
                 catalog_recorder.record_started_video(
                     profile_name=profile_name,
@@ -557,7 +561,7 @@ async def _execute_chain_links(
             mode=OperationKind(request.mode.value),
             exc=exc,
             request=request,
-            flow_media_id=started_media_by_req.get(id(request)),
+            flow_media_ids=[mid for req, mid in started_media_pairs if req is request],
         )
 
     def _on_link_completed(request: GenerateVideoRequest, result: VideoResult) -> None:

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -27,7 +27,8 @@ from gflow_cli._cli_helpers import (
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.video import VideoModel, is_media_uuid, reference_cap_for
 from gflow_cli.config import get_settings
-from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.recorder import OperationRecorder, record_failed_operation_safe
 from gflow_cli.errors import DataStoreError
 from gflow_cli.storage import cloud_info_from_path
 
@@ -95,10 +96,12 @@ async def _generate_and_report(
         console.print("[dim]Generating video — this takes ~2 minutes…[/dim]")
     settings = get_settings()
     recorder = OperationRecorder.open(settings)
+    started_media_ids: list[str] = []
     try:
         async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
 
             def on_started(started: VideoStarted) -> None:
+                started_media_ids.append(started.media_id)
                 try:
                     recorder.record_started_video(
                         profile_name=profile_name,
@@ -139,6 +142,21 @@ async def _generate_and_report(
                 flow_media_id=result.status.media_id,
                 local_path=result.local_path,
             )
+    except Exception as exc:
+        # #341: persist the failure before re-raising — the STARTED row (if
+        # on_started fired) is updated to FAILED, else a fresh row is inserted.
+        record_failed_operation_safe(
+            recorder,
+            logger=logger,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command=f"video {request.mode.value}",
+            mode=OperationKind(request.mode.value),
+            exc=exc,
+            request=request,
+            flow_media_id=started_media_ids[-1] if started_media_ids else None,
+        )
+        raise
     finally:
         recorder.close()
 
@@ -505,10 +523,13 @@ async def _execute_chain_links(
     from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStarted
     from gflow_cli.errors import ChainPartialError
 
+    started_media_by_req: dict[int, str] = {}
+
     def _on_link_started(request: GenerateVideoRequest) -> Any:
         """Build the per-link ``on_started`` forwarded into ``generate_video``."""
 
         def on_started(started: VideoStarted) -> None:
+            started_media_by_req[id(request)] = started.media_id
             try:
                 catalog_recorder.record_started_video(
                     profile_name=profile_name,
@@ -524,6 +545,20 @@ async def _execute_chain_links(
                 )
 
         return on_started
+
+    def _on_link_failed(request: GenerateVideoRequest, exc: BaseException) -> None:
+        """Persist a FAILED catalog row for the aborted link (#341)."""
+        record_failed_operation_safe(
+            catalog_recorder,
+            logger=logger,
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command="video chain",
+            mode=OperationKind(request.mode.value),
+            exc=exc,
+            request=request,
+            flow_media_id=started_media_by_req.get(id(request)),
+        )
 
     def _on_link_completed(request: GenerateVideoRequest, result: VideoResult) -> None:
         """Finalize the catalog row for a downloaded link."""
@@ -559,6 +594,7 @@ async def _execute_chain_links(
             recorder=recorder,
             on_link_started=_on_link_started,
             on_link_completed=_on_link_completed,
+            on_link_failed=_on_link_failed,
             aspect=aspect_enum,
             seed_offset_ms=seed_offset,
             jitter=jitter,

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -389,6 +389,82 @@ def list_videos(
     ]
 
 
+# ─── OperationErrorRow + list_errors ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class OperationErrorRow:
+    started_at: datetime
+    completed_at: datetime | None
+    profile: str
+    command: str | None
+    mode: str
+    model: str | None
+    error_type: str | None
+    error_detail: str | None
+
+
+_LIST_ERRORS_SQL = """
+    SELECT
+        o.started_at   AS started_at,
+        o.completed_at AS completed_at,
+        o.profile_name AS profile,
+        o.command      AS command,
+        o.mode         AS mode,
+        o.model        AS model,
+        o.error_type   AS error_type,
+        o.error_detail AS error_detail
+    FROM operations o
+    WHERE o.status = 'failed'
+      AND (:profile IS NULL OR o.profile_name = :profile)
+    ORDER BY o.started_at DESC
+    LIMIT :limit OFFSET :offset
+"""
+
+
+def list_errors(
+    *,
+    db_path: Path,
+    profile: str | None,
+    limit: int,
+    offset: int,
+) -> list[OperationErrorRow]:
+    """Return FAILED operations newest-first, filtered by profile if given (#341).
+
+    Reads only the persisted (already-redacted) ``error_type``/``error_detail``
+    columns — never re-derives detail from a live exception.
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        profile: If given, only return failures belonging to this profile name.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (for pagination).
+
+    Returns:
+        A list of :class:`OperationErrorRow` instances ordered newest-first.
+    """
+    params = {"profile": profile, "limit": limit, "offset": offset}
+    with _safe_db(db_path) as conn:
+        rows = conn.execute(_LIST_ERRORS_SQL, params).fetchall()
+    return [
+        OperationErrorRow(
+            started_at=datetime.fromisoformat(str(r["started_at"])),
+            completed_at=(
+                datetime.fromisoformat(str(r["completed_at"]))
+                if r["completed_at"] is not None
+                else None
+            ),
+            profile=str(r["profile"]),
+            command=str(r["command"]) if r["command"] is not None else None,
+            mode=str(r["mode"]),
+            model=str(r["model"]) if r["model"] is not None else None,
+            error_type=str(r["error_type"]) if r["error_type"] is not None else None,
+            error_detail=str(r["error_detail"]) if r["error_detail"] is not None else None,
+        )
+        for r in rows
+    ]
+
+
 # ─── ProfileRow + list_profiles ───────────────────────────────────────────────
 
 

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -772,7 +772,7 @@ class OperationRecorder:
                 aspect_ratio=request.aspect.value,
                 error_type=terminal[1],
                 error_detail=terminal[2],
-                completed_at=_now_utc_iso() if terminal[0] is not OperationStatus.STARTED else None,
+                completed_at=_now_utc_iso(),
                 expanded_prompt=expanded_prompt,
             ),
         )

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import json
 import mimetypes
-import sqlite3
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -29,7 +28,7 @@ from gflow_cli.data.redaction import (
 )
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
-from gflow_cli.errors import DataStoreError, GFlowError, MediaAttributionError
+from gflow_cli.errors import GFlowError, MediaAttributionError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -111,10 +110,12 @@ def record_failed_operation_safe(
     """Best-effort wrapper around :meth:`OperationRecorder.record_failed_operation`.
 
     The FAILED write runs inside an ``except`` block that is about to re-raise
-    the real generation error — a data-layer fault here must warn and step
-    aside, never mask it. Catches ``sqlite3.Error`` too because repository
-    read/update helpers are not all mapped to :class:`DataStoreError`.
-    ``recorder`` may be ``None`` (recorder never opened) for caller symmetry.
+    the real generation error — ANY fault here must warn and step aside, never
+    mask it. The broad catch is deliberate (double-fault guard): a
+    ``DataStoreError``/``sqlite3.Error`` from the repository, or an
+    ``AttributeError`` from a duck-typed recorder stand-in, must not replace
+    the original exception the caller is re-raising. ``recorder`` may be
+    ``None`` (recorder never opened) for caller symmetry.
     """
     if recorder is None:
         return
@@ -130,7 +131,7 @@ def record_failed_operation_safe(
             flow_media_id=flow_media_id,
             flow_operation_id=flow_operation_id,
         )
-    except (DataStoreError, sqlite3.Error) as record_exc:
+    except Exception as record_exc:  # noqa: BLE001 — see docstring (double-fault guard)
         logger.warning("failure_record_skipped", error=str(record_exc))
 
 

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import mimetypes
+import sqlite3
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -19,14 +20,22 @@ from gflow_cli.data.models import (
     SceneClipRecord,
     SceneRecord,
 )
-from gflow_cli.data.redaction import PromptFields, PromptMode, prompt_fields, redact_metadata
+from gflow_cli.data.redaction import (
+    PromptFields,
+    PromptMode,
+    prompt_fields,
+    redact_error_detail,
+    redact_metadata,
+)
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
-from gflow_cli.errors import MediaAttributionError
+from gflow_cli.errors import DataStoreError, GFlowError, MediaAttributionError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
+
+    from structlog.typing import FilteringBoundLogger
 
     from gflow_cli.api.dto import AssetInfo, GeneratedImage, ProjectInfo
     from gflow_cli.api.image import GenerateImageRequest
@@ -62,6 +71,67 @@ def _file_bytes(path: Path) -> int | None:
         return path.stat().st_size
     except OSError:
         return None
+
+
+def _classify_failure(exc: BaseException) -> tuple[str, str | None]:
+    """Map an exception to the persisted ``(error_type, error_detail)`` pair (#341).
+
+    :class:`GFlowError`: ``error_type`` is the last segment of the per-class
+    RFC 9457 ``problem_type`` URI (falling back to the class name for the base
+    ``about:blank``); ``error_detail`` is the problem-details detail passed
+    through :func:`redact_error_detail`. Anything else: class name plus a
+    SHA-256 digest of the message — never the message text (privacy rule
+    shared with ``observability.emit_unhandled_event``).
+    """
+    if isinstance(exc, GFlowError):
+        if exc.problem_type.startswith("http"):
+            error_type = exc.problem_type.rsplit("/", 1)[-1]
+        else:
+            error_type = type(exc).__name__
+        detail = exc.to_problem_details().get("detail", "")
+        return error_type, redact_error_detail(detail) if detail else None
+    digest = hashlib.sha256(str(exc).encode("utf-8", errors="replace")).hexdigest()
+    return type(exc).__name__, f"sha256:{digest}"
+
+
+def record_failed_operation_safe(
+    recorder: OperationRecorder | None,
+    *,
+    logger: FilteringBoundLogger,
+    profile_name: str,
+    profile_dir: Path,
+    command: str,
+    mode: OperationKind,
+    exc: BaseException,
+    request: _ToolableRequest | None = None,
+    flow_project_id: str | None = None,
+    flow_media_id: str | None = None,
+    flow_operation_id: str | None = None,
+) -> None:
+    """Best-effort wrapper around :meth:`OperationRecorder.record_failed_operation`.
+
+    The FAILED write runs inside an ``except`` block that is about to re-raise
+    the real generation error — a data-layer fault here must warn and step
+    aside, never mask it. Catches ``sqlite3.Error`` too because repository
+    read/update helpers are not all mapped to :class:`DataStoreError`.
+    ``recorder`` may be ``None`` (recorder never opened) for caller symmetry.
+    """
+    if recorder is None:
+        return
+    try:
+        recorder.record_failed_operation(
+            profile_name=profile_name,
+            profile_dir=profile_dir,
+            command=command,
+            mode=mode,
+            exc=exc,
+            request=request,
+            flow_project_id=flow_project_id,
+            flow_media_id=flow_media_id,
+            flow_operation_id=flow_operation_id,
+        )
+    except (DataStoreError, sqlite3.Error) as record_exc:
+        logger.warning("failure_record_skipped", error=str(record_exc))
 
 
 def escalate_asset_collision(
@@ -803,6 +873,92 @@ class OperationRecorder:
                 local_path=result.local_path,
                 cloud_storage_info=cloud_storage_info,
             )
+
+    # ------------------------------------------------------------------
+    # Failed generations (#341)
+    # ------------------------------------------------------------------
+
+    def record_failed_operation(
+        self,
+        *,
+        profile_name: str,
+        profile_dir: Path,
+        command: str,
+        mode: OperationKind,
+        exc: BaseException,
+        request: _ToolableRequest | None = None,
+        flow_project_id: str | None = None,
+        flow_media_id: str | None = None,
+        flow_operation_id: str | None = None,
+    ) -> None:
+        """Persist a terminal FAILED operation for a generation error (#341).
+
+        ``error_type`` is the last segment of the exception's RFC 9457
+        ``problem_type`` URI (``waf-rejection``, ``content-policy``, ...) —
+        the taxonomy already declared per :class:`~gflow_cli.errors.GFlowError`
+        subclass, so no parallel slug map can drift. Non-``GFlowError``
+        exceptions store the class name and a SHA-256 hash of ``str(exc)``
+        (never the message itself — it may carry tokens; same privacy rule as
+        ``observability.emit_unhandled_event``).
+
+        When ``flow_media_id`` is known and a STARTED row exists for it (the
+        video ``on_started`` pre-insert), that row is updated to FAILED —
+        mirroring ``record_completed_video``. Otherwise a fresh FAILED row is
+        inserted. Rows in any other status are never touched, and the
+        character saga (``services/character_create.py``) deliberately keeps
+        its STARTED rows for resume — do not wire this into it.
+
+        Callers must re-raise the original exception after recording; use
+        :func:`record_failed_operation_safe` so a data-layer fault here can
+        never mask the generation error.
+        """
+        error_type, error_detail = _classify_failure(exc)
+        completed_at = _now_utc_iso()
+        repo = self.repository
+        repo.upsert_profile(profile_name, profile_dir)
+
+        if flow_media_id is not None:
+            op = repo.get_operation_for_output_asset(profile_name, flow_media_id, mode)
+            if op is not None and op.status == OperationStatus.STARTED:
+                repo.update_operation_status(
+                    op.id, OperationStatus.FAILED, completed_at, error_type, error_detail
+                )
+                return
+
+        if request is not None:
+            pf, expanded_prompt = self._resolve_prompts(request)
+            model = request.model.value if request.model is not None else None
+            aspect_ratio = request.aspect.value
+        else:
+            pf, expanded_prompt = prompt_fields(None, mode=self.prompt_mode), None
+            model = None
+            aspect_ratio = None
+
+        op_id = _new_id()
+        repo.insert_operation(
+            OperationRecord(
+                id=op_id,
+                profile_name=profile_name,
+                flow_project_id=flow_project_id,
+                command=command,
+                mode=mode,
+                status=OperationStatus.FAILED,
+                flow_operation_id=flow_operation_id,
+                flow_batch_id=None,
+                prompt=pf.prompt,
+                prompt_hash=pf.prompt_hash,
+                prompt_redacted=pf.prompt_redacted,
+                model=model,
+                aspect_ratio=aspect_ratio,
+                error_type=error_type,
+                error_detail=error_detail,
+                completed_at=completed_at,
+                expanded_prompt=expanded_prompt,
+            ),
+        )
+        tool_meta = self._tool_metadata(request.tool) if request is not None else None
+        if tool_meta is not None:
+            repo.set_operation_metadata(op_id, {"tool": tool_meta})
 
     # ------------------------------------------------------------------
     # Character — started / completed (persist-before-spend saga)

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -29,6 +29,7 @@ from gflow_cli.data.redaction import (
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import GFlowError, MediaAttributionError
+from gflow_cli.observability import exception_message_hash
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -77,20 +78,19 @@ def _classify_failure(exc: BaseException) -> tuple[str, str | None]:
 
     :class:`GFlowError`: ``error_type`` is the last segment of the per-class
     RFC 9457 ``problem_type`` URI (falling back to the class name for the base
-    ``about:blank``); ``error_detail`` is the problem-details detail passed
-    through :func:`redact_error_detail`. Anything else: class name plus a
-    SHA-256 digest of the message — never the message text (privacy rule
-    shared with ``observability.emit_unhandled_event``).
+    ``about:blank`` or a malformed URI); ``error_detail`` is the
+    problem-details detail passed through :func:`redact_error_detail`.
+    Anything else: class name plus ``sha256:<digest>`` of the message — never
+    the message text (privacy rule shared with
+    ``observability.emit_unhandled_event``, same digest for correlation).
     """
     if isinstance(exc, GFlowError):
+        error_type = type(exc).__name__
         if exc.problem_type.startswith("http"):
-            error_type = exc.problem_type.rsplit("/", 1)[-1]
-        else:
-            error_type = type(exc).__name__
+            error_type = exc.problem_type.rsplit("/", 1)[-1] or error_type
         detail = exc.to_problem_details().get("detail", "")
         return error_type, redact_error_detail(detail) if detail else None
-    digest = hashlib.sha256(str(exc).encode("utf-8", errors="replace")).hexdigest()
-    return type(exc).__name__, f"sha256:{digest}"
+    return type(exc).__name__, f"sha256:{exception_message_hash(exc)}"
 
 
 def record_failed_operation_safe(
@@ -104,8 +104,7 @@ def record_failed_operation_safe(
     exc: BaseException,
     request: _ToolableRequest | None = None,
     flow_project_id: str | None = None,
-    flow_media_id: str | None = None,
-    flow_operation_id: str | None = None,
+    flow_media_ids: Sequence[str] = (),
 ) -> None:
     """Best-effort wrapper around :meth:`OperationRecorder.record_failed_operation`.
 
@@ -128,8 +127,7 @@ def record_failed_operation_safe(
             exc=exc,
             request=request,
             flow_project_id=flow_project_id,
-            flow_media_id=flow_media_id,
-            flow_operation_id=flow_operation_id,
+            flow_media_ids=flow_media_ids,
         )
     except Exception as record_exc:  # noqa: BLE001 — see docstring (double-fault guard)
         logger.warning("failure_record_skipped", error=str(record_exc))
@@ -743,8 +741,18 @@ class OperationRecorder:
         flow_media_id: str,
         request: GenerateVideoRequest,
         result: VideoResult,
+        terminal: tuple[OperationStatus, str | None, str | None] = (
+            OperationStatus.SUCCEEDED,
+            None,
+            None,
+        ),
     ) -> None:
-        """Insert a completed video operation when on_started failed or was skipped."""
+        """Insert a terminal video operation when on_started failed or was skipped.
+
+        ``terminal`` is ``(status, error_type, error_detail)`` — SUCCEEDED by
+        default, FAILED/"generation-failed" when the poll completed with
+        ``succeeded=False`` (#341).
+        """
         pf, expanded_prompt = self._resolve_prompts(request)
         op_id = _new_id()
         repo.insert_operation(
@@ -754,7 +762,7 @@ class OperationRecorder:
                 flow_project_id=result.project_id,
                 command=f"video {request.mode.value}",
                 mode=OperationKind(request.mode.value),
-                status=OperationStatus.SUCCEEDED,
+                status=terminal[0],
                 flow_operation_id=result.flow_operation_id,
                 flow_batch_id=None,
                 prompt=pf.prompt,
@@ -762,8 +770,9 @@ class OperationRecorder:
                 prompt_redacted=pf.prompt_redacted,
                 model=request.model.value if request.model is not None else None,
                 aspect_ratio=request.aspect.value,
-                error_type=None,
-                error_detail=None,
+                error_type=terminal[1],
+                error_detail=terminal[2],
+                completed_at=_now_utc_iso() if terminal[0] is not OperationStatus.STARTED else None,
                 expanded_prompt=expanded_prompt,
             ),
         )
@@ -847,23 +856,41 @@ class OperationRecorder:
             ),
         )
 
-        # Update the STARTED operation for this asset to SUCCEEDED
+        # Update the STARTED operation for this asset to its terminal state.
+        # #341 review finding: a poll that COMPLETES with succeeded=False (Flow
+        # rejected/failed the render — failure_reasons set) is a failed
+        # generation, not a success; recording it SUCCEEDED made the most
+        # common real-world failure class invisible to `data list errors`.
         completed_at = _now_utc_iso()
+        if result.status.succeeded:
+            terminal = (OperationStatus.SUCCEEDED, None, None)
+        else:
+            reasons = (
+                ", ".join(result.status.failure_reasons)
+                or result.status.error_message
+                or "unknown reason"
+            )
+            terminal = (
+                OperationStatus.FAILED,
+                "generation-failed",
+                redact_error_detail(reasons),
+            )
         op = repo.get_operation_for_output_asset(
             profile_name,
             flow_media_id,
             OperationKind(request.mode.value),
         )
         if op is not None:
-            repo.update_operation_status(op.id, OperationStatus.SUCCEEDED, completed_at, None, None)
+            repo.update_operation_status(op.id, terminal[0], completed_at, terminal[1], terminal[2])
         else:
-            # on_started may have failed — insert a fresh completed operation
+            # on_started may have failed — insert a fresh terminal operation
             self._insert_fallback_video_operation(
                 repo=repo,
                 profile_name=profile_name,
                 flow_media_id=flow_media_id,
                 request=request,
                 result=result,
+                terminal=terminal,
             )
 
         if result.local_path is not None or cloud_storage_info is not None:
@@ -889,8 +916,7 @@ class OperationRecorder:
         exc: BaseException,
         request: _ToolableRequest | None = None,
         flow_project_id: str | None = None,
-        flow_media_id: str | None = None,
-        flow_operation_id: str | None = None,
+        flow_media_ids: Sequence[str] = (),
     ) -> None:
         """Persist a terminal FAILED operation for a generation error (#341).
 
@@ -902,12 +928,14 @@ class OperationRecorder:
         (never the message itself — it may carry tokens; same privacy rule as
         ``observability.emit_unhandled_event``).
 
-        When ``flow_media_id`` is known and a STARTED row exists for it (the
-        video ``on_started`` pre-insert), that row is updated to FAILED —
-        mirroring ``record_completed_video``. Otherwise a fresh FAILED row is
-        inserted. Rows in any other status are never touched, and the
-        character saga (``services/character_create.py``) deliberately keeps
-        its STARTED rows for resume — do not wire this into it.
+        ``flow_media_ids`` carries EVERY media id the failed call announced
+        via ``on_started`` (a ``count>1`` video fires the callback per output).
+        Each one's STARTED row is updated to FAILED — mirroring
+        ``record_completed_video`` — and an already-FAILED row counts as
+        recorded. Only when none of them resolved to a row is a fresh FAILED
+        row inserted. SUCCEEDED rows are never touched, and the character saga
+        (``services/character_create.py``) deliberately keeps its STARTED rows
+        for resume — do not wire this into it.
 
         Callers must re-raise the original exception after recording; use
         :func:`record_failed_operation_safe` so a data-layer fault here can
@@ -918,13 +946,20 @@ class OperationRecorder:
         repo = self.repository
         repo.upsert_profile(profile_name, profile_dir)
 
-        if flow_media_id is not None:
-            op = repo.get_operation_for_output_asset(profile_name, flow_media_id, mode)
-            if op is not None and op.status == OperationStatus.STARTED:
+        recorded = False
+        for media_id in flow_media_ids:
+            op = repo.get_operation_for_output_asset(profile_name, media_id, mode)
+            if op is None:
+                continue
+            if op.status == OperationStatus.STARTED:
                 repo.update_operation_status(
                     op.id, OperationStatus.FAILED, completed_at, error_type, error_detail
                 )
-                return
+                recorded = True
+            elif op.status == OperationStatus.FAILED:
+                recorded = True  # already terminal — do not duplicate
+        if recorded:
+            return
 
         if request is not None:
             pf, expanded_prompt = self._resolve_prompts(request)
@@ -944,7 +979,7 @@ class OperationRecorder:
                 command=command,
                 mode=mode,
                 status=OperationStatus.FAILED,
-                flow_operation_id=flow_operation_id,
+                flow_operation_id=None,
                 flow_batch_id=None,
                 prompt=pf.prompt,
                 prompt_hash=pf.prompt_hash,

--- a/src/gflow_cli/data/redaction.py
+++ b/src/gflow_cli/data/redaction.py
@@ -12,16 +12,27 @@ SENSITIVE_QUERY_KEYS = ("signature=", "x-goog-signature=", "x-goog-credential=",
 # Free-text secret patterns for error_detail scrubbing (#341). `redact_metadata`
 # redacts by dict key name / URL markers only, so a secret interpolated into an
 # exception message ("HTTP 403: ... Bearer ya29.xxx") would pass through it
-# verbatim — these patterns cover the prose case.
+# verbatim — these patterns cover the prose case. All case-insensitive: header
+# dumps are frequently lowercased ("cookie: sapisid=...").
 _SECRET_TEXT_PATTERNS = (
     re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
     re.compile(r"SAPISIDHASH\s+\S+", re.IGNORECASE),
+    # Google auth cookie pairs — both header ("SAPISID=x") and equals forms.
+    # SAPISIDHASH before SAPISID before the bare SID family so the longest
+    # name wins; \b keeps bare SID from firing inside unrelated words.
     re.compile(
-        r"(?:__Secure-(?:next-auth\.session-token|[13]PSID[A-Z]*)|SAPISID|APISID|SSID|HSID)"
+        r"\b(?:__Secure-(?:next-auth\.session-token|[13]PSID[A-Z]*)"
+        r"|SAPISIDHASH|SAPISID|APISID|SSID|HSID|OSID|LSID|SID)"
         r"\s*=\s*\S+",
+        re.IGNORECASE,
     ),
 )
-_URL_PATTERN = re.compile(r"https?://\S+")
+# Any whitespace-delimited token carrying signed-query material — covers full
+# URLs and bare "path?X-Goog-Signature=..." fragments alike.
+_SIGNED_QUERY_TOKEN_PATTERN = re.compile(
+    r"\S*(?:signature=|x-goog-signature=|x-goog-credential=|expires=)\S*",
+    re.IGNORECASE,
+)
 ERROR_DETAIL_MAX_CHARS = 500
 
 
@@ -74,6 +85,5 @@ def redact_error_detail(detail: str) -> str:
     """
     for pattern in _SECRET_TEXT_PATTERNS:
         detail = pattern.sub("<redacted:secret>", detail)
-    if any(marker in detail.lower() for marker in SENSITIVE_QUERY_KEYS):
-        detail = _URL_PATTERN.sub("<redacted:url>", detail)
+    detail = _SIGNED_QUERY_TOKEN_PATTERN.sub("<redacted:url>", detail)
     return detail[:ERROR_DETAIL_MAX_CHARS]

--- a/src/gflow_cli/data/redaction.py
+++ b/src/gflow_cli/data/redaction.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 PromptMode = Literal["store", "redacted"]
 SENSITIVE_URL_KEYS = {"fifeurl", "signedurl", "downloadurl", "mediaurl"}
 SENSITIVE_QUERY_KEYS = ("signature=", "x-goog-signature=", "x-goog-credential=", "expires=")
+
+# Free-text secret patterns for error_detail scrubbing (#341). `redact_metadata`
+# redacts by dict key name / URL markers only, so a secret interpolated into an
+# exception message ("HTTP 403: ... Bearer ya29.xxx") would pass through it
+# verbatim — these patterns cover the prose case.
+_SECRET_TEXT_PATTERNS = (
+    re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE),
+    re.compile(r"SAPISIDHASH\s+\S+", re.IGNORECASE),
+    re.compile(
+        r"(?:__Secure-(?:next-auth\.session-token|[13]PSID[A-Z]*)|SAPISID|APISID|SSID|HSID)"
+        r"\s*=\s*\S+",
+    ),
+)
+_URL_PATTERN = re.compile(r"https?://\S+")
+ERROR_DETAIL_MAX_CHARS = 500
 
 
 @dataclass(frozen=True)
@@ -46,3 +62,18 @@ def redact_metadata(value: Any) -> Any:
     if isinstance(value, str) and any(marker in value.lower() for marker in SENSITIVE_QUERY_KEYS):
         return "<redacted:url>"
     return value
+
+
+def redact_error_detail(detail: str) -> str:
+    """Scrub a free-text error detail before it is persisted to the DB (#341).
+
+    Applied to ``GFlowError.to_problem_details()['detail']`` on the FAILED
+    operation write path. Scrubs bearer/SAPISIDHASH/cookie-pair secrets, drops
+    URLs carrying signed-query material, and truncates post-redaction as
+    defense-in-depth against a scrub bypass.
+    """
+    for pattern in _SECRET_TEXT_PATTERNS:
+        detail = pattern.sub("<redacted:secret>", detail)
+    if any(marker in detail.lower() for marker in SENSITIVE_QUERY_KEYS):
+        detail = _URL_PATTERN.sub("<redacted:url>", detail)
+    return detail[:ERROR_DETAIL_MAX_CHARS]

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -25,7 +25,12 @@ from gflow_cli.api.dto import BatchSubmissionResult, ProjectInfo
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.config import get_settings, parse_jitter_range
-from gflow_cli.data.recorder import escalate_asset_collision
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.recorder import (
+    OperationRecorder,
+    escalate_asset_collision,
+    record_failed_operation_safe,
+)
 from gflow_cli.errors import (
     EXIT_CODE_MAP,
     BatchIntegrityError,
@@ -42,7 +47,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
     from gflow_cli.api.dto import GeneratedImage
-    from gflow_cli.data.recorder import OperationRecorder
     from gflow_cli.tools.invocation import AppliedTool
 
 console = Console()
@@ -419,11 +423,19 @@ async def run_one_image_prompt(
     idx: int,
     item: BatchPromptItem,
     output_dir: Path,
+    recorder: OperationRecorder | None = None,
+    profile_name: str | None = None,
+    profile_dir: Path | None = None,
+    command: str = "image t2i",
 ) -> BatchOutcome:
     """Generate images for one prompt and download them.
 
     When ``project_id`` is ``None``, the client creates a new Flow project for
     this prompt (isolation mode). Pass an explicit ID to reuse a shared project.
+
+    When ``recorder``/``profile_name``/``profile_dir`` are provided, a failed
+    prompt also persists a FAILED operation row (#341) before the outcome is
+    returned.
     """
     req = GenerateImageRequest(
         prompt=item.text,
@@ -450,6 +462,18 @@ async def run_one_image_prompt(
             saved.append(path)
         return BatchOutcome(index=idx, prompt=item, status="ok", saved_paths=saved)
     except GFlowError as exc:
+        if recorder is not None and profile_name is not None and profile_dir is not None:
+            record_failed_operation_safe(
+                recorder,
+                logger=logger,
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                command=command,
+                mode=OperationKind.T2I,
+                exc=exc,
+                request=req,
+                flow_project_id=project_id,
+            )
         return BatchOutcome(
             index=idx,
             prompt=item,
@@ -472,6 +496,7 @@ async def run_image_batch(
     jitter_range: tuple[float, float] | None = None,
     _profile_name: str | None = None,
     _recorder: OperationRecorder | None = None,
+    _command: str = "image t2i",
 ) -> list[BatchOutcome]:
     """Run prompts sequentially through one FlowApiClient session."""
 
@@ -487,6 +512,10 @@ async def run_image_batch(
             idx=idx,
             item=item,
             output_dir=output_dir,
+            recorder=_recorder,
+            profile_name=_profile_name,
+            profile_dir=profile_dir,
+            command=_command,
         )
 
     return await run_sequential_batch(
@@ -935,6 +964,18 @@ async def _download_results(
     outcomes: list[BatchOutcome] = []
     for item, result in zip(prompts, results, strict=False):
         if result.status != "ok":
+            if result.error is not None and profile_name is not None and profile_dir is not None:
+                record_failed_operation_safe(
+                    recorder,
+                    logger=logger,
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    command="image batch",
+                    mode=OperationKind.T2I,
+                    exc=result.error,
+                    request=_to_request(item),
+                    flow_project_id=result.project_id,
+                )
             outcomes.append(
                 BatchOutcome(
                     index=item.index,
@@ -976,6 +1017,18 @@ async def _download_results(
                 project_id=result.project_id,
                 error=str(exc),
             )
+            if profile_name is not None and profile_dir is not None:
+                record_failed_operation_safe(
+                    recorder,
+                    logger=logger,
+                    profile_name=profile_name,
+                    profile_dir=profile_dir,
+                    command="image batch",
+                    mode=OperationKind.T2I,
+                    exc=exc,
+                    request=_to_request(item),
+                    flow_project_id=result.project_id,
+                )
             outcome = BatchOutcome(
                 index=item.index,
                 prompt=item,

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -461,7 +461,11 @@ async def run_one_image_prompt(
             path = await client.download_image(img, target)
             saved.append(path)
         return BatchOutcome(index=idx, prompt=item, status="ok", saved_paths=saved)
-    except GFlowError as exc:
+    except Exception as exc:
+        # #341: both typed and unexpected failures reach the funnel (the
+        # single-prompt CLI paths catch `Exception`; batch coverage must not
+        # be narrower). Batch semantics unchanged: GFlowError becomes a "fail"
+        # outcome, anything else still propagates.
         if profile_name is not None and profile_dir is not None:
             record_failed_operation_safe(
                 recorder,
@@ -474,6 +478,8 @@ async def run_one_image_prompt(
                 request=req,
                 flow_project_id=project_id,
             )
+        if not isinstance(exc, GFlowError):
+            raise
         return BatchOutcome(
             index=idx,
             prompt=item,
@@ -481,24 +487,6 @@ async def run_one_image_prompt(
             error=f"{type(exc).__name__}: {exc}",
             exit_code=resolve_exit_code(exc),
         )
-    except Exception as exc:
-        # #341 review: non-GFlowError failures (transport crash, OSError on
-        # write) must reach the failure funnel too — the single-prompt CLI
-        # paths catch `Exception`, and batch coverage must not be narrower.
-        # Batch semantics are unchanged: these still propagate, not BatchOutcome.
-        if profile_name is not None and profile_dir is not None:
-            record_failed_operation_safe(
-                recorder,
-                logger=logger,
-                profile_name=profile_name,
-                profile_dir=profile_dir,
-                command=command,
-                mode=OperationKind.T2I,
-                exc=exc,
-                request=req,
-                flow_project_id=project_id,
-            )
-        raise
 
 
 async def run_image_batch(

--- a/src/gflow_cli/image_batch.py
+++ b/src/gflow_cli/image_batch.py
@@ -462,7 +462,7 @@ async def run_one_image_prompt(
             saved.append(path)
         return BatchOutcome(index=idx, prompt=item, status="ok", saved_paths=saved)
     except GFlowError as exc:
-        if recorder is not None and profile_name is not None and profile_dir is not None:
+        if profile_name is not None and profile_dir is not None:
             record_failed_operation_safe(
                 recorder,
                 logger=logger,
@@ -481,6 +481,24 @@ async def run_one_image_prompt(
             error=f"{type(exc).__name__}: {exc}",
             exit_code=resolve_exit_code(exc),
         )
+    except Exception as exc:
+        # #341 review: non-GFlowError failures (transport crash, OSError on
+        # write) must reach the failure funnel too — the single-prompt CLI
+        # paths catch `Exception`, and batch coverage must not be narrower.
+        # Batch semantics are unchanged: these still propagate, not BatchOutcome.
+        if profile_name is not None and profile_dir is not None:
+            record_failed_operation_safe(
+                recorder,
+                logger=logger,
+                profile_name=profile_name,
+                profile_dir=profile_dir,
+                command=command,
+                mode=OperationKind.T2I,
+                exc=exc,
+                request=req,
+                flow_project_id=project_id,
+            )
+        raise
 
 
 async def run_image_batch(
@@ -496,7 +514,9 @@ async def run_image_batch(
     jitter_range: tuple[float, float] | None = None,
     _profile_name: str | None = None,
     _recorder: OperationRecorder | None = None,
-    _command: str = "image t2i",
+    # Required (no default): a mislabeling default would silently stamp a new
+    # caller's failure rows with another command's name (#341 review).
+    _command: str,
 ) -> list[BatchOutcome]:
     """Run prompts sequentially through one FlowApiClient session."""
 
@@ -1017,18 +1037,10 @@ async def _download_results(
                 project_id=result.project_id,
                 error=str(exc),
             )
-            if profile_name is not None and profile_dir is not None:
-                record_failed_operation_safe(
-                    recorder,
-                    logger=logger,
-                    profile_name=profile_name,
-                    profile_dir=profile_dir,
-                    command="image batch",
-                    mode=OperationKind.T2I,
-                    exc=exc,
-                    request=_to_request(item),
-                    flow_project_id=result.project_id,
-                )
+            # NOT recorded as a FAILED operation (#341 review): by this point
+            # the generation itself succeeded and credits were spent — the
+            # collision is local attribution bookkeeping, and recording it
+            # would pollute the failure dataset the feature exists to build.
             outcome = BatchOutcome(
                 index=item.index,
                 prompt=item,

--- a/src/gflow_cli/observability.py
+++ b/src/gflow_cli/observability.py
@@ -157,12 +157,20 @@ def emit_unhandled_event(
     storing PII or tokens that may have ended up in ``str(exc)`` or a frame
     local.
     """
-    msg_bytes = str(exc).encode("utf-8", errors="replace")
     tb_bytes = "".join(traceback.format_tb(exc.__traceback__)).encode("utf-8", errors="replace")
     logger.error(
         "error_unhandled",
         exception_class=type(exc).__name__,
-        message_hash=hashlib.sha256(msg_bytes).hexdigest(),
+        message_hash=exception_message_hash(exc),
         stack_hash=hashlib.sha256(tb_bytes).hexdigest(),
         cli_command=cli_command,
     )
+
+
+def exception_message_hash(exc: BaseException) -> str:
+    """SHA-256 hex digest of ``str(exc)`` — the privacy-safe stand-in for a
+    message that may carry PII or tokens. Shared by ``emit_unhandled_event``
+    and the data layer's FAILED-operation recorder (#341) so log events and
+    catalog rows hash identically and can be correlated.
+    """
+    return hashlib.sha256(str(exc).encode("utf-8", errors="replace")).hexdigest()

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -17,7 +17,12 @@ from gflow_cli.api.video import GenerateVideoRequest, VideoModel, VideoStarted
 from gflow_cli.api.video import Mode as VideoMode
 from gflow_cli.api.video import Tier as VideoTier
 from gflow_cli.config import UiMode, get_settings
-from gflow_cli.data.recorder import OperationRecorder, escalate_asset_collision
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.recorder import (
+    OperationRecorder,
+    escalate_asset_collision,
+    record_failed_operation_safe,
+)
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import DataIntegrityError, DataStoreError, GFlowError
@@ -125,6 +130,12 @@ class FlowWorker:
         out_dir = (
             Path(task.payload["out_dir"]) if "out_dir" in task.payload else settings.output_dir
         )
+
+        # #341: bound before the try so the failure funnel below can persist a
+        # FAILED operation with whatever context was reached before the raise.
+        req: GenerateImageRequest | GenerateVideoRequest | None = None
+        recorder: OperationRecorder | None = None
+        started_media_ids: list[str] = []
 
         try:
             if task.task_type in ("t2i", "i2i"):
@@ -236,6 +247,9 @@ class FlowWorker:
                 recorder = OperationRecorder(
                     DataRepository(self.db), prompt_mode=settings.history_prompts
                 )
+                # Non-optional alias for the closure below (`recorder` is
+                # declared Optional at method scope for the #341 failure funnel).
+                video_recorder = recorder
                 try:
                     async with FlowApiClient(
                         profile_dir=profile_dir,
@@ -246,8 +260,9 @@ class FlowWorker:
                     ) as client:
 
                         def on_started(started: VideoStarted) -> None:
+                            started_media_ids.append(started.media_id)
                             try:
-                                recorder.record_started_video(
+                                video_recorder.record_started_video(
                                     profile_name=self.profile_name,
                                     profile_dir=profile_dir,
                                     request=req,
@@ -332,6 +347,26 @@ class FlowWorker:
                     "detail": str(exc),
                     "exit_code": 1,
                 }
+
+            # #341: mirror the queue's failure record into the operations table
+            # (single authoritative failure history). Skipped for unknown task
+            # types — they never reached a generation.
+            try:
+                op_kind: OperationKind | None = OperationKind(task.task_type)
+            except ValueError:
+                op_kind = None
+            if op_kind is not None:
+                record_failed_operation_safe(
+                    recorder,
+                    logger=logger,
+                    profile_name=self.profile_name,
+                    profile_dir=profile_dir,
+                    command=f"worker {task.task_type}",
+                    mode=op_kind,
+                    exc=exc,
+                    request=req,
+                    flow_media_id=started_media_ids[-1] if started_media_ids else None,
+                )
 
             self.repo.update_task_status(
                 task.task_id,

--- a/src/gflow_cli/worker/daemon.py
+++ b/src/gflow_cli/worker/daemon.py
@@ -23,9 +23,11 @@ from gflow_cli.data.recorder import (
     escalate_asset_collision,
     record_failed_operation_safe,
 )
+from gflow_cli.data.redaction import redact_error_detail
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import DataIntegrityError, DataStoreError, GFlowError
+from gflow_cli.observability import exception_message_hash
 from gflow_cli.paths import image_output_path
 from gflow_cli.storage import cloud_info_from_path
 from gflow_cli.worker.queue import QueueRepository, QueueTask
@@ -339,12 +341,18 @@ class FlowWorker:
                 error_payload["exit_code"] = exit_code
                 if "status" not in error_payload:
                     error_payload["status"] = 500
+                # #341: the queue row persists to the same DB as the redacted
+                # operations row — scrub its detail with the same rules.
+                if "detail" in error_payload:
+                    error_payload["detail"] = redact_error_detail(str(error_payload["detail"]))
             else:
                 error_payload = {
                     "type": "https://gflow-cli.dev/errors/unknown",
                     "title": "Unknown Error",
                     "status": 500,
-                    "detail": str(exc),
+                    # Hash, never the raw message — it may carry tokens (#341,
+                    # same privacy rule as operations.error_detail).
+                    "detail": f"sha256:{exception_message_hash(exc)}",
                     "exit_code": 1,
                 }
 
@@ -356,6 +364,11 @@ class FlowWorker:
             except ValueError:
                 op_kind = None
             if op_kind is not None:
+                # Prefer the mode the STARTED row was written with (the built
+                # request's mode) over task_type — they can disagree when the
+                # payload omits 'mode', and the STARTED-row lookup filters on it.
+                if isinstance(req, GenerateVideoRequest):
+                    op_kind = OperationKind(req.mode.value)
                 record_failed_operation_safe(
                     recorder,
                     logger=logger,
@@ -365,7 +378,7 @@ class FlowWorker:
                     mode=op_kind,
                     exc=exc,
                     request=req,
-                    flow_media_id=started_media_ids[-1] if started_media_ids else None,
+                    flow_media_ids=started_media_ids,
                 )
 
             self.repo.update_task_status(

--- a/tests/api/transports/test_common.py
+++ b/tests/api/transports/test_common.py
@@ -220,3 +220,23 @@ def test_extract_project_id_from_flow_url() -> None:
 
 def test_extract_project_id_returns_none_for_gallery_url() -> None:
     assert extract_project_id("https://labs.google/fx/tools/flow") is None
+
+
+# ---------------------------------------------------------------------------
+# #341: response bodies are redacted BEFORE truncation into error messages
+# ---------------------------------------------------------------------------
+
+
+def test_interpret_response_403_redacts_bearer_token_in_body() -> None:
+    body = "denied; auth was Bearer ya29.a0Af-verysecrettoken1234567890 for this call"
+    with pytest.raises(WafRejectionError) as excinfo:
+        interpret_response("sapisidhash", _resp(403, body))
+    assert "ya29" not in str(excinfo.value)
+    assert "<redacted:secret>" in str(excinfo.value)
+
+
+def test_interpret_response_500_redacts_signed_url_in_body() -> None:
+    body = "err at https://cdn.example/x?X-Goog-Signature=abcdef123456"
+    with pytest.raises(NetworkError) as excinfo:
+        interpret_response("bearer", _resp(500, body))
+    assert "abcdef123456" not in str(excinfo.value)

--- a/tests/cli/test_cli_data_errors.py
+++ b/tests/cli/test_cli_data_errors.py
@@ -49,9 +49,7 @@ def test_list_errors_filters_by_profile(tmp_path: Path) -> None:
     assert [r.profile for r in rows] == ["alpha"]
 
 
-def test_data_list_errors_cli_emits_jsonl(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_data_list_errors_cli_emits_jsonl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = tmp_path / "gflow.db"
     _seed_failed_op(db)
     monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))

--- a/tests/cli/test_cli_data_errors.py
+++ b/tests/cli/test_cli_data_errors.py
@@ -1,0 +1,86 @@
+"""`gflow data list errors` (#341): query + CLI surface + markup safety."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from gflow_cli.cli_data import _emit_errors_table
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.queries import OperationErrorRow, list_errors
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import WafRejectionError
+
+
+def _seed_failed_op(db_path: Path, *, profile: str = "default", detail: str = "blocked") -> None:
+    with DataStore.open(db_path) as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        recorder.record_failed_operation(
+            profile_name=profile,
+            profile_dir=db_path.parent / "p",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=WafRejectionError(detail, status=403),
+        )
+
+
+def test_list_errors_returns_failed_rows_newest_first(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    rows = list_errors(db_path=db, profile=None, limit=20, offset=0)
+    assert len(rows) == 1
+    assert rows[0].error_type == "waf-rejection"
+    assert rows[0].error_detail == "blocked"
+    assert rows[0].command == "image t2i"
+
+
+def test_list_errors_filters_by_profile(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db, profile="alpha")
+    _seed_failed_op(db, profile="beta")
+    rows = list_errors(db_path=db, profile="alpha", limit=20, offset=0)
+    assert [r.profile for r in rows] == ["alpha"]
+
+
+def test_data_list_errors_cli_emits_jsonl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "list", "errors", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["error_type"] == "waf-rejection"
+    assert payload["error_detail"] == "blocked"
+
+
+def test_data_list_errors_cli_empty_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "list", "errors", "--json"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == ""
+
+
+def test_emit_errors_table_escapes_rich_markup(capsys: pytest.CaptureFixture[str]) -> None:
+    row = OperationErrorRow(
+        started_at=datetime(2026, 7, 18, 12, 0),
+        completed_at=None,
+        profile="default",
+        command="image t2i",
+        mode="t2i",
+        model=None,
+        error_type="[bold red]waf[/bold red]",
+        error_detail="detail with [markup] and \x1b[31mansi\x1b[0m",
+    )
+    _emit_errors_table([row])  # must not raise on bracketed/ANSI content
+    out = capsys.readouterr().out
+    assert "waf" in out

--- a/tests/cli/test_failure_funnel.py
+++ b/tests/cli/test_failure_funnel.py
@@ -1,0 +1,116 @@
+"""#341 funnel wiring: generation failures persist FAILED operation rows.
+
+These tests drive the real CLI orchestrators (`video t2v`, `image t2i`) with a
+FlowApiClient whose generate call raises, and assert against the REAL isolated
+catalog DB (the autouse settings fixture points GFLOW_CLI_DB_PATH at a tmp dir)
+that a terminal FAILED row landed with the problem_type-derived error_type —
+then that the original exit code still surfaced (record-then-re-raise).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from gflow_cli.cli_image import image
+from gflow_cli.cli_video import video
+from gflow_cli.errors import WafRejectionError
+
+
+def _failed_ops() -> list[tuple[str, str, str | None, str | None]]:
+    db = Path(os.environ["GFLOW_CLI_DB_PATH"])
+    if not db.exists():
+        return []
+    with sqlite3.connect(db) as conn:
+        return conn.execute(
+            "SELECT command, status, error_type, error_detail"
+            " FROM operations WHERE status='failed'"
+        ).fetchall()
+
+
+def test_video_t2v_failure_persists_failed_operation(tmp_path: Path) -> None:
+    from gflow_cli.api.video import VideoStarted
+
+    async def fake_generate_video(
+        *,
+        req: Any,
+        out_dir: Any,
+        project_id: Any = None,
+        download: Any = None,
+        on_started: Any = None,
+    ) -> Any:
+        if on_started is not None:
+            on_started(VideoStarted(media_id="m1", project_id="p1", flow_operation_id="o1"))
+        raise WafRejectionError("blocked mid-poll", status=403)
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.api.client.FlowApiClient.__aenter__", new_callable=AsyncMock) as enter,
+        # return_value=False: a truthy AsyncMock return would swallow the
+        # in-context exception and defeat the funnel under test.
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aexit__",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        from gflow_cli.api.client import FlowApiClient
+
+        fake_client = MagicMock(spec=FlowApiClient)
+        fake_client.generate_video = fake_generate_video
+        enter.return_value = fake_client
+
+        result = CliRunner().invoke(video, ["t2v", "a slow pan"])
+
+    assert result.exit_code == 10, result.output  # WafRejectionError exit code preserved
+    rows = _failed_ops()
+    assert len(rows) == 1
+    command, status, error_type, error_detail = rows[0]
+    assert command == "video t2v"
+    assert error_type == "waf-rejection"
+    assert error_detail == "blocked mid-poll"
+    # The on_started STARTED row was UPDATED in place, not duplicated.
+    db = Path(os.environ["GFLOW_CLI_DB_PATH"])
+    with sqlite3.connect(db) as conn:
+        (total,) = conn.execute("SELECT COUNT(*) FROM operations").fetchone()
+    assert total == 1
+
+
+def test_image_t2i_failure_persists_failed_operation(tmp_path: Path) -> None:
+    async def fake_generate_image(*, project_id: Any, req: Any) -> Any:
+        raise WafRejectionError("blocked at submit", status=403)
+
+    with (
+        patch("gflow_cli.cli_image._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_image._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.api.client.FlowApiClient.__aenter__", new_callable=AsyncMock) as enter,
+        patch(
+            "gflow_cli.api.client.FlowApiClient.__aexit__",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        from gflow_cli.api.client import FlowApiClient
+        from gflow_cli.api.dto import ProjectInfo
+
+        fake_client = MagicMock(spec=FlowApiClient)
+        fake_client.generate_image = fake_generate_image
+        fake_client.create_project = AsyncMock(
+            return_value=ProjectInfo(project_id="p1", title="t")
+        )
+        enter.return_value = fake_client
+
+        result = CliRunner().invoke(image, ["t2i", "a red fox"])
+
+    assert result.exit_code == 10, result.output
+    rows = _failed_ops()
+    assert len(rows) == 1
+    command, status, error_type, _detail = rows[0]
+    assert command == "image t2i"
+    assert error_type == "waf-rejection"

--- a/tests/cli/test_failure_funnel.py
+++ b/tests/cli/test_failure_funnel.py
@@ -28,8 +28,7 @@ def _failed_ops() -> list[tuple[str, str, str | None, str | None]]:
         return []
     with sqlite3.connect(db) as conn:
         return conn.execute(
-            "SELECT command, status, error_type, error_detail"
-            " FROM operations WHERE status='failed'"
+            "SELECT command, status, error_type, error_detail FROM operations WHERE status='failed'"
         ).fetchall()
 
 
@@ -101,9 +100,7 @@ def test_image_t2i_failure_persists_failed_operation(tmp_path: Path) -> None:
 
         fake_client = MagicMock(spec=FlowApiClient)
         fake_client.generate_image = fake_generate_image
-        fake_client.create_project = AsyncMock(
-            return_value=ProjectInfo(project_id="p1", title="t")
-        )
+        fake_client.create_project = AsyncMock(return_value=ProjectInfo(project_id="p1", title="t"))
         enter.return_value = fake_client
 
         result = CliRunner().invoke(image, ["t2i", "a red fox"])
@@ -114,3 +111,44 @@ def test_image_t2i_failure_persists_failed_operation(tmp_path: Path) -> None:
     command, status, error_type, _detail = rows[0]
     assert command == "image t2i"
     assert error_type == "waf-rejection"
+
+
+def test_batch_prompt_failure_persists_failed_operation(tmp_path: Path) -> None:
+    """#341: a failed multi-prompt/batch row records a FAILED operation when the
+    recorder context is threaded through run_one_image_prompt."""
+    import asyncio
+
+    from gflow_cli.data.recorder import OperationRecorder
+    from gflow_cli.data.repository import DataRepository
+    from gflow_cli.data.store import DataStore
+    from gflow_cli.image_batch import BatchPromptItem, run_one_image_prompt
+
+    async def fake_generate_image(*, project_id: Any, req: Any) -> Any:
+        raise WafRejectionError("blocked in batch", status=403)
+
+    client = MagicMock()
+    client.generate_image = fake_generate_image
+
+    db_path = tmp_path / "gflow.db"
+    with DataStore.open(db_path) as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        outcome = asyncio.run(
+            run_one_image_prompt(
+                client=client,
+                project_id="p1",
+                idx=0,
+                item=BatchPromptItem(text="a red fox"),
+                output_dir=tmp_path,
+                recorder=recorder,
+                profile_name="default",
+                profile_dir=tmp_path / "p",
+                command="image batch",
+            )
+        )
+        assert outcome.status == "fail"
+        row = store.conn.execute(
+            "SELECT command, error_type FROM operations WHERE status='failed'"
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "image batch"
+    assert row[1] == "waf-rejection"

--- a/tests/data/test_failure_recording.py
+++ b/tests/data/test_failure_recording.py
@@ -199,7 +199,7 @@ def test_record_failed_operation_updates_started_video_row(tmp_path: Path) -> No
             mode=OperationKind.T2V,
             exc=WafRejectionError("poll blocked", status=403),
             request=req,
-            flow_media_id="media-1",
+            flow_media_ids=["media-1"],
         )
         (op,) = _fetch_operations(store)  # updated in place — still exactly one row
         assert op["status"] == OperationStatus.FAILED.value
@@ -218,7 +218,7 @@ def test_record_failed_operation_inserts_when_no_started_row(tmp_path: Path) -> 
             mode=OperationKind.T2V,
             exc=WafRejectionError("pre-submit block", status=403),
             request=req,
-            flow_media_id="media-never-inserted",
+            flow_media_ids=["media-never-inserted"],
         )
         (op,) = _fetch_operations(store)
         assert op["status"] == OperationStatus.FAILED.value
@@ -239,7 +239,7 @@ def test_record_failed_operation_never_downgrades_succeeded_row(tmp_path: Path) 
             mode=OperationKind.T2V,
             exc=RuntimeError("late failure"),
             request=req,
-            flow_media_id="media-1",
+            flow_media_ids=["media-1"],
         )
         ops = _fetch_operations(store)
         statuses = sorted(str(op["status"]) for op in ops)
@@ -279,3 +279,118 @@ def test_record_failed_operation_safe_accepts_none_recorder(tmp_path: Path) -> N
         mode=OperationKind.T2I,
         exc=RuntimeError("original"),
     )
+
+
+# ---------------------------------------------------------------------------
+# #341 review-round additions
+# ---------------------------------------------------------------------------
+
+
+def test_redact_error_detail_scrubs_bare_sid_and_equals_sapisidhash() -> None:
+    scrubbed = redact_error_detail(
+        "cookie: sapisid=xyz; SID=g.a000abc; OSID=o1; SAPISIDHASH=169_deadbeef"
+    )
+    assert "g.a000abc" not in scrubbed
+    assert "xyz" not in scrubbed
+    assert "o1" not in scrubbed
+    assert "deadbeef" not in scrubbed
+
+
+def test_redact_error_detail_scrubs_uppercase_and_bare_signed_query() -> None:
+    scrubbed = redact_error_detail(
+        "fail at HTTPS://cdn.example/x?X-Goog-Signature=abc123 and path?expires=999&sig"
+    )
+    assert "abc123" not in scrubbed
+    assert "expires=999" not in scrubbed
+
+
+def test_all_gflow_error_slugs_unique_and_nonempty() -> None:
+    """The error_type vocabulary is derived from problem_type URIs — pin that
+    every subclass yields a distinct, non-empty slug so the taxonomy can't
+    silently collapse (#341 review)."""
+    import gflow_cli.errors as errors_mod
+    from gflow_cli.errors import GFlowError
+
+    def _subclasses(cls: type) -> set[type]:
+        out: set[type] = set()
+        for sub in cls.__subclasses__():
+            out.add(sub)
+            out |= _subclasses(sub)
+        return out
+
+    slugs: dict[str, str] = {}
+    for cls in _subclasses(GFlowError):
+        if cls.__module__ != errors_mod.__name__:
+            continue
+        error_type, _ = _classify_failure(cls("x"))
+        assert error_type, f"{cls.__name__} produced an empty error_type"
+        prior = slugs.get(error_type)
+        # Parent/child pairs sharing a URI would collapse — only identical
+        # problem_type inheritance (no override) is allowed to collide.
+        if prior is not None:
+            assert cls.problem_type == getattr(errors_mod, prior).problem_type, (
+                f"slug {error_type!r} claimed by both {prior} and {cls.__name__} "
+                "with DIFFERENT problem_type URIs"
+            )
+        slugs[error_type] = cls.__name__
+
+
+def test_record_failed_operation_updates_all_started_rows_count_gt_1(tmp_path: Path) -> None:
+    """count>1 fires on_started per output; a failure must not strand siblings."""
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateVideoRequest(prompt="two outputs", mode=Mode.T2V, count=2)
+        for media_id in ("media-a", "media-b"):
+            recorder.record_started_video(
+                profile_name="default",
+                profile_dir=tmp_path / "p",
+                request=req,
+                started=VideoStarted(media_id=media_id, project_id="proj-1"),
+            )
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="video t2v",
+            mode=OperationKind.T2V,
+            exc=WafRejectionError("blocked", status=403),
+            request=req,
+            flow_media_ids=["media-a", "media-b"],
+        )
+        statuses = [
+            str(row["status"])
+            for row in (
+                dict(zip(("status",), r, strict=True))
+                for r in store.conn.execute("SELECT status FROM operations").fetchall()
+            )
+        ]
+    assert statuses == ["failed", "failed"]  # no stranded STARTED sibling, no extra insert
+
+
+def test_record_completed_video_records_failed_when_not_succeeded(tmp_path: Path) -> None:
+    """A poll that completes with succeeded=False is a FAILED generation (#341
+    review) — previously recorded SUCCEEDED and invisible to `data list errors`."""
+    from gflow_cli.api.video import VideoResult, VideoStatus
+
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = _started_video(recorder, tmp_path)
+        result = VideoResult(
+            status=VideoStatus(
+                media_id="media-1",
+                status="MEDIA_GENERATION_STATUS_FAILED",
+                failure_reasons=("PUBLIC_ERROR_UNSAFE_GENERATION",),
+            ),
+            local_path=None,
+            project_id="proj-1",
+            flow_operation_id="op-1",
+        )
+        recorder.record_completed_video(
+            profile_name="default",
+            _profile_dir=tmp_path / "p",
+            request=req,
+            result=result,
+        )
+        (op,) = _fetch_operations(store)
+        assert op["status"] == OperationStatus.FAILED.value
+        assert op["error_type"] == "generation-failed"
+        assert op["error_detail"] == "PUBLIC_ERROR_UNSAFE_GENERATION"

--- a/tests/data/test_failure_recording.py
+++ b/tests/data/test_failure_recording.py
@@ -1,0 +1,281 @@
+"""Failure recording (#341): FAILED operation rows, taxonomy, and redaction."""
+
+import hashlib
+from pathlib import Path
+
+import structlog
+
+from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.api.video import GenerateVideoRequest, Mode, VideoStarted
+from gflow_cli.data.models import OperationKind, OperationStatus
+from gflow_cli.data.recorder import (
+    OperationRecorder,
+    _classify_failure,
+    record_failed_operation_safe,
+)
+from gflow_cli.data.redaction import ERROR_DETAIL_MAX_CHARS, redact_error_detail
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import ContentPolicyError, DataStoreError, WafRejectionError
+
+
+def _fetch_operations(store: DataStore) -> list[dict[str, object]]:
+    rows = store.conn.execute(
+        "SELECT command, mode, status, error_type, error_detail, prompt, prompt_hash, "
+        "prompt_redacted, model, aspect_ratio, completed_at FROM operations"
+    ).fetchall()
+    cols = (
+        "command",
+        "mode",
+        "status",
+        "error_type",
+        "error_detail",
+        "prompt",
+        "prompt_hash",
+        "prompt_redacted",
+        "model",
+        "aspect_ratio",
+        "completed_at",
+    )
+    return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# redact_error_detail
+# ---------------------------------------------------------------------------
+
+
+def test_redact_error_detail_scrubs_bearer_token() -> None:
+    scrubbed = redact_error_detail("HTTP 403: denied for Bearer ya29.a0Af-secret123 token")
+    assert "ya29" not in scrubbed
+    assert "<redacted:secret>" in scrubbed
+
+
+def test_redact_error_detail_scrubs_sapisidhash_and_cookies() -> None:
+    scrubbed = redact_error_detail(
+        "auth SAPISIDHASH 1234_deadbeef failed; cookie __Secure-next-auth.session-token=abc.def"
+    )
+    assert "deadbeef" not in scrubbed
+    assert "abc.def" not in scrubbed
+
+
+def test_redact_error_detail_scrubs_signed_urls() -> None:
+    scrubbed = redact_error_detail(
+        "download failed: https://cdn.example/media.png?X-Goog-Signature=abcd1234"
+    )
+    assert "abcd1234" not in scrubbed
+    assert "<redacted:url>" in scrubbed
+
+
+def test_redact_error_detail_truncates() -> None:
+    assert len(redact_error_detail("x" * 2000)) == ERROR_DETAIL_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# _classify_failure taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_classify_gflow_error_uses_problem_type_slug() -> None:
+    error_type, detail = _classify_failure(WafRejectionError("blocked", status=403))
+    assert error_type == "waf-rejection"
+    assert detail == "blocked"
+
+
+def test_classify_non_gflow_error_hashes_message() -> None:
+    error_type, detail = _classify_failure(RuntimeError("secret123"))
+    assert error_type == "RuntimeError"
+    assert detail is not None
+    assert "secret123" not in detail
+    expected = hashlib.sha256(b"secret123").hexdigest()
+    assert detail == f"sha256:{expected}"
+
+
+# ---------------------------------------------------------------------------
+# record_failed_operation — insert path (images / no prior row)
+# ---------------------------------------------------------------------------
+
+
+def test_record_failed_operation_inserts_failed_row_with_request_metadata(
+    tmp_path: Path,
+) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(prompt="a red fox", aspect=Aspect.PORTRAIT, model=Model.NARWHAL)
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=WafRejectionError("blocked by WAF", status=403),
+            request=req,
+        )
+        (op,) = _fetch_operations(store)
+        assert op["status"] == OperationStatus.FAILED.value
+        assert op["error_type"] == "waf-rejection"
+        assert op["error_detail"] == "blocked by WAF"
+        assert op["command"] == "image t2i"
+        assert op["mode"] == "t2i"
+        assert op["prompt"] == "a red fox"
+        assert op["model"] == Model.NARWHAL.value
+        assert op["completed_at"] is not None
+
+
+def test_record_failed_operation_honors_redacted_prompt_mode(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="redacted")
+        req = GenerateImageRequest(prompt="a refused prompt")
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=ContentPolicyError("policy rejection"),
+            request=req,
+        )
+        (op,) = _fetch_operations(store)
+        assert op["error_type"] == "content-policy"
+        assert op["prompt"] is None
+        assert op["prompt_redacted"] == 1
+        assert op["prompt_hash"] is not None
+
+
+def test_record_failed_operation_scrubs_secret_in_detail(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=WafRejectionError("denied Bearer ya29.topsecret", status=403),
+        )
+        (op,) = _fetch_operations(store)
+        detail = op["error_detail"]
+        assert isinstance(detail, str)
+        assert "topsecret" not in detail
+
+
+def test_record_failed_operation_without_request(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="video t2v",
+            mode=OperationKind.T2V,
+            exc=RuntimeError("boom"),
+        )
+        (op,) = _fetch_operations(store)
+        assert op["status"] == OperationStatus.FAILED.value
+        assert op["error_type"] == "RuntimeError"
+        assert op["prompt"] is None
+
+
+# ---------------------------------------------------------------------------
+# record_failed_operation — video STARTED row update path
+# ---------------------------------------------------------------------------
+
+
+def _started_video(recorder: OperationRecorder, tmp_path: Path) -> GenerateVideoRequest:
+    req = GenerateVideoRequest(prompt="a slow pan", mode=Mode.T2V)
+    recorder.record_started_video(
+        profile_name="default",
+        profile_dir=tmp_path / "p",
+        request=req,
+        started=VideoStarted(media_id="media-1", project_id="proj-1", flow_operation_id="op-1"),
+    )
+    return req
+
+
+def test_record_failed_operation_updates_started_video_row(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = _started_video(recorder, tmp_path)
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="video t2v",
+            mode=OperationKind.T2V,
+            exc=WafRejectionError("poll blocked", status=403),
+            request=req,
+            flow_media_id="media-1",
+        )
+        (op,) = _fetch_operations(store)  # updated in place — still exactly one row
+        assert op["status"] == OperationStatus.FAILED.value
+        assert op["error_type"] == "waf-rejection"
+        assert op["completed_at"] is not None
+
+
+def test_record_failed_operation_inserts_when_no_started_row(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateVideoRequest(prompt="early failure", mode=Mode.T2V)
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="video t2v",
+            mode=OperationKind.T2V,
+            exc=WafRejectionError("pre-submit block", status=403),
+            request=req,
+            flow_media_id="media-never-inserted",
+        )
+        (op,) = _fetch_operations(store)
+        assert op["status"] == OperationStatus.FAILED.value
+
+
+def test_record_failed_operation_never_downgrades_succeeded_row(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = _started_video(recorder, tmp_path)
+        op_row = store.conn.execute("SELECT id FROM operations").fetchone()
+        recorder.repository.update_operation_status(
+            op_row[0], OperationStatus.SUCCEEDED, "2026-07-18T00:00:00Z", None, None
+        )
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="video t2v",
+            mode=OperationKind.T2V,
+            exc=RuntimeError("late failure"),
+            request=req,
+            flow_media_id="media-1",
+        )
+        ops = _fetch_operations(store)
+        statuses = sorted(str(op["status"]) for op in ops)
+        assert statuses == ["failed", "succeeded"]  # new row inserted, old row untouched
+
+
+# ---------------------------------------------------------------------------
+# record_failed_operation_safe
+# ---------------------------------------------------------------------------
+
+
+def test_record_failed_operation_safe_swallows_data_store_error(tmp_path: Path) -> None:
+    class _ExplodingRecorder(OperationRecorder):
+        def record_failed_operation(self, **kwargs: object) -> None:  # type: ignore[override]
+            raise DataStoreError("db gone")
+
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = _ExplodingRecorder(DataRepository(store), prompt_mode="store")
+        record_failed_operation_safe(
+            recorder,
+            logger=structlog.get_logger("test"),
+            profile_name="default",
+            profile_dir=tmp_path / "p",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=RuntimeError("original"),
+        )  # must not raise
+
+
+def test_record_failed_operation_safe_accepts_none_recorder(tmp_path: Path) -> None:
+    record_failed_operation_safe(
+        None,
+        logger=structlog.get_logger("test"),
+        profile_name="default",
+        profile_dir=tmp_path / "p",
+        command="image t2i",
+        mode=OperationKind.T2I,
+        exc=RuntimeError("original"),
+    )

--- a/tests/data/test_failure_recording.py
+++ b/tests/data/test_failure_recording.py
@@ -357,11 +357,7 @@ def test_record_failed_operation_updates_all_started_rows_count_gt_1(tmp_path: P
             flow_media_ids=["media-a", "media-b"],
         )
         statuses = [
-            str(row["status"])
-            for row in (
-                dict(zip(("status",), r, strict=True))
-                for r in store.conn.execute("SELECT status FROM operations").fetchall()
-            )
+            str(r[0]) for r in store.conn.execute("SELECT status FROM operations").fetchall()
         ]
     assert statuses == ["failed", "failed"]  # no stranded STARTED sibling, no extra insert
 

--- a/tests/mcp/test_cli_parity.py
+++ b/tests/mcp/test_cli_parity.py
@@ -69,6 +69,7 @@ _MCP_EXEMPT: dict[str, str] = {
     "character rm": "character mutations — not yet ported",
     "character show": "character mutations — not yet ported",
     "character voices": "character mutations — not yet ported",
+    "data list errors": "local catalog maintenance — not yet ported",
     "data list images": "local catalog maintenance — not yet ported",
     "data list profiles": "local catalog maintenance — not yet ported",
     "data list videos": "local catalog maintenance — not yet ported",

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -370,3 +370,39 @@ async def test_aspect_propagates_to_every_link(tmp_path: Path) -> None:
 
     aspects = {c.kwargs["req"].aspect for c in client.generate_video.await_args_list}
     assert aspects == {Aspect.LANDSCAPE}
+
+
+async def test_on_link_failed_hook_receives_request_and_error(tmp_path: Path) -> None:
+    """#341: a link failure invokes on_link_failed with the link's own request
+    and the original exception, before ChainPartialError is raised."""
+    ok = _ok_result("m0", tmp_path / "link0.mp4")
+    client = MagicMock(name="FlowApiClient")
+    calls: list[Any] = [ok, WireFormatError("i2v routed to t2v backstop")]
+
+    async def _gen(*, req: GenerateVideoRequest, **_: Any) -> VideoResult:
+        item = calls.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        assert item.local_path is not None
+        item.local_path.parent.mkdir(parents=True, exist_ok=True)
+        item.local_path.write_bytes(b"\x00\x00\x00\x18ftypmp42fake-clip")
+        return item
+
+    client.generate_video = AsyncMock(side_effect=_gen)
+    written: list[Path] = []
+    failed: list[tuple[GenerateVideoRequest, BaseException]] = []
+
+    with pytest.raises(ChainPartialError):
+        await run_chain(
+            client=client,
+            links=_two_link_specs(),
+            out_dir=tmp_path,
+            model=VideoModel.VEO_3_1_LITE,
+            extractor=_fake_extractor(written),
+            on_link_failed=lambda request, exc: failed.append((request, exc)),
+        )
+
+    assert len(failed) == 1
+    failed_req, failed_exc = failed[0]
+    assert failed_req.prompt == "the cat stretches and walks off"
+    assert isinstance(failed_exc, WireFormatError)

--- a/tests/worker/test_daemon.py
+++ b/tests/worker/test_daemon.py
@@ -684,3 +684,39 @@ async def test_worker_t2i_record_generic_data_store_error_unchanged(temp_db: Dat
     assert updated.error["type"] == "https://gflow-cli.dev/errors/data-store"
     assert updated.error["type"] != "https://gflow-cli.dev/errors/media-attribution"
     worker.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_persists_failed_operation(temp_db: DataStore) -> None:
+    """#341: a failed task writes BOTH generation_queue.error_json AND a
+    terminal FAILED row in the operations table (operations own terminal truth)."""
+    from gflow_cli.errors import WafRejectionError
+
+    repo = QueueRepository(temp_db)
+    task = repo.enqueue_task(
+        task_id="task-t2i-fail",
+        profile_name="default",
+        task_type="t2i",
+        payload={"prompt": "blocked prompt"},
+    )
+
+    worker = FlowWorker("default", str(temp_db.path))
+    fake_client = FakeFlowApiClient()
+    fake_client.create_project.return_value = MagicMock(project_id="project-abc", title="T")
+    fake_client.generate_image.side_effect = WafRejectionError("blocked by WAF", status=403)
+
+    with patch("gflow_cli.worker.daemon.FlowApiClient", return_value=fake_client):
+        await worker.process_task(task)
+
+    updated = repo.get_task("task-t2i-fail")
+    assert updated is not None
+    assert updated.status == "failed"
+
+    row = temp_db.conn.execute(
+        "SELECT command, mode, status, error_type FROM operations WHERE status='failed'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "worker t2i"
+    assert row[1] == "t2i"
+    assert row[3] == "waf-rejection"
+    worker.close()

--- a/website/docs/DATA_LAYER.md
+++ b/website/docs/DATA_LAYER.md
@@ -133,6 +133,31 @@ For T2V the sequence is split: `record_started_video(...)` fires the moment the 
 
 For batches, each row is recorded individually in a per-row `try/except DataStoreError`, so one row's persistence failure does not stop the rest of the batch.
 
+### Failure recording (#341, v0.39.0+)
+
+Failed generations are first-class catalog citizens: every paid-generation
+orchestrator records a terminal `status="failed"` operation row before
+re-raising the error. The funnel covers `video t2v/i2v/r2v`, `video chain`
+(per-link, via the `on_link_failed` hook), `image t2i/i2i`, multi-prompt
+t2i / `gflow run` / `image batch` manifest rows, `movie run` scenes, and the
+async worker (which mirrors its `generation_queue.error_json` failure into
+`operations` — the operations table owns terminal truth).
+
+- `error_type` is the last segment of the exception's RFC 9457 `problem_type`
+  URI (`waf-rejection`, `content-policy`, `auth-expired`,
+  `transport-timeout`, ...) — the taxonomy is declared per `GFlowError`
+  subclass, never hand-mapped. Non-`GFlowError` exceptions store the class
+  name, with `error_detail` reduced to a SHA-256 hash of the message (never
+  the text — it may carry tokens).
+- Video failures UPDATE the `on_started` STARTED row to `failed` (mirroring
+  `record_completed_video`); failures before `on_started`, and all image
+  failures, INSERT a fresh row with full request metadata.
+- The write itself is best-effort: `record_failed_operation_safe` wraps it in
+  a broad warn-only guard (`failure_record_skipped` structlog event) so a
+  data-layer fault can never mask the generation error or change the exit code.
+- The character-create saga deliberately keeps its STARTED rows for resume —
+  it is excluded from the failure funnel by design.
+
 ---
 
 ## Persistence-failure handling
@@ -179,6 +204,20 @@ The hash is always stored so you can correlate without the plaintext.
 
 This means the recorder OWNS redaction — call sites cannot leak signed URLs into the DB even by accident, because `OperationRecorder` always pipes metadata through `redact_metadata` before writing.
 
+### `error_detail` redaction (#341)
+
+Failure rows persist the exception's Problem-Details `detail` string through
+[`redact_error_detail`](../src/gflow_cli/data/redaction.py): free-text
+`Bearer …` / `SAPISIDHASH …` tokens and auth-cookie pairs become
+`<redacted:secret>`, URLs carrying signed-query markers become
+`<redacted:url>`, and the result is truncated to 500 chars post-redaction as
+defense-in-depth. The experimental REST transports also redact response bodies
+BEFORE truncating them into exception messages, so a clipped secret can't
+reach the DB. Non-`GFlowError` details are stored only as SHA-256 hashes.
+Prompts on FAILED rows honor `GFLOW_CLI_HISTORY_PROMPTS` exactly like success
+rows — note that in `store` mode this includes prompts of content-policy
+REJECTED generations (the same opt-in that stores successful prompts).
+
 ### What the DB still contains
 
 Even with `redacted` mode and metadata stripping, the DB stores: profile names, Flow project/media/workflow/operation IDs, local file paths or cloud URIs, asset dimensions/seeds/timestamps, model and aspect choices, and prompt hashes. If your threat model requires hiding even profile-level activity, exclude `<GFLOW_CLI_HOME>/gflow.db` from backups or set `GFLOW_CLI_DB_PATH` to a per-task ephemeral location.
@@ -189,7 +228,7 @@ See [`SECURITY.md`](SECURITY.md) for the broader threat model.
 
 ## Querying the data layer
 
-### `gflow data list {projects,images,videos,profiles}` — browse the catalog (v0.9.0+)
+### `gflow data list {projects,images,videos,profiles,errors}` — browse the catalog (v0.9.0+)
 
 ```bash
 # Newest 20 projects across all profiles
@@ -206,9 +245,14 @@ gflow data list videos --json | jq '.media_id'
 
 # Profiles with at least one recorded generation
 gflow data list profiles
+
+# Failed generations, newest first (#341): when, which command/mode/model,
+# stable error_type (waf-rejection, content-policy, ...) + redacted detail.
+# The dataset for WAF-cadence and reliability analysis.
+gflow data list errors --profile denon82 --json | jq '{started_at, error_type}'
 ```
 
-Flags shared by all four subcommands:
+Flags shared by all five subcommands:
 
 | Flag | Default | Notes |
 |---|---|---|
@@ -391,6 +435,13 @@ All three errors map to **exit code 16**:
 All three are subclasses of `GFlowError` and re-exported through `gflow_cli.exceptions`. They follow the project's RFC 9457 Problem Details pattern.
 
 See [`errors.py::EXIT_CODE_MAP`](../src/gflow_cli/errors.py) for the complete exit-code mapping.
+
+Distinct from the above (which are errors OF the data layer), the
+`operations.error_type` column stores the taxonomy of RECORDED generation
+failures — the last segment of each exception's `problem_type` URI. Common
+values: `waf-rejection` (HTTP 403 / WAF), `content-policy`, `auth-expired`,
+`transport-timeout`, `wire-format`, `rate-limit`, `ui-mode-unavailable`
+(cohort pin), `media-attribution`. Query them with `gflow data list errors`.
 
 ---
 

--- a/website/docs/DATA_LAYER.md
+++ b/website/docs/DATA_LAYER.md
@@ -149,9 +149,13 @@ async worker (which mirrors its `generation_queue.error_json` failure into
   subclass, never hand-mapped. Non-`GFlowError` exceptions store the class
   name, with `error_detail` reduced to a SHA-256 hash of the message (never
   the text — it may carry tokens).
-- Video failures UPDATE the `on_started` STARTED row to `failed` (mirroring
-  `record_completed_video`); failures before `on_started`, and all image
-  failures, INSERT a fresh row with full request metadata.
+- Video failures UPDATE every `on_started` STARTED row to `failed` (a
+  `count>1` request fires the callback per output — no sibling row is
+  stranded); failures before `on_started`, and all image failures, INSERT a
+  fresh row with full request metadata.
+- A poll that COMPLETES with a Flow-reported failure (`succeeded=false`) is
+  recorded as `failed` with `error_type=generation-failed` and the
+  `failure_reasons` as detail — not as a success.
 - The write itself is best-effort: `record_failed_operation_safe` wraps it in
   a broad warn-only guard (`failure_record_skipped` structlog event) so a
   data-layer fault can never mask the generation error or change the exit code.

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -306,7 +306,7 @@ Options:
 **Path-or-UUID semantics.** Each `--ref` value is classified at the CLI boundary:
 
 - **Looks like a Flow asset UUID** (case-insensitive 8-4-4-4-12 hex, e.g. `ddb6ef97-262d-49f4-8269-4a28c0fae6a2`) → passed through verbatim. No upload, no extra round-trip.
-- **Anything else** → treated as a local path. The CLI canonicalises it (resolving symlinks once at validation time, closing the symlink-laundering vector where `./hero.png -> ~/.ssh/id_rsa` could exfiltrate secrets), uploads it, then uses the resulting UUID.
+- **Anything else** → treated as a local path. The CLI canonicalises it (resolving symlinks once at validation time, closing the symlink-laundering vector where `./hero.png -> ~/.ssh/id_rsa` could exfiltrate secrets), then attaches it — **deduplicated by filename since v0.38.0 (#314):** if the target project's library already holds an asset with the exact same filename, that existing tile is selected in the picker instead of re-uploading, so repeating a ref across runs no longer piles up duplicate library entries. On a picker miss the file is uploaded as before. Caveat: the match is by exact filename only — a *different* image that happens to share the name of one already in the project will be reused, not uploaded; rename the file if you need a fresh upload. (Video `r2v` refs keep upload-only behavior.)
 
 Mix and match in a single call. UUIDs and paths can co-exist on the same command line; order is preserved so `imageInputs[]` matches the order you typed.
 
@@ -888,6 +888,7 @@ gflow data list projects   [--profile NAME] [--limit N] [--offset N] [--json]
 gflow data list images     [--profile NAME] [--limit N] [--offset N] [--json] [--all-copies]
 gflow data list videos     [--profile NAME] [--limit N] [--offset N] [--json] [--all-copies]
 gflow data list profiles                    [--limit N] [--offset N] [--json]
+gflow data list errors     [--profile NAME] [--limit N] [--offset N] [--json]
 
 Options:
   --profile NAME        Filter to one profile (not available on `profiles`).
@@ -925,7 +926,18 @@ gflow data list videos --json | jq '.media_id'
 
 # Profiles with at least one recorded generation
 gflow data list profiles
+
+# Failed generations, newest first (v0.39.0+, #341): started_at, command, mode,
+# model, profile, error_type (waf-rejection, content-policy, ...), redacted detail
+gflow data list errors --profile denon82 --json | jq '{started_at, error_type}'
 ```
+
+`errors` lists terminal `status="failed"` operation rows — every paid
+generation that raised (WAF 403, content policy, cohort pin, timeout, auth)
+is recorded before the CLI exits, so block onset/recovery windows are
+measurable. `error_detail` is redacted before persistence (no tokens, cookies,
+or signed URLs). See
+[`DATA_LAYER.md § Failure recording`](DATA_LAYER.md#failure-recording-341-v0390).
 
 > **`data list profiles` vs `gflow auth list`** — `data list profiles` shows profiles that have **recorded generations** in the catalog; `gflow auth list` shows profiles that have ever **logged in** via `gflow auth login`. A profile that logged in but never generated anything will appear in `auth list` but not in `data list profiles`.
 
@@ -1251,7 +1263,7 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `22` | `UpscaleUnavailableError` | 4K upscale is gated to Flow **Ultra** accounts (HTTP 403) | Use `--scale 2k`, or upgrade the Flow plan                |
 | `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issue #183) | Update gflow-cli; file a bug with the probe name + debug screenshot from the error message |
 | `24` | `BrowserEngineUnavailableError` | `GFLOW_CLI_BROWSER_ENGINE=patchright` but the engine is not installed | `pip install 'gflow-cli[patchright]'`, or unset `GFLOW_CLI_BROWSER_ENGINE` |
-| `25` | `FlowAgentUiError`    | The profile is on Flow's Agentic UI cohort and the classic media panel is unrecoverable for this operation | Use a Classic-cohort profile; see KNOWN_ISSUES on the agentic cohort |
+| `25` | `FlowAgentUiError`    | The profile is on Flow's Agentic UI cohort and the classic media panel is unrecoverable for this operation | Rare since v0.38.0 (#332): the mode controller reliably recovers agentic→classic, so first retry with `--ui-mode classic`; if it persists, see KNOWN_ISSUES on the agentic cohort |
 | `26` | `MediaAttributionError` | Generated media could not be reliably attributed to this request (issue #281) | Re-run; a dedicated project with fewer pre-existing assets avoids the ambiguity |
 | `27` | `MediaUploadRejectedError` | Flow's upload endpoint refused the input file (`uploadImage` 4xx, issue #287) | Re-encode the image (`ffmpeg -q:v 2 -map_metadata -1`), or reference the asset by its media UUID |
 | `28` | `UiModeUnavailableError` | The Flow UI arm this command required (`GFLOW_CLI_UI_MODE`, or inferred — `-i` forces agentic) couldn't be reached after a switch attempt; aborted before submitting — no credits spent (issue #299) | Retry (the cohort flaps per load); try another `--profile`; or relax `GFLOW_CLI_UI_MODE` |


### PR DESCRIPTION
## Summary

Implements #341: every failed paid generation now writes a terminal `FAILED` row to the `operations` table, queryable via the new `gflow data list errors` — so WAF-403 onset/duration/recovery, cohort pins, and policy rejections become measurable instead of reconstructed from memory. No schema migration needed (columns existed; no code path ever wrote them).

## Design (predict council: GO-with-conditions — Architect 7, Security 8, Perf/UX 8, Devil's Advocate 8)

- **Taxonomy = existing RFC 9457 `problem_type`**: `error_type` is the last URI segment (`waf-rejection`, `content-policy`, `auth-expired`, …) declared per `GFlowError` subclass — no hand-rolled slug map to drift. Non-`GFlowError` → class name + `sha256:<digest>` of the message (shared helper with `emit_unhandled_event`; never the text). Slug uniqueness pinned by test.
- **Record-on-catch, then re-raise** at the orchestrator choke points holding full context; exit codes unchanged (pinned by tests). The Devil's-Advocate audit found 3 paths the initial 4-site plan missed — all covered:
  `video t2v/i2v/r2v` · `video chain` (new `on_link_failed` hook in `chain.py`, incl. the download-failed abort) · `image t2i/i2i` · multi-prompt t2i / `gflow run` / `image batch` manifest rows · `movie run` scenes · worker daemon (queue failure mirrored into `operations`; operations own terminal truth).
- **Video**: every `on_started` STARTED row (count>1 fires per output) is updated in place to FAILED; early failures and image paths insert fresh rows. **Flow-reported failures** (`succeeded=false` at poll completion) now record `generation-failed` — previously recorded as SUCCEEDED (review finding; fixed at the root in `record_completed_video`, covers CLI/chain/movie/worker at once).
- **Best-effort by construction**: `record_failed_operation_safe` is warn-only (broad catch — a fault while recording a failure must never mask the original error; regression-tested).
- **Character saga excluded by design** (keeps STARTED rows for resume).

## Security / privacy (council checklist, each testable)

- `error_detail` passes a new free-text scrub (`Bearer`/`SAPISIDHASH` both forms, full Google auth-cookie family incl. bare `SID`/`OSID`/`LSID`, signed-query tokens in or out of URLs, case-insensitive) + 500-char cap post-redaction.
- Prompts on FAILED rows honor `GFLOW_CLI_HISTORY_PROMPTS` exactly like successes (docs note that `store` mode covers refused prompts).
- Pre-existing gap fixed in the same PR: experimental REST transports interpolated raw response bodies into exception messages — now redact-before-truncate, computed only at raise sites (zero 200-path cost).
- Worker `generation_queue.error_json` now redacted/hashed with the same rules (was raw `str(exc)` in the same DB file).
- Rich table escapes every DB-sourced column (prior `Console(markup=True)` incident class).

## CLI surface

`gflow data list errors [--profile] [--limit] [--offset] [--json]` — placed under the `list` subgroup for consistency with `projects/images/videos/profiles` (the issue's `gflow data errors` example maps here). MCP parity via `_MCP_EXEMPT` entry. Exit codes unchanged (`@_guard` → 16).

## Explicit descopes (per council, noted not silent)

- Retention/export path, structured external failure events, `attempt_index`/`waf_recovery_seconds`/`retryable` columns — deferred (no consumer yet).
- `image upscale` path not wired (not claimed by the issue's funnel).
- STARTED-row flips keep the original `command` label (movie/chain failures after `on_started` show the video-mode command — same behavior as success flips today).
- `gflow run`/multi-prompt now open the recorder pre-flight (fail-fast-before-billing, exit 16) — intentional alignment with the documented `image t2i` contract.
- Known residual: attribution collisions (`media-attribution`) recorded on single-shot paths but deliberately NOT on the manifest post-success path (generation succeeded there; recording would pollute the failure dataset). Filter by `error_type` if needed.

## Verification

- 1284 tests green (data/cli/transports/mcp/worker/chain scopes); ruff + format + pyright strict 0 errors; repo-hygiene + doc-links green.
- Funnel wiring pinned end-to-end via CLI-level tests (mocked transport raising `WafRejectionError` → exit code preserved + FAILED row in a real tmp DB, STARTED updated in place, no duplicates).
- Credit-free live check: `gflow data list errors` runs against the real catalog (exit 0, 0 rows — exactly the gap this PR closes going forward). A real failure event can only be captured opportunistically (next WAF block will populate the dataset).
- Docs: DATA_LAYER (failure recording, `error_detail` redaction, taxonomy, querying), USAGE, CHANGELOG; website mirrors synced; plan doc under `docs/superpowers/plans/2026-07-18-issue-341-error-tracking/`.

Refs #341

