### PR TITLE
chore: production-readiness live-gaps — crash-recovery + cancellation live-confirmed, operation_id invariant corrected

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -585,31 +585,37 @@ one of the 14 supported locales or in English.
 
 ---
 
-### `omni-flash` t2v response omits operation name — `flow_operation_id` persists NULL
+### t2v response can omit operation name — `flow_operation_id` persists NULL
 
 - **Status:** Open · **Severity:** Low · **Affects:** v0.9.0+ (data layer)
 
 The data layer's `on_started` callback captures
 `operations[0].operation.name` from each `batchAsyncGenerateVideoText`
-response and persists it as `operations.flow_operation_id`. The
-`omni-flash` model's response shape does not carry that field, so
-omni-flash rows end up with `flow_operation_id` NULL while `veo-*` rows
-carry the expected `operations/...` identifier. The rest of the row
-(prompt, model, aspect, started/completed timestamps, batch ID, output
-paths) is recorded normally.
+response and persists it as `operations.flow_operation_id`. This field
+is **best-effort, not guaranteed for any model**: `omni-flash`'s response
+shape does not carry it, so omni-flash rows end up with
+`flow_operation_id` NULL. **Update 2026-07-21 (live):** the same NULL
+was observed on a live `veo-lite` t2v run (`remote_started` checkpoint
+with `operation_id=None`), on an agentic-UI-cohort account — so `veo-*`
+is not a reliable guarantee either; the original claim that veo-* rows
+always carry the operation name was false. The rest of the row (prompt,
+model, aspect, started/completed timestamps, batch ID, output paths) is
+recorded normally regardless.
 
-**Impact:** cosmetic for now — `gflow data media <id>` and provenance
-lookup by Flow media ID still work. Any future feature that joins on
-`flow_operation_id` (none in the current CLI) would miss omni-flash
-rows.
+**Impact:** cosmetic/provenance-only — `media_id` is the canonical
+handle (poll, download, and every CLI lookup use it, not
+`flow_operation_id`). `gflow data media <id>` and provenance lookup by
+Flow media ID still work. Nothing in the current CLI queries by
+`flow_operation_id`; a future feature that did would miss rows on any
+model whose response omits the operation name.
 
 **Workaround:** none needed if you don't query by `flow_operation_id`.
 
-**Roadmap:** capture an `omni-flash` `batchAsyncGenerateVideoText`
-response sample, identify the equivalent provenance handle (if any), and
-either map it into `flow_operation_id` or document that omni-flash
-legitimately has no such identifier. Track via a follow-up issue once a
-sample is captured.
+**Roadmap:** capture response samples across models (including veo-lite)
+where the operation name is absent, identify the equivalent provenance
+handle (if any), and either map it into `flow_operation_id` or document
+that these cases legitimately have no such identifier. Track via a
+follow-up issue once samples are captured.
 
 ---
 

--- a/docs/LIVE_VERIFICATION_v0.40.0-production-readiness.md
+++ b/docs/LIVE_VERIFICATION_v0.40.0-production-readiness.md
@@ -15,6 +15,56 @@
 > and why, per the design spec's evidence rule
 > (`docs/superpowers/specs/2026-07-19-production-readiness-hardening-design.md`
 > § Evidence deliverable).
+>
+> **Update — see the "2026-07-21 live follow-up" section immediately below:** a
+> second live session closed the crash-recovery `remote_started` chain and the
+> D4 mid-launch cancellation path, added two durable live-gated e2e tests, and
+> corrected a false `flow_operation_id` invariant surfaced live. The lists in
+> this document describe the original v0.40.0 run; the follow-up section is the
+> authoritative update.
+
+## 2026-07-21 live follow-up (0.42.0 cycle)
+
+A second live session (profile `ffroliva`, 2026-07-21) closed several items left
+open by the original run and added durable live-gated e2e tests. `ffroliva` was
+on Flow's agentic UI cohort that day (classic mode unreachable, issue #174 A/B).
+
+**Crash-recovery `remote_started` chain — CONFIRMED (1 credit).** A real
+`veo-lite` t2v driven through the worker path with the C1 checkpoint observer
+completed, and the observer persisted a real `remote_started` checkpoint
+carrying the media handle to the DB — live-confirming the
+observer→checkpoint→DB chain for a *paid* generation. The recovery step
+(`remote_started` → `indeterminate`, never resubmit) is deterministic, proven by
+unit tests plus the credit-free phase-2 of the new e2e test. Durable artifact:
+`tests/e2e/test_crash_recovery_e2e.py` (live-gated, ~1 credit). Auto-reconciliation
+of a crashed paid job remains a deliberate **unimplemented** seam (the safe stub:
+`indeterminate` + manual reconcile).
+
+**Finding — `flow_operation_id` NULL on veo-lite → false invariant corrected.**
+That run also surfaced `operation_id=None` in the `remote_started` checkpoint for
+`veo-lite`, contradicting the prior claim that only omni-flash omits it.
+Root-caused: the operation-name parser is correct; `flow_operation_id` is
+best-effort/optional and `media_id` is the canonical handle (poll + download +
+every CLI lookup use it). The false invariant was corrected in `KNOWN_ISSUES.md`
+and the `client.py` docstring, and a regression test now locks the parser against
+the real veo fixture. No production behavior change — generation completed and
+downloaded correctly on the `None`.
+
+**D4 cancellation (mid-launch) — CONFIRMED (credit-free).** A real Chrome context
+was launched and the operation cancelled during `__aenter__` (before any submit
+gesture); the ProfileLease released (proven by successful re-acquisition) and no
+gflow-owned Chrome process remained. Durable artifact:
+`tests/e2e/test_cancellation_e2e.py` (live-gated, 0 credits). The other three D4
+cancellation sub-paths (mid-context-close with a wedged page, Ctrl-C during
+passive-capture reap, daemon SIGINT in-flight) remain deterministically
+unit-proven (`tests/api/test_concurrency.py`) and are not separately
+live-triggered — they are timing-fragile to reproduce live, and the mid-launch
+path exercises the same `run_teardown_step` release contract.
+
+**Still open (honest).** The full daemon/MCP lifecycle over HTTP (`gflow serve`)
+was not live-exercised (the worker path was exercised directly in the e2e test);
+auto-reconciliation remains unimplemented by design; the three fragile
+cancellation sub-paths remain unit-proven only.
 
 ## Commit and environment
 

--- a/docs/LIVE_VERIFICATION_v0.40.0-production-readiness.md
+++ b/docs/LIVE_VERIFICATION_v0.40.0-production-readiness.md
@@ -265,12 +265,13 @@ step in the live sequence above ran to completion. What was deliberately
   run observed the handle capture but did not drive a crash-and-reconcile
   scenario live. Keep the underlying issue open; this is remaining work, not
   a regression.
-- **Remote macOS/Linux legs of the D2 `profile-lease-matrix` CI job** are
-  pending an authorized push — the POSIX `fcntl.flock` lease branch has not
-  been executed anywhere yet (Windows leg ran locally and is GREEN, see
-  Offline gates below). Per design-spec guidance, remote execution requires
-  explicit push/PR authorization and must not be reported as locally
-  executed.
+- **Remote macOS/Linux legs of the D2 `profile-lease-matrix` CI job**: this
+  gap is now CLOSED. PR #357 was pushed and its CI ran the
+  `profile-lease-matrix` job GREEN on all three OSes — `windows-latest`,
+  `macos-latest`, `ubuntu-latest` — exercising the POSIX `fcntl.flock` lease
+  branch on macOS/Linux for the first time (PR #357, `profile-lease-matrix`
+  job, merged 2026-07-20). This closes the CI-execution gap only; it is
+  CI-level evidence, not a live run against real Flow.
 - **omni-flash NULL-operation-id path** was not exercised — `veo-lite` was
   used deliberately for the T2V generation instead.
 - **D4's four live cancellation paths** (mid-launch cancel, mid-context.close
@@ -364,8 +365,12 @@ blocked paths" above for detail, not just offline-covered):
 - **Daemon/MCP live lifecycle and live queue-claim**: not exercised this
   pass — the live sequence used the direct `gflow image`/`gflow video`
   client path, not `gflow serve`/MCP.
-- **D2 remote CI legs (POSIX `fcntl` lease branch)**: pending an authorized
-  push; unexecuted anywhere in this branch's history.
+- **D2 remote CI legs (POSIX `fcntl` lease branch)**: CLOSED — PR #357 was
+  pushed and its CI ran the `profile-lease-matrix` job GREEN on all three
+  OSes (`windows-latest`, `macos-latest`, `ubuntu-latest`), exercising the
+  POSIX `fcntl.flock` lease branch on macOS/Linux (PR #357,
+  `profile-lease-matrix` job, merged 2026-07-20). CI-level evidence only —
+  not a live-Flow run.
 - **D4's four live cancellation paths**: unit-proven only, not driven live.
 - **omni-flash NULL-operation-id path**: not exercised (veo-lite used
   deliberately instead).

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -78,7 +78,7 @@ We analyzed whether a terminal-driven CLI guided by a text skill (e.g., `skills/
 | :--- | :--- | :--- |
 | **Output Fragility** | Ephemeral `stdout`/`stderr` log outputs are fragile to format adjustments, progress bars, and ANSI colors. | Strictly structured JSON payloads containing explicit metadata and absolute output file URIs. |
 | **Process Lifecycle**| High process startup overhead (Python import latency) on every individual execution. | Warm daemon process. Retains active caching of database metadata. |
-| **Concurrency** | Independent OS runs collide and crash the Chromium profile lock. | Serialized request execution via an internal `asyncio.Lock` queue. |
+| **Concurrency** | A second concurrent process against the same profile is rejected immediately by the cross-process `ProfileLease` with `ProfileLockedError` (exit code 11) — a clean fail-fast, never a crash, never a wait. Different profiles run fully in parallel. | Same `ProfileLease` enforcement applies to the daemon's requests — a same-profile call made while another is in flight (from the CLI or the MCP daemon) is rejected immediately with `ProfileLockedError` rather than queued or crashed; different profiles still run fully in parallel. |
 | **Error Handling** | Agent must scan logs for strings or parse exit codes to check status. | Strongly-typed JSON-RPC errors with mapped codes and clear remediation. |
 | **Transport Safety** | Volatile console printing. | Stdout is strictly isolated for JSON-RPC; all logs and warnings route to stderr. |
 

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -1888,10 +1888,13 @@ class FlowApiClient:
 
         ``on_checkpoint`` (Task C1) receives a ``submit_attempted`` observation
         immediately before the credit-spending transport call, then a
-        ``remote_started`` observation carrying the ``batchAsyncGenerateVideo*``
-        operation name (via the transport's ``on_started`` hook — the first
-        point the video handle is observable; ``operation_id`` is ``None`` for
-        models whose response omits it, e.g. omni-flash).
+        ``remote_started`` observation (via the transport's ``on_started`` hook
+        — the first point the video handle is observable). ``operation_id`` is
+        best-effort/optional: it is captured when the generate response
+        includes ``operations[0].operation.name``, and is ``None`` when that
+        field is absent (observed on veo-lite too, not only omni-flash, live
+        2026-07-21). ``media_id`` is the canonical handle used for polling and
+        download.
 
         Raises:
             RuntimeError: transport is None (client not entered) or the transport

--- a/src/gflow_cli/worker/queue.py
+++ b/src/gflow_cli/worker/queue.py
@@ -309,31 +309,6 @@ class QueueRepository:
         except sqlite3.IntegrityError as exc:
             raise DataIntegrityError(detail=str(exc), route="queue.update_task_status") from exc
 
-    def fail_processing_tasks(self, profile_name: str, error_message: str) -> int:
-        now = _utc_now()
-        error_payload = {
-            "type": "https://gflow-cli.dev/errors/daemon-recovery",
-            "title": "Daemon Boot Recovery",
-            "status": 500,
-            "detail": error_message,
-        }
-        error_str = json.dumps(error_payload)
-        try:
-            with self._store.transaction(immediate=True):
-                cursor = self._store.conn.execute(
-                    """
-                    UPDATE generation_queue
-                    SET status = 'failed',
-                        error_json = ?,
-                        updated_at = ?
-                    WHERE profile_name = ? AND status = 'processing'
-                    """,
-                    (error_str, now, profile_name),
-                )
-                return cursor.rowcount
-        except sqlite3.IntegrityError as exc:
-            raise DataIntegrityError(detail=str(exc), route="queue.fail_processing_tasks") from exc
-
 
 def classify_interrupted(checkpoint: dict[str, Any] | None) -> str:
     """Truthful terminal status for a task interrupted (cancelled or crashed)

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -400,6 +400,16 @@ class TestOperationNameFromGenerateResponse:
     def test_returns_none_when_operations_empty(self) -> None:
         assert operation_name_from_generate_response({"operations": []}) is None
 
+    def test_real_t2v_capture_extracts_operation_name(self) -> None:
+        """Regression lock: a real classic-veo capture must still yield a
+        non-None operation name. Root-caused 2026-07-21 — flow_operation_id
+        is best-effort/optional (None is a legitimate outcome when the
+        generate response omits operations[0].operation.name), but when the
+        field IS present the parser must keep extracting it correctly.
+        """
+        name = operation_name_from_generate_response(_body("02_batchAsyncGenerateVideoText.json"))
+        assert name == "<UUID>"
+
 
 class TestVideoResult:
     def test_video_result_holds_fields(self) -> None:

--- a/tests/e2e/test_cancellation_e2e.py
+++ b/tests/e2e/test_cancellation_e2e.py
@@ -1,0 +1,152 @@
+"""Live E2E: the D4 cancellation-safe browser teardown against a real browser.
+
+Hits the **real Google Flow API** and therefore:
+  - Is NOT collected by default ``pytest`` runs (deselected by the repo's
+    ``-m 'not e2e ...'`` addopts).
+  - Opt-in: ``GFLOW_CLI_E2E_PROFILE=<profile_name> pytest -m e2e``
+  - Requires a logged-in Chrome profile (Pro/Ultra account).
+  - **Zero credits.** The generation task is cancelled DURING
+    ``FlowApiClient.__aenter__`` — deterministically, right after the real
+    persistent Chrome context is launched — which is structurally BEFORE
+    ``generate_image()`` is ever called: Python never runs an ``async with``
+    body when ``__aenter__`` itself raises. No submit gesture is reachable,
+    so no ``submit_attempted`` checkpoint and no credit is possible.
+
+## Behavior under test (D4 cancellation-safe teardown)
+
+When a generation is cancelled (``asyncio.CancelledError``) during browser
+launch — before the credit-spending submit gesture — ``FlowApiClient``'s
+teardown (``_close_browser_resources``, invoked from ``__aenter__``'s
+partial-setup guard) must: close the Playwright context/browser, stop the
+driver, and release the ``ProfileLease`` — leaving the profile immediately
+re-leasable and no gflow-owned Chrome process behind. The deterministic
+fakes in ``tests/api/test_concurrency.py``
+(``test_aenter_partial_failure_tears_down_browser``,
+``test_close_hang_times_out_and_force_closes``,
+``test_force_close_runs_before_driver_stop``, et al.) assert this same
+teardown contract with mocked Playwright; this test exercises it against a
+REAL browser under a REAL cancellation.
+
+## Design (credit-free by construction)
+
+1. Build a ``FlowApiClient`` for the e2e profile and monkeypatch its
+   ``_launch_persistent_context`` to set an ``asyncio.Event`` right after the
+   REAL persistent context launch returns — a deterministic "mid-launch"
+   signal instead of a guessed sleep duration.
+2. Run ``async with client: await client.generate_image(...)`` as an asyncio
+   task. Image t2i is used as the (unreachable) target because it is
+   credit-free even in the hypothetical case it *did* run.
+3. Wait for the event, then cancel the task immediately. The cancellation
+   lands while ``__aenter__`` is still executing (inside ``_enter_setup``,
+   somewhere between the context launch and the bootstrap page navigation /
+   transport setup) — i.e. before ``__aenter__`` has returned, which means
+   the ``async with`` body (the ``generate_image`` call) is provably never
+   entered. There is no scheduling race that could land the cancellation
+   post-submit: nothing resumes ``generate_image`` execution during a
+   Playwright I/O suspension in a *different* coroutine frame.
+4. Assert the awaited task raises ``CancelledError``, and that a FRESH
+   ``ProfileLease`` on the same profile dir is immediately acquirable — the
+   load-bearing proof the OS-level lease was released by teardown. A
+   best-effort check for a leftover gflow-owned Chrome process runs when
+   ``psutil`` is importable (it is not a project dependency, so this is
+   skipped, not failed, when absent — the lease-reacquire assertion is the
+   primary proof either way).
+
+Does NOT cover post-submit cancellation (mid-generation, after
+``submit_attempted``) — that would spend a real credit; it is exercised by
+the deterministic fakes in ``tests/api/test_concurrency.py`` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from playwright.async_api import BrowserContext
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.image import GenerateImageRequest
+from gflow_cli.profile_lease import ProfileLease
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_auth]
+
+_PROMPT = "a calm forest at dawn, cinematic"
+
+# Real headed Chrome launch + navigation on a cold profile is slow; generous
+# so this never flakes on machine load — the signal itself is deterministic,
+# only its wall-clock arrival time is uncertain.
+_LAUNCH_SIGNAL_TIMEOUT_S = 120.0
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_launch_releases_lease_and_closes_browser(
+    e2e_profile_dir: Path, tmp_path: Path
+) -> None:
+    """D4: cancelling pre-submit tears down the real browser and frees the lease."""
+    client = FlowApiClient(profile_dir=e2e_profile_dir, out_dir=tmp_path)
+
+    # Deterministic "context launched" signal — fires the instant the REAL
+    # persistent context exists, so the cancel below always lands mid-launch
+    # rather than racing a guessed sleep against real browser startup time.
+    launched = asyncio.Event()
+    original_launch = client._launch_persistent_context
+
+    async def _launch_and_signal(kwargs: dict[str, Any]) -> BrowserContext:
+        context = await original_launch(kwargs)
+        launched.set()
+        return context
+
+    client._launch_persistent_context = _launch_and_signal  # type: ignore[method-assign]
+
+    async def _run() -> None:
+        async with client:
+            # Unreachable: the cancel below always lands inside __aenter__
+            # (see module docstring, point 3), so this line never executes.
+            # Kept to document/exercise the intended real call shape — t2i
+            # is credit-free even in the hypothetical case it did run.
+            req = GenerateImageRequest(prompt=_PROMPT)
+            await client.generate_image(req=req)
+
+    task = asyncio.create_task(_run())
+    try:
+        await asyncio.wait_for(launched.wait(), timeout=_LAUNCH_SIGNAL_TIMEOUT_S)
+    finally:
+        task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled(), "the generation task must end cancelled, not merely erroring"
+
+    # Load-bearing proof: the OS-level ProfileLease was released by teardown.
+    # A stuck lease would make try_acquire() return False (or, with acquire(),
+    # raise ProfileLockedError) here.
+    fresh_lease = ProfileLease(e2e_profile_dir)
+    assert fresh_lease.try_acquire(), (
+        "profile lease was not released by cancellation teardown — a leftover "
+        "gflow-owned Chrome process is likely still holding it"
+    )
+    fresh_lease.release()
+
+    # Secondary/best-effort: no leftover gflow-owned Chrome process for this
+    # profile. psutil is NOT a project dependency (see profile_lease.py's own
+    # "no psutil dependency" comment), so this check is skipped — not
+    # failed — when it isn't installed. The lease-reacquire assertion above
+    # already proves the OS lock released, which an unrelated process could
+    # not do.
+    try:
+        import psutil
+    except ImportError:
+        return  # psutil unavailable; lease-reacquire proof above stands alone.
+
+    profile_str = str(e2e_profile_dir)
+    leftover = [
+        proc.info["pid"]
+        for proc in psutil.process_iter(["pid", "name", "cmdline"])
+        if proc.info.get("name", "").lower().startswith("chrome")
+        and any(profile_str in (arg or "") for arg in (proc.info.get("cmdline") or []))
+    ]
+    assert not leftover, (
+        f"gflow-owned Chrome process(es) still running for this profile: {leftover}"
+    )

--- a/tests/e2e/test_crash_recovery_e2e.py
+++ b/tests/e2e/test_crash_recovery_e2e.py
@@ -1,0 +1,189 @@
+"""Live E2E: the C5 crash-recovery "safe stub" for a real Flow video submit.
+
+Hits the **real Google Flow API** and therefore:
+  - Is NOT collected by default ``pytest`` runs (deselected by the repo's
+    ``-m 'not e2e ...'`` addopts).
+  - Opt-in: ``GFLOW_CLI_E2E_PROFILE=<profile_name> pytest -m e2e``
+  - Requires a logged-in Chrome profile (Pro/Ultra account).
+  - Burns exactly ONE Veo credit total (see two-phase design below).
+
+## Behavior under test
+
+If the worker dies AFTER a paid submit (checkpoint phase ``submit_attempted``
+or ``remote_started``) but before a terminal result, startup recovery
+(``recover_processing``) must mark the task ``indeterminate`` and NEVER
+resubmit. A pre-submit crash recovers as ``failed`` instead (covered by the
+unit suite in ``tests/worker/test_queue_reconciliation.py`` — no live handle
+exists yet, so there is nothing for this live test to add there).
+
+## Two-phase design (spends exactly ONE real credit)
+
+A fragile mid-flight kill (actually interrupting the worker process while a
+real generation is in flight) would be timing-critical, non-deterministic,
+and could leave the real Flow-side generation running with nothing watching
+it. Instead:
+
+1. **Real submit, capture the real handle.** Drive ONE real t2v generation
+   (model ``veo-lite``, aspect ``9:16``, no ``--duration`` override) through
+   ``FlowWorker.process_task`` — the actual worker code path, with the real
+   checkpoint observer wired exactly as production wires it — against an
+   isolated temp SQLite DB, and let it run to completion. Read back the real
+   ``remote_started`` checkpoint document the observer persisted. This is the
+   live proof that a REAL generation produces a real ``remote_started``
+   checkpoint row via the real observer -> ``update_checkpoint`` ->
+   ``generation_queue.checkpoint_json`` path. (The one credit spent here.)
+
+2. **Simulate the crash + prove recovery.** Write a FRESH ``processing``
+   queue row whose checkpoint IS that captured ``remote_started`` document
+   (i.e. "we crashed right after observing this handle"). Call
+   ``recover_processing`` with a submit-COUNTING client stub and assert:
+   the task's terminal status becomes ``indeterminate``, the non-secret
+   handle (``operation_id`` / ``media_ids``) survives untouched in the
+   checkpoint, and the counting client's submit counters stay at 0 — no
+   resubmit, no second credit, no generation method invoked at all.
+
+``classify_interrupted`` (``worker/queue.py``) keys ONLY on the checkpoint's
+``phase`` field, so step 2's hand-built row exercises exactly the same
+recovery path a genuine crash-after-submit would hit, deterministically,
+using a checkpoint document that is byte-for-byte what a real crash would
+have left behind.
+
+This test does NOT cover auto-reconciliation (turning ``indeterminate`` back
+into a terminal outcome via a live handle -> status readback) — that
+reconcile hook is deliberately unimplemented; see ``recover_processing``'s
+docstring (the F1 / D3 / D4 seam). ``counting_client`` proves today's
+behavior (unused, zero resubmits), not the future reconciler.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gflow_cli.worker.daemon import FlowWorker
+from gflow_cli.worker.queue import recover_processing
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_video, pytest.mark.e2e_data]
+
+_PROMPT = "a calm forest at dawn, cinematic"
+
+
+class _CountingClient:
+    """Recovery reconcile-hook stub — proves recovery never resubmits.
+
+    ``recover_processing`` currently never calls its ``client`` argument at
+    all (the F1 live-page reconcile seam is unimplemented — see its
+    docstring), so both counters staying at 0 is the load-bearing assertion
+    that recovery performed no generation call whatsoever.
+    """
+
+    def __init__(self) -> None:
+        self.image_submit_count = 0
+        self.video_submit_count = 0
+
+    async def generate_image(self, **_: Any) -> None:
+        self.image_submit_count += 1
+
+    async def generate_video(self, **_: Any) -> None:
+        self.video_submit_count += 1
+
+
+@pytest.mark.asyncio
+async def test_crash_after_remote_started_recovers_as_indeterminate_without_resubmit(
+    e2e_profile_dir: Path, tmp_path: Path
+) -> None:
+    profile_name = e2e_profile_dir.name.removeprefix("profile_")
+    db_path = tmp_path / "crash_recovery.db"
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    worker = FlowWorker(profile_name, str(db_path))
+    try:
+        # Isolated DB: the FK on generation_queue.profile_name needs a
+        # matching profiles row. This DB is unique to this test run (tmp_path)
+        # so the user's real gflow.db history can never be touched.
+        worker.db.conn.execute(
+            "INSERT INTO profiles(name, profile_dir, first_seen_at) VALUES (?, ?, ?)",
+            (profile_name, str(e2e_profile_dir), "2026-01-01T00:00:00Z"),
+        )
+
+        # ---- Phase 1: real submit through the real worker path -----------
+        real_task_id = f"e2e-crash-recovery-real-{uuid.uuid4().hex[:8]}"
+        worker.repo.enqueue_task(
+            real_task_id,
+            profile_name,
+            "t2v",
+            {
+                "prompt": _PROMPT,
+                "aspect": "9:16",
+                "model": "veo-lite",
+                "out_dir": str(out_dir),
+            },
+        )
+        claimed = worker.repo.claim_next_pending(profile_name, f"worker:{profile_name}:e2e-test")
+        assert claimed is not None, "failed to claim the freshly enqueued t2v task"
+
+        await worker.process_task(claimed)
+
+        completed = worker.repo.get_task(real_task_id)
+        assert completed is not None
+        assert completed.status == "completed", (
+            f"expected the real t2v submit to complete; got status={completed.status!r} "
+            f"error={completed.error!r}"
+        )
+
+        real_checkpoint = worker.repo.read_checkpoint(real_task_id)
+        assert real_checkpoint is not None, "observer never persisted a checkpoint"
+        assert real_checkpoint["phase"] == "remote_started", (
+            f"expected the last persisted checkpoint phase to be remote_started, "
+            f"got {real_checkpoint!r}"
+        )
+        # operation_id (flow_operation_id) is best-effort/optional by design —
+        # root-caused 2026-07-21: it's captured only when the generate
+        # response includes operations[0].operation.name, and is None when
+        # absent (observed live on veo-lite, not just omni-flash). media_id
+        # is the canonical handle: poll and download key off it, and nothing
+        # in the CLI queries by operation_id. So the REQUIRED safety
+        # assertion is that a canonical handle (media_ids) is present;
+        # operation_id, if present, must merely be the right optional type.
+        assert real_checkpoint["media_ids"], "remote_started checkpoint missing media_ids"
+        assert real_checkpoint["operation_id"] is None or isinstance(
+            real_checkpoint["operation_id"], str
+        ), "operation_id must be a str or None (optional field)"
+
+        # ---- Phase 2: simulate the crash, prove recovery ------------------
+        crash_task_id = f"e2e-crash-recovery-sim-{uuid.uuid4().hex[:8]}"
+        worker.repo.enqueue_task(crash_task_id, profile_name, "t2v", {"prompt": _PROMPT})
+        worker.repo.update_task_status(crash_task_id, "processing")
+        # The checkpoint IS the real remote_started document captured in
+        # Phase 1 — "we crashed right after the observer persisted this handle".
+        worker.repo.write_checkpoint(crash_task_id, real_checkpoint)
+
+        counting_client = _CountingClient()
+        counts = recover_processing(worker.repo, profile_name, counting_client)
+
+        assert counts == {"failed": 0, "indeterminate": 1}
+
+        recovered = worker.repo.get_task(crash_task_id)
+        assert recovered is not None
+        assert recovered.status == "indeterminate", (
+            f"a task crashed after remote_started must recover as indeterminate, "
+            f"got {recovered.status!r}"
+        )
+
+        recovered_checkpoint = worker.repo.read_checkpoint(crash_task_id)
+        assert recovered_checkpoint is not None
+        assert recovered_checkpoint["operation_id"] == real_checkpoint["operation_id"], (
+            "recovery must preserve the real handle untouched"
+        )
+        assert recovered_checkpoint["media_ids"] == real_checkpoint["media_ids"]
+
+        # The load-bearing safety assertion: recovery invoked NO generation
+        # method — no resubmit, no second credit.
+        assert counting_client.image_submit_count == 0
+        assert counting_client.video_submit_count == 0
+    finally:
+        worker.close()

--- a/tests/worker/test_daemon.py
+++ b/tests/worker/test_daemon.py
@@ -116,15 +116,6 @@ def test_queue_repository_crud(temp_db: DataStore) -> None:
     assert task_updated is not None
     assert task_updated.status == "processing"
 
-    # 6. Fail processing tasks (sweep)
-    count = repo.fail_processing_tasks("default", "Daemon crashed")
-    assert count == 1
-    task_swept = repo.get_task("task-123")
-    assert task_swept is not None
-    assert task_swept.status == "failed"
-    assert task_swept.error is not None
-    assert "Daemon crashed" in task_swept.error["detail"]
-
 
 @pytest.mark.asyncio
 async def test_worker_process_t2i_single(temp_db: DataStore) -> None:

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -78,7 +78,7 @@ We analyzed whether a terminal-driven CLI guided by a text skill (e.g., `skills/
 | :--- | :--- | :--- |
 | **Output Fragility** | Ephemeral `stdout`/`stderr` log outputs are fragile to format adjustments, progress bars, and ANSI colors. | Strictly structured JSON payloads containing explicit metadata and absolute output file URIs. |
 | **Process Lifecycle**| High process startup overhead (Python import latency) on every individual execution. | Warm daemon process. Retains active caching of database metadata. |
-| **Concurrency** | Independent OS runs collide and crash the Chromium profile lock. | Serialized request execution via an internal `asyncio.Lock` queue. |
+| **Concurrency** | A second concurrent process against the same profile is rejected immediately by the cross-process `ProfileLease` with `ProfileLockedError` (exit code 11) — a clean fail-fast, never a crash, never a wait. Different profiles run fully in parallel. | Same `ProfileLease` enforcement applies to the daemon's requests — a same-profile call made while another is in flight (from the CLI or the MCP daemon) is rejected immediately with `ProfileLockedError` rather than queued or crashed; different profiles still run fully in parallel. |
 | **Error Handling** | Agent must scan logs for strings or parse exit codes to check status. | Strongly-typed JSON-RPC errors with mapped codes and clear remediation. |
 | **Transport Safety** | Volatile console printing. | Stdout is strictly isolated for JSON-RPC; all logs and warnings route to stderr. |
 


### PR DESCRIPTION
## Production-readiness live-gaps + follow-up (0.42.0 cycle)

Follow-up to the v0.41.0 production-readiness hardening: closes the verification gaps its evidence doc left open, cleans up dead code, and corrects a documentation invariant that a live run disproved. Four focused commits.

### 1. Dead-code + doc cleanup (`557a348`)
- Deleted the now-unreachable `fail_processing_tasks` (superseded by the checkpoint-classifying `recover_processing`) and its one stale test.
- Corrected the stale same-profile-concurrency framing in `docs/MCP.md` + `website/docs/MCP.md` to the real `ProfileLease` / `ProfileLockedError` (exit 11) fail-fast contract.
- Recorded in the evidence doc that the POSIX `fcntl.flock` lease CI legs (macOS/Linux) already ran **green** on the #357 PR CI.

### 2. Correct a false `flow_operation_id` invariant, surfaced live (`3689bf8`)
A live `veo-lite` t2v run produced a `remote_started` checkpoint with `operation_id=None` — contradicting the docs' claim that "only omni-flash omits the operation name." Root-caused: **not a code bug** — the operation-name parser is correct, `flow_operation_id` is best-effort/optional, and `media_id` is the canonical handle (poll + download + every CLI lookup use it; the op-name is literally the same UUID as the media id in the real capture). Fixes:
- Corrected the false invariant in `KNOWN_ISSUES.md` and the `client.py` docstring (best-effort, not guaranteed for any model; `media_id` canonical).
- Added a **regression test** locking the operation-name parser against the real veo capture fixture (previously only tested against synthetic dicts).
- No production behavior change — generation completes and downloads correctly on `None`. Deliberately did **not** fabricate an operation id from a media/workflow id.

### 3. Live-gated e2e tests (`3689bf8`, `62c3104`) — the closed gaps
- `tests/e2e/test_crash_recovery_e2e.py` — a real paid t2v through the worker path persists a real `remote_started` checkpoint with a media handle; recovery classifies it `indeterminate` and never resubmits. **Live-confirmed this session** (1 credit): the observer→checkpoint→DB chain works against real Flow; the safety classification is deterministic. Asserts the true contract (`media_ids` handle present; `operation_id` optional), not the field that proved optional.
- `tests/e2e/test_cancellation_e2e.py` — cancels a real browser launch during `__aenter__` (pre-submit, **credit-free**) and asserts the `ProfileLease` releases (re-acquirable) with no leftover Chrome. **Live-confirmed this session** (0 credits) — the D4 mid-launch teardown-release contract.

Both are `@pytest.mark.e2e`, opt-in via `GFLOW_CLI_E2E_PROFILE`, and skip cleanly by default.

### 4. Evidence follow-up (`61ba0e9`)
Dated `2026-07-21` section in `docs/LIVE_VERIFICATION_v0.40.0-production-readiness.md` recording the two live confirmations, the `operation_id` finding + fix, and — honestly — what remains open.

### Still open (documented, not claimed)
Auto-reconciliation of a crashed paid job remains a deliberate **unimplemented** seam (the safe stub: `indeterminate` + manual reconcile). The full daemon/MCP lifecycle over HTTP (`gflow serve`) was exercised via the worker path directly, not end-to-end over HTTP. Three timing-fragile D4 cancellation sub-paths remain deterministically unit-proven (`tests/api/test_concurrency.py`).

### Verification
Full suite **2530 passed**, 91% coverage (lone failure is the known `uv build` packaging flake — passes in isolation); ruff + `pyright --strict` (0 errors) + repo-hygiene + doc-links all green. Two live runs on `ffroliva` (1 paid credit total). Rebased on current `develop` (includes #359, #360). Ships after v0.41.0, targeting 0.42.0.
