### PR TITLE
fix(transport): refuse standalone-only transports inside FlowApiClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Experimental transport self-lockout.** The `bearer` and `sapisidhash`
+  transports discard a caller-supplied Playwright page and re-acquire the profile
+  `ProfileLease` in their own `setup()`. Driving one via `GFLOW_CLI_TRANSPORT`
+  inside a `FlowApiClient` (which already holds the lease) self-locked with an
+  opaque `ProfileLockedError`. `FlowApiClient` now refuses these standalone-only
+  transports up front with a clear `ConfigurationError` naming the transport and
+  pointing to `ui_automation`/`evaluate_fetch` or standalone use. `evaluate_fetch`
+  is unaffected (it shares the client's page). New `STANDALONE_ONLY_TRANSPORTS`
+  set + `resolve_transport_name()` helper in `api/transports`.
+
 ## [0.42.0] — 2026-07-21
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -395,6 +395,8 @@ We attempted three pure-HTTP transport strategies before settling on `ui_automat
 
 All three now live as standalone modules under `src/gflow_cli/api/transports/experimental/` (`evaluate_fetch.py` / `bearer.py` / `sapisidhash.py`), preserved for reference and future iteration. None survives Google's anti-bot stack for mutation/generation endpoints, so the production path is `ui_automation`.
 
+**Standalone-only transports.** `bearer` and `sapisidhash` discard any caller-supplied Playwright page and launch their own browser under a fresh `ProfileLease`, so they are **standalone-only** — they cannot run inside a `FlowApiClient` that already holds the profile lease (the second acquire would self-lock with `ProfileLockedError`). Selecting either via `GFLOW_CLI_TRANSPORT` (or the Python API) while the client owns the profile now fails fast with a clear `ConfigurationError` naming the transport, rather than the opaque lock error. `evaluate_fetch` is exempt: it reuses the client's shared page and takes no second lease. The standalone-only set lives in `STANDALONE_ONLY_TRANSPORTS` (`api/transports/__init__.py`); to drive `bearer`/`sapisidhash`, run them outside an owning client.
+
 ### What this costs users
 
 - A **persistent Chrome profile** on disk (~150 MB after `playwright install chromium`).

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -54,7 +54,11 @@ from gflow_cli.api.image_upscale import (
 )
 from gflow_cli.api.recaptcha import TokenMinter
 from gflow_cli.api.scene import ConcatInput, Scene, SceneWorkflow
-from gflow_cli.api.transports import make_transport
+from gflow_cli.api.transports import (
+    STANDALONE_ONLY_TRANSPORTS,
+    make_transport,
+    resolve_transport_name,
+)
 from gflow_cli.api.transports.base import (
     FlowTransportStrategy,
     SupportsTransportSetup,
@@ -694,6 +698,21 @@ class FlowApiClient:
         inp = self._transport_input
         config = self._build_transport_setup()
         if inp is None or isinstance(inp, str):
+            # Standalone-only guard: bearer/sapisidhash (S2/S3) discard the shared
+            # page and re-acquire the profile lease in their own setup(), so with
+            # this client already holding self._lease they self-lock with an opaque
+            # ProfileLockedError. Refuse fast with a clear message. Only fires when
+            # the lease is actually held (i.e. inside a live client), so the same
+            # transports stay usable standalone.
+            if self._lease is not None:
+                resolved = resolve_transport_name(inp)
+                if resolved in STANDALONE_ONLY_TRANSPORTS:
+                    raise ConfigurationError(
+                        f"Transport {resolved!r} cannot run inside FlowApiClient: it "
+                        "acquires its own profile lease during setup and would "
+                        "self-lock against the client's lease. Use 'ui_automation' or "
+                        f"'evaluate_fetch', or drive {resolved!r} standalone.",
+                    )
             # Client-owned: resolve from factory, run full lifecycle.
             # Pass self._page so S1 can reuse the already-open context.
             # S2 and S3 accept and ignore the page= kwarg.

--- a/src/gflow_cli/api/transports/__init__.py
+++ b/src/gflow_cli/api/transports/__init__.py
@@ -27,6 +27,17 @@ EXPERIMENTAL_TRANSPORTS: tuple[str, ...] = (
     "sapisidhash",
 )
 
+# Experimental transports whose ``setup()`` discards a caller-supplied ``page=``
+# and re-acquires the profile ``ProfileLease`` under a fresh Playwright launch
+# (bearer.py / sapisidhash.py). They therefore CANNOT run inside a FlowApiClient
+# that already holds the lease — the second acquire self-locks with
+# ProfileLockedError. ``evaluate_fetch`` is dual-mode (it reuses a shared page and
+# takes no second lease) so it is intentionally excluded. FlowApiClient uses this
+# set to refuse such a transport with a clear error instead of the opaque lock.
+# ponytail: hand-maintained set — if a new transport re-acquires the lease, add it
+# here (promote to a transport class attribute once there are more than two).
+STANDALONE_ONLY_TRANSPORTS: frozenset[str] = frozenset({"bearer", "sapisidhash"})
+
 
 def _registry() -> dict[str, type[FlowTransportStrategy]]:
     """Lazy registry import — keeps the factory cheap to import."""
@@ -57,6 +68,16 @@ def transport_choices() -> list[str]:
     return [k for k in _registry() if k not in EXPERIMENTAL_TRANSPORTS]
 
 
+def resolve_transport_name(name: str | None = None) -> str:
+    """Resolve the effective strategy key: explicit ``name`` arg >
+    ``GFLOW_CLI_TRANSPORT`` env > built-in default.
+
+    Exposed so callers that must decide *before* instantiating (e.g. FlowApiClient's
+    standalone-only guard) resolve the key identically to :func:`make_transport`.
+    """
+    return name or os.getenv("GFLOW_CLI_TRANSPORT") or _DEFAULT_TRANSPORT
+
+
 def make_transport(name: str | None = None) -> FlowTransportStrategy:
     """Resolve strategy: explicit `name` arg > GFLOW_CLI_TRANSPORT env > built-in default.
 
@@ -65,7 +86,7 @@ def make_transport(name: str | None = None) -> FlowTransportStrategy:
     ``GFLOW_CLI_EXPERIMENTAL_TRANSPORTS`` env var — gating is at the CLI
     Choice list only, so the Python API stays unrestricted.
     """
-    resolved = name or os.getenv("GFLOW_CLI_TRANSPORT") or _DEFAULT_TRANSPORT
+    resolved = resolve_transport_name(name)
     registry = _registry()
     klass = registry.get(resolved)
     if klass is None:
@@ -78,7 +99,9 @@ def make_transport(name: str | None = None) -> FlowTransportStrategy:
 
 __all__ = [
     "EXPERIMENTAL_TRANSPORTS",
+    "STANDALONE_ONLY_TRANSPORTS",
     "FlowTransportStrategy",
     "make_transport",
+    "resolve_transport_name",
     "transport_choices",
 ]

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -24,7 +24,8 @@ from gflow_cli.api.image import AgentInstruction, Aspect, GenerateImageRequest, 
 from gflow_cli.api.transports.base import SupportsTransportSetup, TransportSetup
 from gflow_cli.api.transports.ui_automation import UiAutomationTransport
 from gflow_cli.config import Settings
-from gflow_cli.errors import BrowserSessionClosedError
+from gflow_cli.errors import BrowserSessionClosedError, ConfigurationError
+from gflow_cli.profile_lease import ProfileLease
 
 
 class TestConstruction:
@@ -321,6 +322,14 @@ async def test_client_with_string_transport_owns_lifecycle(
 # ---------------------------------------------------------------------------
 
 
+def _held_lease(profile_dir: Path) -> ProfileLease:
+    """A ProfileLease standing in for the one the live client holds. The constructor
+    does not acquire (no kernel/registry lock), and the standalone-only guard only
+    checks ``self._lease is not None`` — so an unacquired lease is a faithful,
+    side-effect-free stand-in for 'the client owns this profile'."""
+    return ProfileLease(profile_dir)
+
+
 def _record_lease_events(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """Patch ProfileLease.acquire/release to record ordering without real locks."""
     from gflow_cli.profile_lease import ProfileLease
@@ -408,6 +417,63 @@ async def test_client_lease_contention_raises_before_launch(
         await client.__aenter__()
     assert launch_calls == []  # acquire failed BEFORE the launch was attempted
     assert client._context is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport_name", ["bearer", "sapisidhash"])
+async def test_client_owned_standalone_transport_refused_before_setup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, transport_name: str
+) -> None:
+    """A client that already holds the profile lease must REFUSE a standalone-only
+    experimental transport (bearer/sapisidhash) with a clear ConfigurationError,
+    rather than let the transport's own ``ProfileLease.acquire()`` self-lock with an
+    opaque ProfileLockedError. The refusal fires before the transport is built."""
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    made: list[str | None] = []
+
+    def spy_make(name: str | None = None) -> _FakeTransport:
+        made.append(name)
+        return _FakeTransport()
+
+    monkeypatch.setattr("gflow_cli.api.client.make_transport", spy_make)
+
+    client = FlowApiClient(profile_dir=tmp_path, transport=transport_name)
+    client._lease = _held_lease(tmp_path)  # simulate the client holding the lease
+    with pytest.raises(ConfigurationError) as exc:
+        await client._setup_transport()
+    assert transport_name in str(exc.value)
+    assert made == []  # refused BEFORE the transport was constructed
+
+
+@pytest.mark.asyncio
+async def test_client_owned_standalone_transport_via_env_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard resolves GFLOW_CLI_TRANSPORT the same way make_transport does, so a
+    standalone-only transport chosen via env (transport=None on the client) is also
+    refused."""
+    monkeypatch.setenv("GFLOW_CLI_TRANSPORT", "bearer")
+    monkeypatch.setattr("gflow_cli.api.client.make_transport", lambda name=None: _FakeTransport())
+    client = FlowApiClient(profile_dir=tmp_path, transport=None)
+    client._lease = _held_lease(tmp_path)
+    with pytest.raises(ConfigurationError):
+        await client._setup_transport()
+
+
+@pytest.mark.asyncio
+async def test_client_owned_evaluate_fetch_is_not_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """evaluate_fetch shares the client's page (no second lease) so it is NOT
+    standalone-only — the guard must let it through even while the lease is held."""
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    fake = _FakeTransport()
+    monkeypatch.setattr("gflow_cli.api.client.make_transport", lambda name=None: fake)
+    client = FlowApiClient(profile_dir=tmp_path, transport="evaluate_fetch")
+    client._lease = _held_lease(tmp_path)
+    await client._setup_transport()
+    assert client.transport is fake
+    assert fake.setup_called == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/transports/test_factory.py
+++ b/tests/api/transports/test_factory.py
@@ -58,3 +58,29 @@ def test_factory_accepts_experimental_keys_without_env_gate(monkeypatch):
     monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
     t = make_transport("bearer")
     assert t.name == "bearer"
+
+
+def test_standalone_only_transports_are_the_lease_reacquiring_experimentals():
+    """bearer/sapisidhash discard the shared page and re-acquire their own
+    ProfileLease in setup(); evaluate_fetch is dual-mode (shares the page) so it
+    is intentionally NOT standalone-only."""
+    from gflow_cli.api.transports import STANDALONE_ONLY_TRANSPORTS
+
+    assert STANDALONE_ONLY_TRANSPORTS == frozenset({"bearer", "sapisidhash"})
+    # Every standalone-only key must be a real, registered experimental transport.
+    from gflow_cli.api.transports import EXPERIMENTAL_TRANSPORTS
+
+    assert STANDALONE_ONLY_TRANSPORTS <= set(EXPERIMENTAL_TRANSPORTS)
+
+
+def test_resolve_transport_name_precedence(monkeypatch):
+    """arg > GFLOW_CLI_TRANSPORT env > built-in default — same precedence
+    make_transport uses, exposed so the client guard resolves identically."""
+    from gflow_cli.api.transports import resolve_transport_name
+
+    monkeypatch.delenv("GFLOW_CLI_TRANSPORT", raising=False)
+    assert resolve_transport_name() == "ui_automation"
+    assert resolve_transport_name("bearer") == "bearer"
+    monkeypatch.setenv("GFLOW_CLI_TRANSPORT", "sapisidhash")
+    assert resolve_transport_name() == "sapisidhash"
+    assert resolve_transport_name("bearer") == "bearer"  # explicit arg wins over env


### PR DESCRIPTION
## Summary

`bearer` and `sapisidhash` (S2/S3) discard a caller-supplied Playwright page and re-acquire the profile `ProfileLease` in their own `setup()`. Selecting one via `GFLOW_CLI_TRANSPORT` (or the Python API) inside a `FlowApiClient` — which already holds the lease across the whole transport lifecycle — self-locked with an opaque `ProfileLockedError` at the registry guard.

`FlowApiClient._setup_transport` now refuses these **standalone-only** transports up front (when it holds the lease) with a clear `ConfigurationError` that names the transport and points to `ui_automation`/`evaluate_fetch` or standalone use. `evaluate_fetch` is unaffected — it reuses the client's shared page and takes no second lease.

Flagged by the v0.42.0 D3 whole-branch review; deferred then only because #359 was concurrently editing `client.py`.

## Changes
- `api/transports/__init__.py`: new `STANDALONE_ONLY_TRANSPORTS` frozenset (documented) + `resolve_transport_name()` helper (de-dupes the arg > env > default resolution, shared with the client guard).
- `api/client.py`: standalone-only guard in the client-owned branch of `_setup_transport`, gated on `self._lease is not None` so the same transports stay usable standalone.
- Docs: ARCHITECTURE.md transport section documents the constraint; CHANGELOG Unreleased/Fixed.

## Test plan
- New: 2 factory tests (`STANDALONE_ONLY_TRANSPORTS` membership, `resolve_transport_name` precedence) + 3 client tests (parametrized bearer/sapisidhash refusal before setup, env-var path refusal, evaluate_fetch NOT refused).
- Gates green locally: `ruff check src tests`, `ruff format`, `pyright src` (0 errors), repo-hygiene, doc-links; `pytest tests/api/ tests/test_profile_lease.py` → 577 passed, 2 skipped.
- Not a generation-path change (guard fires before any browser/transport setup) — no live-verify required.