### PR TITLE
chore(docs): website/docs PII-leak guard + crash-recovery decision record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Documentation links
         run: uv run python scripts/ci/check_doc_links.py
 
+      - name: Website docs PII guard (no private identifiers in the published mirror)
+        run: uv run python scripts/ci/check_website_docs_pii.py
+
       - name: Lint
         run: uv run ruff check src tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Run these gates in order before every commit:
 $env:PYTHONUTF8=1
 uv run python scripts/ci/check_repo_hygiene.py
 uv run python scripts/ci/check_doc_links.py
+uv run python scripts/ci/check_website_docs_pii.py
 uv run ruff check src tests
 uv run ruff format --check src tests
 uv run pyright src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`website/docs/` PII-leak CI guard** (`scripts/ci/check_website_docs_pii.py`).
+  The published mkdocs mirror under `website/docs/` is an anonymized copy of
+  canonical `docs/`; this new gate fails CI (and runs in `/gflow:check`) if a
+  known private identifier — `denon82`, the OS username `ffrol`, a real
+  name/email — appears in a published file, catching an anonymization miss
+  before it ships (the failure mode of #362). Public references such as
+  `github.com/ffroliva/gflow-cli` and the APP_AUTHOR path are trap-free by
+  construction, so the guard needs no allow-list.
+
 ## [0.42.0] — 2026-07-21
 
 ### Fixed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -352,6 +352,8 @@ The worker queue (`generation_queue`, used by the `gflow serve` daemon and MCP t
 
 **Why this can't be resolved automatically today:** Flow's generation-status REST endpoint rejects a bare, cookie-only `page.request` re-check with HTTP 401 — only a live, authenticated Playwright SPA re-poll (opening the project page and reading the DOM) can turn a preserved handle back into a real status, and that live re-poll path is not wired into recovery yet (tracked for a future phase; see the C1 handle-spike notes in `docs/superpowers/specs/2026-07-19-production-readiness-hardening-design.md` Appendix A).
 
+**Decision (2026-07-21):** keep the safe stub — `recover_processing` marks post-submit interruptions `indeterminate` and never auto-resubmits, which is already correct. Building the auto-reconciler is deferred until **F1** (credit-free project-page re-entry) is confirmed against live Flow; until then a blind reconciler would be speculative code against unverified blackbox behavior. The `client` reconcile-hook seam and the live-gated `tests/e2e/test_crash_recovery_e2e.py` are already in place for when F1 lands.
+
 **Manual reconciliation:** an `indeterminate` row's checkpoint retains whatever handle/project info was captured before interruption. To resolve one by hand: open the relevant Flow project in the browser and check whether the expected asset appears.
 - **Found** — the generation completed; no action needed (the credit was spent as intended, just not auto-recorded locally).
 - **Not found after a few minutes** — it likely never completed; safe to resubmit the same prompt manually.

--- a/scripts/ci/check_website_docs_pii.py
+++ b/scripts/ci/check_website_docs_pii.py
@@ -1,0 +1,89 @@
+"""Guard: no private identifiers leak into the published ``website/docs/`` mirror.
+
+``website/docs/`` is the ANONYMIZED, mkdocs-published mirror of the canonical
+``docs/`` tree (``denon82`` → ``my-profile``, ``ffrol`` → ``your-user``, real
+email → placeholder, ...). A blind copy or find/replace can republish real PII —
+this is exactly the failure mode of PR #362. This check fails CI if any known
+private token appears in a published file under ``website/docs/``, so an
+anonymization miss can never ship silently.
+
+Forbidden (private) tokens vs. public references that MUST pass:
+
+* ``denon82``          — private Google profile name.
+* ``profile_ffroliva`` — derived private profile directory.
+* ``ffrol``            — private OS username; matched with a word boundary so it
+  does NOT hit the public repo owner ``ffroliva``.
+* ``flavio`` / ``flavio.oliva`` — real name (case-insensitive).
+* ``ffroliva@``        — real email local-part.
+
+The public references that legitimately contain ``ffroliva`` — the repo URL
+``github.com/ffroliva/gflow-cli``, the bare slug ``ffroliva/gflow-cli``, and the
+platformdirs APP_AUTHOR path segment ``ffroliva\\gflow-cli`` — are never matched
+by the patterns above (none is followed by ``@`` or preceded by ``profile_``),
+so no explicit allow-list is needed and the guard is trap-free.
+
+Exit code 0 = clean; 1 = at least one leak. Broken files are printed to stdout
+with the file, line number, and the offending token.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# (compiled pattern, human-readable reason). Each targets a SPECIFIC private
+# token — never the bare substring ``ffroliva``, which appears in public repo
+# URLs and the APP_AUTHOR path and must pass. Keep in sync with the anonymization
+# map in the deferred docs-generator (see the tracking issue).
+FORBIDDEN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"denon82"), "private Google profile name"),
+    (re.compile(r"profile_ffroliva"), "private profile directory"),
+    (re.compile(r"\bffrol\b"), "private OS username"),
+    (re.compile(r"flavio", re.IGNORECASE), "real name"),
+    (re.compile(r"ffroliva@"), "real email address"),
+)
+
+# Published, scannable file types under website/docs/.
+SCANNED_SUFFIXES = (".md", ".html")
+
+
+def find_pii(text: str) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, matched_token, reason)`` for every forbidden token."""
+    hits: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for pattern, reason in FORBIDDEN:
+            for match in pattern.finditer(line):
+                hits.append((lineno, match.group(0), reason))
+    return hits
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    web_docs = repo_root / "website" / "docs"
+    if not web_docs.is_dir():
+        print(f"website/docs not found at {web_docs} — nothing to scan.")
+        return 0
+
+    leaks = 0
+    scanned = 0
+    for path in sorted(web_docs.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in SCANNED_SUFFIXES:
+            continue
+        scanned += 1
+        rel = path.relative_to(repo_root).as_posix()
+        for lineno, token, reason in find_pii(path.read_text(encoding="utf-8")):
+            print(f"{rel}:{lineno}  →  {token!r}  ({reason})")
+            leaks += 1
+
+    if leaks:
+        print(
+            f"\n{leaks} private-identifier leak(s) in website/docs/ — anonymize before publishing."
+        )
+        return 1
+    print(f"No private identifiers found across {scanned} published website/docs files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -13,11 +13,12 @@ Run in order. Stop and report if a step fails after the fix pass.
 
 These steps mirror the CI `test` job in `.github/workflows/ci.yml` **in the same order**. Any command that CI runs as a *verify* (`--check`) is run here as a verify too — see step 4.
 
-**1. Repo hygiene + doc links** (read-only — CI runs both; a broken doc link fails CI)
+**1. Repo hygiene + doc links + website-docs PII guard** (read-only — CI runs all three; a broken doc link or a private identifier in the published `website/docs/` mirror fails CI)
 
 ```bash
 PYTHONUTF8=1 uv run python scripts/ci/check_repo_hygiene.py
 PYTHONUTF8=1 uv run python scripts/ci/check_doc_links.py
+PYTHONUTF8=1 uv run python scripts/ci/check_website_docs_pii.py
 ```
 
 **2. Auto-fix lint and formatting** (rewrites files in place)

--- a/tests/scripts/test_check_website_docs_pii.py
+++ b/tests/scripts/test_check_website_docs_pii.py
@@ -1,0 +1,66 @@
+"""Unit tests for the website/docs PII-leak guard.
+
+The guard forbids SPECIFIC private tokens while letting the public references
+that legitimately contain ``ffroliva`` through untouched — the exact distinction
+PR #362's blind find/replace got wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci import check_website_docs_pii as guard
+
+# Public references that contain 'ffroliva' but MUST pass — the #362 trap.
+ALLOWED = [
+    "See https://github.com/ffroliva/gflow-cli for the source.",
+    "Report a vulnerability: https://github.com/ffroliva/gflow-cli/security/advisories/new",
+    "Subscribe to GitHub Releases for `ffroliva/gflow-cli`.",
+    r"type $env:LOCALAPPDATA\ffroliva\gflow-cli\profile_<name>\Default",
+    "Use a placeholder like you@gmail.com or your.name@gmail.com.",
+    "Example: user+flow@gmail.com works too.",
+    "Log in as your-name with profile_your-name.",  # already-anonymized output
+]
+
+# Private tokens that MUST be flagged.
+FORBIDDEN_SAMPLES = [
+    ("verified end-to-end on denon82 (face...", "denon82"),
+    # backslash-bounded path vector (the real leak is the home dir) without a
+    # literal Windows user-profile path, which the repo-hygiene gate forbids.
+    (r"cache under \ffrol\tmp", "ffrol"),
+    ("the profile dir profile_ffroliva is created", "profile_ffroliva"),
+    ("contact flavio for access", "flavio"),
+    ("Contact FLAVIO.OLIVA directly", "FLAVIO"),
+    ("email ffroliva@gmail.com for support", "ffroliva@"),
+]
+
+
+@pytest.mark.parametrize("line", ALLOWED)
+def test_public_references_pass(line: str) -> None:
+    """No false positives on legitimate public 'ffroliva' references or on
+    already-anonymized placeholder output."""
+    assert guard.find_pii(line) == []
+
+
+@pytest.mark.parametrize(("line", "token"), FORBIDDEN_SAMPLES)
+def test_private_tokens_are_flagged(line: str, token: str) -> None:
+    hits = guard.find_pii(line)
+    assert hits, f"expected a leak in {line!r}"
+    assert any(token in matched for _, matched, _ in hits)
+
+
+def test_ffrol_word_boundary_does_not_match_ffroliva() -> None:
+    """The username guard 'ffrol' must not fire on the public owner 'ffroliva'."""
+    assert guard.find_pii("owner is ffroliva/gflow-cli") == []
+
+
+def test_lineno_is_reported() -> None:
+    text = "clean line\nleak on denon82 here\nclean again"
+    hits = guard.find_pii(text)
+    assert [(lineno, tok) for lineno, tok, _ in hits] == [(2, "denon82")]
+
+
+def test_scanned_suffixes_cover_published_types() -> None:
+    # mkdocs publishes .md pages plus at least one .html mockup — both must scan.
+    assert ".md" in guard.SCANNED_SUFFIXES
+    assert ".html" in guard.SCANNED_SUFFIXES


### PR DESCRIPTION
## Summary

Two lower-urgency docs-governance leftovers from the v0.42.0 cycle.

### 1. `website/docs/` PII-leak CI guard (new)
`website/docs/*` is the anonymized, mkdocs-published mirror of canonical `docs/*` (`denon82`→`my-profile`, `ffrol`→`your-user`, real email→placeholder). It is **100% hand-maintained** — there is no sync/parity tooling — so an anonymization miss can silently republish real PII. That is exactly what PR #362's blind find/replace did (it also broke real public links, fixed in review).

`scripts/ci/check_website_docs_pii.py` fails CI if any known private token (`denon82`, the OS username `ffrol`, a real name/email) appears in a published `website/docs/` file. The patterns target **specific** private tokens, never the bare `ffroliva` substring — so public references (`github.com/ffroliva/gflow-cli`, the `\ffroliva\gflow-cli\` APP_AUTHOR path) pass with **no allow-list** and the guard is trap-free. Wired into `ci.yml`, `/gflow:check`, and the AGENTS.md Impeccable Routine. Passes clean on the current mirror (23 files).

### 2. Crash-recovery reconciler — decision record
Records the decision to **keep the safe stub**: `worker/queue.py::recover_processing` already marks post-submit interruptions `indeterminate` and never auto-resubmits. Building the auto-reconciler is deferred until **F1** (credit-free project-page re-entry) is confirmed against live Flow — a blind reconciler would be speculative code against unverified blackbox behavior. One dated line in `KNOWN_ISSUES.md` so it isn't re-opened as unfinished.

## Deferred (follow-up issue)
The full anonymizing `docs/` → `website/docs/` **generator** (to eliminate double-maintenance) is deferred: the two trees have real content drift, `SECURITY.md` needs special-casing (email removed → advisories URL, not a token swap), and the transform must be context-aware. Tracking issue filed with the exact anonymization map. This PR ships the safe guard that backstops any future generator.

## Test plan
- `tests/scripts/test_check_website_docs_pii.py` — 16 tests: each private token flagged; public `ffroliva` references + already-anonymized placeholders pass; `\bffrol\b` word-boundary does not hit `ffroliva`.
- Gates green locally: repo-hygiene, doc-links, the new guard, `ruff check src tests`, `ruff format`, `pyright`.
