### PR TITLE
docs: cover @Name mention syntax in USAGE.md + USER_GUIDE.md (closes #349)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -370,6 +370,56 @@ gflow image i2i "place this hero in a snowy pass" --ref hero.png \
 > Ids are validated at the CLI boundary (letters/digits/hyphens, ≤128 chars).
 > The entity must already exist in `--project` (see `gflow character create`).
 
+## Referencing saved assets by name (`@Name` mentions)
+
+Instead of ids or paths, you can reference a saved **Character** — or, on image
+paths, a saved media asset — **inline in the prompt** by name, prefixed with `@`.
+The mention is resolved against the project's assets, staged through the same
+reference machinery as `--reference-entity` / `--ref`, then stripped from the text
+the model sees. Shipped in v0.40.0 (#344).
+
+```bash
+# One saved Character by name (t2i needs no image ref)
+gflow image t2i "@CaptainZoro on a rain-soaked neon rooftop, cinematic" --project <id>
+
+# Two saved Characters in one video prompt (each staged as a reference, cap-checked)
+gflow video r2v "@Zoro hands @Mika the sword" --project <id>
+```
+
+**Where `@Name` works** — character mentions on image **and** video; media/asset
+mentions on image **only**:
+
+| Path | Character `@Name` | Media/asset `@Name` |
+|---|---|---|
+| `image t2i` | ✅ | ✅ (in-project asset → `referenceImages`) |
+| `image i2i` | ✅ | ✅ |
+| `video t2v` / `i2v` / `r2v` | ✅ | ❌ — media-on-video is Phase 3; fails fast with **exit 11** |
+
+Rules:
+- **`--project <id>` is required** — mentions resolve against that project's assets.
+- A name resolves against **Characters** (`gflow character create`) *and* saved
+  media assets; on a name clash the **Character wins**. Matching is
+  **case-insensitive**.
+- A Character must have **at least one reference image** before it can be tagged,
+  or the mention fails early.
+- Write a **literal `@`** by doubling it: `@@` → `@` (e.g. `"ping me @@ 5pm"` →
+  `ping me @ 5pm`). An `@` glued to a preceding word (`user@host`) is never a
+  mention, so emails and handles are safe.
+- Unknown or ambiguous names fail fast with **exit 11** (`ConfigurationError`),
+  listing the available or colliding assets. If the asset catalog itself cannot be
+  loaded you get **exit 29** (`MentionIndexUnavailableError`) — so scripts can tell
+  "catalog unreachable" apart from "no such name".
+
+`@Name` and `--reference-entity <id>` resolve to the **same** wire
+(`referenceEntities`) and dedupe against each other: reach for `@Name` for the
+inline, by-name path — it's also the **only** name-based option on video, which
+has no `--reference-entity` flag — and `--reference-entity` when you'd rather pin
+an explicit entity id in a script (image paths only). `--ref` is different: it
+attaches an arbitrary **image** (`referenceImages`), not a saved identity, and can
+be combined with a `@Name` for "this identity, in this look".
+
+See [REFERENCE_STRATEGIES.md](REFERENCE_STRATEGIES.md) for the full decision guide.
+
 ## `gflow image batch`
 
 Generate multiple images from a single manifest file. The format is dispatched by file extension (`.json` or `.tsv`).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -28,6 +28,7 @@
 - [Journey 13 — Diagnosing a persistent `AuthExpiredError` after a successful re-login](#journey-13--diagnosing-a-persistent-authexpirederror-after-a-successful-re-login)
 - [Journey 14 — Embedding `FlowApiClient` in a long-lived worker](#journey-14--embedding-flowapiclient-in-a-long-lived-worker)
 - [Journey 15 — Sending generated assets to S3, MinIO, or GCS](#journey-15--sending-generated-assets-to-s3-minio-or-gcs)
+- [Journey 16 — Consistent characters across a video (`@Name` mentions)](#journey-16--consistent-characters-across-a-video-name-mentions)
 - [Common errors quick-reference](#common-errors-quick-reference)
 
 ---
@@ -945,6 +946,61 @@ Expected: one or more `cloud_uri_N` rows. Then inspect the bucket with
 
 Deep details, object layout, and provider-specific notes live in
 [EXTERNAL_STORAGE.md](EXTERNAL_STORAGE.md).
+
+---
+
+## Journey 16 — Consistent characters across a video (`@Name` mentions)
+
+**Goal:** keep the *same* people on-model across a shot — or a whole sequence — by
+referencing saved Characters **by name, right in the prompt**. No per-shot image
+refs, no id juggling. Character mentions work on both image and video paths (media
+mentions are image-only) — full rules in
+[USAGE.md](USAGE.md#referencing-saved-assets-by-name-name-mentions).
+
+### 16.1 Create the Characters once
+
+Mint each recurring subject as a project-scoped Character. `character create`
+generates its reference image, which a mention needs to resolve.
+
+```bash
+PROJECT=7fa97443-…   # a real project you own
+
+gflow character create --project "$PROJECT" --name Zoro \
+  --face-prompt "weathered swordsman, green bandana, calm eyes"
+gflow character create --project "$PROJECT" --name Mika \
+  --face-prompt "young duelist, silver hair, sharp jaw"
+```
+
+### 16.2 Mention them by name in the prompt
+
+Prefix each name with `@`. Both are staged as references (checked against the
+model's reference cap) and stripped from the text the model actually sees.
+
+```bash
+gflow video r2v "@Zoro hands @Mika the sword at dawn, slow push-in" \
+  --project "$PROJECT"
+```
+
+`@Zoro` and `@Mika` resolve to their Characters, so the two subjects stay
+recognizably themselves. Reuse the same names in every shot for continuity:
+
+```bash
+gflow video r2v "@Mika parries, @Zoro steps back — wide shot" --project "$PROJECT"
+gflow video t2v "@Zoro alone on the cliff at night, rain" --project "$PROJECT"
+```
+
+### 16.3 When a mention doesn't resolve
+
+- `Unknown mention '@Zora'. Available assets: Zoro, Mika` — typo or wrong project.
+  Names are case-insensitive but must exist **in `--project`**. Exit **11**.
+- `@Zoro has no reference images …` — the Character was created without one;
+  re-create it (or add a reference image) before tagging.
+- Need a literal `@` in the prompt (a handle, a time)? Double it: `@@` → `@`. An
+  `@` glued to a word (`me@host`) is never a mention, so emails are safe.
+
+> On the **image** paths you can also mention a saved media asset by name (`@logo`)
+> and combine a `@Name` with `--ref look.png` for "this identity, in this look."
+> Media mentions on the video path are not supported yet (Phase 3).
 
 ---
 

--- a/docs/superpowers/plans/2026-07-18-asset-tagging/PLAN.md
+++ b/docs/superpowers/plans/2026-07-18-asset-tagging/PLAN.md
@@ -1,7 +1,14 @@
 # Asset Tagging (`@` Mentions) Implementation Plan
 
-> **For agentic workers:** Run `/gflow:status --feature asset-tagging` to find the next
-> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+> **✅ SHIPPED — v0.40.0 ([#344](https://github.com/ffroliva/gflow-cli/issues/344)).**
+> This plan is **complete and archived for historical reference**. The `@Name` mention feature
+> (image `t2i`/`i2i` character + media mentions; video `t2v`/`i2v`/`r2v` character mentions) is live
+> and documented in [CHARACTER.md](../../../CHARACTER.md), [REFERENCE_STRATEGIES.md](../../../REFERENCE_STRATEGIES.md),
+> USAGE.md, and USER_GUIDE.md. The task checkboxes below were **not** individually back-ticked
+> (they were never a live post-ship record); treat this document as design history, not a live tracker.
+
+> **For agentic workers (historical):** this plan is done — do not resume it. Run
+> `/gflow:status` for current work.
 
 **Goal:** Users can reference project assets by name inside prompt text (`@CaptainZoro`, `@logo`)
 on `gflow video t2v/r2v` (character mentions) and `gflow image t2i/i2i` (character + media


### PR DESCRIPTION
## Summary

Closes #349 — backfill the two canonical user-facing docs for the `@Name` prompt-mention feature (shipped v0.40.0, #344). Until now it was only documented in `CHARACTER.md` / `REFERENCE_STRATEGIES.md`, so `USAGE.md` (the alphabetical command reference) and `USER_GUIDE.md` (journeys) had zero coverage.

## Changes
- **`USAGE.md`** — new "Referencing saved assets by name (`@Name` mentions)" section: the `@Name` syntax, `@@` literal-`@` escaping, the per-path **scope table** (character mentions on image + video; media/asset mentions image-only, media-on-video → exit 11 Phase 3), the exit-11 (unknown/ambiguous) vs exit-29 (catalog unreachable) error split, and how `@Name` relates to `--reference-entity` (same wire, image-only) and `--ref` (arbitrary image).
- **`USER_GUIDE.md`** — new **Journey 16** for the flagship use case: keeping the same characters on-model across a video via `@Name1 … @Name2` (create characters → mention by name → troubleshoot), plus its TOC entry.
- **Archived** the shipped `docs/superpowers/plans/2026-07-18-asset-tagging/PLAN.md` in place with a `✅ SHIPPED — v0.40.0` banner rather than back-ticking 52 checkboxes I can't individually verify (the issue's secondary ask).

All doc facts were extracted from the canonical `REFERENCE_STRATEGIES.md` / `CHARACTER.md` and cross-checked against `services/mentions.py`, so the scope table + error codes match the shipped code.

## Test plan
- Docs-only; no behavior change (the feature already shipped in v0.40.0).
- Gates green locally: `check_doc_links.py` (27 files), repo-hygiene (637 files), website-docs PII guard.
