### PR TITLE
fix(ui): clean-fail on Flow's media-library/agentic cohort + UI-drift debug engine (Refs #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **UI-drift debug engine** (`capture_ui_diagnostics`). On a `mode_switch_trigger`
+  failure, gflow now dumps the composer's DOM signature — the Material-Symbols
+  ligature inventory, `crop_*` presence, textbox count, URL, and a body-text
+  preview — to a JSON alongside a **full-page** screenshot, so a Flow frontend
+  change is diagnosable from one artifact instead of a bare (often black) viewport
+  shot. (#183)
 - **`website/docs/` PII-leak CI guard** (`scripts/ci/check_website_docs_pii.py`).
   The published mkdocs mirror under `website/docs/` is an anonymized copy of
   canonical `docs/`; this new gate fails CI (and runs in `/gflow:check`) if a
@@ -20,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flow's new media-library / agentic A/B cohort now fails cleanly.** When a
+  project opens into Flow's full-page media-library (or agentic chat) composer —
+  which has no classic `crop_*` aspect/mode control — `gflow image` and
+  `gflow video` now raise a clear, retryable `FlowAgentUiError` ("this cohort
+  flaps; retry shortly") instead of the misleading `UiSelectorDriftError`
+  "file a bug". Detection is a runtime DOM scan at a new shared
+  `_fail_mode_switch` raise site covering **both** the image and video paths.
+  Refs #174, #183.
 - **Experimental transport self-lockout.** The `bearer` and `sapisidhash`
   transports discard a caller-supplied Playwright page and re-acquire the profile
   `ProfileLease` in their own `setup()`. Driving one via `GFLOW_CLI_TRANSPORT`

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -109,6 +109,17 @@ reaches the submit** — the request carries no `referenceEntities`, so the
 submit backstops raise `WireFormatError` (**exit 7**) instead of silently
 returning a text-only generation as success.
 
+**Plain generation on this cohort now fails cleanly (#183).** When a project
+opens into this full-page library (or the agentic chat composer) there is no
+classic `crop_*` aspect/mode control, so `gflow image`/`gflow video` can't drive
+generation. Rather than the old opaque `UiSelectorDriftError` "file a bug", the
+mode-switch raise site now runs a runtime DOM scan and raises a clear, **retryable**
+`FlowAgentUiError` (**exit 25**, "this cohort flaps; retry shortly"), and dumps a
+DOM-signature diagnostics artifact (`diag_mode_switch_miss.json` + a full-page
+screenshot) for reporting. The cohort is server-assigned per page load and flaps
+within ~12h, so a re-run often lands the classic UI. Driving the new UI directly
+is still out of scope.
+
 **How to tell which UI your account has:** in the Flow web editor, click
 **Add Media** — a small dialog means the old (working) UI; a navigation to a
 full-page library means the affected new UI.

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1193,7 +1193,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             MODE_SWITCH_TRIGGER_SELECTORS,
         )
         if trigger is None:
-            await VideoGenerationMixin._fail_mode_switch(page, out_dir, media="image")
+            raise await VideoGenerationMixin._mode_switch_error(page, out_dir, media="image")
         await trigger.click()
         await page.wait_for_timeout(800)
         image_tab = await VideoGenerationMixin._probe_selector_cascade(

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1193,14 +1193,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             MODE_SWITCH_TRIGGER_SELECTORS,
         )
         if trigger is None:
-            shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
-            raise UiSelectorDriftError(
-                selector_drift_detail(
-                    "mode_switch_trigger",
-                    "no matching element found on the Flow editor.",
-                    shot,
-                )
-            )
+            await VideoGenerationMixin._fail_mode_switch(page, out_dir, media="image")
         await trigger.click()
         await page.wait_for_timeout(800)
         image_tab = await VideoGenerationMixin._probe_selector_cascade(

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -20,7 +20,7 @@ import random
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import structlog
 
@@ -170,6 +170,24 @@ AGENTIC_UI_INDICATORS = (
     COMPOSER_AGENT_TOGGLE_SELECTOR,
     AGENT_CHAT_PANEL_CLOSE_SELECTOR,
 )
+
+# Locale-invariant markers of Flow's #174 full-page media-library cohort — the
+# left-nav library ("All Media / Characters / Scenes / Tools / Trash") a project
+# can open into INSTEAD of the generation composer. It has no ``crop_*`` aspect
+# trigger, so ``_switch_to_image_mode``/``_switch_to_video_mode`` cannot drive it.
+# Keyed on the collapse-sidebar control + the "All Media" grid nav (ligatures, not
+# UI text, to stay locale-independent). Confirmed live on ffroliva 2026-07-22.
+LIBRARY_UI_INDICATORS = (
+    "i.google-symbols:text-is('left_panel_close')",
+    "i.google-symbols:text-is('dashboard')",
+)
+
+# Union of markers that mean "the classic media composer is not reachable" —
+# either the forced agentic chat UI or the full-page media library. Consulted
+# ONLY after the ``crop_*`` trigger is confirmed absent AND agent-mode recovery
+# has already failed, so any match here is a decisive "stuck in a non-classic
+# cohort" signal (as opposed to a recoverable Agent pill/panel earlier in the flow).
+NON_CLASSIC_COHORT_INDICATORS = (*AGENTIC_UI_INDICATORS, *LIBRARY_UI_INDICATORS)
 
 # Output-count + duration tabs are selected by aria-label text in
 # `_set_output_count` / `_select_video_duration` — NOT by id-suffix: the count
@@ -635,6 +653,54 @@ def screenshot_clause(shot: Path | None) -> str:
     """' Screenshot: <path>' when one was captured, else '' — a capture
     failure must not put a phantom path (or 'None') in the error text."""
     return f" Screenshot: {shot}" if shot is not None else ""
+
+
+# DOM signature dumped on a UI-drift failure. Keyed on Material-Symbols ligatures
+# (locale-invariant) + a body-text preview so a Flow frontend change is diagnosable
+# from one artifact instead of a bare viewport screenshot.
+_UI_DIAG_JS = r"""() => {
+  const syms = [...document.querySelectorAll('i.google-symbols')]
+    .map(e => (e.textContent || '').trim()).filter(Boolean);
+  return {
+    url: location.href,
+    title: document.title,
+    ligatures: [...new Set(syms)].sort(),
+    ligatureCount: syms.length,
+    cropPresent: syms.some(l => l.startsWith('crop')),
+    textboxes: document.querySelectorAll(
+      'textarea,[contenteditable="true"],[role="textbox"],div[data-slate-editor]').length,
+    bodyTextPreview: (document.body.innerText || '').slice(0, 400),
+  };
+}"""
+
+
+async def capture_ui_diagnostics(page: Any, out_dir: Path | None, name: str) -> Path | None:
+    """UI-drift debug engine: dump the composer's DOM signature (ligature inventory,
+    ``crop_*`` presence, textbox count, url, body-text preview) to ``<name>.json``
+    plus a **full-page** screenshot, so a Flow frontend change is diagnosable from one
+    artifact. Full-page renders reliably where the viewport shot came out black (the
+    #183 live finding). Best-effort — returns the JSON path or ``None``; never raises."""
+    if out_dir is None:
+        return None
+    json_path: Path | None = None
+    try:
+        diag = await page.evaluate(_UI_DIAG_JS)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        json_path = out_dir / f"{name}.json"
+        json_path.write_text(json.dumps(diag, indent=2, ensure_ascii=False), encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        log.debug("ui_automation_video.ui_diagnostics_failed", error=str(e)[:120])
+        return None
+    try:
+        await page.screenshot(path=str(out_dir / f"{name}.png"), full_page=True)
+    except Exception as e:  # noqa: BLE001
+        log.debug("ui_automation_video.ui_diagnostics_screenshot_failed", error=str(e)[:120])
+    log.warning(
+        "ui_automation_video.ui_diagnostics_captured",
+        path=str(json_path),
+        note="ligature inventory + full-page screenshot; screenshot may show account PII",
+    )
+    return json_path
 
 
 async def _capture_picker_dom_dump(
@@ -1186,6 +1252,48 @@ class VideoGenerationMixin:
                 )
 
     @staticmethod
+    async def _detect_non_classic_cohort(page: Page) -> str | None:
+        """Return the first :data:`NON_CLASSIC_COHORT_INDICATORS` selector present,
+        else ``None``. Called at the mode-switch RAISE site — after ``crop_*`` is
+        confirmed absent AND the ~24s crop cascade has already elapsed, so the page
+        is fully rendered and one scan is decisive: the known agentic/media-library
+        cohort (#174/#183 → a clean :class:`FlowAgentUiError`) vs genuine drift."""
+        for sel in NON_CLASSIC_COHORT_INDICATORS:
+            try:
+                if await page.locator(sel).count() > 0:
+                    return sel
+            except Exception:  # noqa: BLE001  # NOSONAR — best-effort probe
+                continue
+        return None
+
+    @staticmethod
+    async def _fail_mode_switch(page: Page, out_dir: Path | None, *, media: str) -> NoReturn:
+        """Raise the right error when the ``mode_switch_trigger`` probe misses on the
+        ``image``/``video`` path: dump DOM diagnostics, then a clean, retryable
+        :class:`FlowAgentUiError` for the known agentic/media-library A/B cohort
+        (#174/#183) or :class:`UiSelectorDriftError` for genuine selector drift.
+        Shared by ``_switch_to_image_mode`` and ``_switch_to_video_mode``."""
+        diag = await capture_ui_diagnostics(page, out_dir, "diag_mode_switch_miss")
+        diag_clause = f" Diagnostics: {diag}" if diag is not None else ""
+        cohort = await VideoGenerationMixin._detect_non_classic_cohort(page)
+        if cohort is not None:
+            raise FlowAgentUiError(
+                detail=(
+                    "Flow opened this project in its new media-library / agentic "
+                    f"composer (server-side A/B cohort, issues #174/#183; matched "
+                    f"{cohort!r}) — there is no classic aspect/mode control for gflow to "
+                    f"drive {media} generation here. This cohort flaps; retrying in a few "
+                    f"minutes often lands the classic UI.{diag_clause}"
+                )
+            )
+        raise UiSelectorDriftError(
+            selector_drift_detail(
+                "mode_switch_trigger", "no matching element found on the Flow editor.", None
+            )
+            + diag_clause
+        )
+
+    @staticmethod
     async def _exit_agent_mode(
         page: Page, *, out_dir: Path | None = None, allow_reload: bool = False
     ) -> bool:
@@ -1265,14 +1373,7 @@ class VideoGenerationMixin:
             MODE_SWITCH_TRIGGER_SELECTORS,
         )
         if trigger is None:
-            shot = await _capture_debug_screenshot(page, out_dir, "debug_no_mode_trigger.png")
-            raise UiSelectorDriftError(
-                selector_drift_detail(
-                    "mode_switch_trigger",
-                    "no matching element found on the Flow editor.",
-                    shot,
-                )
-            )
+            await VideoGenerationMixin._fail_mode_switch(page, out_dir, media="video")
         await trigger.click()
         await page.wait_for_timeout(800)
         video_tab = await VideoGenerationMixin._probe_selector_cascade(

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -20,7 +20,7 @@ import random
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 
@@ -1267,17 +1267,21 @@ class VideoGenerationMixin:
         return None
 
     @staticmethod
-    async def _fail_mode_switch(page: Page, out_dir: Path | None, *, media: str) -> NoReturn:
-        """Raise the right error when the ``mode_switch_trigger`` probe misses on the
-        ``image``/``video`` path: dump DOM diagnostics, then a clean, retryable
-        :class:`FlowAgentUiError` for the known agentic/media-library A/B cohort
-        (#174/#183) or :class:`UiSelectorDriftError` for genuine selector drift.
-        Shared by ``_switch_to_image_mode`` and ``_switch_to_video_mode``."""
+    async def _mode_switch_error(
+        page: Page, out_dir: Path | None, *, media: str
+    ) -> FlowAgentUiError | UiSelectorDriftError:
+        """Build (do NOT raise — the caller raises) the right error for a
+        ``mode_switch_trigger`` miss on the ``image``/``video`` path: dump DOM
+        diagnostics, then a clean, retryable :class:`FlowAgentUiError` for the known
+        agentic/media-library A/B cohort (#174/#183) or :class:`UiSelectorDriftError`
+        for genuine drift. Returning the exception (vs raising here) keeps the
+        None-path terminating *visibly* at the two call sites. Shared by
+        ``_switch_to_image_mode`` and ``_switch_to_video_mode``."""
         diag = await capture_ui_diagnostics(page, out_dir, "diag_mode_switch_miss")
         diag_clause = f" Diagnostics: {diag}" if diag is not None else ""
         cohort = await VideoGenerationMixin._detect_non_classic_cohort(page)
         if cohort is not None:
-            raise FlowAgentUiError(
+            return FlowAgentUiError(
                 detail=(
                     "Flow opened this project in its new media-library / agentic "
                     f"composer (server-side A/B cohort, issues #174/#183; matched "
@@ -1286,7 +1290,7 @@ class VideoGenerationMixin:
                     f"minutes often lands the classic UI.{diag_clause}"
                 )
             )
-        raise UiSelectorDriftError(
+        return UiSelectorDriftError(
             selector_drift_detail(
                 "mode_switch_trigger", "no matching element found on the Flow editor.", None
             )
@@ -1373,7 +1377,7 @@ class VideoGenerationMixin:
             MODE_SWITCH_TRIGGER_SELECTORS,
         )
         if trigger is None:
-            await VideoGenerationMixin._fail_mode_switch(page, out_dir, media="video")
+            raise await VideoGenerationMixin._mode_switch_error(page, out_dir, media="video")
         await trigger.click()
         await page.wait_for_timeout(800)
         video_tab = await VideoGenerationMixin._probe_selector_cascade(

--- a/tests/api/transports/test_agentic_cohort_detection.py
+++ b/tests/api/transports/test_agentic_cohort_detection.py
@@ -113,11 +113,11 @@ async def test_capture_ui_diagnostics_survives_evaluate_error(tmp_path: Path) ->
     assert await capture_ui_diagnostics(page, tmp_path, "x") is None
 
 
-# --- _fail_mode_switch (shared image+video raise site) -------------------------
+# --- _mode_switch_error (shared image+video raise site; RETURNS the exception) --
 
 
 @pytest.mark.asyncio
-async def test_fail_mode_switch_raises_flow_agent_ui_error_on_cohort(tmp_path: Path) -> None:
+async def test_mode_switch_error_is_flow_agent_ui_error_on_cohort(tmp_path: Path) -> None:
     from gflow_cli.errors import FlowAgentUiError
 
     lib = next(s for s in LIBRARY_UI_INDICATORS if "left_panel_close" in s)
@@ -125,20 +125,21 @@ async def test_fail_mode_switch_raises_flow_agent_ui_error_on_cohort(tmp_path: P
     page.evaluate = AsyncMock(return_value={"ligatures": [lib]})
     page.screenshot = AsyncMock()
 
-    with pytest.raises(FlowAgentUiError) as exc:
-        await VideoGenerationMixin._fail_mode_switch(page, tmp_path, media="image")
+    err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="image")
 
-    msg = str(exc.value)
+    assert isinstance(err, FlowAgentUiError)
+    msg = str(err)
     assert "media-library" in msg and "image generation" in msg  # media verb interpolated
 
 
 @pytest.mark.asyncio
-async def test_fail_mode_switch_raises_drift_error_when_no_cohort(tmp_path: Path) -> None:
+async def test_mode_switch_error_is_drift_error_when_no_cohort(tmp_path: Path) -> None:
     from gflow_cli.errors import UiSelectorDriftError
 
     page = _page_with_present(set())  # genuine drift: no agentic/library marker
     page.evaluate = AsyncMock(return_value={"ligatures": []})
     page.screenshot = AsyncMock()
 
-    with pytest.raises(UiSelectorDriftError):
-        await VideoGenerationMixin._fail_mode_switch(page, tmp_path, media="video")
+    err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="video")
+
+    assert isinstance(err, UiSelectorDriftError)

--- a/tests/api/transports/test_agentic_cohort_detection.py
+++ b/tests/api/transports/test_agentic_cohort_detection.py
@@ -1,0 +1,144 @@
+"""Unit tests for the #183 media-library/agentic cohort raise-site handling.
+
+`_detect_non_classic_cohort` scans the union of agentic + full-page media-library
+markers so the shared `_fail_mode_switch` raise site can emit a clean, retryable
+`FlowAgentUiError` instead of the misleading `UiSelectorDriftError`.
+`capture_ui_diagnostics` is the debug-engine DOM+screenshot dump.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gflow_cli.api.transports.ui_automation_video import (
+    LIBRARY_UI_INDICATORS,
+    NON_CLASSIC_COHORT_INDICATORS,
+    VideoGenerationMixin,
+    capture_ui_diagnostics,
+)
+
+
+def _page_with_present(present: set[str]) -> MagicMock:
+    """Page mock whose ``locator(sel).count()`` returns 1 iff sel is in *present*."""
+    page = MagicMock()
+
+    def locator(sel: str) -> MagicMock:
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if sel in present else 0)
+        return loc
+
+    page.locator = MagicMock(side_effect=locator)
+    return page
+
+
+# --- _detect_non_classic_cohort ------------------------------------------------
+
+
+def test_library_indicators_are_a_subset_of_the_cohort_union() -> None:
+    assert set(LIBRARY_UI_INDICATORS) <= set(NON_CLASSIC_COHORT_INDICATORS)
+    # The full-page library is keyed on locale-invariant sidebar ligatures.
+    assert any("left_panel_close" in s for s in LIBRARY_UI_INDICATORS)
+
+
+@pytest.mark.asyncio
+async def test_detects_full_page_library_marker() -> None:
+    lib = next(s for s in LIBRARY_UI_INDICATORS if "left_panel_close" in s)
+    page = _page_with_present({lib})
+    hit = await VideoGenerationMixin._detect_non_classic_cohort(page)
+    assert hit == lib
+
+
+@pytest.mark.asyncio
+async def test_detects_agentic_marker() -> None:
+    agentic = next(s for s in NON_CLASSIC_COHORT_INDICATORS if "apps_spark_2" in s)
+    page = _page_with_present({agentic})
+    hit = await VideoGenerationMixin._detect_non_classic_cohort(page)
+    assert hit == agentic
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_cohort_marker() -> None:
+    """Genuine selector drift (classic composer just renamed something) — no
+    agentic/library marker → None, so the caller keeps UiSelectorDriftError."""
+    page = _page_with_present(set())
+    hit = await VideoGenerationMixin._detect_non_classic_cohort(page)
+    assert hit is None
+
+
+@pytest.mark.asyncio
+async def test_swallows_locator_errors() -> None:
+    page = MagicMock()
+    page.locator = MagicMock(side_effect=RuntimeError("execution context destroyed"))
+    hit = await VideoGenerationMixin._detect_non_classic_cohort(page)
+    assert hit is None  # best-effort: a probe error never raises out of detection
+
+
+# --- capture_ui_diagnostics ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_ui_diagnostics_writes_json_and_screenshot(tmp_path: Path) -> None:
+    page = MagicMock()
+    page.evaluate = AsyncMock(
+        return_value={
+            "url": "https://labs.google/x",
+            "ligatures": ["dashboard"],
+            "cropPresent": False,
+        }
+    )
+    page.screenshot = AsyncMock()
+
+    out = await capture_ui_diagnostics(page, tmp_path, "diag_mode_switch_miss")
+
+    assert out == tmp_path / "diag_mode_switch_miss.json"
+    assert out is not None and out.exists()
+    assert json.loads(out.read_text(encoding="utf-8"))["ligatures"] == ["dashboard"]
+    page.screenshot.assert_awaited_once()
+    assert page.screenshot.await_args.kwargs["full_page"] is True  # the black-shot fix
+
+
+@pytest.mark.asyncio
+async def test_capture_ui_diagnostics_none_without_out_dir() -> None:
+    assert await capture_ui_diagnostics(MagicMock(), None, "x") is None
+
+
+@pytest.mark.asyncio
+async def test_capture_ui_diagnostics_survives_evaluate_error(tmp_path: Path) -> None:
+    page = MagicMock()
+    page.evaluate = AsyncMock(side_effect=RuntimeError("no execution context"))
+    assert await capture_ui_diagnostics(page, tmp_path, "x") is None
+
+
+# --- _fail_mode_switch (shared image+video raise site) -------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_mode_switch_raises_flow_agent_ui_error_on_cohort(tmp_path: Path) -> None:
+    from gflow_cli.errors import FlowAgentUiError
+
+    lib = next(s for s in LIBRARY_UI_INDICATORS if "left_panel_close" in s)
+    page = _page_with_present({lib})
+    page.evaluate = AsyncMock(return_value={"ligatures": [lib]})
+    page.screenshot = AsyncMock()
+
+    with pytest.raises(FlowAgentUiError) as exc:
+        await VideoGenerationMixin._fail_mode_switch(page, tmp_path, media="image")
+
+    msg = str(exc.value)
+    assert "media-library" in msg and "image generation" in msg  # media verb interpolated
+
+
+@pytest.mark.asyncio
+async def test_fail_mode_switch_raises_drift_error_when_no_cohort(tmp_path: Path) -> None:
+    from gflow_cli.errors import UiSelectorDriftError
+
+    page = _page_with_present(set())  # genuine drift: no agentic/library marker
+    page.evaluate = AsyncMock(return_value={"ligatures": []})
+    page.screenshot = AsyncMock()
+
+    with pytest.raises(UiSelectorDriftError):
+        await VideoGenerationMixin._fail_mode_switch(page, tmp_path, media="video")

--- a/tests/api/transports/test_ui_automation_image_mode.py
+++ b/tests/api/transports/test_ui_automation_image_mode.py
@@ -35,6 +35,10 @@ def _cascade_page(visible: set[str]) -> MagicMock:
         else:
             loc.wait_for = AsyncMock(side_effect=Exception("not visible"))
         loc.click = AsyncMock()
+        # No cohort markers by default → _detect_non_classic_cohort returns None,
+        # so a trigger miss routes to UiSelectorDriftError (genuine drift), not
+        # FlowAgentUiError. Cohort tests live in test_agentic_cohort_detection.py.
+        loc.count = AsyncMock(return_value=0)
         return loc
 
     page.locator = MagicMock(side_effect=_locator)
@@ -66,12 +70,14 @@ class TestSwitchToImageMode:
             await UiAutomationTransport._switch_to_image_mode(page, out_dir=None)
 
     @pytest.mark.asyncio
-    async def test_trigger_miss_detail_carries_screenshot_path(self, tmp_path: Path) -> None:
-        # The screenshot path is the diagnostic payload issue-#183 reporters
-        # need — assert it survives into the user-visible detail.
+    async def test_trigger_miss_detail_carries_diagnostics_path(self, tmp_path: Path) -> None:
+        # On a genuine drift (no cohort marker), the drift error now points at the
+        # richer debug-engine diagnostics artifact (ligature inventory + full-page
+        # screenshot) instead of a bare viewport shot — the payload #183 reporters need.
         page = _cascade_page(set())
+        page.evaluate = AsyncMock(return_value={"ligatures": [], "cropPresent": False})
         page.screenshot = AsyncMock()
-        with pytest.raises(UiSelectorDriftError, match="debug_no_mode_trigger.png"):
+        with pytest.raises(UiSelectorDriftError, match="diag_mode_switch_miss"):
             await UiAutomationTransport._switch_to_image_mode(page, out_dir=tmp_path)
         page.screenshot.assert_awaited()
 


### PR DESCRIPTION
## Summary

Refs #174, #183 — makes Flow's new **media-library / agentic A/B cohort fail cleanly**, and adds a **DOM+screenshot debug engine**.

When a project opens into Flow's full-page media-library (or agentic chat) composer there is no classic `crop_*` aspect/mode control, so `_switch_to_image_mode` / `_switch_to_video_mode`'s `mode_switch_trigger` probe exhausts and raised the opaque `UiSelectorDriftError` ("file a bug").

## Changes
A shared **`_fail_mode_switch`** raise site now serves **both** the image and video paths:
- **`capture_ui_diagnostics`** (the debug engine) — dumps the composer's DOM signature (Material-Symbols ligature inventory, `crop_*` presence, textbox count, URL, body-text) to `diag_mode_switch_miss.json` plus a **full-page** screenshot (fixes the black-viewport shot).
- **`_detect_non_classic_cohort`** — a runtime DOM scan over agentic indicators + new `LIBRARY_UI_INDICATORS`; on a match → clear, retryable **`FlowAgentUiError`** (exit 25, "this cohort flaps; retry shortly") instead of `UiSelectorDriftError`. Genuine drift still gets `UiSelectorDriftError`.
- Docs: CHANGELOG (Added: debug engine · Fixed: clean-fail), KNOWN_ISSUES #174 section.

## Live verification (ffroliva, 0 credits)
- ✅ **Debug engine proven** — it captured a real Flow **app crash** (`"Application error: a client-side exception"`) at a failure point where the old black screenshot showed nothing.
- ✅ **No false positive** — that app-crash correctly fell through to `UiSelectorDriftError` (no cohort markers matched).
- ✅ **No regression** — the classic happy path still generates (6 of 11 fresh t2i rolls succeeded).
- ⚠️ **`FlowAgentUiError`-on-library path is LIKELY, not yet live-CONFIRMED.** The library cohort (recon-captured DOM: `apps_spark_2` / `left_panel_close` / `dashboard`) flapped classic-favoring during testing; 11 fresh rolls never re-landed it. Detection is unit-tested (keyed on the exact recon ligatures) + review-clean, but per the repo rule (`can't verify in current env → LIKELY, not CONFIRMED`) this **Refs**, not Closes, #183 — it confirms on the next library flap.

## Reviews
`/code-review` (high) + `/ponytail-review` were run and applied: added video-path coverage, collapsed poll → single-shot (page is already rendered after the ~24s cascade), dropped the redundant second screenshot, and DRY'd both failure blocks to one shared helper.

## Test plan
- New `test_agentic_cohort_detection.py` + updated `test_ui_automation_image_mode.py`.
- Gates green: ruff, pyright (0 errors), repo-hygiene (638 files), doc-links (27), transports suite (573 passed / 1 skipped).

## Follow-ups surfaced by the debug engine (separate, not this PR)
- Intermittent `WireFormatError` HTTP 400 at `batchGenerateImages` on the classic path (3 of 9 classic runs; the rest succeeded).
- Flow app-crashes surface as `UiSelectorDriftError` "file a bug" — a retryable `FlowAppError` classification would be cleaner now that the debug engine makes them visible.
- Stale `ProfileLease` lock file blocked all runs with "held by another process" though no process held it (manual delete cleared it).
