### PR TITLE
fix(ui): classify Flow web-app crashes as retryable FlowAppError (exit 31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gflow video` now raise a clear, retryable `FlowAgentUiError` ("this cohort
   flaps; retry shortly") instead of the misleading `UiSelectorDriftError`
   "file a bug". Detection is a runtime DOM scan at a new shared
-  `_fail_mode_switch` raise site covering **both** the image and video paths.
+  `_mode_switch_error` raise site covering **both** the image and video paths.
   Refs #174, #183.
+- **Flow web-app crashes now fail cleanly instead of "file a bug".** When Flow's
+  web app renders its client-side-exception error boundary (a transient Flow
+  crash) instead of the editor, the mode-switch raise site now raises a retryable
+  `FlowAppError` (exit code 31) — "transient Flow error, retry shortly" — rather
+  than the misleading `UiSelectorDriftError`. Detected via the Flow error-page
+  title; surfaced by the #183 UI-drift debug engine.
 - **Experimental transport self-lockout.** The `bearer` and `sapisidhash`
   transports discard a caller-supplied Playwright page and re-acquire the profile
   `ProfileLease` in their own `setup()`. Driving one via `GFLOW_CLI_TRANSPORT`

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -44,6 +44,7 @@ from gflow_cli.api.video import (
 from gflow_cli.errors import (
     AuthExpiredError,
     FlowAgentUiError,
+    FlowAppError,
     MediaUploadRejectedError,
     ModelModeIncompatibilityError,
     TransportTimeoutError,
@@ -1267,18 +1268,38 @@ class VideoGenerationMixin:
         return None
 
     @staticmethod
+    async def _is_flow_app_crash(page: Page) -> bool:
+        """True if Flow's web app rendered its client-side-exception error boundary
+        (a transient Flow crash) instead of the editor — keyed on the (English,
+        Next.js-hardcoded) error-page title. Best-effort; never raises."""
+        try:
+            title = (await page.title()) or ""
+        except Exception:  # noqa: BLE001  # NOSONAR — best-effort probe
+            return False
+        return "application error" in title.lower()
+
+    @staticmethod
     async def _mode_switch_error(
         page: Page, out_dir: Path | None, *, media: str
-    ) -> FlowAgentUiError | UiSelectorDriftError:
+    ) -> FlowAppError | FlowAgentUiError | UiSelectorDriftError:
         """Build (do NOT raise — the caller raises) the right error for a
         ``mode_switch_trigger`` miss on the ``image``/``video`` path: dump DOM
-        diagnostics, then a clean, retryable :class:`FlowAgentUiError` for the known
-        agentic/media-library A/B cohort (#174/#183) or :class:`UiSelectorDriftError`
+        diagnostics, then classify — a transient :class:`FlowAppError` if Flow's app
+        crashed, a clean retryable :class:`FlowAgentUiError` for the known
+        agentic/media-library A/B cohort (#174/#183), else :class:`UiSelectorDriftError`
         for genuine drift. Returning the exception (vs raising here) keeps the
         None-path terminating *visibly* at the two call sites. Shared by
         ``_switch_to_image_mode`` and ``_switch_to_video_mode``."""
         diag = await capture_ui_diagnostics(page, out_dir, "diag_mode_switch_miss")
         diag_clause = f" Diagnostics: {diag}" if diag is not None else ""
+        if await VideoGenerationMixin._is_flow_app_crash(page):
+            return FlowAppError(
+                detail=(
+                    "Flow's web app crashed (client-side exception) before the editor "
+                    f"rendered, so there is no {media} generation control to drive."
+                    f"{diag_clause}"
+                )
+            )
         cohort = await VideoGenerationMixin._detect_non_classic_cohort(page)
         if cohort is not None:
             return FlowAgentUiError(

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -21,6 +21,7 @@ __all__ = [
     "DataStoreError",
     "FlowAgentUiError",
     "FlowApiError",
+    "FlowAppError",
     "FrameExtractionError",
     "GFlowError",
     "MediaAttributionError",
@@ -485,6 +486,23 @@ class FlowAgentUiError(GFlowError):
     )
 
 
+class FlowAppError(GFlowError):
+    """Raised when Google Flow's web app itself crashed — a client-side exception
+    (its React error boundary), not a gflow-cli issue. The editor never rendered,
+    so no generation control exists to drive. **Transient and retryable** (exit
+    code 31). Detected at the mode-switch raise site via the Flow error-page title,
+    which otherwise surfaces as a misleading ``UiSelectorDriftError`` "file a bug".
+    """
+
+    problem_type = "https://gflow-cli.dev/errors/flow-app"
+    title = "Google Flow web app error"
+    _default_remediation = (
+        "Google Flow's web app failed to load (a client-side exception on "
+        "labs.google) — a transient Flow-side error, not a gflow-cli bug. Retry in a "
+        "moment; if it persists, check https://labs.google/fx and try a fresh session."
+    )
+
+
 class UiModeUnavailableError(GFlowError):
     """Raised when the Flow UI arm a command REQUIRES (``--ui-mode`` /
     ``GFLOW_CLI_UI_MODE``, or inferred — e.g. ``-i`` instructions force agentic)
@@ -898,6 +916,7 @@ EXIT_CODE_MAP: dict[type[GFlowError], int] = {
     # ConfigurationError (its parent) so the isinstance walk lands on 24, not 11.
     BrowserEngineUnavailableError: 24,
     FlowAgentUiError: 25,
+    FlowAppError: 31,
     # UiModeUnavailableError (issue #299): a command's required arm (--ui-mode /
     # inferred) couldn't be reached after a best-effort switch. Direct GFlowError
     # subclass — retryable policy abort, distinct from FlowAgentUiError (25).

--- a/tests/api/transports/test_agentic_cohort_detection.py
+++ b/tests/api/transports/test_agentic_cohort_detection.py
@@ -32,6 +32,7 @@ def _page_with_present(present: set[str]) -> MagicMock:
         return loc
 
     page.locator = MagicMock(side_effect=locator)
+    page.title = AsyncMock(return_value="Google Flow")  # not the app-crash error page
     return page
 
 
@@ -143,3 +144,20 @@ async def test_mode_switch_error_is_drift_error_when_no_cohort(tmp_path: Path) -
     err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="video")
 
     assert isinstance(err, UiSelectorDriftError)
+
+
+@pytest.mark.asyncio
+async def test_mode_switch_error_is_flow_app_error_on_app_crash(tmp_path: Path) -> None:
+    from gflow_cli.errors import FlowAppError
+
+    # Flow's React error boundary rendered (title), not the editor — a transient
+    # Flow crash. Takes priority over cohort/drift classification.
+    page = _page_with_present(set())
+    page.title = AsyncMock(return_value="Application error: a client-side exception has occurred")
+    page.evaluate = AsyncMock(return_value={"ligatures": []})
+    page.screenshot = AsyncMock()
+
+    err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="image")
+
+    assert isinstance(err, FlowAppError)
+    assert "crashed" in str(err)


### PR DESCRIPTION
## Summary

The #183 UI-drift **debug engine** surfaced a distinct failure mode: when Google Flow's web app renders its client-side-exception **error boundary** (a transient React crash) instead of the editor, the `mode_switch_trigger` probe exhausts and raised the misleading `UiSelectorDriftError` ("Google updated their frontend — file a bug"). But it's a **transient Flow-side crash, retryable**, not a gflow-cli bug.

## Changes
- New **`FlowAppError`** (exit code **31**, retryable) in `errors.py`.
- `_mode_switch_error` now calls `_is_flow_app_crash(page)` **first** (keyed on the Next.js error-page title, `"Application error: a client-side exception…"`) → returns `FlowAppError` for the transient crash, taking priority over the cohort/drift classification. Covers **both** the image and video paths.
- CHANGELOG (+ fixed a stale `_fail_mode_switch` → `_mode_switch_error` reference from #368).

## Evidence
Observed live 2026-07-22 (ffroliva): a `t2i` attempt failed with the debug engine capturing `title: "Application error: a client-side exception has occurred"`, `ligatures: []`, `cropPresent: false` — a real Flow app crash the old path mislabelled as selector drift.

## Test plan
- New `test_mode_switch_error_is_flow_app_error_on_app_crash`; existing cohort/drift/image-mode tests unaffected (the app-crash check no-ops on a normal title).
- Gates green: ruff, pyright (0 errors), doc-links (27), errors-taxonomy test (validates exit-code map + `__all__`), cohort + image-mode suites.

Refs #183 (surfaced by its debug engine).
