### PR TITLE
fix(profile-lease): clarify ProfileLockedError remediation (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Profile-lock remediation message** now names the real cause and recovery.
+  `ProfileLockedError` (exit 11) previously told operators to "wait for it to
+  finish" — implying an unbounded wait — and to hunt for a `gflow`/Chrome
+  process. In practice a blocking lock is a kernel *advisory* lock held by a
+  **live** process (often a `python.exe` a `chrome.exe` scan misses); the OS
+  releases it the instant the holder dies, so a leftover lock *file* never
+  blocks acquisition. The message now points to the recorded owner PID
+  (surfaced locally since v0.43.0) and says to just retry when nothing is
+  running. The lock itself is unchanged — auto-reclaim was considered and
+  rejected as unsafe (an unlink→new-inode race could put two browsers on one
+  profile, the exact corruption the lease prevents). Refs #370.
+
 ## [0.43.0] — 2026-07-23
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -31,22 +31,27 @@ targeted dismissal once the next occurrence is captured. **Workaround:**
 re-run the command; open the project once manually in Chrome to consume the
 banner.
 
-### Reported stale profile lock blocks acquisition (unreproduced)
+### Profile lock reported as "held by another process" with no obvious owner
 
-- **Status:** Open ([#370](https://github.com/ffroliva/gflow-cli/issues/370))
-- **Severity:** Medium (blocks the profile until resolved) · **Affected:** `ProfileLease` acquisition (exit 11)
+- **Status:** Resolved ([#370](https://github.com/ffroliva/gflow-cli/issues/370)) · remediation message clarified
+- **Severity:** Low (by design; fails closed — never corrupts) · **Affected:** `ProfileLease` acquisition (exit 11)
 
-A user report of `ProfileLockedError` with no apparently-live owner. Not
-reproduced: in every observed case the kernel advisory lock was held by a
-real process (e.g. a pytest child that outlived its parent shell). The
-kernel lock is authoritative — a merely *stale metadata file* cannot block
-acquisition, and gflow will never auto-delete a lock file or kill a
-recorded PID based on metadata. Since v0.43.0, contention reports the
-recorded owner's PID and observed start time locally (lock-file metadata
-now starts at offset 1 so Windows contenders can read it while byte 0 is
-kernel-locked), and a metadata-only incident bundle is written before any
-Chrome launch. **Workaround:** find and close the owning process (the
-error's local output names its PID), or use a different `--profile`.
+`ProfileLockedError` can surface when no `chrome.exe` / `gflow` process is
+obvious. This is **working as intended, not a stale-file bug.** The profile
+lock is a kernel *advisory* byte-range lock, which the OS releases the instant
+its holder dies — so a leftover lock *file* can never block acquisition. If
+`acquire` is blocked, a **live** process genuinely holds it, most often a
+`python.exe` (a prior gflow run, or a pytest child that outlived its shell)
+that a scan for `chrome.exe` misses. gflow deliberately never auto-deletes a
+lock file or kills a recorded PID from metadata: an unlink→new-inode race could
+put two browsers on one profile — the exact corruption the lease exists to
+prevent. Since v0.43.0 contention reports the recorded owner's PID and observed
+start time locally (metadata starts at offset 1 so Windows contenders can read
+it while byte 0 is kernel-locked), and the remediation message now names the
+live-owner reality and tells you to just retry when nothing is running.
+**Workaround:** close the process at the PID the error prints
+(`Get-Process -Id <pid>` / `ps -p <pid>`, then `Stop-Process -Id <pid>` /
+`kill <pid>`), or use a different `--profile`.
 
 ### Unexplained image-generation HTTP 400 (observed live 2026-07-22)
 

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -372,9 +372,11 @@ class ProfileLockedError(ConfigurationError):
     title = "Profile locked"
     owner_evidence: OwnerEvidence | None = None
     _default_remediation = (
-        "Another process holds this profile: close a running gflow serve "
-        "daemon or stray Chrome windows using the profile dir, or use a "
-        "different profile name."
+        "A live process holds this profile: a gflow command, a `gflow serve` "
+        "daemon, or a Chrome/python process using the profile dir. Close it and "
+        "retry, or use a different profile name. If nothing is running, the "
+        "kernel lock is already released — a leftover lock file never blocks "
+        "acquisition, so just retry."
     )
 
 

--- a/src/gflow_cli/profile_lease.py
+++ b/src/gflow_cli/profile_lease.py
@@ -169,8 +169,12 @@ def _raise_locked(
     err = ProfileLockedError(
         detail=f"profile {canonical} is locked ({reason})",
         remediation_hint=(
-            "Another gflow process or task currently holds this profile. Wait "
-            "for it to finish and retry, or run with a different --profile."
+            "A live process still holds this profile — commonly a prior gflow "
+            "command, a `gflow serve` daemon, or a leftover Chrome/python "
+            "process (the recorded owner PID is shown with this error). Close "
+            "it and retry, or use a different --profile. If nothing is running, "
+            "the lock is already released — a leftover lock file never blocks "
+            "acquisition, so just retry."
         ),
     )
     err.owner_evidence = evidence  # private; never serialized (design §6.4)

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -56,6 +56,28 @@ def test_release_allows_reacquire(tmp_path: Path) -> None:
     ProfileLease(tmp_path / "profile").acquire().release()
 
 
+def test_contention_remediation_names_live_owner_not_indefinite_wait(
+    tmp_path: Path,
+) -> None:
+    """#370: a blocking lock always has a *live* owner (the kernel releases an
+    advisory lock the instant its holder dies, so a leftover file never blocks).
+    The remediation must not tell a stuck operator to 'wait for it to finish'
+    (implies an unbounded wait) — it must name the live-owner reality and the
+    'just retry if nothing is running' escape. Guards the honest wording."""
+    first = ProfileLease(tmp_path / "profile").acquire()
+    canonical = profile_lease._canonicalize(tmp_path / "profile")
+    profile_lease._registry.pop(canonical, None)
+    try:
+        with pytest.raises(ProfileLockedError) as exc_info:
+            ProfileLease(tmp_path / "profile").acquire()
+    finally:
+        first.release()
+    hint = exc_info.value.remediation_hint
+    assert "Wait for it to finish" not in hint
+    assert "live process" in hint
+    assert "just retry" in hint
+
+
 def test_different_profiles_can_acquire_in_parallel(tmp_path: Path) -> None:
     first = ProfileLease(tmp_path / "one").acquire()
     second = ProfileLease(tmp_path / "two").acquire()

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -31,22 +31,27 @@ targeted dismissal once the next occurrence is captured. **Workaround:**
 re-run the command; open the project once manually in Chrome to consume the
 banner.
 
-### Reported stale profile lock blocks acquisition (unreproduced)
+### Profile lock reported as "held by another process" with no obvious owner
 
-- **Status:** Open ([#370](https://github.com/ffroliva/gflow-cli/issues/370))
-- **Severity:** Medium (blocks the profile until resolved) · **Affected:** `ProfileLease` acquisition (exit 11)
+- **Status:** Resolved ([#370](https://github.com/ffroliva/gflow-cli/issues/370)) · remediation message clarified
+- **Severity:** Low (by design; fails closed — never corrupts) · **Affected:** `ProfileLease` acquisition (exit 11)
 
-A user report of `ProfileLockedError` with no apparently-live owner. Not
-reproduced: in every observed case the kernel advisory lock was held by a
-real process (e.g. a pytest child that outlived its parent shell). The
-kernel lock is authoritative — a merely *stale metadata file* cannot block
-acquisition, and gflow will never auto-delete a lock file or kill a
-recorded PID based on metadata. Since v0.43.0, contention reports the
-recorded owner's PID and observed start time locally (lock-file metadata
-now starts at offset 1 so Windows contenders can read it while byte 0 is
-kernel-locked), and a metadata-only incident bundle is written before any
-Chrome launch. **Workaround:** find and close the owning process (the
-error's local output names its PID), or use a different `--profile`.
+`ProfileLockedError` can surface when no `chrome.exe` / `gflow` process is
+obvious. This is **working as intended, not a stale-file bug.** The profile
+lock is a kernel *advisory* byte-range lock, which the OS releases the instant
+its holder dies — so a leftover lock *file* can never block acquisition. If
+`acquire` is blocked, a **live** process genuinely holds it, most often a
+`python.exe` (a prior gflow run, or a pytest child that outlived its shell)
+that a scan for `chrome.exe` misses. gflow deliberately never auto-deletes a
+lock file or kills a recorded PID from metadata: an unlink→new-inode race could
+put two browsers on one profile — the exact corruption the lease exists to
+prevent. Since v0.43.0 contention reports the recorded owner's PID and observed
+start time locally (metadata starts at offset 1 so Windows contenders can read
+it while byte 0 is kernel-locked), and the remediation message now names the
+live-owner reality and tells you to just retry when nothing is running.
+**Workaround:** close the process at the PID the error prints
+(`Get-Process -Id <pid>` / `ps -p <pid>`, then `Stop-Process -Id <pid>` /
+`kill <pid>`), or use a different `--profile`.
 
 ### Unexplained image-generation HTTP 400 (observed live 2026-07-22)
 


### PR DESCRIPTION
## Summary

Fixes the misleading `ProfileLockedError` (exit 11) remediation message. **Text-only** change to the two remediation strings — the lock mechanism is unchanged.

A blocking profile lock is **always** held by a live process: the kernel releases an advisory byte-range lock the instant its holder dies, so a leftover lock *file* can never block acquisition. The old message told operators to "wait for it to finish" (an unbounded wait) and to hunt for a `gflow`/Chrome process — but the real holder is often a `python.exe` a `chrome.exe` scan misses.

### Changed
- `src/gflow_cli/profile_lease.py` — raise-site remediation hint (the string users see on contention)
- `src/gflow_cli/errors.py` — `ProfileLockedError._default_remediation`
- `tests/test_profile_lease.py` — new test guarding the honest wording
- `KNOWN_ISSUES.md` — reframed entry (Medium/Open → Low/Resolved); documents the auto-release invariant + PID-based diagnosis
- `website/docs/KNOWN_ISSUES.md` — regenerated mirror (drift check green)
- `CHANGELOG.md` — `[Unreleased]` Fixed entry

### Why not auto-reclaim?
Issue #370 proposed stale-lock detection + reclaim. A 5-persona `/gflow:predict` council returned a unanimous **STOP** on reclaim: a leftover file cannot block acquire (kernel auto-releases on holder death), and every reclaim path is unsafe — offset-1 metadata is spoofable, `process_start_time` is import-time wall-clock (not OS creation time), and an unlink→new-inode race could put two browsers on one profile (the exact corruption the lease prevents). The safe, correct fix is the honest message; auto-reclaim is rejected by design.

## Test plan
- [x] `pytest tests/test_profile_lease.py tests/test_errors.py` → 72 passed, 1 skipped
- [x] New test asserts the message drops "wait for it to finish" and names the live-owner + "just retry" reality
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] website/docs drift check + PII guard green

Refs #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
