### PR TITLE
feat(data): data errors export + prune for failed-op history (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`gflow data errors` — bounded retention + export for failed-operation
+  history** (#345). `gflow data errors export [--older-than AGE] [-o FILE]`
+  dumps failed operations as JSONL (unbounded, newest-first) for offline
+  archival — also closing the export path deferred from #341. `gflow data
+  errors prune --older-than AGE [--dry-run]` deletes failures older than AGE
+  (`90d` / `24h` / `30m`); `--older-than` is **required** and there is no
+  automatic/background pruning — deletion is always an explicit operator
+  action. Both honor `--profile` and the exit-16 `DataStoreError` convention.
+
 ### Fixed
 
 - **Profile-lock remediation message** now names the real cause and recovery.

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -161,10 +161,12 @@ async worker (which mirrors its `generation_queue.error_json` failure into
   data-layer fault can never mask the generation error or change the exit code.
 - The character-create saga deliberately keeps its STARTED rows for resume —
   it is excluded from the failure funnel by design.
-- `failed` rows accumulate without an automatic cap in this release: `gflow
-  data prune` targets stale in-flight/completed entries, not failed-operation
-  history. Bounded retention and a dedicated export are tracked in
-  [#345](https://github.com/ffroliva/gflow-cli/issues/345).
+- `failed` rows have **no automatic cap** by design — there is no background
+  pruning. Use `gflow data errors prune --older-than <age>` for explicit
+  retention and `gflow data errors export` to archive history first (see
+  [`data errors`](#gflow-data-errors--bounded-retention--export-345) below,
+  [#345](https://github.com/ffroliva/gflow-cli/issues/345)). Note `gflow data
+  prune` is unrelated: it targets stale `local_files`, not failure history.
 
 ---
 
@@ -299,6 +301,39 @@ gflow data prune
 
 Only **local files** (where `storage_provider` is NULL) are scanned; cloud-stored
 assets are ignored to prevent accidental pruning of remote objects.
+
+### `gflow data errors` — bounded retention + export (#345)
+
+Maintain the failed-operation history (the `data list errors` funnel). Two
+subcommands, both explicit operator actions — there is **no automatic/background
+pruning**.
+
+```bash
+# Archive every failure as JSONL (unbounded; newest-first) before deleting
+gflow data errors export -o failures.jsonl
+
+# Archive only the slice you are about to prune
+gflow data errors export --older-than 90d -o old-failures.jsonl
+
+# Preview what a retention prune would delete (no changes)
+gflow data errors prune --older-than 90d --dry-run
+
+# Delete failures older than 90 days
+gflow data errors prune --older-than 90d
+```
+
+- `--older-than` takes an age like `90d` / `24h` / `30m` (`d` days, `h` hours,
+  `m` minutes; positive integers only). It is **required** on `prune` so
+  deletion is always a deliberate age choice; on `export` it is optional
+  (default: all failures).
+- `--profile NAME` scopes either command to one profile.
+- `export` writes JSONL to `-o/--output FILE`, or to stdout when omitted —
+  reusing the same serialization as `data list errors --json`.
+- Deletion errors map to **exit 16** (`DataStoreError`), consistent with the
+  rest of `gflow data`.
+
+Archive first if you need the failure history for offline WAF-cadence /
+reliability analysis — pruning is irreversible.
 
 ### `gflow data media <media_id>` — read a single asset
 
@@ -507,7 +542,7 @@ Live tests (`@pytest.mark.live`) and E2E tests (`@pytest.mark.e2e`) are opt-in a
 - **`gflow data ls` / `gflow data show <operation_id>`** — richer browsing without leaving the terminal.
 - **Cost tracking** — once enough operation metadata is reliable, surface "credits spent this month" per profile / model / aspect.
 - **Postgres / Supabase adapter** — for users running gflow on shared workers or wanting cross-machine sync. The repository surface is already designed for this swap.
-- **`gflow data export`** — dump the catalog as JSON / Parquet for downstream analytics.
+- **`gflow data export`** (full catalog → JSON / Parquet) — the failed-operation slice shipped as `gflow data errors export` (JSONL, #345); a full-catalog / Parquet dump for downstream analytics is still open.
 
 These are tracked in [`PLAN.md`](../PLAN.md) under the data-layer phase backlog.
 

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -4,8 +4,9 @@ import dataclasses
 import functools
 import json
 import os
+import re
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,7 @@ from gflow_cli.data.queries import (
     ProfileRow,
     ProjectRow,
     VideoRow,
+    export_errors,
     list_errors,
     list_images,
     list_profiles,
@@ -69,15 +71,20 @@ def _truncate(s: str | None, n: int = 40) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _row_json(row: Any) -> str:
+    """Serialize a frozen catalog row to one JSON line (datetimes → ISO, Paths → str)."""
+    d = dataclasses.asdict(row)
+    for k, v in d.items():
+        if isinstance(v, datetime):
+            d[k] = v.isoformat()
+        elif isinstance(v, Path):
+            d[k] = str(v)
+    return json.dumps(d)
+
+
 def _emit_jsonl(rows: list[Any]) -> None:
     for row in rows:
-        d = dataclasses.asdict(row)
-        for k, v in d.items():
-            if isinstance(v, datetime):
-                d[k] = v.isoformat()
-            elif isinstance(v, Path):
-                d[k] = str(v)
-        click.echo(json.dumps(d))
+        click.echo(_row_json(row))
 
 
 def _emit_projects_table(rows: list[ProjectRow]) -> None:
@@ -492,3 +499,105 @@ def prune_cmd(dry_run: bool, profile: str | None) -> None:
                 pruned_count += len(chunk)
 
         click.echo(f"Pruned {pruned_count} dead local_files row(s).")
+
+
+# ---------------------------------------------------------------------------
+# `gflow data errors` — bounded retention + export for failed history (#345)
+# ---------------------------------------------------------------------------
+
+
+_AGE_RE = re.compile(r"^\s*(\d+)\s*([dhm])\s*$")
+_AGE_UNITS = {"d": "days", "h": "hours", "m": "minutes"}
+_OLDER_THAN_HELP = "Age like 90d / 24h / 30m (d=days, h=hours, m=minutes)."
+
+
+def _parse_older_than(text: str) -> timedelta:
+    """Parse a retention age like ``90d`` / ``24h`` / ``30m`` → ``timedelta``.
+
+    Units: ``d`` days, ``h`` hours, ``m`` minutes; the value must be a positive
+    integer. Raises ``click.BadParameter`` on anything else so deletion stays an
+    explicit, unambiguous operator choice.
+    """
+    match = _AGE_RE.match(text)
+    if match is None:
+        raise click.BadParameter(
+            f"Invalid age {text!r}. Use <number><unit> with unit d/h/m (e.g. 90d, 24h, 30m)."
+        )
+    value = int(match.group(1))
+    if value <= 0:
+        raise click.BadParameter(f"Age must be a positive number, got {text!r}.")
+    return timedelta(**{_AGE_UNITS[match.group(2)]: value})
+
+
+@data.group(name="errors")
+def errors_group() -> None:
+    """Maintain the failed-operation history: export (archive) and prune (#345)."""
+
+
+@errors_group.command(name="export")
+@_PROFILE_OPT
+@click.option(
+    "--older-than",
+    "older_than",
+    default=None,
+    metavar="AGE",
+    help=f"Only export failures older than this. {_OLDER_THAN_HELP} Default: all.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write JSONL to this file. Default: stdout.",
+)
+@_guard
+def errors_export_cmd(profile: str | None, older_than: str | None, output: Path | None) -> None:
+    """Export failed operations as JSONL — archive history before pruning (#345).
+
+    Unbounded (no --limit): dumps every failure newest-first. Pair with
+    ``gflow data errors prune`` to reclaim space after archiving.
+    """
+    delta = _parse_older_than(older_than) if older_than else None
+    rows = export_errors(db_path=_db_path(), profile=profile, older_than=delta)
+    if output is None:
+        _emit_jsonl(rows)
+        return
+    with output.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(_row_json(row) + "\n")
+    click.echo(f"Exported {len(rows)} failed operation(s) to {output}.")
+
+
+@errors_group.command(name="prune")
+@_PROFILE_OPT
+@click.option(
+    "--older-than",
+    "older_than",
+    required=True,
+    metavar="AGE",
+    help=f"Delete failures older than this (required). {_OLDER_THAN_HELP}",
+)
+@click.option("--dry-run", is_flag=True, help="Report what would be deleted without deleting.")
+@_guard
+def errors_prune_cmd(profile: str | None, older_than: str, dry_run: bool) -> None:
+    """Delete failed operations older than AGE — explicit retention (#345).
+
+    No automatic/background pruning: deletion is always a deliberate operator
+    action. Archive first with ``gflow data errors export`` if you need the
+    history for offline analysis. ``--older-than`` is required.
+    """
+    delta = _parse_older_than(older_than)
+    with DataStore.open(_db_path()) as store:
+        count = DataRepository(store).prune_failed_operations(
+            older_than=delta, profile=profile, dry_run=dry_run
+        )
+    if count == 0:
+        click.echo("No failed operations older than the cutoff.")
+    elif dry_run:
+        click.echo(
+            f"{count} failed operation(s) older than {older_than} would be deleted. "
+            "--dry-run: no changes made."
+        )
+    else:
+        click.echo(f"Pruned {count} failed operation(s) older than {older_than}.")

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from gflow_cli.data.store import DataStore
@@ -404,6 +404,33 @@ class OperationErrorRow:
     error_detail: str | None
 
 
+def _as_utc(dt: datetime) -> datetime:
+    """Coerce a catalog timestamp to UTC-aware.
+
+    Timestamps are written UTC-aware ("…Z", see ``repository._utc_now``), but a
+    legacy/naive value must still compare against an aware cutoff without raising
+    — assume UTC when tzinfo is absent.
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def _row_to_operation_error(r: Any) -> OperationErrorRow:
+    return OperationErrorRow(
+        started_at=datetime.fromisoformat(str(r["started_at"])),
+        completed_at=(
+            datetime.fromisoformat(str(r["completed_at"]))
+            if r["completed_at"] is not None
+            else None
+        ),
+        profile=str(r["profile"]),
+        command=str(r["command"]) if r["command"] is not None else None,
+        mode=str(r["mode"]),
+        model=str(r["model"]) if r["model"] is not None else None,
+        error_type=str(r["error_type"]) if r["error_type"] is not None else None,
+        error_detail=str(r["error_detail"]) if r["error_detail"] is not None else None,
+    )
+
+
 _LIST_ERRORS_SQL = """
     SELECT
         o.started_at   AS started_at,
@@ -446,23 +473,54 @@ def list_errors(
     params = {"profile": profile, "limit": limit, "offset": offset}
     with _safe_db(db_path) as conn:
         rows = conn.execute(_LIST_ERRORS_SQL, params).fetchall()
-    return [
-        OperationErrorRow(
-            started_at=datetime.fromisoformat(str(r["started_at"])),
-            completed_at=(
-                datetime.fromisoformat(str(r["completed_at"]))
-                if r["completed_at"] is not None
-                else None
-            ),
-            profile=str(r["profile"]),
-            command=str(r["command"]) if r["command"] is not None else None,
-            mode=str(r["mode"]),
-            model=str(r["model"]) if r["model"] is not None else None,
-            error_type=str(r["error_type"]) if r["error_type"] is not None else None,
-            error_detail=str(r["error_detail"]) if r["error_detail"] is not None else None,
-        )
-        for r in rows
-    ]
+    return [_row_to_operation_error(r) for r in rows]
+
+
+_EXPORT_ERRORS_SQL = """
+    SELECT
+        o.started_at   AS started_at,
+        o.completed_at AS completed_at,
+        o.profile_name AS profile,
+        o.command      AS command,
+        o.mode         AS mode,
+        o.model        AS model,
+        o.error_type   AS error_type,
+        o.error_detail AS error_detail
+    FROM operations o
+    WHERE o.status = 'failed'
+      AND (:profile IS NULL OR o.profile_name = :profile)
+    ORDER BY o.started_at DESC
+"""
+
+
+def export_errors(
+    *,
+    db_path: Path,
+    profile: str | None = None,
+    older_than: timedelta | None = None,
+) -> list[OperationErrorRow]:
+    """Return ALL failed operations newest-first, for archival (#345).
+
+    Like :func:`list_errors` but unbounded (no ``limit``/``offset``) and with an
+    optional ``older_than`` age filter, so an operator can archive the exact set
+    they are about to prune. Pure read; the CLI serializes the rows to JSONL.
+
+    Args:
+        db_path: Absolute path to the SQLite catalog.
+        profile: If given, only return failures belonging to this profile name.
+        older_than: If given, only return failures whose ``started_at`` is older
+            than ``now - older_than``. When ``None``, every failure is returned.
+
+    Returns:
+        A list of :class:`OperationErrorRow` instances ordered newest-first.
+    """
+    with _safe_db(db_path) as conn:
+        rows = conn.execute(_EXPORT_ERRORS_SQL, {"profile": profile}).fetchall()
+    result = [_row_to_operation_error(r) for r in rows]
+    if older_than is not None:
+        cutoff = datetime.now(UTC) - older_than
+        result = [row for row in result if _as_utc(row.started_at) < cutoff]
+    return result
 
 
 # ─── ProfileRow + list_profiles ───────────────────────────────────────────────

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 
 def _utc_now() -> str:
     return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _coerce_utc(dt: datetime) -> datetime:
+    """UTC-aware view of a catalog timestamp; assume UTC if a legacy value is naive."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
 _ASSET_LOOKUP_COLUMNS = (
@@ -315,6 +320,52 @@ class DataRepository:
                 """,
                 (status.value, completed_at, error_type, error_detail, operation_id),
             )
+
+    def prune_failed_operations(
+        self,
+        *,
+        older_than: timedelta,
+        profile: str | None = None,
+        dry_run: bool = False,
+    ) -> int:
+        """Delete failed operations older than *older_than*; return how many were
+        deleted (or, when *dry_run*, WOULD be deleted).
+
+        Explicit retention for #345 — never invoked automatically. Rows are
+        matched in Python against ``now - older_than`` (robust to timestamp
+        format), then deleted by id in chunks. Child ``operation_assets`` rows
+        (rare for failures, but not assumed absent) are removed first to satisfy
+        the ``operations(id)`` foreign key with ``PRAGMA foreign_keys = ON``.
+        """
+        cutoff = datetime.now(UTC) - older_than
+        rows = self._store.conn.execute(
+            "SELECT id, started_at FROM operations"
+            " WHERE status = 'failed'"
+            " AND (:profile IS NULL OR profile_name = :profile)",
+            {"profile": profile},
+        ).fetchall()
+        stale_ids = [
+            str(r["id"])
+            for r in rows
+            if _coerce_utc(datetime.fromisoformat(str(r["started_at"]))) < cutoff
+        ]
+        if dry_run or not stale_ids:
+            return len(stale_ids)
+        # SQLite variable limit is usually 999; 500 is safe.
+        chunk_size = 500
+        with self._store.transaction(immediate=True):
+            for i in range(0, len(stale_ids), chunk_size):
+                chunk = stale_ids[i : i + chunk_size]
+                placeholders = ",".join("?" * len(chunk))
+                self._store.conn.execute(
+                    f"DELETE FROM operation_assets WHERE operation_id IN ({placeholders})",
+                    chunk,
+                )
+                self._store.conn.execute(
+                    f"DELETE FROM operations WHERE id IN ({placeholders})",
+                    chunk,
+                )
+        return len(stale_ids)
 
     def set_operation_metadata(
         self,

--- a/tests/cli/test_cli_data_errors_retention.py
+++ b/tests/cli/test_cli_data_errors_retention.py
@@ -1,0 +1,169 @@
+"""`gflow data errors export` + `prune` — bounded retention & export (#345)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from gflow_cli.cli_data import _parse_older_than
+from gflow_cli.data.models import OperationKind
+from gflow_cli.data.queries import export_errors, list_errors
+from gflow_cli.data.recorder import OperationRecorder
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+from gflow_cli.errors import WafRejectionError
+
+
+def _seed_failed_op(db_path: Path, *, profile: str = "default", detail: str = "blocked") -> None:
+    with DataStore.open(db_path) as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        recorder.record_failed_operation(
+            profile_name=profile,
+            profile_dir=db_path.parent / "p",
+            command="image t2i",
+            mode=OperationKind.T2I,
+            exc=WafRejectionError(detail, status=403),
+        )
+
+
+def _backdate_all(db_path: Path, *, days: int) -> None:
+    """Rewrite every operation's started_at to `days` ago (recorder's UTC 'Z' format)."""
+    ts = (
+        (datetime.now(UTC) - timedelta(days=days))
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+    with DataStore.open(db_path) as store, store.transaction(immediate=True):
+        store.conn.execute("UPDATE operations SET started_at = ?", (ts,))
+
+
+# --- _parse_older_than ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("90d", timedelta(days=90)),
+        ("24h", timedelta(hours=24)),
+        ("30m", timedelta(minutes=30)),
+        (" 7d ", timedelta(days=7)),
+    ],
+)
+def test_parse_older_than_valid(text: str, expected: timedelta) -> None:
+    assert _parse_older_than(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "abc", "90x", "d", "0d", "-5d", "90"])
+def test_parse_older_than_rejects_junk(text: str) -> None:
+    with pytest.raises(click.BadParameter):
+        _parse_older_than(text)
+
+
+# --- export_errors ----------------------------------------------------------
+
+
+def test_export_errors_returns_all_unbounded(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    for _ in range(3):
+        _seed_failed_op(db)
+    assert len(export_errors(db_path=db)) == 3
+
+
+def test_export_errors_older_than_filters(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)  # recent
+    assert export_errors(db_path=db, older_than=timedelta(days=30)) == []
+    _backdate_all(db, days=100)
+    assert len(export_errors(db_path=db, older_than=timedelta(days=30))) == 1
+
+
+def test_data_errors_export_cli_to_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    out = tmp_path / "errors.jsonl"
+    result = CliRunner().invoke(main, ["data", "errors", "export", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["error_type"] == "waf-rejection"
+
+
+# --- prune ------------------------------------------------------------------
+
+
+def test_prune_deletes_only_old_rows(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db, profile="old")
+    _backdate_all(db, days=100)  # make the first row old
+    _seed_failed_op(db, profile="fresh")  # a recent row
+    with DataStore.open(db) as store:
+        deleted = DataRepository(store).prune_failed_operations(older_than=timedelta(days=90))
+    assert deleted == 1
+    remaining = list_errors(db_path=db, profile=None, limit=20, offset=0)
+    assert [r.profile for r in remaining] == ["fresh"]
+
+
+def test_prune_dry_run_deletes_nothing(tmp_path: Path) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    _backdate_all(db, days=100)
+    with DataStore.open(db) as store:
+        would = DataRepository(store).prune_failed_operations(
+            older_than=timedelta(days=90), dry_run=True
+        )
+    assert would == 1
+    assert len(list_errors(db_path=db, profile=None, limit=20, offset=0)) == 1
+
+
+def test_prune_clears_operation_assets_children(tmp_path: Path) -> None:
+    """A failed op with a linked operation_assets row must prune without an FK
+    error (child rows removed first)."""
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    with DataStore.open(db) as store, store.transaction(immediate=True):
+        conn = store.conn
+        op_id = conn.execute("SELECT id FROM operations WHERE status='failed'").fetchone()["id"]
+        conn.execute(
+            "INSERT INTO assets (id, profile_name, flow_media_id, kind, status, created_at)"
+            " VALUES ('a1', 'default', 'm1', 'image', 'ok', '2020-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            "INSERT INTO operation_assets (operation_id, asset_id, role, position)"
+            " VALUES (?, 'a1', 'input', 0)",
+            (op_id,),
+        )
+    _backdate_all(db, days=100)
+    with DataStore.open(db) as store:
+        deleted = DataRepository(store).prune_failed_operations(older_than=timedelta(days=90))
+    assert deleted == 1
+    with DataStore.open(db) as store:
+        assert store.conn.execute("SELECT COUNT(*) c FROM operation_assets").fetchone()["c"] == 0
+
+
+def test_data_errors_prune_requires_older_than(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "gflow.db"
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "errors", "prune"])
+    assert result.exit_code == 2
+    assert "--older-than" in result.output
+
+
+def test_data_errors_prune_cli_reports_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    _backdate_all(db, days=100)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "errors", "prune", "--older-than", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "Pruned 1" in result.output

--- a/tests/cli/test_cli_data_errors_retention.py
+++ b/tests/cli/test_cli_data_errors_retention.py
@@ -167,3 +167,36 @@ def test_data_errors_prune_cli_reports_count(
     result = CliRunner().invoke(main, ["data", "errors", "prune", "--older-than", "90d"])
     assert result.exit_code == 0, result.output
     assert "Pruned 1" in result.output
+
+
+def test_data_errors_export_cli_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "errors", "export"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output.strip().splitlines()[-1])["error_type"] == "waf-rejection"
+
+
+def test_data_errors_prune_dry_run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)
+    _backdate_all(db, days=100)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(
+        main, ["data", "errors", "prune", "--older-than", "90d", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "would be deleted" in result.output
+    assert len(list_errors(db_path=db, profile=None, limit=20, offset=0)) == 1
+
+
+def test_data_errors_prune_cli_nothing_to_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = tmp_path / "gflow.db"
+    _seed_failed_op(db)  # recent — not older than 90d
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    result = CliRunner().invoke(main, ["data", "errors", "prune", "--older-than", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "No failed operations older than the cutoff." in result.output

--- a/tests/mcp/test_cli_parity.py
+++ b/tests/mcp/test_cli_parity.py
@@ -69,6 +69,8 @@ _MCP_EXEMPT: dict[str, str] = {
     "character rm": "character mutations — not yet ported",
     "character show": "character mutations — not yet ported",
     "character voices": "character mutations — not yet ported",
+    "data errors export": "local catalog maintenance — deliberately CLI-only (#345)",
+    "data errors prune": "destructive local retention — deliberately CLI-only (#345)",
     "data list errors": "local catalog maintenance — not yet ported",
     "data list images": "local catalog maintenance — not yet ported",
     "data list profiles": "local catalog maintenance — not yet ported",

--- a/website/docs/DATA_LAYER.md
+++ b/website/docs/DATA_LAYER.md
@@ -161,10 +161,12 @@ async worker (which mirrors its `generation_queue.error_json` failure into
   data-layer fault can never mask the generation error or change the exit code.
 - The character-create saga deliberately keeps its STARTED rows for resume —
   it is excluded from the failure funnel by design.
-- `failed` rows accumulate without an automatic cap in this release: `gflow
-  data prune` targets stale in-flight/completed entries, not failed-operation
-  history. Bounded retention and a dedicated export are tracked in
-  [#345](https://github.com/ffroliva/gflow-cli/issues/345).
+- `failed` rows have **no automatic cap** by design — there is no background
+  pruning. Use `gflow data errors prune --older-than <age>` for explicit
+  retention and `gflow data errors export` to archive history first (see
+  [`data errors`](#gflow-data-errors--bounded-retention--export-345) below,
+  [#345](https://github.com/ffroliva/gflow-cli/issues/345)). Note `gflow data
+  prune` is unrelated: it targets stale `local_files`, not failure history.
 
 ---
 
@@ -299,6 +301,39 @@ gflow data prune
 
 Only **local files** (where `storage_provider` is NULL) are scanned; cloud-stored
 assets are ignored to prevent accidental pruning of remote objects.
+
+### `gflow data errors` — bounded retention + export (#345)
+
+Maintain the failed-operation history (the `data list errors` funnel). Two
+subcommands, both explicit operator actions — there is **no automatic/background
+pruning**.
+
+```bash
+# Archive every failure as JSONL (unbounded; newest-first) before deleting
+gflow data errors export -o failures.jsonl
+
+# Archive only the slice you are about to prune
+gflow data errors export --older-than 90d -o old-failures.jsonl
+
+# Preview what a retention prune would delete (no changes)
+gflow data errors prune --older-than 90d --dry-run
+
+# Delete failures older than 90 days
+gflow data errors prune --older-than 90d
+```
+
+- `--older-than` takes an age like `90d` / `24h` / `30m` (`d` days, `h` hours,
+  `m` minutes; positive integers only). It is **required** on `prune` so
+  deletion is always a deliberate age choice; on `export` it is optional
+  (default: all failures).
+- `--profile NAME` scopes either command to one profile.
+- `export` writes JSONL to `-o/--output FILE`, or to stdout when omitted —
+  reusing the same serialization as `data list errors --json`.
+- Deletion errors map to **exit 16** (`DataStoreError`), consistent with the
+  rest of `gflow data`.
+
+Archive first if you need the failure history for offline WAF-cadence /
+reliability analysis — pruning is irreversible.
 
 ### `gflow data media <media_id>` — read a single asset
 
@@ -507,7 +542,7 @@ Live tests (`@pytest.mark.live`) and E2E tests (`@pytest.mark.e2e`) are opt-in a
 - **`gflow data ls` / `gflow data show <operation_id>`** — richer browsing without leaving the terminal.
 - **Cost tracking** — once enough operation metadata is reliable, surface "credits spent this month" per profile / model / aspect.
 - **Postgres / Supabase adapter** — for users running gflow on shared workers or wanting cross-machine sync. The repository surface is already designed for this swap.
-- **`gflow data export`** — dump the catalog as JSON / Parquet for downstream analytics.
+- **`gflow data export`** (full catalog → JSON / Parquet) — the failed-operation slice shipped as `gflow data errors export` (JSONL, #345); a full-catalog / Parquet dump for downstream analytics is still open.
 
 These are tracked in [`PLAN.md`](../PLAN.md) under the data-layer phase backlog.
 


### PR DESCRIPTION
## Summary

Ships #345: bounded retention + export for the failed-operation history (the `gflow data list errors` funnel from #341). Browser-free, data-layer only.

New `gflow data errors` group — chosen over overloading the existing `data prune` (which cleans orphaned local files, a different table):

| Command | Purpose |
|---|---|
| `data errors export [--older-than AGE] [-o FILE]` | Dump failed ops as JSONL (unbounded, newest-first). Also closes the export path deferred from #341. |
| `data errors prune --older-than AGE [--dry-run]` | Delete failures older than AGE. `--older-than` required; **no** automatic/background pruning. |

`--older-than` accepts `90d` / `24h` / `30m` (positive integers). Both honor `--profile` and the exit-16 `DataStoreError` convention.

### Implementation
- `queries.py` — `export_errors()` mirrors `list_errors` (no limit/offset, optional age filter); row mapping refactored into a shared `_row_to_operation_error`.
- `repository.py` — `prune_failed_operations()` matches rows in Python against `now - AGE` (robust to timestamp format, mirrors the existing `data prune`), deletes by id in chunks, and clears `operation_assets` children first to satisfy the FK (`PRAGMA foreign_keys = ON`).
- `cli_data.py` — `data errors` group + `_parse_older_than`; `_emit_jsonl` refactored into a reusable `_row_json` for file output.
- **Deferred (YAGNI):** the optional `operations(status, started_at)` index — note-only in the issue, not worth a migration at current row counts.

### Design note
Retention deletion is deliberately conservative: explicit-only, `--older-than` required, `--dry-run` supported, and export-before-prune is the documented workflow (pruning is irreversible).

## Test plan
- [x] `_parse_older_than` valid + invalid (`0d`, `-5d`, missing unit all rejected)
- [x] `export_errors` unbounded + `--older-than` filter
- [x] prune: cutoff (deletes only old), `--dry-run` (deletes nothing), `--older-than` required (exit 2), FK child-delete, CLI count
- [x] Full slice: `pytest tests/cli/ tests/test_cli_data.py tests/test_data_queries.py` → 496 passed
- [x] ruff + pyright (0 errors) clean; website drift + PII guard green

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
