### PR TITLE
fix(mcp): disambiguate gflow_list_tools and ship initialize-time instructions

### DIFF
--- a/src/gflow_cli/mcp/resources.py
+++ b/src/gflow_cli/mcp/resources.py
@@ -59,7 +59,8 @@ Browse the local project catalog.
 Browse reusable Flow Character entities.
 
 ### gflow_list_tools
-List available gflow prompt tools (name, title, description, category).
+List optional prompt-rewriting presets ("prompt tools") for the generation
+tools' `tools` parameter. Not the MCP tool catalog.
 
 ## Important Rules
 1. **Use tools, not shell commands.** Do NOT run `gflow image t2i ...` via the terminal.

--- a/src/gflow_cli/mcp/server.py
+++ b/src/gflow_cli/mcp/server.py
@@ -27,8 +27,23 @@ log = structlog.get_logger()
 _SERVER_NAME = "gflow-cli"
 _SERVER_VERSION = __version__
 
+# Handed to clients at initialize; the first orientation an agent reads.
+_SERVER_INSTRUCTIONS = """\
+gflow-cli drives the user's own Google Flow session: Veo video and Imagen \
+image generation.
+
+- To verify the connection, call gflow_list_projects (fast, local, credits-free).
+- Image generation is credits-free; gflow_generate_video SPENDS the user's Veo \
+credits — confirm with the user before calling it.
+- gflow_list_tools lists optional prompt-rewriting presets ("prompt tools") for \
+the generation tools' `tools` parameter — it is NOT this server's tool catalog.
+- If a tool returns an auth error, tell the user to run \
+`gflow auth login --browser chrome`.
+"""
+
 server = FastMCP(
     name=_SERVER_NAME,
+    instructions=_SERVER_INSTRUCTIONS,
 )
 # FastMCP does not expose a public API to configure the server version.
 # As a workaround, we assign it directly to the underlying Server instance.

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -930,7 +930,13 @@ async def gflow_generate_video(
 
 @server.tool(
     name="gflow_list_tools",
-    description="List available gflow prompt tools (name, title, description, category).",
+    description=(
+        'List gflow\'s optional prompt-rewriting presets ("prompt tools", e.g. '
+        "creative-director), which can be passed via the `tools` parameter of "
+        "gflow_generate_image / gflow_generate_video to enhance a prompt before "
+        "generation. NOT this MCP server's tool catalog — to sanity-check the "
+        "connection, call gflow_list_projects instead."
+    ),
 )
 async def gflow_list_tools() -> dict[str, Any]:
     """List available prompt tools that can be passed to gflow_generate_image/video.

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -39,6 +39,22 @@ class TestMcpToolListing:
             f"Missing tools: {expected - tool_names}. Found: {tool_names}"
         )
 
+    def test_server_ships_agent_instructions(self, mcp_server: Any) -> None:
+        """The initialize-time instructions must orient agents: how to verify the
+        connection, that video spends credits, and that gflow_list_tools lists
+        prompt presets rather than this server's tool catalog (#misread risk)."""
+        instructions = mcp_server.instructions
+        assert instructions
+        assert "gflow_list_projects" in instructions
+        assert "credits" in instructions.lower()
+
+    def test_list_tools_description_disambiguates_prompt_presets(self, mcp_server: Any) -> None:
+        """gflow_list_tools is about prompt-rewriting presets; its description must
+        say so explicitly, or agents read it as MCP-tool enumeration."""
+        description = mcp_server._tool_manager._tools["gflow_list_tools"].description
+        assert "prompt" in description.lower()
+        assert "not" in description.lower()
+
     def test_generate_image_tool_has_required_params(self, mcp_server: Any) -> None:
         """gflow_generate_image should accept prompt + model/aspect/count/seed/tools/profile."""
         tool = mcp_server._tool_manager._tools["gflow_generate_image"]


### PR DESCRIPTION
## What

Field report turned patch. Testing the MCP server from the Claude desktop app (Claude Opus 4.8), the agent was asked to "test the gflow mcp", called `gflow_list_tools`, misread the payload as this server's (empty) tool catalog, and concluded the server was broken — while all 11 tools were registered and working.

Root cause: `gflow_list_tools` is the most natural first call for any agent probing an unfamiliar server, and its one-line description ("List available gflow prompt tools") never says what a *prompt tool* is or that it isn't MCP-tool enumeration.

Three changes, no behavior change:

- **`gflow_list_tools` description** now states it lists prompt-rewriting presets for the generation tools' `tools` parameter, is **not** the MCP tool catalog, and points connection checks at `gflow_list_projects`.
- **Initialize-time `instructions`** on the FastMCP server — the first orientation an agent reads at handshake: verify via `gflow_list_projects`, video spends credits (confirm with the user first), auth-error remediation, and the same `list_tools` disambiguation. Mirrors the existing agent-guide resource, but clients surface `instructions` automatically while resources must be discovered.
- **Agent-guide resource** wording synced.

## Tests

Two new tests in `tests/mcp/test_server.py` lock in the instructions content and the disambiguating description. `uv run pytest tests/mcp` → 101 passed; ruff check/format and pyright (strict) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)