### PR TITLE
fix(ui_automation): handle HTTP 429 rate-limiting with RateLimitError and adaptive backoff

### DIFF
--- a/src/gflow_cli/api/_retry.py
+++ b/src/gflow_cli/api/_retry.py
@@ -20,7 +20,7 @@ Internal API (test-only):
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from tenacity import (
     AsyncRetrying,
@@ -40,18 +40,41 @@ MAX_ATTEMPTS = 3
 RETRY_AFTER_CAP_SECONDS = 60.0
 
 
+def _get_headers_dict(obj: Any) -> dict[str, str] | None:
+    if obj is None:
+        return None
+    headers_val: Any = getattr(obj, "headers", None)
+    if headers_val is None and isinstance(obj, dict):
+        d_obj: dict[Any, Any] = cast("dict[Any, Any]", obj)
+        headers_val = d_obj.get("headers")
+        if headers_val is None:
+            headers_val = d_obj
+    if headers_val is None:
+        return None
+    if isinstance(headers_val, dict):
+        d_hdr: dict[Any, Any] = cast("dict[Any, Any]", headers_val)
+        return {str(k).lower(): str(v) for k, v in d_hdr.items()}
+    if hasattr(headers_val, "get"):
+        get_fn: Any = headers_val.get
+        val: Any = get_fn("retry-after") or get_fn("Retry-After")
+        if val is not None:
+            return {"retry-after": str(val)}
+    return None
+
+
 def parse_retry_after(response: Any) -> float | None:
     """Extract the ``Retry-After`` header (seconds form only). Caps at 60s.
 
     Returns ``None`` if header absent or malformed. The HTTP-date form of
     ``Retry-After`` is intentionally NOT supported — Flow's upstream emits
     integer seconds in observed captures, and parsing RFC 7231 dates would
-    add a dependency without buying observable value.
+    add a dependency without buying observable value. Accepts objects with a
+    ``.headers`` attribute, dicts with a ``"headers"`` key, or direct header dicts.
     """
-    headers = getattr(response, "headers", None)
-    if headers is None:
+    headers_dict = _get_headers_dict(response)
+    if not headers_dict:
         return None
-    raw = headers.get("retry-after") if hasattr(headers, "get") else None
+    raw = headers_dict.get("retry-after")
     if not raw:
         return None
     try:

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -1984,10 +1984,13 @@ class FlowApiClient:
         req_with_token = _dc_replace(req, recaptcha_token=token)
         if on_checkpoint is not None:
             on_checkpoint(GenerationCheckpoint(phase="submit_attempted"))
-        images = await self.transport.generate_images(
-            project_id=project_id,
-            request=req_with_token,
-        )
+        images: list[GeneratedImage] = []
+        async for retrying in post_with_retry():
+            with retrying:
+                images = await self.transport.generate_images(
+                    project_id=project_id,
+                    request=req_with_token,
+                )
         if not images:
             raise ContentPolicyError(
                 detail="empty media[]",

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 import structlog
 
+from gflow_cli.api._retry import parse_retry_after
 from gflow_cli.api.character import CHARACTER_MODELS, CharacterImageRequest
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
@@ -43,6 +44,7 @@ from gflow_cli.errors import (
     BatchPartialError,
     ContentPolicyError,
     GFlowError,
+    RateLimitError,
     UiSelectorDriftError,
     WafRejectionError,
     WireFormatError,
@@ -539,8 +541,9 @@ def _images_from_responses(
     """Process captured batchGenerateImages responses.
 
     Returns ``(images, first_error_status, first_error_route)``. Raises
-    :class:`AuthExpiredError` on 401 and :class:`WafRejectionError` on 403,
-    which the caller must surface — these are not first-error candidates.
+    :class:`AuthExpiredError` on 401, :class:`WafRejectionError` on 403, and
+    :class:`RateLimitError` on 429, which the caller must surface — these are not
+    first-error candidates.
     """
     images: list[GeneratedImage] = []
     first_error_status: int | None = None
@@ -570,6 +573,23 @@ def _images_from_responses(
                 ),
                 status=403,
                 route=route_str,
+            )
+        if status == 429:
+            retry_after = parse_retry_after(response)
+            log.warning(
+                "ui_automation.batch_429_body",
+                body_prefix=str(body)[:200],
+                route=route_str,
+                retry_after=retry_after,
+            )
+            raise RateLimitError(
+                detail=(
+                    "batchGenerateImages HTTP 429 — rate limit hit."
+                    + (f" Retry after {retry_after:.0f}s." if retry_after is not None else "")
+                ),
+                status=429,
+                route=route_str,
+                retry_after=retry_after,
             )
         if status != 200:
             first_error_status = first_error_status or status
@@ -2036,11 +2056,23 @@ class UiAutomationTransport(VideoGenerationMixin):
                     url=response.url,
                 )
                 return
+            headers: dict[str, str] = {}
+            raw_hdrs: Any = getattr(response, "headers", None)
+            if raw_hdrs is not None:
+                try:
+                    if callable(raw_hdrs):
+                        raw_hdrs = raw_hdrs()
+                    if isinstance(raw_hdrs, dict):
+                        raw_dict: dict[Any, Any] = cast("dict[Any, Any]", raw_hdrs)
+                        headers = {str(k): str(v) for k, v in raw_dict.items()}
+                except Exception:
+                    pass
             captured.append(
                 {
                     "status": response.status,
                     "url": response.url,
                     "body": body,
+                    "headers": headers,
                     "ts": time.monotonic(),
                 },
             )

--- a/tests/api/test_retry.py
+++ b/tests/api/test_retry.py
@@ -112,6 +112,16 @@ def test_parse_retry_after_missing_returns_none():
     assert parse_retry_after(_resp(429)) is None
 
 
+def test_parse_retry_after_dict_with_headers_key():
+    assert parse_retry_after({"headers": {"retry-after": "45"}}) == 45.0
+    assert parse_retry_after({"headers": {"Retry-After": "25"}}) == 25.0
+
+
+def test_parse_retry_after_direct_headers_dict():
+    assert parse_retry_after({"retry-after": "15"}) == 15.0
+    assert parse_retry_after({"Retry-After": "10"}) == 10.0
+
+
 @pytest.mark.asyncio
 async def test_event_gated_retry_does_not_block_real_time():
     """Async test that uses asyncio.Event-gated wait so it runs in <0.1s.

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -3261,3 +3261,64 @@ class TestReferenceEntitiesInterception:
 
         # If unmodified, continue_ is called with no post_data argument
         mock_route.continue_.assert_awaited_once_with()
+
+
+def test_images_from_responses_raises_ratelimiterror_on_429():
+    """HTTP 429 response in _images_from_responses MUST raise RateLimitError with retry_after."""
+    from gflow_cli.api.transports.ui_automation import _images_from_responses
+    from gflow_cli.errors import RateLimitError
+
+    responses = [
+        {
+            "status": 429,
+            "url": "https://aisandbox-pa.googleapis.com/v1/projects/p1/flowMedia:batchGenerateImages",
+            "body": {"error": {"message": "Resource exhausted"}},
+            "headers": {"retry-after": "45"},
+        }
+    ]
+
+    with pytest.raises(RateLimitError) as exc_info:
+        _images_from_responses(responses)
+
+    err = exc_info.value
+    assert err.status == 429
+    assert err.retry_after == 45.0
+    assert "429" in str(err)
+    assert "45s" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_attach_batch_response_listener_records_headers():
+    """_attach_batch_response_listener MUST capture response headers into the response dict."""
+    from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+
+    fake_page = MagicMock()
+    listener_cb = None
+
+    def on_sub(event: str, cb: Any) -> None:
+        nonlocal listener_cb
+        if event == "response":
+            listener_cb = cb
+
+    fake_page.on = on_sub
+
+    captured, detach = UiAutomationTransport._attach_batch_response_listener(
+        fake_page, project_id="p123"
+    )
+    assert listener_cb is not None
+
+    fake_response = MagicMock()
+    fake_response.url = (
+        "https://aisandbox-pa.googleapis.com/v1/projects/p123/flowMedia:batchGenerateImages"
+    )
+    fake_response.status = 429
+    fake_response.headers = {"retry-after": "30", "content-type": "application/json"}
+    fake_response.json = AsyncMock(return_value={"error": "rate limit"})
+
+    await listener_cb(fake_response)
+
+    assert len(captured) == 1
+    assert captured[0]["status"] == 429
+    assert captured[0]["headers"] == {"retry-after": "30", "content-type": "application/json"}
+
+    detach()


### PR DESCRIPTION
## Summary
Fixes mishandling of HTTP 429 rate limits in ui_automation transport (Issue #379).

- **Header Capture**: Captures response headers in ui_automation._attach_batch_response_listener.
- **Typed Exception**: Updates parse_retry_after to support dict payloads with 'headers' keys and branches HTTP 429 to RateLimitError carrying retry_after in _images_from_responses.
- **Adaptive Backoff**: Wraps self.transport.generate_images in FlowApiClient._drive_images_generation with post_with_retry() so tenacity adaptively backs off for retry_after seconds and retries.

## Verification Status
- [x] Unit test suite (tests/api/test_retry.py & tests/api/transports/test_ui_automation.py) passes 100% (188 passed).
- [x] Pyright strict clean (0 errors, 0 warnings).
- [x] Ruff lint & format check clean.
- [x] Repo hygiene, doc links, and PII checks clean.
- [ ] Live headed-browser verification against real Flow HTTP 429 rate limit (requires live 429 hit).

Refs #379