### PR TITLE
fix(cli): tier-aware credit confirmations for chain and movie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tier-aware credit confirmations:** `gflow video chain` and `gflow movie run`
+  no longer present pending work as an exact one-credit-per-link/scene charge.
+  Plans, confirmation prompts, `--dry-run` output, Click help, and current docs
+  now report the count of *pending video operations* and direct operators to
+  Google Flow for current model/duration/tier pricing, which varies by account
+  tier and Flow policy. Execution, resume/stale accounting, `--yes`, JSON
+  output, flags, and exit codes are unchanged.
+
 ### Added
 
 - **Top Banner & Modal Dismissal (#369):** Expanded `_detect_overlay` and

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,9 +343,9 @@ each link in turn, so total wallclock is the sum of all link waits).
 |---|---|---|
 | `--model` | `veo-lite` | `veo-lite` / `veo-fast` / `veo-quality` / `veo-lite-lp`. `omni-flash` is rejected — it can't seed i2v links (issue #125). |
 | `--max-links N` | unset | Cap link count; exit 11 (`ConfigurationError`) if the manifest has more. A spend guardrail. |
-| `-y` / `--yes` | off | Skip the per-credit cost confirmation prompt. |
-| `--dry-run` | off | Print the plan + credit estimate and spend nothing. |
-| `--resume-from CHAIN_ID` | unset | Resume a prior chain by its id; already-paid links are skipped (not re-billed). |
+| `-y` / `--yes` | off | Skip the pending video operation confirmation prompt. |
+| `--dry-run` | off | Print the pending video operation plan and submit nothing. |
+| `--resume-from CHAIN_ID` | unset | Resume a prior chain by its id; already-completed links are skipped (not regenerated). |
 | `--jitter F` | `0.0` | Random `0..F` second pause **between** links (anti-bot cadence; never before link 0). |
 | `--seed-offset MS` | `0` | Extract the seed frame this many ms before EOF (fade-to-black guard). |
 | `--aspect` | `9:16` | `9:16` / `16:9`. Applied uniformly to every link (continuity requirement). |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,6 +55,8 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [docs/superpowers/plans/2026-07-18-asset-tagging/PLAN.md](superpowers/plans/2026-07-18-asset-tagging/PLAN.md) | Task-by-task implementation plan for asset tagging (spike gate → resolver → CLI/MCP → live e2e) | Tracking task-by-task execution of the `@`-mention feature |
 | [docs/superpowers/specs/2026-07-19-live-verify-design.md](superpowers/specs/2026-07-19-live-verify-design.md) | `/gflow:live-verify` design spec: pre-flight state check + per-feature live-verification gate generalizing release step 4b, council-reviewed | Reviewing or implementing the live-verification enforcement skill |
 | [docs/superpowers/plans/2026-07-19-live-verify/PLAN.md](superpowers/plans/2026-07-19-live-verify/PLAN.md) | Task-by-task implementation plan for `/gflow:live-verify` (skill file → AGENTS.md/check.md wiring → INDEX row) | Tracking task-by-task execution of the live-verify skill |
+| [docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md](superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md) | Edge-case matrix for replacing fixed chain/movie credit estimates with truthful pending-operation guidance | Reviewing the financial-safety, resume, dry-run, and compatibility scenarios |
+| [docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md](superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md) | TDD implementation plan for tier-aware chain/movie planning and confirmation output | Tracking the isolated runtime pricing-guidance bugfix |
 
 ## Agent commands
 

--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -231,12 +231,15 @@ For each scene, `gflow movie` merges global manifest cards with scene overrides 
 |------|---------|--------|
 | `--profile <name>` | default profile | Chrome profile to drive (must be a `chrome`-strategy profile). |
 | `--out-dir <dir>` | manifest `output_dir` | Override the output directory. |
-| `--dry-run` | off | Print the plan + credit estimate; make **no** API calls. |
+| `--dry-run` | off | Print the pending video operation plan; make **no** API calls. |
 | `--fail-fast` / `--continue-on-error` | continue | Stop on the first scene failure, or attempt the rest (default). |
 | `--stitch` | off | After generating, hard-concat all clips into one preview mp4 (ffmpeg, no transitions). |
 
 ## Credits
 
 - Character creation (image generation) is **free** — no credits, no reCAPTCHA.
-- Each **scene** is one video generation = **1 credit**, spent at submit (step 2
-  above). A `--dry-run` shows the estimate without spending anything.
+- Each **scene** is one pending video generation operation, submitted at step 2
+  above. Current credit use varies by model, duration, account tier, and Flow
+  policy — check Google Flow before submitting. An accepted operation may
+  consume credits even if later polling or download fails. A `--dry-run` prints
+  the plan without submitting anything.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -633,10 +633,13 @@ Link 0 is a text-to-video (T2V) generation; every later link is an
 image-to-video (I2V) generation **seeded by the extracted last frame of the
 previous clip**, giving visual continuity with no server-side stitching.
 
-> ⚠️ **Costs N credits — one per link.** A chain is N sequential paid Veo
-> generations. Run `--dry-run` first to print the plan and the credit estimate
-> without spending anything. The cost-confirmation prompt is shown unless you
-> pass `-y` / `--yes`.
+> ⚠️ **Each link is a pending video generation operation.** A chain submits N
+> sequential Veo generations that may consume credits; current cost varies by
+> model, duration, account tier, and Flow policy — check Google Flow before
+> submitting. An accepted operation may consume credits even if later polling
+> or download fails. Run `--dry-run` first to print the plan without
+> submitting anything. The confirmation prompt is shown unless you pass
+> `-y` / `--yes`.
 
 > **Requires the `chain` extra.** The last-frame extractor decodes the previous
 > clip with [PyAV](https://pyav.org/) (no system ffmpeg needed). Install it
@@ -708,13 +711,13 @@ concatenate them server-side.** Chain does not auto-concat: see the
 **Examples:**
 
 ```bash
-# Preview the plan + credit cost — spends nothing
+# Preview the pending video operation plan — submits nothing
 gflow video chain story.jsonl --dry-run
 
-# Generate the chain (one credit per link), no confirmation prompt
+# Generate the chain (one pending video operation per link), no confirmation prompt
 gflow video chain story.jsonl --model veo-fast --aspect 16:9 --yes
 
-# Resume a chain that died partway — already-paid links are skipped
+# Resume a chain that died partway — already-completed links are skipped
 gflow video chain story.jsonl --resume-from 1f2e3d4c-...
 
 # Seed 150 ms before EOF to dodge a fade-to-black final frame

--- a/docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md
+++ b/docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md
@@ -1,0 +1,198 @@
+# Tier-aware Credit Confirmations Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature tier-aware-credit-confirmations` to find
+> the next unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** Stop `gflow video chain` and `gflow movie run` from presenting pending video work as an
+exact one-credit-per-operation charge while preserving all execution, resume, confirmation, and
+machine-output behavior.
+
+**Architecture:** Keep the change at the existing Click presentation boundary in
+`cli_video.py` and `cli_movie.py`. Reuse each command's current pending/completed/stale decisions,
+rename local credit variables to operation counts, and direct users to Google Flow for current
+model/duration/tier pricing. Do not add a pricing service, entitlement probe, new flag, new movie
+confirmation, transport call, log event, or MCP schema field.
+
+**Predict verdict:** GO — confidence 9/10. The UX lens returned CAUTION only until movie's current
+non-interactive behavior was made explicit; the resolved decision is to keep it unchanged.
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| Critical | A user approves paid work using a false numeric estimate | Remove numeric credit math and say the count is pending video operations, not a charge |
+| High | Resume or stale-scene accounting diverges from execution | Reuse `remaining_links` and the existing completed/stale predicate; pin both in tests |
+| High | A wording change moves client/tool/browser work before the safety gate | Test dry-run and declined confirmation with tripwire mocks |
+| High | Human-output changes leak into JSON or MCP contracts | Add JSON shape regression coverage; change no flags, DTOs, or schemas |
+| Medium | Docs, Click help, tests, and agent guidance drift | Search all current one-credit/credit-estimate claims and update canonical mirrors together |
+| Medium | Scope grows into guessed dynamic pricing | Explicit non-goal; Flow remains authoritative until a verified price source exists |
+
+---
+
+## File structure
+
+### New files
+
+```text
+docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md
+  Severity-ranked edge cases and test matrix.
+docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md
+  This implementation plan.
+```
+
+### Modified files
+
+```text
+src/gflow_cli/cli_video.py
+  Chain plan/help/confirmation describe pending operations and variable Flow pricing.
+src/gflow_cli/cli_movie.py
+  Movie plan lines and totals describe pending operations rather than credits.
+tests/cli/test_cli_video_chain.py
+  Red/green Click regressions for dry-run, resume, decline, --yes, and JSON stability.
+tests/cli/test_cli_movie.py
+  Red/green Click regressions for completed/stale/new scene accounting.
+tests/features/video_chain.feature
+tests/features/test_video_chain_steps.py
+  BDD wording and resume/dry-run acceptance scenarios.
+docs/USAGE.md
+docs/MOVIE.md
+skills/gflow-cli/SKILL.md
+  Current user and agent guidance; no fixed per-link/per-scene price.
+website/docs/USAGE.md
+website/docs/MOVIE.md
+  Generated canonical mirrors.
+CHANGELOG.md
+  Unreleased fix note for corrected operator pricing guidance.
+```
+
+Other current test docstrings/help strings found by the final bounded search may be updated only
+when they repeat the same fixed one-credit contract. Historical changelog, known-issue, spike, and
+live-verification evidence remains unchanged.
+
+---
+
+## Task 1 — Write failing CLI and BDD regressions
+
+**What:** Pin truthful pending-operation output and the unchanged safety/compatibility boundaries
+before production edits.
+
+**Files:**
+
+- `tests/cli/test_cli_video_chain.py` — chain plan, resume, confirmation, and JSON assertions.
+- `tests/cli/test_cli_movie.py` — movie plan completed/stale/new accounting.
+- `tests/features/video_chain.feature` — user-visible dry-run and resume scenarios.
+- `tests/features/test_video_chain_steps.py` — mocked step bindings and assertions.
+
+**Steps:**
+
+- [ ] Replace the old fixed-credit expectations with the desired pending-operation contract.
+- [ ] Add a resumed dry-run scenario whose completed links are excluded.
+- [ ] Pin the variable-cost warning and Flow-authority guidance.
+- [ ] Pin the absence of `Estimated credits`, `one per link/scene`, and numeric charge claims.
+- [ ] Prove declined chain confirmation constructs no client and invokes no tool/generation work.
+- [ ] Prove `--yes` and JSON output behavior remain unchanged.
+- [ ] Run the focused tests and record the expected failures against the old production wording.
+
+**Tests created (red):**
+
+- [ ] Fresh chain dry-run reports N pending video operations without a numeric credit estimate.
+- [ ] Resumed chain dry-run counts only remaining links.
+- [ ] Declined confirmation performs zero external work.
+- [ ] Movie dry-run counts new and stale scenes but skips completed scenes.
+- [ ] JSON result schema remains unchanged.
+
+Do not commit the intentionally red scaffold. Commit it atomically with Task 2 after green.
+
+---
+
+## Task 2 — Implement the minimal CLI presentation fix
+
+**What:** Make the failing tests pass with local count/name/text changes only.
+
+**Files:**
+
+- `src/gflow_cli/cli_video.py`
+- `src/gflow_cli/cli_movie.py`
+- Task 1 test files
+
+**Steps:**
+
+- [ ] In chain plan/confirmation, use the existing `remaining_links` count and remove numeric
+  credit language.
+- [ ] Print a plain-ASCII warning that video operations may consume credits and current cost varies
+  by model, duration, account tier, and Flow policy.
+- [ ] Keep the existing chain confirmation position and `--yes` behavior.
+- [ ] In movie plan output, show `pending`/`re-run` status and total pending video operations using
+  the existing completed/stale decision.
+- [ ] Keep movie non-interactive and preserve normal/dry-run execution ordering.
+- [ ] Change no request DTO, API call, browser path, JSON key, flag, exit code, or MCP mapping.
+- [ ] Run focused unit and BDD tests green.
+- [ ] Run `/gflow:check`; commit tests and production code atomically.
+
+**Tests green:**
+
+- [ ] `uv run pytest tests/cli/test_cli_video_chain.py tests/cli/test_cli_movie.py tests/features/test_video_chain_steps.py -q`
+- [ ] Existing adjacent chain/movie tests remain green.
+
+---
+
+## Task 3 — Align current documentation, skills, and mirrors
+
+**What:** Remove the same fixed-price contract from directly related current guidance while
+preserving historical evidence.
+
+**Files:**
+
+- `docs/USAGE.md`
+- `docs/MOVIE.md`
+- `skills/gflow-cli/SKILL.md`
+- `website/docs/USAGE.md`
+- `website/docs/MOVIE.md`
+- `CHANGELOG.md`
+- Current test/help/docstring files discovered by the bounded search, if directly equivalent
+
+**Steps:**
+
+- [ ] Say N links/scenes are N pending video generation operations, not N Flow credits.
+- [ ] State that current credit use varies by model, duration, account tier, promotion, and Flow
+  policy; direct the operator to verify in Flow.
+- [ ] Describe submitted failures conservatively: an accepted priced operation may consume credits
+  even if later polling/download fails.
+- [ ] Keep historical observed amounts and release evidence unchanged.
+- [ ] Regenerate `website/docs/` with the canonical generator.
+- [ ] Add an Unreleased changelog entry.
+- [ ] Run links, PII, mirror, Ruff/format, Pyright, and focused tests; commit.
+
+---
+
+## Task 4 — Final bounded audit and review
+
+**What:** Prove the runtime contract and its direct current documentation are consistent without
+absorbing the broader eligibility-doc branch.
+
+**Steps:**
+
+- [ ] Search current CLI/help/tests/docs/skills for `one credit per`, `one per link`,
+  `Estimated credits`, numeric `credit(s)` plans, and `credit estimate`.
+- [ ] Classify every remaining match as current-safe, historical evidence, or unrelated backlog.
+- [ ] Verify executable diff changes only human presentation/count variable names and test
+  expectations; no generation or transport calls change.
+- [ ] Run the full Impeccable Routine with the repository's non-live marker guidance.
+- [ ] Run an independent spec review followed by a quality review.
+- [ ] Re-check open PRs/remote branches before creating a PR.
+
+---
+
+## Definition of done
+
+- [ ] Every Critical/High scenario in `SCENARIO.md` is covered.
+- [ ] Red-green TDD evidence is recorded for the old fixed-credit output.
+- [ ] Chain resume and movie stale/completed counts match execution decisions.
+- [ ] Dry-run and declined confirmation remain zero-I/O.
+- [ ] `--yes`, JSON, flags, exit codes, MCP schemas, transport, and auth remain unchanged.
+- [ ] Current direct docs/skills/mirrors contain no fixed one-credit-per-operation promise.
+- [ ] Historical evidence is preserved.
+- [ ] `CHANGELOG.md` `[Unreleased]` is updated.
+- [ ] `/gflow:check` is green with at least 80% coverage.
+- [ ] Final independent reviews are green.
+- [ ] No `# TODO` appears in the diff without a tracked issue.

--- a/docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md
+++ b/docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md
@@ -1,0 +1,90 @@
+# Scenario: Tier-aware credit confirmations
+
+## Coverage map
+
+This change is intentionally confined to human-facing CLI planning and confirmation text.
+It does not alter generation requests, browser automation, authentication, persistence, or
+the JSON result schema.
+
+Relevant dimensions:
+
+- **D4 — Batch manifest & resume:** completed chain links and movie scenes must remain excluded;
+  stale movie scenes must remain pending.
+- **D7 — Error propagation & exit codes:** declining the existing chain confirmation must still
+  abort before any browser, client, tool, or submission work.
+- **D8 — Cross-platform paths/output:** replacement text must be plain ASCII and render in
+  PowerShell, cmd, and POSIX terminals.
+- **D11 — Input validation & boundary values:** zero, one, and many pending operations must retain
+  existing validation and resume behavior.
+- **D12 — Observability & output contracts:** human output changes, but JSON envelopes, structured
+  logs, flags, exit codes, and MCP schemas must not.
+
+Skipped dimensions:
+
+- **D1/D2/D3/D5/D6/D9/D10:** no session, WAF/reCAPTCHA, selector, Page-pool, data-layer,
+  transport, or headed-browser behavior changes.
+
+## Scenario table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D4/D12 | Fresh three-link chain dry-run | High | Prints three pending video operations, variable-cost/Flow-authority guidance, no numeric credit estimate, and submits nothing | Unit + BDD |
+| 2 | D4/D12 | Resume a three-link chain with two completed links | High | Counts only one pending operation and does not imply completed links will be charged again | Unit + BDD |
+| 3 | D7 | Operator declines the existing chain confirmation | Critical | Aborts before client construction, tool application, browser startup, or submission | Unit |
+| 4 | D7/D12 | Operator passes `--yes` | Medium | Bypasses only the existing prompt; validation, resume filtering, and JSON result shape remain unchanged | Unit |
+| 5 | D4/D11 | Movie dry-run mixes completed, stale, and new scenes | High | Completed scenes show skipped; stale and new scenes count as pending video operations; no numeric credit estimate; no API calls | Unit |
+| 6 | D12 | Normal movie run remains non-interactive | High | No new confirmation prompt or flag is introduced; existing execution ordering is unchanged | Unit / code review |
+| 7 | D12 | Chain succeeds with `--json --yes` | High | Machine-readable success envelope is unchanged and contains no new pricing fields or prose | Unit |
+| 8 | D4/D11 | Resumed chain has zero remaining links | High | Existing early return remains; no confirmation or client construction occurs | Unit |
+| 9 | D8/D11 | Exactly one versus multiple pending operations | Low | Text remains grammatical and ASCII-safe without changing the count | Unit |
+| 10 | D12 | A submitted video later fails | Medium | Guidance says operations may consume credits under Flow policy; it does not promise success-based billing | Docs / review |
+| 11 | D12 | Historical evidence names an observed past credit amount | Low | Historical live-verification and incident records remain unchanged | Search / review |
+
+## Must-cover before merge (Critical + High)
+
+1. Declined chain confirmation performs no client, tool, browser, or submission work.
+2. Fresh and resumed chain plans report only pending operation counts and no numeric credit charge.
+3. Movie plans derive pending work from the existing completed/stale predicate.
+4. Dry-run remains zero-I/O for both commands.
+5. Chain JSON success/error envelopes remain unchanged.
+6. Zero-remaining resume behavior remains an early no-op.
+
+## Deferred (Medium + Low — log as issues, not blockers)
+
+1. A dynamic pricing or entitlement API is deliberately deferred until Google exposes a verified,
+   stable source; no speculative abstraction is added.
+2. Adding a new `gflow movie run` confirmation is a separate compatibility decision. Movie remains
+   non-interactive and operators use `--dry-run` for preflight.
+3. Historical documents retain the prices observed at the time of their recorded live run.
+
+## Suggested BDD scenarios
+
+```gherkin
+Feature: Tier-aware video operation guidance
+
+  Scenario: Dry-run reports pending chain work without guessing credits
+    Given a chain manifest with 3 links
+    When I run the chain with --dry-run
+    Then the output reports 3 pending video operations
+    And the output directs me to check the current cost in Flow
+    And the output contains no numeric credit estimate
+    And no generation was submitted
+
+  Scenario: Resume counts only unfinished chain links
+    Given a chain manifest with 3 links
+    And the recorder reports 2 completed links
+    When I resume the chain with --dry-run
+    Then the output reports 1 pending video operation
+    And the output contains no numeric credit estimate
+```
+
+Movie completed/stale/new accounting is covered directly at the Click boundary because no movie
+BDD feature exists and duplicating the substantial movie fixtures would add test-only machinery.
+
+## Known-issues cross-reference
+
+- Issue #125's chain route-abort and partial-result behavior is unchanged.
+- Chain resume continuity limitations remain unchanged; only the truthful count shown before
+  pending work changes.
+- The quota-display backlog remains open. This change explicitly avoids presenting local operation
+  counts as an account-credit balance or exact charge.

--- a/skills/gflow-cli/SKILL.md
+++ b/skills/gflow-cli/SKILL.md
@@ -179,7 +179,8 @@ gflow scene create --project "$PROJECT_ID" "$CLIP_A" "$CLIP_B" -o extended.mp4
 
 ```bash
 # manifest.jsonl: one JSON object per line. Link 0 = t2v; later links = i2v seeded by the
-# previous clip's last frame. One credit per link. veo models only.
+# previous clip's last frame. Each link is a pending video operation; credit
+# use varies by model/duration/tier — check Flow. veo models only.
 gflow video chain ./story.jsonl --out-dir ./out/ --dry-run   # preview the plan first
 gflow video chain ./story.jsonl --out-dir ./out/             # then run for real
 ```

--- a/src/gflow_cli/cli_movie.py
+++ b/src/gflow_cli/cli_movie.py
@@ -13,7 +13,7 @@ where **one scene = one clip = one generation**. The runner:
 
 By default the run is **generate-only**. Pass ``--stitch`` for an optional
 ffmpeg hard-concat *preview* (no transitions, not a deliverable). A dry-run
-(``--dry-run``) prints the plan and credit estimate without spending.
+(``--dry-run``) prints the pending video operation plan without making API calls.
 """
 
 from __future__ import annotations
@@ -178,7 +178,7 @@ def template(output: Path, force: bool) -> None:
     "--dry-run",
     is_flag=True,
     default=False,
-    help="Print plan and credit estimate; make no API calls.",
+    help="Print the pending video operation plan; make no API calls.",
 )
 @click.option(
     "--continue-on-error/--fail-fast",
@@ -287,7 +287,7 @@ def _style_tag(s: Scene, style: StyleSpec) -> str:
     return ("  " + " ".join(bits)) if bits else ""
 
 
-def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, cost: int) -> str:
+def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool) -> str:
     """Return the single-line plan summary for one scene."""
     mode = "r2v" if s.characters else "t2v"
     refs = f"  refs=\\[{', '.join(s.characters)}]" if s.characters else ""
@@ -297,9 +297,9 @@ def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, c
     if done:
         status = "[dim]skip (done)[/dim]"
     elif stale:
-        status = f"re-run (style changed)  {cost} credit(s)"
+        status = "pending (re-run: style changed)"
     else:
-        status = f"{cost} credit(s)"
+        status = "pending"
     style_tag = _style_tag(s, style)
     return f"    \\[{mode}] {s.id!r}{framing_tag}{model_tag}{dur_tag}{refs}{style_tag}  {status}"
 
@@ -307,7 +307,7 @@ def _format_scene_line(s: Scene, style: StyleSpec, *, done: bool, stale: bool, c
 def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
     console.print("\n[bold]Plan:[/bold]")
 
-    # Characters (text identity in P1 — no credits)
+    # Characters (text identity only in P1)
     if manifest.characters:
         console.print("\n  Characters:")
         for name, c in manifest.characters.items():
@@ -317,7 +317,7 @@ def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
 
     # Scenes
     console.print("\n  Scenes:")
-    scene_credits = 0
+    pending_operations = 0
     for s in manifest.scenes:
         done_state = state.scenes.get(s.id)
         done = False
@@ -325,11 +325,16 @@ def _print_plan(manifest: MovieManifest, state: MovieState) -> None:
         if done_state is not None and done_state.status == "completed":
             stale = done_state.is_stale_for(compose_prompt(manifest.style, s, manifest.characters))
             done = not stale
-        cost = 0 if done else 1
-        scene_credits += cost
-        console.print(_format_scene_line(s, manifest.style, done=done, stale=stale, cost=cost))
+        if not done:
+            pending_operations += 1
+        console.print(_format_scene_line(s, manifest.style, done=done, stale=stale))
 
-    console.print(f"\n  Estimated credits: ~{scene_credits}")
+    operation_noun = "operation" if pending_operations == 1 else "operations"
+    console.print(f"\n  {pending_operations} pending video {operation_noun}")
+    console.print(
+        "  Video operations may consume credits. Current cost varies by model, duration, "
+        "account tier, and Flow policy; check Google Flow before submitting."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -422,7 +422,7 @@ def _resolve_chain_model(model: str | None) -> VideoModel:
     A chain renders link 0 as T2V and every later link as I2V seeded by the
     previous clip's last frame, so the model MUST support i2v interpolation.
     ``omni-flash`` silently drops the start frame at submit and routes to T2V
-    (issue #125), which would break continuity AND burn a credit per link — so
+    (issue #125), which would break continuity and could consume credits — so
     reject it at the CLI boundary with ``ModelModeIncompatibilityError`` (exit
     17). The Click ``Choice`` already excludes ``omni-flash``; this guard also
     covers a direct programmatic call or a future alias.
@@ -456,12 +456,17 @@ def _print_chain_plan(
 
     typed_links: list[ChainLinkSpec] = list(links)
     remaining = len(typed_links) - skipped
+    operation_noun = "operation" if remaining == 1 else "operations"
     console.print(f"[bold]Chain plan[/bold] ([dim]{chain_id}[/dim])")
     console.print(
         f"  {len(typed_links)} link(s), aspect {aspect}, model {model.value}"
         + (f" — {skipped} already completed, {remaining} to generate" if skipped else "")
     )
-    console.print(f"  [yellow]Estimated cost: {remaining} credit(s)[/yellow] (one per link)")
+    console.print(f"  [yellow]{remaining} pending video {operation_noun}[/yellow]")
+    console.print(
+        "  Video operations may consume credits. Current cost varies by model, duration, "
+        "account tier, and Flow policy; check Google Flow before submitting."
+    )
     for idx, spec in enumerate(typed_links):
         mode = "t2v" if idx == 0 else "i2v"
         link_model = spec.model.value if spec.model is not None else model.value
@@ -702,9 +707,9 @@ async def _run_chain(
 ) -> None:
     """Drive a sequential last-frame I2V chain from a JSONL manifest.
 
-    The cost gate (``--yes`` / confirm), ``--max-links`` cap, ``--dry-run``
-    short-circuit, and ``--resume-from`` skip-paid-links logic all run BEFORE a
-    client is created so a rejected/dry run spends nothing and opens no browser.
+    The submission gate (``--yes`` / confirm), ``--max-links`` cap, ``--dry-run``
+    short-circuit, and ``--resume-from`` completed-link filtering all run BEFORE
+    a client is created so a rejected/dry run submits nothing and opens no browser.
     """
     from pathlib import Path as _Path
 
@@ -728,8 +733,8 @@ async def _run_chain(
 
     settings = get_settings()
 
-    # Resume: bind the prior chain_id, query already-paid links, skip them so
-    # they are NOT regenerated (no re-billing). A fresh run mints a new id.
+    # Resume: bind the prior chain_id and skip completed links so they are not
+    # regenerated. A fresh run mints a new id.
     chain_id, skipped = _resolve_chain_resume(
         resume_from,
         links,
@@ -745,7 +750,7 @@ async def _run_chain(
         return
 
     remaining_links = links[skipped:]
-    cost = len(remaining_links)
+    pending_operations = len(remaining_links)
 
     if dry_run:
         _print_chain_plan(
@@ -755,7 +760,7 @@ async def _run_chain(
             skipped=skipped,
             chain_id=chain_id,
         )
-        console.print("[dim]--dry-run: no credits spent, no clips generated.[/dim]")
+        console.print("[dim]--dry-run: no video operations submitted, no clips generated.[/dim]")
         return
 
     if not as_json:
@@ -768,8 +773,9 @@ async def _run_chain(
         )
 
     if not yes:
+        operation_noun = "operation" if pending_operations == 1 else "operations"
         click.confirm(
-            f"Generate {cost} chain link(s) for ~{cost} credit(s)?",
+            f"Submit {pending_operations} pending video {operation_noun}?",
             abort=True,
         )
 
@@ -1331,9 +1337,10 @@ def r2v(
         "Sequential last-frame chain: link 0 is text-to-video, every later link "
         "is image-to-video seeded by the previous clip's last frame, giving "
         "visual continuity with no server-side stitching.\n\n"
-        "COSTS N CREDITS — one per link in the manifest (minus links already "
-        "completed when you --resume-from). Use --dry-run first to print the "
-        "plan and the credit estimate without spending anything.\n\n"
+        "Each unfinished link is a pending video operation. Current credit use "
+        "varies by model, duration, account tier, and Flow policy; check Google "
+        "Flow before submitting. Use --dry-run first to print the plan without "
+        "submitting anything.\n\n"
         "Only Veo 3.1 models are accepted (omni-flash silently drops the seed "
         "frame and routes to text-to-video, issue #125). The MANIFEST is a JSONL "
         'file: one JSON object per line, each with a required "prompt" and '
@@ -1370,19 +1377,19 @@ def r2v(
     "-y",
     "yes",
     is_flag=True,
-    help="Skip the cost confirmation prompt (each link costs one credit).",
+    help="Skip the pending video operation confirmation prompt.",
 )
 @click.option(
     "--dry-run",
     "dry_run",
     is_flag=True,
-    help="Resolve the manifest and print the plan + credit cost; spend nothing.",
+    help="Resolve the manifest and print the pending operation plan; submit nothing.",
 )
 @click.option(
     "--resume-from",
     "resume_from",
     default=None,
-    help="Resume a prior chain by its chain id; already-paid links are skipped.",
+    help="Resume a prior chain by its chain id; already-completed links are skipped.",
 )
 @click.option(
     "--jitter",

--- a/tests/cli/test_cli_movie.py
+++ b/tests/cli/test_cli_movie.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -37,6 +38,16 @@ def _make_video_result(*, succeeded: bool = True, flow_op_id: str | None = "op-1
     r.flow_operation_id = flow_op_id
     r.local_path = Path("/out/video.mp4")
     return r
+
+
+def _assert_no_numeric_credit_claim(output: str) -> None:
+    numeric_credit_lines = [
+        line
+        for line in output.splitlines()
+        if any(char.isdigit() for char in line)
+        and re.search(r"\bcredit(?:s|\(s\))?", line, re.IGNORECASE)
+    ]
+    assert not numeric_credit_lines, f"numeric credit claim(s): {numeric_credit_lines}"
 
 
 def _manifest(
@@ -170,19 +181,51 @@ class TestMovieDryRun:
         result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
         assert result.exit_code == 0
         assert "Alice" in result.output
-        assert "credit" in result.output.lower()
 
-    def test_dry_run_estimates_credits(self, tmp_path: Path) -> None:
+    def test_dry_run_counts_new_and_stale_scenes_as_pending_operations(
+        self, tmp_path: Path
+    ) -> None:
         runner = CliRunner()
         toml = (
             'title = "F"\nproject = "p"\n'
-            '[[scenes]]\nid = "s1"\naction = "y"\n'
-            '[[scenes]]\nid = "s2"\naction = "z"\n'
+            '[[scenes]]\nid = "completed"\naction = "Already rendered"\n'
+            '[[scenes]]\nid = "stale"\naction = "Changed prompt"\n'
+            '[[scenes]]\nid = "new"\naction = "Never rendered"\n'
         )
         manifest = _write_toml(tmp_path / "movie.toml", toml)
-        result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+        state = MovieState(title="F", project="p")
+        state.scenes["completed"] = SceneState(
+            media_id="media-completed",
+            flow_operation_id="op-completed",
+            local_path="/out/completed.mp4",
+            status="completed",
+        )
+        state.scenes["stale"] = SceneState(
+            media_id="media-stale",
+            flow_operation_id="op-stale",
+            local_path="/out/stale.mp4",
+            status="completed",
+            prompt="Previous composed prompt.",
+        )
+        state.save(MovieState.state_path_for(manifest))
+
+        with patch("gflow_cli.cli_movie.FlowApiClient") as mock_client:
+            result = runner.invoke(cli_main, ["movie", "run", str(manifest), "--dry-run"])
+
         assert result.exit_code == 0
-        assert "Estimated credits: ~2" in result.output
+        completed_line = next(line for line in result.output.splitlines() if "'completed'" in line)
+        stale_line = next(line for line in result.output.splitlines() if "'stale'" in line)
+        new_line = next(line for line in result.output.splitlines() if "'new'" in line)
+        assert "skip" in completed_line.lower()
+        assert "re-run" in stale_line.lower()
+        assert "pending" in new_line.lower()
+        assert "2 pending video operations" in result.output
+        assert "current cost" in result.output.lower()
+        assert "Flow" in result.output
+        assert "Estimated credits" not in result.output
+        _assert_no_numeric_credit_claim(result.output)
+        assert "one per scene" not in result.output.lower()
+        mock_client.assert_not_called()
 
     def test_dry_run_no_api_calls(self, tmp_path: Path) -> None:
         """Dry-run must not invoke FlowApiClient."""
@@ -913,13 +956,13 @@ class TestFormatSceneLine:
 
         # T2V scene (no characters)
         s1 = Scene(id="s1", action="A", framing="medium", duration=4)
-        line = _format_scene_line(s1, StyleSpec(), done=False, stale=False, cost=2)
+        line = _format_scene_line(s1, StyleSpec(), done=False, stale=False)
         assert "\\[t2v]" in line
         assert "refs=" not in line
 
         # R2V scene (with characters)
         s2 = Scene(id="s2", action="B", framing="wide", duration=8, characters=("Hero",))
-        line2 = _format_scene_line(s2, StyleSpec(), done=False, stale=False, cost=2)
+        line2 = _format_scene_line(s2, StyleSpec(), done=False, stale=False)
         assert "\\[r2v]" in line2
         assert "refs=\\[Hero]" in line2
 

--- a/tests/cli/test_cli_video_chain.py
+++ b/tests/cli/test_cli_video_chain.py
@@ -8,6 +8,8 @@ are exercised at the Click layer in isolation.
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -53,6 +55,16 @@ def _fake_link_result(index: int, tmp_path: Path) -> Any:
     )
 
 
+def _assert_no_numeric_credit_claim(output: str) -> None:
+    numeric_credit_lines = [
+        line
+        for line in output.splitlines()
+        if any(char.isdigit() for char in line)
+        and re.search(r"\bcredit(?:s|\(s\))?", line, re.IGNORECASE)
+    ]
+    assert not numeric_credit_lines, f"numeric credit claim(s): {numeric_credit_lines}"
+
+
 def _patches(tmp_path: Path):
     """Common patches: profile resolution + a fake recorder (no DB)."""
     fake_recorder = MagicMock()
@@ -83,7 +95,7 @@ def test_chain_missing_manifest_file_errors(tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
-def test_chain_dry_run_spends_nothing_and_prints_cost(tmp_path: Path) -> None:
+def test_chain_dry_run_reports_pending_operations_and_variable_cost(tmp_path: Path) -> None:
     runner = CliRunner()
     manifest = _manifest(tmp_path, 3)
     p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
@@ -91,17 +103,121 @@ def test_chain_dry_run_spends_nothing_and_prints_cost(tmp_path: Path) -> None:
         p_resolve,
         p_provider,
         p_rec,
+        patch("gflow_cli.cli_video._apply_tools_to_chain_links") as mock_apply_tools,
         patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
         patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
     ):
-        result = runner.invoke(video, ["chain", str(manifest), "--dry-run"])
+        result = runner.invoke(
+            video,
+            ["chain", str(manifest), "--tool", "rewrite", "--dry-run"],
+        )
 
     assert result.exit_code == 0, result.output
-    # Plan + credit estimate printed, but nothing generated and no client built.
-    assert "3 credit(s)" in result.output
-    assert "no credits spent" in result.output
+    mock_apply_tools.assert_not_called()
     mock_run.assert_not_awaited()
     mock_client_init.assert_not_called()
+    assert "3 pending video operations" in result.output
+    assert "current cost" in result.output.lower()
+    assert "Flow" in result.output
+    assert all(
+        term in result.output.lower()
+        for term in ("varies", "model", "duration", "account tier", "flow policy")
+    )
+    assert "Estimated credits" not in result.output
+    _assert_no_numeric_credit_claim(result.output)
+    assert "one per link" not in result.output.lower()
+
+
+def test_chain_resumed_dry_run_counts_only_remaining_operations(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+    fake_recorder = MagicMock()
+    fake_recorder.completed_links.return_value = [MagicMock(), MagicMock()]
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch(
+            "gflow_cli.data.chain_repo.ChainLinkRecorder.open",
+            return_value=fake_recorder,
+        ),
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+        patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
+    ):
+        result = runner.invoke(
+            video,
+            ["chain", str(manifest), "--resume-from", "chain-abc", "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "2 already completed" in result.output
+    assert "1 pending video operation" in result.output
+    _assert_no_numeric_credit_claim(result.output)
+    assert "one per link" not in result.output.lower()
+    mock_run.assert_not_awaited()
+    mock_client_init.assert_not_called()
+
+
+def test_chain_resume_with_all_links_completed_returns_before_external_work(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 3)
+    fake_recorder = MagicMock()
+    fake_recorder.completed_links.return_value = [MagicMock(), MagicMock(), MagicMock()]
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch(
+            "gflow_cli.data.chain_repo.ChainLinkRecorder.open",
+            return_value=fake_recorder,
+        ),
+        patch("gflow_cli.cli_video.click.confirm") as mock_confirm,
+        patch("gflow_cli.cli_video._apply_tools_to_chain_links") as mock_apply_tools,
+        patch("gflow_cli.cli_video.FlowApiClient") as mock_client,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+    ):
+        result = runner.invoke(
+            video,
+            ["chain", str(manifest), "--resume-from", "chain-abc", "--tool", "rewrite"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "already complete" in result.output.lower()
+    mock_confirm.assert_not_called()
+    mock_apply_tools.assert_not_called()
+    mock_client.assert_not_called()
+    mock_run.assert_not_awaited()
+
+
+def test_chain_declined_confirmation_performs_no_external_work(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 2)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video._apply_tools_to_chain_links") as mock_apply_tools,
+        patch("gflow_cli.cli_video.FlowApiClient") as mock_client,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+    ):
+        result = runner.invoke(
+            video,
+            ["chain", str(manifest), "--tool", "rewrite"],
+            input="n\n",
+        )
+
+    assert result.exit_code == 130, result.output
+    mock_apply_tools.assert_not_called()
+    mock_client.assert_not_called()
+    mock_run.assert_not_awaited()
+    prompt_line = next(line for line in result.output.splitlines() if "[y/N]" in line)
+    assert "2 pending video operations" in prompt_line
+    _assert_no_numeric_credit_claim(result.output)
+    assert "one per link" not in result.output.lower()
 
 
 def test_chain_max_links_rejects_overlong_manifest(tmp_path: Path) -> None:
@@ -164,6 +280,51 @@ def test_chain_happy_path_calls_run_chain_with_links_and_recorder(tmp_path: Path
     from gflow_cli.api.video import VideoModel
 
     assert kwargs["model"] is VideoModel.VEO_3_1_LITE
+
+
+def test_chain_yes_json_preserves_success_schema_and_bypasses_prompt(tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest = _manifest(tmp_path, 2)
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    results = [_fake_link_result(0, tmp_path), _fake_link_result(1, tmp_path)]
+
+    fake_client = MagicMock()
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.cli_video.FlowApiClient", return_value=fake_client),
+        patch("gflow_cli.cli_video.click.confirm") as mock_confirm,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock, return_value=results),
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--yes", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert set(payload) == {
+        "status",
+        "command",
+        "chain_id",
+        "partial",
+        "links",
+        "completed_paths",
+    }
+    assert payload["status"] == "ok"
+    assert payload["command"] == "video chain"
+    assert payload["partial"] is False
+    assert payload["links"] == [
+        {
+            "index": result_item.index,
+            "media_id": result_item.media_id,
+            "local_path": str(result_item.local_path),
+        }
+        for result_item in results
+    ]
+    assert payload["completed_paths"] == [str(result_item.local_path) for result_item in results]
+    mock_confirm.assert_not_called()
 
 
 def test_chain_wires_operation_recorder_and_records_each_link(tmp_path: Path) -> None:
@@ -330,8 +491,6 @@ def test_chain_partial_json_emits_single_parseable_document(tmp_path: Path) -> N
     Re-raising through the shared handler would emit a second (error-shaped)
     document, leaving stdout unparseable.
     """
-    import json
-
     runner = CliRunner()
     manifest = _manifest(tmp_path, 3)
     p_resolve, p_provider, p_rec, _ = _patches(tmp_path)

--- a/tests/e2e/test_chain_e2e.py
+++ b/tests/e2e/test_chain_e2e.py
@@ -8,8 +8,10 @@ Hits the **real Google Flow API** and therefore:
   - Requires a logged-in Chrome profile (Pro/Ultra account) AND the ``chain``
     optional extra (PyAV) for the last-frame extractor:
     ``pip install 'gflow-cli[chain]'``.
-  - **Burns N Veo credits — one per link.** This test uses a 2-link manifest, so
-    it spends ~2 credits per run. Do NOT run in CI without gating.
+  - **Submits one pending Veo video operation per link, which may consume
+    credits.** This test uses a 2-link manifest (2 operations per run); current
+    credit use varies by model, duration, account tier, and Flow policy — check
+    Google Flow. Do NOT run in CI without gating.
 
 Criterion covered:
   CHAIN-E2E-1 — ``run_chain`` over a 2-link manifest (link 0 = T2V, link 1 = I2V

--- a/tests/features/test_video_chain_steps.py
+++ b/tests/features/test_video_chain_steps.py
@@ -17,6 +17,7 @@ never internals.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -97,6 +98,16 @@ def _fake_link_result(index: int, tmp_path: Path) -> Any:
         local_path=clip,
         media_id=f"media-{index}",
     )
+
+
+def _assert_no_numeric_credit_claim(output: str) -> None:
+    numeric_credit_lines = [
+        line
+        for line in output.splitlines()
+        if any(char.isdigit() for char in line)
+        and re.search(r"\bcredit(?:s|\(s\))?", line, re.IGNORECASE)
+    ]
+    assert not numeric_credit_lines, f"numeric credit claim(s): {numeric_credit_lines}"
 
 
 # ---------------------------------------------------------------------------
@@ -208,12 +219,34 @@ def _run_chain_dry_run(
 ) -> None:
     """--dry-run must short-circuit before any generation. We install a
     tripwire ``run_chain`` that fails the test if awaited, then assert it was
-    never called (proving zero credits)."""
+    never called (proving zero generation work)."""
     mock_run = AsyncMock(side_effect=AssertionError("run_chain must not run on --dry-run"))
     monkeypatch.setattr("gflow_cli.chain.run_chain", mock_run)
     chain_state["run_chain"] = mock_run
     cli_result_holder["result"] = runner.invoke(
         video, ["chain", str(chain_state["manifest"]), "--dry-run"]
+    )
+
+
+@when("I resume the chain with --dry-run")
+def _resume_chain_dry_run(
+    runner: CliRunner,
+    cli_result_holder: dict[str, Any],
+    chain_state: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run = AsyncMock(side_effect=AssertionError("run_chain must not run on --dry-run"))
+    monkeypatch.setattr("gflow_cli.chain.run_chain", mock_run)
+    chain_state["run_chain"] = mock_run
+    cli_result_holder["result"] = runner.invoke(
+        video,
+        [
+            "chain",
+            str(chain_state["manifest"]),
+            "--resume-from",
+            "chain-abc",
+            "--dry-run",
+        ],
     )
 
 
@@ -279,13 +312,28 @@ def _check_not_regenerated(chain_state: dict[str, Any]) -> None:
     chain_state["recorder"].completed_links.assert_called()
 
 
-@then(parsers.parse("the output reports the credit cost for {n:d} links"))
-def _check_credit_cost(cli_result_holder: dict[str, Any], n: int) -> None:
+@then(parsers.parse("the output reports {n:d} pending video operation"))
+@then(parsers.parse("the output reports {n:d} pending video operations"))
+def _check_pending_operations(cli_result_holder: dict[str, Any], n: int) -> None:
     result = cli_result_holder["result"]
-    assert f"{n} credit(s)" in result.output, result.output
+    noun = "operation" if n == 1 else "operations"
+    assert f"{n} pending video {noun}" in result.output, result.output
+
+
+@then("the output directs me to check the current cost in Flow")
+def _check_flow_cost_guidance(cli_result_holder: dict[str, Any]) -> None:
+    output = cli_result_holder["result"].output
+    assert "current cost" in output.lower(), output
+    assert "Flow" in output, output
+
+
+@then("the output contains no numeric credit estimate")
+def _check_no_numeric_credit_estimate(cli_result_holder: dict[str, Any]) -> None:
+    output = cli_result_holder["result"].output
+    assert "Estimated credits" not in output, output
+    _assert_no_numeric_credit_claim(output)
 
 
 @then("no generation was submitted")
-def _check_no_generation(chain_state: dict[str, Any], cli_result_holder: dict[str, Any]) -> None:
+def _check_no_generation(chain_state: dict[str, Any]) -> None:
     chain_state["run_chain"].assert_not_awaited()
-    assert "no credits spent" in cli_result_holder["result"].output

--- a/tests/features/video_chain.feature
+++ b/tests/features/video_chain.feature
@@ -22,10 +22,20 @@ Feature: Video chain orchestration
     And link 3 was never generated
     And the partial result carries the earlier clip paths
 
-  Scenario: Dry-run reports cost without spending credits
+  Scenario: Dry-run reports pending chain work without guessing credits
     When I run the chain with --dry-run
     Then the chain exit code is 0
-    And the output reports the credit cost for 3 links
+    And the output reports 3 pending video operations
+    And the output directs me to check the current cost in Flow
+    And the output contains no numeric credit estimate
+    And no generation was submitted
+
+  Scenario: Resume dry-run counts only unfinished chain links
+    Given the recorder reports 2 completed links
+    When I resume the chain with --dry-run
+    Then the chain exit code is 0
+    And the output reports 1 pending video operation
+    And the output contains no numeric credit estimate
     And no generation was submitted
 
   Scenario: A crash between download and extraction resumes at extraction

--- a/website/docs/CONFIGURATION.md
+++ b/website/docs/CONFIGURATION.md
@@ -343,9 +343,9 @@ each link in turn, so total wallclock is the sum of all link waits).
 |---|---|---|
 | `--model` | `veo-lite` | `veo-lite` / `veo-fast` / `veo-quality` / `veo-lite-lp`. `omni-flash` is rejected — it can't seed i2v links (issue #125). |
 | `--max-links N` | unset | Cap link count; exit 11 (`ConfigurationError`) if the manifest has more. A spend guardrail. |
-| `-y` / `--yes` | off | Skip the per-credit cost confirmation prompt. |
-| `--dry-run` | off | Print the plan + credit estimate and spend nothing. |
-| `--resume-from CHAIN_ID` | unset | Resume a prior chain by its id; already-paid links are skipped (not re-billed). |
+| `-y` / `--yes` | off | Skip the pending video operation confirmation prompt. |
+| `--dry-run` | off | Print the pending video operation plan and submit nothing. |
+| `--resume-from CHAIN_ID` | unset | Resume a prior chain by its id; already-completed links are skipped (not regenerated). |
 | `--jitter F` | `0.0` | Random `0..F` second pause **between** links (anti-bot cadence; never before link 0). |
 | `--seed-offset MS` | `0` | Extract the seed frame this many ms before EOF (fade-to-black guard). |
 | `--aspect` | `9:16` | `9:16` / `16:9`. Applied uniformly to every link (continuity requirement). |

--- a/website/docs/MOVIE.md
+++ b/website/docs/MOVIE.md
@@ -231,12 +231,15 @@ For each scene, `gflow movie` merges global manifest cards with scene overrides 
 |------|---------|--------|
 | `--profile <name>` | default profile | Chrome profile to drive (must be a `chrome`-strategy profile). |
 | `--out-dir <dir>` | manifest `output_dir` | Override the output directory. |
-| `--dry-run` | off | Print the plan + credit estimate; make **no** API calls. |
+| `--dry-run` | off | Print the pending video operation plan; make **no** API calls. |
 | `--fail-fast` / `--continue-on-error` | continue | Stop on the first scene failure, or attempt the rest (default). |
 | `--stitch` | off | After generating, hard-concat all clips into one preview mp4 (ffmpeg, no transitions). |
 
 ## Credits
 
 - Character creation (image generation) is **free** — no credits, no reCAPTCHA.
-- Each **scene** is one video generation = **1 credit**, spent at submit (step 2
-  above). A `--dry-run` shows the estimate without spending anything.
+- Each **scene** is one pending video generation operation, submitted at step 2
+  above. Current credit use varies by model, duration, account tier, and Flow
+  policy — check Google Flow before submitting. An accepted operation may
+  consume credits even if later polling or download fails. A `--dry-run` prints
+  the plan without submitting anything.

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -633,10 +633,13 @@ Link 0 is a text-to-video (T2V) generation; every later link is an
 image-to-video (I2V) generation **seeded by the extracted last frame of the
 previous clip**, giving visual continuity with no server-side stitching.
 
-> ⚠️ **Costs N credits — one per link.** A chain is N sequential paid Veo
-> generations. Run `--dry-run` first to print the plan and the credit estimate
-> without spending anything. The cost-confirmation prompt is shown unless you
-> pass `-y` / `--yes`.
+> ⚠️ **Each link is a pending video generation operation.** A chain submits N
+> sequential Veo generations that may consume credits; current cost varies by
+> model, duration, account tier, and Flow policy — check Google Flow before
+> submitting. An accepted operation may consume credits even if later polling
+> or download fails. Run `--dry-run` first to print the plan without
+> submitting anything. The confirmation prompt is shown unless you pass
+> `-y` / `--yes`.
 
 > **Requires the `chain` extra.** The last-frame extractor decodes the previous
 > clip with [PyAV](https://pyav.org/) (no system ffmpeg needed). Install it
@@ -708,13 +711,13 @@ concatenate them server-side.** Chain does not auto-concat: see the
 **Examples:**
 
 ```bash
-# Preview the plan + credit cost — spends nothing
+# Preview the pending video operation plan — submits nothing
 gflow video chain story.jsonl --dry-run
 
-# Generate the chain (one credit per link), no confirmation prompt
+# Generate the chain (one pending video operation per link), no confirmation prompt
 gflow video chain story.jsonl --model veo-fast --aspect 16:9 --yes
 
-# Resume a chain that died partway — already-paid links are skipped
+# Resume a chain that died partway — already-completed links are skipped
 gflow video chain story.jsonl --resume-from 1f2e3d4c-...
 
 # Seed 150 ms before EOF to dodge a fade-to-black final frame


### PR DESCRIPTION
## Summary

`gflow video chain` and `gflow movie run` presented pending work as an exact **one-credit-per-link/scene** charge. Live verification with a fresh free-tier account (during the #369/PR #389 e2e) proved pricing varies by model, duration, account tier, and Flow policy — so the fixed estimate could misinform an operator approving paid work.

- Plans, confirmation prompts, `--dry-run` output, and Click help now report the **pending video operation count** and direct operators to Google Flow for current pricing.
- Resume/stale accounting, `--yes`, JSON output, flags, exit codes, transport, and MCP schemas are **unchanged** (presentation boundary only).
- Current docs, `CONFIGURATION`/`USAGE`/`MOVIE`, the `gflow-cli` skill, the chain e2e docstring, and website mirrors are aligned; historical live-verification evidence preserved.

Planning artifacts: `docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/` (predict verdict GO 9/10; RED→GREEN TDD evidence in the commit history).

Note: the parked `docs/expand-flow-access-eligibility` branch rebases on top of this once merged (doc-council RED finding is resolved by this PR).

## Test plan

- [x] RED phase: 6 expected failures against old fixed-credit output (53 passing)
- [x] GREEN: 60/60 focused chain/movie CLI + BDD tests
- [x] Full suite: 2797 passed, 5 skipped, coverage 91.44% (gate 80%)
- [x] Ruff check + format, Pyright 0/0, hygiene/links/PII/mirror gates green
- [ ] Human review of the new operator-facing wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)