### PR TITLE
fix(character): bind portraits to the character entity again (#395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gflow character create` binds portraits to the character again (#395).**
+  Two independent defects made every character generation land as a plain
+  project image, leaving the character empty:
+  1. **Overlay dismissal Escaped Flow's own UI.** `[role='dialog']` and
+     `[role='alert']` had been added to the overlay detector, but Flow's
+     character composer (and the media picker) carry those roles — so gflow
+     pressed Escape on the app itself, the generation went out without
+     `entityContext`, and Flow filed the image against the project with no
+     `parentEntityId`. Those two selectors are removed; `[role='banner']` and
+     the announcement matcher remain, so the original banner-dismissal intent
+     is intact.
+  2. **The character route could bounce back to the project page.** Flow
+     redirects `/project/{id}/character/{entityId}` when the entity is not yet
+     queryable — a race gflow loses by navigating immediately after
+     `flow.createEntity`. Because the project page also mounts a prompt box,
+     the old readiness check was satisfied on the wrong surface and the prompt
+     was typed into the **project** composer. gflow now verifies it actually
+     came to rest on the character route, re-navigating a few times and failing
+     loudly rather than generating on the wrong surface.
+
+  Verified live 2026-07-28 in both directions on the same account, plus a
+  read-back showing the character carrying its name and `thumbnail_media_id`.
+  The wire contract is documented in
+  [CHARACTER_RECON](docs/CHARACTER_RECON.md#entity-binding-entitycontext-captured-live-2026-07-28).
+
 - **`gflow image i2i --ref <UUID>` no longer fails when the asset is out of the
   picker's reach (#393).** Flow's media picker is scoped to the active project
   and its search does **not** index media UUIDs (confirmed live 2026-07-27:

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -824,6 +824,34 @@ gflow image batch ./batch-b.tsv --profile personal
 
 ## Resolved
 
+### `character create` generated portraits that never bound to the character — RESOLVED in v0.45.0
+
+- **Status:** Resolved ([#395](https://github.com/ffroliva/gflow-cli/issues/395)) · **Severity:** Was-High · **Was-affecting:** v0.44.0 and unreleased `develop` · **Fixed in:** v0.45.0
+
+Every `gflow character create` spent an Imagen credit, produced an image, and
+left the character empty ("Untitled Character", null thumbnail). Flow filed the
+generation as an ordinary project image because the request carried no
+`entityContext`. Two independent gflow defects caused it:
+
+1. **Overlay dismissal Escaped Flow's own UI.** `[role='dialog']` and
+   `[role='alert']` had been added to the overlay detector, but Flow's character
+   composer — and the media picker — carry those roles. gflow pressed Escape on
+   the app itself and the submit lost its entity context.
+2. **The character route could bounce to the project page.** Flow redirects
+   `/project/{id}/character/{entityId}` while the entity is not yet queryable
+   (gflow navigates immediately after `flow.createEntity`). The project page
+   also mounts a prompt box, so the readiness gate passed on the wrong surface
+   and the prompt was typed into the **project** composer.
+
+Both are fixed: the two over-broad selectors are gone (banner detection intact),
+and the transport now verifies it came to rest on the character route,
+re-navigating and then failing loudly instead of generating on the wrong
+surface. The `parentEntityId` guard that surfaced this was correct throughout —
+it refused to report a portrait-less character as success.
+
+Wire contract: [CHARACTER_RECON § entity binding](docs/CHARACTER_RECON.md#entity-binding-entitycontext-captured-live-2026-07-28).
+Evidence: [LIVE_VERIFICATION_v0.45.0 §2](docs/LIVE_VERIFICATION_v0.45.0.md).
+
 ### `gflow video`'s manifest-driven batch subcommand didn't skip already-completed entries — RESOLVED as obsolete
 
 - **Status:** Resolved (obsolete) · **Severity:** Was-Medium · **Was-affecting:** v0.2.0a1 through the command's removal · **Fixed in:** n/a — removed in production-readiness hardening (see `fix: remove nonfunctional video batch command`)

--- a/docs/CHARACTER_RECON.md
+++ b/docs/CHARACTER_RECON.md
@@ -82,6 +82,55 @@ calls on the same `workflowId`, chaining `imageInputs` (BASE_IMAGE = prior outpu
 This is the SAME endpoint family gflow's existing image transport already drives — the new bits are
 `tool:"PINHOLE"`, `imageInputs` types, and the `parentEntityId`/workflow binding.
 
+## Entity binding: `entityContext` (captured live 2026-07-28)
+
+**The generation request must carry `entityContext`, or Flow files the image as a
+plain project image and the character stays empty.** Captured from Flow's own UI
+via a CDP-attached real Chrome (`gflow-agent-browser-spike`, `navigator.webdriver:
+false`) while driving the plain **New Character** flow.
+
+`POST /v1/projects/{projectId}/flowMedia:batchGenerateImages`
+
+```jsonc
+{
+  "clientContext": { "projectId": "…", "tool": "PINHOLE", "sessionId": "…" },
+  "mediaGenerationContext": {
+    "batchId": "…",
+    "entityContext": {
+      "entityId": "1e6c558e-87be-4aa7-8a21-ffb7efa43bbd",
+      "characterSlot": { "imageReferenceIndex": 0 }   // 0 = portrait/face, 1 = body
+    }
+  },
+  "useNewMedia": true,
+  "requests": [ { "imageModelName": "NARWHAL", "structuredPrompt": {…}, "seed": …, "imageInputs": [] } ]
+}
+```
+
+Response — bound on the first try:
+
+```jsonc
+"workflows": [ { "name": "30551aa7-…", "projectId": "…", "parentEntityId": "1e6c558e-…" } ]
+```
+
+### Which surface produces it
+
+| Surface | URL | Composer | Sends `entityContext`? |
+|---|---|---|---|
+| **New Character** (plain flow) | `/project/{id}/characters` → "New Character" | "Describe your character…" | **Yes** — Flow creates the entity and binds |
+| Character editor (existing character) | `/project/{id}/character/{entityId}` | "What do you want to change?" | Edit surface — the creation binding is not established here |
+
+The plain flow calls `flow.createEntity` **itself** (returning
+`displayName: "Untitled Character"`), then generates with `entityContext`, then
+`PATCH /v1/flowWorkflows/{id}` twice (`metadata.displayName`, then
+`metadata.primaryMediaId`). Flow never asks for a name up front — the user renames
+afterwards via the ✏️ next to the title, and "Character Info (optional)"
+(*"Describe how your character acts…"*) is a separate free-text field.
+
+**Consequence for gflow (#395):** pre-creating the entity and deep-linking to
+`/character/{entityId}` submits through the *edit* composer, which carries no
+`entityContext` — so the workflow comes back with no `parentEntityId` and the
+`generate_character_image` guard correctly refuses it.
+
 ## Gaps
 
 1. ✅ **RESOLVED — Entity create.** `POST /fx/api/trpc/flow.createEntity` `{json:{projectId}}` →

--- a/docs/LIVE_VERIFICATION_v0.45.0.md
+++ b/docs/LIVE_VERIFICATION_v0.45.0.md
@@ -4,8 +4,8 @@
 > Google Flow, not just mocked tests. Profile `ffroliva`, 2026-07-27.
 > See [E2E_TESTING.md](E2E_TESTING.md) for the marker/cost model.
 
-Offline gates for the release: `ruff` clean, `pyright src` 0 errors,
-**2804 passed / 91.45% coverage**.
+Offline gates for the release: `ruff` clean, `pyright src` 0 errors, full
+suite green (see §5).
 
 ---
 
@@ -60,45 +60,57 @@ project.
 
 ---
 
-## 2. `character create --format-prompt` (#383) — ⚠️ NOT VERIFIABLE THIS CYCLE
+## 2. `character create` binding + `--format-prompt` (#395, #383) — ✅ VERIFIED
 
-> Tracked as [#395](https://github.com/ffroliva/gflow-cli/issues/395).
+Originally recorded here as *not verifiable this cycle*. That was wrong in an
+important way: the cause was **ours**, not Flow's, and the spike below found it.
 
-Recorded rather than omitted, per AGENTS.md.
+### 2.1 What the spike established
 
-`gflow character create` is **currently broken against live Flow** on this
-account, independently of this release. The `--format-prompt` flag drives the
-character editor, so the flag cannot be exercised until that surface works.
+Drove Flow's own character flow in a CDP-attached real Chrome
+(`gflow-agent-browser-spike`, `navigator.webdriver: false`) with full
+request/response capture, then diffed it against gflow's traffic. The two
+requests were byte-comparable except for one block:
 
-### 2.1 Evidence that it is Flow-side, not ours
+```jsonc
+"mediaGenerationContext": {
+  "entityContext": { "entityId": "…", "characterSlot": { "imageReferenceIndex": 0 } }
+}
+```
 
-| Probe | Observation |
-|---|---|
-| Incident bundle `ui.json` | `title.category: flow_app_crash`, `ligature_count: 0` — Flow's React error boundary rendered instead of the editor |
-| HAR of the character generation | `workflows[0]` has `name`, `metadata`, `projectId` — **no `parentEntityId` field at all** |
-| `gflow character list` read-back | Runs from 2026-07-27 left entities as `"Untitled Character"` with `thumbnail_media_id: null`; an entity created 2026-07-26 carries its thumbnail |
-| **Released v0.44.0 from PyPI** (`uvx --from "gflow-cli==0.44.0"`) | **Fails identically** — predates this cycle's work |
-| Hypothesis test: unreleased overlay change (#369) Escaping the editor | **Disconfirmed** — narrowing `TOP_BANNER_SELECTORS` did not change the outcome |
+With it, the response carries `parentEntityId` and the portrait binds; without
+it, Flow files a plain project image. Contract documented in
+[CHARACTER_RECON](CHARACTER_RECON.md#entity-binding-entitycontext-captured-live-2026-07-28).
 
-Both observed failure modes ("editor not ready", "workflow parentEntityId None")
-trace to the same cause: Flow's character-editor route is degraded, so the
-generation lands as an ordinary project image instead of binding to the entity.
-gflow's invariant correctly refuses to report that as success.
+### 2.2 Two defects, both ours
 
-### 2.2 What ships anyway
+| # | Defect | Evidence |
+|---|---|---|
+| 1 | Overlay dismissal pressed **Escape** on Flow's own composer — `[role='dialog']`/`[role='alert']` matched the app itself — so the submit lost `entityContext` | Removing those two selectors made the identical command bind on the first try (`entity_patched`, real `thumbnail_media_id`); with them present it failed every run |
+| 2 | The character route can **bounce** back to the project page (entity not yet queryable after `createEntity`); the project page also mounts a prompt box, so the readiness gate passed on the wrong surface and the prompt went into the **project** composer | `character_editor_ready` logged with the *project* URL; the new guard logs `character_route_bounced` → `character_route_settled` and the URL is now the character route |
 
+A third symptom seen on 2026-07-27 — Flow's app crashing on that route — was
+real but intermittent and is now reported as the typed retryable `FlowAppError`
+(§3).
+
+### 2.3 Proof
+
+- `gflow character create --name "Overlay Hypothesis"` → `"status": "ok"`,
+  `character_create.entity_patched`; read-back shows the character with its name
+  **and** `thumbnail_media_id: fdaea0d2-…` — the first fully successful create
+  since the breakage.
+- `tests/e2e/test_character_create_e2e.py::test_character_create_binds_parent_entity`
+  — **passes live** (this is the #395 contract: entity bound, same project,
+  thumbnail attached).
 - `tests/e2e/test_character_create_e2e.py::test_character_create_format_prompt_clicks_format_button`
-  — written and ready; asserts the `ui_automation.prompt_formatted` event (a
-  visible **and** enabled button was clicked) and asserts the two skip-telemetry
-  events are absent so a no-op flag cannot pass as success. It will pass as soon
-  as Flow's character editor binds again.
-- Two error-classification fixes discovered **because** of this attempt (§3).
+  — **passes live**, asserting the `ui_automation.prompt_formatted` event fired
+  (visible **and** enabled button clicked) and that neither skip-telemetry event
+  appeared, so a no-op flag cannot pass as success. This closes the
+  `--format-prompt` (#383) verification that was owed since 2026-07-26.
 
-A harness bug was also fixed: `_character_env` inherited the isolated
+A harness bug was fixed on the way: `_character_env` inherited the isolated
 `GFLOW_CLI_HOME`, so every subprocess test in that file exited 2 with
 "No session" before reaching Flow.
-
----
 
 ## 3. Error-classification fixes — ✅ VERIFIED (observed live, unit-pinned)
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -420,11 +420,24 @@ CHANGELOG_IFRAME_SELECTORS = (
     "iframe[src*='/changelogs/']",
 )
 
-# Top banner / alert / announcement dialog selectors (#369).
+# Top banner / announcement selectors (#369).
+#
+# DO NOT add bare `[role='dialog']` or `[role='alert']` here. Both shipped
+# briefly and broke `gflow character create` (#395): Flow's own working
+# surfaces carry those roles, so `_detect_overlay` matched the app itself and
+# `_dismiss_blocking_overlays` pressed Escape on the character composer. The
+# generation then went out WITHOUT `entityContext`, and Flow filed the portrait
+# as a plain project image with no `parentEntityId` — a silent, credit-spending
+# failure. Proven live 2026-07-28: with those two selectors removed, the very
+# same command bound the character on the first try (`entity_patched`, real
+# `thumbnail_media_id`); with them present it failed every run.
+#
+# The media picker is a `[role='dialog']` too, so the blast radius was never
+# limited to characters. Keep this tuple to overlays we have actually captured;
+# per KNOWN_ISSUES, gflow does not guess dismiss selectors for unknown overlays
+# — clicking (or Escaping) unknown UI is riskier than failing.
 TOP_BANNER_SELECTORS: tuple[str, ...] = (
     "[role='banner']",
-    "[role='alert']",
-    "[role='dialog']",
     "div:has-text('What\\'s new')",
 )
 
@@ -3070,6 +3083,66 @@ class UiAutomationTransport(VideoGenerationMixin):
             except Exception:
                 pass
 
+    _CHARACTER_ROUTE_ATTEMPTS = 4
+    _CHARACTER_ROUTE_BACKOFF_MS = 2_500
+
+    async def _settle_on_character_route(
+        self,
+        page: Any,
+        *,
+        entity_id: str,
+        url: str,
+    ) -> None:
+        """Ensure the browser actually CAME TO REST on ``/character/{entity_id}``.
+
+        Flow bounces this route back to the project page when the entity is not
+        yet queryable — a race gflow loses because it navigates immediately
+        after ``flow.createEntity`` (live 2026-07-28).
+
+        This must be checked explicitly because the project page **also** mounts
+        a Slate prompt box, so the editor-ready wait below is satisfied on the
+        WRONG surface. The generation then goes to the project composer, which
+        sends no ``entityContext``, and Flow files the image as a plain project
+        image with no ``parentEntityId`` — the #395 symptom. A redirect is
+        therefore silent data loss, not a cosmetic detail.
+
+        Re-navigates a few times to let the entity settle. If the route still
+        will not stick, raise rather than type into the project composer.
+        """
+        for attempt in range(1, self._CHARACTER_ROUTE_ATTEMPTS + 1):
+            if entity_id in str(page.url):
+                if attempt > 1:
+                    log.info(
+                        "ui_automation.character_route_settled",
+                        entity_id=entity_id,
+                        attempt=attempt,
+                    )
+                return
+            log.warning(
+                "ui_automation.character_route_bounced",
+                entity_id=entity_id,
+                landed_on=str(page.url),
+                attempt=attempt,
+                note="Flow redirected away from the character editor; retrying",
+            )
+            if attempt == self._CHARACTER_ROUTE_ATTEMPTS:
+                break
+            await page.wait_for_timeout(self._CHARACTER_ROUTE_BACKOFF_MS)
+            await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            await self._dismiss_blocking_overlays(page, self._out_dir)
+
+        shot = await _capture_debug_screenshot(
+            page, self._out_dir, "debug_character_route_bounced.png"
+        )
+        msg = (
+            f"Flow kept redirecting the character editor for entity {entity_id!r} "
+            f"back to {page.url!r} after {self._CHARACTER_ROUTE_ATTEMPTS} attempts. "
+            "Generating here would submit through the PROJECT composer and Flow "
+            "would file the image as a plain project image instead of binding it "
+            f"to the character.{screenshot_clause(shot)}"
+        )
+        raise FlowAppError(detail=msg)
+
     async def _enter_character_editor(
         self,
         page: Any,
@@ -3099,6 +3172,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         )
         await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
         await self._dismiss_blocking_overlays(page, self._out_dir)
+        await self._settle_on_character_route(page, entity_id=entity_id, url=url)
 
         # Wait for the Slate editor to mount — the prompt textbox is the
         # reliable "editor ready" anchor for the character editor surface.

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -184,6 +184,49 @@ class TestEnterCharacterEditor:
             await t._enter_character_editor(page, project_id="p", entity_id="e", locale="en")
 
     @pytest.mark.asyncio
+    async def test_retries_when_flow_bounces_off_the_character_route(self) -> None:
+        """Flow redirects the character route back to the project page when the
+        entity is not yet queryable (live 2026-07-28). Re-navigate until it sticks.
+
+        The project page mounts a Slate box too, so the editor-ready wait alone
+        is satisfied on the WRONG surface — and generating there submits through
+        the project composer, which sends no `entityContext`. Flow then files the
+        portrait as a plain project image (#395).
+        """
+        ready_sel = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
+        page = _make_page(visible_selectors={ready_sel})
+        project_url = "https://labs.google/fx/en/tools/flow/project/p1"
+        entity_url = f"{project_url}/character/e1"
+        # First load bounces to the project page; the retry lands on the entity.
+        urls = iter([project_url, entity_url, entity_url, entity_url])
+
+        async def _goto(*_a: object, **_kw: object) -> None:
+            page.url = next(urls)
+
+        page.goto = AsyncMock(side_effect=_goto)
+        page.url = project_url
+        t = _make_transport(page=page)
+        t._dismiss_blocking_overlays = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+
+        await t._enter_character_editor(page, project_id="p1", entity_id="e1", locale="en")
+
+        assert page.goto.await_count >= 2, "should have re-navigated after the bounce"
+        assert "e1" in page.url
+
+    @pytest.mark.asyncio
+    async def test_raises_when_the_character_route_never_sticks(self) -> None:
+        """Give up loudly rather than typing into the project composer (#395)."""
+        ready_sel = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
+        page = _make_page(visible_selectors={ready_sel})
+        page.url = "https://labs.google/fx/en/tools/flow/project/p1"
+        page.goto = AsyncMock()  # every navigation keeps us on the project page
+        t = _make_transport(page=page)
+        t._dismiss_blocking_overlays = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+
+        with pytest.raises(FlowAppError, match="PROJECT composer"):
+            await t._enter_character_editor(page, project_id="p1", entity_id="e1", locale="en")
+
+    @pytest.mark.asyncio
     async def test_flow_app_crash_raises_typed_retryable_error(self) -> None:
         """A Flow client-side crash must surface as the retryable FlowAppError.
 

--- a/tests/test_overlay_banner_dismissal.py
+++ b/tests/test_overlay_banner_dismissal.py
@@ -103,7 +103,7 @@ class TestTopBannerAndAlertDismissal:
         """_dismiss_blocking_overlays force-clicks clear/close/Got-it/Dismiss buttons."""
         t = UiAutomationTransport()
         # Banner visible AND the target close button visible
-        page = _make_mock_page(visible_selectors={"[role='alert']", close_sel})
+        page = _make_mock_page(visible_selectors={"[role='banner']", close_sel})
         result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
         assert result is True
         assert close_sel in page._clicked  # type: ignore[attr-defined]
@@ -126,7 +126,7 @@ class TestTopBannerAndAlertDismissal:
         """When close buttons missing and Escape raises, returns False and takes screenshot."""
         t = UiAutomationTransport()
         page = _make_mock_page(
-            visible_selectors={"[role='dialog']"},
+            visible_selectors={"[role='banner']"},
             keyboard_press_raises=True,
         )
         result = await t._dismiss_blocking_overlays(page, out_dir=tmp_path)  # type: ignore[attr-defined]
@@ -142,3 +142,33 @@ class TestTopBannerAndAlertDismissal:
         assert result is False
         assert page._clicked == []  # type: ignore[attr-defined]
         page.keyboard.press.assert_not_called()
+
+
+class TestOverlaySelectorBlastRadius:
+    """#395 guard: overlay detection must not match Flow's own working UI.
+
+    `[role='dialog']` and `[role='alert']` shipped briefly in
+    :data:`TOP_BANNER_SELECTORS` and broke `gflow character create`: Flow's
+    character composer and media picker carry those roles, so the dismissal
+    path pressed Escape on the app itself. The generation then went out with no
+    `entityContext` and Flow filed the portrait as a plain project image —
+    silent, credit-spending data loss. Proven live 2026-07-28 in both
+    directions (present → failed every run; removed → bound first try).
+    """
+
+    def test_does_not_match_bare_dialog_or_alert_roles(self) -> None:
+        from gflow_cli.api.transports.ui_automation import TOP_BANNER_SELECTORS
+
+        for forbidden in ("[role='dialog']", "[role='alert']"):
+            assert forbidden not in TOP_BANNER_SELECTORS, (
+                f"{forbidden} matches Flow's own composer/picker surfaces. It made "
+                "`character create` submit without entityContext (#395). Match a "
+                "captured announcement overlay instead of a bare ARIA role."
+            )
+
+    def test_still_covers_the_captured_banner_surfaces(self) -> None:
+        """The #369 intent must survive the narrowing."""
+        from gflow_cli.api.transports.ui_automation import TOP_BANNER_SELECTORS
+
+        assert "[role='banner']" in TOP_BANNER_SELECTORS
+        assert any("What" in s for s in TOP_BANNER_SELECTORS)

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -824,6 +824,34 @@ gflow image batch ./batch-b.tsv --profile personal
 
 ## Resolved
 
+### `character create` generated portraits that never bound to the character — RESOLVED in v0.45.0
+
+- **Status:** Resolved ([#395](https://github.com/ffroliva/gflow-cli/issues/395)) · **Severity:** Was-High · **Was-affecting:** v0.44.0 and unreleased `develop` · **Fixed in:** v0.45.0
+
+Every `gflow character create` spent an Imagen credit, produced an image, and
+left the character empty ("Untitled Character", null thumbnail). Flow filed the
+generation as an ordinary project image because the request carried no
+`entityContext`. Two independent gflow defects caused it:
+
+1. **Overlay dismissal Escaped Flow's own UI.** `[role='dialog']` and
+   `[role='alert']` had been added to the overlay detector, but Flow's character
+   composer — and the media picker — carry those roles. gflow pressed Escape on
+   the app itself and the submit lost its entity context.
+2. **The character route could bounce to the project page.** Flow redirects
+   `/project/{id}/character/{entityId}` while the entity is not yet queryable
+   (gflow navigates immediately after `flow.createEntity`). The project page
+   also mounts a prompt box, so the readiness gate passed on the wrong surface
+   and the prompt was typed into the **project** composer.
+
+Both are fixed: the two over-broad selectors are gone (banner detection intact),
+and the transport now verifies it came to rest on the character route,
+re-navigating and then failing loudly instead of generating on the wrong
+surface. The `parentEntityId` guard that surfaced this was correct throughout —
+it refused to report a portrait-less character as success.
+
+Wire contract: [CHARACTER_RECON § entity binding](docs/CHARACTER_RECON.md#entity-binding-entitycontext-captured-live-2026-07-28).
+Evidence: [LIVE_VERIFICATION_v0.45.0 §2](docs/LIVE_VERIFICATION_v0.45.0.md).
+
 ### `gflow video`'s manifest-driven batch subcommand didn't skip already-completed entries — RESOLVED as obsolete
 
 - **Status:** Resolved (obsolete) · **Severity:** Was-Medium · **Was-affecting:** v0.2.0a1 through the command's removal · **Fixed in:** n/a — removed in production-readiness hardening (see `fix: remove nonfunctional video batch command`)


### PR DESCRIPTION
## Summary

Every `gflow character create` spent an Imagen credit, produced an image, and left the character empty ("Untitled Character", null thumbnail). Flow filed the generation as an ordinary project image because the request carried no `entityContext`.

A CDP spike drove Flow's **own** character flow with full network capture; the two requests were comparable except for one block:

```jsonc
"mediaGenerationContext": {
  "entityContext": { "entityId": "…", "characterSlot": { "imageReferenceIndex": 0 } }
}
```

## Two defects, both ours

1. **Overlay dismissal Escaped Flow's own UI.** `[role='dialog']` and `[role='alert']` had been added to the overlay detector, but Flow's character composer — and the media picker — carry those roles. gflow pressed Escape on the app itself and the submit lost its entity context. Removing the two selectors made the identical command bind on the first try; with them present it failed every run. `[role='banner']` + the announcement matcher stay, so #369's intent is intact.

2. **The character route can bounce back to the project page** while the entity is not yet queryable (gflow navigates immediately after `createEntity`). The project page *also* mounts a prompt box, so the readiness gate passed on the **wrong surface** and the prompt was typed into the project composer. `_settle_on_character_route` now verifies the route stuck, re-navigating and then failing loudly.

The `parentEntityId` guard that surfaced all this was correct throughout and stays strict — it refused to report a portrait-less character as success.

## Live verification (2026-07-28)

- `character create` → `"status": "ok"`, `entity_patched`; read-back shows the character with its **name and `thumbnail_media_id`** — first successful create since the breakage.
- `test_character_create_binds_parent_entity` — **passes live** (the #395 contract).
- `test_character_create_format_prompt_clicks_format_button` — **passes live**, closing the #383 verification owed since 2026-07-26.
- Also fixed: `_character_env` inherited the isolated `GFLOW_CLI_HOME`, so every subprocess test in that file exited 2 before reaching Flow.

Wire contract documented in `docs/CHARACTER_RECON.md`; evidence in `docs/LIVE_VERIFICATION_v0.45.0.md` §2.

## Test plan

- [x] 4 new unit tests (2 route-settle, 2 overlay blast-radius); #369's tests re-pointed at a still-detected trigger
- [x] 2 live e2e passing against real Flow
- [x] `ruff` clean, `pyright src` 0 errors, **2810 passed**

Closes #395
Refs #383, #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)