### PR TITLE
chore(docs): gate mkdocs nav completeness and fold the website into doc-review

### DIFF
--- a/scripts/ci/generate_website_docs.py
+++ b/scripts/ci/generate_website_docs.py
@@ -117,6 +117,27 @@ def _mirrored_targets() -> list[Path]:
     return targets
 
 
+def _nav_orphans() -> list[str]:
+    """Published `.md` pages that `mkdocs.yml` never lists in `nav:`.
+
+    An orphan still builds and deploys, but nothing links to it — it exists on
+    the site only for whoever guesses the URL. Mirroring a doc and wiring it
+    into the nav are two separate acts, and the mirror check only ever caught
+    the first, so a new page could ship invisible.
+
+    Substring match against the whole `nav:` block: entries are `File: NAME.md`
+    and nesting depth does not matter, so this stays true no matter how the nav
+    is reorganized. Requires no YAML parser (mkdocs' own `!!python/name:` tags
+    make it non-trivial to parse anyway).
+    """
+    mkdocs = _REPO / "website" / "mkdocs.yml"
+    if not mkdocs.exists():
+        return []
+    text = mkdocs.read_text(encoding="utf-8")
+    nav = text[text.index("nav:") :] if "nav:" in text else ""
+    return sorted(p.name for p in _WEB.glob("*.md") if p.name not in nav and p.name != "index.md")
+
+
 def main(argv: list[str]) -> int:
     check = "--check" in argv
     drift: list[str] = []
@@ -135,13 +156,17 @@ def main(argv: list[str]) -> int:
             written += 1
 
     if check:
-        if drift:
-            print("website/docs mirror is stale — regenerate with:")
-            print("  python scripts/ci/generate_website_docs.py")
-            for d in drift:
-                print(f"  DRIFT: {d}")
+        orphans = _nav_orphans()
+        if drift or orphans:
+            if drift:
+                print("website/docs mirror is stale — regenerate with:")
+                print("  python scripts/ci/generate_website_docs.py")
+                for d in drift:
+                    print(f"  DRIFT: {d}")
+            for o in orphans:
+                print(f"  NAV-ORPHAN: {o} is published but absent from website/mkdocs.yml nav")
             return 1
-        print(f"website/docs mirror in sync ({len(_mirrored_targets())} files).")
+        print(f"website/docs mirror in sync ({len(_mirrored_targets())} files), nav complete.")
         return 0
     print(f"Regenerated {written} website/docs file(s) from canonical.")
     return 0

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -22,9 +22,14 @@ PYTHONUTF8=1 uv run python scripts/ci/check_website_docs_pii.py
 PYTHONUTF8=1 uv run python scripts/ci/generate_website_docs.py --check
 ```
 
-The last check fails if canonical `docs/` changed but the published
-`website/docs/` mirror was not regenerated. Fix with
-`uv run python scripts/ci/generate_website_docs.py` and stage `website/docs/`.
+The last check fails on either half of the published-site contract:
+
+- `DRIFT:` — canonical `docs/` changed but the `website/docs/` mirror was not
+  regenerated. Fix with `uv run python scripts/ci/generate_website_docs.py` and
+  stage `website/docs/`.
+- `NAV-ORPHAN:` — a page is published but no `nav:` entry in
+  `website/mkdocs.yml` points at it, so it is live but unreachable. Add the
+  entry under the right nav section.
 
 **2. Auto-fix lint and formatting** (rewrites files in place)
 

--- a/skills/doc-review/SKILL.md
+++ b/skills/doc-review/SKILL.md
@@ -99,12 +99,14 @@ If `scripts/ci/check_doc_links.py` is absent, create it from the v0.8.1 plan (it
 
 ---
 
-## 4b · Published website mirror (`website/docs/`)
+## 4b · Published website (`website/`) — part of the documentation work, not a follow-up
 
-`website/docs/` is the mkdocs-material site published to GitHub Pages — an
-**anonymized copy** of canonical `docs/`. It has drifted silently for months
-before (PR #362 shipped a PII leak; content lagged canonical for whole
-releases) because nothing gates staleness. This section closes that.
+`website/` is the mkdocs-material site published to GitHub Pages, and
+`website/docs/` is an **anonymized copy** of canonical `docs/`. Treat updating
+it as part of the same change that touched the docs: a documentation uplift is
+not done until the published surface reflects it. The mirror has drifted
+silently for months before (PR #362 shipped a PII leak; content lagged
+canonical for whole releases), which is why all three gates below exist.
 
 **1. PII gate (the CI check — a leak fails the build):**
 
@@ -115,7 +117,7 @@ uv run python scripts/ci/check_website_docs_pii.py
 
 Expected: `No private identifiers found across N published website/docs files.`
 
-**2. Content-drift check — the mirror is generated from canonical by
+**2. Content-drift + nav check — the mirror is generated from canonical by
 `scripts/ci/generate_website_docs.py` (the anonymization map is data in that
 script). Verify it is in sync (this is the same check CI runs):**
 
@@ -124,18 +126,30 @@ $env:PYTHONUTF8=1
 uv run python scripts/ci/generate_website_docs.py --check
 ```
 
-Expected: `website/docs mirror in sync (N files).` Any `DRIFT:` line is a
-**FAIL** — a canonical doc changed and the mirror was not regenerated. Fix it:
+Expected: `website/docs mirror in sync (N files), nav complete.`
 
-```bash
-uv run python scripts/ci/generate_website_docs.py   # regenerate, then stage website/docs/
-```
+- Any `DRIFT:` line is a **FAIL** — a canonical doc changed and the mirror was
+  not regenerated. Fix it:
+
+  ```bash
+  uv run python scripts/ci/generate_website_docs.py   # regenerate, then stage website/docs/
+  ```
+
+- Any `NAV-ORPHAN:` line is a **FAIL** — the page is published but no `nav:`
+  entry in `website/mkdocs.yml` points at it, so it exists on the site only for
+  whoever guesses the URL. Mirroring a doc and wiring it into the nav are two
+  separate acts; add the entry under the right nav section and re-run.
+
+**3. New canonical doc → decide explicitly whether it is published.** Not every
+doc belongs on the site (release evidence, recon specs, and plans generally do
+not). If it should be published: create the file under `website/docs/`, add its
+`nav:` entry in `website/mkdocs.yml`, and the generator maintains the content
+thereafter. If it should not, say so in the review so the omission is a
+decision rather than an oversight.
 
 `CHANGELOG.md` and the bespoke site pages (`index.md`, `agents.md`,
 `installation.md`, `onboarding*.md`) are intentionally NOT generated — the
-generator's `WEBSITE_ONLY` set excludes them. If a NEW canonical doc should be
-published, add its file under `website/docs/` and the generator maintains it
-thereafter.
+generator's `WEBSITE_ONLY` set excludes them.
 
 ---
 

--- a/tests/scripts/test_generate_website_docs.py
+++ b/tests/scripts/test_generate_website_docs.py
@@ -12,6 +12,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO = Path(__file__).resolve().parents[2]
 
 
@@ -68,3 +70,28 @@ def test_bespoke_pages_are_never_generated() -> None:
     """The site's distinct landing/onboarding pages have no canonical source."""
     for name in ("index.md", "agents.md", "installation.md", "onboarding.md"):
         assert _gen._source_for(name) is None  # noqa: SLF001
+
+
+def test_nav_orphan_detection_flags_unlinked_pages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A published page with no `nav:` entry is a FAIL.
+
+    Mirroring a doc and wiring it into `mkdocs.yml` are separate acts, and the
+    drift check only ever caught the first — so a new page could ship live but
+    unreachable. Pins both directions on a synthetic site tree.
+    """
+    web = tmp_path / "website" / "docs"
+    web.mkdir(parents=True)
+    (web / "LINKED.md").write_text("x", encoding="utf-8")
+    (web / "index.md").write_text("x", encoding="utf-8")
+    (tmp_path / "website" / "mkdocs.yml").write_text(
+        "site_name: t\nnav:\n  - Linked: LINKED.md\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(_gen, "_REPO", tmp_path)
+    monkeypatch.setattr(_gen, "_WEB", web)
+
+    assert _gen._nav_orphans() == []
+
+    (web / "ORPHAN.md").write_text("x", encoding="utf-8")
+    assert _gen._nav_orphans() == ["ORPHAN.md"]


### PR DESCRIPTION
## Summary

Mirroring a canonical doc into `website/docs/` and wiring its `nav:` entry in `website/mkdocs.yml` are two separate acts, and only the first was ever gated. A page could ship live but **unreachable** — published for whoever guesses the URL.

`generate_website_docs.py --check` now also reports `NAV-ORPHAN:`, so the existing CI job and `/gflow:check` enforce it with no new machinery.

Nav is complete today, so this closes a latent gap rather than fixing a live bug. Verified both directions: clean tree passes (`mirror in sync (18 files), nav complete.`), a planted orphan is caught.

## Skill changes

`/gflow:doc-review` §4b rewritten to treat the published site as **part of the same change that touched the docs**, not a follow-up, and to force an explicit publish/don't-publish decision for any new canonical doc — so an omission is a recorded decision rather than an oversight.

`/gflow:check` wording updated to explain both failure halves (`DRIFT:` and `NAV-ORPHAN:`).

## Design note

A separate mkdocs skill was considered and **rejected**: enforcement already exists at both deterministic thresholds — CI on every PR (`ci.yml`) and `/gflow:check` pre-commit — and the whole surface is three commands. Worth revisiting if website work grows past that (nav curation, `mkdocs serve` preview, deploy verification, versioned docs).

Also worth noting for the record: the site is **MkDocs Material, not Jekyll**.

## Test plan

- [x] New test pins `_nav_orphans()` in both directions on a synthetic site tree
- [x] `ruff check src tests` clean, existing mirror tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)