### PR TITLE
fix(ui): count setter survives Flow's 1x->x1 label rename; typed drift error (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`image t2i` failed whenever `-n` differed from the displayed count — including
+  the default `-n 1` (#404).** Flow renamed the composer's count-tab labels from
+  `1x`/`x2`/… to `x1`/`x2`/…, so the count setter's label filter silently dropped
+  the count-1 tab and its positional pick clicked the wrong tab (reporting
+  per-click success while the value never changed). The count tab is now selected
+  by the digit in its label across both cohorts, the read-back recognises a
+  selected `x1`, and non-convergence raises `UiSelectorDriftError` (exit 23)
+  naming desired vs displayed — instead of a bare `RuntimeError` that
+  observability hashed into an opaque `UnexpectedError`. The per-click
+  `count_click_result` log now carries `effect_observed`, and the video output
+  count setter probes both label cohorts too. Verified live on the classic
+  composer (new e2e: `tests/e2e/test_classic_count_setter_e2e.py`).
+
 ## [0.46.0] — 2026-07-28
 
 ### Changed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -118,7 +118,8 @@ denon82 profile (aborted pre-submit, saving the 10-credit generation).
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
 renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
-(9:16/16:9), count (1x–x4), and the model dropdown (Veo 3.1 - Lite), and
+(9:16/16:9), count (1x–x4; labels renamed to xN since — see #404), and the
+model dropdown (Veo 3.1 - Lite), and
 nothing else. The earlier locale hypothesis is refuted: the UI renders in
 Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
 no duration row to click. Whether Flow removed clip-length selection for this

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -629,10 +629,14 @@ issue and not blocked by any code change in this repo.
   locale-leak fix.
 
 **Earlier — Phase 7 multi-image-prompt work** addressed the count-tab selectors:
-- `_COUNT_TAB_TEXT_RE = ^(1x|x[2-4])$` only matches the digit+x format Flow
+- `_COUNT_TAB_TEXT_RE = ^(1x|x[1-4])$` only matches the digit+x format Flow
   renders identically in every locale (numbers/symbols are not translated).
-- `_set_count` falls back to positional `.nth(count - 1)` when the read-back
-  text is unrecognised — locale-invariant.
+  Widened for #404: Flow renamed the count-1 label from `1x` to `x1`
+  (uniform `xN`, live-verified 2026-07-31); both cohorts are accepted.
+- `_set_count` clicks the tab carrying the desired DIGIT (`1x`/`x1` for
+  count=1), not a position — the #404 rename shrank the old filtered set and
+  shifted every `.nth(count - 1)` pick by one. Non-convergence raises
+  `UiSelectorDriftError` (exit 23) with desired vs displayed counts.
 
 **Earlier — PR #48:**
 - Added `--lang=en-US` Chromium launch arg; parts of `NEW_PROJECT_SELECTORS` /

--- a/scripts/dev/spike_issue404_count_tabs_recon.py
+++ b/scripts/dev/spike_issue404_count_tabs_recon.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+r"""Issue #404 recon — classic composer count tabs: why does clicking
+``nth(0) of _count_tabs_locator`` report success but never change the
+displayed count? (0 credits)
+
+Replicates ``_set_count``'s exact steps using the transport's own static
+helpers (``_open_gen_settings_panel`` / ``_read_displayed_count`` /
+``_count_tabs_locator`` / ``_dump_count_panel_dom``), then probes the
+candidate fix: clicking the count tab whose TEXT contains the desired digit,
+scoped to the tablist that owns the currently aria-selected count tab.
+
+Navigation only — no prompt is submitted, no generate route is hit, 0 credits.
+
+Usage (headed, supervised):
+
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\spike_issue404_count_tabs_recon.py \
+        --profile ffroliva --project 9d7b750f-b4a8-4c2f-b5b0-a059cbfbae73
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _ROOT / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.ui_automation import (  # noqa: E402
+    UiAutomationTransport,
+    _count_tabs_locator,
+)
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+    VideoGenerationMixin,
+)
+
+# Per count tab: text, aria-selected, rect, and a fingerprint of the owning
+# tablist (sibling tab texts in DOM order) so duplicate tablists are visible.
+_TABS_TOPOLOGY_JS = """
+() => {
+  const isCount = (t) => /^(1x|x[2-4])$/.test((t || '').trim());
+  const tablists = [...document.querySelectorAll("[role='tablist']")];
+  return {
+    tablists: tablists.map((tl, i) => {
+      const r = tl.getBoundingClientRect();
+      return {
+        index: i,
+        tabTexts: [...tl.querySelectorAll("[role='tab']")].map(
+          (t) => (t.innerText || '').trim().slice(0, 40)),
+        rect: { x: r.x, y: r.y, w: r.width, h: r.height },
+        visible: r.width > 0 && r.height > 0,
+      };
+    }),
+    countTabs: [...document.querySelectorAll("[role='tab']")]
+      .filter((t) => isCount(t.innerText))
+      .map((t) => {
+        const tl = t.closest("[role='tablist']");
+        const r = t.getBoundingClientRect();
+        return {
+          text: (t.innerText || '').trim(),
+          ariaSelected: t.getAttribute('aria-selected'),
+          tablistIndex: tl ? tablists.indexOf(tl) : null,
+          rect: { x: r.x, y: r.y, w: r.width, h: r.height },
+          visible: r.width > 0 && r.height > 0,
+        };
+      }),
+  };
+}
+"""
+
+
+async def _ensure_classic(page: Any, result: dict[str, Any]) -> bool:
+    media_present = await VideoGenerationMixin._media_panel_present(page)  # noqa: SLF001
+    result["mediaPanelPresent_onLoad"] = media_present
+    if not media_present:
+        pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
+        if await pill.count() > 0:
+            await pill.click(force=True, timeout=5_000)
+            await page.wait_for_timeout(1_500)
+            media_present = await VideoGenerationMixin._media_panel_present(page)  # noqa: SLF001
+    result["classicMode"] = media_present
+    return media_present
+
+
+async def _run(*, profile_dir: Path, project_id: str, locale: str, out_path: Path) -> int:
+    out_dir = out_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Any] = {
+        "spike": "issue404-count-tabs-recon",
+        "capturedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "project": project_id,
+    }
+    T = UiAutomationTransport
+
+    async with build_client(profile_dir, headless=False) as client:
+        page = await client._checkout_page()  # noqa: SLF001
+        try:
+            editor_url = routes.project_editor_url(locale, project_id)
+            step("1", f"goto {editor_url}", prefix="404")
+            await page.goto(editor_url, wait_until="domcontentloaded", timeout=45_000)
+            await page.wait_for_timeout(4_000)
+            await page.keyboard.press("Escape")
+
+            if not await _ensure_classic(page, result):
+                result["error"] = "could not reach classic mode"
+                return 1
+
+            step("2", "opening generation settings panel (transport helper)", prefix="404")
+            panel_open = await T._is_settings_panel_open(page)  # noqa: SLF001
+            if not panel_open:
+                panel_open = await T._open_gen_settings_panel(page)  # noqa: SLF001
+            result["panelOpened"] = panel_open
+            if not panel_open:
+                result["error"] = "settings panel did not open"
+                return 1
+
+            # The real t2i path switches to IMAGE mode before configuring
+            # settings (#40) — replicate via the ligature-keyed mode tab
+            # (locale-invariant, memory: flow-locale-leak-icon-ligatures).
+            step("2b", "selecting Image mode tab (ligature-keyed)", prefix="404")
+            image_tab = page.locator(
+                "[role='tab']:has(i.google-symbols:text-is('image'))"
+            ).first
+            await image_tab.wait_for(state="visible", timeout=5_000)
+            await image_tab.click()
+            await page.wait_for_timeout(800)
+            result["imageModeSelected"] = await image_tab.get_attribute("aria-selected")
+            await page.screenshot(path=str(out_dir / "404_1_panel_open.png"))
+
+            # Full role dump via the transport's own diagnostic (issue #24 shape).
+            await T._dump_count_panel_dom(page, out_dir, 404)  # noqa: SLF001
+            result["topology_before"] = await page.evaluate(_TABS_TOPOLOGY_JS)
+            result["displayed_before"] = await T._read_displayed_count(page)  # noqa: SLF001
+
+            step("3", "replicating failing click: nth(0) of _count_tabs_locator", prefix="404")
+            tabs = _count_tabs_locator(page)
+            result["filtered_set_size"] = await tabs.count()
+            target = tabs.nth(0)
+            result["nth0_before_click"] = await target.evaluate(
+                """(t) => {
+                  const tablists = [...document.querySelectorAll("[role='tablist']")];
+                  return {
+                    text: (t.innerText || '').trim(),
+                    ariaSelected: t.getAttribute('aria-selected'),
+                    tablistIndex: tablists.indexOf(t.closest("[role='tablist']")),
+                    outerHTML: t.outerHTML.slice(0, 400),
+                  };
+                }"""
+            )
+            try:
+                await target.wait_for(state="visible", timeout=3_000)
+                await target.click()
+                await page.wait_for_timeout(300)
+                result["nth0_click"] = "landed"
+            except Exception as e:  # noqa: BLE001
+                result["nth0_click"] = f"error: {e}"
+            result["nth0_after_click_ariaSelected"] = await target.get_attribute("aria-selected")
+            result["displayed_after_nth0"] = await T._read_displayed_count(page)  # noqa: SLF001
+            result["topology_after_nth0"] = await page.evaluate(_TABS_TOPOLOGY_JS)
+            await page.screenshot(path=str(out_dir / "404_2_after_nth0.png"))
+
+            step("4", "candidate fix: text-keyed click scoped to selected tablist", prefix="404")
+            fix = await page.evaluate(
+                """() => {
+                  // Union of old ("1x", "x2"..) and new ("x1", "x2"..) label cohorts.
+                  const isCount = (t) => /^(1x|x[1-4])$/.test((t || '').trim());
+                  const selected = [...document.querySelectorAll(
+                    "[role='tab'][aria-selected='true']")].filter((t) => isCount(t.innerText));
+                  if (!selected.length) return { found: false, reason: 'no selected count tab' };
+                  const tl = selected[0].closest("[role='tablist']");
+                  if (!tl) return { found: false, reason: 'selected tab has no tablist' };
+                  const target = [...tl.querySelectorAll("[role='tab']")].find(
+                    (t) => /^(1x|x1)$/.test((t.innerText || '').trim()));
+                  if (!target) return { found: false, reason: 'no count-1 tab in selected tablist' };
+                  target.setAttribute('data-spike-404-target', '1');
+                  return { found: true };
+                }"""
+            )
+            result["fix_target"] = fix
+            if fix.get("found"):
+                fix_btn = page.locator("[data-spike-404-target='1']").first
+                await fix_btn.click(timeout=5_000)
+                await page.wait_for_timeout(300)
+                result["fix_after_click_ariaSelected"] = await fix_btn.get_attribute(
+                    "aria-selected"
+                )
+                result["displayed_after_fix"] = await T._read_displayed_count(page)  # noqa: SLF001
+                await page.screenshot(path=str(out_dir / "404_3_after_fix.png"))
+
+                step("5", "persistence: Escape-close, reopen, re-read", prefix="404")
+                await page.keyboard.press("Escape")
+                await page.wait_for_timeout(400)
+                reopened = await T._open_gen_settings_panel(page)  # noqa: SLF001
+                result["panelReopened"] = reopened
+                result["displayed_after_reopen"] = await T._read_displayed_count(page)  # noqa: SLF001
+                result["topology_after_reopen"] = await page.evaluate(_TABS_TOPOLOGY_JS)
+                await page.screenshot(path=str(out_dir / "404_4_reopened.png"))
+
+            # Cleanup: earlier probe runs flipped the VIDEO count row to x1 on
+            # this project — restore Flow's x2 default so the recon leaves no
+            # sticky state behind.
+            step("6", "cleanup: restore video count row to x2", prefix="404")
+            video_tab = page.locator(
+                "[role='tab']:has(i.google-symbols:text-is('videocam'))"
+            ).first
+            if await video_tab.count() > 0:
+                await video_tab.click()
+                await page.wait_for_timeout(800)
+                x2_tab = page.locator("[role='tab']:text-is('x2')").first
+                if await x2_tab.count() > 0:
+                    await x2_tab.click()
+                    await page.wait_for_timeout(300)
+                    result["videoCountRestored"] = await x2_tab.get_attribute(
+                        "aria-selected"
+                    )
+        finally:
+            client._checkin_page(page)  # noqa: SLF001
+            out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(f"\n[404] json -> {out_path}", flush=True)
+    for key in (
+        "displayed_before",
+        "filtered_set_size",
+        "nth0_before_click",
+        "nth0_click",
+        "nth0_after_click_ariaSelected",
+        "displayed_after_nth0",
+        "fix_target",
+        "fix_after_click_ariaSelected",
+        "displayed_after_fix",
+        "displayed_after_reopen",
+    ):
+        print(f"[404] {key} = {json.dumps(result.get(key), ensure_ascii=False)}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Issue #404: classic composer count-tab recon (0 credits)"
+    )
+    p.add_argument("--profile", default=os.environ.get("GFLOW_CLI_PROFILE", "ffroliva"))
+    p.add_argument(
+        "--project",
+        default=os.environ.get("GFLOW_CLI_PROJECT"),
+        required="GFLOW_CLI_PROJECT" not in os.environ,
+    )
+    p.add_argument("--locale", default=os.environ.get("GFLOW_CLI_LOCALE", "en"))
+    p.add_argument("--out", default=None)
+    args = p.parse_args(argv)
+
+    profile_dir = resolve_profile_dir(args.profile)
+    out_path = (
+        Path(args.out) if args.out else default_out_path("spike_issue404_count_tabs", ".json")
+    )
+    step("--", f"profile={args.profile} project={args.project}", prefix="404")
+    try:
+        return asyncio.run(
+            _run(
+                profile_dir=profile_dir,
+                project_id=args.project,
+                locale=args.locale,
+                out_path=out_path,
+            )
+        )
+    except KeyboardInterrupt:
+        print("[404] aborted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/drivers/agentic.py
+++ b/src/gflow_cli/api/transports/drivers/agentic.py
@@ -109,7 +109,8 @@ _FIND_PANEL_ROOT_JS_PRELUDE = """
     let node = backBtn.parentElement;
     for (let depth = 0; depth < 8 && node; depth++) {
       const hasCountTablist = [...node.querySelectorAll("[role='tab']")].some((t) =>
-        /^(1x|x[2-4])$/.test((t.textContent || '').trim())
+        // Both label cohorts: legacy "1x" and the renamed "x1" (issue #404).
+        /^(1x|x[1-4])$/.test((t.textContent || '').trim())
       );
       if (hasCountTablist) {
         if (depth < bestDepth) { panelRoot = node; backBtnEl = backBtn; bestDepth = depth; }

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -528,13 +528,14 @@ def _count_tabs_locator(page: Page) -> Locator:
     """Return a Playwright Locator that matches ONLY the 4 count tabs.
 
     Filters ``role="tab"`` elements by text matching :data:`_COUNT_TAB_TEXT_RE`
-    (``1x``, ``x2``, ``x3``, ``x4``). This pattern is unique to count tabs —
-    Mode tabs and Aspect tabs never match it — so the filter survives all three
-    Radix tablists being present in the DOM simultaneously.
+    (legacy ``1x``/``x2``/``x3``/``x4`` and renamed ``x1``/``x2``/``x3``/``x4``,
+    issue #404). The pattern is unique to count tabs — Mode tabs and Aspect
+    tabs never match it — so the filter survives all three Radix tablists
+    being present in the DOM simultaneously.
 
-    DOM evidence: ``tmp/dom_dump.json`` captured on profile denon82 (Portuguese
-    locale, 2026-05-22) shows all three tablists rendered; count tabs are the
-    only ones whose ``text`` is ``"1x"`` / ``"x2"`` / ``"x3"`` / ``"x4"``.
+    DOM evidence: ``tmp/dom_dump.json`` (profile denon82, pt-BR, 2026-05-22)
+    for the legacy cohort; ``scripts/dev/spike_issue404_count_tabs_recon.py``
+    output (profile ffroliva, 2026-07-31) for the renamed cohort.
     """
     return page.locator('[role="tab"]').filter(has_text=_COUNT_TAB_TEXT_RE)
 
@@ -1677,8 +1678,8 @@ class UiAutomationTransport(VideoGenerationMixin):
         """Read the currently-displayed image count from the settings panel.
 
         Locale-invariant: filters ``[aria-selected="true"]`` tabs by
-        :data:`_COUNT_TAB_TEXT_RE` so only count tabs ("1x", "x2", "x3",
-        "x4") are considered.  Mode tabs ("image\\nImagem") and Aspect tabs
+        :data:`_COUNT_TAB_TEXT_RE` so only count tabs (both label cohorts,
+        e.g. "1x"/"x1", "x2") are considered.  Mode tabs ("image\\nImagem") and Aspect tabs
         ("16:9", etc.) are selected simultaneously in the Radix tablist DOM
         and would poison the old unfiltered ``[aria-selected="true"]`` query.
 
@@ -1702,7 +1703,8 @@ class UiAutomationTransport(VideoGenerationMixin):
         """True if the generation-settings panel count tabs are currently visible.
 
         Uses :func:`_count_tabs_locator` — the panel is open when at least one
-        count tab (text matching ``1x`` / ``x2`` / ``x3`` / ``x4``) is visible.
+        count tab (text matching either label cohort, e.g. ``1x``/``x1``,
+        ``x2``) is visible.
         This is locale-invariant and immune to Mode/Aspect tab false-positives.
         """
         try:
@@ -2081,8 +2083,8 @@ class UiAutomationTransport(VideoGenerationMixin):
             )
 
             # Success when the click landed AND read-back digit matches, OR
-            # when read-back returned None (unrecognised locale text — position
-            # click was deterministic so trust it).
+            # when read-back returned None (no selected count tab recognised —
+            # the digit-keyed click targeted the right tab, so trust it).
             if clicked and (displayed is None or displayed == count):
                 log.info(
                     _EVT_COUNT_SETTER_COMPLETED,

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -509,11 +509,14 @@ _EVT_COUNT_SETTER_COMPLETED = "ui_automation.count_setter_completed"
 # Extracted to a module-level constant to satisfy SonarCloud S1192.
 _EVT_OVERLAY_DISMISSED = "ui_automation.overlay_dismissed"
 
-# Regex that matches count-tab text exactly: "1x", "x2", "x3", "x4".
+# Regex that matches count-tab text exactly, across BOTH label cohorts:
+# legacy "1x"/"x2"/"x3"/"x4" and the renamed "x1"/"x2"/"x3"/"x4" observed
+# live 2026-07-31 (issue #404 — Flow unified the labels to xN, which made the
+# old `^(1x|x[2-4])$` filter silently drop the count-1 tab).
 # These are the ONLY role="tab" elements whose text fits this pattern —
 # Mode tabs ("image\nImagem") and Aspect tabs ("16:9", "crop_square") do not.
 # The pattern is locale-invariant: Flow never translates the digit+x label.
-_COUNT_TAB_TEXT_RE = re.compile(r"^(1x|x[2-4])$")
+_COUNT_TAB_TEXT_RE = re.compile(r"^(1x|x[1-4])$")
 
 # Subdirectory inside out_dir where diagnostic artefacts are written.
 # Keeps count_before/after screenshots and DOM dumps out of the user-facing
@@ -534,6 +537,16 @@ def _count_tabs_locator(page: Page) -> Locator:
     only ones whose ``text`` is ``"1x"`` / ``"x2"`` / ``"x3"`` / ``"x4"``.
     """
     return page.locator('[role="tab"]').filter(has_text=_COUNT_TAB_TEXT_RE)
+
+
+def _count_tab_locator_for(page: Page, count: int) -> Locator:
+    """Locator for THE count tab carrying digit ``count``.
+
+    Keyed on the digit in the label rather than position, so it survives the
+    label-cohort rename (legacy ``1x`` → current ``x1``, issue #404) and any
+    reordering/shrinking of the filtered tab set.
+    """
+    return page.locator('[role="tab"]').filter(has_text=re.compile(rf"^({count}x|x{count})$"))
 
 
 # Reverse map: domain Aspect enum → CLI string accepted by the settings panel.
@@ -1956,21 +1969,25 @@ class UiAutomationTransport(VideoGenerationMixin):
         out_dir: Path | None = None,
         prompt_idx: int | None = None,
     ) -> None:
-        """Click the count tab by position — locale-invariant, read-back verify with retry.
+        """Click the count tab by its DIGIT — locale-invariant, read-back verify with retry.
 
-        Algorithm (#24 DOM-evidence-driven rewrite):
+        Algorithm (#404 rewrite of the #24 positional pick):
         1. Ensure the settings panel is open without toggling it closed
            (stay-mounted batch: panel may already be open from the prior prompt).
-        2. Read the currently-displayed count via :func:`_count_tabs_locator`
-           filtered by :data:`_COUNT_TAB_TEXT_RE` — immune to Mode/Aspect tabs.
+        2. Read the currently-displayed count via :data:`_COUNT_TAB_TEXT_RE` —
+           immune to Mode/Aspect tabs, matches both label cohorts.
         3. If it already matches ``count``, return early (no click needed).
-        4. Call ``_count_tabs_locator(page).nth(count - 1)`` and click —
-           positional within the filtered set, no text matching.
+        4. Click the tab selected by :func:`_count_tab_locator_for` — keyed on
+           the digit in the label (``1x``/``x1`` for count=1), NOT position:
+           Flow's label rename shrank the old filtered set and shifted every
+           positional pick by one (issue #404).
         5. Read back the digit and confirm the change.
-        6. Retry up to 3 attempts total; raise ``RuntimeError`` on non-convergence.
+        6. Retry up to 3 attempts total; raise :class:`UiSelectorDriftError`
+           (exit 23) on non-convergence — a bare ``RuntimeError`` would be
+           message-hashed by observability into an opaque ``UnexpectedError``.
 
-        When read-back returns ``None`` (unrecognised locale text), the
-        position-based click is trusted — it is deterministic regardless.
+        When read-back returns ``None`` (no selected count tab recognised),
+        the digit-keyed click is trusted — it is deterministic regardless.
 
         Four structlog events are emitted for diagnosability:
         - ``ui_automation.count_setter_entered``
@@ -2028,17 +2045,15 @@ class UiAutomationTransport(VideoGenerationMixin):
                 )
                 return
 
-            # Locate count tabs via text-pattern filter (locale-invariant).
-            # _count_tabs_locator returns role="tab" elements whose text matches
-            # ^(1x|x[2-4])$ — unique to count tabs across all three Radix tablists.
             panel_visible_before = await UiAutomationTransport._is_settings_panel_open(page)
             clicked = False
             click_error: str | None = None
 
-            tabs_locator = _count_tabs_locator(page)
-            # 0-indexed: count=1 → nth(0), count=2 → nth(1), etc.
-            target_tab = tabs_locator.nth(count - 1)
-            selector_desc = f"nth({count - 1}) of _count_tabs_locator"
+            # Digit-keyed pick: the tab whose label carries the desired digit
+            # ("1x"/"x1" for count=1). Position-independent — survives the
+            # label-cohort rename and filtered-set drift (issue #404).
+            target_tab = _count_tab_locator_for(page, count).first
+            selector_desc = f"count-tab label ~ /^({count}x|x{count})$/"
             log.info(
                 "ui_automation.count_click_attempted",
                 target=f"count={count}",
@@ -2060,6 +2075,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                 "ui_automation.count_click_result",
                 target=f"count={count}",
                 success=clicked,
+                effect_observed=displayed == count,
                 current_displayed_count_after=displayed,
                 error=click_error,
             )
@@ -2090,12 +2106,16 @@ class UiAutomationTransport(VideoGenerationMixin):
             success=False,
             attempts=_max_attempts,
         )
-        msg = (
-            f"_set_count({count}) failed to update Flow UI; "
-            f"still showing {displayed!r} after {_max_attempts} attempts"
-        )
-        raise RuntimeError(
-            msg,
+        shot = await _capture_debug_screenshot(page, out_dir, "debug_count_setter_drift.png")
+        raise UiSelectorDriftError(
+            selector_drift_detail(
+                "count_tab",
+                f"count setter failed to converge: desired={count}, "
+                f"displayed={displayed} after {_max_attempts} attempts. "
+                f"Flow's count control may have changed again "
+                f"(labels are matched as {count}x/x{count}).",
+                shot,
+            )
         )
 
     # ------------------------------------------------------------------

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1426,14 +1426,18 @@ class VideoGenerationMixin:
     @staticmethod
     async def _set_output_count(page: Page, n: int) -> None:
         """Set the output count to `n` (1-4). Flow defaults to x2 (two videos =
-        double credits — spec §10.5). Disambiguated by aria-label text
-        ('1x'/'x2'/'x3'/'x4'), NOT id-suffix — '-trigger-4' collides with the
-        DURATION 4s tab. Non-fatal on miss."""
-        label = "1x" if n == 1 else f"x{n}"
+        double credits — spec §10.5). Disambiguated by label text, NOT
+        id-suffix — '-trigger-4' collides with the DURATION 4s tab. The
+        count-1 label exists in two cohorts ('x1' current, '1x' legacy —
+        issue #404 rename); both are probed. Non-fatal on miss."""
+        labels = ("x1", "1x") if n == 1 else (f"x{n}",)
+        selectors = tuple(f"[role='tab']:text-is('{label}')" for label in labels) + tuple(
+            f"[role='tab']:has-text('{label}')" for label in labels
+        )
         tab = await VideoGenerationMixin._probe_selector_cascade(
             page,
             "count_tab",
-            (f"[role='tab']:text-is('{label}')", f"[role='tab']:has-text('{label}')"),
+            selectors,
         )
         if tab is None:
             log.warning(

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2176,8 +2176,9 @@ class TestReadDisplayedCount:
     """_read_displayed_count returns digit from the selected COUNT tab only.
 
     The new implementation filters [aria-selected="true"] by _COUNT_TAB_TEXT_RE
-    (``^(1x|x[2-4])$``) so Mode tabs ("image\\nImagem") and Aspect tabs ("16:9")
-    that are also aria-selected never pollute the result.
+    (``^(1x|x[1-4])$`` — both label cohorts, #404) so Mode tabs
+    ("image\\nImagem") and Aspect tabs ("16:9") that are also aria-selected
+    never pollute the result.
     """
 
     @pytest.mark.asyncio

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -40,7 +40,7 @@ from gflow_cli.api.transports.ui_automation_video import (
     VideoGenerationMixin,
     zip_entity_refs,
 )
-from gflow_cli.errors import ContentPolicyError, WafRejectionError
+from gflow_cli.errors import ContentPolicyError, UiSelectorDriftError, WafRejectionError
 
 # ---------------------------------------------------------------------------
 # Async helpers shared across units
@@ -1874,117 +1874,156 @@ def _make_selected_tab_page(
     return page
 
 
+class _FakeNullLoc:
+    """Matches nothing — selectors the fake doesn't model."""
+
+    @property
+    def first(self) -> _FakeNullLoc:
+        return self
+
+    async def count(self) -> int:
+        return 0
+
+    async def is_visible(self, timeout: int = 500) -> bool:
+        return False
+
+    async def text_content(self, timeout: int = 500) -> None:
+        return None
+
+    async def wait_for(self, *, state: str, timeout: int) -> None:
+        raise TimeoutError("no such element")
+
+    async def click(self, **kw: object) -> None:
+        raise TimeoutError("no such element")
+
+
+class _FakeCountTab:
+    """A single count tab; ``click()`` records its index and — once the
+    configured ``effective_after`` click number is reached — selects it."""
+
+    def __init__(self, page: _FakeCountPanelPage, idx: int) -> None:
+        self._page = page
+        self._idx = idx
+
+    async def is_visible(self, timeout: int = 400) -> bool:
+        return True
+
+    async def wait_for(self, *, state: str, timeout: int) -> None:
+        pass
+
+    async def click(self, **kw: object) -> None:
+        p = self._page
+        p.clicked_indices.append(self._idx)
+        p._clicks_so_far += 1
+        if p._clicks_so_far >= p._effective_after:
+            p._selected_idx = self._idx
+
+
+class _FakeTabSet:
+    """A (possibly filtered) set of count tabs — ``.filter(has_text=…)``
+    really applies the regex to the labels, so a regex that misses a label
+    shrinks the set exactly as on the real page (the #404 failure mode the
+    old MagicMock fixture couldn't represent)."""
+
+    def __init__(self, page: _FakeCountPanelPage, indices: tuple[int, ...]) -> None:
+        self._page = page
+        self._indices = indices
+
+    def filter(self, *, has_text: Any) -> _FakeTabSet:
+        keep = tuple(i for i in self._indices if has_text.search(self._page._labels[i]) is not None)
+        return _FakeTabSet(self._page, keep)
+
+    async def count(self) -> int:
+        return len(self._indices)
+
+    @property
+    def first(self) -> _FakeCountTab | _FakeNullLoc:
+        return self.nth(0)
+
+    def nth(self, i: int) -> _FakeCountTab | _FakeNullLoc:
+        if 0 <= i < len(self._indices):
+            return _FakeCountTab(self._page, self._indices[i])
+        return _FakeNullLoc()
+
+
+class _FakeSelectedSet:
+    """``[role="tab"][aria-selected="true"]`` — the selected count tab,
+    filterable by label like the real locator."""
+
+    def __init__(self, page: _FakeCountPanelPage, matched: bool = False) -> None:
+        self._page = page
+        self._matched = matched
+
+    def filter(self, *, has_text: Any) -> _FakeSelectedSet:
+        idx = self._page._selected_idx
+        matched = idx is not None and has_text.search(self._page._labels[idx]) is not None
+        return _FakeSelectedSet(self._page, matched)
+
+    async def count(self) -> int:
+        return 1 if self._matched else 0
+
+    @property
+    def first(self) -> _FakeSelectedSet:
+        return self
+
+    async def text_content(self, timeout: int = 500) -> str | None:
+        idx = self._page._selected_idx
+        return self._page._labels[idx] if idx is not None else None
+
+
+class _FakeCountPanelPage:
+    """Label-driven fake of the settings panel's count-tab DOM.
+
+    Models BOTH label cohorts faithfully: legacy ``("1x", "x2", "x3", "x4")``
+    and the renamed ``("x1", "x2", "x3", "x4")`` observed live 2026-07-31
+    (issue #404). ``effective_after`` sets the click number from which clicks
+    actually change the selection (a huge value models the drifted UI where
+    clicks land but never take effect).
+    """
+
+    def __init__(
+        self,
+        *,
+        labels: tuple[str, ...] = ("1x", "x2", "x3", "x4"),
+        selected_idx: int | None = 0,
+        effective_after: int = 1,
+    ) -> None:
+        self._labels = labels
+        self._selected_idx = selected_idx
+        self._effective_after = effective_after
+        self._clicks_so_far = 0
+        self.clicked_indices: list[int] = []
+        self.keyboard = MagicMock()
+        self.keyboard.press = AsyncMock()
+
+    def locator(self, selector: str) -> Any:
+        if 'aria-selected="true"' in selector:
+            return _FakeSelectedSet(self)
+        if '[role="tab"]' in selector:
+            return _FakeTabSet(self, tuple(range(len(self._labels))))
+        return _FakeNullLoc()
+
+    async def wait_for_timeout(self, _ms: int) -> None:
+        pass
+
+    async def screenshot(self, *, path: str, full_page: bool = False) -> None:
+        Path(path).write_bytes(b"\x89PNG fake")
+
+    async def evaluate(self, *_a: object, **_k: object) -> dict[str, Any]:
+        return {}
+
+
 def _make_tablist_page(
     *,
-    tab_count: int = 4,
-    selected_idx: int = 0,
-    selected_text: str = "1x",
-    readback_after_click: str | None = None,
-) -> tuple[MagicMock, list[int]]:
-    """Build a fake page modelling the new ``_count_tabs_locator`` / ``_read_displayed_count``.
-
-    The new implementation calls:
-    - ``page.locator('[role="tab"]').filter(has_text=RE).nth(i)`` for click
-    - ``page.locator('[role="tab"][aria-selected="true"]').filter(has_text=RE)``
-      for read-back
-
-    Returns ``(page, clicked_indices)`` where ``clicked_indices`` accumulates
-    the nth-index of every ``click()`` call.
-
-    ``selected_text`` defaults to ``"1x"`` (the count-1 tab label). After any
-    click, ``readback_after_click`` is returned by the read-back filter.
-    """
-    page = MagicMock()
-    page.wait_for_timeout = AsyncMock()
-    page.keyboard = MagicMock()
-    page.keyboard.press = AsyncMock()
-
-    clicked_indices: list[int] = []
-    click_count_store: list[int] = [0]
-
-    # Build per-tab mocks (0-indexed).
-    tab_mocks: list[MagicMock] = []
-    for i in range(tab_count):
-        t = MagicMock()
-        t.is_visible = AsyncMock(return_value=True)
-        t.wait_for = AsyncMock()
-        tab_idx = i  # capture
-
-        async def _click_tab(idx: int = tab_idx, **kw: object) -> None:
-            clicked_indices.append(idx)
-            click_count_store[0] += 1
-
-        t.click = AsyncMock(side_effect=_click_tab)
-        tab_mocks.append(t)
-
-    def _make_count_tabs_filtered_loc() -> MagicMock:
-        """Filtered locator for _count_tabs_locator: all 4 count tabs."""
-        filtered = MagicMock()
-        filtered.first = tab_mocks[0]
-
-        def _nth(i: int) -> MagicMock:
-            return tab_mocks[i] if 0 <= i < tab_count else MagicMock()
-
-        filtered.nth = MagicMock(side_effect=_nth)
-        return filtered
-
-    def _make_selected_filtered_loc() -> MagicMock:
-        """Filtered locator for _read_displayed_count: aria-selected + RE filter."""
-        filtered = MagicMock()
-
-        async def _count_selected() -> int:
-            # selected_text matches RE → count=1; else count=0.
-            has_clicked = readback_after_click is not None and click_count_store[0] > 0
-            text = readback_after_click if has_clicked else selected_text
-            return 1 if (text and _COUNT_TAB_TEXT_RE.match(text.strip())) else 0
-
-        filtered.count = AsyncMock(side_effect=_count_selected)
-
-        first_loc = MagicMock()
-
-        async def _text(timeout: int = 500) -> str | None:
-            if readback_after_click is not None and click_count_store[0] > 0:
-                return readback_after_click
-            return selected_text
-
-        first_loc.text_content = AsyncMock(side_effect=_text)
-        filtered.first = first_loc
-        return filtered
-
-    def _locator(sel: str) -> MagicMock:
-        wrapper = MagicMock()
-
-        if '[role="tab"]' in sel and "aria-selected" not in sel:
-            # _count_tabs_locator: page.locator('[role="tab"]').filter(has_text=RE)
-            outer = MagicMock()
-            outer.filter = MagicMock(return_value=_make_count_tabs_filtered_loc())
-            # Also wire first/is_visible for _is_settings_panel_open
-            outer.first = tab_mocks[0]
-            return outer
-
-        if 'aria-selected="true"' in sel:
-            # _read_displayed_count: page.locator('[role="tab"][aria-selected="true"]').filter(...)
-            outer = MagicMock()
-            outer.filter = MagicMock(return_value=_make_selected_filtered_loc())
-            outer.first = tab_mocks[selected_idx]
-            return outer
-
-        if "button[aria-selected]" in sel:
-            loc = MagicMock()
-            wrapper.first = loc
-            loc.is_visible = AsyncMock(return_value=True)
-            return wrapper
-
-        # Default — invisible/unmatched.
-        loc = MagicMock()
-        wrapper.first = loc
-        loc.is_visible = AsyncMock(return_value=False)
-        loc.count = AsyncMock(return_value=0)
-        return wrapper
-
-    page.locator = MagicMock(side_effect=_locator)
-    page._clicked_indices = clicked_indices  # type: ignore[attr-defined]
-    return page, clicked_indices
+    labels: tuple[str, ...] = ("1x", "x2", "x3", "x4"),
+    selected_idx: int | None = 0,
+    effective_after: int = 1,
+) -> tuple[_FakeCountPanelPage, list[int]]:
+    """Build the label-driven fake page; returns ``(page, clicked_indices)``."""
+    page = _FakeCountPanelPage(
+        labels=labels, selected_idx=selected_idx, effective_after=effective_after
+    )
+    return page, page.clicked_indices
 
 
 # ---------------------------------------------------------------------------
@@ -2038,13 +2077,18 @@ class TestExtractCountDigit:
 
 
 class TestCountTabTextRe:
-    """_COUNT_TAB_TEXT_RE must match exactly 1x/x2/x3/x4 and nothing else."""
+    """_COUNT_TAB_TEXT_RE must match both count-label cohorts and nothing else.
+
+    Legacy cohort: 1x/x2/x3/x4. Renamed cohort (live 2026-07-31, issue #404):
+    x1/x2/x3/x4 — Flow unified the labels to xN.
+    """
 
     @pytest.mark.parametrize(
         ("text", "should_match"),
         [
-            # Count tab labels (must match)
+            # Count tab labels (must match) — both cohorts
             ("1x", True),
+            ("x1", True),  # renamed count-1 label (issue #404)
             ("x2", True),
             ("x3", True),
             ("x4", True),
@@ -2058,11 +2102,12 @@ class TestCountTabTextRe:
             ("3:4", False),
             ("crop_16_9", False),
             ("", False),
-            # Locale-variant forms that used to work in the old impl (now filtered out)
-            ("x1", False),  # x1 is NOT a Flow count tab — Flow uses 1x for count=1
+            # Locale-variant forms that used to work in the old impl (still filtered out)
             ("1 image", False),
             ("1 imagem", False),
             ("2 imagens", False),
+            ("x5", False),
+            ("5x", False),
         ],
     )
     def test_pattern(self, text: str, should_match: bool) -> None:
@@ -2192,128 +2237,126 @@ class TestReadDisplayedCount:
         assert result is None
 
 
-class TestSetCountRetry:
-    """_set_count uses position-based click with digit read-back; raises after 3 failed attempts.
+_LEGACY_COHORT = ("1x", "x2", "x3", "x4")
+# Renamed labels observed live 2026-07-31 on the classic composer (issue #404).
+_NEW_COHORT = ("x1", "x2", "x3", "x4")
 
-    The new implementation uses _count_tabs_locator (text-pattern filtered) for
-    nth() click, so selected_text / readback_after_click use RE-matching labels
-    ("1x", "x2", "x3", "x4") to model the real DOM.
+_NEVER_EFFECTIVE = 10**9  # clicks land but never change the selection
+
+
+def _panel_open() -> Any:
+    return patch.object(
+        UiAutomationTransport,
+        "_is_settings_panel_open",
+        new=AsyncMock(return_value=True),
+    )
+
+
+class TestSetCountRetry:
+    """_set_count picks the count tab by its DIGIT (label text), verifies via
+    read-back, and raises UiSelectorDriftError after 3 failed attempts.
+
+    Flow renamed the count-1 label from "1x" to "x1" (issue #404); the fake
+    models both cohorts and really applies locator filters to the labels.
     """
+
+    @pytest.mark.parametrize("label", ["1x", "x1", "x2", "x3", "x4"])
+    def test_count_tab_regex_accepts_both_cohorts(self, label: str) -> None:
+        assert _COUNT_TAB_TEXT_RE.match(label) is not None
+
+    @pytest.mark.parametrize("label", ["x5", "5x", "1", "x", "1x1", ""])
+    def test_count_tab_regex_rejects_non_count_labels(self, label: str) -> None:
+        assert _COUNT_TAB_TEXT_RE.match(label) is None
 
     @pytest.mark.asyncio
     async def test_returns_early_when_count_already_matches(self) -> None:
         """If the displayed count already matches desired, no tab click is made."""
-        # Panel open, selected count tab shows "x2" → count=2 already, no click.
-        page, clicked = _make_tablist_page(selected_text="x2")
-        with patch.object(
-            UiAutomationTransport,
-            "_is_settings_panel_open",
-            new=AsyncMock(return_value=True),
-        ):
-            await UiAutomationTransport._set_count(page, 2)  # type: ignore[attr-defined]
+        page, clicked = _make_tablist_page(labels=_LEGACY_COHORT, selected_idx=1)
+        with _panel_open():
+            await UiAutomationTransport._set_count(page, 2)  # type: ignore[arg-type]
         assert clicked == []
 
     @pytest.mark.asyncio
-    async def test_position_click_nth_index(self) -> None:
-        """_set_count(3) must call nth(2).click() — 0-indexed position."""
-        # Readback returns "x3" after click so the method completes normally.
-        page, clicked = _make_tablist_page(selected_text="1x", readback_after_click="x3")
-        with (
-            patch.object(
-                UiAutomationTransport,
-                "_is_settings_panel_open",
-                new=AsyncMock(return_value=True),
-            ),
-            patch.object(
-                UiAutomationTransport,
-                "_read_displayed_count",
-                new=AsyncMock(side_effect=[1, 3]),  # before=1, after=3
-            ),
-        ):
-            await UiAutomationTransport._set_count(page, 3)  # type: ignore[attr-defined]
-        # nth(2) was clicked (count=3 → index 2).
-        assert 2 in clicked
+    @pytest.mark.parametrize("labels", [_LEGACY_COHORT, _NEW_COHORT])
+    async def test_count_one_clicks_the_digit_one_tab(self, labels: tuple[str, ...]) -> None:
+        """#404 regression: -n 1 must click the count-1 tab in BOTH label
+        cohorts. On the renamed cohort the old positional pick clicked the
+        already-selected x2 tab and looped to failure."""
+        page, clicked = _make_tablist_page(labels=labels, selected_idx=1)  # showing 2
+        with _panel_open():
+            await UiAutomationTransport._set_count(page, 1)  # type: ignore[arg-type]
+        assert clicked == [0]
 
     @pytest.mark.asyncio
-    async def test_succeeds_when_readback_returns_none(self) -> None:
-        """When read-back is None (unrecognised locale text), position click is trusted."""
-        page, clicked = _make_tablist_page(selected_text="imageImagem", readback_after_click=None)
-        with (
-            patch.object(
-                UiAutomationTransport,
-                "_is_settings_panel_open",
-                new=AsyncMock(return_value=True),
-            ),
-            patch.object(
-                UiAutomationTransport,
-                "_read_displayed_count",
-                # before: None (filtered out by RE); after click: None (still filtered)
-                new=AsyncMock(return_value=None),
-            ),
-        ):
-            # Should NOT raise — deterministic position click is trusted when readback=None.
-            await UiAutomationTransport._set_count(page, 1)  # type: ignore[attr-defined]
-        assert 0 in clicked  # nth(0) was clicked for count=1
+    async def test_count_three_clicks_the_digit_three_tab(self) -> None:
+        page, clicked = _make_tablist_page(labels=_NEW_COHORT, selected_idx=1)
+        with _panel_open():
+            await UiAutomationTransport._set_count(page, 3)  # type: ignore[arg-type]
+        assert clicked == [2]
 
     @pytest.mark.asyncio
-    async def test_clicks_tab_and_succeeds_on_first_attempt(self) -> None:
-        """Happy path: displayed=None (unrecognised), click succeeds, read-back matches."""
-        page, clicked = _make_tablist_page(selected_text="1x", readback_after_click="1x")
-        with (
-            patch.object(
-                UiAutomationTransport,
-                "_is_settings_panel_open",
-                new=AsyncMock(return_value=True),
-            ),
-            patch.object(
-                UiAutomationTransport,
-                "_read_displayed_count",
-                new=AsyncMock(side_effect=[None, 1]),  # before=None, after=1
-            ),
-        ):
-            await UiAutomationTransport._set_count(page, 1)  # type: ignore[attr-defined]
-        assert 0 in clicked  # nth(0) for count=1
+    async def test_read_displayed_count_sees_selected_x1(self) -> None:
+        """#404: a selected renamed "x1" tab must read back as count 1."""
+        page, _ = _make_tablist_page(labels=_NEW_COHORT, selected_idx=0)
+        assert await UiAutomationTransport._read_displayed_count(page) == 1  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
-    async def test_raises_after_three_failed_attempts(self) -> None:
-        """If read-back never converges after 3 attempts, RuntimeError is raised."""
-        page, clicked = _make_tablist_page(selected_text="x2", readback_after_click="x2")
-        with (
-            patch.object(
-                UiAutomationTransport,
-                "_is_settings_panel_open",
-                new=AsyncMock(return_value=True),
-            ),
-            patch.object(
-                UiAutomationTransport,
-                "_read_displayed_count",
-                # Always returns 2 — mismatch when we want 1.
-                new=AsyncMock(return_value=2),
-            ),
-            pytest.raises(RuntimeError, match="_set_count\\(1\\) failed to update Flow UI"),
-        ):
-            await UiAutomationTransport._set_count(page, 1)  # type: ignore[attr-defined]
+    async def test_trusts_click_when_no_count_tab_selected(self) -> None:
+        """Read-back None (no aria-selected count tab) → the digit-keyed click
+        is trusted rather than retried to exhaustion."""
+        page, clicked = _make_tablist_page(
+            labels=_NEW_COHORT, selected_idx=None, effective_after=_NEVER_EFFECTIVE
+        )
+        with _panel_open():
+            await UiAutomationTransport._set_count(page, 1)  # type: ignore[arg-type]
+        assert clicked == [0]
 
     @pytest.mark.asyncio
-    async def test_retry_succeeds_on_second_attempt(self) -> None:
-        """If read-back returns wrong value on attempt 1, then correct on attempt 2,
-        _set_count succeeds without raising."""
-        page, clicked = _make_tablist_page(selected_text="x2", readback_after_click="1x")
-        with (
-            patch.object(
-                UiAutomationTransport,
-                "_is_settings_panel_open",
-                new=AsyncMock(return_value=True),
-            ),
-            patch.object(
-                UiAutomationTransport,
-                "_read_displayed_count",
-                # Sequence: initial=2, after-click-1=2 (mismatch), after-click-2=1 (match).
-                new=AsyncMock(side_effect=[2, 2, 1]),
-            ),
-        ):
-            await UiAutomationTransport._set_count(page, 1)  # type: ignore[attr-defined]
-        assert len(clicked) >= 1
+    async def test_retry_succeeds_when_click_takes_effect_on_second_attempt(self) -> None:
+        page, clicked = _make_tablist_page(labels=_NEW_COHORT, selected_idx=1, effective_after=2)
+        with _panel_open():
+            await UiAutomationTransport._set_count(page, 1)  # type: ignore[arg-type]
+        assert clicked == [0, 0]
+
+    @pytest.mark.asyncio
+    async def test_raises_selector_drift_after_three_failed_attempts(self) -> None:
+        """Non-convergence must raise the typed UiSelectorDriftError (exit 23)
+        naming desired vs displayed — not a bare RuntimeError whose message is
+        hashed by observability into an opaque UnexpectedError (#404)."""
+        page, clicked = _make_tablist_page(
+            labels=_NEW_COHORT, selected_idx=1, effective_after=_NEVER_EFFECTIVE
+        )
+        with _panel_open(), pytest.raises(UiSelectorDriftError) as exc_info:
+            await UiAutomationTransport._set_count(page, 1)  # type: ignore[arg-type]
+        msg = str(exc_info.value)
+        assert "desired=1" in msg
+        assert "displayed=2" in msg
+        assert "Screenshot:" not in msg  # no out_dir -> no screenshot clause
+        assert clicked == [0, 0, 0]
+
+    @pytest.mark.asyncio
+    async def test_drift_error_includes_screenshot_when_out_dir(self, tmp_path: Path) -> None:
+        page, _ = _make_tablist_page(
+            labels=_NEW_COHORT, selected_idx=1, effective_after=_NEVER_EFFECTIVE
+        )
+        with _panel_open(), pytest.raises(UiSelectorDriftError) as exc_info:
+            await UiAutomationTransport._set_count(page, 1, out_dir=tmp_path)  # type: ignore[arg-type]
+        assert "Screenshot:" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_count_click_result_logs_effect_observed(self) -> None:
+        """The per-click log must expose whether the click changed the value —
+        'success: true' with no visible effect was the misleading shape in #404."""
+        from structlog.testing import capture_logs
+
+        page, _ = _make_tablist_page(
+            labels=_NEW_COHORT, selected_idx=1, effective_after=_NEVER_EFFECTIVE
+        )
+        with _panel_open(), capture_logs() as logs, pytest.raises(UiSelectorDriftError):
+            await UiAutomationTransport._set_count(page, 1)  # type: ignore[arg-type]
+        click_results = [e for e in logs if e["event"] == "ui_automation.count_click_result"]
+        assert click_results, "expected count_click_result events"
+        assert all(e["effect_observed"] is False for e in click_results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/transports/test_ui_automation_batch.py
+++ b/tests/api/transports/test_ui_automation_batch.py
@@ -14,6 +14,7 @@ invariants tested:
 
 from __future__ import annotations
 
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -958,8 +959,18 @@ class _LocatorRecorder:
     so ``_read_displayed_count`` returns the new digit on the next read-back.
     """
 
-    def __init__(self, tab_count: int = 4, initial_selected: int = 0) -> None:
+    def __init__(
+        self,
+        tab_count: int = 4,
+        initial_selected: int = 0,
+        labels: tuple[str, ...] | None = None,
+    ) -> None:
         self._tab_count = tab_count
+        # Default to the legacy label cohort; pass ("x1", "x2", "x3", "x4")
+        # to model the renamed cohort observed live 2026-07-31 (issue #404).
+        self._labels: tuple[str, ...] = labels or tuple(
+            "1x" if i == 0 else f"x{i + 1}" for i in range(tab_count)
+        )
         self._selected_idx: int = initial_selected
         # clicked_indices: records the nth-index of every click, in call order.
         self.clicked_indices: list[int] = []
@@ -988,28 +999,34 @@ class _LocatorRecorder:
     class _TabListLoc:
         """Represents ``page.locator('[role="tab"]')`` — supports ``.filter()`` for count tabs.
 
-        The new _count_tabs_locator calls:
-          page.locator('[role="tab"]').filter(has_text=_COUNT_TAB_TEXT_RE)
-
-        filter() returns self (the recorder already models only count tabs).
+        ``filter(has_text=RE)`` really applies the regex to the tab labels
+        (issue #404: a filter-blind fake hid the renamed-label failure mode),
+        returning a set over the matching ORIGINAL indices.
         """
 
-        def __init__(self, recorder: _LocatorRecorder) -> None:
+        def __init__(
+            self, recorder: _LocatorRecorder, indices: tuple[int, ...] | None = None
+        ) -> None:
             self._recorder = recorder
+            self._indices: tuple[int, ...] = (
+                indices if indices is not None else tuple(range(recorder._tab_count))
+            )
 
-        def filter(self, **kwargs: object) -> _LocatorRecorder._TabListLoc:
-            """Return self — recorder already models only count tabs."""
-            return self
+        def filter(self, *, has_text: re.Pattern[str]) -> _LocatorRecorder._TabListLoc:
+            keep = tuple(i for i in self._indices if has_text.search(self._recorder._labels[i]))
+            return _LocatorRecorder._TabListLoc(self._recorder, keep)
 
         async def count(self) -> int:
-            return self._recorder._tab_count
+            return len(self._indices)
 
         @property
-        def first(self) -> _LocatorRecorder._TabLoc:
-            return _LocatorRecorder._TabLoc(0, self._recorder)
+        def first(self) -> _LocatorRecorder._TabLoc | _LocatorRecorder._NullLoc:
+            return self.nth(0)
 
-        def nth(self, i: int) -> _LocatorRecorder._TabLoc:
-            return _LocatorRecorder._TabLoc(i, self._recorder)
+        def nth(self, i: int) -> _LocatorRecorder._TabLoc | _LocatorRecorder._NullLoc:
+            if 0 <= i < len(self._indices):
+                return _LocatorRecorder._TabLoc(self._indices[i], self._recorder)
+            return _LocatorRecorder._NullLoc()
 
     class _TabLoc:
         """Represents a single count tab at position ``idx``."""
@@ -1038,28 +1055,30 @@ class _LocatorRecorder:
         first.text_content() returns the count-tab label for the selected tab.
         """
 
-        def __init__(self, recorder: _LocatorRecorder) -> None:
+        def __init__(self, recorder: _LocatorRecorder, matched: bool = True) -> None:
             self._recorder = recorder
+            self._matched = matched
 
-        def filter(self, **kwargs: object) -> _LocatorRecorder._SelectedLoc:
-            """Return self — recorder already models the selected count tab."""
-            return self
+        def filter(self, *, has_text: re.Pattern[str]) -> _LocatorRecorder._SelectedLoc:
+            """Honor the regex against the selected tab's label (issue #404)."""
+            label = self._recorder._labels[self._recorder._selected_idx]
+            return _LocatorRecorder._SelectedLoc(
+                self._recorder, matched=has_text.search(label) is not None
+            )
 
         async def count(self) -> int:
-            return 1  # always exactly one count tab selected
+            return 1 if self._matched else 0
 
         @property
         def first(self) -> _LocatorRecorder._SelectedLoc:
             return self
 
         async def is_visible(self, timeout: int = 500) -> bool:
-            return True
+            return self._matched
 
         async def text_content(self, timeout: int = 500) -> str:
-            # Return the count-tab label for the currently-selected tab (1-indexed).
-            # Flow uses "1x" for count=1, "x2" for count=2, etc.
-            idx = self._recorder._selected_idx
-            return "1x" if idx == 0 else f"x{idx + 1}"
+            # The label of the currently-selected count tab.
+            return self._recorder._labels[self._recorder._selected_idx]
 
     class _NullLoc:
         """Matches nothing — used for selectors the recorder doesn't handle."""
@@ -1111,13 +1130,10 @@ async def test_set_count_clicks_x1_for_count_1() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_count_position_based_no_text_matching() -> None:
-    """Position-based click: count=3 maps to nth(2) regardless of label text.
-
-    This replaces the old test_set_count_fallback_label_nx_used_when_xn_absent.
-    The new implementation never matches on label text — it uses nth() position
-    exclusively, so locale or label-format differences are irrelevant.
-    """
+async def test_set_count_digit_keyed_click_count_3() -> None:
+    """Digit-keyed click: count=3 clicks the tab labelled "x3" (original
+    index 2) — selection is keyed on the digit in the label, so it survives
+    the #404 label rename and any positional drift of the filtered set."""
     page = _LocatorRecorder(tab_count=4, initial_selected=0)  # current=1, want=3
     with patch.object(
         UiAutomationTransport, "_open_gen_settings_panel", new=AsyncMock(return_value=True)

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -313,6 +313,15 @@ class TestSetOutputCountOne:
         page.locator.assert_any_call(sel)
 
     @pytest.mark.asyncio
+    async def test_clicks_the_renamed_x1_tab(self) -> None:
+        """#404: Flow renamed the count-1 label from '1x' to 'x1' — the setter
+        must probe BOTH label cohorts before declaring a miss."""
+        sel = "[role='tab']:text-is('x1')"
+        page = _cascade_page({sel})
+        await VideoGenerationMixin._set_output_count_one(page)
+        page.locator.assert_any_call(sel)
+
+    @pytest.mark.asyncio
     async def test_missing_count_tab_is_non_fatal(self) -> None:
         page = _cascade_page(set())
         await VideoGenerationMixin._set_output_count_one(page)  # must not raise

--- a/tests/e2e/test_agentic_count_enforcement_e2e.py
+++ b/tests/e2e/test_agentic_count_enforcement_e2e.py
@@ -24,6 +24,10 @@ import structlog
 from gflow_cli.api import routes
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+from gflow_cli.api.transports.ui_automation_video import (
+    COMPOSER_AGENT_TOGGLE_SELECTOR,
+    VideoGenerationMixin,
+)
 
 pytestmark = [pytest.mark.e2e, pytest.mark.e2e_image]
 
@@ -60,6 +64,18 @@ async def _set_mismatched_sticky_count(
         )
         await page.wait_for_timeout(4_000)
         await page.keyboard.press("Escape")
+
+        # Flow's current cohort loads the editor in CLASSIC mode (media panel
+        # present) — the tune icon only exists on the Agent composer, so
+        # toggle into Agent mode first (same pill the #313 spike used).
+        if await VideoGenerationMixin._media_panel_present(page):  # noqa: SLF001
+            pill = page.locator(COMPOSER_AGENT_TOGGLE_SELECTOR).first
+            assert await pill.count() > 0, (
+                "editor loaded in classic mode but the Agent toggle pill was "
+                "not found — Agent composer unreachable"
+            )
+            await pill.click(force=True, timeout=5_000)
+            await page.wait_for_timeout(1_500)
 
         tune_btn = page.locator(_TUNE_BUTTON_SELECTOR).first
         await tune_btn.wait_for(state="visible", timeout=10_000)

--- a/tests/e2e/test_agentic_count_enforcement_e2e.py
+++ b/tests/e2e/test_agentic_count_enforcement_e2e.py
@@ -66,12 +66,21 @@ async def _set_mismatched_sticky_count(
         await tune_btn.click(timeout=5_000)
         await page.wait_for_timeout(1_000)
 
-        label = {1: "1x", 2: "x2", 3: "x3", 4: "x4"}[wrong_count]
+        # Anchor on x2+x3 (present in BOTH label cohorts — Flow renamed the
+        # count-1 label from '1x' to 'x1', issue #404); for count=1 try the
+        # renamed label first, then the legacy one.
+        labels = ("x1", "1x") if wrong_count == 1 else (f"x{wrong_count}",)
         count_tablist = page.locator(
-            "[role='tablist']:has(button:text-is('1x')):has(button:text-is('x2'))"
+            "[role='tablist']:has(button:text-is('x2')):has(button:text-is('x3'))"
         ).first
-        target_btn = count_tablist.locator(f"button:text-is('{label}')").first
-        await target_btn.click(timeout=5_000)
+        clicked = False
+        for label in labels:
+            target_btn = count_tablist.locator(f"button:text-is('{label}')").first
+            if await target_btn.count() > 0:
+                await target_btn.click(timeout=5_000)
+                clicked = True
+                break
+        assert clicked, f"no count tab found for {wrong_count} (tried {labels})"
         await page.wait_for_timeout(300)
 
         # Structurally locate + click Save (locale-invariant — see
@@ -91,7 +100,7 @@ async def _set_mismatched_sticky_count(
                   const texts = [...t.querySelectorAll('button')].map(
                     (b) => (b.textContent || '').trim()
                   );
-                  return texts.includes('1x') && texts.includes('x2');
+                  return texts.includes('x2') && texts.includes('x3');
                 });
                 if (hasCountTablist) {
                   const visible = [...node.querySelectorAll('button')].filter((b) => {

--- a/tests/e2e/test_classic_count_setter_e2e.py
+++ b/tests/e2e/test_classic_count_setter_e2e.py
@@ -1,0 +1,89 @@
+"""Live e2e regression test for issue #404: Flow renamed the classic
+composer's count-tab labels from ``1x``/``x2``/… to ``x1``/``x2``/…, which
+broke ``_set_count``'s label filter — ``-n 1`` (the CLI default) clicked the
+wrong tab, logged per-click success, and the run died with an opaque
+``UnexpectedError`` before any generation was submitted.
+
+Spends Imagen quota (0 Flow credits — only video costs credits). Skipped by
+default; opt in with ``GFLOW_CLI_E2E_PROFILE=<profile>`` and ``-m e2e_image``.
+
+The test mirrors the reporter's invocation: classic UI mode, real t2i path,
+then asserts exactly the requested count comes back. A fresh project starts
+at Flow's default of 2 displayed images, so ``count=1`` reproduces the
+requested != displayed precondition of #404 (the renamed ``x1`` tab must be
+found and clicked); ``count=2`` covers the already-matching early-exit.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import structlog
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_image]
+
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 2])
+async def test_classic_t2i_generates_exactly_the_requested_count(
+    count: int,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """LIVE (#404): classic-mode t2i with ``-n <count>`` must generate exactly
+    ``count`` images. count=1 is the regression case — Flow displays 2 by
+    default, so the count setter must locate and click the renamed x1 tab."""
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(tmp_path / f"e2e_404_{count}.db"))
+    # The reporter's invocation ran --ui-mode classic; force it deterministically
+    # regardless of the server-side A/B cohort flap.
+    monkeypatch.setenv("GFLOW_CLI_UI_MODE", "classic")
+    reset_settings()
+
+    name = os.environ.get(_E2E_PROFILE_ENV, "").strip()
+    if not name:
+        pytest.skip(f"set {_E2E_PROFILE_ENV} to a logged-in profile, run with -m e2e_image")
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+
+    profile = _resolve_profile_dir(name)
+    if not profile.exists():
+        pytest.skip(f"profile not found: {profile} — run `gflow auth login --profile {name}`")
+
+    # Mirror the reporter's environment: 9:16 aspect, nano2 (NARWHAL) model.
+    req = GenerateImageRequest(
+        prompt=f"a small ceramic bowl on a wooden table, e2e variant count-{count}",
+        aspect=Aspect.PORTRAIT,
+        model=Model.NARWHAL,
+    )
+
+    async with FlowApiClient(profile_dir=profile, out_dir=tmp_path) as client:
+        project = await client.create_project(title=f"gflow-cli e2e 404 count-{count}")
+        images = await client.generate_images_batch(
+            project_id=project.project_id, req=req, count=count
+        )
+
+    assert len(images) == count, (
+        f"requested {count} images but got {len(images)} back — the classic "
+        f"count setter failed to converge on the live composer (#404)"
+    )
+
+    completed = [
+        e
+        for e in install_log_capture.entries
+        if e.get("event") == "ui_automation.count_setter_completed"
+    ]
+    assert completed, "expected the classic count setter to run and log completion"
+    final = completed[-1]
+    assert final.get("success") is True, (
+        f"count setter did not converge on the live composer: {final}"
+    )

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -118,7 +118,8 @@ my-profile profile (aborted pre-submit, saving the 10-credit generation).
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
 renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
-(9:16/16:9), count (1x–x4), and the model dropdown (Veo 3.1 - Lite), and
+(9:16/16:9), count (1x–x4; labels renamed to xN since — see #404), and the
+model dropdown (Veo 3.1 - Lite), and
 nothing else. The earlier locale hypothesis is refuted: the UI renders in
 Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
 no duration row to click. Whether Flow removed clip-length selection for this

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -629,10 +629,14 @@ issue and not blocked by any code change in this repo.
   locale-leak fix.
 
 **Earlier — Phase 7 multi-image-prompt work** addressed the count-tab selectors:
-- `_COUNT_TAB_TEXT_RE = ^(1x|x[2-4])$` only matches the digit+x format Flow
+- `_COUNT_TAB_TEXT_RE = ^(1x|x[1-4])$` only matches the digit+x format Flow
   renders identically in every locale (numbers/symbols are not translated).
-- `_set_count` falls back to positional `.nth(count - 1)` when the read-back
-  text is unrecognised — locale-invariant.
+  Widened for #404: Flow renamed the count-1 label from `1x` to `x1`
+  (uniform `xN`, live-verified 2026-07-31); both cohorts are accepted.
+- `_set_count` clicks the tab carrying the desired DIGIT (`1x`/`x1` for
+  count=1), not a position — the #404 rename shrank the old filtered set and
+  shifted every `.nth(count - 1)` pick by one. Non-convergence raises
+  `UiSelectorDriftError` (exit 23) with desired vs displayed counts.
 
 **Earlier — PR #48:**
 - Added `--lang=en-US` Chromium launch arg; parts of `NEW_PROJECT_SELECTORS` /


### PR DESCRIPTION
## Summary

Closes #404.

Flow renamed the composer's count-tab labels from `1x`/`x2`/`x3`/`x4` to `x1`/`x2`/`x3`/`x4` (uniform `xN`, live-verified 2026-07-31 in both the image and video rows of the classic settings popover). That single rename broke `_set_count` twice over:

- `_COUNT_TAB_TEXT_RE = ^(1x|x[2-4])$` no longer matched the count-1 tab, so the filtered set shrank to `[x2, x3, x4]` and the positional `nth(count - 1)` pick shifted by one: `-n 1` (the CLI default) clicked the already-selected `x2` tab (silent no-op, or actively set 2 when the panel showed 1), `-n 2` only worked via the already-matching early-exit, `-n 3` would set 4, `-n 4` would time out.
- `_read_displayed_count` used the same regex, so a selected `x1` read back as `None`.
- On exhaustion the setter raised a bare `RuntimeError`, which `observability.py` message-hashes — the reporter saw only `UnexpectedError` exit 1 and needed an incident-bundle dig (`_set_count` was the last hard-failing settings setter not migrated to the PR #184 typed-error contract).

## Fix

- Widen `_COUNT_TAB_TEXT_RE` to both label cohorts: `^(1x|x[1-4])$`.
- Select the count tab by the **digit in its label** (`_count_tab_locator_for`, matches `{n}x|x{n}`), not by position — correct in both cohorts and immune to the filtered set shrinking or reordering again. On the legacy DOM the digit-keyed pick selects the same tab the positional pick did, so the still-working cohort cannot regress.
- Raise `UiSelectorDriftError` (exit 23) with `desired=… displayed=…` on non-convergence, plus a debug screenshot when `out_dir` is set.
- Add `effect_observed` to the `count_click_result` log so an ineffective click is no longer reported as bare `success: true`.
- Probe both cohorts in the video output-count setter (`x1` first, then legacy `1x`) and in the agentic panel-root finder JS.
- Make the count-tab test fakes label-driven and filter-honoring — the old fakes ignored locator filters, which is exactly how this drift class stayed invisible to the unit suite (one legacy test even pinned the bare `RuntimeError` as intended).

## Root-cause evidence

Credit-free DOM recon against the live classic composer (`scripts/dev/spike_issue404_count_tabs_recon.py`, profile `ffroliva`): image count row renders `['x1','x2','x3','x4']`; `nth(0)` of the old filtered set resolves to the selected `x2`; a digit-keyed click on `x1` flips `aria-selected` immediately and **persists across close/reopen — no Save commit needed** (the `/gflow:predict` gate's re-scope boundary was not triggered; verdict GO 8/10).

## Council review (post-push)

Full council ran on `2cbfdd8`: consensus **YELLOW (soft block)** — no logic/design defects; D1 correctness, D3 security, D4 tests, D5 memory, D9 docs, D13 scripts, D14 YAGNI all GREEN. The three must-fix items were resolved:

1. ✅ Stale "position click" comment in `_set_count` — fixed in `14d40a1`.
2. ✅ Stale `_count_tabs_locator` (and sibling) docstrings — fixed in `14d40a1`.
3. ✅/⚠️ Live evidence per changed surface — see table below (agentic run attempted; video waiver recorded).

## Verification status (per surface)

| Surface | Changed code | Live evidence |
|---|---|---|
| Classic image count setter | regex, digit-keyed pick, typed error | ✅ **Live e2e green on the reporter's exact environment** (Windows 11, profile `ffroliva`, classic, 9:16, NARWHAL): new `tests/e2e/test_classic_count_setter_e2e.py` — 2 passed, 89 s, 0 Flow credits; `count=1` reproduces the #404 precondition (fresh project displays 2) and generates exactly 1 image |
| Agentic panel-root finder + settings-panel drive | JS regex union (superset matcher, legacy cohort unaffected); e2e helper made cohort-tolerant | ✅ **Live e2e green, all 4 params** (`test_agentic_count_enforcement_e2e.py`, count 1–4 against a deliberately mismatched sticky default, profile `ffroliva`, 2026-07-31, 0 Flow credits). The first attempt failed in the test's own *setup* — Flow now loads the editor in classic mode, so the raw-Playwright setup that went straight for the `tune` icon timed out before reaching any changed line; commit `beeb833` repairs the setup (toggle into Agent mode via the composer pill first). |
| Video output-count setter | cascade widened to probe `x1` first (legacy selectors unchanged, still tried) | ⚠️ Waiver: full cascade not driven end-to-end (video generation spends Veo credits). DOM-level live evidence from the recon spike: the video count row renders `x1..x4`, and a `[role='tab']:text-is('x2')` click (the exact selector shape the cascade uses) was executed live and took effect during the spike's cleanup step. Miss remains non-fatal by design (`Flow default (x2) applies`). |

Offline gates: RED→GREEN TDD (10 new/updated failing tests first), 620 passed / 1 skipped in the touched scopes, `ruff check` + `ruff format --check` clean (CI-exact), `pyright src` 0 errors, repo-hygiene / doc-links / website-mirror checks green.

- [ ] Human review + promote from draft (per issue-resolve envelope: never self-promote). Confirm the 3.11/3.12/3.13 CI matrix is green on `14d40a1` before merging.

## Notes for the reviewer

- The #313 agentic count-enforcement e2e helper also assumed the legacy `1x` label; it now anchors on `x2`+`x3` and tries both cohorts for count=1. The agentic driver's own never-raising enforcement loop is otherwise untouched (it shares `_count_tabs_locator`, which the regex widening repairs). Its `tabs.nth(count-1)` pick is the idiom class #404 killed — council listed migrating it to `_count_tab_locator_for` as a nice-to-have follow-up.
- `KNOWN_ISSUES.md` Phase-7 note updated (it documented the positional fallback that turned out to be the failure mode); `website/docs/` mirror regenerated.
- During recon the probe briefly set the *video* count row of dev project `gflow-cli t2i` to `x1`; it was restored to Flow's `x2` default in the same session.
