### PR TITLE
fix(data): record entity provenance on generation operations (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Entity attachments left no trace in the catalog, making character provenance
+  unrecoverable (#402).** `--reference-entity` / `--reference-entity-name` reached
+  the transport but were never recorded, so no `image t2i`, `image i2i` or movie
+  R2V operation carried the entity it was generated from — while `--ref` media
+  refs were recorded in full, with ordering. When character identity drift showed
+  up, the catalog could not answer "which entity produced this image?".
+  Generation operations now persist `entity_ids` and `entity_names` in
+  `operations.metadata_json`, in attach order, on succeeded and failed rows alike
+  — a FAILED row carrying `entity_ids` distinguishes a rejected attach from a run
+  that never requested an entity. Tool and entity provenance are composed into a
+  single `set_operation_metadata` write, since that call replaces the whole
+  column. Forward-only: operations recorded before this release cannot be
+  backfilled. See [DATA_LAYER](docs/DATA_LAYER.md#operation-metadata_json-provenance).
 - **The MCP server was broken on every fresh install.** `pyproject.toml`
   declared an unbounded `mcp>=1.0.0`. `uv.lock` pinned `1.28.1`, so CI and
   contributors stayed green — but `pip install gflow-cli` / `uv tool install
@@ -31,25 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path was left unrouted at the app root — a silent failure where the SSE stream
   opens and only the follow-up POSTs 404. Fixed with an explicit alias and
   pinned by a regression test.
-
-### Changed
-
-- **MCP 2026-07-28 spec support.** The server now speaks the stateless
-  `2026-07-28` protocol *and* the legacy handshake era (`2024-11-05` …
-  `2025-11-25`) from one binary — the SDK's `serve_dual_era_loop` negotiates per
-  connection from the client's first request. No protocol code on our side.
-  Analysis: [docs/superpowers/spikes/2026-08-01-mcp-2026-07-28-spec-impact.md](docs/superpowers/spikes/2026-08-01-mcp-2026-07-28-spec-impact.md).
-- **`gflow serve` now defaults to Streamable HTTP at `/mcp`.** The 2026-07-28
-  spec reclassified HTTP+SSE as deprecated. The old transport stays available
-  for one deprecation cycle via `gflow serve --transport sse`, which logs a
-  warning. `stateless_http` is deliberately **not** enabled: gflow's value is a
-  warm daemon holding one live Chromium profile behind a `ProfileLease`, which
-  is the opposite of the scale-out model that flag serves.
-- **List results now advertise cache hints.** `tools/list`, `prompts/list`, and
-  `resources/list` carry a one-hour `ttlMs` (they are fixed at import time by
-  decorators); `resources/read` gets five minutes because it reads
-  `KNOWN_ISSUES.md` off disk. `cacheScope` is `private` throughout — responses
-  are user-scoped by construction.
 
 ## [0.46.1] — 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that never requested an entity. Tool and entity provenance are composed into a
   single `set_operation_metadata` write, since that call replaces the whole
   column. Forward-only: operations recorded before this release cannot be
-  backfilled. See [DATA_LAYER](docs/DATA_LAYER.md#operation-metadata_json-provenance).
+  Live gate: `tests/e2e/test_entity_provenance_e2e.py` (opt-in via
+  `GFLOW_CLI_E2E_RUN_ENTITY_PROV=1`) verifies the recorded entity matches a
+  generation Flow actually accepted, including the rejected-attach case.
 - **The MCP server was broken on every fresh install.** `pyproject.toml`
   declared an unbounded `mcp>=1.0.0`. `uv.lock` pinned `1.28.1`, so CI and
   contributors stayed green — but `pip install gflow-cli` / `uv tool install

--- a/docs/DATA_LAYER.md
+++ b/docs/DATA_LAYER.md
@@ -34,11 +34,40 @@ The schema is adapter-shaped so a future Postgres backend can slot in without ch
 | `profiles` | Logical profile name (e.g. `default`), profile dir, first/last-seen timestamps | First operation per profile |
 | `projects` | Flow project ID + display title per profile | First operation that touches the project |
 | `assets` | One row per Flow media ID (image OR video) — model, aspect, dimensions, seed, generation ID, status | Upload response, image generation response, video start, video completion |
-| `operations` | One row per CLI command invocation — mode (`upload_image`/`t2i`/`i2i`/`t2v`/`i2v`/`r2v`), prompt, model, aspect, started/completed timestamps, error type/detail, Flow operation/batch IDs | Each command run |
+| `operations` | One row per CLI command invocation — mode (`upload_image`/`t2i`/`i2i`/`t2v`/`i2v`/`r2v`), prompt, model, aspect, started/completed timestamps, error type/detail, Flow operation/batch IDs, plus [`metadata_json` provenance](#operation-metadata_json-provenance) | Each command run |
 | `operation_assets` | Many-to-many between operations and assets, with role (`input`/`output`/`seed_start`/`seed_end`/`reference`) and ordered position | When the operation links its inputs/outputs |
 | `local_files` | One row per downloaded asset location — local path or cloud URI, sha256/byte count when local, media type | After each download/upload completes |
 
 Schema lives in [`src/gflow_cli/data/migrations/0001_initial.sql`](../src/gflow_cli/data/migrations/0001_initial.sql).
+
+### Operation `metadata_json` provenance
+
+`operations.metadata_json` answers "what composed this generation?" — the parts
+that aren't columns. Keys are written only when they apply, so an operation with
+neither a tool nor an entity leaves the column `NULL`:
+
+| Key | Shape | Written when |
+|---|---|---|
+| `tool` | `{name, version, model, params, config_hash}` (redacted mode: `{name, version, params_hash, config_hash}`) | `--tool` rewrote the prompt |
+| `entity_ids` | `["entity-abc", …]` — Flow CHARACTER entity ids, in attach order | `--reference-entity` was used |
+| `entity_names` | `["Ana", …]` — display names paired with `--reference-entity-name` | `--reference-entity-name` was used |
+| `entity_id` / `name` | scalar id + display name of the entity being created | `character create` only |
+
+Entity keys cover `image t2i`, `image i2i`, and movie R2V — the surfaces that
+accept `--reference-entity` — on succeeded **and** failed rows. A FAILED row
+carrying `entity_ids` is how a rejected attach (the transport's wire backstop
+refusing to report a text-only generation as an entity-referenced success) stays
+distinguishable from a run that never requested an entity. Before v0.47.0 the
+entity keys were absent on every generation operation, so character provenance
+could not be reconstructed for those runs — the gap is forward-only, not
+backfillable (issue [#402](https://github.com/ffroliva/gflow-cli/issues/402)).
+
+Unlike `assets.metadata_json`, this column is **not** passed through
+`redact_metadata`. Entity ids and names are Flow-side handles the user picked
+rather than prompt text, so they stay readable in `redacted` prompt mode — the
+same treatment `character create` already gave them. Keep that in mind before
+adding a key here: anything prompt-derived must be hashed by its own builder
+(as `tool` does) rather than relying on column-level redaction.
 
 ### What is NOT recorded
 

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -79,6 +79,7 @@ e2e ─┬─ e2e_auth     (auth/session, health check — zero credits)
 | `GFLOW_CLI_E2E_VIDEO_ASPECT` | `"landscape"` | Aspect ratio for video e2e: `landscape` or `portrait`. |
 | `GFLOW_CLI_E2E_VIDEO_MODEL` | `"omni-flash"` | Veo model for i2v tests: `omni-flash` or `veo-fast`. |
 | `GFLOW_CLI_E2E_VIDEO_DURATION` | `"4"` | Seconds of video to generate in i2v tests (minimum credit unit). |
+| `GFLOW_CLI_E2E_RUN_ENTITY_PROV` | `"0"` | Set to `"1"` to run the entity-provenance e2e (#402) — asserts a generation Flow actually accepted records its `entity_ids` / `entity_names` in `operations.metadata_json`. Opt-in because it spends Imagen credits. |
 | `GFLOW_CLI_E2E_BATCH_MANIFEST` | `test_assets/sample_batch.tsv` | TSV manifest for the batch image e2e. |
 | `GFLOW_CLI_E2E_BATCH_JITTER` | `"1"` | Set to `"0"` to disable inter-request jitter in batch tests. |
 | `GFLOW_CLI_E2E_PROMPT` | *(safe default)* | Prompt override for the smoke test. |

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -344,6 +344,34 @@ class OperationRecorder:
             "config_hash": tool.config_hash,
         }
 
+    def _generation_metadata(
+        self,
+        request: _ToolableRequest,
+    ) -> dict[str, object]:
+        """Compose the full ``metadata_json`` payload for a generation operation.
+
+        Built as ONE dict on purpose: :meth:`DataRepository.set_operation_metadata`
+        replaces the whole column, so writing tool and entity provenance in two
+        sequential calls would silently drop whichever went first.
+
+        ``entity_ids`` / ``entity_names`` answer "which character produced this?"
+        (issue #402) — without them a `--reference-entity` generation left no
+        trace of the entity anywhere in the catalog, while `--ref` media were
+        recorded in full. Order is preserved: it mirrors the attach order the
+        transport sent. Both keys are stored verbatim even in ``redacted`` mode —
+        they are Flow-side handles the user picked, not prompt text, and
+        ``record_character_started`` already stores the same pair unredacted.
+        """
+        metadata: dict[str, object] = {}
+        tool_meta = self._tool_metadata(request.tool)
+        if tool_meta is not None:
+            metadata["tool"] = tool_meta
+        if request.reference_entities:
+            metadata["entity_ids"] = list(request.reference_entities)
+        if request.reference_entity_names:
+            metadata["entity_names"] = list(request.reference_entity_names)
+        return metadata
+
     # ------------------------------------------------------------------
     # Image upload
     # ------------------------------------------------------------------
@@ -552,9 +580,9 @@ class OperationRecorder:
         # downstream queries like "SELECT * FROM operations WHERE completed_at
         # IS NULL" don't surface successful runs.
         repo.update_operation_status(op_id, OperationStatus.SUCCEEDED, _now_utc_iso(), None, None)
-        tool_meta = self._tool_metadata(request.tool)
-        if tool_meta is not None:
-            repo.set_operation_metadata(op_id, {"tool": tool_meta})
+        metadata = self._generation_metadata(request)
+        if metadata:
+            repo.set_operation_metadata(op_id, metadata)
 
         # Link input assets (I2I seed images)
         for i, media_id in enumerate(input_media_ids):
@@ -740,9 +768,9 @@ class OperationRecorder:
             ),
         )
         repo.link_operation_asset(op_id, asset_id, OperationAssetRole.OUTPUT, 0)
-        tool_meta = self._tool_metadata(request.tool)
-        if tool_meta is not None:
-            repo.set_operation_metadata(op_id, {"tool": tool_meta})
+        metadata = self._generation_metadata(request)
+        if metadata:
+            repo.set_operation_metadata(op_id, metadata)
 
     def _insert_fallback_video_operation(
         self,
@@ -790,9 +818,9 @@ class OperationRecorder:
         asset_lookup = repo.get_asset_by_flow_media_id(profile_name, flow_media_id)
         if asset_lookup is not None:
             repo.link_operation_asset(op_id, asset_lookup.id, OperationAssetRole.OUTPUT, 0)
-        tool_meta = self._tool_metadata(request.tool)
-        if tool_meta is not None:
-            repo.set_operation_metadata(op_id, {"tool": tool_meta})
+        metadata = self._generation_metadata(request)
+        if metadata:
+            repo.set_operation_metadata(op_id, metadata)
 
     def _persist_completed_video_file(
         self,
@@ -1003,9 +1031,12 @@ class OperationRecorder:
                 expanded_prompt=expanded_prompt,
             ),
         )
-        tool_meta = self._tool_metadata(request.tool) if request is not None else None
-        if tool_meta is not None:
-            repo.set_operation_metadata(op_id, {"tool": tool_meta})
+        # A FAILED row carrying entity_ids is the negative case the catalog was
+        # missing (#402): an entity-attach that tripped the wire backstop is now
+        # distinguishable from a run that never requested an entity at all.
+        metadata = self._generation_metadata(request) if request is not None else {}
+        if metadata:
+            repo.set_operation_metadata(op_id, metadata)
 
     # ------------------------------------------------------------------
     # Character — started / completed (persist-before-spend saga)

--- a/tests/data/test_failure_recording.py
+++ b/tests/data/test_failure_recording.py
@@ -1,6 +1,7 @@
 """Failure recording (#341): FAILED operation rows, taxonomy, and redaction."""
 
 import hashlib
+import json
 from pathlib import Path
 
 import structlog
@@ -119,6 +120,33 @@ def test_record_failed_operation_inserts_failed_row_with_request_metadata(
         assert op["prompt"] == "a red fox"
         assert op["model"] == Model.NARWHAL.value
         assert op["completed_at"] is not None
+
+
+def test_record_failed_operation_records_entity_provenance(tmp_path: Path) -> None:
+    """A failed entity-attach must stay attributable (#402): the FAILED row keeps
+    the requested entity ids, so a wire-backstop rejection is distinguishable
+    from a run that never asked for an entity."""
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(
+            prompt="the same character",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            reference_entities=("entity-abc",),
+            reference_entity_names=("Ana",),
+        )
+        recorder.record_failed_operation(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            command="image i2i",
+            mode=OperationKind.I2I,
+            exc=WafRejectionError("blocked by WAF", status=403),
+            request=req,
+        )
+        row = store.conn.execute("SELECT metadata_json FROM operations WHERE mode='i2i'").fetchone()
+        meta = json.loads(row["metadata_json"])
+        assert meta["entity_ids"] == ["entity-abc"]
+        assert meta["entity_names"] == ["Ana"]
 
 
 def test_record_failed_operation_honors_redacted_prompt_mode(tmp_path: Path) -> None:

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -470,6 +470,179 @@ def test_record_generated_images_without_tool_writes_no_tool_metadata(tmp_path: 
         assert "tool" not in meta
 
 
+# ---------------------------------------------------------------------------
+# metadata_json entity provenance — which character entity produced this? (#402)
+# ---------------------------------------------------------------------------
+
+
+def _op_meta(store: DataStore, mode: str) -> dict[str, object]:
+    row = store.conn.execute(
+        "SELECT metadata_json FROM operations WHERE mode = ?", (mode,)
+    ).fetchone()
+    return json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+
+
+def test_record_generated_images_persists_entity_provenance(tmp_path: Path) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(
+            prompt="the same character, on a beach",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            reference_entities=("entity-abc", "entity-def"),
+            reference_entity_names=("Ana", "Bruno"),
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="i2i",
+        )
+        meta = _op_meta(store, "i2i")
+        # Send order is provenance: entity_ids[0] is the first attached entity.
+        assert meta["entity_ids"] == ["entity-abc", "entity-def"]
+        assert meta["entity_names"] == ["Ana", "Bruno"]
+
+
+def test_record_generated_images_entity_provenance_does_not_clobber_tool(tmp_path: Path) -> None:
+    """``set_operation_metadata`` overwrites the whole column, so entity and tool
+    provenance must be composed into a single write — not two sequential ones."""
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(
+            prompt="expanded",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            original_prompt="cat",
+            tool=_applied_tool(),  # type: ignore[arg-type]
+            reference_entities=("entity-abc",),
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="i2i",
+        )
+        meta = _op_meta(store, "i2i")
+        assert meta["entity_ids"] == ["entity-abc"]
+        assert isinstance(meta["tool"], dict)
+        assert meta["tool"]["name"] == "creative-director"
+
+
+def test_record_generated_images_without_entities_writes_no_entity_metadata(
+    tmp_path: Path,
+) -> None:
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        req = GenerateImageRequest(prompt="cat", aspect=Aspect.PORTRAIT, model=Model.NARWHAL)
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="t2i",
+        )
+        meta = _op_meta(store, "t2i")
+        assert "entity_ids" not in meta
+        assert "entity_names" not in meta
+
+
+def test_record_generated_images_persists_entity_provenance_in_redacted_mode(
+    tmp_path: Path,
+) -> None:
+    """Entity ids/names are Flow-side handles the user chose, not prompt text —
+    they stay readable in redacted mode, matching ``record_character_started``."""
+    saved = tmp_path / "image.png"
+    saved.write_bytes(b"image-bytes")
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="redacted")
+        req = GenerateImageRequest(
+            prompt="a beach",
+            aspect=Aspect.PORTRAIT,
+            model=Model.NARWHAL,
+            reference_entities=("entity-abc",),
+            reference_entity_names=("Ana",),
+        )
+        recorder.record_generated_images(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            project=ProjectInfo(project_id="p1", title="t"),
+            request=req,
+            images=[_generated_image()],
+            saved_paths=[saved],
+            input_media_ids=[],
+            operation_kind="i2i",
+        )
+        meta = _op_meta(store, "i2i")
+        assert meta["entity_ids"] == ["entity-abc"]
+        assert meta["entity_names"] == ["Ana"]
+
+
+def test_record_started_video_persists_entity_provenance(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="the same character, walking",
+            mode=Mode.R2V,
+            aspect=VideoAspect.PORTRAIT,
+            reference_entities=("entity-abc",),
+            reference_entity_names=("Ana",),
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="operation-video-1",
+            ),
+        )
+        meta = _op_meta(store, "r2v")
+        assert meta["entity_ids"] == ["entity-abc"]
+        assert meta["entity_names"] == ["Ana"]
+
+
+def test_record_started_video_without_entities_writes_no_entity_metadata(tmp_path: Path) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        recorder = OperationRecorder(DataRepository(store), prompt_mode="store")
+        request = GenerateVideoRequest(
+            prompt="a dog surfing",
+            mode=Mode.T2V,
+            aspect=VideoAspect.PORTRAIT,
+        )
+        recorder.record_started_video(
+            profile_name="default",
+            profile_dir=tmp_path / "profile_default",
+            request=request,
+            started=VideoStarted(
+                media_id="media-video-1",
+                project_id="flow-project-video-1",
+                flow_operation_id="operation-video-1",
+            ),
+        )
+        meta = _op_meta(store, "t2v")
+        assert "entity_ids" not in meta
+        assert "entity_names" not in meta
+
+
 class TestIsMediaRecorded:
     """Recorder-level half of the #281 pre-download attribution guard.
 

--- a/tests/e2e/test_entity_provenance_e2e.py
+++ b/tests/e2e/test_entity_provenance_e2e.py
@@ -121,12 +121,19 @@ def _fresh_project_and_entity() -> tuple[str, str]:
     profile isn't usable, matching the other e2e modules' posture.
     """
     from gflow_cli.api.client import FlowApiClient
-    from gflow_cli.auth import profile_dir as resolve_profile_dir
+    from gflow_cli.config import Settings
 
     name = os.environ.get(_E2E_PROFILE_ENV, "").strip()
     if not name:
         pytest.skip(f"set {_E2E_PROFILE_ENV} to a logged-in profile name")
-    profile_dir = resolve_profile_dir(name)
+
+    old_home = os.environ.pop("GFLOW_CLI_HOME", None)
+    try:
+        profile_dir = Settings(_env_file=None).profile_subdir(name)  # pyright: ignore[reportCallIssue]
+    finally:
+        if old_home is not None:
+            os.environ["GFLOW_CLI_HOME"] = old_home
+
     if not profile_dir.exists():
         pytest.skip(f"profile dir not found: {profile_dir}")
 

--- a/tests/e2e/test_entity_provenance_e2e.py
+++ b/tests/e2e/test_entity_provenance_e2e.py
@@ -1,0 +1,338 @@
+"""Live E2E for entity provenance recording (#402).
+
+The unit tests in ``tests/data/test_recorder.py`` prove the recorder writes what
+the *request* carried. They cannot prove the recorded set matches what Flow
+actually **accepted** — that is the gap this file closes, and the reason #402's
+fix shipped as ``Refs`` rather than ``Closes``.
+
+Each test drives a real generation with ``--reference-entity`` against a live
+Pro/Ultra account, then asserts ``operations.metadata_json`` carries the entity
+that produced the output:
+
+  - t2i + entity  → succeeded row carries ``entity_ids`` / ``entity_names``
+  - i2i + entity  → same, on the surface where #402 lost 333 generations
+  - bad entity id → FAILED row STILL carries ``entity_ids`` (intent recorded
+    even when the attach is rejected — the negative case that made a
+    silently-dropped reference indistinguishable from a good one)
+
+The entity itself is minted with ``client.create_entity``, which is a FREE REST
+call (no reCAPTCHA, no credit) — so the only spend here is the image generation.
+
+# Opt-in gates
+
+  - ``GFLOW_CLI_E2E_PROFILE``            master gate; Chrome-strategy profile name
+  - ``GFLOW_CLI_E2E_RUN_ENTITY_PROV``   default "0"; set to "1" to run (spends
+                                         Imagen credits)
+
+# Spending
+
+  - t2i + entity:  ~1 Imagen credit
+  - i2i + entity:  ~2 Imagen credits (one seed t2i, then the i2i itself)
+  - bad entity id: 0 credits expected — the attach is refused before submit
+
+Doc: ``docs/DATA_LAYER.md`` §"Operation ``metadata_json`` provenance"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_RUN_ENTITY_PROV_ENV = "GFLOW_CLI_E2E_RUN_ENTITY_PROV"
+_E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
+
+_ENTITY_NAME = "e2e-provenance-character"
+_T2I_PROMPT = "portrait of a calm woman with dark wavy hair, soft studio lighting"
+_I2I_PROMPT = "the same woman, now standing on a windy beach at golden hour"
+
+# Generous because real Flow latency: image ~30-60s, plus picker interaction.
+_IMAGE_TIMEOUT_S = 300
+# A rejected attach fails fast, but the picker cascade still exhausts its tiers.
+_REJECT_TIMEOUT_S = 240
+
+
+# ---------------------------------------------------------------------------
+# Opt-in guard + helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_entity_prov_optin() -> None:
+    """Skip unless ``GFLOW_CLI_E2E_RUN_ENTITY_PROV=1`` (these spend credits)."""
+    if os.environ.get(_RUN_ENTITY_PROV_ENV, "0").strip() != "1":
+        pytest.skip(
+            f"{_RUN_ENTITY_PROV_ENV} != 1 — entity-provenance e2e is opt-in "
+            "because it spends Imagen credits. Set it to 1 to run the live "
+            "verification gate for #402."
+        )
+
+
+def _run_gflow(
+    args: list[str], env: dict[str, str], timeout: float
+) -> subprocess.CompletedProcess[str]:
+    """Run ``gflow`` in a subprocess and capture stdout/stderr/exit-code."""
+    cmd = [sys.executable, "-m", "gflow_cli", *args]
+    return subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _open_db(env: dict[str, str]) -> sqlite3.Connection:
+    db_path = Path(env["GFLOW_CLI_DB_PATH"])
+    assert db_path.exists(), f"data layer never wrote to {db_path}"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _operation_metadata(conn: sqlite3.Connection, mode: str) -> dict[str, object]:
+    """Return the parsed ``metadata_json`` of the single operation for *mode*."""
+    rows = conn.execute(
+        "SELECT status, metadata_json FROM operations WHERE mode = ?", (mode,)
+    ).fetchall()
+    assert len(rows) == 1, f"expected exactly 1 {mode} operation, got {[dict(r) for r in rows]}"
+    raw = rows[0]["metadata_json"]
+    assert raw, (
+        f"{mode} operation carries NULL metadata_json — this is the #402 "
+        "regression: the entity attach left no trace in the catalog"
+    )
+    parsed = json.loads(raw)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _fresh_project_and_entity() -> tuple[str, str]:
+    """Mint a real Flow project + CHARACTER entity over REST. Free, no credits.
+
+    Returns ``(project_id, entity_id)``. Skips (rather than fails) when the
+    profile isn't usable, matching the other e2e modules' posture.
+    """
+    from gflow_cli.api.client import FlowApiClient
+    from gflow_cli.auth import profile_dir as resolve_profile_dir
+
+    name = os.environ.get(_E2E_PROFILE_ENV, "").strip()
+    if not name:
+        pytest.skip(f"set {_E2E_PROFILE_ENV} to a logged-in profile name")
+    profile_dir = resolve_profile_dir(name)
+    if not profile_dir.exists():
+        pytest.skip(f"profile dir not found: {profile_dir}")
+
+    async def _mint() -> tuple[str, str]:
+        async with FlowApiClient(profile_dir=profile_dir) as client:
+            project = await client.create_project(title="e2e-entity-provenance")
+            entity_id = await client.create_entity(project.project_id)
+            assert entity_id, "createEntity returned no entity id"
+            return project.project_id, entity_id
+
+    return asyncio.run(_mint())
+
+
+# ---------------------------------------------------------------------------
+# t2i — the cheapest surface that accepts --reference-entity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e_image
+@pytest.mark.e2e_data
+def test_t2i_entity_attach_records_provenance(e2e_env: dict[str, str]) -> None:
+    """Live t2i with an attached entity: ~1 Imagen credit.
+
+    The gate for #402: after a generation Flow actually accepted, the catalog
+    must be able to answer "which character produced this?".
+    """
+    _require_entity_prov_optin()
+    project_id, entity_id = _fresh_project_and_entity()
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+
+    result = _run_gflow(
+        [
+            "image",
+            "t2i",
+            _T2I_PROMPT,
+            "--project",
+            project_id,
+            "--reference-entity",
+            entity_id,
+            "--reference-entity-name",
+            _ENTITY_NAME,
+            "--profile",
+            profile,
+        ],
+        env=e2e_env,
+        timeout=_IMAGE_TIMEOUT_S,
+    )
+    assert result.returncode == 0, (
+        f"gflow image t2i --reference-entity exited {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    conn = _open_db(e2e_env)
+    try:
+        meta = _operation_metadata(conn, "t2i")
+        assert meta.get("entity_ids") == [entity_id], (
+            f"entity_ids missing or wrong: {meta!r} (expected [{entity_id!r}])"
+        )
+        assert meta.get("entity_names") == [_ENTITY_NAME], (
+            f"entity_names missing or wrong: {meta!r}"
+        )
+        status = conn.execute("SELECT status FROM operations WHERE mode='t2i'").fetchone()
+        assert status["status"] == "succeeded"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# i2i — the surface where #402 lost 333 generations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e_image
+@pytest.mark.e2e_data
+def test_i2i_entity_attach_records_provenance(e2e_env: dict[str, str]) -> None:
+    """Live i2i with an attached entity: ~2 Imagen credits (seed t2i + i2i).
+
+    i2i is the surface the issue measured at 0/333 coverage, so it gets its own
+    gate rather than riding on the t2i result.
+    """
+    _require_entity_prov_optin()
+    project_id, entity_id = _fresh_project_and_entity()
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+    out_dir = Path(e2e_env["GFLOW_CLI_OUTPUT_DIR"])
+
+    # 1. Seed frame — a plain t2i in the same project (no entity attached).
+    seed = _run_gflow(
+        ["image", "t2i", _T2I_PROMPT, "--project", project_id, "--profile", profile],
+        env=e2e_env,
+        timeout=_IMAGE_TIMEOUT_S,
+    )
+    assert seed.returncode == 0, (
+        f"seed t2i exited {seed.returncode}\nSTDOUT:\n{seed.stdout}\nSTDERR:\n{seed.stderr}"
+    )
+    seeds = [
+        p
+        for p in sorted(out_dir.rglob("*"))
+        if p.is_file() and p.suffix.lower() in (".png", ".jpg", ".jpeg", ".webp")
+    ]
+    assert seeds, f"seed t2i produced no image in {out_dir}"
+
+    # 2. i2i off that frame, WITH the entity attached.
+    result = _run_gflow(
+        [
+            "image",
+            "i2i",
+            _I2I_PROMPT,
+            "--ref",
+            str(seeds[0]),
+            "--project",
+            project_id,
+            "--reference-entity",
+            entity_id,
+            "--reference-entity-name",
+            _ENTITY_NAME,
+            "--profile",
+            profile,
+        ],
+        env=e2e_env,
+        timeout=_IMAGE_TIMEOUT_S,
+    )
+    assert result.returncode == 0, (
+        f"gflow image i2i --reference-entity exited {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    conn = _open_db(e2e_env)
+    try:
+        meta = _operation_metadata(conn, "i2i")
+        assert meta.get("entity_ids") == [entity_id], (
+            f"entity_ids missing or wrong on i2i: {meta!r} (expected [{entity_id!r}])"
+        )
+        assert meta.get("entity_names") == [_ENTITY_NAME], (
+            f"entity_names missing or wrong on i2i: {meta!r}"
+        )
+        # The media ref must STILL be recorded alongside the entity — the fix
+        # must not have regressed the provenance that already worked.
+        links = conn.execute(
+            "SELECT role, position FROM operation_assets WHERE role='input'"
+        ).fetchall()
+        assert links, "i2i input media ref no longer linked in operation_assets"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Negative case — a rejected attach must still be attributable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e_image
+@pytest.mark.e2e_data
+def test_rejected_entity_attach_still_records_provenance(e2e_env: dict[str, str]) -> None:
+    """An entity id that does not exist in the target project must fail the run
+    AND leave a FAILED row carrying the requested ``entity_ids``.
+
+    This is the case that made #402 expensive to diagnose: before the fix a
+    silently-dropped reference and a successful attach were indistinguishable
+    after the fact. Expected to spend 0 credits — the attach is refused before
+    submit — but it is marked ``e2e_image`` because that is not guaranteed
+    against a live blackbox.
+    """
+    _require_entity_prov_optin()
+    project_id, _real_entity = _fresh_project_and_entity()
+    profile = e2e_env["GFLOW_CLI_PROFILE"]
+
+    # Well-formed (passes --reference-entity's charset validation) but absent
+    # from the project, so the picker can never stage it.
+    bogus_entity = "e2e-nonexistent-entity-0000"
+
+    result = _run_gflow(
+        [
+            "image",
+            "t2i",
+            _T2I_PROMPT,
+            "--project",
+            project_id,
+            "--reference-entity",
+            bogus_entity,
+            "--profile",
+            profile,
+        ],
+        env=e2e_env,
+        timeout=_REJECT_TIMEOUT_S,
+    )
+    assert result.returncode != 0, (
+        "a non-existent entity must NOT report success — a text-only generation "
+        f"was reported as an entity-referenced one.\nSTDOUT:\n{result.stdout}"
+    )
+
+    conn = _open_db(e2e_env)
+    try:
+        rows = conn.execute(
+            "SELECT status, error_type, metadata_json FROM operations WHERE mode='t2i'"
+        ).fetchall()
+        assert rows, "the failed run recorded no operation row at all"
+        failed = [r for r in rows if r["status"] == "failed"]
+        assert failed, f"expected a FAILED t2i row, got {[dict(r) for r in rows]}"
+        raw = failed[0]["metadata_json"]
+        assert raw, (
+            "FAILED row carries NULL metadata_json — a rejected attach is still "
+            "indistinguishable from a run that never requested an entity"
+        )
+        meta = json.loads(raw)
+        assert meta.get("entity_ids") == [bogus_entity], (
+            f"FAILED row lost the requested entity id: {meta!r}"
+        )
+    finally:
+        conn.close()

--- a/website/docs/DATA_LAYER.md
+++ b/website/docs/DATA_LAYER.md
@@ -34,11 +34,40 @@ The schema is adapter-shaped so a future Postgres backend can slot in without ch
 | `profiles` | Logical profile name (e.g. `default`), profile dir, first/last-seen timestamps | First operation per profile |
 | `projects` | Flow project ID + display title per profile | First operation that touches the project |
 | `assets` | One row per Flow media ID (image OR video) — model, aspect, dimensions, seed, generation ID, status | Upload response, image generation response, video start, video completion |
-| `operations` | One row per CLI command invocation — mode (`upload_image`/`t2i`/`i2i`/`t2v`/`i2v`/`r2v`), prompt, model, aspect, started/completed timestamps, error type/detail, Flow operation/batch IDs | Each command run |
+| `operations` | One row per CLI command invocation — mode (`upload_image`/`t2i`/`i2i`/`t2v`/`i2v`/`r2v`), prompt, model, aspect, started/completed timestamps, error type/detail, Flow operation/batch IDs, plus [`metadata_json` provenance](#operation-metadata_json-provenance) | Each command run |
 | `operation_assets` | Many-to-many between operations and assets, with role (`input`/`output`/`seed_start`/`seed_end`/`reference`) and ordered position | When the operation links its inputs/outputs |
 | `local_files` | One row per downloaded asset location — local path or cloud URI, sha256/byte count when local, media type | After each download/upload completes |
 
 Schema lives in [`src/gflow_cli/data/migrations/0001_initial.sql`](../src/gflow_cli/data/migrations/0001_initial.sql).
+
+### Operation `metadata_json` provenance
+
+`operations.metadata_json` answers "what composed this generation?" — the parts
+that aren't columns. Keys are written only when they apply, so an operation with
+neither a tool nor an entity leaves the column `NULL`:
+
+| Key | Shape | Written when |
+|---|---|---|
+| `tool` | `{name, version, model, params, config_hash}` (redacted mode: `{name, version, params_hash, config_hash}`) | `--tool` rewrote the prompt |
+| `entity_ids` | `["entity-abc", …]` — Flow CHARACTER entity ids, in attach order | `--reference-entity` was used |
+| `entity_names` | `["Ana", …]` — display names paired with `--reference-entity-name` | `--reference-entity-name` was used |
+| `entity_id` / `name` | scalar id + display name of the entity being created | `character create` only |
+
+Entity keys cover `image t2i`, `image i2i`, and movie R2V — the surfaces that
+accept `--reference-entity` — on succeeded **and** failed rows. A FAILED row
+carrying `entity_ids` is how a rejected attach (the transport's wire backstop
+refusing to report a text-only generation as an entity-referenced success) stays
+distinguishable from a run that never requested an entity. Before v0.47.0 the
+entity keys were absent on every generation operation, so character provenance
+could not be reconstructed for those runs — the gap is forward-only, not
+backfillable (issue [#402](https://github.com/ffroliva/gflow-cli/issues/402)).
+
+Unlike `assets.metadata_json`, this column is **not** passed through
+`redact_metadata`. Entity ids and names are Flow-side handles the user picked
+rather than prompt text, so they stay readable in `redacted` prompt mode — the
+same treatment `character create` already gave them. Keep that in mind before
+adding a key here: anything prompt-derived must be hashed by its own builder
+(as `tool` does) rather than relying on column-level redaction.
 
 ### What is NOT recorded
 

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -79,6 +79,7 @@ e2e ─┬─ e2e_auth     (auth/session, health check — zero credits)
 | `GFLOW_CLI_E2E_VIDEO_ASPECT` | `"landscape"` | Aspect ratio for video e2e: `landscape` or `portrait`. |
 | `GFLOW_CLI_E2E_VIDEO_MODEL` | `"omni-flash"` | Veo model for i2v tests: `omni-flash` or `veo-fast`. |
 | `GFLOW_CLI_E2E_VIDEO_DURATION` | `"4"` | Seconds of video to generate in i2v tests (minimum credit unit). |
+| `GFLOW_CLI_E2E_RUN_ENTITY_PROV` | `"0"` | Set to `"1"` to run the entity-provenance e2e (#402) — asserts a generation Flow actually accepted records its `entity_ids` / `entity_names` in `operations.metadata_json`. Opt-in because it spends Imagen credits. |
 | `GFLOW_CLI_E2E_BATCH_MANIFEST` | `test_assets/sample_batch.tsv` | TSV manifest for the batch image e2e. |
 | `GFLOW_CLI_E2E_BATCH_JITTER` | `"1"` | Set to `"0"` to disable inter-request jitter in batch tests. |
 | `GFLOW_CLI_E2E_PROMPT` | *(safe default)* | Prompt override for the smoke test. |


### PR DESCRIPTION
## Summary

Refs #402.

Generation operations accepted `--reference-entity` / `--reference-entity-name` but never recorded them, so the local catalog could not answer *"which character entity produced this image?"* — while `--ref` media refs were recorded in full, with ordering. `entity_id` was persisted in exactly one place, `record_character_started` (`recorder.py:1065`), which only ever covers entity **creation**.

Generation ops now persist `entity_ids` and `entity_names` in `operations.metadata_json`, in attach order:

- `record_generated_images` — `image t2i` / `image i2i`
- `record_started_video` — movie R2V
- `_insert_fallback_video_operation` — the path taken when `on_started` failed or was skipped, so an R2V run that took the fallback doesn't silently lose provenance
- `record_failed_operation` — a FAILED row carrying `entity_ids` is how a rejected attach (the transport's wire backstop refusing to report a text-only generation as an entity-referenced success) stays distinguishable from a run that never requested an entity

**No migration** — `metadata_json` already exists, and the values were already in scope at every write site (both request dataclasses carry the fields; they were simply dropped).

### The trap this avoids

`set_operation_metadata` executes `UPDATE operations SET metadata_json = ?` — it replaces the **whole** column (`repository.py:417-427`). Adding a second call alongside the existing `{"tool": …}` write would have silently clobbered tool provenance. Both are therefore composed into one `_generation_metadata` dict before a single write, and `test_record_generated_images_entity_provenance_does_not_clobber_tool` pins that.

### Notes on scope

- **Forward-only.** Operations recorded before this change cannot be backfilled — no surviving source in the schema or logs. The issue's 333 existing `image i2i` generations stay unattributable.
- **`video i2v` is intentionally untouched.** `--reference-entity` is only exposed on `image t2i` / `image i2i` (`cli_image.py:747`, `cli_image.py:1469`); `cli_video.py:887` only mentions the flag in help text. The issue's "0 of 98 i2v ops" row is expected behaviour, not a gap.
- **The issue's proposed fix #2 (an `entity` role on `operation_assets`) was not taken.** `OperationAssetRole.REFERENCE` already exists and is unused, but `operation_assets.asset_id` is FK'd to `assets(id)` and entities are not assets — so that shape needs a sibling table plus a migration. Left for a follow-up if the ordering symmetry is wanted; `metadata_json` already preserves attach order today. Same for the issue's secondary observation (splitting `role='input'` into base-frame vs reference) — separate concern, separate change.
- **Entity keys are stored unredacted**, matching `record_character_started`. They are Flow-side handles the user picked, not prompt text, and redacting them would defeat the provenance lookup this fixes. Documented in DATA_LAYER so the next key added here doesn't assume column-level redaction exists.

## Validation

- [x] Focused tests added or updated for behavior changes — 7 unit tests (`tests/data/test_recorder.py`, `tests/data/test_failure_recording.py`) covering both generation paths, the tool-clobber regression, redacted mode, the failed-op path, and negative cases. Confirmed red before the fix, green after. Plus 3 live e2e scenarios (below).
- [x] Documentation updated — `docs/DATA_LAYER.md` gains an "Operation `metadata_json` provenance" section (keys, when written, the no-redaction contract); `docs/E2E_TESTING.md` registers the new opt-in gate; `website/docs/` mirrors regenerated via `scripts/ci/generate_website_docs.py`; CHANGELOG entry under Unreleased.
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved across 27 files
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run pyright src` — 0 errors, 0 warnings
- [x] `uv run python scripts/ci/check_repo_hygiene.py` — 684 files, no violations
- [x] `uv run python scripts/ci/check_website_docs_pii.py` — clean
- [x] `uv run ruff format --check src tests` — 340 files already formatted
- [x] Relevant pytest command: `uv run python -m pytest tests/ -m "not live and not e2e and not smoke"` — **2103 passed**, 19 skipped
- [x] **CI green on `07bcdbe`** — all 16 checks pass, including the test matrix on 3.11 / 3.12 / 3.13 and the **SonarCloud gate** (zero new issues).

### Verification status

- [x] **Browser-free surface verified here** — pure recorder/repository logic over SQLite, unit-testable on any host.
- [ ] **Live e2e not yet run** — needs a human on a real Pro/Ultra account. The scenarios are committed rather than described, so this is a checkbox someone can actually tick:

  ```
  GFLOW_CLI_E2E_PROFILE=your-profile-name GFLOW_CLI_E2E_RUN_ENTITY_PROV=1 \
    uv run pytest -m e2e tests/e2e/test_entity_provenance_e2e.py -v
  ```

  `tests/e2e/test_entity_provenance_e2e.py` covers three cases:

  | Scenario | Asserts | Spend |
  |---|---|---|
  | `test_t2i_entity_attach_records_provenance` | succeeded t2i row carries `entity_ids` / `entity_names` | ~1 Imagen credit |
  | `test_i2i_entity_attach_records_provenance` | same on i2i — the surface that lost 333 generations — and that the `--ref` media link did **not** regress | ~2 Imagen credits |
  | `test_rejected_entity_attach_still_records_provenance` | a non-existent entity id fails the run **and** the FAILED row still carries `entity_ids` | 0 expected |

  The entity is minted with `client.create_entity` (free REST call, no reCAPTCHA, no credit), so the only spend is the generation itself. All three skip cleanly without `GFLOW_CLI_E2E_PROFILE` and are deselected from the default suite.

Still `Refs #402` rather than `Closes` until that run is green — the unit tests prove the recorder writes what the *request* carried, not that it matches what Flow *accepted*.

### Note on a local-only failure

`tests/auth/test_verification.py::TestVerifyFlowSession::test_dpapi_runtime_error_triggers_playwright_fallback` failed on the Linux container this branch was developed on. It was confirmed identical on clean `develop` with the diff stashed, and it **passes in CI** on all three Python versions — so it was an environment artifact (no Chrome at the path the test expects), not a regression from this change. Recorded here only so the earlier note in this description isn't left dangling.

## Contribution Checklist

- [x] This PR targets `develop`, unless it is a release or emergency fix
- [x] My commits use my real Git identity or GitHub noreply email
- [ ] External contribution commits include `Signed-off-by:` (`git commit -s`) — n/a, not an external contribution
- [x] I did not include secrets, cookies, account tokens, signed URLs, or private captured data
- [x] I reviewed any AI-assisted changes before submitting