### PR TITLE
docs(spec): asset addressing, storage portability, and error guidance (#411)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-asset-addressing/PLAN.md
+++ b/docs/superpowers/plans/2026-08-02-asset-addressing/PLAN.md
@@ -1,0 +1,300 @@
+# Asset Addressing & Storage Portability — Implementation Plan
+
+**Goal:** every byte gflow-cli writes is addressable through the catalog and verifiable by hash,
+regardless of backend; a user can resolve any generation to its artifact with one scriptable
+command, move that artifact between local and cloud storage without losing provenance, and every
+error on this surface names the exact command that fixes it.
+
+**Architecture:** keep `gflow_cli.storage`'s UPath-based backend dispatch unchanged; add a frozen
+`Location` value object as the write path's return type; make the storage key canonical (built
+once, never recovered by subtraction); give every byte-producing surface a catalog row by admitting
+a **derived artifact** class (`assets.flow_media_id` nullable). **No `AssetStore` Protocol, no
+strategy classes** — see spec § 10.1. Full contract:
+[specs/2026-08-02-asset-addressing-design.md](../../specs/2026-08-02-asset-addressing-design.md).
+
+**Origin:** [#411](https://github.com/ffroliva/gflow-cli/issues/411). Note that #411's literal ask
+(`-o/--output`) is **deferred** — it is closed by Task 2.1's read API, not by a flag (spec § 10.4).
+
+**Council verdict:** internal 6-dimension council, 2026-08-02 — **RED** on the originally proposed
+shape (D1 correctness/mode-coverage RED, D14 over-engineering RED, D3/D4/D7/D8 YELLOW). This plan
+implements the superseding design. **`/gflow:predict` has not been run against this revised spec —
+run it before starting Phase 2.**
+
+**⚠️ External-review gap:** the council ran `small`-tier; `codex` and `agy` were unavailable, so
+both RED verdicts come from same-model-family reviewers. Re-run `/gflow:llm-council` with the
+external layer before Phase 2.
+
+**⛔ Environment constraint:** Phase 0 tasks 0.1, 0.3, 0.4, 0.5 and all of Phase 1 touch generation
+recording paths. Per AGENTS.md, offline green is **LIKELY-working, never CONFIRMED** — these need a
+live run on an operator machine with an authenticated Chrome-strategy profile and real credits
+before the PR is called done. Phase 2 (port) does **not** contact Flow and is exempt. Any PR
+produced from a cloud/CI session must leave the live-verification boxes unchecked and say so.
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Local video layout change (flat → `videos/<date>/`) breaks user scripts globbing `--out-dir/*.mp4` | Explicit CHANGELOG entry + open question 2 answered before Task 1.3; consider a one-minor-version compat flag |
+| High | `assets.flow_media_id` nullable weakens `UNIQUE(profile_name, flow_media_id)` dedupe | Partial unique index excluding NULLs; synthetic `gflow:derived:<sha>` handle carries the identity |
+| Medium | Chain + cloud is already broken (PyAV cannot decode `gs://`) — fixing it may expand scope | Task 0.5 ships the honest error first; download-to-temp is a separate decision (open question 1) |
+| Medium | `containers` suite is not CI-gated, so cloud adapter changes have no safety net | Task 0.10 forces the choice: wire the job or document opt-in explicitly |
+| Medium | `memory://` is documented but unproven — port tests could be built on a fiction | Task 0.11 proves it or removes the claim, before Phase 2 depends on it |
+| Low | `ConfigurationError` split touches 114 raise sites | Split changes class defaults only; no raise site needs editing |
+
+---
+
+## File structure
+
+### New files
+```
+src/gflow_cli/locations.py
+  Location frozen dataclass; resolve_location(); key builders (image/video/character/scene/frame)
+src/gflow_cli/data/migrations/0010_asset_addressing.sql
+  assets.flow_media_id nullable (table rebuild, 0009 pattern); local_files.provenance
+tests/test_locations.py
+  Key scheme, sanitization at construction, local/cloud resolution, extension correction
+tests/data/test_migration_0010.py
+  Migration applies, is checksum-stable, preserves existing rows (test_store_migrations.py pattern)
+tests/cli/test_data_media_json.py
+  `gflow data media --json` contract, incl. cloud rows and multi-location assets
+tests/cli/test_data_port.py
+  Port ordering, idempotency, partial failure, --prune-source, --dry-run (fake store)
+tests/test_error_remediation.py
+  All-subclass remediation coverage + on-topic assertions (currently-failing regression)
+tests/conftest_fake_store.py
+  Dict-backed fake storage fixture — the primary offline harness for port
+```
+
+### Modified files
+```
+src/gflow_cli/storage.py            Location construction + centralized key sanitization; typed ImportError
+src/gflow_cli/paths.py              Delete dead video_output_path; key builders move to locations.py
+src/gflow_cli/api/client.py         Collapse 3 duplicated relative_to blocks; honor out_dir; return Location
+src/gflow_cli/api/transports/ui_automation_video.py   Use the shared key builder; kill layout divergence
+src/gflow_cli/data/recorder.py      sha256/bytes for cloud; cloud_storage_info on character path; provenance
+src/gflow_cli/data/repository.py    provenance column; derived-artifact upsert
+src/gflow_cli/cli_image.py          Upscale records to catalog
+src/gflow_cli/services/character_create.py   Stop str()-ing a UPath and re-parsing as Path
+src/gflow_cli/chain.py              Seed-frame artifact recording; cloud guard
+src/gflow_cli/cli_data.py           `data media --json`; new `data port`; remediation hints
+src/gflow_cli/errors.py             ManifestValidationError / PromptValidationError split
+src/gflow_cli/config.py             Reject userinfo in GFLOW_CLI_STORAGE_URI
+src/gflow_cli/json_output.py        locations[] alongside local_path
+docs/CONFIGURATION.md, docs/EXTERNAL_STORAGE.md, docs/DATA_LAYER.md, docs/SECURITY.md, CHANGELOG.md
+PLAN.md                             Close Phase 8 as superseded; retire the line-468 backlog item
+```
+
+---
+
+## Phase 0 — Repair (no new concepts)
+
+Every task here is a live defect the council found. Each is independently shippable, offline-testable,
+and carries no design risk. **Phase 0 can merge before Phases 1–2 are designed further.**
+
+### Task 0.1 — Compute `sha256` and `bytes` for cloud writes
+- [ ] Failing test: record a cloud-backed image/video, assert `local_files.sha256` is non-NULL
+- [ ] Hash from the in-memory buffer at all three sites — `recorder.py:456-457`, `:518-519`, `:845-846`
+      currently do `sha256=... if cloud_storage_info is None else None`; the bytes are already
+      buffered (`client.py:1557` and the concat/upscale equivalents), so no re-read or network call
+- [ ] Assert no extra read: the hash is computed from the same `bytes` object that is written
+- **Why first:** Phase 2's port cannot verify integrity without it (spec § 2.4).
+
+### Task 0.2 — `upsample_image` honors its own `out_dir`
+- [ ] Failing test: `image upscale --out-dir <tmp>` with `GFLOW_CLI_STORAGE_URI` set produces a
+      date-partitioned key, not a flat basename
+- [ ] Fix: `client.py:281-289` stores the constructor's `out_dir=` as `self._out_dir` but the key
+      derivation at `:1934-1936` reads `self.settings.output_dir` — so **every** `upscale --out-dir`
+      with cloud storage hits the lossy fallback unconditionally
+
+### Task 0.3 — `image upscale` records to the catalog
+- [ ] Failing test: after `image upscale`, `gflow data list images` contains the upscaled asset
+- [ ] Fix: `_run_upscale` (`cli_image.py:585-612`) never instantiates `OperationRecorder` — add
+      recording with the same `record_failed_operation_safe` guard used elsewhere
+- [ ] Confirm the recorder failure path cannot lose a paid generation
+
+### Task 0.4 — `character create` stops corrupting the catalog under cloud storage
+- [ ] Failing test: `character create` with `GFLOW_CLI_STORAGE_URI` set records
+      `storage_provider="gcs"` and an intact `gs://…` URI
+- [ ] Fix A: `services/character_create.py:176,224` does `str(p0)`/`str(p1)` on what may be a cloud
+      `UPath`; `recorder.py:1204` re-parses it with plain `pathlib.Path` and calls `.resolve()`,
+      producing a nonsensical local path
+- [ ] Fix B: `record_character_completed` (`recorder.py:1132-1188`) has no `cloud_storage_info`
+      parameter, so `:1263-1264` hardcodes `storage_provider=None, cloud_uri=None` regardless of
+      backend — add the parameter and thread it through
+
+### Task 0.5 — chain + cloud storage fails honestly
+- [ ] Failing test: `video chain` with `GFLOW_CLI_STORAGE_URI` set raises `ConfigurationError`
+      (exit 11) with the spec § 4.6 remediation, instead of failing obscurely at link 2
+- [ ] Root cause: seed frames are written as bare local `Path`s (`chain.py:257,379-385`), and
+      `extract_last_frame` decodes with PyAV, which cannot open a `gs://`/`s3://` source — so every
+      link after the first is already broken today
+- [ ] **Open question 1 gates the permanent fix** (fail fast vs download-to-temp); this task ships
+      the honest error either way
+
+### Task 0.6 — the cloud-extra install hint reaches the user
+- [ ] Failing test: with `GFLOW_CLI_STORAGE_URI=gs://…` and `universal_pathlib` absent, the CLI
+      exits 11 and prints `pip install 'gflow-cli[gcs]'`
+- [ ] Fix: `storage.py:68-81` authors the correct message then raises a raw `ImportError`, which is
+      not a `GFlowError`, so the catch-all discards it and prints "Unexpected error." Re-raise as
+      `ConfigurationError` — pattern already correct at `api/_engine.py:184-187`
+
+### Task 0.7 — error taxonomy split + enforcement
+- [ ] Failing test A: walk `GFlowError.__subclasses__()` and assert every class resolves to a
+      non-empty remediation — generalizes `tests/test_self_documenting_errors.py:41-57`, which
+      hardcodes 8 of 36 classes
+- [ ] Failing test B (on-topic): a manifest-validation error's remediation must not contain
+      "transport" / "make_transport" — **this fails today**
+- [ ] Fix: add `ManifestValidationError` and `PromptValidationError` subclasses with correct
+      defaults. `ConfigurationError` is raised 119 times with only 5 passing a hint; the inherited
+      default (`errors.py:339-342`) is transport-specific and wrong for 53 sites in
+      `movie_manifest.py` and 32 in `image_batch.py`
+- [ ] Re-point those raise sites at the new classes (mechanical; no message rewriting)
+- [ ] Add `remediation_hint=` to the two `gflow data media` raise sites (`cli_data.py:302-306`,
+      `:314-322`) — the ambiguous-profile case has good text in `detail` but not in
+      `remediation_hint`, so `--json` consumers get the wrong guidance
+
+### Task 0.8 — delete dead code, collapse duplication
+- [ ] Delete `video_output_path` (`paths.py:114-122`) — zero production callers; remove its test
+- [ ] Collapse the three duplicated `relative_to` blocks (`client.py:1583-1585`, `:1796-1798`,
+      `:1934-1936`) into one private helper — this also fixes a live divergence where two sites
+      `mkdir` in the `else` branch and one does not (`:1588` vs `:1801`/`:1940`)
+- [ ] Expected: net ≈ −30 lines
+
+### Task 0.9 — reject credentials in storage URIs
+- [ ] Failing test: `GFLOW_CLI_STORAGE_URI=s3://KEY:SECRET@bucket/` is rejected at settings load
+- [ ] Fix `config.py:357-369` (currently a prefix check only) to reject embedded userinfo
+- [ ] Add `local_files.path` / `cloud_uri` to the redaction test matrix; update
+      `docs/SECURITY.md:120-122`, which does not currently list them
+
+### Task 0.10 — decide the `containers` CI story
+- [ ] Either wire a `containers` job into `.github/workflows/ci.yml`, **or** document in
+      `docs/EXTERNAL_STORAGE.md` that S3/GCS adapter tests are developer opt-in and not a merge gate
+- [ ] Today the default addopts exclude the marker and CI has no Docker reference, so
+      `tests/integration/test_storage_{s3,gcs}.py` never runs anywhere automatically
+
+### Task 0.11 — prove or remove `memory://`
+- [ ] Add a `memory://` round-trip test through `storage_path` + `write_asset_async`, **or** remove
+      the claim from `config.py:365` and `storage.py:15,34,110`
+- [ ] It is currently allowed and documented as the test-only backend with **zero** references in
+      `tests/` — Phase 2 must not build on it unproven
+
+### Task 0.12 — Phase 0 gates
+- [ ] `/gflow:check` green
+- [ ] CHANGELOG entry under `[Unreleased]`
+- [ ] Live-verify one `image upscale`, one `character create`, and one `video chain` on an operator
+      machine (tasks 0.2–0.5 touch generation paths)
+
+---
+
+## Phase 1 — Canonical keys and the read API
+
+**Do not start before Phase 0 merges** — Phase 1 builds on corrected write paths.
+
+### Task 1.1 — `Location` value object
+- [ ] Test: construction sanitizes `key` via `_sanitize_key`; traversal (`../`) raises
+- [ ] Test: `uri` derives correctly for local, `gs://`, `s3://`
+- [ ] Implement `src/gflow_cli/locations.py` per spec § 4.1 — frozen dataclass, no Protocol
+
+### Task 1.2 — canonical key builders
+- [ ] Table test covering all five key shapes (spec § 4.3)
+- [ ] Test: extension correction updates `Location.key` before the catalog row is written, so key
+      and reality never diverge
+- [ ] Move builders out of `paths.py`; replace the inline duplicate at
+      `ui_automation_video.py:1146-1157`
+
+### Task 1.3 — unify local and cloud video layout ⚠️ breaking
+- [ ] Test: local video lands at `videos/<YYYY-MM-DD>/<media_id>.mp4`, matching cloud
+- [ ] **Requires open question 2 answered first** (accept the break vs compat flag)
+- [ ] CHANGELOG entry flagged BREAKING
+
+### Task 1.4 — migration 0010
+- [ ] Test: applies cleanly, checksum recorded, existing rows preserved
+      (`tests/data/test_store_migrations.py` pattern)
+- [ ] `assets.flow_media_id` nullable via table rebuild (`0009_queue_claims.sql` pattern — SQLite
+      cannot alter constraints in place); partial unique index excluding NULLs
+- [ ] `local_files.provenance` (`generated` | `derived` | `referenced`)
+- [ ] **No Python, no `Settings`, no filesystem access in the SQL** — the runner executes verbatim
+      inside one transaction on every `DataStore.open()` (spec § 6.3)
+
+### Task 1.5 — derived artifacts get catalog rows
+- [ ] Test: `scene create --output` produces an addressable asset; `scenes.output_path` still reads
+      correctly as a derived view
+- [ ] Test: chain seed frames produce addressable artifacts; `chain_links.seed_frame_path` unchanged
+- [ ] Synthetic handle `gflow:derived:<sha256[:16]>`
+
+### Task 1.6 — `image upload` referenced-file class
+- [ ] Test: an uploaded source file records `provenance="referenced"` and is not treated as
+      gflow-written bytes
+
+### Task 1.7 — `gflow data media --json`
+- [ ] Test: JSON contract per spec § 4.4, including multi-location and cloud-only assets
+- [ ] Test: not-found and ambiguous cases carry the Task 0.7 remediation in `--json`
+- [ ] Add `locations[]` to generation-command `--json`, retaining `local_path`
+
+### Task 1.8 — Phase 1 gates
+- [ ] `/gflow:check` green · docs updated (`CONFIGURATION.md:58-59,400`, `DATA_LAYER.md`,
+      `EXTERNAL_STORAGE.md`) · `check_doc_links.py` green
+- [ ] Live-verify one t2i, one t2v, one scene create, one chain run
+- [ ] **Close #411** referencing Task 1.7
+
+---
+
+## Phase 2 — Port
+
+**Prerequisite: Task 0.1 must be merged** — without cloud hashes, port cannot verify integrity, and
+a "verified" port would be unverified by construction.
+
+### Task 2.0 — run `/gflow:predict` and the external council layer
+- [ ] `/gflow:predict` on the revised spec (never run against this shape)
+- [ ] `/gflow:llm-council` at `medium` or `high` tier with `codex` installed
+
+### Task 2.1 — fake dict-backed store harness
+- [ ] `tests/conftest_fake_store.py` — the primary offline harness; keep imports light so the
+      default suite's collection weight does not grow (AGENTS.md: full-suite OOM)
+
+### Task 2.2 — `gflow data port`
+- [ ] Test: additive by default — port produces a **second** `Location`, source untouched
+- [ ] Test: ordering — bytes → hash → compare → commit catalog → (optional) delete source
+- [ ] Test: hash mismatch aborts with both copies intact
+- [ ] Test: crash after bytes-write, before catalog commit → resume is a no-op, no orphan rows
+- [ ] Test: re-running a completed port is idempotent
+- [ ] Test: `--prune-source` deletes the old location only after the new one verifies
+- [ ] Test: `--dry-run` performs no writes
+- [ ] `transfer_state` (`pending` → `verified` → `committed`) drives idempotency
+- [ ] All spec § 4.6 port errors, with remediation
+
+### Task 2.3 — adapter verification
+- [ ] MinIO / fake-gcs round-trip under the `containers` marker
+- [ ] Report honestly per Task 0.10's outcome — if not CI-gated, say "developer-verified", never
+      "CI-verified"
+
+### Task 2.4 — Phase 2 gates
+- [ ] `/gflow:check` green · `/gflow:sonar` green
+- [ ] Port needs **no** live-verify — it never contacts Flow's API (spec § 4.5)
+
+---
+
+## Phase 3 — Deferred
+
+Not in this plan; listed so they are not silently lost.
+
+- `storage_key` column and `gflow data reconcile` — revisit when drift is **measured** (spec § 10.3)
+- `local_files.path` polymorphism / table rebuild (spec § 6.2)
+- `-o/--output` on generation commands — as sugar, `type=str` never `click.Path` (spec § 10.4)
+- Orphan adoption — carries a security cost (spec § 10.3)
+
+---
+
+## Housekeeping (this PR)
+
+- [ ] Close `PLAN.md` Phase 8 (lines 674-685) as superseded by `gflow_cli.storage`, recording the
+      CI-coverage caveat
+- [ ] Retire `PLAN.md:468` ("Unify Output Resolution") — resolved by spec § 4.3
+
+---
+
+## Open questions — must be answered before the tasks they gate
+
+1. **Chain + cloud** (gates Task 0.5's permanent fix): fail fast, or download-to-temp before PyAV?
+2. **Local video layout** (gates Task 1.3): accept the break, or compat flag for one minor version?
+3. **`containers` in CI** (gates Task 0.10): wire the job, or document opt-in?

--- a/docs/superpowers/specs/2026-08-02-asset-addressing-design.md
+++ b/docs/superpowers/specs/2026-08-02-asset-addressing-design.md
@@ -1,0 +1,378 @@
+# Asset addressing, storage portability, and error guidance — design spec
+
+> **Status:** PROPOSED · **Date:** 2026-08-02 · **Council-reviewed:** 2026-08-02
+> (internal 6-dimension council — D1 correctness/mode-coverage **RED**, D14 over-engineering **RED**,
+> D3 security / D4 tests / D7 data-layer / D8 CLI-UX **YELLOW**; overall **RED** on the originally
+> proposed shape, which this spec supersedes)
+> **Origin:** [#411](https://github.com/ffroliva/gflow-cli/issues/411) asked for an `-o/--output`
+> flag on the generation commands. Triage found the flag treats a symptom; this spec fixes the
+> addressing model underneath it.
+> **Companion plan:** [plans/2026-08-02-asset-addressing/PLAN.md](../plans/2026-08-02-asset-addressing/PLAN.md)
+> **External-review caveat:** the council ran `small`-tier — `codex` and `agy` were unavailable in
+> the review environment, so both RED verdicts rest on same-model-family reviewers. Re-run the
+> external layer before executing Phase 2 or later.
+
+---
+
+## 1. Goal
+
+Make a generated asset **addressable and verifiable** regardless of where its bytes live, so that:
+
+```bash
+# scripting: resolve any generation to its artifact, local or cloud
+gflow image t2i "a serene mountain lake" --json | jq -r '.images[0].media_name'
+gflow data media <media_id> --json      | jq -r '.locations[0].uri'
+
+# portability: move an asset between backends without losing provenance
+gflow data port <media_id> --to local
+```
+
+The **asset** is the entity. A **file is one location of that asset**. The path or URI is an
+implementation detail behind the catalog, not the user's contract.
+
+## 2. Problem
+
+### 2.1 The catalog is write-mostly
+
+`local_files` already models 1:N locations per asset
+(`data/migrations/0001_initial.sql:79-90`, `UNIQUE(asset_id, path)`) with `storage_provider` and
+`cloud_uri` added in `0002_add_cloud_storage.sql`. `gflow data media` already iterates
+`asset.local_files` and prints `local_path_N` / `cloud_uri_N`. But it renders a Rich table **only** —
+there is no `--json`, so the one command that answers "where is this asset?" cannot be scripted.
+That, not filename unpredictability, is why #411's reporter reached for `-o`.
+
+### 2.2 Keys are recovered by subtraction, lossily
+
+`image_output_path` / `video_output_path` build an absolute local path; the storage key is then
+recovered by string subtraction at three sites, with a silent lossy fallback:
+
+```python
+try:    key = out_path.relative_to(self.settings.output_dir).as_posix()
+except ValueError:  key = out_path.name          # layout fidelity lost
+```
+
+`api/client.py:1583-1585` (`download_image`), `:1796-1798` (`concatenate_scene`),
+`:1934-1936` (`upsample_image`). The comment at `client.py:1578` promises "cloud keys mirror the
+local directory structure"; the fallback silently breaks that promise.
+
+Cloud rows remain **recoverable** (`cloud_uri = storage_uri + key_actually_used`, so stripping the
+prefix always recovers the key that was written). What is lost is layout fidelity. **Local** rows
+are the fragile case: `record_upload_image` (`data/recorder.py:454`) and character files
+(`:1259`) store `path.resolve()` for caller-supplied paths with no constraint to `output_dir`, so
+`relative_to()` raising is an expected case, not an error.
+
+### 2.3 The premise does not hold for five surfaces
+
+| Surface | Why it has no `assets` row | Evidence |
+|---|---|---|
+| `image upscale` | Writes through the storage layer but **never instantiates `OperationRecorder`** | `cli_image.py:585-612` |
+| `scene create --output` | Concat result is media-id-less ("ephemeral on Flow's side"), stored in a bespoke `scenes.output_path` column | `migrations/0004_add_scene_output_path.sql:1-5`, `recorder.py:693-697` |
+| chain seed frames | Written as a bare local `Path`, tracked only in `chain_links.seed_frame_path` | `chain.py:257,379-385` |
+| `movie run` | Writes a JSON handoff sidecar carrying raw path strings | `cli_movie.py:565,734-749` |
+| `image upload` | References a pre-existing user file; writes no bytes | `cli_image.py:396-437` |
+
+Any location model that does not reconcile `chain_links.seed_frame_path`, `scenes.output_path`, and
+the movie sidecar **adds a fourth addressing scheme instead of unifying to one**.
+
+### 2.4 Integrity is unavailable exactly where it matters
+
+`sha256` is skipped for every cloud row — `recorder.py:456-457`, `:518-519`, `:845-846`
+(`sha256=... if cloud_storage_info is None else None`). At all three sites the bytes are already
+buffered in memory (`client.py:1557` and the concat/upscale equivalents), so hashing is free. Until
+this is fixed, any port to or from cloud is a copy with **no integrity check by construction**.
+
+### 2.5 Errors do not guide
+
+The framework is sound — `GFlowError._default_remediation` / `remediation_hint`
+(`errors.py:68-106`) renders identically in Rich (`_cli_helpers.py:299-314`) and `--json`
+(`json_output.py:54-79`). Usage is not: `ConfigurationError` is raised **119 times and 5 pass a
+`remediation_hint`**. The other 114 inherit a transport-specific default (`errors.py:339-342`),
+so 53 manifest-validation sites and 32 batch-validation sites tell the user to check transport
+registration. Separately, `storage.py:68-81` authors a correct install hint and then raises a raw
+`ImportError`, which is not a `GFlowError` and is discarded by the catch-all handler.
+
+## 3. Scope
+
+**In scope.** Correct the write path so keys are canonical rather than recovered; give every
+byte-producing surface a catalog row; compute integrity hashes for all backends; expose a
+machine-readable read API; add an additive cloud↔local port; make errors on these surfaces
+actionable and enforce that with tests.
+
+**Non-goals.**
+
+- **An `AssetStore` Protocol with per-backend strategy classes.** Rejected — see § 10.1.
+- **Migration `0010` / `storage_key` / `gflow data reconcile`.** Deferred — see § 10.3.
+- **`-o/--output` on the generation commands (#411's literal ask).** Deferred to a follow-up as
+  sugar; § 4.4 fixes the underlying need. See § 10.4.
+- **Reworking `UNIQUE(asset_id, path)` polymorphism.** Requires a table rebuild; out of scope
+  (§ 9.2).
+- **Azure Blob or any fourth backend.** No named user.
+
+## 4. Contract
+
+### 4.1 `Location` — a value object, not an interface
+
+```python
+@dataclass(frozen=True)
+class Location:
+    backend: str        # "local" | "gcs" | "s3"
+    key: str            # canonical, backend-independent: "images/2026-08-02/<media>_1.jpg"
+    uri: str            # concrete: "file:///…" | "gs://bucket/prefix/<key>" | "s3://…"
+    sha256: str
+    bytes: int
+    media_type: str
+```
+
+`key` is the stable identity; `uri` is derived. `Location` is returned by the write path so callers
+stop receiving a bare `Path`/`UPath` with no digest or media-type — the single real gap in today's
+storage layer.
+
+**Construction invariant:** `key` is sanitized at `Location.__post_init__` via the existing
+`_sanitize_key` (`storage.py:55-65`). Sanitization is centralized here, not per-backend.
+
+### 4.2 What is an asset, and what is not
+
+Three artifact classes, explicitly:
+
+| Class | Definition | Catalog home | Examples |
+|---|---|---|---|
+| **Generated asset** | gflow-cli produced the bytes and Flow issued a `media_id` | `assets` + N × `local_files` | t2i, i2i, batch, t2v, i2v, r2v, chain clips, character slots, upscale output |
+| **Derived artifact** | gflow-cli produced the bytes; **no Flow `media_id` exists** | `assets` with `flow_media_id = NULL`, + `local_files` | scene concat output, chain seed frames |
+| **Referenced file** | A pre-existing user file gflow-cli did not write | `local_files` row only, `provenance="referenced"` | `image upload` source |
+
+The **derived artifact** class is the missing piece that makes the model total. It requires relaxing
+`assets.flow_media_id` to nullable, with a synthetic stable id (`gflow:derived:<sha256[:16]>`) as
+the addressing handle. Without it, scene concat and chain seed frames remain unaddressable.
+
+`scenes.output_path` and `chain_links.seed_frame_path` become **derived, backward-compatible views**
+of the corresponding `local_files` row — they are not removed in this change, but they stop being
+the source of truth.
+
+### 4.3 Key scheme
+
+One scheme, applied uniformly, replacing the local/cloud divergence at
+`ui_automation_video.py:1146-1157`:
+
+```
+images/<YYYY-MM-DD>/<media_name>_<index>.<ext>
+videos/<YYYY-MM-DD>/<media_id>.mp4
+characters/<YYYY-MM-DD>/character_<entity_id>_slot<slot>.<ext>
+scenes/<YYYY-MM-DD>/<scene_id>.mp4
+frames/<YYYY-MM-DD>/<chain_id>_link<index>_lastframe.jpg
+```
+
+Resolution is one function, replacing the three duplicated `relative_to` blocks:
+
+```python
+def resolve_location(*, key: str, output_dir: Path, storage_uri: str | None) -> AnyPath
+```
+
+**Behavioural change (breaking, must be changelogged):** local video output moves from flat
+`<out_dir>/<media_id>.mp4` to `videos/<YYYY-MM-DD>/<media_id>.mp4`, matching what cloud already
+does. Scripts globbing `--out-dir/*.mp4` will need updating. `--out-dir` continues to override the
+root; the key is appended beneath it.
+
+**Extension correction** stays byte-derived (`adjust_key_extension`, issue #96) — Flow's CDN
+returns JPEG for `.png` targets. The corrected extension is reflected in `Location.key` before the
+catalog row is written, so key and reality never diverge.
+
+### 4.4 Read API
+
+```
+gflow data media <media_id> [--profile NAME] [--json]
+```
+
+`--json` emits:
+
+```json
+{
+  "status": "ok",
+  "media_id": "...", "project_id": "...", "kind": "video", "profile": "...",
+  "locations": [
+    {"backend": "gcs", "key": "videos/2026-08-02/abc.mp4",
+     "uri": "gs://bucket/prefix/videos/2026-08-02/abc.mp4",
+     "sha256": "…", "bytes": 5242880, "media_type": "video/mp4"}
+  ]
+}
+```
+
+Existing generation-command `--json` (already shipping `local_path`) gains `locations[]` alongside
+it; `local_path` is retained for compatibility.
+
+### 4.5 Port
+
+```
+gflow data port <media_id> --to {local|cloud} [--prune-source] [--dry-run]
+```
+
+**Additive by default.** Port produces a *second* `Location`; it is never destructive on its own.
+`--prune-source` removes the old location only after the new one verifies.
+
+Ordering is fixed and non-negotiable — bytes are the source of truth, the catalog is the
+reconcilable side (`docs/DATA_LAYER.md:214`, "the catalog can be reconciled later… the file cannot
+be un-billed"):
+
+1. Write destination bytes
+2. Hash the destination
+3. Compare against the source hash — mismatch aborts, leaving both sides intact
+4. Append the new `Location` row and commit
+5. Only then, under `--prune-source`, delete the source object
+
+On a post-copy catalog failure, **leave the new copy in place as an orphan**; never roll back bytes.
+Idempotency comes from a `transfer_state` on the pending row (`pending` → `verified` → `committed`),
+so a re-run after interruption is a no-op rather than a duplicate write.
+
+Port never contacts Flow's API, so it is **not** subject to the live-verify gate.
+
+### 4.6 Error contract
+
+Every error on this surface satisfies: *the message names what went wrong, and the remediation names
+the exact command or flag that fixes it.* An error that does not is a defect, not a style issue.
+
+| Trigger | Class | Exit | Message | Remediation |
+|---|---|---|---|---|
+| Cloud extra not installed | `ConfigurationError` (was: raw `ImportError`) | 11 | `Cloud storage requires the matching extra.` | `Install it: pip install 'gflow-cli[gcs]'` (or `[s3]`) |
+| `port` with missing credentials | `ConfigurationError` + raise-site hint | 11 | `No credentials found for <provider>.` | `Set GOOGLE_APPLICATION_CREDENTIALS (gs://) or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (s3://), then retry.` |
+| `port` object missing at backend | `DataIntegrityError` | 16 | `Catalog record for <id> points to <uri>, but the object no longer exists there.` | `Re-generate the asset, or remove the stale location with 'gflow data prune'.` |
+| `port` hash mismatch | `DataIntegrityError` | 16 | `Copy verification failed: source <sha> != destination <sha>.` | `Re-run 'gflow data port'; both copies were left intact.` |
+| `data media <id>` not found | `DataStoreError` + raise-site hint | 16 | `No local media record found: <id>.` | `Check the ID for typos, or run 'gflow data list media' to see valid IDs.` |
+| `data media <id>` ambiguous | `DataStoreError` + raise-site hint | 16 | `Media '<id>' exists under multiple profiles: [...]` | `Pass --profile NAME to disambiguate.` |
+| chain + cloud storage | `ConfigurationError` | 11 | `Chain seed-frame extraction cannot read from cloud storage.` | `Run 'gflow video chain' without GFLOW_CLI_STORAGE_URI, then 'gflow data port' the clips afterwards.` |
+
+**No new exit codes.** `click.UsageError` → 2, `ConfigurationError` → 11,
+`DataStoreError`/`DataIntegrityError` → 16 (`errors.py:825-844`, `:933-935`) cover every case.
+
+**Root fix, not per-site patching:** split `ConfigurationError` into `ManifestValidationError` and
+`PromptValidationError` with topically-correct defaults, so 114 raise sites become correct by
+construction instead of each needing a bespoke hint.
+
+**Enforcement** (two tests, because the existing one checks presence, not applicability):
+
+1. Generalize `tests/test_self_documenting_errors.py:41-57` — it hardcodes 8 of 36 subclasses, so a
+   new class can ship with an empty hint and nothing fails. Walk `__subclasses__()` instead.
+2. Assert hints are **on-topic**: a manifest-validation error's hint must not mention "transport".
+   This test fails today.
+
+## 5. Security invariants
+
+1. **No credentials in destination strings.** Reject embedded userinfo (`s3://KEY:SECRET@bucket/`)
+   at the `GFLOW_CLI_STORAGE_URI` validator (`config.py:357-369`, currently prefix-check only).
+   `safe_path_text` (`_cli_helpers.py:256-283`) strips CWD/home prefixes but has no credential
+   scrubbing, and resolved paths are printed to console (`cli_image.py:975,1352`) and persisted to
+   `local_files.path`/`cloud_uri`, neither of which passes through `redact_metadata`
+   (`data/redaction.py:55-75`; `docs/SECURITY.md:120-122` does not list them).
+2. **Cloud URIs are not filesystem paths** — do not route them through `safe_path_text`; they carry
+   no local-machine information.
+3. **MCP exposes no write destination.** Today zero MCP parameters reach a write path
+   (`mcp/tools.py:624-769` — `profile` is resolved server-side, `project` is never a path). This
+   spec keeps it that way. `tests/mcp/test_cli_parity.py` is command-level and does not force
+   otherwise.
+4. **Key sanitization is centralized** at `Location.__post_init__`, so no future backend can skip it.
+
+## 6. Data layer
+
+### 6.1 What changes now
+
+- `assets.flow_media_id` becomes nullable, to admit the **derived artifact** class (§ 4.2).
+- `local_files` gains `provenance` (`generated` | `derived` | `referenced`).
+- `sha256` and `bytes` are populated for **all** backends.
+
+### 6.2 What is explicitly deferred
+
+`local_files.path` remains polymorphic (`repository.py:747-750` stuffs the cloud URI into `path` to
+satisfy `NOT NULL` + `UNIQUE(asset_id, path)`). Making `path` legacy requires a **table rebuild** —
+SQLite cannot alter a UNIQUE in place; the in-repo precedent is `0009_queue_claims.sql`'s
+create-copy-drop-rename — and touches `repository.py:996-1034`, `cli_data.py:476-481`, and four raw
+SQL blocks in `queries.py`. That is a separate change with its own plan.
+
+### 6.3 Migration constraints (binding)
+
+Migrations execute `.sql` **verbatim** with no Python hook (`store.py:47-71`), inside one
+`BEGIN IMMEDIATE` (`:240-248`), and `apply_migrations()` runs on **every** `DataStore.open()` — i.e.
+every `gflow` invocation. Therefore:
+
+- No migration in this change may compute values from `Settings` or touch the filesystem.
+- Any data backfill must be a resumable CLI command, never migration machinery — a failed backfill
+  inside `apply_migrations()` raises `DataMigrationError`, which then blocks every future
+  invocation.
+- `DataMigrationError` is reserved for schema incompatibility. Row-level failures use
+  `DataStoreError` / `DataIntegrityError`.
+
+## 7. Testing & verification
+
+| Piece | Offline | `containers` (Docker) | Live Flow |
+|---|---|---|---|
+| `Location`, key scheme, `resolve_location` | ✅ | | |
+| Port algorithm (ordering, resumability, partial failure) | ✅ via fake dict-backed store | | |
+| `data media --json` contract | ✅ | | |
+| Error taxonomy + remediation tests | ✅ | | |
+| sha256-on-cloud-write | ✅ (pure function of bytes) | | ⚠️ recording slice touches a generation path |
+| s3fs / gcsfs adapter correctness | | ✅ MinIO + fake-gcs | |
+| Catalog rows for upscale / character / scene | ✅ | | ⚠️ generation path |
+
+**Two harness facts that constrain this plan:**
+
+- `memory://` is allowed by `config.py:365` and documented as the test backend
+  (`storage.py:15,34,110`) but has **zero references in `tests/`**. It is an unverified claim; do
+  not build the port test strategy on it without first proving it round-trips.
+- The only byte-level cloud harness (`tests/integration/test_storage_{s3,gcs}.py`, MinIO/fake-gcs
+  via `testcontainers`) is marked `containers` and excluded by default addopts;
+  `.github/workflows/ci.yml` has no Docker reference. Adapter tests are therefore **developer
+  opt-in, not a merge gate**, until a CI job exists. This must be stated, not assumed.
+
+Do not use `moto` — it is not a dependency and conflicts with the `s3fs`/`aiobotocore` pins.
+
+## 8. Documentation impact
+
+`docs/CONFIGURATION.md:400` currently states "file paths are not accepted (rename after the fact if
+needed)" and `:58-59` documents the `--out` / `--out-dir` split. Both need rewriting.
+`docs/EXTERNAL_STORAGE.md`, `docs/DATA_LAYER.md`, and `docs/SECURITY.md` § redaction scope all
+change. `scripts/ci/check_doc_links.py` is a merge gate.
+
+## 9. Rollout
+
+Phase 0 is independently shippable and carries no new concepts — it is pure defect repair. Phases 1
+and 2 each stand alone. Nothing in this spec requires a big-bang change.
+
+## 10. Decisions and rejected alternatives
+
+### 10.1 Rejected: `AssetStore` Protocol with per-backend strategies
+`UPath` IS-A `Path`, and fsspec's gcsfs/s3fs already implement the `put/open/exists/url` surface the
+Protocol would re-declare (`storage.py:32,68-81,113-145`). Three strategy classes wrapping a library
+that already unifies them is precisely AGENTS.md's banned pattern — "no speculative abstractions
+(interface/factory with one implementation)" — made worse by turning one implementation into three
+thin wrappers. Blast radius would be 8 production modules plus 5 test files. **Keep UPath; add the
+`Location` dataclass**, which is the only genuine gap.
+
+### 10.2 Decided: close PLAN.md Phase 8 as superseded
+Phase 8 (`PLAN.md:674-685`) specifies a `StorageBackend` Protocol, `GFLOW_CLI_STORAGE_BACKEND`, and
+a `--storage-backend` flag. `gflow_cli.storage` shipped a different, working design — one validated
+`GFLOW_CLI_STORAGE_URI` (`config.py:345-368`) with 8 production call sites. Reopening Phase 8 under
+a new name would ship the over-engineering it was right-sized away from. **Caveat:** its integration
+suites do not run in CI (§ 7), so record that gap when closing it. `PLAN.md:468` ("Unify Output
+Resolution") is genuinely retired by § 4.3.
+
+### 10.3 Deferred: migration `0010`, `storage_key`, and `gflow data reconcile`
+The backfill cannot live in a migration (§ 6.3); `storage_key` as an additive column does not fix
+the `UNIQUE` polymorphism (§ 6.2); the write-time sha256 fix (§ 2.4) beats reconcile-backfill, which
+would cost a network read per object. Decisively: **reconcile cannot repair a catalog that
+structurally omits upscale and scene-concat outputs** — fix the write path first (§ 4.2). Orphan
+adoption additionally lowers the attacker bar from "controls Flow's API response" to "can write into
+the output directory". Revisit when drift is **measured**, not assumed.
+
+### 10.4 Deferred: `-o/--output` (#411 as literally filed)
+The reporter's need is met by § 4.4 plus existing `--json`. When `-o` is eventually built it must
+take `type=str`, never `click.Path` — verified empirically, `Path("s3://bucket/k.png")` collapses to
+`s3:/bucket/k.png` on POSIX and `s3:\bucket\k.png` on Windows. It must reject multi-asset runs
+(precedent: `cli_image.py:787-819`) and require `--force` to overwrite (precedent:
+`cli_scene.py:100-102`).
+
+## 11. Open questions
+
+1. **Chain + cloud storage** (§ 4.6, Phase 0.5): fail fast with a clear error, or download-to-temp
+   before PyAV extraction? Failing fast is smaller and honest; download-to-temp preserves the
+   feature. Needs an owner decision.
+2. **Local video layout change** (§ 4.3): accept the break with a CHANGELOG entry, or keep flat
+   output behind a compatibility flag for one minor version?
+3. **`containers` in CI** (§ 7): wire the job now, or ship with adapter tests documented as
+   opt-in?


### PR DESCRIPTION
## Summary

Docs-only. Produces the **spec and plan** for the work behind #411 — no code changes.

Triage of #411 (add `-o/--output` to the generation commands) found the flag treats a symptom. An internal six-dimension council review returned **RED** on the originally proposed shape (D1 correctness/mode-coverage RED, D14 over-engineering RED, D3/D4/D7/D8 YELLOW). This PR lands the superseding design and sequences the work.

**Spec** — `docs/superpowers/specs/2026-08-02-asset-addressing-design.md`

- The asset is the entity; a file is one **location** of it. Adds a frozen `Location` value object as the write path's return type — today callers get a bare `Path`/`UPath` with no digest or media-type.
- **Rejects** an `AssetStore` Protocol with per-backend strategies. `UPath` already unifies local/`gs://`/`s3://`, so three wrappers around fsspec would be a speculative abstraction across 8 production modules.
- Admits a third artifact class — **derived** (no Flow `media_id`) — so `scene create --output` and chain seed frames become addressable. Without it the model is not total: five surfaces produce real files with no `assets` row.
- Makes the storage key **canonical** rather than recovered by string subtraction, and unifies the local/cloud video layout divergence.
- Specifies additive **port** semantics: write bytes → hash → compare → commit catalog → optionally prune source. Never destructive by default.
- Specifies an **error contract** where every remediation names the command that fixes the problem, plus two enforcement tests.
- Defers migration `0010`, `gflow data reconcile`, and `-o` itself, each with recorded rationale.

**Plan** — `docs/superpowers/plans/2026-08-02-asset-addressing/PLAN.md`

- **Phase 0** repairs 12 live defects the council found, independently shippable and offline-testable — including cloud writes never computing `sha256`, `image upscale` recording nothing to the catalog at all, `character create` corrupting catalog rows under cloud storage, chain being already broken under cloud storage (PyAV cannot decode a `gs://` source), and 114 of 119 `ConfigurationError` raise sites emitting a transport hint for manifest and batch validation failures.
- **Phase 1** lands canonical keys and `gflow data media --json` — which is what actually closes #411.
- **Phase 2** lands port, gated on the `sha256` fix, since without cloud hashes a "verified" port is unverified by construction.

Three open questions are recorded and each names the task it gates.

`Refs #411` — not `Closes`. The issue closes when Phase 1 Task 1.7 ships.

## Validation

Docs-only change; no `src/` or `tests/` files touched, so the lint/type/test gates are not applicable to this diff.

- [x] Focused tests added or updated for behavior changes — n/a, no behavior change
- [x] Documentation updated or explicitly marked not applicable — this PR *is* the documentation
- [x] `uv run python scripts/ci/check_doc_links.py` — `All links resolved across 27 files.`
- [ ] `uv run ruff check src tests` — not run; no `src/` or `tests/` changes in this diff
- [ ] `uv run pyright src` — not run; no `src/` changes in this diff
- [ ] Relevant pytest command: not run; no code changes in this diff

Also run: `check_repo_hygiene.py` (686 files, no violations) and `check_website_docs_pii.py` (clean).

## Contribution Checklist

- [x] This PR targets `develop`, unless it is a release or emergency fix
- [x] My commits use my real Git identity or GitHub noreply email
- [ ] External contribution commits include `Signed-off-by:` (`git commit -s`) — n/a, not an external contribution
- [x] I did not include secrets, cookies, account tokens, signed URLs, or private captured data
- [ ] I reviewed any AI-assisted changes before submitting — **for the human reviewer to confirm**

## Reviewer notes

Two things worth knowing before reading:

1. **The council ran without its external layer.** `codex` and `agy` were both unavailable in the review environment, so this was a `small`-tier run and *both* RED verdicts come from same-model-family reviewers — exactly the blind spot the external layer exists to cover. The plan gates Phase 2 on re-running it. Treat the Phase 0 defect list as high-confidence (each item cites `file:line`) and the design decisions as needing a second opinion.
2. **The branch name is non-conventional.** `check_repo_hygiene.py` flags it as advisory: this should be `docs/` per AGENTS.md, but the branch was fixed by the automation that produced the PR. Worth renaming before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0166aY3RtwdaMfCtytV2VMU6)_