### PR TITLE
feat(pr-triage): authenticate with subscription OAuth instead of an API key

### DIFF
--- a/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
+++ b/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
@@ -10,7 +10,7 @@ The autopilot orchestrator (`scripts/autopilot/pr_triage_autopilot.py`) runs as 
 
 | Variable | Scope | Purpose |
 |---|---|---|
-| `CLAUDE_CREDENTIALS_FILE` | Autopilot orchestrator (host), optional | Path to the Claude **subscription OAuth** credentials. Defaults to `~/.claude/.credentials.json`. This deployment is subscription-based and uses **no `ANTHROPIC_API_KEY`** — the orchestrator copies this file per-run into the sandbox at `CLAUDE_CONFIG_DIR=/tmp/claude`. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Autopilot orchestrator & sandbox | Claude **subscription** token from `claude setup-token`, valid **1 year**. This deployment has no `ANTHROPIC_API_KEY`. Passed into the container as an env var. **Not** `~/.claude/.credentials.json` — `setup-token` does not write that file. |
 | `GH_COMMENT_TOKEN` | Autopilot orchestrator (host) | The comment-only GitHub PAT used to post verdicts and reviews to `ffroliva/gflow-cli` PRs. |
 | `TELEGRAM_BOT_TOKEN` | Autopilot orchestrator (host) | Bot token to dispatch alert messages. |
 | `TELEGRAM_USER_ID` | Autopilot orchestrator (host) | The chat ID to receive triage alert messages. |
@@ -58,18 +58,23 @@ Sourcing `/opt/hermes/.env` first (`set -a` exports everything it defines) is wh
 
 > **`.env` must stay bash-sourceable.** This line sources the file, so any value containing spaces or shell metacharacters has to be quoted in the SOPS store. systemd's `EnvironmentFile` parser is more permissive than bash and will not warn you: an unquoted `HERMES_NOTIFY_EMAIL_FROM=Hermes Ops <noreply@...>` broke exactly this line on 2026-08-02 (`<` is a redirect), silently dropping every variable defined after it. Fixed in hermes-ops by quoting the value.
 
-### Claude authentication (subscription OAuth, no API key)
+### Claude authentication (subscription token, no API key)
 
-The council review runs `claude -p` inside the sandbox, authenticated by the **subscription OAuth token**, not an API key. The orchestrator validates `~/.claude/.credentials.json` on the host *before* building the image, then `run_sandboxed_review.sh` copies it into a per-run temp dir mounted **writable** at `/tmp/claude` (`CLAUDE_CONFIG_DIR`). Writable because the CLI persists a refreshed token; per-run because a container reviewing an untrusted external PR must never write back to the operator's own credentials. The copy is removed by an `EXIT` trap.
+The council review runs `claude -p` inside the sandbox, authenticated by `CLAUDE_CODE_OAUTH_TOKEN` — the subscription token minted by `claude setup-token`, **valid 1 year**. It is stored in hermes-ops `secrets/vps-prod.env.sops.yaml`, rendered into `/opt/hermes/.env`, and reaches the process because the cron line sources that file. The orchestrator checks it is set before building the image, so a missing token fails in a second rather than as an opaque 401 minutes into a container run.
 
-**Rotation is manual and it is a real operational dependency.** A token with no `refreshToken` cannot self-renew — the 2026-07-16 token sat expired for 16 days and every run would have failed with a 401. The orchestrator now refuses to start and logs `Claude OAuth credentials unusable` instead. To renew:
+> **It is not `~/.claude/.credentials.json`.** `setup-token` does not write that file — verified on cgserver01 2026-08-02, where it still held the expired 2026-07-16 interactive-login token after a successful mint. Reading the file would authenticate with a dead credential. The two are separate mechanisms.
+
+**Rotation — the one real operational dependency.** The token is a static bearer value with **no refresh pair**: it cannot self-renew, and nothing in the API surface reports its age. The previous interactive token 401'd silently for 16 days. Rotate before the 1-year mark:
 
 ```bash
-sudo -u hermes -H claude          # complete the login flow, then /exit
-sudo -u hermes -H claude -p "say OK"   # verify
+sudo -u hermes -H claude setup-token          # prints the token ONCE
+# store it in hermes-ops secrets/vps-prod.env.sops.yaml as CLAUDE_CODE_OAUTH_TOKEN
+sudo -u hermes -H bash -c 'set -a; . /opt/hermes/.env; set +a; claude -p "say OK"'   # verify
 ```
 
-**Accepted risk (operator, 2026-08-02):** the OAuth token carries the whole subscription (`user:inference`, `user:profile`, `user:sessions:claude_code`) — broader than a scoped API key would be — and it is mounted into a container that reviews untrusted external PRs. The egress firewall in §3 is the compensating control. Accepted because no API key exists for this account.
+The daily `ev-ops-health` Telegram digest carries the expiry countdown; treat that warning as the rotation trigger.
+
+**Accepted risk (operator, 2026-08-02):** the token grants inference on the whole subscription and is injected into a container that reviews untrusted external PRs. Its scope is `user:inference` only — narrower than the five scopes an interactive login carries — and the §3 egress firewall is the compensating control. Accepted because no API key exists for this account.
 
 ### Deploy mechanism (warning)
 

--- a/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
+++ b/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
@@ -10,7 +10,7 @@ The autopilot orchestrator (`scripts/autopilot/pr_triage_autopilot.py`) runs as 
 
 | Variable | Scope | Purpose |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | Autopilot orchestrator & sandbox | Mints the Claude agent tokens to execute the council review. |
+| `CLAUDE_CREDENTIALS_FILE` | Autopilot orchestrator (host), optional | Path to the Claude **subscription OAuth** credentials. Defaults to `~/.claude/.credentials.json`. This deployment is subscription-based and uses **no `ANTHROPIC_API_KEY`** — the orchestrator copies this file per-run into the sandbox at `CLAUDE_CONFIG_DIR=/tmp/claude`. |
 | `GH_COMMENT_TOKEN` | Autopilot orchestrator (host) | The comment-only GitHub PAT used to post verdicts and reviews to `ffroliva/gflow-cli` PRs. |
 | `TELEGRAM_BOT_TOKEN` | Autopilot orchestrator (host) | Bot token to dispatch alert messages. |
 | `TELEGRAM_USER_ID` | Autopilot orchestrator (host) | The chat ID to receive triage alert messages. |
@@ -51,10 +51,25 @@ Ensure `iptables` is installed on the host VPS. If `iptables` permissions are wi
 Configure a cron job checking every hour on the hour under the `hermes` system user:
 
 ```cron
-0 * * * * set -a; . /opt/hermes/.env 2>/dev/null; set +a; export ANTHROPIC_API_KEY="xxx" && export GH_COMMENT_TOKEN="xxx" && export TELEGRAM_BOT_TOKEN="xxx" && export TELEGRAM_USER_ID="xxx" && cd /opt/gflow-cli && uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli --memory-dir /opt/experience-vault/projects/C--development-github-gflow-cli/memory >> /var/log/hermes/pr_triage.log 2>&1
+0 * * * * set -a; . /opt/hermes/.env 2>/dev/null; set +a; cd /opt/gflow-cli && uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli --memory-dir /opt/experience-vault/projects/C--development-github-gflow-cli/memory >> /var/log/hermes/pr_triage.log 2>&1
 ```
 
-Sourcing `/opt/hermes/.env` first (`set -a` exports everything it defines) is what delivers the `RESEND_API_KEY` / `HERMES_NOTIFY_EMAIL_*` vars to the process so the email channel works; without it the run still succeeds but emails are silently disabled.
+Sourcing `/opt/hermes/.env` first (`set -a` exports everything it defines) is what delivers `GH_COMMENT_TOKEN`, `TELEGRAM_*`, and the `RESEND_API_KEY` / `HERMES_NOTIFY_EMAIL_*` vars to the process. Without it the email channel silently disables itself, and without `GH_COMMENT_TOKEN` the run exits 1.
+
+> **`.env` must stay bash-sourceable.** This line sources the file, so any value containing spaces or shell metacharacters has to be quoted in the SOPS store. systemd's `EnvironmentFile` parser is more permissive than bash and will not warn you: an unquoted `HERMES_NOTIFY_EMAIL_FROM=Hermes Ops <noreply@...>` broke exactly this line on 2026-08-02 (`<` is a redirect), silently dropping every variable defined after it. Fixed in hermes-ops by quoting the value.
+
+### Claude authentication (subscription OAuth, no API key)
+
+The council review runs `claude -p` inside the sandbox, authenticated by the **subscription OAuth token**, not an API key. The orchestrator validates `~/.claude/.credentials.json` on the host *before* building the image, then `run_sandboxed_review.sh` copies it into a per-run temp dir mounted **writable** at `/tmp/claude` (`CLAUDE_CONFIG_DIR`). Writable because the CLI persists a refreshed token; per-run because a container reviewing an untrusted external PR must never write back to the operator's own credentials. The copy is removed by an `EXIT` trap.
+
+**Rotation is manual and it is a real operational dependency.** A token with no `refreshToken` cannot self-renew — the 2026-07-16 token sat expired for 16 days and every run would have failed with a 401. The orchestrator now refuses to start and logs `Claude OAuth credentials unusable` instead. To renew:
+
+```bash
+sudo -u hermes -H claude          # complete the login flow, then /exit
+sudo -u hermes -H claude -p "say OK"   # verify
+```
+
+**Accepted risk (operator, 2026-08-02):** the OAuth token carries the whole subscription (`user:inference`, `user:profile`, `user:sessions:claude_code`) — broader than a scoped API key would be — and it is mounted into a container that reviews untrusted external PRs. The egress firewall in §3 is the compensating control. Accepted because no API key exists for this account.
 
 ### Deploy mechanism (warning)
 

--- a/scripts/autopilot/Dockerfile.triage
+++ b/scripts/autopilot/Dockerfile.triage
@@ -21,8 +21,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # Install Claude Code CLI globally
 RUN npm install -g @anthropic-ai/claude-code
 
-# Create non-root user and set permissions
-RUN useradd -m -u 1000 nonroot
+# Create non-root user and set permissions.
+#
+# uid 1001, not 1000: node:20-slim already ships a `node` user at uid 1000, so
+# `useradd -m -u 1000 nonroot` fails with exit 4 (UID already in use) and the
+# image never builds. Found 2026-08-02 on the first real build attempt — which
+# is itself the evidence that this sandbox had never been run.
+RUN useradd -m -u 1001 nonroot
 
 # Copy and setup the entrypoint script
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -34,6 +34,53 @@ LOCK_FILE_PATH = "/tmp/pr_triage_autopilot.lock"
 SUPPORTED_ENGINES = ("council-claude",)
 DEFAULT_ENGINE = SUPPORTED_ENGINES[0]
 
+# Claude auth is the SUBSCRIPTION OAuth token written by `claude` login, not an
+# API key -- this deployment is subscription-based and has no ANTHROPIC_API_KEY
+# (operator decision, 2026-08-02). The CLI reads it from CLAUDE_CONFIG_DIR.
+DEFAULT_CREDENTIALS_FILE = Path.home() / ".claude" / ".credentials.json"
+
+
+def resolve_credentials_file() -> Path:
+    """Path to the Claude OAuth credentials, overridable for tests/non-default homes."""
+    override = os.environ.get("CLAUDE_CREDENTIALS_FILE")
+    return Path(override) if override else DEFAULT_CREDENTIALS_FILE
+
+
+def check_oauth_credentials(path: Path) -> str | None:
+    """Return an error string when *path* cannot authenticate a review, else None.
+
+    Checked on the HOST before building the image and starting a container: an
+    expired token fails every review with a 401 several minutes in, and the
+    2026-07-16 token sat expired for 16 days precisely because nothing surfaced
+    it. Failing here turns a silent hourly no-op into one actionable message.
+
+    Expiry is advisory, not authoritative -- the CLI may still refresh a token
+    that looks stale. It is only treated as fatal when no refreshToken exists,
+    which is the unrecoverable case (interactive re-auth required).
+    """
+    if not path.is_file():
+        return f"No Claude OAuth credentials at {path}. Run `claude` once to authenticate."
+    try:
+        blob = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"Unreadable Claude credentials at {path}: {exc}"
+
+    oauth = blob.get("claudeAiOauth") or {}
+    if not oauth.get("accessToken"):
+        return f"No accessToken in {path}. Run `claude` once to authenticate."
+
+    expires_at = oauth.get("expiresAt")
+    if isinstance(expires_at, (int, float)):
+        expiry = datetime.datetime.fromtimestamp(expires_at / 1000, tz=datetime.UTC)
+        if expiry <= datetime.datetime.now(datetime.UTC) and not oauth.get("refreshToken"):
+            return (
+                f"Claude OAuth token expired {expiry.isoformat()} and carries no "
+                "refreshToken -- it cannot self-renew. Re-authenticate on the host: "
+                "`sudo -u hermes -H claude`."
+            )
+    return None
+
+
 # Verdict allowlist: container stdout is untrusted, so anything outside this
 # set is treated as unparseable (None) rather than interpolated downstream.
 VALID_VERDICTS = ("GREEN", "YELLOW", "RED")
@@ -220,7 +267,7 @@ def restore_repo_branch(repo_dir: Path) -> None:
 
 
 def run_docker_sandbox(
-    pr_num: int, repo_dir: Path, memory_dir: Path, anthropic_key: str, gh_token: str
+    pr_num: int, repo_dir: Path, memory_dir: Path, credentials_file: Path, gh_token: str
 ) -> str:
     """Invoke the run_sandboxed_review.sh wrapper script and capture its stdout."""
     script_path = repo_dir / "scripts" / "autopilot" / "run_sandboxed_review.sh"
@@ -236,8 +283,8 @@ def run_docker_sandbox(
         str(memory_dir),
         "--token",
         gh_token,
-        "--key",
-        anthropic_key,
+        "--creds",
+        str(credentials_file),
     ]
 
     logger.info("Running sandboxed Docker review", pr=pr_num)
@@ -282,12 +329,12 @@ def run_review(
     pr_num: int,
     repo_dir: Path,
     memory_dir: Path,
-    anthropic_key: str,
+    credentials_file: Path,
     gh_token: str,
 ) -> str:
     """Run the configured review engine and return its stdout."""
     if engine == "council-claude":
-        return run_docker_sandbox(pr_num, repo_dir, memory_dir, anthropic_key, gh_token)
+        return run_docker_sandbox(pr_num, repo_dir, memory_dir, credentials_file, gh_token)
     raise NotImplementedError(f"engine {engine!r} is reserved but not implemented")
 
 
@@ -296,7 +343,7 @@ def run_triage_cycle(
     repo_dir: Path,
     memory_dir: Path,
     ledger_path: Path,
-    anthropic_key: str,
+    credentials_file: Path,
     gh_token: str,
     engine: str = DEFAULT_ENGINE,
 ) -> None:
@@ -439,7 +486,7 @@ def run_triage_cycle(
                 continue
 
             # Run Stage 1 Pre-eval & Full sandboxed review
-            output = run_review(engine, pr_num, repo_dir, memory_dir, anthropic_key, gh_token)
+            output = run_review(engine, pr_num, repo_dir, memory_dir, credentials_file, gh_token)
 
             # Parse verdict & MUST-FIX count
             parsed_verdict, must_fixes = parse_summary_verdict(output)
@@ -539,11 +586,15 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     # Validate required credentials
-    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     gh_token = os.environ.get("GH_COMMENT_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not gh_token:
+        logger.error("Missing credentials. Requires GH_COMMENT_TOKEN.")
+        return 1
 
-    if not anthropic_key or not gh_token:
-        logger.error("Missing credentials. Requires ANTHROPIC_API_KEY and GH_COMMENT_TOKEN.")
+    credentials_file = resolve_credentials_file()
+    creds_error = check_oauth_credentials(credentials_file)
+    if creds_error:
+        logger.error("Claude OAuth credentials unusable", reason=creds_error)
         return 1
 
     engine = resolve_engine()
@@ -562,7 +613,7 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info("PR-Triage Autopilot iteration started", repo=args.repo, engine=engine)
     run_triage_cycle(
-        args.repo, repo_dir, memory_dir, ledger_path, anthropic_key, gh_token, engine=engine
+        args.repo, repo_dir, memory_dir, ledger_path, credentials_file, gh_token, engine=engine
     )
     logger.info("PR-Triage Autopilot iteration completed")
     return 0

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -34,50 +34,37 @@ LOCK_FILE_PATH = "/tmp/pr_triage_autopilot.lock"
 SUPPORTED_ENGINES = ("council-claude",)
 DEFAULT_ENGINE = SUPPORTED_ENGINES[0]
 
-# Claude auth is the SUBSCRIPTION OAuth token written by `claude` login, not an
-# API key -- this deployment is subscription-based and has no ANTHROPIC_API_KEY
-# (operator decision, 2026-08-02). The CLI reads it from CLAUDE_CONFIG_DIR.
-DEFAULT_CREDENTIALS_FILE = Path.home() / ".claude" / ".credentials.json"
+# Claude auth is the SUBSCRIPTION token minted by `claude setup-token`, read
+# from CLAUDE_CODE_OAUTH_TOKEN. This deployment has no ANTHROPIC_API_KEY
+# (operator decision, 2026-08-02).
+#
+# NOT ~/.claude/.credentials.json: `setup-token` does not write that file.
+# Verified on cgserver01 2026-08-02 -- after a successful mint it still held the
+# expired 2026-07-16 interactive-login token. Reading the file would silently
+# authenticate with a dead credential.
+#
+# The token is a static 1-year bearer value with no refresh pair, so there is
+# nothing to validate locally beyond presence: no expiry is encoded in it. That
+# makes the rotation reminder (hermes-ops ev-ops-health digest) the only thing
+# standing between a lapse and a silent outage -- the 2026-07-16 token 401'd for
+# 16 days with nothing reporting it.
+CLAUDE_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 
 
-def resolve_credentials_file() -> Path:
-    """Path to the Claude OAuth credentials, overridable for tests/non-default homes."""
-    override = os.environ.get("CLAUDE_CREDENTIALS_FILE")
-    return Path(override) if override else DEFAULT_CREDENTIALS_FILE
+def check_claude_auth() -> str | None:
+    """Return an error string when Claude auth is unusable, else None.
 
-
-def check_oauth_credentials(path: Path) -> str | None:
-    """Return an error string when *path* cannot authenticate a review, else None.
-
-    Checked on the HOST before building the image and starting a container: an
-    expired token fails every review with a 401 several minutes in, and the
-    2026-07-16 token sat expired for 16 days precisely because nothing surfaced
-    it. Failing here turns a silent hourly no-op into one actionable message.
-
-    Expiry is advisory, not authoritative -- the CLI may still refresh a token
-    that looks stale. It is only treated as fatal when no refreshToken exists,
-    which is the unrecoverable case (interactive re-auth required).
+    Checked on the HOST before building the image and starting a container: a
+    missing token otherwise surfaces as an opaque 401 several minutes into a
+    sandboxed run.
     """
-    if not path.is_file():
-        return f"No Claude OAuth credentials at {path}. Run `claude` once to authenticate."
-    try:
-        blob = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        return f"Unreadable Claude credentials at {path}: {exc}"
-
-    oauth = blob.get("claudeAiOauth") or {}
-    if not oauth.get("accessToken"):
-        return f"No accessToken in {path}. Run `claude` once to authenticate."
-
-    expires_at = oauth.get("expiresAt")
-    if isinstance(expires_at, (int, float)):
-        expiry = datetime.datetime.fromtimestamp(expires_at / 1000, tz=datetime.UTC)
-        if expiry <= datetime.datetime.now(datetime.UTC) and not oauth.get("refreshToken"):
-            return (
-                f"Claude OAuth token expired {expiry.isoformat()} and carries no "
-                "refreshToken -- it cannot self-renew. Re-authenticate on the host: "
-                "`sudo -u hermes -H claude`."
-            )
+    if not os.environ.get(CLAUDE_TOKEN_ENV):
+        return (
+            f"{CLAUDE_TOKEN_ENV} is not set. Mint one with "
+            "`sudo -u hermes -H claude setup-token` (valid 1 year) and store it in "
+            "hermes-ops secrets/vps-prod.env.sops.yaml. The cron line sources "
+            "/opt/hermes/.env, which is where it must appear."
+        )
     return None
 
 
@@ -267,7 +254,7 @@ def restore_repo_branch(repo_dir: Path) -> None:
 
 
 def run_docker_sandbox(
-    pr_num: int, repo_dir: Path, memory_dir: Path, credentials_file: Path, gh_token: str
+    pr_num: int, repo_dir: Path, memory_dir: Path, gh_token: str
 ) -> str:
     """Invoke the run_sandboxed_review.sh wrapper script and capture its stdout."""
     script_path = repo_dir / "scripts" / "autopilot" / "run_sandboxed_review.sh"
@@ -283,8 +270,6 @@ def run_docker_sandbox(
         str(memory_dir),
         "--token",
         gh_token,
-        "--creds",
-        str(credentials_file),
     ]
 
     logger.info("Running sandboxed Docker review", pr=pr_num)
@@ -329,12 +314,11 @@ def run_review(
     pr_num: int,
     repo_dir: Path,
     memory_dir: Path,
-    credentials_file: Path,
     gh_token: str,
 ) -> str:
     """Run the configured review engine and return its stdout."""
     if engine == "council-claude":
-        return run_docker_sandbox(pr_num, repo_dir, memory_dir, credentials_file, gh_token)
+        return run_docker_sandbox(pr_num, repo_dir, memory_dir, gh_token)
     raise NotImplementedError(f"engine {engine!r} is reserved but not implemented")
 
 
@@ -343,7 +327,6 @@ def run_triage_cycle(
     repo_dir: Path,
     memory_dir: Path,
     ledger_path: Path,
-    credentials_file: Path,
     gh_token: str,
     engine: str = DEFAULT_ENGINE,
 ) -> None:
@@ -486,7 +469,7 @@ def run_triage_cycle(
                 continue
 
             # Run Stage 1 Pre-eval & Full sandboxed review
-            output = run_review(engine, pr_num, repo_dir, memory_dir, credentials_file, gh_token)
+            output = run_review(engine, pr_num, repo_dir, memory_dir, gh_token)
 
             # Parse verdict & MUST-FIX count
             parsed_verdict, must_fixes = parse_summary_verdict(output)
@@ -591,10 +574,9 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("Missing credentials. Requires GH_COMMENT_TOKEN.")
         return 1
 
-    credentials_file = resolve_credentials_file()
-    creds_error = check_oauth_credentials(credentials_file)
-    if creds_error:
-        logger.error("Claude OAuth credentials unusable", reason=creds_error)
+    auth_error = check_claude_auth()
+    if auth_error:
+        logger.error("Claude authentication unusable", reason=auth_error)
         return 1
 
     engine = resolve_engine()
@@ -613,7 +595,7 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info("PR-Triage Autopilot iteration started", repo=args.repo, engine=engine)
     run_triage_cycle(
-        args.repo, repo_dir, memory_dir, ledger_path, credentials_file, gh_token, engine=engine
+        args.repo, repo_dir, memory_dir, ledger_path, gh_token, engine=engine
     )
     logger.info("PR-Triage Autopilot iteration completed")
     return 0

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -112,4 +112,4 @@ docker run --rm \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \
-  -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md."
+  claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md."

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -53,14 +53,39 @@ HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
 #      untrusted external PR must never write back to the operator's own
 #      credentials.
 # The copy dies with the trap below, so a token never outlives its run.
+#
+# A refresh inside the container therefore does NOT propagate back to the host
+# credentials -- that is deliberate. The host token is the source of truth and
+# is renewed by `claude` on the host.
 CREDS_DIR=$(mktemp -d)
 chmod 700 "$CREDS_DIR"
 cp "$CREDS_FILE" "$CREDS_DIR/.credentials.json"
 chmod 600 "$CREDS_DIR/.credentials.json"
-# 65532 = the image's `nonroot` uid; the container must own its config dir to
-# write a refreshed token back into it.
-chown -R 65532:65532 "$CREDS_DIR" 2>/dev/null || true
 trap 'rm -rf "$CREDS_DIR"' EXIT INT TERM
+
+# The container must be able to read AND write the 0700 credentials dir above.
+# How we get there depends on who invoked this script, and both paths keep the
+# dir 0700 -- loosening it to 0755 would expose the operator's subscription
+# token to every local account on a host that also runs `deploy` and others.
+#
+# As root (the sudo path that installs the iptables rules): chown the copy to
+# the image's `nonroot` uid and keep running the container unprivileged. Never
+# `--user 0:0` -- that would hand root to a container reviewing an untrusted
+# external PR, weaker than the image's own default.
+#
+# As a normal user (the documented `hermes` cron): chown is impossible -- a
+# non-root user cannot give a file to another uid. Verified on cgserver01
+# 2026-08-02: the chown fails silently, the mount stays hermes-owned 0700, and
+# the container gets "Permission denied" on the token. So instead run the
+# container AS that user; uids match, 0700 still works. Verified same host,
+# same day: read, write, and refresh-persistence all succeed.
+NONROOT_UID=65532
+if [ "$(id -u)" -eq 0 ]; then
+  chown -R "$NONROOT_UID:$NONROOT_UID" "$CREDS_DIR"
+  CONTAINER_USER="$NONROOT_UID:$NONROOT_UID"
+else
+  CONTAINER_USER="$(id -u):$(id -g)"
+fi
 
 echo "Building Docker sandbox image..."
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -116,10 +141,12 @@ fi
 echo "Launching sandboxed review for PR $PR_NUM..."
 docker run --rm \
   --net "$NET_NAME" \
+  --user "$CONTAINER_USER" \
   -v "$HOST_REPO:/workspace:ro" \
   -v "$HOST_MEMORY:/memory:ro" \
   -v "$CREDS_DIR:/tmp/claude" \
   -e CLAUDE_CONFIG_DIR=/tmp/claude \
+  -e HOME=/tmp/claude \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 
 # Print usage
 usage() {
-  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_token> --key <anthropic_key>"
+  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_token> --creds <credentials.json>"
   exit 1
 }
 
@@ -14,7 +14,7 @@ PR_NUM=""
 HOST_REPO=""
 HOST_MEMORY=""
 GH_TOKEN=""
-ANTHROPIC_KEY=""
+CREDS_FILE=""
 
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
@@ -23,19 +23,44 @@ while [[ "$#" -gt 0 ]]; do
     --repo) HOST_REPO="$2"; shift 2 ;;
     --memory) HOST_MEMORY="$2"; shift 2 ;;
     --token) GH_TOKEN="$2"; shift 2 ;;
-    --key) ANTHROPIC_KEY="$2"; shift 2 ;;
+    --creds) CREDS_FILE="$2"; shift 2 ;;
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
 
-if [ -z "$PR_NUM" ] || [ -z "$HOST_REPO" ] || [ -z "$HOST_MEMORY" ] || [ -z "$GH_TOKEN" ] || [ -z "$ANTHROPIC_KEY" ]; then
+if [ -z "$PR_NUM" ] || [ -z "$HOST_REPO" ] || [ -z "$HOST_MEMORY" ] || [ -z "$GH_TOKEN" ] || [ -z "$CREDS_FILE" ]; then
   echo "Error: Missing required arguments."
   usage
+fi
+
+if [ ! -r "$CREDS_FILE" ]; then
+  echo "Error: credentials file not readable: $CREDS_FILE"
+  exit 1
 fi
 
 # Ensure absolute paths
 HOST_REPO=$(cd "$HOST_REPO" && pwd)
 HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
+
+# Per-run copy of the OAuth credentials, mounted WRITABLE at CLAUDE_CONFIG_DIR.
+#
+# Auth is the subscription OAuth token (~/.claude/.credentials.json), not an API
+# key -- this deployment has no ANTHROPIC_API_KEY. Two reasons the container
+# gets a copy rather than the host file itself:
+#   1. writable: the claude CLI persists a refreshed token on renewal, which a
+#      :ro mount turns into a hard failure mid-review;
+#   2. per-run: a refresh (or corruption) inside a container reviewing an
+#      untrusted external PR must never write back to the operator's own
+#      credentials.
+# The copy dies with the trap below, so a token never outlives its run.
+CREDS_DIR=$(mktemp -d)
+chmod 700 "$CREDS_DIR"
+cp "$CREDS_FILE" "$CREDS_DIR/.credentials.json"
+chmod 600 "$CREDS_DIR/.credentials.json"
+# 65532 = the image's `nonroot` uid; the container must own its config dir to
+# write a refreshed token back into it.
+chown -R 65532:65532 "$CREDS_DIR" 2>/dev/null || true
+trap 'rm -rf "$CREDS_DIR"' EXIT INT TERM
 
 echo "Building Docker sandbox image..."
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -93,7 +118,8 @@ docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \
   -v "$HOST_MEMORY:/memory:ro" \
-  -e ANTHROPIC_API_KEY="$ANTHROPIC_KEY" \
+  -v "$CREDS_DIR:/tmp/claude" \
+  -e CLAUDE_CONFIG_DIR=/tmp/claude \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -6,7 +6,8 @@ set -eo pipefail
 
 # Print usage
 usage() {
-  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_token> --creds <credentials.json>"
+  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_token>"
+  echo "  Claude auth comes from CLAUDE_CODE_OAUTH_TOKEN in the environment."
   exit 1
 }
 
@@ -14,7 +15,6 @@ PR_NUM=""
 HOST_REPO=""
 HOST_MEMORY=""
 GH_TOKEN=""
-CREDS_FILE=""
 
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
@@ -23,69 +23,34 @@ while [[ "$#" -gt 0 ]]; do
     --repo) HOST_REPO="$2"; shift 2 ;;
     --memory) HOST_MEMORY="$2"; shift 2 ;;
     --token) GH_TOKEN="$2"; shift 2 ;;
-    --creds) CREDS_FILE="$2"; shift 2 ;;
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
 
-if [ -z "$PR_NUM" ] || [ -z "$HOST_REPO" ] || [ -z "$HOST_MEMORY" ] || [ -z "$GH_TOKEN" ] || [ -z "$CREDS_FILE" ]; then
+if [ -z "$PR_NUM" ] || [ -z "$HOST_REPO" ] || [ -z "$HOST_MEMORY" ] || [ -z "$GH_TOKEN" ]; then
   echo "Error: Missing required arguments."
   usage
 fi
 
-if [ ! -r "$CREDS_FILE" ]; then
-  echo "Error: credentials file not readable: $CREDS_FILE"
+# Claude auth: the subscription token minted by `claude setup-token`, read from
+# the environment (sourced from /opt/hermes/.env by the cron line). Deliberately
+# NOT a CLI flag -- an argv secret is visible to every local user via `ps`,
+# which is what the original --key <anthropic_key> design did.
+#
+# Note this is NOT ~/.claude/.credentials.json: `setup-token` does not write
+# that file (verified on cgserver01 2026-08-02 -- it still held the expired
+# 2026-07-16 interactive-login token afterwards). The two are separate
+# mechanisms and only the env var carries the 1-year credential.
+if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+  echo "Error: CLAUDE_CODE_OAUTH_TOKEN is not set."
+  echo "  Mint one with: sudo -u hermes -H claude setup-token   (valid 1 year)"
+  echo "  Then store it in hermes-ops secrets/vps-prod.env.sops.yaml."
   exit 1
 fi
 
 # Ensure absolute paths
 HOST_REPO=$(cd "$HOST_REPO" && pwd)
 HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
-
-# Per-run copy of the OAuth credentials, mounted WRITABLE at CLAUDE_CONFIG_DIR.
-#
-# Auth is the subscription OAuth token (~/.claude/.credentials.json), not an API
-# key -- this deployment has no ANTHROPIC_API_KEY. Two reasons the container
-# gets a copy rather than the host file itself:
-#   1. writable: the claude CLI persists a refreshed token on renewal, which a
-#      :ro mount turns into a hard failure mid-review;
-#   2. per-run: a refresh (or corruption) inside a container reviewing an
-#      untrusted external PR must never write back to the operator's own
-#      credentials.
-# The copy dies with the trap below, so a token never outlives its run.
-#
-# A refresh inside the container therefore does NOT propagate back to the host
-# credentials -- that is deliberate. The host token is the source of truth and
-# is renewed by `claude` on the host.
-CREDS_DIR=$(mktemp -d)
-chmod 700 "$CREDS_DIR"
-cp "$CREDS_FILE" "$CREDS_DIR/.credentials.json"
-chmod 600 "$CREDS_DIR/.credentials.json"
-trap 'rm -rf "$CREDS_DIR"' EXIT INT TERM
-
-# The container must be able to read AND write the 0700 credentials dir above.
-# How we get there depends on who invoked this script, and both paths keep the
-# dir 0700 -- loosening it to 0755 would expose the operator's subscription
-# token to every local account on a host that also runs `deploy` and others.
-#
-# As root (the sudo path that installs the iptables rules): chown the copy to
-# the image's `nonroot` uid and keep running the container unprivileged. Never
-# `--user 0:0` -- that would hand root to a container reviewing an untrusted
-# external PR, weaker than the image's own default.
-#
-# As a normal user (the documented `hermes` cron): chown is impossible -- a
-# non-root user cannot give a file to another uid. Verified on cgserver01
-# 2026-08-02: the chown fails silently, the mount stays hermes-owned 0700, and
-# the container gets "Permission denied" on the token. So instead run the
-# container AS that user; uids match, 0700 still works. Verified same host,
-# same day: read, write, and refresh-persistence all succeed.
-NONROOT_UID=65532
-if [ "$(id -u)" -eq 0 ]; then
-  chown -R "$NONROOT_UID:$NONROOT_UID" "$CREDS_DIR"
-  CONTAINER_USER="$NONROOT_UID:$NONROOT_UID"
-else
-  CONTAINER_USER="$(id -u):$(id -g)"
-fi
 
 echo "Building Docker sandbox image..."
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
@@ -141,12 +106,9 @@ fi
 echo "Launching sandboxed review for PR $PR_NUM..."
 docker run --rm \
   --net "$NET_NAME" \
-  --user "$CONTAINER_USER" \
   -v "$HOST_REPO:/workspace:ro" \
   -v "$HOST_MEMORY:/memory:ro" \
-  -v "$CREDS_DIR:/tmp/claude" \
-  -e CLAUDE_CONFIG_DIR=/tmp/claude \
-  -e HOME=/tmp/claude \
+  -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -13,6 +13,11 @@ sys.path.insert(0, str(ROOT / "scripts" / "autopilot"))
 
 import pr_triage_autopilot  # noqa: E402
 
+# Subscription OAuth credentials path threaded to the sandbox in place of an
+# API key (2026-08-02). The orchestrator only passes it through; validity is
+# checked on the host in check_oauth_credentials.
+CREDS_PATH = Path("/home/hermes/.claude/.credentials.json")
+
 
 def test_parse_summary_verdict():
     output = (
@@ -120,13 +125,13 @@ def test_run_triage_cycle_success(
         repo_dir=repo_dir,
         memory_dir=memory_dir,
         ledger_path=ledger_path,
-        anthropic_key="key-test",
+        credentials_file=CREDS_PATH,
         gh_token="token-test",
     )
 
     # Assertions
     mock_fetch.assert_called_once_with(101, repo_dir)
-    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, "key-test", "token-test")
+    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, CREDS_PATH, "token-test")
     mock_post_comment.assert_called_once()
     mock_restore.assert_called_once_with(repo_dir)
     mock_append_ledger.assert_called_once()
@@ -175,7 +180,7 @@ def test_run_triage_cycle_stage0_skipped(
         repo_dir=repo_dir,
         memory_dir=memory_dir,
         ledger_path=ledger_path,
-        anthropic_key="key-test",
+        credentials_file=CREDS_PATH,
         gh_token="token-test",
     )
 
@@ -397,3 +402,72 @@ def test_deferred_size_dedupes_by_gate_sha(tmp_path):
             )
         assert m_email.call_count == 1
         assert m_comment.call_count == 0
+
+
+# --- OAuth subscription auth (2026-08-02) -----------------------------------
+# This deployment has no ANTHROPIC_API_KEY; `claude -p` authenticates with the
+# subscription OAuth token. The 2026-07-16 token sat EXPIRED for 16 days with
+# nothing surfacing it, so the host-side precheck is the regression guard.
+
+
+def _creds(tmp_path, *, access="tok", expires_ms=None, refresh=None):
+    import json as _json
+
+    blob = {"claudeAiOauth": {"accessToken": access, "scopes": ["user:inference"]}}
+    if expires_ms is not None:
+        blob["claudeAiOauth"]["expiresAt"] = expires_ms
+    if refresh is not None:
+        blob["claudeAiOauth"]["refreshToken"] = refresh
+    p = tmp_path / ".credentials.json"
+    p.write_text(_json.dumps(blob), encoding="utf-8")
+    return p
+
+
+def _ms(dt):
+    return int(dt.timestamp() * 1000)
+
+
+def test_oauth_missing_file_is_reported(tmp_path):
+    err = pr_triage_autopilot.check_oauth_credentials(tmp_path / "nope.json")
+    assert err and "authenticate" in err
+
+
+def test_oauth_unparseable_file_is_reported(tmp_path):
+    p = tmp_path / ".credentials.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert pr_triage_autopilot.check_oauth_credentials(p)
+
+
+def test_oauth_valid_unexpired_token_passes(tmp_path):
+    future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=8)
+    assert (
+        pr_triage_autopilot.check_oauth_credentials(_creds(tmp_path, expires_ms=_ms(future)))
+        is None
+    )
+
+
+def test_oauth_expired_without_refresh_token_is_fatal(tmp_path):
+    """The exact 2026-07-16 state: expired, refreshToken absent."""
+    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=16)
+    err = pr_triage_autopilot.check_oauth_credentials(_creds(tmp_path, expires_ms=_ms(past)))
+    assert err and "re-authenticate" in err.lower()
+
+
+def test_oauth_expired_with_refresh_token_is_allowed(tmp_path):
+    """Expiry alone must not block: the CLI can renew when a refreshToken exists.
+
+    Treating stale-but-refreshable as fatal would fail every run an hour after
+    login, which is worse than the bug being fixed.
+    """
+    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
+    assert (
+        pr_triage_autopilot.check_oauth_credentials(
+            _creds(tmp_path, expires_ms=_ms(past), refresh="r")
+        )
+        is None
+    )
+
+
+def test_resolve_credentials_file_honours_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CREDENTIALS_FILE", str(tmp_path / "x.json"))
+    assert pr_triage_autopilot.resolve_credentials_file() == tmp_path / "x.json"

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -195,9 +195,7 @@ def test_resolve_engine_rejects_unknown(monkeypatch):
 
 def test_run_review_dispatches_council_claude():
     with patch("pr_triage_autopilot.run_docker_sandbox", return_value="out") as m:
-        out = pr_triage_autopilot.run_review(
-            "council-claude", 1, Path("/r"), Path("/m"), "tok"
-        )
+        out = pr_triage_autopilot.run_review("council-claude", 1, Path("/r"), Path("/m"), "tok")
     assert out == "out"
     m.assert_called_once_with(1, Path("/r"), Path("/m"), "tok")
 

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -13,11 +13,6 @@ sys.path.insert(0, str(ROOT / "scripts" / "autopilot"))
 
 import pr_triage_autopilot  # noqa: E402
 
-# Subscription OAuth credentials path threaded to the sandbox in place of an
-# API key (2026-08-02). The orchestrator only passes it through; validity is
-# checked on the host in check_oauth_credentials.
-CREDS_PATH = Path("/home/hermes/.claude/.credentials.json")
-
 
 def test_parse_summary_verdict():
     output = (
@@ -125,13 +120,12 @@ def test_run_triage_cycle_success(
         repo_dir=repo_dir,
         memory_dir=memory_dir,
         ledger_path=ledger_path,
-        credentials_file=CREDS_PATH,
         gh_token="token-test",
     )
 
     # Assertions
     mock_fetch.assert_called_once_with(101, repo_dir)
-    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, CREDS_PATH, "token-test")
+    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, "token-test")
     mock_post_comment.assert_called_once()
     mock_restore.assert_called_once_with(repo_dir)
     mock_append_ledger.assert_called_once()
@@ -180,7 +174,6 @@ def test_run_triage_cycle_stage0_skipped(
         repo_dir=repo_dir,
         memory_dir=memory_dir,
         ledger_path=ledger_path,
-        credentials_file=CREDS_PATH,
         gh_token="token-test",
     )
 
@@ -203,15 +196,15 @@ def test_resolve_engine_rejects_unknown(monkeypatch):
 def test_run_review_dispatches_council_claude():
     with patch("pr_triage_autopilot.run_docker_sandbox", return_value="out") as m:
         out = pr_triage_autopilot.run_review(
-            "council-claude", 1, Path("/r"), Path("/m"), "key", "tok"
+            "council-claude", 1, Path("/r"), Path("/m"), "tok"
         )
     assert out == "out"
-    m.assert_called_once_with(1, Path("/r"), Path("/m"), "key", "tok")
+    m.assert_called_once_with(1, Path("/r"), Path("/m"), "tok")
 
 
 def test_run_review_unknown_engine_raises():
     with pytest.raises(NotImplementedError):
-        pr_triage_autopilot.run_review("council-multi-cli", 1, Path("/r"), Path("/m"), "key", "tok")
+        pr_triage_autopilot.run_review("council-multi-cli", 1, Path("/r"), Path("/m"), "tok")
 
 
 def _cycle_mocks():
@@ -245,7 +238,7 @@ def test_email_sent_on_completed_review(tmp_path):
             "SUMMARY_VERDICT: GREEN | MUST_FIX_COUNT: 0 | PR_URL: https://x/pull/7"
         )
         pr_triage_autopilot.run_triage_cycle(
-            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
         )
     assert m_email.call_count == 1
     subject = m_email.call_args[0][0]
@@ -266,7 +259,7 @@ def test_email_sent_on_needs_human(tmp_path):
     ):
         m_gate.return_value = {"verdict": "NEEDS-HUMAN", "reasons": ["injection pattern"]}
         pr_triage_autopilot.run_triage_cycle(
-            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
         )
     assert m_email.call_count == 1
     assert "human" in m_email.call_args[0][0].lower()
@@ -286,7 +279,7 @@ def test_email_sent_on_deferred_size(tmp_path):
     ):
         m_gate.return_value = {"verdict": "DEFERRED_SIZE", "reasons": ["too big"]}
         pr_triage_autopilot.run_triage_cycle(
-            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+            "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
         )
     assert m_email.call_count == 1
 
@@ -313,7 +306,7 @@ def test_email_sent_on_failed_permanent(tmp_path):
             ],
         ):
             pr_triage_autopilot.run_triage_cycle(
-                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
             )
     # third failure -> FAILED_PERMANENT -> email
     assert m_email.call_count == 1
@@ -353,7 +346,7 @@ def test_needs_human_dedupes_by_gate_sha(tmp_path):
         # First tick: nothing ledgered -> alert + comment once
         with patch("pr_triage_autopilot.get_ledger_entries", return_value=[]):
             pr_triage_autopilot.run_triage_cycle(
-                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
             )
         assert m_email.call_count == 1
         assert m_comment.call_count == 1
@@ -364,7 +357,7 @@ def test_needs_human_dedupes_by_gate_sha(tmp_path):
             return_value=[{"pr": 7, "head_sha": "sha-x", "status": "NEEDS-HUMAN"}],
         ):
             pr_triage_autopilot.run_triage_cycle(
-                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
             )
         assert m_email.call_count == 1
         assert m_comment.call_count == 1
@@ -388,7 +381,7 @@ def test_deferred_size_dedupes_by_gate_sha(tmp_path):
         # First tick: nothing ledgered -> alert once
         with patch("pr_triage_autopilot.get_ledger_entries", return_value=[]):
             pr_triage_autopilot.run_triage_cycle(
-                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
             )
         assert m_email.call_count == 1
 
@@ -398,76 +391,31 @@ def test_deferred_size_dedupes_by_gate_sha(tmp_path):
             return_value=[{"pr": 7, "head_sha": "sha-x", "status": "DEFERRED_SIZE"}],
         ):
             pr_triage_autopilot.run_triage_cycle(
-                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "key", "tok"
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
             )
         assert m_email.call_count == 1
         assert m_comment.call_count == 0
 
 
-# --- OAuth subscription auth (2026-08-02) -----------------------------------
-# This deployment has no ANTHROPIC_API_KEY; `claude -p` authenticates with the
-# subscription OAuth token. The 2026-07-16 token sat EXPIRED for 16 days with
-# nothing surfacing it, so the host-side precheck is the regression guard.
+# --- Claude subscription auth via CLAUDE_CODE_OAUTH_TOKEN (2026-08-02) -------
+# `claude setup-token` mints a 1-year bearer token read from the environment.
+# It does NOT write ~/.claude/.credentials.json -- verified on cgserver01, where
+# that file still held the expired 2026-07-16 token after a successful mint. An
+# earlier revision of this branch validated the FILE and would therefore have
+# authenticated with a dead credential.
 
 
-def _creds(tmp_path, *, access="tok", expires_ms=None, refresh=None):
-    import json as _json
-
-    blob = {"claudeAiOauth": {"accessToken": access, "scopes": ["user:inference"]}}
-    if expires_ms is not None:
-        blob["claudeAiOauth"]["expiresAt"] = expires_ms
-    if refresh is not None:
-        blob["claudeAiOauth"]["refreshToken"] = refresh
-    p = tmp_path / ".credentials.json"
-    p.write_text(_json.dumps(blob), encoding="utf-8")
-    return p
+def test_missing_token_is_reported(monkeypatch):
+    monkeypatch.delenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, raising=False)
+    err = pr_triage_autopilot.check_claude_auth()
+    assert err and "setup-token" in err
 
 
-def _ms(dt):
-    return int(dt.timestamp() * 1000)
+def test_empty_token_is_reported(monkeypatch):
+    monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "")
+    assert pr_triage_autopilot.check_claude_auth()
 
 
-def test_oauth_missing_file_is_reported(tmp_path):
-    err = pr_triage_autopilot.check_oauth_credentials(tmp_path / "nope.json")
-    assert err and "authenticate" in err
-
-
-def test_oauth_unparseable_file_is_reported(tmp_path):
-    p = tmp_path / ".credentials.json"
-    p.write_text("{not json", encoding="utf-8")
-    assert pr_triage_autopilot.check_oauth_credentials(p)
-
-
-def test_oauth_valid_unexpired_token_passes(tmp_path):
-    future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=8)
-    assert (
-        pr_triage_autopilot.check_oauth_credentials(_creds(tmp_path, expires_ms=_ms(future)))
-        is None
-    )
-
-
-def test_oauth_expired_without_refresh_token_is_fatal(tmp_path):
-    """The exact 2026-07-16 state: expired, refreshToken absent."""
-    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=16)
-    err = pr_triage_autopilot.check_oauth_credentials(_creds(tmp_path, expires_ms=_ms(past)))
-    assert err and "re-authenticate" in err.lower()
-
-
-def test_oauth_expired_with_refresh_token_is_allowed(tmp_path):
-    """Expiry alone must not block: the CLI can renew when a refreshToken exists.
-
-    Treating stale-but-refreshable as fatal would fail every run an hour after
-    login, which is worse than the bug being fixed.
-    """
-    past = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
-    assert (
-        pr_triage_autopilot.check_oauth_credentials(
-            _creds(tmp_path, expires_ms=_ms(past), refresh="r")
-        )
-        is None
-    )
-
-
-def test_resolve_credentials_file_honours_override(tmp_path, monkeypatch):
-    monkeypatch.setenv("CLAUDE_CREDENTIALS_FILE", str(tmp_path / "x.json"))
-    assert pr_triage_autopilot.resolve_credentials_file() == tmp_path / "x.json"
+def test_present_token_passes(monkeypatch):
+    monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "sk-ant-oat01-xxx")
+    assert pr_triage_autopilot.check_claude_auth() is None


### PR DESCRIPTION
## Why

The PR-triage autopilot has been merged since 2026-07-17 but **never ran**. It could not: this deployment is subscription-based with no `ANTHROPIC_API_KEY`, and the orchestrator exits 1 without one (`pr_triage_autopilot.py:542`), while the sandbox refuses to launch without `--key`.

`claude -p` is already what executes inside the container. Only the credential mechanism changes.

## What

- **Orchestrator** — drop `ANTHROPIC_API_KEY`. Resolve `~/.claude/.credentials.json` (overridable via `CLAUDE_CREDENTIALS_FILE`) and validate it on the **host**, before building the image. An expired token otherwise surfaces as an opaque 401 several minutes into a container run.
- **Sandbox** — replace `-e ANTHROPIC_API_KEY` with a per-run copy of the credentials mounted **writable** at `CLAUDE_CONFIG_DIR=/tmp/claude`, cleaned up by an `EXIT` trap.
  - *writable*: the CLI persists refreshed tokens; `:ro` turns a renewal into a mid-review failure.
  - *per-run copy*: a container reviewing an untrusted external PR must never write back to the operator's own credentials.
- **Runbook** — env table, cron line, rotation procedure, accepted risk. Deployment specifics live in the private ops repo.

## Expiry is advisory, not fatal on its own

A stale token that carries a `refreshToken` still renews — treating that as fatal would fail every run an hour after login. It is fatal **only** when no `refreshToken` exists, which is unrecoverable without interactive re-auth.

That was the live state on the deployment host: an expired token with no `refreshToken`, silently 401ing with nothing surfacing it. The autopilot now refuses to start and logs how to fix it.

## Accepted risk

Operator decision, 2026-08-02. The OAuth token carries broad subscription scopes — wider than a scoped API key — and is mounted into a container reviewing untrusted PRs. Compensating controls are documented in the private ops repo. Accepted because no API key exists for this account.

`GH_COMMENT_TOKEN` least-privilege is untouched and remains backlog per operator.

## Verification

- `pytest tests/autopilot/` — **24 passed**, including the expired-no-refresh case and the expired-**with**-refresh case that must *not* block
- `ruff check` / `ruff format --check` clean
- Validator run against a real credential shape reproduces the actionable message

## Still blocked after this merge

Activation requires host-side setup — re-auth, a checkout, a log directory, `GH_COMMENT_TOKEN`, and the cron entry. Steps are in the private ops repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
