### PR TITLE
fix(pr-triage): send Telegram alert on missing credentials or auth failure

### DIFF
--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -573,12 +573,18 @@ def main(argv: list[str] | None = None) -> int:
         or os.environ.get("GH_TOKEN")
     )
     if not gh_token:
-        logger.error("Missing credentials. Requires GH_COMMENT_TOKEN, GITHUB_TOKEN, or GH_TOKEN.")
+        err_msg = "Missing credentials. Requires GH_COMMENT_TOKEN, GITHUB_TOKEN, or GH_TOKEN."
+        logger.error(err_msg)
+        send_telegram_alert(f"🚨 PR-Triage Autopilot ALERT: {err_msg}")
         return 1
 
     auth_error = check_claude_auth()
     if auth_error:
         logger.error("Claude authentication unusable", reason=auth_error)
+        send_telegram_alert(
+            "🚨 PR-Triage Autopilot ALERT: Claude authentication unusable on host.\n"
+            f"Reason: {auth_error}"
+        )
         return 1
 
     engine = resolve_engine()

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -417,3 +417,24 @@ def test_empty_token_is_reported(monkeypatch):
 def test_present_token_passes(monkeypatch):
     monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "sk-ant-oat01-xxx")
     assert pr_triage_autopilot.check_claude_auth() is None
+
+
+def test_main_sends_telegram_alert_on_missing_token(monkeypatch, tmp_path):
+    monkeypatch.delenv("GH_COMMENT_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    with patch("pr_triage_autopilot.send_telegram_alert") as m_alert:
+        ret = pr_triage_autopilot.main(["--repo-dir", str(tmp_path), "--memory-dir", str(tmp_path)])
+        assert ret == 1
+        assert m_alert.call_count == 1
+        assert "Missing credentials" in m_alert.call_args[0][0]
+
+
+def test_main_sends_telegram_alert_on_auth_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.delenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, raising=False)
+    with patch("pr_triage_autopilot.send_telegram_alert") as m_alert:
+        ret = pr_triage_autopilot.main(["--repo-dir", str(tmp_path), "--memory-dir", str(tmp_path)])
+        assert ret == 1
+        assert m_alert.call_count == 1
+        assert "Claude authentication unusable" in m_alert.call_args[0][0]


### PR DESCRIPTION
Closes #421. Hardens alerting by dispatching Telegram notifications when credentials are missing or check_claude_auth() fails, preventing silent authentication outages.