### PR TITLE
ci(deps): give the CVE gate a clock and surface what uv.lock hides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,19 @@
 
 version: 2
 updates:
-  # Python dependencies (pip/uv — Dependabot reads pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies.
+  #
+  # This MUST be "uv", not "pip". The "pip" ecosystem reads pyproject.toml only
+  # and has no visibility into uv.lock — but every install path in this repo
+  # (`uv sync`, CI, the release build) resolves from the LOCKFILE. The result
+  # was a repo where no transitive dependency had ever received an update PR:
+  # scan the Dependabot history before 2026-08 and every single PR is a direct
+  # dev dep (ruff, patchright) or a GitHub Action. `cryptography` is pulled in
+  # via browser-cookie3, appears nowhere in pyproject.toml, and so sat on a
+  # version with a published CVE until the v0.50.0 release PR tripped pip-audit.
+  # The "uv" ecosystem reads pyproject.toml AND uv.lock, so transitive pins
+  # finally get bumped. See docs.astral.sh/uv/guides/integration/dependabot/.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -16,7 +27,12 @@ updates:
       - "dependencies"
       - "python"
     ignore:
-      # Playwright has its own browser download step; pin manually.
+      # playwright minors are gated by the `<1.60.0` upper bound in
+      # pyproject.toml, not by this rule — an untested driver minor silently
+      # wedged video generation (see the bound's comment). This entry keeps
+      # majors out even if that bound is ever widened. Raising playwright is a
+      # deliberate, live-verified act; the weekly `deps-watch` workflow reports
+      # how far behind the pin has drifted so it does not freeze unnoticed.
       - dependency-name: "playwright"
         update-types: ["version-update:semver-major"]
 

--- a/.github/workflows/deps-watch.yml
+++ b/.github/workflows/deps-watch.yml
@@ -1,0 +1,71 @@
+name: Dependency watch
+
+# ── Why this exists, on a CLOCK ──────────────────────────────────────────────
+# CI's `deps-audit` job runs the same pip-audit command, but only `on: push` and
+# `on: pull_request`. That gate has no clock: an advisory published *after* the
+# last push stays invisible until someone happens to push. That is exactly how
+# CVE-2026-69247 (cryptography 49.0.0) reached the v0.50.0 release PR — the
+# lockfile had been sitting on the vulnerable version for days and nothing was
+# scheduled to re-check it. This workflow gives that gate a timer.
+#
+# It also answers the question no existing job answers: "what CAN we update?"
+# Every other job installs via `uv sync` against uv.lock, so the lockfile hides
+# both halves of the picture — what upstream has published, and what our own
+# declared bounds are currently refusing. Both are printed below.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC — one hour before Dependabot's 08:00 Europe/Lisbon run,
+    # so the audit result is already on screen when the bump PRs land.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    name: Audit + report upgradable dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      # ── The gate: fails the run, which emails the repo owner ───────────────
+      - name: Audit locked dependencies for known CVEs
+        run: |
+          uv export --frozen --format requirements-txt --no-emit-project > requirements-audit.txt
+          uvx pip-audit -r requirements-audit.txt
+
+      # ── The reports: never fail the run, and still run when the audit fails
+      #    (a red audit is precisely when you want to know what's upgradable) ─
+      - name: Report what our bounds allow us to take now
+        if: always()
+        # Resolves the newest versions pyproject.toml's ranges permit, without
+        # writing uv.lock. This is the "safe to merge today" list.
+        run: |
+          echo '## Upgradable within current bounds' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uv lock --upgrade --dry-run 2>&1 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report what upstream has published
+        if: always()
+        # Unlike the step above, this ignores our constraints and reports the
+        # true latest on PyPI — so a package frozen by one of OUR upper bounds
+        # shows up here and nowhere else. This is the expiry alarm for those
+        # bounds: `playwright>=1.59.0,<1.60.0` is deliberate (an untested driver
+        # silently wedged video generation — see the comment in pyproject.toml),
+        # but a deliberate pin still needs a periodic "how stale is it now?"
+        # signal, and raising it requires a live-verified generation first.
+        run: |
+          uv sync --frozen
+          echo '## Latest upstream (ignores our bounds)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uv pip list --outdated >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Closes the two gaps that let CVE-2026-69247 (`cryptography` 49.0.0) reach the v0.50.0 release PR, and that let `playwright` freeze at 1.59.0 with no signal. Config-only — no `src/` or `tests/` changes.

## Root causes

**1. Dependabot could not see `uv.lock`.** The config used `package-ecosystem: "pip"`, which reads `pyproject.toml` only. Every install path in this repo resolves from the *lockfile*, so no transitive dependency had ever received an update PR — scan the Dependabot history and every single PR is a direct dev dep (`ruff`, `patchright`) or a GitHub Action. `cryptography` arrives via `browser-cookie3`, appears nowhere in `pyproject.toml`, and so sat on a vulnerable version unwatched. Switched to `package-ecosystem: "uv"`, which reads both files.

**2. The CVE gate had no clock.** CI's `deps-audit` job runs the correct `pip-audit` command, but only `on: push` and `on: pull_request`. An advisory published *after* the last push stays invisible until someone happens to push — the release PR was simply the first push after the advisory dropped.

## Changes

- `.github/dependabot.yml` — `pip` → `uv` ecosystem.
- `.github/workflows/deps-watch.yml` (new) — weekly Monday 07:00 UTC + `workflow_dispatch`:
  - runs the same `pip-audit` on a timer (fails the run, which emails the owner);
  - reports **what our bounds allow now** (`uv lock --upgrade --dry-run`);
  - reports **what upstream actually published** (`uv pip list --outdated`).

The last report is the one that answers "what can we update?" — it ignores our constraints, so a package frozen by one of *our* upper bounds shows up there and nowhere else. Today it reads `playwright 1.59.0 -> 1.62.0`. That bound stays deliberate (an untested driver silently wedged video generation), but it now has a visible staleness signal instead of freezing unnoticed. Both reports land in the run's Step Summary and never fail the build.

## Verification

- [x] Both YAML files parse; triggers and ecosystems assert as expected
- [x] Both `uv` report commands run clean locally against this tree
- [x] Repo hygiene (703 tracked files), doc links, website-docs mirror — clean
- [ ] `workflow_dispatch` run on this branch after merge to confirm the Step Summary renders

## Note on scope

This does **not** retro-fix v0.50.0 — that version is already public on PyPI and immutable. The CVE patch and version bump shipped *in* 0.50.0; this PR prevents the next one from being found the same way.
