### PR TITLE
fix(ci): deps-watch reports never reached the Step Summary

### DIFF
--- a/.github/workflows/deps-watch.yml
+++ b/.github/workflows/deps-watch.yml
@@ -51,7 +51,11 @@ jobs:
         run: |
           echo '## Upgradable within current bounds' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          uv lock --upgrade --dry-run 2>&1 >> "$GITHUB_STEP_SUMMARY"
+          # uv writes this report to STDERR, so it must be folded into stdout
+          # BEFORE the pipe. `... 2>&1 >> file` would be wrong: that order sends
+          # stdout to the file and leaves stderr on the terminal, which silently
+          # published an empty summary section. tee keeps both destinations.
+          uv lock --upgrade --dry-run 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report what upstream has published
@@ -67,5 +71,5 @@ jobs:
           uv sync --frozen
           echo '## Latest upstream (ignores our bounds)' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          uv pip list --outdated >> "$GITHUB_STEP_SUMMARY"
+          uv pip list --outdated 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Follow-up defect in #434, caught by actually running the workflow.

`uv lock --upgrade --dry-run 2>&1 >> "$GITHUB_STEP_SUMMARY"` has its redirects in the wrong order. That form points **stdout** at the file and leaves **stderr** on the terminal — and `uv` writes the upgrade report to stderr. So the entire report went to the run log while the summary section published empty.

Confirmed on [run 30913837833](https://github.com/ffroliva/gflow-cli/actions/runs/30913837833): the `Update X -> Y` lines appear in the step log, which is only possible if they went to stderr rather than into the summary file.

## Fix

Both report steps now use `2>&1 | tee -a "$GITHUB_STEP_SUMMARY"`, which folds stderr into stdout *before* the pipe and keeps the output visible in the log as well as the summary.

## Test plan

- [x] YAML parses
- [ ] `workflow_dispatch` re-run after merge, confirming both sections render with content