### PR TITLE
test(e2e): narrow the credit-spending success paths to the viable transport

### DIFF
--- a/tests/e2e/test_transports_e2e.py
+++ b/tests/e2e/test_transports_e2e.py
@@ -103,7 +103,7 @@ def _make_client(strategy: str, profile: Path) -> FlowApiClient:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.parametrize("strategy", LIVE_STRATEGIES)
 @pytest.mark.asyncio
 @pytest.mark.e2e_image
 async def test_e2e_single_image_gen(strategy: str, e2e_profile_dir: Path) -> None:
@@ -346,7 +346,7 @@ async def test_e2e_i2v_start_end_frame_attach(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.parametrize("strategy", LIVE_STRATEGIES)
 @pytest.mark.asyncio
 @pytest.mark.e2e_batch
 async def test_e2e_5_sequential_batches(strategy: str, e2e_profile_dir: Path) -> None:
@@ -381,6 +381,16 @@ async def test_e2e_5_sequential_batches(strategy: str, e2e_profile_dir: Path) ->
 @pytest.mark.e2e_image
 async def test_e2e_recoverable_auth_expiry(strategy: str, e2e_profile_dir: Path) -> None:
     """C4a: Deliberately staling the cached credential triggers a silent refresh.
+
+    NOT narrowed to ``LIVE_STRATEGIES``, unlike the other success-path tests in
+    this module, and that is deliberate. This test carries purpose-built
+    staleness injection for ``bearer`` and ``sapisidhash``, so narrowing it
+    would silently delete the only refresh-path coverage those transports have.
+    It currently cannot pass for them either — they fail at ``setup()``, before
+    the injection point below is reached (KNOWN_ISSUES.md: obsolete, only
+    ``evaluate_fetch`` is viable). Resolve it together with the decision to
+    either repair or delete ``api/transports/experimental/`` — not by quietly
+    dropping the parametrization here.
 
     Strategy-specific staleness injection:
       bearer       — set _cached.expires_at to now - 1 (already expired)
@@ -463,7 +473,7 @@ async def test_e2e_unrecoverable_auth_expiry(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("strategy", STRATEGIES)
+@pytest.mark.parametrize("strategy", LIVE_STRATEGIES)
 @pytest.mark.asyncio
 @pytest.mark.e2e_image
 async def test_e2e_generate_image_without_project_id(strategy: str, e2e_profile_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #448, which fixed this same defect in the **zero-credit** tests. Three **credit-spending** generation tests still asserted a success path against the obsolete `bearer` and `sapisidhash` transports, so 2 of every 3 parametrizations were guaranteed to fail:

- `test_e2e_single_image_gen`
- `test_e2e_5_sequential_batches`
- `test_e2e_generate_image_without_project_id`

KNOWN_ISSUES.md is explicit: *"These are obsolete — only `evaluate_fetch` is viable."* Both transports were **directly observed failing at `setup()`** during the #448 work — before any request is issued — so a generation test using them cannot reach generation.

## Deliberately NOT narrowed

| test | why it keeps `STRATEGIES` |
|---|---|
| `test_e2e_recoverable_auth_expiry` | Carries **purpose-built staleness injection** for `bearer` and `sapisidhash`. Narrowing it would silently delete the only refresh-path coverage those transports have. It cannot pass for them today either (setup fails before the injection point), but the fix belongs with the decision to **repair or delete** `api/transports/experimental/` — not a quiet parametrization drop. Documented in its docstring so it does not read as an oversight. |
| `test_e2e_unrecoverable_auth_expiry` | An **error path** — points at an empty profile and requires `setup()` to *raise*. That is precisely why it already passes on all three. Correct as written. |

## Verification — and its limit

Verified by **collection**, not execution:

```
test_e2e_single_image_gen[evaluate_fetch]
test_e2e_5_sequential_batches[evaluate_fetch]
test_e2e_generate_image_without_project_id[evaluate_fetch]
test_e2e_recoverable_auth_expiry[evaluate_fetch]
test_e2e_recoverable_auth_expiry[bearer]
test_e2e_recoverable_auth_expiry[sapisidhash]
```

`ruff`, `ruff format --check`, `pyright` (0 errors) all clean.

**These tests spend Imagen credits and I did not run them.** This change rests on the documented root cause plus the observed `setup()` failure, not on a green run. Worth one credit-spending confirmation before trusting the suite end to end.