### PR TITLE
fix(ui): harden overlay selectors for locale invariance across 9 languages (Refs #403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Flow release overlay detection for visible watermark toggle modal (#403).** Added `*:has-text('View all changelogs')` to `TOP_BANNER_SELECTORS` and `button:has-text('Get started')` to `OVERLAY_CLOSE_BUTTON_SELECTORS` in `ui_automation.py` to detect and dismiss inline release-note modals on fresh account profiles.
+- **Flow release overlay detection for visible watermark toggle modal (#403).** Added locale-invariant structural anchors (`a[href*='changelog']`, `[role='dialog']:has(a[href*='changelog']) button`) and a 9-locale cascade (EN, PT, ES, DE, FR, IT, JA, ZH, KO) to `TOP_BANNER_SELECTORS` and `OVERLAY_CLOSE_BUTTON_SELECTORS` in `ui_automation.py` to reliably detect and dismiss release-note modals across localized profiles.
 
 ## [0.52.0] — 2026-08-05
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -438,14 +438,29 @@ CHANGELOG_IFRAME_SELECTORS = (
 # — clicking (or Escaping) unknown UI is riskier than failing.
 TOP_BANNER_SELECTORS: tuple[str, ...] = (
     "[role='banner']",
+    # Tier 1: Locale-invariant structural anchors
+    "a[href*='changelog']",
+    "a[href*='changelogs']",
+    # Tier 2: Multi-locale text cascades
     "div:has-text('What\\'s new')",
     "*:has-text('View all changelogs')",
+    "*:has-text('Ver histórico de alterações')",
+    "*:has-text('Ver todas as novidades')",
+    "*:has-text('Ver historial de cambios')",
+    "*:has-text('Alle Änderungsprotokolle anzeigen')",
+    "*:has-text('Voir toutes les modifications')",
+    "*:has-text('Visualizza tutte le modifiche')",
+    "*:has-text('変更履歴をすべて表示')",
+    "*:has-text('查看所有更新日志')",
+    "*:has-text('모든 변경사항 보기')",
 )
 
 # Close-button selectors tried after a changelog iframe or banner overlay is detected.
 # Ordered from most-specific to most-generic so a precise match wins first.
 # All are tried before the Escape fallback.
 OVERLAY_CLOSE_BUTTON_SELECTORS = (
+    # Tier 1: Structural & ARIA anchors (locale-invariant)
+    "[role='dialog']:has(a[href*='changelog']) button",
     "[aria-label='Close']",
     "[aria-label='close']",
     "[aria-label='Dismiss']",
@@ -457,12 +472,46 @@ OVERLAY_CLOSE_BUTTON_SELECTORS = (
     "button:has(i.google-symbols:text('close'))",
     "button:has(i:text('close'))",
     "[aria-label*='Got it' i]",
-    "button:has-text('Got it')",
     "[role='dialog'] button:has(i:text('close'))",
     "[role='dialog'] button[aria-label*='close' i]",
     "button[data-dismiss]",
-    "button:has-text('See what\\'s new')",
+    # Tier 2: Multi-locale CTA text cascades
+    "button:has-text('Got it')",
     "button:has-text('Get started')",
+    "button:has-text('See what\\'s new')",
+    # PT
+    "button:has-text('Primeiros passos')",
+    "button:has-text('Começar')",
+    "button:has-text('Entendi')",
+    "button:has-text('Ver novidades')",
+    # ES
+    "button:has-text('Primeros pasos')",
+    "button:has-text('Comenzar')",
+    "button:has-text('Empezar')",
+    "button:has-text('Entendido')",
+    # DE
+    "button:has-text('Erste Schritte')",
+    "button:has-text('Loslegen')",
+    "button:has-text('Verstanden')",
+    # FR
+    "button:has-text('Premiers pas')",
+    "button:has-text('Commencer')",
+    'button:has-text("J\'ai compris")',
+    # IT
+    "button:has-text('Per iniziare')",
+    "button:has-text('Inizia')",
+    "button:has-text('Ho capito')",
+    # JA
+    "button:has-text('使ってみる')",
+    "button:has-text('はじめる')",
+    "button:has-text('開始')",
+    "button:has-text('了解')",
+    # ZH
+    "button:has-text('开始使用')",
+    "button:has-text('了解')",
+    # KO
+    "button:has-text('시작하기')",
+    "button:has-text('확인')",
 )
 
 # Detectors for the "Welcome to Google Flow" splash screen.

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1835,6 +1835,19 @@ class TestDismissBlockingOverlays:
         assert result is True
         assert page._clicked == ["button:has-text('Get started')"]  # type: ignore[attr-defined]
 
+    @pytest.mark.asyncio
+    async def test_watermark_toggle_changelog_overlay_dismissed_pt_br(self) -> None:
+        """Issue #403 (Locale-invariance): Portuguese inline changelog modal with
+        'Primeiros passos' is detected and dismissed cleanly."""
+        t = UiAutomationTransport()
+        page = _make_overlay_page(
+            iframe_visible=True,
+            specific_close_selector="button:has-text('Primeiros passos')",
+        )
+        result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
+        assert result is True
+        assert page._clicked == ["button:has-text('Primeiros passos')"]  # type: ignore[attr-defined]
+
 
 # ---------------------------------------------------------------------------
 # Unit 3.13 — _read_displayed_count + _set_count retry logic


### PR DESCRIPTION
## Summary

Follow-up hardening for **Issue #403**: English-only text selectors in `TOP_BANNER_SELECTORS` and `OVERLAY_CLOSE_BUTTON_SELECTORS` fail when Flow renders under localized user accounts or `GFLOW_CLI_LOCALE` overrides (e.g. Portuguese `pt-BR`, Spanish `es`, German `de`, French `fr`, Japanese `ja`, etc.).

## Changes

1. **Structural Anchors (Locale-Invariant)**
   - Added `a[href*='changelog']` and `a[href*='changelogs']` to `TOP_BANNER_SELECTORS` (matches changelog footer links regardless of display language).
   - Added `[role='dialog']:has(a[href*='changelog']) button` to `OVERLAY_CLOSE_BUTTON_SELECTORS` (targets the primary modal action button structurally).

2. **Multi-Locale Text Cascades**
   - Expanded detection and dismissal cascades across 9 supported languages (EN, PT, ES, DE, FR, IT, JA, ZH, KO).
   - Added PT action buttons (`Primeiros passos`, `Começar`, `Entendi`, `Ver novidades`) and PT changelog text (`Ver histórico de alterações`, `Ver todas as novidades`).

3. **Test Suite**
   - Added `test_watermark_toggle_changelog_overlay_dismissed_pt_br` in `test_ui_automation.py`.

Refs #403
