### PR TITLE
feat(ui): add randomized delay jittering to humanize driver interaction timing (Closes #315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Driver interaction delay humanization (#315).** Added `_jitter_ms` timing entropy helper to `ui_automation.py` to randomize Playwright interaction wait durations around base values, mitigating anti-automation fingerprinting without degrading batch throughput.
+
 ### Fixed
 
 - **Flow release overlay detection for visible watermark toggle modal (#403).** Added locale-invariant structural anchors (`a[href*='changelog']`, `[role='dialog']:has(a[href*='changelog']) button`) and a 9-locale cascade (EN, PT, ES, DE, FR, IT, JA, ZH, KO) to `TOP_BANNER_SELECTORS` and `OVERLAY_CLOSE_BUTTON_SELECTORS` in `ui_automation.py` to reliably detect and dismiss release-note modals across localized profiles.

--- a/docs/superpowers/plans/2026-08-06-driver-delay-jittering/PLAN.md
+++ b/docs/superpowers/plans/2026-08-06-driver-delay-jittering/PLAN.md
@@ -1,0 +1,93 @@
+# Driver Delay Jittering & Humanization Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature driver-delay-jittering` to find the next unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** Humanize UI automation timing by replacing rigid Playwright `wait_for_timeout(N)` calls with randomized timing jitter (`_jitter_ms`), mitigating automated bot signature detection without impacting batch throughput. Prompt copy/pasting remains atomic.
+
+**Architecture:** Implement pure `_jitter_ms` helper and `_wait_jitter(page, base_ms)` transport method in [`ui_automation.py`](file:///C:/development/github/gflow-cli/src/gflow_cli/api/transports/ui_automation.py).
+
+**Predict verdict:** GO — confidence 9.8/10
+
+**Risk register:**
+| Severity | Risk | Mitigation |
+|---|---|---|
+| Low | Negative or fractional millisecond values passed to Playwright | Clamp `_jitter_ms` to `max(0, int(round(jittered)))` |
+
+---
+
+## File structure
+
+### Modified files
+```
+src/gflow_cli/api/transports/ui_automation.py
+  Add _jitter_ms helper function and _wait_jitter method; update wait_for_timeout call sites.
+tests/api/transports/test_ui_automation.py
+  Add unit tests for _jitter_ms bounds and variance.
+KNOWN_ISSUES.md
+  Add resolved entry for Issue #315 delay humanization.
+CHANGELOG.md
+  Add [Unreleased] entry for Issue #315 enhancement.
+```
+
+---
+
+## Task 1 — Unit Test Scaffold for Delay Jittering
+
+**What:** Add unit tests in `tests/api/transports/test_ui_automation.py` covering boundary values (`0ms`), variance bounds, and `_wait_jitter` Playwright call delegation.
+
+**Files:**
+- `tests/api/transports/test_ui_automation.py`
+
+**Steps:**
+- [ ] Add `test_jitter_ms_zero_returns_zero` asserting `_jitter_ms(0) == 0`.
+- [ ] Add `test_jitter_ms_variance_bounds` asserting 100 samples of `_jitter_ms(1000, 0.25)` fall in `[750, 1250]`.
+- [ ] Add `test_wait_jitter_delegates_to_page_wait_for_timeout` asserting integer millis passed to `page.wait_for_timeout`.
+
+---
+
+## Task 2 — Core Implementation in `ui_automation.py`
+
+**What:** Implement `_jitter_ms` and `_wait_jitter`, and refactor static `wait_for_timeout` calls in `ui_automation.py`.
+
+**Files:**
+- `src/gflow_cli/api/transports/ui_automation.py`
+
+**Steps:**
+- [ ] Implement `_jitter_ms(base_ms: int, variance: float = 0.25) -> int`.
+- [ ] Implement `_wait_jitter(page: Page, base_ms: int, variance: float = 0.25) -> None`.
+- [ ] Update static `page.wait_for_timeout` calls in editor navigation, modal dismissals, and submission flows to use `_wait_jitter`.
+- [ ] Verify unit tests pass.
+
+---
+
+## Task 3 — Quality Gates & Pre-Commit Validation
+
+**What:** Run the Impeccable Routine (`/gflow:check`).
+
+**Steps:**
+- [ ] `uv run python scripts/ci/check_repo_hygiene.py`
+- [ ] `uv run python scripts/ci/check_doc_links.py`
+- [ ] `uv run ruff check src tests`
+- [ ] `uv run ruff format --check src tests`
+- [ ] `uv run pyright src`
+- [ ] `uv run python -m pytest -q tests/api/transports/test_ui_automation.py`
+
+---
+
+## Task 4 — Documentation & Changelog Update
+
+**What:** Update `CHANGELOG.md` and `KNOWN_ISSUES.md`.
+
+**Files:**
+- `CHANGELOG.md`
+
+**Steps:**
+- [ ] Add entry under `[Unreleased]` in `CHANGELOG.md`.
+
+---
+
+## Definition of Done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated

--- a/docs/superpowers/plans/2026-08-06-driver-delay-jittering/SCENARIO.md
+++ b/docs/superpowers/plans/2026-08-06-driver-delay-jittering/SCENARIO.md
@@ -1,0 +1,26 @@
+# Scenario: Issue #315 — Driver Delay Jittering & Interaction Humanization
+
+## Coverage Map
+- **Active Dimensions:**
+  - **D2 (WAF / reCAPTCHA scoring):** Randomizing wait delays breaks deterministic timing signatures that static `wait_for_timeout(N)` calls emit.
+  - **D5 (Concurrency & Page pool):** Ensure randomized delays do not cause worker thread or page checkout deadlocks.
+  - **D11 (Input validation & boundaries):** Bounds checking — `_jitter_ms(0)` must return `0` (never negative or fractional ms).
+- **Skipped Dimensions:** D1, D3, D4, D6, D7, D8, D9, D10, D12 (unaffected by internal delay helper).
+
+---
+
+## Scenario Table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D11 Boundaries | `_jitter_ms(0)` is called | High | Returns `0` strictly (no negative delays) | Unit |
+| 2 | D2 WAF entropy | `_jitter_ms(1000, variance=0.25)` is called 100 times | High | Returns values bounded between 750ms and 1250ms with non-zero variance | Unit |
+| 3 | D5 Concurrency | `_wait_jitter(page, base_ms)` is awaited | High | Calls `page.wait_for_timeout(jittered_ms)` with integer milliseconds | Unit |
+
+---
+
+## Must-Cover Before Merge
+1. Add `_jitter_ms(base_ms: int, variance: float = 0.25) -> int` to `ui_automation.py`.
+2. Add `_wait_jitter(page: Page, base_ms: int, variance: float = 0.25)` helper method in `UiAutomationTransport`.
+3. Update key interaction delay calls (`wait_for_timeout`) in `ui_automation.py` to use `_wait_jitter`.
+4. Unit tests in `tests/api/transports/test_ui_automation.py` validating `_jitter_ms` boundary conditions and variance.

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -781,6 +781,18 @@ def _entity_ids_from_request_body(post_data: str | None) -> set[str]:
     return out
 
 
+def _jitter_ms(base_ms: int, variance: float = 0.25) -> int:
+    """Calculate a randomized delay duration bounded around base_ms.
+
+    Adds timing entropy to browser interaction delays to break deterministic Playwright
+    automation fingerprints. Returns 0 if base_ms <= 0.
+    """
+    if base_ms <= 0:
+        return 0
+    delta = int(round(base_ms * max(0.0, min(1.0, variance))))
+    return max(1, random.randint(base_ms - delta, base_ms + delta))
+
+
 class UiAutomationTransport(VideoGenerationMixin):
     """D.2.4 — Playwright UI mimicry strategy.
 
@@ -798,6 +810,12 @@ class UiAutomationTransport(VideoGenerationMixin):
     """
 
     name = "ui_automation"
+
+    async def _wait_jitter(self, page: Page, base_ms: int, variance: float = 0.25) -> None:
+        """Wait for a jittered duration using page.wait_for_timeout."""
+        jittered = _jitter_ms(base_ms, variance=variance)
+        if jittered > 0:
+            await page.wait_for_timeout(jittered)
 
     def __init__(self) -> None:
         self._pw_cm: Any | None = None
@@ -1301,7 +1319,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         if trigger is None:
             raise await VideoGenerationMixin._mode_switch_error(page, out_dir, media="image")
         await trigger.click()
-        await page.wait_for_timeout(800)
+        await page.wait_for_timeout(_jitter_ms(800))
         image_tab = await VideoGenerationMixin._probe_selector_cascade(
             page,
             "image_mode_tab",
@@ -1317,9 +1335,9 @@ class UiAutomationTransport(VideoGenerationMixin):
                 )
             )
         await image_tab.click()
-        await page.wait_for_timeout(1200)
+        await page.wait_for_timeout(_jitter_ms(1200))
         await page.keyboard.press("Escape")
-        await page.wait_for_timeout(200)
+        await page.wait_for_timeout(_jitter_ms(200))
         log.info("ui_automation.image_mode_entered")
 
     # ------------------------------------------------------------------
@@ -1395,7 +1413,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                 # Explicit short timeout: never inherit Playwright's 30s default on
                 # a best-effort nicety sitting in front of the submit.
                 await locator.click(timeout=5000)
-                await page.wait_for_timeout(500)
+                await page.wait_for_timeout(_jitter_ms(500))
                 log.info("ui_automation.prompt_formatted", selector=selector)
                 return True
             except Exception as e:
@@ -1439,7 +1457,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         # insert_text fires a single beforeinput event that Slate.js handles
         # natively — near-instant vs keyboard.type() which is ~1.5s/char.
         await page.keyboard.insert_text(prompt_text)
-        await page.wait_for_timeout(500)
+        await page.wait_for_timeout(_jitter_ms(500))
 
         if format_prompt:
             await self.format_character_prompt(page)

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -3387,3 +3387,35 @@ async def test_attach_batch_response_listener_records_headers():
     assert captured[0]["headers"] == {"retry-after": "30", "content-type": "application/json"}
 
     detach()
+
+
+class TestJitterMsAndWaitJitter:
+    """Issue #315: Unit tests for randomized delay jittering."""
+
+    def test_jitter_ms_zero_returns_zero(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _jitter_ms
+
+        assert _jitter_ms(0) == 0
+        assert _jitter_ms(-100) == 0
+
+    def test_jitter_ms_variance_bounds(self) -> None:
+        from gflow_cli.api.transports.ui_automation import _jitter_ms
+
+        samples = [_jitter_ms(1000, 0.25) for _ in range(100)]
+        assert all(750 <= s <= 1250 for s in samples)
+        # Verify non-zero variance (randomized values differ)
+        assert len(set(samples)) > 1
+
+    @pytest.mark.asyncio
+    async def test_wait_jitter_delegates_to_page_wait_for_timeout(self) -> None:
+        from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+
+        t = UiAutomationTransport()
+        mock_page = MagicMock()
+        mock_page.wait_for_timeout = AsyncMock()
+
+        await t._wait_jitter(mock_page, 500)
+        mock_page.wait_for_timeout.assert_called_once()
+        called_ms = mock_page.wait_for_timeout.call_args[0][0]
+        assert isinstance(called_ms, int)
+        assert 375 <= called_ms <= 625


### PR DESCRIPTION
## Summary

Humanizes Playwright interaction timing in `ui_automation.py` by adding randomized delay jittering to `wait_for_timeout` calls ([Issue #315](https://github.com/ffroliva/gflow-cli/issues/315)). Breaks deterministic timing signatures used by WAF algorithms to fingerprint Playwright bots, without impacting batch throughput.

## Scope & Design

- **IN SCOPE:** Added `_jitter_ms(base_ms, variance=0.25)` helper and `_wait_jitter(page, base_ms)` transport method. Static wait durations (`800ms`, `1200ms`, `500ms`, `200ms`) now evaluate with a randomized ±25% uniform variance.
- **OUT OF SCOPE (Per User Directive & YAGNI):** Character-by-character typing simulation. Professional prompt engineers copy/paste prompts atomically. Fast clipboard injection (`insert_text`) remains the standard behavior.

## Verification status

- [x] Unit test `test_jitter_ms_zero_returns_zero` passes (`_jitter_ms(0) == 0`)
- [x] Unit test `test_jitter_ms_variance_bounds` passes (100 samples bounded strictly in `[750, 1250]`)
- [x] Unit test `test_wait_jitter_delegates_to_page_wait_for_timeout` passes
- [x] All 7 pre-commit quality gates green (`/gflow:check`)

Closes #315
