### PR TITLE
chore(deps): bump sse-starlette from 3.4.6 to 3.4.8

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2874,15 +2874,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.6"
+version = "3.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lands the **sse-starlette 3.4.6 → 3.4.8** patch that was held hostage inside the auto-closed Dependabot group PR #465.

Background: #465 grouped this clean patch with the forbidden playwright 1.61.0 → 1.62.0 minor (the version documented as silently hanging `video i2v` after frame upload). After #466 merged — teaching Dependabot to ignore playwright minors and all patchright bumps — Dependabot auto-closed #465 entirely, and its next scheduled run is not until Monday. This PR lands the good half now.

- **Lock-only change**: `pyproject.toml` allows `sse-starlette>=2.0.0`, so only `uv.lock` moves (3 lines).
- Refs #465, refs #466.

## Validation

- `uv lock --upgrade-package sse-starlette` — resolved 125 packages, updated only `sse-starlette v3.4.6 -> v3.4.8`
- Diff inspected: single package entry in `uv.lock`, nothing else touched
- No src/test/doc changes — trusting CI for the test matrix (full local suite OOMs per AGENTS.md)

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting