### PR TITLE
docs(auth): clearer close-the-browser guidance in gflow auth login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Driver interaction delay humanization (#315).** Added `_jitter_ms` timing entropy helper to `ui_automation.py` to randomize Playwright interaction wait durations around base values, mitigating anti-automation fingerprinting without degrading batch throughput.
 
+### Changed
+
+- **Clearer close-the-browser guidance in `gflow auth login`.** Reworded the final passive-capture step in `real_chrome.py` from the abrupt "CLOSE THE BROWSER" command into plain-language guidance: closing the Chrome window is how you signal you're done, after which gflow verifies the Flow session automatically. No behavior change — the manual close stays required on the real-Chrome path, because Chrome holds an exclusive lock on its cookie store while running (verified empirically), so gflow cannot auto-detect completion there without breaking the zero-automation-surface stealth model.
+
 ### Fixed
 
 - **Dependabot could re-offer the known-bad playwright 1.62.0 every Monday (#465).** The `uv` ecosystem does not respect a version bound standing in an update's way — it **rewrites** it, so the deliberate `playwright>=1.61.0,<1.62.0` bound in `pyproject.toml` never gated Dependabot as `.github/dependabot.yml` claimed. PR #465 widened it to `<1.63.0` and locked 1.62.0, the exact version documented as hanging every `video i2v` right after the frame upload. Dependabot now ignores playwright `semver-minor` alongside `semver-major` (patch bumps stay allowed so a driver CVE fix needs no gflow release), guarded by `tests/test_playwright_pin.py::test_dependabot_ignores_playwright_minor_bumps`.

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -95,8 +95,11 @@ def _print_login_instructions() -> None:
         "   Signing in to Google is NOT enough; gflow needs a completed Flow app sign-in.",
     )
     _console.print(
-        "4. Then [bold yellow]CLOSE THE BROWSER[/bold yellow] — gflow verifies "
-        "the Flow session automatically.",
+        "4. When you're finished, simply [bold]close the Chrome window[/bold] — "
+        "that's how you let gflow know you're done.",
+    )
+    _console.print(
+        "   gflow then verifies your Flow session automatically; there's nothing else to do.",
     )
     _console.print("-" * 60)
     _console.print("Launching Chrome...")


### PR DESCRIPTION
## Summary

- Rewords the final step of `gflow auth login` from the abrupt **"CLOSE THE BROWSER"** command into plain-language guidance: closing the Chrome window is how you signal you're done, after which gflow verifies the Flow session automatically.
- No behavior change. The manual close stays required on the real-Chrome path.

## Why

The old wording read as a jarring command and made the manual close feel like a workaround rather than an intentional step. An investigation (a throwaway spike, deliberately not committed) confirmed Chrome holds an **exclusive lock on its cookie store for minutes** while running, so gflow cannot auto-detect sign-in completion on the zero-automation-surface path without breaking the stealth model. So we improved the message instead of shipping an unreliable auto-close.

## Test plan

- [x] `ruff format` / `ruff check` clean on `real_chrome.py`
- [x] `pytest tests/auth/test_real_chrome.py` → 4 passed
- [x] Rendered instruction output verified by hand
- [x] ponytail-review + code-review (xhigh): clean for this change