### PR TITLE
feat(security): store llm_api_key and daemon_token as SecretStr (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Secret settings can no longer leak through a `Settings` dump (#474).** `llm_api_key` (`GFLOW_CLI_LLM_API_KEY`) and `daemon_token` (`GFLOW_CLI_DAEMON_TOKEN`/`GFLOW_DAEMON_TOKEN`) are now stored as Pydantic `SecretStr`, so `repr()`, `str()`, and `model_dump_json()` of the settings object mask them by construction — defense-in-depth on top of the existing logging-boundary redaction. Values are unwrapped only at the single point of use (the prompt-tools LLM client).
+
 ## [0.54.0] — 2026-08-12
 
 ### Changed

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlsplit
 
 from dotenv import dotenv_values
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from gflow_cli import paths
@@ -410,7 +410,7 @@ class Settings(BaseSettings):
             "OpenAI-compatible Gemini endpoint. Override via GFLOW_CLI_LLM_BASE_URL."
         ),
     )
-    llm_api_key: str | None = Field(
+    llm_api_key: SecretStr | None = Field(
         default=None,
         description=(
             "Credential presented to GFLOW_CLI_LLM_BASE_URL as an Authorization: Bearer "
@@ -603,7 +603,7 @@ class Settings(BaseSettings):
     log_format: LogFormat = LogFormat.AUTO
 
     # --- daemon -----------------------------------------------------------
-    daemon_token: str | None = Field(
+    daemon_token: SecretStr | None = Field(
         default=None,
         validation_alias=AliasChoices("GFLOW_CLI_DAEMON_TOKEN", "GFLOW_DAEMON_TOKEN"),
         description="API token to authenticate calls to the daemon server.",

--- a/src/gflow_cli/tools/runtime.py
+++ b/src/gflow_cli/tools/runtime.py
@@ -156,8 +156,9 @@ def apply_tool(
     instruction = build_instruction(spec.config, style, category)
     if expander is None:
         settings = get_settings()
+        api_key = settings.llm_api_key.get_secret_value() if settings.llm_api_key else None
         expander = PromptExpander(
-            settings.llm_api_key,
+            api_key,
             base_url=settings.llm_base_url,
             # Precedence lives in resolve_model so this and the provenance
             # record in invocation.py cannot drift: TOML pin (the tool author

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -420,7 +420,7 @@ class TestDaemonSettings:
         import inspect
 
         source = inspect.getsource(Settings)
-        assert source.count("daemon_token: str | None") == 1
+        assert source.count("daemon_token: SecretStr | None") == 1
 
     def test_daemon_token_keeps_both_env_aliases(self) -> None:
         """Pin the SURVIVING definition's contract: both env var spellings
@@ -437,11 +437,13 @@ class TestDaemonSettings:
 
     def test_daemon_token_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GFLOW_DAEMON_TOKEN", "secret-token")
-        assert Settings().daemon_token == "secret-token"
+        token = Settings().daemon_token
+        assert token is not None and token.get_secret_value() == "secret-token"
 
         monkeypatch.setenv("GFLOW_CLI_DAEMON_TOKEN", "other-token")
         reset_settings()
-        assert Settings().daemon_token == "other-token"
+        token = Settings().daemon_token
+        assert token is not None and token.get_secret_value() == "other-token"
 
     def test_daemon_port_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GFLOW_DAEMON_PORT", "9000")
@@ -457,6 +459,28 @@ class TestDaemonSettings:
         monkeypatch.setenv("GFLOW_DAEMON_PORT", "70000")
         with pytest.raises(ValidationError):
             Settings()
+
+
+class TestSecretFieldMasking:
+    """Secret settings must be unreadable from any Settings dump by
+    construction, not just at logging boundaries (issue #474)."""
+
+    def test_dumps_never_contain_secret_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GFLOW_CLI_LLM_API_KEY", "sk-CANARY-LLM-KEY")
+        monkeypatch.setenv("GFLOW_CLI_DAEMON_TOKEN", "CANARY-DAEMON-TOKEN")
+        s = Settings()
+        for dump in (repr(s), str(s), s.model_dump_json()):
+            assert "sk-CANARY-LLM-KEY" not in dump
+            assert "CANARY-DAEMON-TOKEN" not in dump
+
+    def test_secret_values_still_accessible(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GFLOW_CLI_LLM_API_KEY", "sk-abc")
+        monkeypatch.setenv("GFLOW_CLI_DAEMON_TOKEN", "tok")
+        s = Settings()
+        assert s.llm_api_key is not None
+        assert s.llm_api_key.get_secret_value() == "sk-abc"
+        assert s.daemon_token is not None
+        assert s.daemon_token.get_secret_value() == "tok"
 
 
 class TestIncidentCapture:
@@ -500,7 +524,8 @@ class TestLlmSettings:
         monkeypatch.setenv("GFLOW_CLI_LLM_MODEL", "openai/gpt-4o-mini")
         s = Settings()
         assert s.llm_base_url == "https://gw.example/v1"
-        assert s.llm_api_key == "sk-abc"
+        assert s.llm_api_key is not None
+        assert s.llm_api_key.get_secret_value() == "sk-abc"
         assert s.llm_model == "openai/gpt-4o-mini"
 
     def test_empty_base_url_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -473,15 +473,6 @@ class TestSecretFieldMasking:
             assert "sk-CANARY-LLM-KEY" not in dump
             assert "CANARY-DAEMON-TOKEN" not in dump
 
-    def test_secret_values_still_accessible(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("GFLOW_CLI_LLM_API_KEY", "sk-abc")
-        monkeypatch.setenv("GFLOW_CLI_DAEMON_TOKEN", "tok")
-        s = Settings()
-        assert s.llm_api_key is not None
-        assert s.llm_api_key.get_secret_value() == "sk-abc"
-        assert s.daemon_token is not None
-        assert s.daemon_token.get_secret_value() == "tok"
-
 
 class TestIncidentCapture:
     """GFLOW_CLI_INCIDENT_CAPTURE — private incident diagnostics (S35)."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -420,7 +420,9 @@ class TestDaemonSettings:
         import inspect
 
         source = inspect.getsource(Settings)
-        assert source.count("daemon_token: SecretStr | None") == 1
+        # Count ANY annotation spelling — a reintroduced duplicate with the old
+        # `str | None` annotation would silently shadow the SecretStr field.
+        assert source.count("daemon_token:") == 1
 
     def test_daemon_token_keeps_both_env_aliases(self) -> None:
         """Pin the SURVIVING definition's contract: both env var spellings

--- a/tests/tools/test_runtime.py
+++ b/tests/tools/test_runtime.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from gflow_cli.config import reset_settings
 from gflow_cli.tools.expander import ExpansionResult, PromptExpander
 from gflow_cli.tools.registry import get_tool, reset_registry
 from gflow_cli.tools.runtime import (
@@ -22,6 +25,28 @@ def test_build_instruction_appends_domain() -> None:
     assert "cinema" in instr.lower() or "ARRI" in instr  # domain vocab injected
     base = build_instruction(cfg, None)
     assert len(instr) > len(base)
+
+
+def test_apply_tool_unwraps_secret_llm_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default-expander path must hand PromptExpander the RAW key string,
+    not the SecretStr wrapper (issue #474) — otherwise the gateway would get
+    'Authorization: Bearer **********'."""
+    monkeypatch.setenv("GFLOW_CLI_LLM_API_KEY", "sk-raw-unwrapped")
+    reset_settings()
+    captured: dict[str, object] = {}
+
+    def fake_expander(api_key: object, **kwargs: object) -> MagicMock:
+        captured["api_key"] = api_key
+        mock = MagicMock()
+        mock.expand.return_value = ExpansionResult(
+            original="cat", expanded="cat", was_expanded=False
+        )
+        return mock
+
+    with patch("gflow_cli.tools.runtime.PromptExpander", side_effect=fake_expander):
+        apply_tool(get_tool("creative-director"), "cat", {})
+
+    assert captured["api_key"] == "sk-raw-unwrapped"
 
 
 def test_apply_tool_strips_banned_from_output() -> None:


### PR DESCRIPTION
## Summary

Closes #474 (Tier-1 quick win from the linkedin-mcp catalog).

`llm_api_key` and `daemon_token` were plain `str` on `Settings`, so a `repr()`, `str()`, or `model_dump_json()` of the settings object exposed them — redaction existed only at logging/exception boundaries. Both are now Pydantic `SecretStr`, masked by construction.

- `config.py`: two field-type changes + import. Env parsing unchanged (pydantic coerces env strings natively; both `GFLOW_CLI_DAEMON_TOKEN`/`GFLOW_DAEMON_TOKEN` aliases pinned by existing tests).
- `tools/runtime.py`: the single consumer unwraps via `get_secret_value()` at the point of use.
- `cli.py:498` (serve token gate) needs no change: `SecretStr.__bool__` delegates to the inner value (verified empirically — `SecretStr('')` is falsy).
- New canary test: repr/str/model_dump_json must never contain the raw values.
- Review hardening: seam test proving PromptExpander receives the RAW key (a regression would send `Bearer **********` to the gateway), and the daemon_token duplicate-definition guard now counts any annotation spelling (#243 bug class).

## Reviews run

- **code-review (xhigh)**: no correctness bugs; 2 hardening findings — both applied.
- **ponytail-review**: 1 redundant test deleted (−9 lines); rest judged minimal.

## Validation

- `pytest tests/test_config.py tests/tools tests/test_diagnostics_events.py` — 149+ passed, scoped per AGENTS.md (full suite OOMs locally; CI runs the sweep)
- `ruff check` + `ruff format --check` — clean
- `pyright src` — 73 errors on this machine but **identical count on untouched develop** (local env skew, all in untouched `mcp/*`/`ui/app.py`); CI pyright is the gate
- `check_repo_hygiene.py` (726 files), `check_doc_links.py` (27 files) — clean
- Live verification: n/a — no generation-path change

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting