### PR TITLE
feat(auth): gflow auth status proves the Flow session and exits 0/1 (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`gflow auth status` now proves the Flow session and exits 0/1 (#471).** The command previously only checked that the profile directory and cookies file exist — it could report OK on a dead session. It now runs the fast `verify_flow_profile` probe (cookie snapshot + Flow session endpoint; no browser, no credits) and exits 0 only on a verified session, printing the verified account email; any other outcome exits 1 with a `gflow auth login` remediation hint. Fail-closed: an unreachable endpoint is a failure, never an OK.
+
 ### Security
 
 - **Secret settings can no longer leak through a `Settings` dump (#474).** `llm_api_key` (`GFLOW_CLI_LLM_API_KEY`) and `daemon_token` (`GFLOW_CLI_DAEMON_TOKEN`/`GFLOW_DAEMON_TOKEN`) are now stored as Pydantic `SecretStr`, so `repr()`, `str()`, and `model_dump_json()` of the settings object mask them by construction — defense-in-depth on top of the existing logging-boundary redaction. Values are unwrapped only at the single point of use (the prompt-tools LLM client).

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -197,18 +197,19 @@ accidental interference or data corruption.
 
 ### `gflow auth status`
 
-Reports whether a profile exists, where it lives, and whether the cookies file is present.
+Reports where the profile lives, then **proves the session**: it probes the Flow session endpoint with the profile's cookies (no browser, no credits) and exits `0` only when the session is verified — `1` otherwise. Handy for scripts: `gflow auth status && gflow run ...`.
 
 ```bash
 $ gflow auth status
-Profile 'default' is configured.
   profile: /home/you/.local/share/gflow-cli/profile_default
   exists: True
   cookies_present: True
   cookies_path: /home/you/.local/share/gflow-cli/profile_default/Default/Cookies
+  browser_engine: playwright
+Flow session verified as you@example.com.
 ```
 
-> Note: `cookies_present: True` only confirms the file exists — not that the session is still valid with Google. The first real API call (e.g. `gflow image t2i`) is the actual probe. If Google has invalidated the session, the call will fail with an authentication error and you'll be prompted to re-run `auth login`.
+> Note: `cookies_present: True` only confirms the file exists. The final verdict line is the live probe result: a dead session prints a `gflow auth login` remediation hint and exits 1; a probe that cannot reach the endpoint (offline, 5xx) also exits 1 but suggests checking connectivity instead of re-logging in.
 
 ### `gflow auth list`
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -84,7 +84,7 @@ The session cookies persist across reboots until Google invalidates them — typ
 gflow auth status
 ```
 
-Expected: `cookies_present: True` + `profile_dir: <path>`. If it says `False`, re-run `gflow auth login`.
+Expected: `Flow session verified as <your account>.` and exit code 0 — the command probes the live Flow session (no browser, no credits). If it exits 1, follow the printed hint (usually re-run `gflow auth login`).
 
 You're done. Skip to [Journey 2](#journey-2--your-first-video-single-t2v).
 
@@ -320,7 +320,8 @@ Then check current session state:
 
 ```bash
 gflow auth status
-# Likely output: cookies_present: True, but Google has invalidated the session.
+# A dead session exits 1 and says so, e.g.:
+#   "Signed in to Google, but not to the Flow app." + a gflow auth login hint.
 ```
 
 ### 7.2 Refresh

--- a/scripts/record_demo.ps1
+++ b/scripts/record_demo.ps1
@@ -110,15 +110,14 @@ if (-not (Test-Path $assetsDir)) {
 
 # -------- AUTH PRECHECK --------
 Step "Verifying auth on profile '$ProfileName' (no quota burn yet)"
-# Note: `gflow auth status` only checks for an exported state.json (used by
-# HTTP transports). The default UiAutomationTransport reads cookies straight
-# from the Playwright profile dir's Chromium store, which `auth status`
-# cannot see. So "no session" here is often a false negative. We surface it
-# as an advisory and let the real `gflow run` be the actual test.
+# Note: `gflow auth status` probes the live Flow session endpoint with the
+# profile's cookies and exits non-zero when it cannot verify one (#471).
+# Keep it ADVISORY here: an offline/firewalled probe must not block a
+# recording session — the real `gflow run` is the actual test.
 $statusOutput = (& uv run gflow auth status 2>&1) | Out-String
 Write-Host $statusOutput
 if ($LASTEXITCODE -ne 0) {
-    Die "gflow auth status exited $LASTEXITCODE. Cannot continue."
+    Warn "gflow auth status exited $LASTEXITCODE - continuing; the real 'gflow run' is the actual test."
 }
 $profileDir = "$env:LOCALAPPDATA\ffroliva\gflow-cli\profile_$ProfileName"
 if (-not (Test-Path $profileDir)) {

--- a/skills/gflow-cli/SKILL.md
+++ b/skills/gflow-cli/SKILL.md
@@ -47,7 +47,7 @@ Before any gflow-cli invocation, verify:
    - Quick: `uvx --from gflow-cli gflow --help` (no install)
    - Persistent: `uv tool install gflow-cli && gflow --help`
 4. **Playwright Chromium** has been downloaded once: `uvx --from gflow-cli playwright install chromium` (~150 MB).
-5. **A signed-in profile** exists: `gflow auth status` should show `Profile 'default' is configured`. If not, run `gflow auth login` and walk the user through the one-time browser sign-in.
+5. **A signed-in profile** exists: `gflow auth status` should print `Flow session verified` and exit 0 (it probes the live Flow session endpoint — no browser, no credits; exit 1 means dead or missing session). If not, run `gflow auth login` and walk the user through the one-time browser sign-in.
 6. **The user has Flow access** — Google AI Ultra or Pro subscription with Flow rolled out. If `gflow image upload` returns 403, this is the cause.
 
 ## Core commands

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -273,22 +273,42 @@ def auth_login(profile: str | None, browser: str | None) -> None:
 @auth.command("status")
 @click.option("--profile", default=None)
 def auth_status(profile: str | None) -> None:
-    """Show whether a specific profile has a saved session."""
+    """Show whether a profile has a saved session and verify it against Flow.
+
+    Probes the Flow session endpoint with the profile's cookies (no browser,
+    no credits). Exits 0 when the session is verified, 1 otherwise.
+    """
     name = profile or _resolve_or_exit()
     s = auth_mod.status(name)
-    if s["exists"] and s["cookies_present"]:
-        console.print(f"[green]Profile '{name}' is configured.[/green]")
-    else:
-        console.print(
-            f"[yellow]Profile '{name}' has no session.[/yellow] "
-            f"Run [bold]gflow auth login --profile {name}[/bold].",
-        )
     for k, v in s.items():
         console.print(f"  {k}: {v}")
     # Surface the active browser engine so a two-engine setup is debuggable.
     from gflow_cli.config import get_settings
 
     console.print(f"  browser_engine: {get_settings().browser_engine}")
+
+    if not (s["exists"] and s["cookies_present"]):
+        console.print(
+            f"[yellow]Profile '{name}' has no session.[/yellow] "
+            f"Run [bold]gflow auth login --profile {name}[/bold].",
+        )
+        sys.exit(1)
+
+    # Files on disk say nothing about whether the session still works — prove
+    # it (issue #471). Fail-closed: only a verified session exits 0.
+    from gflow_cli.auth import verification
+
+    status_result = asyncio.run(
+        verification.verify_flow_profile(auth_mod.profile_dir(name), source="status")
+    )
+    if not status_result.authenticated:
+        console.print(
+            f"[yellow]{status_result.detail}[/yellow] "
+            f"Run [bold]gflow auth login --profile {name}[/bold] to refresh the session.",
+        )
+        sys.exit(1)
+    who = f" as [bold]{status_result.user_email}[/bold]" if status_result.user_email else ""
+    console.print(f"[green]Flow session verified{who}.[/green]")
 
 
 @auth.command("list")

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -296,18 +296,30 @@ def auth_status(profile: str | None) -> None:
 
     # Files on disk say nothing about whether the session still works — prove
     # it (issue #471). Fail-closed: only a verified session exits 0.
+    from rich.markup import escape
+
     from gflow_cli.auth import verification
 
+    console.print("[dim]Probing Flow session (may take up to ~45s on a slow network)...[/dim]")
     status_result = asyncio.run(
         verification.verify_flow_profile(auth_mod.profile_dir(name), source="status")
     )
     if not status_result.authenticated:
-        console.print(
-            f"[yellow]{status_result.detail}[/yellow] "
-            f"Run [bold]gflow auth login --profile {name}[/bold] to refresh the session.",
-        )
+        if status_result.outcome is verification.FlowSessionOutcome.VERIFICATION_ERROR:
+            # Re-login cannot fix an unreachable endpoint — don't send the
+            # user into an interactive browser flow for a network problem.
+            console.print(
+                f"[yellow]{status_result.detail}[/yellow] "
+                "Check network connectivity and retry; re-login is only needed "
+                "if the session is actually dead.",
+            )
+        else:
+            console.print(
+                f"[yellow]{status_result.detail}[/yellow] "
+                f"Run [bold]gflow auth login --profile {name}[/bold] to refresh the session.",
+            )
         sys.exit(1)
-    who = f" as [bold]{status_result.user_email}[/bold]" if status_result.user_email else ""
+    who = f" as [bold]{escape(status_result.user_email)}[/bold]" if status_result.user_email else ""
     console.print(f"[green]Flow session verified{who}.[/green]")
 
 

--- a/tests/cli/test_auth_status.py
+++ b/tests/cli/test_auth_status.py
@@ -1,0 +1,80 @@
+"""`gflow auth status` proves the Flow session and exits 0/1 (issue #471).
+
+The probe is `verify_flow_profile` — mocked here (network-free); its own
+behavior is covered by tests/auth/test_verification*.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
+from gflow_cli.cli import main
+from gflow_cli.config import get_settings
+
+
+def _make_profile(name: str) -> Path:
+    pdir = get_settings().profile_subdir(name)
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "Cookies").write_bytes(b"")
+    return pdir
+
+
+def _mock_probe(
+    monkeypatch: pytest.MonkeyPatch, outcome: FlowSessionOutcome, email: str | None = None
+) -> dict[str, int]:
+    calls = {"n": 0}
+
+    async def fake_probe(profile_dir: Path, *, source: str = "chrome") -> FlowSessionStatus:
+        calls["n"] += 1
+        return FlowSessionStatus(outcome=outcome, user_email=email, source=source)
+
+    monkeypatch.setattr("gflow_cli.auth.verification.verify_flow_profile", fake_probe)
+    return calls
+
+
+def test_exit_0_when_flow_session_verified(monkeypatch: pytest.MonkeyPatch) -> None:
+    _make_profile("probed")
+    calls = _mock_probe(monkeypatch, FlowSessionOutcome.AUTHENTICATED, "user@example.com")
+
+    result = CliRunner().invoke(main, ["auth", "status", "--profile", "probed"])
+
+    assert result.exit_code == 0
+    assert calls["n"] == 1
+    assert "user@example.com" in result.output
+
+
+def test_exit_1_with_hint_when_session_dead(monkeypatch: pytest.MonkeyPatch) -> None:
+    _make_profile("probed")
+    calls = _mock_probe(monkeypatch, FlowSessionOutcome.GOOGLE_SESSION_ONLY)
+
+    result = CliRunner().invoke(main, ["auth", "status", "--profile", "probed"])
+
+    assert result.exit_code == 1
+    assert calls["n"] == 1
+    assert "gflow auth login" in result.output
+
+
+def test_exit_1_without_probe_when_no_cookies(monkeypatch: pytest.MonkeyPatch) -> None:
+    pdir = get_settings().profile_subdir("empty")
+    pdir.mkdir(parents=True, exist_ok=True)  # no Cookies file
+    calls = _mock_probe(monkeypatch, FlowSessionOutcome.AUTHENTICATED)
+
+    result = CliRunner().invoke(main, ["auth", "status", "--profile", "empty"])
+
+    assert result.exit_code == 1
+    assert calls["n"] == 0  # nothing to probe without cookies
+    assert "gflow auth login" in result.output
+
+
+def test_exit_1_on_verification_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail-closed: an unreachable endpoint is NOT an authenticated session."""
+    _make_profile("probed")
+    _mock_probe(monkeypatch, FlowSessionOutcome.VERIFICATION_ERROR)
+
+    result = CliRunner().invoke(main, ["auth", "status", "--profile", "probed"])
+
+    assert result.exit_code == 1

--- a/tests/cli/test_auth_status.py
+++ b/tests/cli/test_auth_status.py
@@ -71,10 +71,25 @@ def test_exit_1_without_probe_when_no_cookies(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_exit_1_on_verification_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fail-closed: an unreachable endpoint is NOT an authenticated session."""
+    """Fail-closed: an unreachable endpoint is NOT an authenticated session —
+    but the remediation must point at connectivity, not a pointless re-login."""
     _make_profile("probed")
     _mock_probe(monkeypatch, FlowSessionOutcome.VERIFICATION_ERROR)
 
     result = CliRunner().invoke(main, ["auth", "status", "--profile", "probed"])
 
     assert result.exit_code == 1
+    assert "gflow auth login" not in result.output
+    assert "connectivity" in result.output
+
+
+def test_bracketed_email_renders_without_markup_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A server-supplied email is untrusted text — Rich markup must be escaped
+    (this repo's known bracketed-text crash class)."""
+    _make_profile("probed")
+    _mock_probe(monkeypatch, FlowSessionOutcome.AUTHENTICATED, "[user]@example.com")
+
+    result = CliRunner().invoke(main, ["auth", "status", "--profile", "probed"])
+
+    assert result.exit_code == 0
+    assert result.exception is None

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -9,11 +9,19 @@ Feature: Authentication
     Then the exit code is 0
     And the output contains "No profiles found"
 
-  Scenario: Status of a profile
+  Scenario: Status of a profile with a live Flow session
     Given a profile "experiments" exists
+    And the Flow session probe reports authenticated
     When I run "gflow auth status --profile experiments"
     Then the exit code is 0
     And the output contains "experiments"
+
+  Scenario: Status of a profile whose session is dead
+    Given a profile "experiments" exists
+    And the Flow session probe reports no session
+    When I run "gflow auth status --profile experiments"
+    Then the exit code is 1
+    And the output contains "gflow auth login"
 
   Scenario: Use a profile
     Given a profile "experiments" exists

--- a/tests/features/test_auth_steps.py
+++ b/tests/features/test_auth_steps.py
@@ -20,6 +20,7 @@ from click.testing import CliRunner
 from pytest_bdd import given, scenarios, then, when
 
 from gflow_cli import config
+from gflow_cli.auth.verification import FlowSessionOutcome, FlowSessionStatus
 from gflow_cli.cli import main
 from gflow_cli.errors import AuthExpiredError
 
@@ -98,6 +99,23 @@ def _profile_experiments_exists(tmp_path: Path) -> None:
     (pdir / "Cookies").write_bytes(b"")
 
 
+def _patch_probe(monkeypatch: pytest.MonkeyPatch, outcome: FlowSessionOutcome) -> None:
+    async def fake_probe(profile_dir: Path, *, source: str = "chrome") -> FlowSessionStatus:
+        return FlowSessionStatus(outcome=outcome, user_email=None, source=source)
+
+    monkeypatch.setattr("gflow_cli.auth.verification.verify_flow_profile", fake_probe)
+
+
+@given("the Flow session probe reports authenticated")
+def _probe_authenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_probe(monkeypatch, FlowSessionOutcome.AUTHENTICATED)
+
+
+@given("the Flow session probe reports no session")
+def _probe_no_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_probe(monkeypatch, FlowSessionOutcome.NO_SESSION)
+
+
 @given("the mocked FlowApiClient raises AuthExpiredError")
 def _mock_auth_expired(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Patch ``_run_t2i`` to raise :class:`AuthExpiredError` so the CLI
@@ -150,6 +168,12 @@ def _run_image_t2i_some_prompt(runner: CliRunner, cli_result_holder: dict[str, A
 def _check_exit_0(cli_result_holder: dict[str, Any]) -> None:
     result = cli_result_holder["result"]
     assert result.exit_code == 0, result.output
+
+
+@then("the exit code is 1")
+def _check_exit_1(cli_result_holder: dict[str, Any]) -> None:
+    result = cli_result_holder["result"]
+    assert result.exit_code == 1, result.output
 
 
 @then("the exit code is 3")

--- a/website/docs/AUTHENTICATION.md
+++ b/website/docs/AUTHENTICATION.md
@@ -197,18 +197,19 @@ accidental interference or data corruption.
 
 ### `gflow auth status`
 
-Reports whether a profile exists, where it lives, and whether the cookies file is present.
+Reports where the profile lives, then **proves the session**: it probes the Flow session endpoint with the profile's cookies (no browser, no credits) and exits `0` only when the session is verified — `1` otherwise. Handy for scripts: `gflow auth status && gflow run ...`.
 
 ```bash
 $ gflow auth status
-Profile 'default' is configured.
   profile: /home/you/.local/share/gflow-cli/profile_default
   exists: True
   cookies_present: True
   cookies_path: /home/you/.local/share/gflow-cli/profile_default/Default/Cookies
+  browser_engine: playwright
+Flow session verified as you@example.com.
 ```
 
-> Note: `cookies_present: True` only confirms the file exists — not that the session is still valid with Google. The first real API call (e.g. `gflow image t2i`) is the actual probe. If Google has invalidated the session, the call will fail with an authentication error and you'll be prompted to re-run `auth login`.
+> Note: `cookies_present: True` only confirms the file exists. The final verdict line is the live probe result: a dead session prints a `gflow auth login` remediation hint and exits 1; a probe that cannot reach the endpoint (offline, 5xx) also exits 1 but suggests checking connectivity instead of re-logging in.
 
 ### `gflow auth list`
 

--- a/website/docs/USER_GUIDE.md
+++ b/website/docs/USER_GUIDE.md
@@ -84,7 +84,7 @@ The session cookies persist across reboots until Google invalidates them — typ
 gflow auth status
 ```
 
-Expected: `cookies_present: True` + `profile_dir: <path>`. If it says `False`, re-run `gflow auth login`.
+Expected: `Flow session verified as <your account>.` and exit code 0 — the command probes the live Flow session (no browser, no credits). If it exits 1, follow the printed hint (usually re-run `gflow auth login`).
 
 You're done. Skip to [Journey 2](#journey-2--your-first-video-single-t2v).
 
@@ -320,7 +320,8 @@ Then check current session state:
 
 ```bash
 gflow auth status
-# Likely output: cookies_present: True, but Google has invalidated the session.
+# A dead session exits 1 and says so, e.g.:
+#   "Signed in to Google, but not to the Flow app." + a gflow auth login hint.
 ```
 
 ### 7.2 Refresh


### PR DESCRIPTION
## Summary

Closes #471 (Tier-1 quick win from the linkedin-mcp catalog).

`gflow auth status` only checked that the profile dir and cookies file exist — it reported OK on a dead session. It now runs the existing `verify_flow_profile` probe (cookie snapshot + Flow session endpoint; **no browser, no credits**) and:

- exits **0** only on a verified session, printing the verified account email (escaped before Rich markup — the known bracketed-text crash class),
- exits **1** otherwise with a remediation hint: `gflow auth login` for a dead/missing session, a **connectivity** hint for VERIFICATION_ERROR (re-login can't fix an unreachable endpoint),
- announces the probe so a slow-network wait is not silent,
- fail-closed: an unreachable endpoint is never an OK.

Consumers swept: `scripts/record_demo.ps1` treats the precheck as advisory now (its old 'status cannot see profile cookies' comment was already stale); `docs/AUTHENTICATION.md`, `docs/USER_GUIDE.md`, `skills/gflow-cli/SKILL.md` updated to the new contract. MCP parity: `auth status` is in the exempt list (interactive session management).

## Reviews run

- **code-review (high)**: 6 verified findings (record_demo.ps1 regression, 2 stale docs, wrong remediation on VERIFICATION_ERROR, silent 45s worst-case wait, Rich markup injection) — **all applied** with pinning tests.
- **ponytail-review**: lean already — probe reuses `auth_mod.profile_dir` + `verification` module inline, no new flags/abstractions.

## Validation

- 12 scoped tests green (4→6 new unit tests + updated BDD scenarios with mocked probe; full suite OOMs locally, CI runs the sweep)
- `ruff check` / `ruff format --check` / `check_doc_links.py` / `check_repo_hygiene.py` — clean
- **Live-verified on the affected surface**: real profile, real Flow endpoint — probe line + `Flow session verified as ffroliva@gmail.com.`, exit 0

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting