### PR TITLE
feat(diagnostics): pre-filled bug-report template on every incident (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Incident bundles now include a pre-filled bug-report template (#476).** On every captured incident, the recorder stages `report.md` alongside the existing artifacts: version/platform, error class + exit code + retryability, phase/route, and pointers to the captured evidence — built exclusively from the allowlisted manifest fields (never raw exception text). The CLI error message now prints the report path next to the bundle path, and retention treats `report.md` as recorder-owned. Downgrade caveat: gflow <= 0.54.x does not recognize `report.md`, so its retention classifies new bundles as unknown and stops pruning them — delete `<GFLOW_CLI_HOME>/incidents` manually if you downgrade. The report is meant to be copied out of the bundle before editing (the template says so), and the e2e privacy scanner now leak-scans `*.md` alongside the JSON artifacts.
+
 ### Changed
 
 - **`gflow auth status` now proves the Flow session and exits 0/1 (#471).** The command previously only checked that the profile directory and cookies file exist — it could report OK on a dead session. It now runs the fast `verify_flow_profile` probe (cookie snapshot + Flow session endpoint; no browser, no credits) and exits 0 only on a verified session, printing the verified account email; any other outcome exits 1 with a `gflow auth login` remediation hint. Fail-closed: an unreachable endpoint is a failure, never an OK.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -338,7 +338,7 @@ GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
 **Default:** `true`
 **When to disable:** shared machines where even structural failure metadata should not persist, or scripted runs that must write nothing outside the output dir.
 
-**Privacy:** the automatic JSON artifacts (`manifest.json`, `ui.json`, `network.json`, `browser.json`) are built from an explicit allowlist — no prompts, tokens, cookies, headers, request/response bodies, signed URLs, raw page titles, raw error/console text, or unknown hosts/routes ever enter them. The screenshot is inherently sensitive (it can show your account identity, prompts, and media) and therefore lives under the bundle's `sensitive/` subdirectory — **review it before sharing**. Nothing is ever uploaded; retention is bounded (at most 50 complete bundles / 250 MiB, pruned oldest-first at startup). Raw HAR capture stays separate and strictly opt-in via `GFLOW_CLI_HAR_PATH`.
+**Privacy:** the automatic artifacts (`manifest.json`, `ui.json`, `network.json`, `browser.json`, and the pre-filled `report.md` bug-report template) are built from an explicit allowlist — no prompts, tokens, cookies, headers, request/response bodies, signed URLs, raw page titles, raw error/console text, or unknown hosts/routes ever enter them. The screenshot is inherently sensitive (it can show your account identity, prompts, and media) and therefore lives under the bundle's `sensitive/` subdirectory — **review it before sharing**. Nothing is ever uploaded; retention is bounded (at most 50 complete bundles / 250 MiB, pruned oldest-first at startup). Raw HAR capture stays separate and strictly opt-in via `GFLOW_CLI_HAR_PATH`.
 
 ### `GFLOW_CLI_HAR_PATH`
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -87,6 +87,9 @@ object) between the UTC timestamp and a collision-resistant random suffix:
 │                             # category, canonical route, status, duration
 ├── browser.json              # last ≤100 console warn/error + ≤50 page errors —
 │                             # class/category + length only, never message text
+├── report.md                 # pre-filled Markdown bug report: version/platform,
+│                             # error class + exit code, artifact pointers — fill
+│                             # in "What I was doing" and attach when filing
 ├── sensitive/screenshot.png  # UI-state failures only — REVIEW BEFORE SHARING
 └── .pending                  # present only while a capture is still staging
 ```

--- a/scripts/dev/incident_bundle_quality.py
+++ b/scripts/dev/incident_bundle_quality.py
@@ -135,7 +135,9 @@ def _load(bundle: Path, name: str) -> object | None:
 
 def _scan_leaks(bundle: Path, secrets: list[str]) -> list[str]:
     hits: list[str] = []
-    for artifact in sorted(bundle.rglob("*.json")):
+    # *.md covers report.md — the one artifact users are told to attach to a
+    # public issue, so it must clear the same leak gate as the JSON evidence.
+    for artifact in sorted([*bundle.rglob("*.json"), *bundle.rglob("*.md")]):
         text = artifact.read_text(encoding="utf-8", errors="replace")
         for secret in secrets:
             if secret and secret in text:

--- a/src/gflow_cli/_cli_helpers.py
+++ b/src/gflow_cli/_cli_helpers.py
@@ -304,14 +304,22 @@ def _handle_gflow_error(exc: GFlowError, *, cli_command: str) -> int:
     _console.print(f"[red]{exc.title}:[/red] {exc.detail or ''}")
     if exc.remediation_hint:
         _console.print(f"[yellow]-> {exc.remediation_hint}[/yellow]")
-    ref = exc.incident_ref
-    if ref is not None and ref.path is not None:
-        _console.print(
-            f"Incident bundle: {ref.path} — review before sharing; sensitive "
-            "artifacts may contain account or media data.",
-            markup=False,
-        )
+    _print_incident_ref(exc.incident_ref)
     return _exit_code_for(exc)
+
+
+def _print_incident_ref(ref: Any) -> None:
+    """One incident sentence for both error paths (S04/S21); the report line
+    keys on the ref's artifact tuple — the same source of truth as --json."""
+    if ref is None or getattr(ref, "path", None) is None:
+        return
+    _console.print(
+        f"Incident bundle: {ref.path} — review before sharing; sensitive "
+        "artifacts may contain account or media data.",
+        markup=False,
+    )
+    if "report.md" in getattr(ref, "artifacts", ()):
+        _console.print(f"Pre-filled bug report: {ref.path / 'report.md'}", markup=False)
 
 
 def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
@@ -338,13 +346,7 @@ def _handle_unhandled_error(exc: BaseException, *, cli_command: str) -> int:
     # Unexpected exceptions ALSO get incident bundles (should_capture returns
     # True for them) — surface the path or the evidence is written and never
     # found before retention ages it out.
-    ref = getattr(exc, "incident_ref", None)
-    if ref is not None and getattr(ref, "path", None) is not None:
-        _console.print(
-            f"Incident bundle: {ref.path} — review before sharing; sensitive "
-            "artifacts may contain account or media data.",
-            markup=False,
-        )
+    _print_incident_ref(getattr(exc, "incident_ref", None))
     return 1
 
 

--- a/src/gflow_cli/diagnostics.py
+++ b/src/gflow_cli/diagnostics.py
@@ -784,6 +784,63 @@ def build_manifest(
     }
 
 
+def render_report(manifest: dict[str, object]) -> bytes:
+    """Markdown bug-report template pre-filled from the manifest (issue #476).
+
+    Renders allowlisted manifest fields ONLY — the raw exception text never
+    reaches this function (S01), and sensitive/ artifacts are called out for
+    review before sharing."""
+    raw_error = manifest.get("error")
+    error: dict[str, object] = (
+        cast("dict[str, object]", raw_error) if isinstance(raw_error, dict) else {}
+    )
+    raw_artifacts = manifest.get("artifacts")
+    artifacts: dict[str, object] = (
+        cast("dict[str, object]", raw_artifacts) if isinstance(raw_artifacts, dict) else {}
+    )
+    pointers = (
+        "\n".join(
+            f"- `{name}`"
+            + (
+                " — review before sharing (may show account/media data)"
+                if kind == "sensitive"
+                else ""
+            )
+            for name, kind in sorted(artifacts.items())
+        )
+        or "- (no artifacts captured)"
+    )
+    lines = [
+        "# gflow-cli bug report",
+        "",
+        f"> Pre-filled from incident `{manifest.get('incident_id')}`. COPY THIS FILE",
+        "> OUT OF THE BUNDLE before editing — retention prunes old bundles and",
+        "> would take your notes with them. Complete the 'What I was doing'",
+        "> section, review every artifact, then file at",
+        "> https://github.com/ffroliva/gflow-cli/issues/new attaching this file,",
+        "> `manifest.json`, and any artifacts you are comfortable sharing.",
+        "",
+        f"- **gflow-cli:** {manifest.get('cli_version')} · "
+        f"Python {manifest.get('python_version')} · {manifest.get('os_family')}",
+        f"- **When (UTC):** {manifest.get('created_utc')}",
+        f"- **Command:** {manifest.get('command') or 'unknown'} "
+        f"(transport: {manifest.get('transport') or 'n/a'})",
+        f"- **Error:** `{error.get('class')}` (`{error.get('problem_type')}`) — "
+        f"exit code {error.get('exit_code')}, retryable: {error.get('retryable')}",
+        f"- **Phase/route:** {error.get('phase') or '-'} / {error.get('route') or '-'}",
+        "",
+        "## What I was doing",
+        "",
+        "<!-- the exact command you ran and what you expected to happen -->",
+        "",
+        "## Captured evidence (in this bundle)",
+        "",
+        pointers,
+        "",
+    ]
+    return "\n".join(lines).encode("utf-8")
+
+
 # --- IncidentRecorder (design §4.2, §5.2, §6.1–§6.2) -----------------------
 
 
@@ -1205,6 +1262,52 @@ class IncidentRecorder:
             if self._screenshot_wanted(exc):
                 await self._stage_screenshot(bundle, page, incident_id, artifacts, status, deadline)
 
+        from gflow_cli.errors import GFlowError, is_retryable
+        from gflow_cli.json_output import exit_code_for
+
+        exc_class = type(exc).__name__
+        problem_type = str(getattr(exc, "problem_type", "unexpected"))
+        exit_code = exit_code_for(exc) if isinstance(exc, GFlowError) else 1
+        retryable = is_retryable(exc) if isinstance(exc, GFlowError) else False
+        created_utc = datetime.now(UTC).isoformat()
+
+        # Pre-filled bug report (issue #476), staged LAST so it can point at
+        # every other artifact and so the IncidentRef tuple — the single
+        # source of truth for the Rich and --json surfaces — includes it.
+        # Best-effort: a report failure records status and never costs the
+        # bundle (S23). Rendered from the same allowlist as the manifest;
+        # har_state/finalized_utc are unknown here and the report omits both.
+        try:
+            report_manifest = build_manifest(
+                incident_id=incident_id,
+                settings=self._settings,
+                created_utc=created_utc,
+                finalized_utc=None,
+                cli_version=self._cli_version(),
+                exc_class=exc_class,
+                problem_type=problem_type,
+                exit_code=exit_code,
+                retryable=retryable,
+                route=route or "",
+                phase=phase,
+                command=self.command,
+                transport=self.transport,
+                artifacts=artifacts,
+                artifact_status=status,
+                har_state="pending",
+                suppressed_count=0,
+            )
+            bundle.write_artifact("report.md", render_report(report_manifest))
+            artifacts["report.md"] = "report"
+            status["report.md"] = "complete"
+        except Exception as report_exc:  # noqa: BLE001 — best-effort (S23)
+            status["report.md"] = "failed"
+            # A partially-written report must not be advertised or shared.
+            (bundle.path / "report.md").unlink(missing_ok=True)
+            emit_capture_failed(
+                incident_id, exc_class=type(report_exc).__name__, artifact_kind="report"
+            )
+
         overall = "complete"
         if any(v != "complete" for v in status.values()):
             overall = "partial" if any(v == "complete" for v in status.values()) else "failed"
@@ -1214,21 +1317,18 @@ class IncidentRecorder:
             path=bundle.path,
             artifacts=tuple(sorted(artifacts)),
         )
-        from gflow_cli.errors import GFlowError, is_retryable
-        from gflow_cli.json_output import exit_code_for
-
         return _StagedBundle(
             ref=ref,
             bundle=bundle,
-            exc_class=type(exc).__name__,
-            problem_type=str(getattr(exc, "problem_type", "unexpected")),
-            exit_code=exit_code_for(exc) if isinstance(exc, GFlowError) else 1,
-            retryable=is_retryable(exc) if isinstance(exc, GFlowError) else False,
+            exc_class=exc_class,
+            problem_type=problem_type,
+            exit_code=exit_code,
+            retryable=retryable,
             route=route or "",
             phase=phase,
             artifacts=artifacts,
             artifact_status=status,
-            created_utc=datetime.now(UTC).isoformat(),
+            created_utc=created_utc,
         )
 
     @staticmethod
@@ -1365,7 +1465,7 @@ _MANIFEST_PARSE_CAP_BYTES = 64 * 1024
 # The exact artifact universe a gflow bundle may contain. ANY other entry
 # marks the directory unknown → untouched.
 _ALLOWED_TOP_FILES = frozenset(
-    {"manifest.json", "ui.json", "network.json", "browser.json", ".pending"}
+    {"manifest.json", "ui.json", "network.json", "browser.json", "report.md", ".pending"}
 )
 _ALLOWED_SENSITIVE_FILES = frozenset({"screenshot.png"})
 

--- a/tests/cli/test_incident_output.py
+++ b/tests/cli/test_incident_output.py
@@ -41,6 +41,40 @@ def test_local_incident_output_warns_review_before_sharing(
     assert "account or media data" in out
 
 
+def test_report_path_printed_when_ref_carries_report(
+    captured_console: io.StringIO, tmp_path: Path
+) -> None:
+    """Issue #476: the report line keys on the ref's artifact tuple — the same
+    source of truth the --json surface serializes."""
+    exc = FlowAppError("crash")
+    exc.incident_ref = IncidentRef(
+        id="corr-fp",
+        capture_status="complete",
+        path=tmp_path,
+        artifacts=("report.md", "ui.json"),
+    )
+    cli_helpers._handle_gflow_error(exc, cli_command="video t2v")
+    out = captured_console.getvalue()
+    assert "Pre-filled bug report:" in out
+    assert str(tmp_path / "report.md") in out
+
+
+def test_no_report_line_when_report_write_failed(
+    captured_console: io.StringIO, tmp_path: Path
+) -> None:
+    """A ref without report.md (write failed and was unlinked) must not
+    advertise a report."""
+    exc = FlowAppError("crash")
+    exc.incident_ref = IncidentRef(
+        id="corr-fp",
+        capture_status="partial",
+        path=tmp_path,
+        artifacts=("ui.json",),
+    )
+    cli_helpers._handle_gflow_error(exc, cli_command="video t2v")
+    assert "Pre-filled bug report:" not in captured_console.getvalue()
+
+
 def test_no_incident_sentence_without_a_bundle(captured_console: io.StringIO) -> None:
     code = cli_helpers._handle_gflow_error(FlowAppError("crash"), cli_command="video t2v")
     assert code == 31

--- a/tests/test_diagnostics_recorder.py
+++ b/tests/test_diagnostics_recorder.py
@@ -106,6 +106,39 @@ class TestShouldCapture:
 
 
 @pytest.mark.asyncio
+class TestBugReportTemplate:
+    """Finalized bundles carry a pre-filled Markdown bug report (issue #476)."""
+
+    async def test_staged_bundle_contains_prefilled_report(self, tmp_path: Path) -> None:
+        rec = _recorder(tmp_path)
+        ref = await rec.capture_failure(FlowAppError("crash"), page=FakePage(), phase="mode_switch")
+        assert ref is not None and ref.path is not None
+        # Written at STAGE time so the frozen IncidentRef tuple — the single
+        # source of truth for the Rich and --json surfaces — includes it.
+        assert "report.md" in ref.artifacts
+        report = (ref.path / "report.md").read_text(encoding="utf-8")
+        assert "FlowAppError" in report
+        assert "31" in report  # mapped exit code
+        assert "ui.json" in report  # artifact pointer
+        assert "COPY THIS FILE" in report  # retention can prune the bundle
+        await rec.finalize_all(close_ok=True)
+        manifest = json.loads((ref.path / "manifest.json").read_text(encoding="utf-8"))
+        assert str(manifest["cli_version"]) in report
+        assert str(manifest["os_family"]) in report
+        assert manifest["artifacts"]["report.md"] == "report"
+        assert manifest["artifact_status"]["report.md"] == "complete"
+
+    async def test_report_never_contains_exception_text(self, tmp_path: Path) -> None:
+        """Same allowlist discipline as the manifest (S01): the raw exception
+        message must never reach the report."""
+        rec = _recorder(tmp_path)
+        ref = await rec.capture_failure(FlowAppError(CANARY), page=FakePage(), phase="p")
+        assert ref is not None and ref.path is not None
+        await rec.finalize_all(close_ok=True)
+        assert CANARY not in (ref.path / "report.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
 class TestCaptureFailure:
     async def test_ui_failure_stages_dom_and_screenshot(self, tmp_path: Path) -> None:
         rec = _recorder(tmp_path)

--- a/tests/test_diagnostics_retention.py
+++ b/tests/test_diagnostics_retention.py
@@ -107,6 +107,20 @@ class TestRetentionSafety:
         assert (outside / "precious.txt").exists()
         assert (outside / "manifest.json").exists()
 
+    def test_bundle_with_report_is_still_classified_and_prunable(self, tmp_path: Path) -> None:
+        """report.md is recorder-owned (issue #476) — it must not flip a bundle
+        to 'unknown', which would exempt it from pruning forever."""
+        root = _root(tmp_path)
+        bundles = []
+        for i in range(3):
+            b = BundleDir.create_exclusive(root, f"r{i}", now=_NOW.replace(minute=i))
+            b.write_artifact("ui.json", b"{}")
+            b.write_artifact("report.md", b"# report")
+            b.finalize({"schema": "gflow-incident-v1", "incident_id": f"r{i}"})
+            bundles.append(b.path)
+        run_retention(root, max_complete=1)
+        assert sum(p.exists() for p in bundles) == 1
+
     def test_count_and_byte_limits_enforced(self, tmp_path: Path) -> None:
         root = _root(tmp_path)
         for i in range(4):

--- a/website/docs/CONFIGURATION.md
+++ b/website/docs/CONFIGURATION.md
@@ -338,7 +338,7 @@ GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
 **Default:** `true`
 **When to disable:** shared machines where even structural failure metadata should not persist, or scripted runs that must write nothing outside the output dir.
 
-**Privacy:** the automatic JSON artifacts (`manifest.json`, `ui.json`, `network.json`, `browser.json`) are built from an explicit allowlist — no prompts, tokens, cookies, headers, request/response bodies, signed URLs, raw page titles, raw error/console text, or unknown hosts/routes ever enter them. The screenshot is inherently sensitive (it can show your account identity, prompts, and media) and therefore lives under the bundle's `sensitive/` subdirectory — **review it before sharing**. Nothing is ever uploaded; retention is bounded (at most 50 complete bundles / 250 MiB, pruned oldest-first at startup). Raw HAR capture stays separate and strictly opt-in via `GFLOW_CLI_HAR_PATH`.
+**Privacy:** the automatic artifacts (`manifest.json`, `ui.json`, `network.json`, `browser.json`, and the pre-filled `report.md` bug-report template) are built from an explicit allowlist — no prompts, tokens, cookies, headers, request/response bodies, signed URLs, raw page titles, raw error/console text, or unknown hosts/routes ever enter them. The screenshot is inherently sensitive (it can show your account identity, prompts, and media) and therefore lives under the bundle's `sensitive/` subdirectory — **review it before sharing**. Nothing is ever uploaded; retention is bounded (at most 50 complete bundles / 250 MiB, pruned oldest-first at startup). Raw HAR capture stays separate and strictly opt-in via `GFLOW_CLI_HAR_PATH`.
 
 ### `GFLOW_CLI_HAR_PATH`
 

--- a/website/docs/DEBUGGING.md
+++ b/website/docs/DEBUGGING.md
@@ -87,6 +87,9 @@ object) between the UTC timestamp and a collision-resistant random suffix:
 │                             # category, canonical route, status, duration
 ├── browser.json              # last ≤100 console warn/error + ≤50 page errors —
 │                             # class/category + length only, never message text
+├── report.md                 # pre-filled Markdown bug report: version/platform,
+│                             # error class + exit code, artifact pointers — fill
+│                             # in "What I was doing" and attach when filing
 ├── sensitive/screenshot.png  # UI-state failures only — REVIEW BEFORE SHARING
 └── .pending                  # present only while a capture is still staging
 ```


### PR DESCRIPTION
## Summary

Closes #476 (Tier-1 quick win from the linkedin-mcp catalog).

Every incident bundle now stages a **`report.md`** — a pre-filled Markdown bug report carrying version/platform, error class + exit code + retryability, phase/route, and pointers to the captured artifacts (`sensitive/` ones flagged for review). Built **exclusively from the allowlisted manifest fields**: raw exception text can never reach it (canary-pinned). The CLI error output prints the report path next to the bundle path, and the `--json` envelope carries it via the artifacts tuple.

Key design point (from the council review): the report is written at **stage** time, not finalize — the frozen `IncidentRef` tuple snapshotted at stage is the single source of truth for both the Rich and `--json` surfaces, so writing earlier keeps every surface consistent with zero duplicated state.

Hardening that came out of review, all applied:
- failed report write → `artifact_status: failed`, partial file unlinked (never advertise garbage), kind-token `capture_failed` event
- `report.md` added to retention's `_ALLOWED_TOP_FILES` (pinned by a retention test); downgrade skew documented in CHANGELOG (≤0.54.x retention treats new bundles as unknown)
- template instructs copying the file out before editing — retention must never delete hand-written notes
- e2e privacy scanner now leak-scans `*.md` alongside `*.json`
- one `_print_incident_ref` helper replaces the duplicated print blocks in both error paths
- docs swept: DEBUGGING.md bundle tree, CONFIGURATION.md privacy disclosure, website mirror regenerated

## Reviews run

- **code-review (high, 4-agent fan-out)**: 9 findings — all applied (the `--json` parity gap drove the stage-time design; one refuted claim was dropped by the reviewer itself).
- **ponytail-review**: lean; the one dead-code filter it would have flagged was removed in the rework.

## Validation

- 49 incident-suite tests + 14 json_output tests green (recorder, retention, events, CLI output, BDD incident scenarios)
- `ruff check`/`format --check`, `check_doc_links`, website-mirror `--check`, `check_repo_hygiene` — clean
- `pyright src`: 73 errors — identical to the develop baseline in the same venv (pre-existing local env skew, none in touched files); CI pyright is the gate
- Live verification: n/a — no generation path touched; the incident pipeline is fully covered by fake-page unit + BDD suites
- Note: tests must run from a short path on Windows — a deep worktree path pushes `sensitive/screenshot.png` past MAX_PATH (discovered during this work, worktree relocated)

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting