### PR TITLE
docs: remove the false Ultra/Pro subscription requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,13 @@ Supported tools that auto-discover this file: Cursor, Codex, Aider, Antigravity 
 - Python 3.11+ · `uv`-managed · `hatchling` builds · Playwright Chromium transport · `pyright` strict · `ruff` · `pytest`.
 - Single-package modular monolith. Top-level modules under `src/gflow_cli/`: `api/`, `auth/`, `data/`, `mcp/`, `services/`, `tools/`, `ui/`, `worker/`, `browser_manager.py`, `cli.py`, `_cli_helpers.py`, `cli_character.py`, `cli_data.py`, `cli_image.py`, `cli_instructions.py`, `cli_models.py`, `cli_movie.py`, `cli_run.py`, `cli_scene.py`, `cli_tools.py`, `cli_video.py`, `chain.py`, `chain_manifest.py`, `composition.py`, `config.py`, `errors.py`, `exceptions.py`, `image_batch.py`, `movie_manifest.py`, `observability.py`, `paths.py`, `profile_store.py`.
 - Command surface: `gflow auth`, `gflow image` (t2i/i2i/batch/upload/upscale), `gflow video` (t2v/i2v/r2v/chain — no `batch` subcommand; the nonfunctional stub was removed, loop `gflow video t2v`/`i2v` from the shell for multi-clip runs), `gflow character` (create/list/show/rm/voices — reusable project-scoped Flow Character entities), `gflow scene` (create/show — Add Clip / Scenes, with `create --output` for credit-free server-side extended video), `gflow instructions` (persistent Agent-Mode brief cards — add/list/enable/disable/rm/apply/toggle-mode, credits-free, `--project` required), `gflow movie` (run/template — multi-scene manifest pipeline), `gflow tools` (list/show/run — prompt-rewriting tools, also `--tool` on generation commands), `gflow data` (catalog queries), `gflow models`, `gflow run`, `gflow mcp` (run/setup — stdio MCP server), and `gflow serve` (Streamable HTTP at `/mcp`; `--transport sse` is deprecated).
-- Requires a Google AI Ultra or Pro subscription with Flow access. All generations bill against the user's own Google account.
+- Works with any Google account that has Flow access. All generations bill against the user's own Google account.
 
 ## Headed-browser dependency (architectural reality)
 
 gflow-cli currently drives Flow via a **real Chrome session managed by Playwright** — `ui_automation` transport. Google's auth + reCAPTCHA stack rejects Playwright's bundled Chromium and most headless approaches. This is the project's defining trade-off:
 
-- ✅ Works end-to-end against live Pro/Ultra accounts.
+- ✅ Works end-to-end against live Google accounts.
 - ❌ Requires a saved Chrome profile, a display server for one-time login, and ~150 MB for Chromium.
 - ❌ Cannot run on serverless / headless CI workers without prerecorded profile transplant.
 - ❌ Per-account horizontal concurrency is capped by what one warm Page pool can drive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Removed the false "requires a Google AI Ultra or Pro subscription" claim across all docs.** Any Google account with Flow access can use gflow-cli — a paid plan only affects credit allowances and tier-gated features (e.g. 4K upscale stays Ultra-only). Swept README, AGENTS.md, DISCLAIMER.md, USER_GUIDE, CONFIGURATION, AUTHENTICATION, DEBUGGING, the medium tutorial, and the gflow-cli skill; factual tier-gating notes are unchanged.
+
 ### Added
 
 - **Incident bundles now include a pre-filled bug-report template (#476).** On every captured incident, the recorder stages `report.md` alongside the existing artifacts: version/platform, error class + exit code + retryability, phase/route, and pointers to the captured evidence — built exclusively from the allowlisted manifest fields (never raw exception text). The CLI error message now prints the report path next to the bundle path, and retention treats `report.md` as recorder-owned. Downgrade caveat: gflow <= 0.54.x does not recognize `report.md`, so its retention classifies new bundles as unknown and stops pruning them — delete `<GFLOW_CLI_HOME>/incidents` manually if you downgrade. The report is meant to be copied out of the bundle before editing (the template says so), and the e2e privacy scanner now leak-scans `*.md` alongside the JSON artifacts.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -19,7 +19,7 @@ If you need a stable, supported, contractual API, use the [official Google Gen A
 
 To use `gflow-cli` you must:
 
-1. **Own a valid Google account** with active access to [Google Flow](https://labs.google/fx/tools/flow) — typically an [AI Ultra or AI Pro](https://gemini.google/subscriptions/) subscription as of late 2025.
+1. **Own a valid Google account** with active access to [Google Flow](https://labs.google/fx/tools/flow) — any Google account works; a paid plan ([AI Pro or AI Ultra](https://gemini.google/subscriptions/)) only affects credit allowances and tier-gated features.
 2. **Comply with Google's terms of service** for that account, including:
    - [Google Terms of Service](https://policies.google.com/terms)
    - [Generative AI Additional Terms](https://policies.google.com/terms/generative-ai)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Tests: TDD](https://img.shields.io/badge/tests-TDD-brightgreen.svg)](CONTRIBUTING.md)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli)
 
-> ⚠️ **Read this before you install.** gflow-cli is **unofficial, alpha, and reverse-engineered — not affiliated with Google**. It drives a headed browser on *your own* Google Flow session, so treat it as your own account risk: automation is subject to Google's ToS, and endpoints or UI can change without notice. It requires a Google AI **Ultra or Pro** subscription with Flow access, and every generation bills your account. Read the full [DISCLAIMER](DISCLAIMER.md).
+> ⚠️ **Read this before you install.** gflow-cli is **unofficial, alpha, and reverse-engineered — not affiliated with Google**. It drives a headed browser on *your own* Google Flow session, so treat it as your own account risk: automation is subject to Google's ToS, and endpoints or UI can change without notice. It works with **any Google account** that has Flow access, and every generation bills against your account's Flow credit allowance. Read the full [DISCLAIMER](DISCLAIMER.md).
 >
 > 💳 **What failure costs you.** Credits are only spent on Veo *video* generation — images and composition ops are free, so most breakage costs nothing. When Flow's UI drifts mid-run, the CLI fails fast and loudly with distinct exit codes (e.g. selector drift = exit 23) instead of resubmitting, and batch items are recorded locally *before* submission so a broken run never silently burns credits on a stale state. See [KNOWN_ISSUES](KNOWN_ISSUES.md) for the current risk list.
 >
@@ -21,7 +21,7 @@
 
 ## Why gflow-cli?
 
-You pay for Google AI Ultra or Pro, you have Veo credits, and you run real batch work. gflow-cli gives you:
+You have a Google account with Flow access, you have Veo credits, and you run real batch work. gflow-cli gives you:
 
 - **Batch generation.** Loop prompts straight from the shell: `for p in $(cat prompts.txt); do gflow image t2i "$p"; done`. Image batching plus `gflow video t2v` / `i2v` / `r2v` all ship today.
 - **Consistent subjects.** `gflow character create` mints a Flow Character (face and body reference) so the same person appears from one generation to the next.
@@ -29,7 +29,7 @@ You pay for Google AI Ultra or Pro, you have Veo credits, and you run real batch
 - **Pipelines.** Wire Veo into your content automation, AI-video stack, or batch experiments.
 - **Terminal-native.** After one `gflow auth login`, you stay in the shell. No clicking through dialogs.
 
-Same Veo and Imagen models, same quality, same Ultra/Pro billing, now programmatic.
+Same Veo and Imagen models, same quality, same billing against your own Google account, now programmatic.
 
 ## 60-second quick start
 
@@ -73,7 +73,7 @@ One command in, real Flow output back. Left: `gflow image t2i` generating a phot
 
 ![gflow image t2i runs a single 9:16 prompt, streams structlog output, and writes a PNG to disk](https://raw.githubusercontent.com/ffroliva/gflow-cli/main/docs/assets/example-run.gif)
 
-A single `gflow image t2i "..." --aspect 9:16 --model nano2` call against a logged-in Pro/Ultra profile. The terminal streams the run's `structlog` JSON, then lists the written PNG. Chromium drives the Flow editor silently in the background.
+A single `gflow image t2i "..." --aspect 9:16 --model nano2` call against a logged-in Flow profile. The terminal streams the run's `structlog` JSON, then lists the written PNG. Chromium drives the Flow editor silently in the background.
 
 Reproduce the recording with [`scripts/record_demo.ps1`](scripts/record_demo.ps1) (Windows, OBS, ffmpeg, gifski). More formats, including the side-by-side split-screen: **[docs/DEMOS.md](docs/DEMOS.md)**.
 
@@ -131,7 +131,7 @@ Full milestone history lives in [CHANGELOG.md](CHANGELOG.md). Where the project 
 
 ## License & legal
 
-[MIT License](LICENSE) © 2026 Flavio Oliva (`ffroliva`). The MIT license covers `gflow-cli`'s code only. It grants no rights to Flow, Veo model output, or any Google service. Google's own terms (Labs Additional Terms, Ultra/Pro subscription terms) govern your generations. See the [DISCLAIMER](DISCLAIMER.md).
+[MIT License](LICENSE) © 2026 Flavio Oliva (`ffroliva`). The MIT license covers `gflow-cli`'s code only. It grants no rights to Flow, Veo model output, or any Google service. Google's own terms (Labs Additional Terms and any plan-specific subscription terms) govern your generations. See the [DISCLAIMER](DISCLAIMER.md).
 
 ## Acknowledgements
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -10,7 +10,7 @@ This page documents the full lifecycle: capture, storage, reuse, refresh, multi-
 |---|---|
 | Re-implement Google's OAuth dance | Google's web SSO involves anti-automation challenges (CAPTCHA, device verification). A community SDK can't reliably ship that. |
 | Extract the bearer token from cookies and use `httpx` directly | Tokens are short-lived and tied to a refresh flow we don't have. Re-implementing the refresh is brittle. |
-| Use a service-account JSON | Flow doesn't currently support service accounts on the AI Ultra/Pro consumer tier. |
+| Use a service-account JSON | Flow doesn't currently support service accounts on the consumer tier. |
 | Pure stored cookie jar (no Playwright) | Some Flow endpoints set additional `x-` headers based on Chromium fingerprint; matching them by hand is fragile. |
 | **Playwright persistent context (chosen)** | Captures session once, reuses indefinitely, refreshes automatically on idle, auto-attaches every header Flow expects. One-time cost: a ~150 MB Chromium download. |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,7 +109,7 @@ Deep setup, verification, and security notes live in
 ### `GFLOW_CLI_PROVIDER`
 
 **What:** Backend to use for generations.
-**Values:** `flow` (default — reverse-engineered, requires Ultra/Pro) | `official` (planned v0.5+ — Phase 5 official Veo SDK swap, will require a Gemini API key).
+**Values:** `flow` (default — reverse-engineered, works with any Google account that has Flow access) | `official` (planned v0.5+ — Phase 5 official Veo SDK swap, will require a Gemini API key).
 **Default:** `flow`
 **CLI override:** none yet — set the env var to switch backends once `official` is wired.
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -184,7 +184,7 @@ without manual copying. Caveats verified during the v0.7.0 work:
 ### 3. Firecrawl (`firecrawl-scrape` / `firecrawl-interact`)
 Best for unauthenticated docs (e.g., Material Symbols icon names, third-
 party API references). Not ideal for Flow itself — Flow requires a
-logged-in Pro/Ultra session that Firecrawl's hosted browser doesn't
+logged-in Flow session that Firecrawl's hosted browser doesn't
 share with your local profile.
 
 ### 4. Playwright trace viewer

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,11 +2,11 @@
 
 > **Goal:** task-oriented walkthroughs for the most common workflows. Reference material (every flag, every env var, every error class) lives in [USAGE.md](USAGE.md), [CONFIGURATION.md](CONFIGURATION.md), [AUTHENTICATION.md](AUTHENTICATION.md), and [ARCHITECTURE.md](ARCHITECTURE.md). This guide tells you *what to do* in concrete situations.
 
-**Audience:** Google AI Ultra / Pro subscribers who want to drive Flow (Veo + Imagen) from the terminal instead of the web UI.
+**Audience:** anyone with a Google account and Flow access who wants to drive Flow (Veo + Imagen) from the terminal instead of the web UI.
 
 **Prerequisites:**
 - Python 3.11+ (required for `from source` installs; `uvx` / `uv tool install` ship a managed Python)
-- An active Google AI Ultra or Pro subscription
+- A Google account with access to Google Flow (a paid AI Pro/Ultra plan only affects credit allowances)
 - ~500 MB disk (Chromium binary via Playwright)
 
 ---
@@ -69,7 +69,7 @@ This is a ~150 MB download. It happens once per user.
 gflow auth login
 ```
 
-A Chromium window opens. Sign in to your Google account that has the AI Ultra / Pro subscription. **Solve any captchas Google shows you** — `gflow-cli` cannot solve them; that's intentional (anti-bot detection). When the Flow dashboard loads, return to your terminal and confirm.
+A Chromium window opens. Sign in to the Google account you use for Flow. **Solve any captchas Google shows you** — `gflow-cli` cannot solve them; that's intentional (anti-bot detection). When the Flow dashboard loads, return to your terminal and confirm.
 
 Your session is saved under (one of):
 - Windows: `%LOCALAPPDATA%\gflow-cli\profile_default\`
@@ -405,7 +405,7 @@ Only the **Python import path** changed (`flow_cli` → `gflow_cli`). The PyPI d
 
 ## Journey 10 — Budgeting credits before a batch run
 
-Your AI Ultra/Pro subscription includes a finite Veo / Imagen credit allowance — these journeys spend real money. Before kicking off a 200-prompt run, get a rough cost estimate.
+Your Google plan includes a finite Veo / Imagen credit allowance — these journeys spend real money. Before kicking off a 200-prompt run, get a rough cost estimate.
 
 ### 10.1 Check the balance
 
@@ -587,7 +587,7 @@ Once it passes, fix the prompt in `prompts.txt` and rerun the loop.
 Flow returned `429 Too Many Requests`. The `tenacity` retry layer already retried up to 3× with exponential jittered backoff (1 s → 2 s → 4 s, ±25% jitter, capped at 60 s when `Retry-After` is set). If it still failed, you're hitting either:
 
 - **Sustained rate limit** — the API thinks you're spamming. Wait and resume.
-- **Daily quota** — your Ultra/Pro allowance for the day is exhausted. Check the credit balance UI.
+- **Daily quota** — your plan's allowance for the day is exhausted. Check the credit balance UI.
 
 **Recovery steps, in order:**
 
@@ -737,7 +737,7 @@ gflow auth login --profile <name> --browser chrome
 ```
 
 1. Chrome opens to `https://labs.google/fx/tools/flow?hl=en`.
-2. Sign in to your Google account with the AI Ultra / Pro subscription.
+2. Sign in to the Google account you use for Flow.
 3. When the Flow editor loads, **close Chrome**.
 4. `gflow auth login` probes the profile with `channel="chrome"`, verifies SAPISID is
    present, and writes `.gflow_browser_strategy = "chrome"` to the profile directory.
@@ -1016,4 +1016,4 @@ gflow video t2v "@Zoro alone on the cliff at night, rain" --project "$PROJECT"
 - [SECURITY.md](SECURITY.md) — threat model, redaction strategy, what's on disk.
 - [KNOWN_ISSUES.md](../KNOWN_ISSUES.md) — workarounds for current limitations.
 
-_Built for Google AI Ultra / Pro subscribers who'd rather automate than click. Same Veo model, same quality, same billing — without the browser._
+_Built for Flow users who'd rather automate than click. Same Veo model, same quality, same billing — without the browser._

--- a/docs/medium_tutorial.md
+++ b/docs/medium_tutorial.md
@@ -9,7 +9,7 @@ gflow-cli is an unofficial Python command-line interface. It uses a reverse-engi
 Before you begin, ensure you have:
 * Python 3.11 or newer.
 * The `uv` package manager.
-* A Google account with a Google AI Ultra or Pro subscription and access to Google Flow.
+* A Google account with access to Google Flow.
 * A desktop environment to complete the one-time authentication.
 
 ## Step 1: Install gflow-cli and Chromium

--- a/skills/gflow-cli/SKILL.md
+++ b/skills/gflow-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: gflow-cli
 version: "1.2"
 skillopt_epoch: 0
-description: Use when the user wants to drive Google Flow (Veo image-to-video, Veo text-to-video, Imagen / Nano Banana image generation) from the terminal or a script — including text-to-video, image-to-video, image-to-image, batch image pipelines, or burning Flow Ultra/Pro credits programmatically. The CLI is `gflow` (or `flow`); install with `uv tool install gflow-cli` or run ad-hoc with `uvx --from gflow-cli gflow ...`. Drives the real Flow web UI through a headed Chrome session (Playwright) after a one-time browser sign-in — it does not bypass the UI, it automates it.
+description: Use when the user wants to drive Google Flow (Veo image-to-video, Veo text-to-video, Imagen / Nano Banana image generation) from the terminal or a script — including text-to-video, image-to-video, image-to-image, batch image pipelines, or spending Flow credits programmatically. The CLI is `gflow` (or `flow`); install with `uv tool install gflow-cli` or run ad-hoc with `uvx --from gflow-cli gflow ...`. Drives the real Flow web UI through a headed Chrome session (Playwright) after a one-time browser sign-in — it does not bypass the UI, it automates it.
 optimization_notes: |
   Known weak spots for the SkillOpt training loop (targets for epoch 1+):
   - Wrong subcommand: agents emit 'gflow video generate' / 'gflow video create' instead of 'gflow video t2v' or 'gflow video i2v'
@@ -48,7 +48,7 @@ Before any gflow-cli invocation, verify:
    - Persistent: `uv tool install gflow-cli && gflow --help`
 4. **Playwright Chromium** has been downloaded once: `uvx --from gflow-cli playwright install chromium` (~150 MB).
 5. **A signed-in profile** exists: `gflow auth status` should print `Flow session verified` and exit 0 (it probes the live Flow session endpoint — no browser, no credits; exit 1 means dead or missing session). If not, run `gflow auth login` and walk the user through the one-time browser sign-in.
-6. **The user has Flow access** — Google AI Ultra or Pro subscription with Flow rolled out. If `gflow image upload` returns 403, this is the cause.
+6. **The user has Flow access** — any Google account with Flow rolled out works. If `gflow image upload` returns 403, missing Flow access is the cause.
 
 ## Core commands
 

--- a/website/docs/AUTHENTICATION.md
+++ b/website/docs/AUTHENTICATION.md
@@ -10,7 +10,7 @@ This page documents the full lifecycle: capture, storage, reuse, refresh, multi-
 |---|---|
 | Re-implement Google's OAuth dance | Google's web SSO involves anti-automation challenges (CAPTCHA, device verification). A community SDK can't reliably ship that. |
 | Extract the bearer token from cookies and use `httpx` directly | Tokens are short-lived and tied to a refresh flow we don't have. Re-implementing the refresh is brittle. |
-| Use a service-account JSON | Flow doesn't currently support service accounts on the AI Ultra/Pro consumer tier. |
+| Use a service-account JSON | Flow doesn't currently support service accounts on the consumer tier. |
 | Pure stored cookie jar (no Playwright) | Some Flow endpoints set additional `x-` headers based on Chromium fingerprint; matching them by hand is fragile. |
 | **Playwright persistent context (chosen)** | Captures session once, reuses indefinitely, refreshes automatically on idle, auto-attaches every header Flow expects. One-time cost: a ~150 MB Chromium download. |
 

--- a/website/docs/CONFIGURATION.md
+++ b/website/docs/CONFIGURATION.md
@@ -109,7 +109,7 @@ Deep setup, verification, and security notes live in
 ### `GFLOW_CLI_PROVIDER`
 
 **What:** Backend to use for generations.
-**Values:** `flow` (default — reverse-engineered, requires Ultra/Pro) | `official` (planned v0.5+ — Phase 5 official Veo SDK swap, will require a Gemini API key).
+**Values:** `flow` (default — reverse-engineered, works with any Google account that has Flow access) | `official` (planned v0.5+ — Phase 5 official Veo SDK swap, will require a Gemini API key).
 **Default:** `flow`
 **CLI override:** none yet — set the env var to switch backends once `official` is wired.
 

--- a/website/docs/DEBUGGING.md
+++ b/website/docs/DEBUGGING.md
@@ -184,7 +184,7 @@ without manual copying. Caveats verified during the v0.7.0 work:
 ### 3. Firecrawl (`firecrawl-scrape` / `firecrawl-interact`)
 Best for unauthenticated docs (e.g., Material Symbols icon names, third-
 party API references). Not ideal for Flow itself — Flow requires a
-logged-in Pro/Ultra session that Firecrawl's hosted browser doesn't
+logged-in Flow session that Firecrawl's hosted browser doesn't
 share with your local profile.
 
 ### 4. Playwright trace viewer

--- a/website/docs/USER_GUIDE.md
+++ b/website/docs/USER_GUIDE.md
@@ -2,11 +2,11 @@
 
 > **Goal:** task-oriented walkthroughs for the most common workflows. Reference material (every flag, every env var, every error class) lives in [USAGE.md](USAGE.md), [CONFIGURATION.md](CONFIGURATION.md), [AUTHENTICATION.md](AUTHENTICATION.md), and [ARCHITECTURE.md](ARCHITECTURE.md). This guide tells you *what to do* in concrete situations.
 
-**Audience:** Google AI Ultra / Pro subscribers who want to drive Flow (Veo + Imagen) from the terminal instead of the web UI.
+**Audience:** anyone with a Google account and Flow access who wants to drive Flow (Veo + Imagen) from the terminal instead of the web UI.
 
 **Prerequisites:**
 - Python 3.11+ (required for `from source` installs; `uvx` / `uv tool install` ship a managed Python)
-- An active Google AI Ultra or Pro subscription
+- A Google account with access to Google Flow (a paid AI Pro/Ultra plan only affects credit allowances)
 - ~500 MB disk (Chromium binary via Playwright)
 
 ---
@@ -69,7 +69,7 @@ This is a ~150 MB download. It happens once per user.
 gflow auth login
 ```
 
-A Chromium window opens. Sign in to your Google account that has the AI Ultra / Pro subscription. **Solve any captchas Google shows you** — `gflow-cli` cannot solve them; that's intentional (anti-bot detection). When the Flow dashboard loads, return to your terminal and confirm.
+A Chromium window opens. Sign in to the Google account you use for Flow. **Solve any captchas Google shows you** — `gflow-cli` cannot solve them; that's intentional (anti-bot detection). When the Flow dashboard loads, return to your terminal and confirm.
 
 Your session is saved under (one of):
 - Windows: `%LOCALAPPDATA%\gflow-cli\profile_default\`
@@ -405,7 +405,7 @@ Only the **Python import path** changed (`flow_cli` → `gflow_cli`). The PyPI d
 
 ## Journey 10 — Budgeting credits before a batch run
 
-Your AI Ultra/Pro subscription includes a finite Veo / Imagen credit allowance — these journeys spend real money. Before kicking off a 200-prompt run, get a rough cost estimate.
+Your Google plan includes a finite Veo / Imagen credit allowance — these journeys spend real money. Before kicking off a 200-prompt run, get a rough cost estimate.
 
 ### 10.1 Check the balance
 
@@ -587,7 +587,7 @@ Once it passes, fix the prompt in `prompts.txt` and rerun the loop.
 Flow returned `429 Too Many Requests`. The `tenacity` retry layer already retried up to 3× with exponential jittered backoff (1 s → 2 s → 4 s, ±25% jitter, capped at 60 s when `Retry-After` is set). If it still failed, you're hitting either:
 
 - **Sustained rate limit** — the API thinks you're spamming. Wait and resume.
-- **Daily quota** — your Ultra/Pro allowance for the day is exhausted. Check the credit balance UI.
+- **Daily quota** — your plan's allowance for the day is exhausted. Check the credit balance UI.
 
 **Recovery steps, in order:**
 
@@ -737,7 +737,7 @@ gflow auth login --profile <name> --browser chrome
 ```
 
 1. Chrome opens to `https://labs.google/fx/tools/flow?hl=en`.
-2. Sign in to your Google account with the AI Ultra / Pro subscription.
+2. Sign in to the Google account you use for Flow.
 3. When the Flow editor loads, **close Chrome**.
 4. `gflow auth login` probes the profile with `channel="chrome"`, verifies SAPISID is
    present, and writes `.gflow_browser_strategy = "chrome"` to the profile directory.
@@ -1016,4 +1016,4 @@ gflow video t2v "@Zoro alone on the cliff at night, rain" --project "$PROJECT"
 - [SECURITY.md](SECURITY.md) — threat model, redaction strategy, what's on disk.
 - [KNOWN_ISSUES.md](../KNOWN_ISSUES.md) — workarounds for current limitations.
 
-_Built for Google AI Ultra / Pro subscribers who'd rather automate than click. Same Veo model, same quality, same billing — without the browser._
+_Built for Flow users who'd rather automate than click. Same Veo model, same quality, same billing — without the browser._

--- a/website/docs/onboarding-mockup.html
+++ b/website/docs/onboarding-mockup.html
@@ -450,7 +450,7 @@
   <h2>Prerequisites</h2>
   <div class="req-badges">
     <span class="req-badge"><span class="check">✓</span> Python 3.11+ (uv installs a managed Python)</span>
-    <span class="req-badge"><span class="check">✓</span> Google AI Ultra or Pro subscription</span>
+    <span class="req-badge"><span class="check">✓</span> Google account with Flow access</span>
     <span class="req-badge"><span class="check">✓</span> Google Chrome installed</span>
     <span class="req-badge"><span class="check">✓</span> Display for one-time browser login</span>
   </div>


### PR DESCRIPTION
## Summary

Owner correction: **any Google account with Flow access can use gflow-cli** — the "requires a Google AI Ultra or Pro subscription" claim was wrong. A paid AI Pro/Ultra plan only affects credit allowances and tier-gated features.

Swept (14 files + mockup): README (warning banner, pitch, license note), AGENTS.md, DISCLAIMER.md, docs/USER_GUIDE.md (audience, prerequisites, sign-in steps, quota wording, footer), docs/CONFIGURATION.md, docs/AUTHENTICATION.md, docs/DEBUGGING.md, docs/medium_tutorial.md, skills/gflow-cli/SKILL.md, website mirror (regenerated) and the onboarding mockup badge.

**Unchanged on purpose**: factual tier gating — 4K upscale stays documented as Ultra-only (USAGE.md, IMAGE_UPSCALE_RECON.md, `errors.py`/`cli_image.py` messages) — and frozen `LIVE_VERIFICATION_*` release evidence stays as history.

## Validation

- `check_doc_links.py` (27 files), website mirror `--check`-clean after regen, `check_repo_hygiene.py` (730 files), `check_website_docs_pii.py` — all green with pipefail-verified exit codes
- Docs-only: no code, no tests affected

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting