### PR TITLE
feat(mcp): implement gflow mcp setup — client-config generator (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`gflow mcp setup` is implemented (#475).** The long-stubbed command now writes the gflow MCP server entry into the target client's config: `--target claude-desktop` (default), `cursor`, or `vscode` (VS Code's `servers` + `"type": "stdio"` schema). Non-destructive by construction: existing config content is merged, a pre-existing file is backed up as `<name>.gflow-backup`, a manual `gflow-cli` entry is converged in place instead of duplicated, and a corrupt config fails loud (exit 11) without ever being touched. Also fixed the bogus `%APPDATA%\Castano\Claude` path in docs/MCP.md.
+
 ### Fixed
 
 - **Removed the false "requires a Google AI Ultra or Pro subscription" claim across all docs.** Any Google account with Flow access can use gflow-cli — a paid plan only affects credit allowances and tier-gated features (e.g. 4K upscale stays Ultra-only). Swept README, AGENTS.md, DISCLAIMER.md, USER_GUIDE, CONFIGURATION, AUTHENTICATION, DEBUGGING, the medium tutorial, and the gflow-cli skill; factual tier-gating notes are unchanged.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -159,6 +159,8 @@ This merges the server entry into your Claude Desktop configuration file — exi
 
 Other targets: `gflow mcp setup --target cursor` (`~/.cursor/mcp.json`) and `--target vscode` (the user-profile `mcp.json`, written with VS Code's `servers` + `"type": "stdio"` schema).
 
+> **Existing entries are preserved:** if your config already has a `gflow` or `gflow-cli` server entry (including the local-clone `uv --directory` variant below), `gflow mcp setup` leaves it completely untouched and reports "Already configured" — it only ever adds a missing entry.
+
 #### Manual Configuration
 Depending on how you installed `gflow-cli`, add one of the following configuration blocks under the `mcpServers` key of your `claude_desktop_config.json`:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -152,9 +152,12 @@ Run the configuration helper command in your terminal:
 ```bash
 gflow mcp setup
 ```
-This automatically appends the server entry to your Claude Desktop configuration file:
-* **Windows:** `%APPDATA%\Castano\Claude\claude_desktop_config.json`
+This merges the server entry into your Claude Desktop configuration file — existing content is preserved, and a pre-existing file is backed up as `<name>.gflow-backup` first. A corrupt config fails loud (exit 11) and is never overwritten:
+* **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 * **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+* **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+Other targets: `gflow mcp setup --target cursor` (`~/.cursor/mcp.json`) and `--target vscode` (the user-profile `mcp.json`, written with VS Code's `servers` + `"type": "stdio"` schema).
 
 #### Manual Configuration
 Depending on how you installed `gflow-cli`, add one of the following configuration blocks under the `mcpServers` key of your `claude_desktop_config.json`:

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -490,7 +490,7 @@ def mcp_setup(target: str) -> None:
     from gflow_cli.mcp import setup as setup_mod
 
     try:
-        path = setup_mod.apply(target)
+        path, changed = setup_mod.apply(target)
     except ConfigurationError as exc:
         console.print(f"[red]{ConfigurationError.title}:[/red] {exc.detail or exc}")
         console.print(
@@ -498,9 +498,19 @@ def mcp_setup(target: str) -> None:
             "gflow mcp setup — it never overwrites a file it cannot parse.[/dim]"
         )
         sys.exit(11)
-    console.print(f"[green]gflow MCP server configured for {target}.[/green]")
-    console.print(f"  config: {path}")
-    console.print(f"[dim]Restart {target} to load the server.[/dim]")
+    except OSError as exc:
+        # Read-only/locked config file, permission problems, disk errors.
+        console.print(f"[red]Could not write the client config:[/red] {type(exc).__name__}: {exc}")
+        sys.exit(11)
+    if changed:
+        console.print(f"[green]gflow MCP server configured for {target}.[/green]")
+        console.print(f"  config: {path}")
+        console.print(f"[dim]Restart {target} to load the server.[/dim]")
+    else:
+        console.print(
+            f"[green]Already configured[/green] — an existing gflow entry in {path} "
+            "was left untouched."
+        )
 
 
 # --- serve ------------------------------------------------------------------

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -481,14 +481,26 @@ def mcp_run(profile: str | None) -> None:
     help="Target IDE/agent to configure.",
 )
 def mcp_setup(target: str) -> None:
-    """Auto-configure MCP server for a supported IDE/agent.
+    """Auto-configure the gflow MCP server for a supported IDE/agent.
 
-    Writes the server configuration block to the target's config file.
+    Merges the server entry into the target's config file (existing content
+    is preserved; a pre-existing file is backed up as <name>.gflow-backup).
     """
-    console.print(
-        f"[yellow]MCP setup for {target} is not yet implemented.[/yellow]\n"
-        "[dim]Manual setup: add the gflow MCP server config to your IDE settings.[/dim]"
-    )
+    from gflow_cli.errors import ConfigurationError
+    from gflow_cli.mcp import setup as setup_mod
+
+    try:
+        path = setup_mod.apply(target)
+    except ConfigurationError as exc:
+        console.print(f"[red]{ConfigurationError.title}:[/red] {exc.detail or exc}")
+        console.print(
+            "[dim]Fix (or move away) the existing config file and re-run "
+            "gflow mcp setup — it never overwrites a file it cannot parse.[/dim]"
+        )
+        sys.exit(11)
+    console.print(f"[green]gflow MCP server configured for {target}.[/green]")
+    console.print(f"  config: {path}")
+    console.print(f"[dim]Restart {target} to load the server.[/dim]")
 
 
 # --- serve ------------------------------------------------------------------

--- a/src/gflow_cli/mcp/setup.py
+++ b/src/gflow_cli/mcp/setup.py
@@ -1,0 +1,100 @@
+"""`gflow mcp setup` — write the gflow server entry into an MCP client config.
+
+Non-destructive by construction (issue #475): existing config content is
+merged, never replaced; a pre-existing file is backed up next to itself
+before the first write; a corrupt config fails loud (ConfigurationError,
+exit 11) and is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from gflow_cli.errors import ConfigurationError
+
+#: The server entry every target receives (vscode adds ``"type": "stdio"``).
+SERVER_ENTRY: dict[str, Any] = {"command": "gflow", "args": ["mcp", "run"]}
+
+#: Keys accepted as "already ours" — docs/MCP.md's manual blocks use
+#: ``gflow-cli``; setup converges an existing entry instead of duplicating it.
+_OUR_KEYS = ("gflow", "gflow-cli")
+
+#: target -> (root key, needs stdio type marker)
+_TARGET_SHAPE: dict[str, tuple[str, bool]] = {
+    "claude-desktop": ("mcpServers", False),
+    "cursor": ("mcpServers", False),
+    "vscode": ("servers", True),
+}
+
+
+def _app_config_root() -> Path:
+    """Per-OS root for application config files."""
+    if sys.platform == "win32":
+        return Path(os.environ["APPDATA"])
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support"
+    return Path.home() / ".config"
+
+
+def config_path_for(target: str) -> Path:
+    """The target client's MCP config file location on this OS."""
+    if target == "claude-desktop":
+        return _app_config_root() / "Claude" / "claude_desktop_config.json"
+    if target == "cursor":
+        # Cursor uses a home dotfile on every OS.
+        return Path.home() / ".cursor" / "mcp.json"
+    if target == "vscode":
+        return _app_config_root() / "Code" / "User" / "mcp.json"
+    msg = f"Unknown MCP setup target: {target!r}"
+    raise ConfigurationError(msg)
+
+
+def merge_server_entry(existing_text: str | None, *, target: str) -> str:
+    """Merge the gflow server entry into ``existing_text`` (None = new file).
+
+    Returns the new JSON document. Raises ConfigurationError on a corrupt or
+    non-object config so the caller never clobbers a file it cannot parse.
+    """
+    root_key, stdio_type = _TARGET_SHAPE[target]
+    if existing_text is None or not existing_text.strip():
+        config: dict[str, Any] = {}
+    else:
+        try:
+            parsed: Any = json.loads(existing_text)
+        except ValueError as exc:
+            msg = f"Existing config is not valid JSON: {exc}"
+            raise ConfigurationError(msg) from exc
+        if not isinstance(parsed, dict):
+            msg = "Existing config root is not a JSON object."
+            raise ConfigurationError(msg)
+        config = cast("dict[str, Any]", parsed)
+
+    servers = config.setdefault(root_key, {})
+    if not isinstance(servers, dict):
+        msg = f"Existing config {root_key!r} is not a JSON object."
+        raise ConfigurationError(msg)
+    servers = cast("dict[str, Any]", servers)
+
+    entry: dict[str, Any] = {"type": "stdio", **SERVER_ENTRY} if stdio_type else dict(SERVER_ENTRY)
+    key = next((k for k in _OUR_KEYS if k in servers), "gflow")
+    servers[key] = entry
+    return json.dumps(config, indent=2) + "\n"
+
+
+def apply(target: str) -> Path:
+    """Write/merge the server entry into the target's config; return its path.
+
+    A pre-existing file is copied to ``<name>.gflow-backup`` before the write.
+    """
+    path = config_path_for(target)
+    existing = path.read_text(encoding="utf-8") if path.exists() else None
+    merged = merge_server_entry(existing, target=target)
+    if existing is not None:
+        path.with_name(path.name + ".gflow-backup").write_text(existing, encoding="utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(merged, encoding="utf-8")
+    return path

--- a/src/gflow_cli/mcp/setup.py
+++ b/src/gflow_cli/mcp/setup.py
@@ -1,9 +1,11 @@
 """`gflow mcp setup` — write the gflow server entry into an MCP client config.
 
 Non-destructive by construction (issue #475): existing config content is
-merged, never replaced; a pre-existing file is backed up next to itself
-before the first write; a corrupt config fails loud (ConfigurationError,
-exit 11) and is never touched.
+merged, never replaced; a pre-existing gflow/gflow-cli entry — however the
+user wrote it (e.g. docs/MCP.md's local-clone `uv --directory` variant) — is
+left entirely untouched; a pre-existing file is backed up once (the first
+backup stays pristine); writes are atomic (tmp + os.replace); a corrupt
+config fails loud (ConfigurationError, exit 11) and is never touched.
 """
 
 from __future__ import annotations
@@ -19,8 +21,8 @@ from gflow_cli.errors import ConfigurationError
 #: The server entry every target receives (vscode adds ``"type": "stdio"``).
 SERVER_ENTRY: dict[str, Any] = {"command": "gflow", "args": ["mcp", "run"]}
 
-#: Keys accepted as "already ours" — docs/MCP.md's manual blocks use
-#: ``gflow-cli``; setup converges an existing entry instead of duplicating it.
+#: Keys treated as "already ours" — docs/MCP.md's manual blocks use
+#: ``gflow-cli``; an existing entry under either key is preserved as-is.
 _OUR_KEYS = ("gflow", "gflow-cli")
 
 #: target -> (root key, needs stdio type marker)
@@ -34,10 +36,14 @@ _TARGET_SHAPE: dict[str, tuple[str, bool]] = {
 def _app_config_root() -> Path:
     """Per-OS root for application config files."""
     if sys.platform == "win32":
-        return Path(os.environ["APPDATA"])
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            msg = "APPDATA is not set — cannot locate the client config directory."
+            raise ConfigurationError(msg)
+        return Path(appdata)
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support"
-    return Path.home() / ".config"
+    return Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
 
 
 def config_path_for(target: str) -> Path:
@@ -53,11 +59,13 @@ def config_path_for(target: str) -> Path:
     raise ConfigurationError(msg)
 
 
-def merge_server_entry(existing_text: str | None, *, target: str) -> str:
+def merge_server_entry(existing_text: str | None, *, target: str) -> str | None:
     """Merge the gflow server entry into ``existing_text`` (None = new file).
 
-    Returns the new JSON document. Raises ConfigurationError on a corrupt or
-    non-object config so the caller never clobbers a file it cannot parse.
+    Returns the new JSON document, or ``None`` when the config already has a
+    gflow/gflow-cli entry — the user's own entry (command, args, env) is
+    never rewritten. Raises ConfigurationError on a corrupt or non-object
+    config so the caller never clobbers a file it cannot parse.
     """
     root_key, stdio_type = _TARGET_SHAPE[target]
     if existing_text is None or not existing_text.strip():
@@ -66,7 +74,14 @@ def merge_server_entry(existing_text: str | None, *, target: str) -> str:
         try:
             parsed: Any = json.loads(existing_text)
         except ValueError as exc:
-            msg = f"Existing config is not valid JSON: {exc}"
+            hint = (
+                " VS Code configs may contain comments/trailing commas (JSONC), "
+                "which gflow cannot safely edit — add the server entry manually "
+                "(see docs/MCP.md § Setup Instructions)."
+                if target == "vscode"
+                else ""
+            )
+            msg = f"Existing config is not valid JSON: {exc}.{hint}"
             raise ConfigurationError(msg) from exc
         if not isinstance(parsed, dict):
             msg = "Existing config root is not a JSON object."
@@ -79,22 +94,40 @@ def merge_server_entry(existing_text: str | None, *, target: str) -> str:
         raise ConfigurationError(msg)
     servers = cast("dict[str, Any]", servers)
 
+    if any(k in servers for k in _OUR_KEYS):
+        return None
     entry: dict[str, Any] = {"type": "stdio", **SERVER_ENTRY} if stdio_type else dict(SERVER_ENTRY)
-    key = next((k for k in _OUR_KEYS if k in servers), "gflow")
-    servers[key] = entry
+    servers["gflow"] = entry
     return json.dumps(config, indent=2) + "\n"
 
 
-def apply(target: str) -> Path:
-    """Write/merge the server entry into the target's config; return its path.
+def apply(target: str) -> tuple[Path, bool]:
+    """Ensure the server entry exists in the target's config.
 
-    A pre-existing file is copied to ``<name>.gflow-backup`` before the write.
+    Returns ``(path, changed)`` — ``changed`` is False when an entry already
+    existed and nothing was written. On the first write over a pre-existing
+    file, a one-time pristine copy is kept as ``<name>.gflow-backup`` (never
+    overwritten by later runs). The write itself is atomic (tmp +
+    ``os.replace``) so a crash can never truncate the client's config.
     """
     path = config_path_for(target)
-    existing = path.read_text(encoding="utf-8") if path.exists() else None
+    existing: str | None = None
+    if path.exists():
+        try:
+            # utf-8-sig: tolerate the BOM PowerShell's UTF8 encoding writes.
+            existing = path.read_text(encoding="utf-8-sig")
+        except UnicodeDecodeError as exc:
+            msg = f"Existing config is not UTF-8 encoded: {exc}"
+            raise ConfigurationError(msg) from exc
     merged = merge_server_entry(existing, target=target)
+    if merged is None:
+        return path, False
     if existing is not None:
-        path.with_name(path.name + ".gflow-backup").write_text(existing, encoding="utf-8")
+        backup = path.with_name(path.name + ".gflow-backup")
+        if not backup.exists():  # the FIRST backup is the pristine one — keep it
+            backup.write_text(existing, encoding="utf-8")
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(merged, encoding="utf-8")
-    return path
+    tmp = path.with_name(path.name + ".gflow-tmp")
+    tmp.write_text(merged, encoding="utf-8")
+    os.replace(tmp, path)
+    return path, True

--- a/tests/mcp/test_setup.py
+++ b/tests/mcp/test_setup.py
@@ -1,0 +1,137 @@
+"""`gflow mcp setup` — MCP client-config generator (issue #475).
+
+docs/MCP.md has promised this command since the stub shipped; it now writes
+(or non-destructively merges) the gflow server entry into the target client's
+config file, with a backup of any pre-existing file.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli.cli import main
+from gflow_cli.errors import ConfigurationError
+from gflow_cli.mcp import setup as setup_mod
+
+
+class TestConfigPathFor:
+    def test_claude_desktop_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("APPDATA", str(Path("C:/u/AppData/Roaming")))
+        expected = Path("C:/u/AppData/Roaming") / "Claude" / "claude_desktop_config.json"
+        assert setup_mod.config_path_for("claude-desktop") == expected
+
+    def test_claude_desktop_macos(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        expected = (
+            tmp_path / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        )
+        assert setup_mod.config_path_for("claude-desktop") == expected
+
+    def test_claude_desktop_linux(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        expected = tmp_path / ".config" / "Claude" / "claude_desktop_config.json"
+        assert setup_mod.config_path_for("claude-desktop") == expected
+
+    def test_cursor_is_home_dotfile_everywhere(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert setup_mod.config_path_for("cursor") == tmp_path / ".cursor" / "mcp.json"
+
+    def test_vscode_linux(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        expected = tmp_path / ".config" / "Code" / "User" / "mcp.json"
+        assert setup_mod.config_path_for("vscode") == expected
+
+
+class TestMergeServerEntry:
+    def test_creates_config_from_nothing(self) -> None:
+        cfg = json.loads(setup_mod.merge_server_entry(None, target="claude-desktop"))
+        assert cfg["mcpServers"]["gflow"] == {"command": "gflow", "args": ["mcp", "run"]}
+
+    def test_preserves_unrelated_keys_and_servers(self) -> None:
+        existing = json.dumps({"theme": "dark", "mcpServers": {"other": {"command": "x"}}})
+        cfg = json.loads(setup_mod.merge_server_entry(existing, target="claude-desktop"))
+        assert cfg["theme"] == "dark"
+        assert cfg["mcpServers"]["other"] == {"command": "x"}
+        assert cfg["mcpServers"]["gflow"]["command"] == "gflow"
+
+    def test_updates_manual_gflow_cli_key_in_place_without_duplicate(self) -> None:
+        """docs/MCP.md's manual blocks use the key 'gflow-cli' — setup must
+        converge that entry, not add a second server."""
+        existing = json.dumps({"mcpServers": {"gflow-cli": {"command": "stale"}}})
+        cfg = json.loads(setup_mod.merge_server_entry(existing, target="claude-desktop"))
+        assert cfg["mcpServers"]["gflow-cli"] == {"command": "gflow", "args": ["mcp", "run"]}
+        assert "gflow" not in cfg["mcpServers"]
+
+    def test_vscode_uses_servers_key_and_stdio_type(self) -> None:
+        cfg = json.loads(setup_mod.merge_server_entry(None, target="vscode"))
+        assert cfg["servers"]["gflow"] == {
+            "type": "stdio",
+            "command": "gflow",
+            "args": ["mcp", "run"],
+        }
+
+    def test_invalid_json_raises_configuration_error(self) -> None:
+        with pytest.raises(ConfigurationError):
+            setup_mod.merge_server_entry("{definitely not json", target="claude-desktop")
+
+    def test_non_object_root_raises_configuration_error(self) -> None:
+        with pytest.raises(ConfigurationError):
+            setup_mod.merge_server_entry(json.dumps([1, 2]), target="claude-desktop")
+
+
+class TestApplyAndCli:
+    def test_merges_existing_file_and_backs_it_up(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "claude_desktop_config.json"
+        target_file.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}}), "utf-8")
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        result = CliRunner().invoke(main, ["mcp", "setup"])
+
+        assert result.exit_code == 0, result.output
+        cfg = json.loads(target_file.read_text(encoding="utf-8"))
+        assert cfg["mcpServers"]["gflow"]["args"] == ["mcp", "run"]
+        assert cfg["mcpServers"]["other"] == {"command": "x"}
+        backup = target_file.with_name(target_file.name + ".gflow-backup")
+        assert json.loads(backup.read_text(encoding="utf-8"))["mcpServers"] == {
+            "other": {"command": "x"}
+        }
+        # Rich soft-wraps long paths in a narrow console — compare unwrapped.
+        assert str(target_file) in result.output.replace("\n", "")
+
+    def test_creates_file_and_parents_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "deep" / "nested" / "mcp.json"
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        result = CliRunner().invoke(main, ["mcp", "setup", "--target", "cursor"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(target_file.read_text(encoding="utf-8"))["mcpServers"]["gflow"]
+        assert not target_file.with_name(target_file.name + ".gflow-backup").exists()
+
+    def test_corrupt_config_exits_11_and_leaves_file_untouched(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "claude_desktop_config.json"
+        target_file.write_text("{broken", encoding="utf-8")
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        result = CliRunner().invoke(main, ["mcp", "setup"])
+
+        assert result.exit_code == 11
+        assert target_file.read_text(encoding="utf-8") == "{broken"
+        assert "Traceback" not in result.output

--- a/tests/mcp/test_setup.py
+++ b/tests/mcp/test_setup.py
@@ -36,6 +36,7 @@ class TestConfigPathFor:
 
     def test_claude_desktop_linux(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)  # set on GitHub runners
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         expected = tmp_path / ".config" / "Claude" / "claude_desktop_config.json"
         assert setup_mod.config_path_for("claude-desktop") == expected

--- a/tests/mcp/test_setup.py
+++ b/tests/mcp/test_setup.py
@@ -48,9 +48,28 @@ class TestConfigPathFor:
 
     def test_vscode_linux(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         expected = tmp_path / ".config" / "Code" / "User" / "mcp.json"
         assert setup_mod.config_path_for("vscode") == expected
+
+    def test_linux_honours_xdg_config_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """VS Code (Electron) reads $XDG_CONFIG_HOME — writing ~/.config while
+        it is set would be a silent no-op (council review)."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        expected = tmp_path / "xdg" / "Code" / "User" / "mcp.json"
+        assert setup_mod.config_path_for("vscode") == expected
+
+    def test_windows_without_appdata_raises_configuration_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("APPDATA", raising=False)
+        with pytest.raises(ConfigurationError):
+            setup_mod.config_path_for("claude-desktop")
 
 
 class TestMergeServerEntry:
@@ -65,13 +84,17 @@ class TestMergeServerEntry:
         assert cfg["mcpServers"]["other"] == {"command": "x"}
         assert cfg["mcpServers"]["gflow"]["command"] == "gflow"
 
-    def test_updates_manual_gflow_cli_key_in_place_without_duplicate(self) -> None:
-        """docs/MCP.md's manual blocks use the key 'gflow-cli' — setup must
-        converge that entry, not add a second server."""
-        existing = json.dumps({"mcpServers": {"gflow-cli": {"command": "stale"}}})
-        cfg = json.loads(setup_mod.merge_server_entry(existing, target="claude-desktop"))
-        assert cfg["mcpServers"]["gflow-cli"] == {"command": "gflow", "args": ["mcp", "run"]}
-        assert "gflow" not in cfg["mcpServers"]
+    def test_existing_user_entry_is_never_rewritten(self) -> None:
+        """docs/MCP.md's local-clone block uses key 'gflow-cli' with a custom
+        `uv --directory` command (+ possibly env) — setup must not clobber it
+        or add a duplicate (council review)."""
+        custom = {"command": "uv", "args": ["--directory", "/x", "run", "gflow", "mcp", "run"]}
+        existing = json.dumps({"mcpServers": {"gflow-cli": custom}})
+        assert setup_mod.merge_server_entry(existing, target="claude-desktop") is None
+
+    def test_existing_gflow_key_also_short_circuits(self) -> None:
+        existing = json.dumps({"mcpServers": {"gflow": {"command": "custom", "env": {"A": "1"}}}})
+        assert setup_mod.merge_server_entry(existing, target="claude-desktop") is None
 
     def test_vscode_uses_servers_key_and_stdio_type(self) -> None:
         cfg = json.loads(setup_mod.merge_server_entry(None, target="vscode"))
@@ -122,6 +145,51 @@ class TestApplyAndCli:
         assert result.exit_code == 0, result.output
         assert json.loads(target_file.read_text(encoding="utf-8"))["mcpServers"]["gflow"]
         assert not target_file.with_name(target_file.name + ".gflow-backup").exists()
+
+    def test_second_run_is_a_noop_and_backup_stays_pristine(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Re-running setup must not rewrite the config NOR overwrite the
+        one pristine backup of the user's original file (council review)."""
+        target_file = tmp_path / "claude_desktop_config.json"
+        original = json.dumps({"mcpServers": {"other": {"command": "x"}}})
+        target_file.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        first = CliRunner().invoke(main, ["mcp", "setup"])
+        assert first.exit_code == 0
+        merged_once = target_file.read_text(encoding="utf-8")
+
+        second = CliRunner().invoke(main, ["mcp", "setup"])
+        assert second.exit_code == 0
+        assert "Already configured" in second.output
+        assert target_file.read_text(encoding="utf-8") == merged_once
+        backup = target_file.with_name(target_file.name + ".gflow-backup")
+        assert backup.read_text(encoding="utf-8") == original  # pristine v1
+
+    def test_bom_config_is_accepted(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """PowerShell's UTF8 encoding writes a BOM — that is not corruption."""
+        target_file = tmp_path / "claude_desktop_config.json"
+        target_file.write_bytes(b'\xef\xbb\xbf{"mcpServers": {}}')
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        result = CliRunner().invoke(main, ["mcp", "setup"])
+
+        assert result.exit_code == 0, result.output
+        cfg = json.loads(target_file.read_text(encoding="utf-8"))
+        assert cfg["mcpServers"]["gflow"]["command"] == "gflow"
+
+    def test_non_utf8_config_exits_11_without_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target_file = tmp_path / "claude_desktop_config.json"
+        target_file.write_bytes(b'{"caf\xe9": 1}')  # latin-1, invalid UTF-8
+        monkeypatch.setattr(setup_mod, "config_path_for", lambda t: target_file)
+
+        result = CliRunner().invoke(main, ["mcp", "setup"])
+
+        assert result.exit_code == 11
+        assert "Traceback" not in result.output
 
     def test_corrupt_config_exits_11_and_leaves_file_untouched(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -159,6 +159,8 @@ This merges the server entry into your Claude Desktop configuration file — exi
 
 Other targets: `gflow mcp setup --target cursor` (`~/.cursor/mcp.json`) and `--target vscode` (the user-profile `mcp.json`, written with VS Code's `servers` + `"type": "stdio"` schema).
 
+> **Existing entries are preserved:** if your config already has a `gflow` or `gflow-cli` server entry (including the local-clone `uv --directory` variant below), `gflow mcp setup` leaves it completely untouched and reports "Already configured" — it only ever adds a missing entry.
+
 #### Manual Configuration
 Depending on how you installed `gflow-cli`, add one of the following configuration blocks under the `mcpServers` key of your `claude_desktop_config.json`:
 

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -152,9 +152,12 @@ Run the configuration helper command in your terminal:
 ```bash
 gflow mcp setup
 ```
-This automatically appends the server entry to your Claude Desktop configuration file:
-* **Windows:** `%APPDATA%\Castano\Claude\claude_desktop_config.json`
+This merges the server entry into your Claude Desktop configuration file — existing content is preserved, and a pre-existing file is backed up as `<name>.gflow-backup` first. A corrupt config fails loud (exit 11) and is never overwritten:
+* **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 * **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+* **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+Other targets: `gflow mcp setup --target cursor` (`~/.cursor/mcp.json`) and `--target vscode` (the user-profile `mcp.json`, written with VS Code's `servers` + `"type": "stdio"` schema).
 
 #### Manual Configuration
 Depending on how you installed `gflow-cli`, add one of the following configuration blocks under the `mcpServers` key of your `claude_desktop_config.json`:


### PR DESCRIPTION
## Summary

Closes #475 (the last Tier-1 quick win from the linkedin-mcp catalog).

Replaces the long-stubbed `gflow mcp setup` with a real client-config generator — `docs/MCP.md` has promised this command since the stub shipped. Targets: `claude-desktop` (default), `cursor`, `vscode` (VS Code's `servers` + `"type": "stdio"` schema; Linux honours `XDG_CONFIG_HOME`).

**Non-destructive by construction** (shaped heavily by the council review):
- An existing `gflow`/`gflow-cli` entry — including docs/MCP.md's own local-clone `uv --directory` variant and any user `env` block — is **never rewritten**; setup only adds a missing entry and reports "Already configured". Second runs are true no-ops.
- The single `.gflow-backup` is pristine: written only when absent, so a retry cannot destroy the only copy of the original.
- Atomic write (tmp + `os.replace`); `utf-8-sig` reads (PowerShell BOM); non-UTF-8 → exit 11, no traceback; corrupt JSON never touched; vscode JSONC limitation explained with a manual-setup pointer; APPDATA-unset and read-only/locked files → clean exit 11.
- Also fixed the bogus `%APPDATA%\Castano\Claude` path in docs/MCP.md.

Logic is in `mcp/setup.py` as pure functions; the CLI is thin wiring. `mcp setup` is already in the CLI↔MCP parity exempt list.

## Reviews run

- **code-review (high)**: 8 findings survived adversarial verification (entry-clobber + one-shot-backup were the headliners) — **all 8 applied** with pinning tests; 3 candidates refuted by the reviewer (one empirically).
- **ponytail-review**: three pure functions + a shape table, no new deps, no speculative flags. Lean.

## Validation

- 137 MCP tests green (20 new: 7 path-resolution incl. XDG/APPDATA edges, 7 merge semantics, 6 CLI flows incl. idempotence/pristine-backup/BOM/non-UTF-8)
- `ruff` / doc links / website mirror `--check` / repo hygiene — clean (pipefail-verified); `pyright src` at the 73-error local baseline
- **Live-verified end-to-end** on this machine: real CLI binary against a scratch copy of the real Claude Desktop config (real APPDATA resolution) — correct merged entry, exit 0, original untouched

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity
- [x] No secrets, cookies, tokens, or private captured data
- [x] I reviewed the changes before submitting