### PR TITLE
fix(errors): honest evidence pointers for mode-switch drift (Refs #493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mode-switch drift errors now name the right evidence (#493).** An external
+  report showed a third, unrecognized Flow editor layout (composer frame slots +
+  Agent toggle, no classic `crop_*` settings button) falling through to
+  `UiSelectorDriftError` (exit 23). The fall-through detail now states that no
+  known Flow cohort matched — i.e. the editor may be a new layout this version
+  does not recognize — and the class remediation no longer asks for a "debug
+  screenshot from this message" that the mode-switch probe never writes: it
+  points at the artifacts that actually exist (the PII-safe
+  `diag_mode_switch_miss.json` DOM signature and/or the referenced screenshot,
+  plus the incident bundle's `report.md`). Recognizing the new variant itself is
+  tracked in #493 and needs an affected account's diagnostics JSON.
+
 ### Added
 
 - **Opt-in bounded wait for profile-lease contention (#478).** `GFLOW_CLI_LEASE_WAIT_SECONDS=N` makes a command that hits same-profile contention poll the kernel lock (0.5 s cadence, sync and async call sites alike) and take over as soon as the current holder — a CLI command or a `gflow serve` daemon queue task, both of which release at their natural end — finishes; on timeout it raises the same `ProfileLockedError` (exit 11). Default `0` keeps the historical fail-fast. Triage note: the issue's fuller cooperative-handoff protocol (release-request channel, minimum-hold window) was validated against the actual architecture and dropped — the daemon acquires the lease per task, so every holder's safe release point already coincides with lease release; holders are never asked to release early, which satisfies the no-release-mid-call requirement by construction. Same-process contention always fails fast (waiting on yourself deadlocks).

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -198,9 +198,10 @@ retryable exit-25 cohort classification. The selector cascade itself is
 locale-invariant — the reporter's Portuguese UI is unrelated.
 
 The error detail now names this hypothesis and the run writes a PII-safe DOM
-signature to `diag_mode_switch_miss.json` (structural allowlist: ligature
-names, tag counts — no cookies, tokens, prompts, or page text). **If you hit
-this, attach that JSON file to
+signature to `diag_mode_switch_miss.json` when it can be captured (structural
+allowlist: ligature names, tag counts — no cookies, tokens, prompts, or page
+text; if the file is absent, attach the incident bundle's `report.md`
+instead). **If you hit this, attach that JSON file to
 [#493](https://github.com/ffroliva/gflow-cli/issues/493)** — recognizing the
 variant (and restoring a clean retryable classification, or full support) needs
 exactly that DOM signature. Re-running later may land the classic editor if

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -181,6 +181,31 @@ accepted. Two corrections fixed it (verified end-to-end on macOS Apple Silicon):
 
 Evidence: [LIVE_VERIFICATION_v0.23.0](docs/LIVE_VERIFICATION_v0.23.0.md).
 
+### New Flow editor variant (composer frame slots + Agent toggle) is not recognized
+
+- **Status:** **Open** — awaiting a DOM signature from an affected account;
+  tracked in [#493](https://github.com/ffroliva/gflow-cli/issues/493)
+- **Severity:** High · **Affects:** `gflow image` / `gflow video` generation on
+  accounts that received the new editor, any locale
+
+A third Flow editor layout was reported on 2026-08-13 (macOS, v0.55.0; also
+v0.53.1): frame-slot buttons ("Initial"/"Final") sit directly on the composer
+next to an "Agent" pill, and there is **no** classic `crop_*` aspect/settings
+button for gflow to drive. The layout matches **none** of the known cohort
+indicators (agentic chat composer, full-page media library), so the mode-switch
+step falls through to `UiSelectorDriftError` (**exit 23**) instead of the
+retryable exit-25 cohort classification. The selector cascade itself is
+locale-invariant — the reporter's Portuguese UI is unrelated.
+
+The error detail now names this hypothesis and the run writes a PII-safe DOM
+signature to `diag_mode_switch_miss.json` (structural allowlist: ligature
+names, tag counts — no cookies, tokens, prompts, or page text). **If you hit
+this, attach that JSON file to
+[#493](https://github.com/ffroliva/gflow-cli/issues/493)** — recognizing the
+variant (and restoring a clean retryable classification, or full support) needs
+exactly that DOM signature. Re-running later may land the classic editor if
+the rollout is still an A/B arm.
+
 ### Flow's new full-page media-library UI breaks entity attach (A/B rollout)
 
 - **Status:** **Open** — Flow-side staged rollout; tracked in
@@ -203,8 +228,8 @@ classic `crop_*` aspect/mode control, so `gflow image`/`gflow video` can't drive
 generation. Rather than the old opaque `UiSelectorDriftError` "file a bug", the
 mode-switch raise site now runs a runtime DOM scan and raises a clear, **retryable**
 `FlowAgentUiError` (**exit 25**, "this cohort flaps; retry shortly"), and dumps a
-DOM-signature diagnostics artifact (`diag_mode_switch_miss.json` + a full-page
-screenshot) for reporting. The cohort is server-assigned per page load and flaps
+DOM-signature diagnostics artifact (`diag_mode_switch_miss.json`; the incident
+bundle carries the full-page screenshot under `sensitive/`) for reporting. The cohort is server-assigned per page load and flaps
 within ~12h, so a re-run often lands the classic UI. Driving the new UI directly
 is still out of scope.
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -45,10 +45,11 @@ historical UI-flake noted in
 [`LIVE_VERIFICATION_v0.7.0.md`](LIVE_VERIFICATION_v0.7.0.md#open-follow-ups)
 (transient overlay swallowed the arrow-forward click).
 
-**Two extra debug-screenshot file names worth searching for in the out dir**
-when the mode switch itself fails: `debug_no_mode_trigger.png` (crop-icon
-dropdown trigger not found) and `debug_no_image_tab.png` (Image tab missing
-inside the open dropdown).
+**Two extra artifact file names worth searching for in the out dir** when the
+mode switch itself fails: `diag_mode_switch_miss.json` (crop-icon dropdown
+trigger not found — a structural DOM signature; this probe writes no
+screenshot) and `debug_no_image_tab.png` (Image tab missing inside the open
+dropdown).
 
 Pipe `--verbose` output through `Select-String` (PowerShell) or `grep` to
 filter:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1348,7 +1348,7 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `20` | `FrameExtractionError` | Could not extract the last frame for a video chain link | Check the source video downloaded intact; retry the link  |
 | `21` | `ChainPartialError`   | A video chain stopped mid-way; earlier links completed | Resume from the last completed link shown in the error     |
 | `22` | `UpscaleUnavailableError` | 4K upscale is gated to Flow **Ultra** accounts (HTTP 403) | Use `--scale 2k`, or upgrade the Flow plan                |
-| `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issue #183) | Update gflow-cli; file a bug with the probe name + debug screenshot from the error message |
+| `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issues #183, #493) | Update gflow-cli; file a bug with the probe name + the diagnostics JSON / debug screenshot referenced in the error message |
 | `24` | `BrowserEngineUnavailableError` | `GFLOW_CLI_BROWSER_ENGINE=patchright` but the engine is not installed | `pip install 'gflow-cli[patchright]'`, or unset `GFLOW_CLI_BROWSER_ENGINE` |
 | `25` | `FlowAgentUiError`    | The profile is on Flow's Agentic UI cohort and the classic media panel is unrecoverable for this operation | Rare since v0.38.0 (#332): the mode controller reliably recovers agentic→classic, so first retry with `--ui-mode classic`; if it persists, see KNOWN_ISSUES on the agentic cohort |
 | `26` | `MediaAttributionError` | Generated media could not be reliably attributed to this request (issue #281) | Re-run; a dedicated project with fewer pre-existing assets avoids the ambiguity |

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -1338,7 +1338,11 @@ class VideoGenerationMixin:
             )
         return UiSelectorDriftError(
             selector_drift_detail(
-                "mode_switch_trigger", "no matching element found on the Flow editor.", None
+                "mode_switch_trigger",
+                "no matching element found on the Flow editor. No known Flow "
+                "cohort matched either — the editor may be a new Flow UI layout "
+                "this gflow-cli version does not recognize yet (issue #493).",
+                None,
             )
             + diag_clause
         )

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -514,8 +514,8 @@ class UiSelectorDriftError(GFlowError):
 
     Indicates that Flow's frontend has changed in a way that invalidates one
     of the selector probes (mode-switch trigger, mode tab, sub-mode tab, etc.).
-    The ``detail`` names the probe label and includes the debug screenshot path
-    when one was captured.
+    The ``detail`` names the probe label and includes the debug screenshot or
+    diagnostics JSON path when one was captured.
 
     This is a hard failure — gflow cannot safely proceed without the control —
     but it is *diagnosed*, not opaque: the user gets the probe name and the
@@ -529,9 +529,10 @@ class UiSelectorDriftError(GFlowError):
         "A Flow editor UI element could not be located — Google may have updated "
         "their frontend. Check for a newer gflow-cli release, then file a bug at "
         "https://github.com/ffroliva/gflow-cli/issues referencing the probe name "
-        "and attaching the debug screenshot from this message, if one was captured "
-        "(review it first — the viewport may show your account name/avatar; do NOT "
-        "include tokens or signed URLs)."
+        "and attaching the diagnostics JSON and/or debug screenshot referenced in "
+        "this message, plus the incident bundle's report.md when one was written "
+        "(review artifacts before sharing — screenshots may show your account "
+        "name/avatar; do NOT include tokens or signed URLs)."
     )
 
 

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -519,7 +519,7 @@ class UiSelectorDriftError(GFlowError):
 
     This is a hard failure — gflow cannot safely proceed without the control —
     but it is *diagnosed*, not opaque: the user gets the probe name and the
-    screenshot for inspection.  Exit code 23 lets scripted callers branch on
+    captured artifact for inspection.  Exit code 23 lets scripted callers branch on
     "the UI changed and needs a selector update" versus generic error (1).
     """
 
@@ -550,9 +550,9 @@ class FlowAgentUiError(GFlowError):
         "Your account has been placed in Google Flow's new 'Agentic UI' A/B cohort, "
         "which removes the classic media generation controls. gflow-cli does not "
         "currently support driving this interface. Try using a different Chrome profile, "
-        "or wait for a future update. If you need to share a bug report, review the "
-        "diagnostic screenshot first — the viewport may show personal info (do NOT "
-        "include tokens or credentials)."
+        "or wait for a future update. If you need to share a bug report, review any "
+        "screenshot in the incident bundle first — the viewport may show personal info "
+        "(do NOT include tokens or credentials)."
     )
 
 

--- a/tests/api/transports/test_agentic_cohort_detection.py
+++ b/tests/api/transports/test_agentic_cohort_detection.py
@@ -176,6 +176,26 @@ async def test_mode_switch_error_is_drift_error_when_no_cohort(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_mode_switch_drift_detail_flags_unrecognized_variant(tmp_path: Path) -> None:
+    """#493: reaching the drift fall-through PROVES no known cohort indicator
+    matched — the editor may be a brand-new Flow layout (e.g. the composer
+    frame-slots + Agent-toggle variant). The detail must carry that hypothesis
+    so the report that reaches the tracker points at the right cause."""
+    from gflow_cli.errors import UiSelectorDriftError
+
+    page = _page_with_present(set())
+    page.evaluate = AsyncMock(return_value={"ligatures": []})
+    page.screenshot = AsyncMock()
+
+    err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="video")
+
+    assert isinstance(err, UiSelectorDriftError)
+    msg = str(err)
+    assert "mode_switch_trigger" in msg
+    assert "does not recognize" in msg
+
+
+@pytest.mark.asyncio
 async def test_mode_switch_error_is_flow_app_error_on_app_crash(tmp_path: Path) -> None:
     from gflow_cli.errors import FlowAppError
 

--- a/tests/api/transports/test_agentic_cohort_detection.py
+++ b/tests/api/transports/test_agentic_cohort_detection.py
@@ -164,26 +164,13 @@ async def test_mode_switch_error_is_flow_agent_ui_error_on_cohort(tmp_path: Path
 
 @pytest.mark.asyncio
 async def test_mode_switch_error_is_drift_error_when_no_cohort(tmp_path: Path) -> None:
-    from gflow_cli.errors import UiSelectorDriftError
-
-    page = _page_with_present(set())  # genuine drift: no agentic/library marker
-    page.evaluate = AsyncMock(return_value={"ligatures": []})
-    page.screenshot = AsyncMock()
-
-    err = await VideoGenerationMixin._mode_switch_error(page, tmp_path, media="video")
-
-    assert isinstance(err, UiSelectorDriftError)
-
-
-@pytest.mark.asyncio
-async def test_mode_switch_drift_detail_flags_unrecognized_variant(tmp_path: Path) -> None:
     """#493: reaching the drift fall-through PROVES no known cohort indicator
     matched — the editor may be a brand-new Flow layout (e.g. the composer
     frame-slots + Agent-toggle variant). The detail must carry that hypothesis
     so the report that reaches the tracker points at the right cause."""
     from gflow_cli.errors import UiSelectorDriftError
 
-    page = _page_with_present(set())
+    page = _page_with_present(set())  # genuine drift: no agentic/library marker
     page.evaluate = AsyncMock(return_value={"ligatures": []})
     page.screenshot = AsyncMock()
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -691,3 +691,18 @@ def test_specific_remediation_hints() -> None:
         == "Verify input video file is readable and non-corrupt. Ensure gflow-cli[chain] "
         "dependencies (PyAV) are installed."
     )
+
+
+def test_ui_selector_drift_remediation_names_real_artifacts() -> None:
+    """#493: the class remediation asked for a 'debug screenshot from this
+    message' — but the mode-switch probe writes a diagnostics JSON and no
+    screenshot, so the ask pointed at an artifact that does not exist. The
+    remediation must cover the artifacts drift sites actually reference."""
+    from gflow_cli.errors import UiSelectorDriftError
+
+    hint = UiSelectorDriftError().remediation_hint
+    assert "diagnostics" in hint.lower()
+    assert "report.md" in hint
+    assert "referenced in this message" in hint
+    # The privacy caveat must survive the rewording.
+    assert "review" in hint.lower()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -703,6 +703,5 @@ def test_ui_selector_drift_remediation_names_real_artifacts() -> None:
     hint = UiSelectorDriftError().remediation_hint
     assert "diagnostics" in hint.lower()
     assert "report.md" in hint
-    assert "referenced in this message" in hint
     # The privacy caveat must survive the rewording.
-    assert "review" in hint.lower()
+    assert "do NOT include tokens" in hint

--- a/website/docs/DEBUGGING.md
+++ b/website/docs/DEBUGGING.md
@@ -45,10 +45,11 @@ historical UI-flake noted in
 [`LIVE_VERIFICATION_v0.7.0.md`](LIVE_VERIFICATION_v0.7.0.md#open-follow-ups)
 (transient overlay swallowed the arrow-forward click).
 
-**Two extra debug-screenshot file names worth searching for in the out dir**
-when the mode switch itself fails: `debug_no_mode_trigger.png` (crop-icon
-dropdown trigger not found) and `debug_no_image_tab.png` (Image tab missing
-inside the open dropdown).
+**Two extra artifact file names worth searching for in the out dir** when the
+mode switch itself fails: `diag_mode_switch_miss.json` (crop-icon dropdown
+trigger not found — a structural DOM signature; this probe writes no
+screenshot) and `debug_no_image_tab.png` (Image tab missing inside the open
+dropdown).
 
 Pipe `--verbose` output through `Select-String` (PowerShell) or `grep` to
 filter:

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -198,9 +198,10 @@ retryable exit-25 cohort classification. The selector cascade itself is
 locale-invariant — the reporter's Portuguese UI is unrelated.
 
 The error detail now names this hypothesis and the run writes a PII-safe DOM
-signature to `diag_mode_switch_miss.json` (structural allowlist: ligature
-names, tag counts — no cookies, tokens, prompts, or page text). **If you hit
-this, attach that JSON file to
+signature to `diag_mode_switch_miss.json` when it can be captured (structural
+allowlist: ligature names, tag counts — no cookies, tokens, prompts, or page
+text; if the file is absent, attach the incident bundle's `report.md`
+instead). **If you hit this, attach that JSON file to
 [#493](https://github.com/ffroliva/gflow-cli/issues/493)** — recognizing the
 variant (and restoring a clean retryable classification, or full support) needs
 exactly that DOM signature. Re-running later may land the classic editor if

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -181,6 +181,31 @@ accepted. Two corrections fixed it (verified end-to-end on macOS Apple Silicon):
 
 Evidence: [LIVE_VERIFICATION_v0.23.0](docs/LIVE_VERIFICATION_v0.23.0.md).
 
+### New Flow editor variant (composer frame slots + Agent toggle) is not recognized
+
+- **Status:** **Open** — awaiting a DOM signature from an affected account;
+  tracked in [#493](https://github.com/ffroliva/gflow-cli/issues/493)
+- **Severity:** High · **Affects:** `gflow image` / `gflow video` generation on
+  accounts that received the new editor, any locale
+
+A third Flow editor layout was reported on 2026-08-13 (macOS, v0.55.0; also
+v0.53.1): frame-slot buttons ("Initial"/"Final") sit directly on the composer
+next to an "Agent" pill, and there is **no** classic `crop_*` aspect/settings
+button for gflow to drive. The layout matches **none** of the known cohort
+indicators (agentic chat composer, full-page media library), so the mode-switch
+step falls through to `UiSelectorDriftError` (**exit 23**) instead of the
+retryable exit-25 cohort classification. The selector cascade itself is
+locale-invariant — the reporter's Portuguese UI is unrelated.
+
+The error detail now names this hypothesis and the run writes a PII-safe DOM
+signature to `diag_mode_switch_miss.json` (structural allowlist: ligature
+names, tag counts — no cookies, tokens, prompts, or page text). **If you hit
+this, attach that JSON file to
+[#493](https://github.com/ffroliva/gflow-cli/issues/493)** — recognizing the
+variant (and restoring a clean retryable classification, or full support) needs
+exactly that DOM signature. Re-running later may land the classic editor if
+the rollout is still an A/B arm.
+
 ### Flow's new full-page media-library UI breaks entity attach (A/B rollout)
 
 - **Status:** **Open** — Flow-side staged rollout; tracked in
@@ -203,8 +228,8 @@ classic `crop_*` aspect/mode control, so `gflow image`/`gflow video` can't drive
 generation. Rather than the old opaque `UiSelectorDriftError` "file a bug", the
 mode-switch raise site now runs a runtime DOM scan and raises a clear, **retryable**
 `FlowAgentUiError` (**exit 25**, "this cohort flaps; retry shortly"), and dumps a
-DOM-signature diagnostics artifact (`diag_mode_switch_miss.json` + a full-page
-screenshot) for reporting. The cohort is server-assigned per page load and flaps
+DOM-signature diagnostics artifact (`diag_mode_switch_miss.json`; the incident
+bundle carries the full-page screenshot under `sensitive/`) for reporting. The cohort is server-assigned per page load and flaps
 within ~12h, so a re-run often lands the classic UI. Driving the new UI directly
 is still out of scope.
 

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -1348,7 +1348,7 @@ shell scripts can branch on the failure mode without parsing stderr.
 | `20` | `FrameExtractionError` | Could not extract the last frame for a video chain link | Check the source video downloaded intact; retry the link  |
 | `21` | `ChainPartialError`   | A video chain stopped mid-way; earlier links completed | Resume from the last completed link shown in the error     |
 | `22` | `UpscaleUnavailableError` | 4K upscale is gated to Flow **Ultra** accounts (HTTP 403) | Use `--scale 2k`, or upgrade the Flow plan                |
-| `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issue #183) | Update gflow-cli; file a bug with the probe name + debug screenshot from the error message |
+| `23` | `UiSelectorDriftError` | A Flow editor control could not be located — Google changed the frontend (issues #183, #493) | Update gflow-cli; file a bug with the probe name + the diagnostics JSON / debug screenshot referenced in the error message |
 | `24` | `BrowserEngineUnavailableError` | `GFLOW_CLI_BROWSER_ENGINE=patchright` but the engine is not installed | `pip install 'gflow-cli[patchright]'`, or unset `GFLOW_CLI_BROWSER_ENGINE` |
 | `25` | `FlowAgentUiError`    | The profile is on Flow's Agentic UI cohort and the classic media panel is unrecoverable for this operation | Rare since v0.38.0 (#332): the mode controller reliably recovers agentic→classic, so first retry with `--ui-mode classic`; if it persists, see KNOWN_ISSUES on the agentic cohort |
 | `26` | `MediaAttributionError` | Generated media could not be reliably attributed to this request (issue #281) | Re-run; a dedicated project with fewer pre-existing assets avoids the ambiguity |


### PR DESCRIPTION
## Summary

Refs #493 — external report (macOS, v0.55.0/v0.53.1): every `gflow video r2v` fails immediately with `UiSelectorDriftError: probe=mode_switch_trigger` (exit 23). The reporter's screenshot shows a **third, unrecognized Flow editor variant** (frame slots directly on the composer + an "Agente" toggle, no classic `crop_*` settings button). Reaching the exit-23 fall-through *proves* none of the known cohort indicators matched — this is a new layout, not the known agentic/media-library cohorts, and not a locale issue (the cascade is icon-ligature-based, locale-invariant).

A 5-persona `/gflow:predict` gate was run on the originally-proposed reload-re-roll rescue and returned **STOP on the reload half** (a mid-flow reload violates the test-locked single-sanctioned-reload-site invariant in `mode_control.py:159-165`; the #338 record shows the comparable arm was *pinned*, not flapping per-load; ~2.9× failure latency; diagnostics overwrite). The **message/remediation half got a unanimous GO** and is what this PR ships. Recognizing the new variant (flipping 23 → retryable 25, or full support) requires the affected account's DOM signature, which has been requested on the issue.

## What changed

- `ui_automation_video.py` — the `_mode_switch_error` fall-through detail (shared by image + video paths, fall-through branch only) now states that no known Flow cohort matched and the editor may be a new, unrecognized layout (issue #493).
- `errors.py` — `UiSelectorDriftError._default_remediation` no longer asks for a "debug screenshot from this message" that the mode-switch probe never writes (it emits a diagnostics JSON, no screenshot). It now points at the artifacts drift sites actually reference: the PII-safe `diag_mode_switch_miss.json` DOM signature and/or the referenced screenshot, plus the incident bundle's `report.md`. Fixes the stale ask for **every** drift site at once.
- `KNOWN_ISSUES.md` — new Open entry for the third editor variant with the "attach `diag_mode_switch_miss.json` to #493" ask; corrected the #174 entry's stale claim that the diagnostics wrapper writes a screenshot (the incident bundle owns it under `sensitive/`).
- `docs/USAGE.md` — exit-23 row now references the diagnostics JSON (both changes propagated to `website/docs/` via `scripts/ci/generate_website_docs.py`, verified with `--check`).
- `CHANGELOG.md` — Unreleased → Fixed entry.
- Tests: new `test_mode_switch_drift_detail_flags_unrecognized_variant` (cohort-detection suite) and `test_ui_selector_drift_remediation_names_real_artifacts` (errors suite). Red-at-HEAD verified via `git grep` (neither asserted string exists at HEAD).

## Deliberately NOT in this PR (predict-gate outcome)

- No reload-retry rescue (STOP verdict: invariant violation, unevidenced flap assumption for this variant, latency/diagnostics regressions).
- No speculative detection selectors for the new variant (its DOM shape is unknown until the reporter's diagnostics JSON arrives).
- No selector, exit-code, flag, or MCP-surface changes (no CLI/MCP parity impact).

## Verification status

- [x] Red-at-HEAD proven (`git grep` — asserted strings absent), new tests green after fix
- [x] 244 tests green across the affected suites (`test_errors`, `test_agentic_cohort_detection`, `test_ui_automation_video`, `test_ui_automation_image_mode`, `test_cli_image_selector_drift`, `test_mode_control`, `test_selector_symmetry`)
- [x] `ruff check src tests` + `ruff format --check src tests` clean (the exact CI gate)
- [x] `scripts/ci/check_repo_hygiene.py`, `check_doc_links.py`, `check_website_docs_pii.py`, `generate_website_docs.py --check` all clean
- [x] Branch rebased onto develop @ `1148cc2` (CI green)
- [ ] `pyright src` — local worktree runs show pre-existing environment noise in `mcp/*`/`ui/app.py` (the known worktree-pyright false-positive class; reproduced on Python 3.12 and 3.13, zero diagnostics in the files this PR touches, develop CI green on the same gate). **CI is authoritative here.**
- [ ] **Needs human e2e:** the affected surface (the new Flow editor variant) exists only on the reporter's account/cohort — it cannot be reached from this environment. The changed strings are error-path only; a normal generation on a classic-cohort account confirms the happy path is untouched. Falsifiable signals for the verifier: happy path logs `ui_automation_video.selector_matched probe=mode_switch_trigger` then `video_mode_entered`; an affected account logs `selector_probe_failed probe=mode_switch_trigger` followed by the `diag_mode_switch_miss.json` write.

## Council review (post-push, SHA-pinned)

An 8-dimension council (`/gflow:pr-council-review`) ran against the first pushed commit: D0 mechanical CI gate + D1 correctness, D2 quality, D3 security, D4 tests, D5 memory, D6 UI/locale, D9 docs drift, D14 YAGNI. Verdict: **YELLOW → fixed in the follow-up commit**. The one must-fix (D9): `docs/DEBUGGING.md` promised a `debug_no_mode_trigger.png` that no code writes — same wrong-artifact class this PR fixes; corrected to `diag_mode_switch_miss.json`. Applied nice-to-haves: finished the `UiSelectorDriftError` docstring rewording, aligned `FlowAgentUiError`'s screenshot caveat with the incident-bundle reality, hedged the KNOWN_ISSUES capture claim ("when it can be captured"), folded the duplicated drift test into the existing one, tightened the remediation test's privacy assert. Declined with justification: the remediation's `report.md` clause stays (it is the only pointer on the JSON/MCP error surface); synthetic drift-detail fixtures in tests stay untouched (they assert exit codes, not wording). D3 verified end-to-end that instructing users to attach `diag_mode_switch_miss.json` + `report.md` publicly is safe (structural allowlist, sanitized URLs, HMAC-hashed ids, no cookie API on the capture path).

## Follow-ups (issue-side, for the maintainer to relay)

Zero-code experiments for the reporter (from the predict gate's Devil's-Advocate analysis):
1. Attach `diag_mode_switch_miss.json` (already requested on #493) — its ligature inventory is the DOM signature needed for a one-tuple recognition fix.
2. Grep their structured log for `ui_automation_video.exit_agent_mode_no_panel` — present means something was clickable (the #338 gated reload could apply); absent means any reload rescue would have been placebo.
3. Try `gflow image t2i --ui-mode classic` — exercises the one sanctioned reload rescue on the image path and discriminates pinned vs re-rollable arm.
4. Hard-reload the Flow editor 5-10× in a normal browser — does the classic `crop_*` toolbar ever appear?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
