### PR TITLE
docs(mcp): remove false safety claims (credit budgets, pre-flight auth) — doc-truth sweep (Closes #495)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -251,8 +251,7 @@ Non-loopback binds (e.g. `--host 0.0.0.0`) require `GFLOW_DAEMON_TOKEN` to be se
 
 Because the MCP server runs locally, inheriting the host user's permissions and access to their authenticated browser cookies, the following security constraints are enforced:
 
-1. **Pre-flight Auth Validation:** Before launching Chromium/Playwright (which would hang on interactive stdin prompts if cookies are expired), the server checks session validity. If unauthenticated, it returns:
-   `"Authentication required. Run 'gflow auth login' in your local terminal."`
+1. **Profile Pre-flight:** Before enqueuing work, each tool resolves and validates the target profile directory (`_resolve_and_validate_profile` — existence and home-boundary checks). There is **no session-validity probe before launching Chromium**: expired cookies surface as a typed `AuthExpiredError` from the generation run itself, with the remediation `Run 'gflow auth login' in your local terminal.`
 2. **Channel Isolation:** All internal `structlog` configurations are forced to write to `sys.stderr`. The standard output stream (`sys.stdout`) is globally captured and redirected to `sys.stderr` for any unexpected prints, preserving the integrity of the stdio JSON-RPC pipe.
 3. **Windows Stdio Encoding:** During startup, stdio streams are explicitly reconfigured:
    ```python
@@ -260,5 +259,5 @@ Because the MCP server runs locally, inheriting the host user's permissions and 
    sys.stdin.reconfigure(encoding='utf-8')
    ```
    This prevents crashes caused by non-ASCII prompt strings on Windows.
-4. **Local Rate-Limiting:** Enforces a token-bucket rate limiter with a capacity of 8 tokens and a refill rate of 1 token every 20 seconds (allowing burst filmmaking tasks without timeouts). It also evaluates cumulative session and daily limits (`GFLOW_CLI_SESSION_CREDIT_LIMIT` and `GFLOW_CLI_DAILY_BUDGET`) against SQLite logs, failing fast to prevent credit depletion attacks.
-5. **CLI-MCP Parameter Symmetry:** Automated checks in the CI test suite (`tests/mcp/test_server.py`) compare CLI Click parameters with registered MCP tool signatures, ensuring that any added options or flags in the CLI are instantly mirrored in the MCP layer to prevent schema drift.
+4. **Local Rate-Limiting:** Enforces a token-bucket rate limiter with a capacity of 8 tokens and a refill rate of 1 token every 20 seconds (allowing burst filmmaking tasks without timeouts). This is the **only** spend brake — there is no credit-budget accounting or per-session/daily cap (#495; a registration-time `--no-spend` gate is tracked in #496).
+5. **CLI-MCP Parameter Symmetry:** Automated checks in the CI test suite (`tests/mcp/test_cli_parity.py`) compare CLI Click parameters with registered MCP tool signatures, ensuring that any added options or flags in the CLI are instantly mirrored in the MCP layer to prevent schema drift.

--- a/src/gflow_cli/mcp/resources.py
+++ b/src/gflow_cli/mcp/resources.py
@@ -50,7 +50,7 @@ Generate images using Google's Imagen model.
 Generate videos using Google's Veo model.
 - **Modes:** t2v (text-to-video), i2v (image-to-video), r2v (reference-to-video)
 - **Aspects:** 9:16 (portrait), 16:9 (landscape)
-- **Note:** i2v/r2v require an image_path
+- **Note:** i2v requires `initial_frame`; r2v requires `reference_images`
 
 ### gflow_list_projects
 Browse the local project catalog.

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -5,8 +5,8 @@ Each tool is registered on the shared MCPServer instance and delegates
 to FlowWorker / DataStore / data.queries for actual execution.
 
 Rate limiting: a token-bucket (capacity=8, refill=1/20s) prevents runaway
-agentic loops from burning credits. Session and daily budget limits are
-enforced by checking spent amounts against SQLite records.
+agentic loops from burning credits. There is NO credit-budget accounting —
+rate limiting is the only spend brake (#495).
 
 Task claiming: the direct-execution path enqueues a task then claims it via
 the atomic ``QueueRepository.claim_task`` (the same BEGIN IMMEDIATE claim the

--- a/tests/mcp/test_cli_parity.py
+++ b/tests/mcp/test_cli_parity.py
@@ -14,12 +14,12 @@ has no instructions support — agentic-video is a deliberate typed divergence
 (``drivers/agentic.py`` raises ``FlowAgentUiError``). An ``instructions`` param
 on the video tool would be silently dropped, so it is intentionally absent.
 
-Note on ``--output``/``-o`` (#411): intentionally NOT mirrored on the generate
-tools. The MCP generation path runs through the worker queue, whose codec
-(``worker/codec.py``) does not decode an ``output_file`` key and whose daemon
-hardcodes the date-partitioned destination — an ``output`` param there would be
-a silent no-op (a v0.48.0 pre-release audit caught exactly that and removed
-it). Wire the key through codec + daemon before re-adding the param.
+Note on ``--output``/``-o`` (#411): mirrored since the wiring landed — both
+generate tools accept ``output`` (``tools.py``) and put ``output_file`` in the
+task payload, which the daemon decodes and relocates the artifact to
+(``worker/daemon.py``). A v0.48.0 pre-release audit removed an earlier dead
+param that the queue never read; the docstring here claimed that state long
+after the real wiring shipped (#495).
 
 Note on ``image t2i --jitter`` (#241): intentionally NOT mirrored on
 ``gflow_generate_image``. The jitter paces submissions *between prompts* in a

--- a/tests/mcp/test_resources.py
+++ b/tests/mcp/test_resources.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+"""Truth guards for MCP resources (#495).
+
+The agent guide is our own instruction sheet — an agent following it must
+never be told to pass a parameter that does not exist on the registered
+tools. #495 caught the guide naming ``image_path`` while the real video
+parameters are ``initial_frame`` / ``reference_images``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mcp_guide_names_real_video_params() -> None:
+    from gflow_cli.mcp.resources import mcp_guide
+
+    text = await mcp_guide()
+    assert "image_path" not in text, "#495: image_path is not a real parameter"
+    assert "initial_frame" in text
+    assert "reference_images" in text

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -251,8 +251,7 @@ Non-loopback binds (e.g. `--host 0.0.0.0`) require `GFLOW_DAEMON_TOKEN` to be se
 
 Because the MCP server runs locally, inheriting the host user's permissions and access to their authenticated browser cookies, the following security constraints are enforced:
 
-1. **Pre-flight Auth Validation:** Before launching Chromium/Playwright (which would hang on interactive stdin prompts if cookies are expired), the server checks session validity. If unauthenticated, it returns:
-   `"Authentication required. Run 'gflow auth login' in your local terminal."`
+1. **Profile Pre-flight:** Before enqueuing work, each tool resolves and validates the target profile directory (`_resolve_and_validate_profile` — existence and home-boundary checks). There is **no session-validity probe before launching Chromium**: expired cookies surface as a typed `AuthExpiredError` from the generation run itself, with the remediation `Run 'gflow auth login' in your local terminal.`
 2. **Channel Isolation:** All internal `structlog` configurations are forced to write to `sys.stderr`. The standard output stream (`sys.stdout`) is globally captured and redirected to `sys.stderr` for any unexpected prints, preserving the integrity of the stdio JSON-RPC pipe.
 3. **Windows Stdio Encoding:** During startup, stdio streams are explicitly reconfigured:
    ```python
@@ -260,5 +259,5 @@ Because the MCP server runs locally, inheriting the host user's permissions and 
    sys.stdin.reconfigure(encoding='utf-8')
    ```
    This prevents crashes caused by non-ASCII prompt strings on Windows.
-4. **Local Rate-Limiting:** Enforces a token-bucket rate limiter with a capacity of 8 tokens and a refill rate of 1 token every 20 seconds (allowing burst filmmaking tasks without timeouts). It also evaluates cumulative session and daily limits (`GFLOW_CLI_SESSION_CREDIT_LIMIT` and `GFLOW_CLI_DAILY_BUDGET`) against SQLite logs, failing fast to prevent credit depletion attacks.
-5. **CLI-MCP Parameter Symmetry:** Automated checks in the CI test suite (`tests/mcp/test_server.py`) compare CLI Click parameters with registered MCP tool signatures, ensuring that any added options or flags in the CLI are instantly mirrored in the MCP layer to prevent schema drift.
+4. **Local Rate-Limiting:** Enforces a token-bucket rate limiter with a capacity of 8 tokens and a refill rate of 1 token every 20 seconds (allowing burst filmmaking tasks without timeouts). This is the **only** spend brake — there is no credit-budget accounting or per-session/daily cap (#495; a registration-time `--no-spend` gate is tracked in #496).
+5. **CLI-MCP Parameter Symmetry:** Automated checks in the CI test suite (`tests/mcp/test_cli_parity.py`) compare CLI Click parameters with registered MCP tool signatures, ensuring that any added options or flags in the CLI are instantly mirrored in the MCP layer to prevent schema drift.


### PR DESCRIPTION
## Summary

Deletes MCP safety claims that do not exist in code (council-adjudicated in #495: delete the claims, do not implement the features):

- **MCP.md §5.1** — no pre-flight session-validity probe exists; now describes the real profile-dir validation (`_resolve_and_validate_profile`) and the typed `AuthExpiredError` path.
- **MCP.md §5.4** — `GFLOW_CLI_SESSION_CREDIT_LIMIT` / `GFLOW_CLI_DAILY_BUDGET` have zero code hits; the false budget-cap promise (real money) is removed. Token-bucket stated as the only spend brake; points at #496 for the planned `--no-spend` gate.
- **MCP.md §5.5** — parity checks are in `test_cli_parity.py`, not `test_server.py` (extra drift found during verification).
- **tools.py docstring** — budget fiction removed.
- **test_cli_parity.py docstring** — the `--output` note claimed the daemon hardcodes destinations; `worker/daemon.py:239-250` decodes `output_file` and both generate tools send it (`tools.py:812-813`, `:880-881`).
- **mcp-guide resource** — i2v/r2v take `initial_frame` / `reference_images`, not the nonexistent `image_path`; new truth-guard test `tests/mcp/test_resources.py` pins it (written failing first).

Deliberate DoD reading: `docs/superpowers/` planning artifacts keep the env-var strings as unshipped-plan history — they are project-management records slated for consolidation, not user-facing claims.

## Verification status

- [x] TDD: truth-guard test failed before the fix, green after
- [x] `tests/mcp/` suite: 138 passed
- [x] ruff check + format-check, pyright: clean
- [x] doc links, website PII, mirror sync: green
- [x] DoD grep: no budget env-var mentions outside `docs/superpowers/`
- [x] Browser-free surface — fully verifiable here; no residual e2e gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)