### PR TITLE
chore(ci): OpenSSF Scorecard self-run with published results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+name: OpenSSF Scorecard
+
+# Self-run of the OpenSSF Scorecard supply-chain checks (T2 batch decision,
+# 2026-08-13). Deliberately enabled AFTER the permissions + SHA-pinning
+# hardening landed, so the first published public score reflects the hardened
+# state — Token-Permissions and Pinned-Dependencies are heavily weighted.
+# publish_results feeds the public API/badge:
+#   https://api.scorecard.dev/projects/github.com/ffroliva/gflow-cli/badge
+
+on:
+  # Re-evaluates the Branch-Protection check when protection rules change.
+  branch_protection_rule:
+  schedule:
+    - cron: "30 3 * * 1" # weekly, Monday 03:30 UTC
+  push:
+    branches: [develop] # default branch — required for publish_results
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF to the Security tab
+      id-token: write # OIDC identity for publish_results signing
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishing makes the score available via the public API and badge.
+          # The repo is public; every input to the score already is too.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **CI supply-chain hardening.** Every workflow now runs with a least-privilege token (`ci.yml` gained the top-level `permissions: contents: read` it was missing — the other eight already had one; gitleaks elevates `pull-requests: write` per-job); every `uses:` action across all nine workflows is pinned to a full commit SHA with a version comment (dependabot's `github-actions` group keeps pins fresh); the CI test jobs enforce a test-count floor via `scripts/ci/check_test_count.py` ("a green build that ran nothing is not green"); and `check_repo_hygiene.py` now fails on version disagreement between `pyproject.toml`, `__init__.py`, and `.codex-plugin/plugin.json`.
+- **OpenSSF Scorecard self-run.** A new SHA-pinned `scorecard.yml` workflow (weekly + on push to `develop`) runs the OpenSSF Scorecard supply-chain checks with `publish_results: true`, feeding the public API/badge and the repo Security tab — enabled deliberately after the permissions/pinning hardening so the first published score reflects the hardened state.
 
 ## [0.56.0] — 2026-08-13
 


### PR DESCRIPTION
## Summary

Second CI-hardening PR (ordering per the assessed plan: permissions + SHA-pinning landed first in #508, so the first published public score reflects the hardened state).

- New `scorecard.yml`: `ossf/scorecard-action` **SHA-pinned to v2.4.4**, running weekly (Mon 03:30 UTC), on push to `develop` (the default branch — required for publishing), and on `branch_protection_rule` changes.
- `publish_results: true` → the public Scorecard API and badge (`https://api.scorecard.dev/projects/github.com/ffroliva/gflow-cli/badge`) serve the score; SARIF is uploaded to the repo Security tab (`codeql-action/upload-sarif`, pinned v4).
- Least-privilege: workflow-level `read-all`; the job elevates only `security-events: write` (SARIF) and `id-token: write` (OIDC signing for publish).
- No third-party scanner beyond Scorecard (per the #484 decision).

Badge in README + website index and a docs/SECURITY.md section follow in a third PR **after** the badge endpoint returns a real score (it can't before this workflow's first develop run publishes).

## Verification

- Workflow YAML parses; all three `uses:` pinned to full SHAs resolved via `gh api` (scorecard-action v2.4.4, upload-artifact v7.0.1, codeql-action v4).
- Repo hygiene gate green.
- The first real publish is only observable post-merge on a develop push — I'll verify the run and the badge endpoint before opening the badge PR.

## Docs

CHANGELOG [Unreleased] § Security extended.