### PR TITLE
chore: sweep the /code-review dropped-tail findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (issue titles + status + slugs, a few KB); one templated resource
   (`gflow://docs/known-issues/{slug}`) serves a single issue's full text,
   capped at 16 KB. No unbounded read path remains.
+
 ### Added
 
 - **`gflow mcp run --no-spend` (#496).** Registration-time gating of the
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `remediation_hint` points at the CLI login (or at retrying, for a network
   `verification_error` that re-login cannot fix). `auth status` accordingly
   moves out of the MCP parity exemptions; login/logout stay CLI-only.
+
 ### Fixed
 
 - **MCP response-contract breaches (#498).** Both generate tools now refuse

--- a/docs/superpowers/spikes/2026-08-01-mcp-2026-07-28-spec-impact.md
+++ b/docs/superpowers/spikes/2026-08-01-mcp-2026-07-28-spec-impact.md
@@ -229,8 +229,10 @@ Today, expired cookies produce a terminal error: *"Authentication required. Run 
 your local terminal."* The agent's operation dies and the user context-switches to a shell. MRTR lets
 us return `InputRequiredResult` instead and resume the original request once the user acts. The same
 mechanism fits confirmation-before-spend, which matters for a tool that burns metered Flow credits —
-the rate limiter and `GFLOW_CLI_DAILY_BUDGET` currently fail *closed* with an error where a
-confirmation round-trip would be the better UX.
+the rate limiter currently fails *closed* with an error where a confirmation round-trip would be
+the better UX. (Historical note: this spike originally also named `GFLOW_CLI_DAILY_BUDGET`, which
+never existed in code — the fictional budget claims were removed in #495; the real spend gate is
+`--no-spend`, #496.)
 
 Worth scoping carefully: MRTR needs `requestState` to be reconstructible, and our generation payloads
 are large. Prototype behind the auth case first, where the state is small.

--- a/tests/mcp/test_http_transport.py
+++ b/tests/mcp/test_http_transport.py
@@ -88,5 +88,5 @@ async def test_serve_speaks_streamable_http(tmp_path) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.communicate(timeout=10)
-    # Clean shutdown: terminate must actually end the process.
-    assert proc.returncode is not None
+    # (communicate() above only returns once the process has exited, so no
+    # separate returncode assert — it could never fail.)


### PR DESCRIPTION
Final sweep of the xhigh review's below-cap findings: CHANGELOG heading spacing, the unfalsifiable shutdown assert, and the spike doc's fictional `GFLOW_CLI_DAILY_BUDGET` claim (annotated, not scrubbed — it is a dated historical record). Test-helper dedup deliberately skipped (3 small copies beat cross-package plumbing).

- [x] transport smoke green; ruff/format/doc-links/mirror clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)