### PR TITLE
chore(deps): bump astral-sh/setup-uv from 7.6.0 to 9.0.0 (manual relay of #523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Audit locked dependencies for known CVEs
         # Fails the build on any known advisory. Accept later via: pip-audit --ignore-vuln <GHSA-id>
         #
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Set up Python
         run: uv python install 3.13
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/deps-watch.yml
+++ b/.github/workflows/deps-watch.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/governance-advisory.yml
+++ b/.github/workflows/governance-advisory.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0 # full history so `git diff origin/<base>..HEAD` resolves
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Classify touched paths (advisory, never blocks)
         run: |

--- a/.github/workflows/governance-benchmark.yml
+++ b/.github/workflows/governance-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0 # full history — the backtest replays every commit
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run backtest (advisory; writes to job summary)
         run: uv run python scripts/dev/materiality_backtest.py >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Set up Python
         run: uv python install 3.12


### PR DESCRIPTION
## Summary

Dependabot's exact commit from #523, cherry-picked and pushed by a maintainer so `pull_request` CI can dispatch: GitHub silently creates **no workflow runs** for the workflows a dependabot PR itself modifies (verified on #523 — unmodified workflows dispatched, all five modified ones didn't), so #523 could never self-validate.

- `astral-sh/setup-uv` 7.6.0 → 9.0.0 (SHA-pinned) across ci.yml, deps-watch.yml, governance-advisory.yml, governance-benchmark.yml, release.yml.
- Breaking-change review: v8 removed moving tags (irrelevant — we pin SHAs) and the deprecated custom-manifest input format (unused); v9 changed `prune-cache` default and cache internals. Every usage in this repo is a bare `uses:` with zero inputs — no impact.
- #523 will auto-close as up-to-date once this merges.

Refs #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)