### PR TITLE
spike(video): per-model capability matrix — root-causes the #451/#288 duration drift

### DIFF
--- a/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
+++ b/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
@@ -1,0 +1,73 @@
+# Spike evidence — per-model capability matrix in the classic video composer
+
+**Date:** 2026-08-14 · **Verdict: ROOT CAUSE FOUND for #451 / #288 — the duration
+control is MODEL-CONDITIONAL, not "dropped by Flow".** `api/video.py:44`'s claim
+that "the four `VEO_3_1_*` models cap at 8s" is wrong: they expose **no duration
+control at all**. Only `Omni Flash` renders a duration row.
+
+## Method
+
+Zero credits — navigation + settings-popover reads only. Never typed a prompt,
+never clicked Generate. Selecting a model in the picker does not bill.
+
+`scripts/dev/capture_video_model_capability_matrix.py --profile ffroliva
+--project 5ee3e625-…`: opened the real editor, restored the classic composer
+(`mode_control.ensure_media_mode`, since the account's persisted
+`isAgentModeToggled` can serve the agentic arm), then for **each** registered
+`VideoModel` selected it in the picker and read the open popover's
+`[role='tab']` inventory, the live credit line, and the composer chip.
+
+Raw capture: `scripts/dev/_spike_out/video_model_capability_matrix_*.json`
+(gitignored). Owner screenshots of the same states are in issue #451.
+
+## Result
+
+| Model | Duration tabs | Count tabs | Credits | Ingredients |
+|---|---|---|---|---|
+| `omni_flash` | **`4s` `6s` `8s` `10s`** | `x1`–`x4` | 15 (@10s), 7 (@4s) | accepted |
+| `veo_3_1_lite` | **none** | `x1`–`x4` | 10 | accepted |
+| `veo_3_1_fast` | **none** | `x1`–`x4` | 20 | accepted |
+| `veo_3_1_quality` | **none** | `x1`–`x4` | 100 | **REJECTED** |
+| `veo_3_1_lite_lower_priority` | picker miss | — | — | — |
+
+Ingredient column is from owner recon (an attached ingredient is required to
+observe it; the automated run had none attached). `Veo 3.1 - Quality` greys the
+ingredient thumbnail with **"You cannot use image ingredients with this model."**
+while `Veo 3.1 - Fast` and `Omni Flash` accept the same asset.
+
+## Interpretation
+
+1. **#451 / #288 are not selector drift and never were a Playwright regression.**
+   The prior A/B (`playwright` 1.59 vs 1.61) found the duration tabs missing on
+   BOTH, and the locale hypothesis was refuted — because the tabs were never
+   there for the model under test. `_select_video_duration` hunts a control the
+   Veo 3.1 models do not render, so `--duration` can only ever work on
+   `omni_flash`. The resulting exit 23 reports "UI drift" for what is really a
+   **model capability mismatch**.
+2. **`VideoModel` is missing an ingredient-capability axis.** `supports_frames()`
+   exists for i2v, but nothing models "accepts image ingredients", so
+   `gflow video r2v --model veo-quality --ref x.jpg` drives an impossible
+   combination and burns selector timeouts instead of failing fast at the DTO.
+3. **Credit cost is readable in the DOM** (`Generating will use N credits`) and
+   varies by model **and duration** (omni: 7 @4s → 15 @10s). Nothing in the
+   transport reads it today. This is the missing input for the deferred
+   tier-aware credit-confirmation work.
+4. **A dynamic composer chip now summarises the selection.** Captured raw
+   textContent: `Video · 10scrop_9_16x1` — i.e. duration + aspect **icon
+   ligature** + count. It is a genuine read-back affordance (verify what is
+   actually selected), but any matcher must strip Material Symbols ligatures —
+   the usual locale-leak trap.
+5. `veo_3_1_lite_lower_priority` did not match its picker selector in this run;
+   its `:not()` exclusion form needs re-deriving. Recorded, not fixed here.
+
+## Recommended follow-ups (none applied in this spike)
+
+- Correct `api/video.py:44`'s docstring and add a `supports_duration()` capability
+  (true only for `OMNI_FLASH` on current evidence), then fail `--duration` fast at
+  the DTO for models without the control, with a message naming the model — not
+  a drift error.
+- Add an ingredient-capability predicate and reject `r2v` + `veo_3_1_quality`
+  pre-submit.
+- Re-verify the matrix on a second account before hard-coding: this is a live UI
+  observation on one cohort, and Flow's arms flap
+  (see [[flow-agent-settings-panel-sticky-defaults]], `#404` label-rename precedent).

--- a/scripts/dev/capture_video_model_capability_matrix.py
+++ b/scripts/dev/capture_video_model_capability_matrix.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+r"""Live $0 recon — per-model capability matrix for the classic video composer.
+
+WHY (2026-08-14 owner recon): the settings popover is **model-conditional**.
+Screenshots showed `Omni Flash` rendering a duration row (4s/6s/8s/10s) while
+`Veo 3.1 - Quality/Lite/Fast` render **no duration control at all**, and
+`Veo 3.1 - Quality` rejecting image ingredients ("You cannot use image
+ingredients with this model.") that `Veo 3.1 - Fast` accepts.
+
+`api/video.py:44` currently claims "the four VEO_3_1_* models cap at 8s", which
+assumes they expose a duration control. If they expose none, that is the
+unexplained root cause of #451 / #288 (`--duration` "broken", A/B-identical on
+playwright 1.59 and 1.61 — never a Playwright regression, never locale).
+
+This spike reads the popover for EVERY model and dumps a structured matrix:
+duration tabs, count tabs, the live credit cost, the composer tag, and any
+ingredient-rejection notice.
+
+**Credit-free by construction:** navigation + popover reads only. It never types
+a prompt and never clicks Generate. Selecting a model in the picker does not
+bill; only submission does.
+
+Usage:
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\capture_video_model_capability_matrix.py \
+        --profile ffroliva --project 5ee3e625-ff3f-44a1-9f17-1434f432f30e
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+sys.path.insert(0, str(_ROOT / "scripts" / "dev"))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.mode_control import CROP_SELECTORS  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    MODEL_PICKER_TRIGGER,
+    VIDEO_MODEL_OPTION_SELECTORS,
+)
+from gflow_cli.api.video import VideoModel  # noqa: E402
+
+
+async def _wait_editor(page: Any) -> bool:
+    for _ in range(30):
+        if (
+            await page.locator('div[role="textbox"], textarea').count() > 0
+            or await page.locator("button").count() > 8
+        ):
+            return True
+        await page.wait_for_timeout(1000)
+    return False
+
+
+async def _open_settings(page: Any) -> bool:
+    """Ensure the settings popover is OPEN, idempotently.
+
+    The crop_* trigger is a TOGGLE: clicking it while the popover is already
+    open closes it. Clicking unconditionally produced empty reads alternating
+    with model-picker misses (the picker lives *inside* the popover), so probe
+    for the menu first and only click when it is absent.
+    """
+    if await page.locator("[role='menu']").count() > 0:
+        return True
+    for sel in CROP_SELECTORS:
+        loc = page.locator(sel).first
+        if await loc.count() > 0:
+            try:
+                await loc.click(timeout=4000)
+                await page.wait_for_timeout(600)
+            except Exception:  # noqa: BLE001 - benign: a racing render may have opened it
+                pass
+            return await page.locator("[role='menu']").count() > 0
+    return False
+
+
+async def _menu_state(page: Any) -> dict[str, Any]:
+    """Structured read of the OPEN settings popover — pure DOM, no clicks."""
+    return await page.evaluate(
+        """() => {
+          const menu = document.querySelector("[role='menu']");
+          const scope = menu || document.body;
+          const tabs = [...scope.querySelectorAll("[role='tab']")].map(t => ({
+            label: (t.getAttribute('aria-label') || t.textContent || '').trim(),
+            id: t.id || null,
+            selected: t.getAttribute('aria-selected') === 'true',
+          })).filter(t => t.label);
+          const text = (scope.textContent || '').replace(/\\s+/g, ' ').trim();
+          const creditRe = /Generating will use\\s+([\\d,]+)\\s+credits?/i;
+          const credits = (text.match(creditRe) || [])[1] || null;
+          // The composer's dynamic summary chip, e.g. "Video · 4s ▭ x1".
+          const chip = [...document.querySelectorAll('button, div')]
+            .map(e => (e.textContent || '').replace(/\\s+/g, ' ').trim())
+            .filter(t => /^Video\\b/.test(t) && t.length <= 40)
+            .sort((a, b) => a.length - b.length)[0] || null;
+          return {
+            menu_present: !!menu,
+            tabs,
+            credits_text: credits,
+            composer_chip: chip,
+            model_trigger_label: (document.querySelector(
+              "button[aria-haspopup='menu'] , button") && null),
+            ingredient_reject: document.body.innerText
+              .toLowerCase().includes('cannot use image ingredients'),
+          };
+        }"""
+    )
+
+
+def _classify(tabs: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Split the popover's tab labels into duration vs count vs aspect."""
+    duration, count, aspect, other = [], [], [], []
+    for t in tabs:
+        label = t["label"]
+        if label.rstrip().endswith("s") and label[:-1].strip().isdigit():
+            duration.append(label)
+        elif label.lower().startswith("x") and label[1:].strip().isdigit():
+            count.append(label)
+        elif ":" in label:
+            aspect.append(label)
+        else:
+            other.append(label)
+    return {"duration": duration, "count": count, "aspect": aspect, "other": other}
+
+
+async def _select_model(page: Any, model: VideoModel) -> bool:
+    """Open the model picker and click *model*. No submit; nothing is billed."""
+    trigger = page.locator(MODEL_PICKER_TRIGGER).first
+    if await trigger.count() == 0:
+        return False
+    try:
+        await trigger.click(timeout=4000)
+        await page.wait_for_timeout(500)
+    except Exception:  # noqa: BLE001
+        return False
+    option = page.locator(VIDEO_MODEL_OPTION_SELECTORS[model]).first
+    if await option.count() == 0:
+        await page.keyboard.press("Escape")
+        return False
+    try:
+        await option.click(timeout=4000)
+        await page.wait_for_timeout(800)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+async def _run(profile: str, project: str) -> int:
+    rows: list[dict[str, Any]] = []
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+
+        step("nav", f"goto editor for project {project}")
+        await page.goto(
+            routes.project_editor_url("en", project),
+            wait_until="domcontentloaded",
+            timeout=60_000,
+        )
+        if not await _wait_editor(page):
+            step("nav", "ERROR: editor never became ready")
+            return 1
+
+        # The account's `isAgentModeToggled` persists server-side, so the editor
+        # can load agentic (no crop_* trigger, no classic settings popover).
+        # Restore classic with the production primitive — this is the sanctioned
+        # pre-bind reload site, and this spike is pre-bind recon.
+        if not await _open_settings(page):
+            step("mode", "no classic composer — running ensure_media_mode()")
+            from gflow_cli.api.transports import mode_control  # noqa: PLC0415
+
+            acted = await mode_control.ensure_media_mode(page, allow_reload=True)
+            step("mode", f"  ensure_media_mode acted={acted}")
+            await _wait_editor(page)
+
+        if not await _open_settings(page):
+            step("menu", "ERROR: still no crop_* settings trigger after mode recovery")
+            return 1
+
+        baseline = await _menu_state(page)
+        step("menu", f"baseline tabs={len(baseline['tabs'])} credits={baseline['credits_text']}")
+
+        for model in VideoModel:
+            step(model.value, "selecting...")
+            await _open_settings(page)
+            ok = await _select_model(page, model)
+            if not ok:
+                rows.append({"model": model.value, "selected": False})
+                step(model.value, "  picker miss — recorded, continuing")
+                continue
+            await _open_settings(page)
+            state = await _menu_state(page)
+            groups = _classify(state["tabs"])
+            row = {
+                "model": model.value,
+                "selected": True,
+                "duration_tabs": groups["duration"],
+                "has_duration_control": bool(groups["duration"]),
+                "count_tabs": groups["count"],
+                "aspect_tabs": groups["aspect"],
+                "credits_text": state["credits_text"],
+                "composer_chip": state["composer_chip"],
+                "ingredient_rejected": state["ingredient_reject"],
+            }
+            rows.append(row)
+            step(
+                model.value,
+                f"  duration={groups['duration'] or 'NONE'} "
+                f"count={groups['count']} credits={state['credits_text']} "
+                f"chip={state['composer_chip']!r} ingr_reject={state['ingredient_reject']}",
+            )
+
+    out = default_out_path("video_model_capability_matrix")
+    payload = {
+        "project": project,
+        "profile": profile,
+        "note": "credit-free: navigation + popover reads only, never submitted",
+        "models": rows,
+    }
+    out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+
+    print("\n=== MATRIX ===")
+    for r in rows:
+        if not r.get("selected"):
+            print(f"  {r['model']:<16} PICKER MISS")
+            continue
+        # Format the list to a string FIRST — `[...] or 'NONE'` yields a list
+        # when non-empty, and a list has no __format__ for a width spec.
+        duration = "/".join(r["duration_tabs"]) or "NONE"
+        print(
+            f"  {r['model']:<28} duration={duration:<20} "
+            f"count={len(r['count_tabs'])} credits={r['credits_text']} "
+            f"ingr_reject={r['ingredient_rejected']}"
+        )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    return asyncio.run(_run(args.profile, args.project))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Owner UI recon showed the classic video settings popover is **model-conditional**. A credit-free spike over every registered `VideoModel` confirms it and **root-causes #451 / #288**.

| Model | Duration tabs | Count | Credits | Ingredients |
|---|---|---|---|---|
| `omni_flash` | **`4s` `6s` `8s` `10s`** | x1–x4 | 15 @10s / 7 @4s | accepted |
| `veo_3_1_lite` | **none** | x1–x4 | 10 | accepted |
| `veo_3_1_fast` | **none** | x1–x4 | 20 | accepted |
| `veo_3_1_quality` | **none** | x1–x4 | 100 | **rejected** |
| `veo_3_1_lite_lower_priority` | picker miss | — | — | — |

## Why this matters

`api/video.py:44` states *"Only `OMNI_FLASH` exposes a 10s duration; the four `VEO_3_1_*` models cap at 8s"* — which assumes they render a duration control. **They render none.**

So `_select_video_duration` has been hunting a control those models never draw. That is why #451/#288:

- looked like **selector drift**,
- reproduced **identically on playwright 1.59 and 1.61** (so the version bound was never the cause),
- and **refuted the locale hypothesis** (the cascade is icon-ligature-only).

It was never a Playwright regression and never locale. `--duration` can only ever work on `omni_flash`.

## Also captured

- **Live credit cost in the DOM** (`Generating will use N credits`), varying by model *and* duration (omni: 7 @4s → 15 @10s). Nothing reads it today — this is the missing input for the deferred tier-aware credit-confirmation work.
- **A new dynamic composer chip.** Raw textContent: `Video · 10scrop_9_16x1` — duration + aspect **icon ligature** + count. Useful as a read-back affordance, but any matcher must strip Material Symbols ligatures (the usual locale-leak trap).
- **Ingredients are model-gated** — `Veo 3.1 - Quality` greys the thumbnail with *"You cannot use image ingredients with this model."* We have `supports_frames()` for i2v but no ingredient axis, so `r2v --model veo-quality --ref x.jpg` drives an impossible combination.

## Safety

Navigation + popover reads only. **No prompt typed, no Generate click, zero credits.** Selecting a model in the picker does not bill. The spike restores the classic composer via `mode_control.ensure_media_mode` first, since the account's persisted `isAgentModeToggled` can serve the agentic arm.

## Scope

**No product code changed.** Follow-ups are listed in the spike doc and deliberately left for a separate decision:

1. Correct the `api/video.py:44` docstring; add `supports_duration()` (true only for `OMNI_FLASH` on current evidence) and fail `--duration` fast at the DTO with a message naming the model, rather than an exit-23 drift error.
2. Add an ingredient-capability predicate; reject `r2v` + `veo_3_1_quality` pre-submit.
3. Re-derive the `veo_3_1_lite_lower_priority` picker selector (its `:not()` form missed).

**Re-verify on a second account before hard-coding a capability table** — this is one cohort's live UI, and Flow's arms flap (the #404 label rename is the precedent).

## Test plan

- [x] Spike run green at $0, matrix reproduced across two runs
- [x] `ruff check` / `format --check` clean on the new script (the 54 pre-existing errors elsewhere in `scripts/dev/` are untouched and ungated — CI lints `src tests` only)
- [x] hygiene (751), doc links (29), website mirror in sync
- [x] No `src/` changes, so no test or pyright delta

Refs #451, Refs #288