### PR TITLE
spike(video): confirm the model capability matrix on a 2nd account (pt-BR)

### DIFF
--- a/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
+++ b/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
@@ -68,6 +68,44 @@ while `Veo 3.1 - Fast` and `Omni Flash` accept the same asset.
   a drift error.
 - Add an ingredient-capability predicate and reject `r2v` + `veo_3_1_quality`
   pre-submit.
-- Re-verify the matrix on a second account before hard-coding: this is a live UI
-  observation on one cohort, and Flow's arms flap
-  (see [[flow-agent-settings-panel-sticky-defaults]], `#404` label-rename precedent).
+- Re-derive the `veo_3_1_lite_lower_priority` picker selector — it missed on
+  **both** accounts, so its `:not()` exclusion form is genuinely broken rather
+  than cohort-specific.
+
+## Second-account confirmation (`denon82`, pt-BR) — 2026-08-14
+
+Re-ran on a **different account in a different locale**. The matrix is
+**identical**, which removes the one-cohort caveat for the duration finding:
+
+| Model | Duration tabs | Credits (denon82) | Credits (ffroliva) |
+|---|---|---|---|
+| `omni_flash` | **`4s` `6s` `8s` `10s`** | 12 @8s | 15 @10s |
+| `veo_3_1_lite` | **none** | 10 | 10 |
+| `veo_3_1_fast` | **none** | 20 | 20 |
+| `veo_3_1_quality` | **none** | 100 | 100 |
+| `veo_3_1_lite_lower_priority` | picker MISS | — | picker MISS |
+
+Credits match exactly for the three Veo models; `omni_flash` differs only
+because the selected duration differs (12 @8s vs 15 @10s), which independently
+confirms **duration-scaled pricing**.
+
+### Locale findings (pt-BR) — the ligature rule holds
+
+- Video-mode tabs read `crop_freeFrames`, `chrome_extensionElementos`
+  ("Ingredients" → "Elementos"), `crop_9_169:16`, `crop_16_916:9`.
+  **Text is localized; the Material Symbols ligature is not.** Selecting by
+  ligature worked unchanged across both locales — a live re-confirmation of
+  [[flow-locale-leak-icon-ligatures]] (#56).
+- The composer chip reads `Vídeo · 8scrop_16_9x1` — localized word, embedded
+  ligature. Any chip matcher must strip ligatures AND not assume "Video".
+- The credit line is localized too; an English-only
+  `/Generating will use N credits/` regex returns `null` on pt-BR and reads as
+  "no cost shown". Match a number adjacent to a `cr[ée]dito?s?|credits?` stem.
+
+### Spike bug this exposed (worth keeping)
+
+The composer can be in **Image** mode, where the popover shows five aspect tabs
+and **no video model picker** — every model lookup then misses. The first
+denon82 run reported 5/5 picker misses for exactly this reason. Selecting the
+Video tab first (by the `videocam` ligature) fixed it. Production does this via
+`switch_to_video_mode`; any recon script must too.

--- a/scripts/dev/capture_video_model_capability_matrix.py
+++ b/scripts/dev/capture_video_model_capability_matrix.py
@@ -82,6 +82,28 @@ async def _open_settings(page: Any) -> bool:
     return False
 
 
+async def _ensure_video_mode(page: Any) -> bool:
+    """Select the popover's Video tab (the model picker only exists there).
+
+    Keyed on the Material Symbols ligature ``videocam``, NOT the tab text: on a
+    pt-BR account the label reads ``videocamVídeo``, and text matching would
+    miss (memory: flow-locale-leak-icon-ligatures). Without this the popover
+    stays in Image mode — five aspect tabs, no video model picker — and every
+    model lookup misses, which is exactly what denon82 showed.
+    """
+    tab = page.locator("[role='tab']:has(i.google-symbols:text-is('videocam'))").first
+    if await tab.count() == 0:
+        return False
+    if await tab.get_attribute("aria-selected") == "true":
+        return True
+    try:
+        await tab.click(timeout=4000)
+        await page.wait_for_timeout(700)
+    except Exception:  # noqa: BLE001 - verified by the caller's re-read
+        return False
+    return True
+
+
 async def _menu_state(page: Any) -> dict[str, Any]:
     """Structured read of the OPEN settings popover — pure DOM, no clicks."""
     return await page.evaluate(
@@ -94,22 +116,30 @@ async def _menu_state(page: Any) -> dict[str, Any]:
             selected: t.getAttribute('aria-selected') === 'true',
           })).filter(t => t.label);
           const text = (scope.textContent || '').replace(/\\s+/g, ' ').trim();
-          const creditRe = /Generating will use\\s+([\\d,]+)\\s+credits?/i;
+          // Locale-tolerant: match a number next to a credit-word stem, which
+          // covers en "120 credits", pt "120 creditos/creditos", es "creditos".
+          // An English-only /Generating will use N credits/ silently returns
+          // null on a pt-BR UI and reads as "no cost shown" (memory:
+          // flow-locale-leak-icon-ligatures).
+          const creditRe = /([\\d.,]+)\\s*(?:cr[e\\u00e9]dito?s?|credits?)/i;
           const credits = (text.match(creditRe) || [])[1] || null;
-          // The composer's dynamic summary chip, e.g. "Video · 4s ▭ x1".
+          // The composer's dynamic summary chip, e.g. "Video · 4s x1".
+          // "Video" is a product-ish word that also reads in pt ("Video"), but
+          // keep the raw menu text so a locale miss is visible, not silent.
           const chip = [...document.querySelectorAll('button, div')]
             .map(e => (e.textContent || '').replace(/\\s+/g, ' ').trim())
-            .filter(t => /^Video\\b/.test(t) && t.length <= 40)
+            .filter(t => /^V[i\\u00ed]deo\\b/i.test(t) && t.length <= 40)
             .sort((a, b) => a.length - b.length)[0] || null;
+          const body = document.body.innerText.toLowerCase();
           return {
             menu_present: !!menu,
             tabs,
             credits_text: credits,
             composer_chip: chip,
-            model_trigger_label: (document.querySelector(
-              "button[aria-haspopup='menu'] , button") && null),
-            ingredient_reject: document.body.innerText
-              .toLowerCase().includes('cannot use image ingredients'),
+            menu_text: text.slice(0, 400),
+            page_lang: document.documentElement.lang || null,
+            ingredient_reject: body.includes('cannot use image ingredients')
+              || body.includes('ingredientes de imagem'),
           };
         }"""
     )
@@ -186,16 +216,41 @@ async def _run(profile: str, project: str) -> int:
             step("menu", "ERROR: still no crop_* settings trigger after mode recovery")
             return 1
 
+        video_ok = await _ensure_video_mode(page)
+        step("mode", f"video tab selected={video_ok}")
         baseline = await _menu_state(page)
         step("menu", f"baseline tabs={len(baseline['tabs'])} credits={baseline['credits_text']}")
 
         for model in VideoModel:
             step(model.value, "selecting...")
             await _open_settings(page)
+            await _ensure_video_mode(page)
             ok = await _select_model(page, model)
             if not ok:
-                rows.append({"model": model.value, "selected": False})
-                step(model.value, "  picker miss — recorded, continuing")
+                # A miss is a RESULT, not a dead end — capture what the popover
+                # actually rendered so a cohort/locale difference is diagnosable
+                # instead of an unexplained "PICKER MISS".
+                miss_state = await _menu_state(page)
+                trigger_count = await page.locator(MODEL_PICKER_TRIGGER).count()
+                menuitems = await page.evaluate(
+                    """() => [...document.querySelectorAll("[role='menuitem']")]
+                           .map(e => (e.textContent || '').replace(/\\s+/g,' ').trim())
+                           .slice(0, 20)"""
+                )
+                rows.append(
+                    {
+                        "model": model.value,
+                        "selected": False,
+                        "menu_text": miss_state["menu_text"],
+                        "page_lang": miss_state["page_lang"],
+                        "tabs": [t["label"] for t in miss_state["tabs"]],
+                        "model_trigger_count": trigger_count,
+                        "menuitems_seen": menuitems,
+                    }
+                )
+                step(
+                    model.value, f"  picker miss — tabs={[t['label'] for t in miss_state['tabs']]}"
+                )
                 continue
             await _open_settings(page)
             state = await _menu_state(page)
@@ -210,6 +265,8 @@ async def _run(profile: str, project: str) -> int:
                 "credits_text": state["credits_text"],
                 "composer_chip": state["composer_chip"],
                 "ingredient_rejected": state["ingredient_reject"],
+                "page_lang": state["page_lang"],
+                "menu_text": state["menu_text"],
             }
             rows.append(row)
             step(
@@ -224,6 +281,8 @@ async def _run(profile: str, project: str) -> int:
         "project": project,
         "profile": profile,
         "note": "credit-free: navigation + popover reads only, never submitted",
+        "baseline": baseline,
+        "model_picker_trigger": MODEL_PICKER_TRIGGER,
         "models": rows,
     }
     out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")


### PR DESCRIPTION
## Summary

Follow-up to #534, which flagged its own caveat: *"this is one cohort's live UI on one account — re-verify before hard-coding."* Done. Re-ran on **denon82 (different account, pt-BR locale)** and the matrix is **identical**.

| Model | Duration tabs | Credits (denon82) | Credits (ffroliva) |
|---|---|---|---|
| `omni_flash` | **`4s` `6s` `8s` `10s`** | 12 @8s | 15 @10s |
| `veo_3_1_lite` | **none** | 10 | 10 |
| `veo_3_1_fast` | **none** | 20 | 20 |
| `veo_3_1_quality` | **none** | 100 | 100 |
| `veo_3_1_lite_lower_priority` | picker MISS | — | picker MISS |

**The one-cohort caveat on the #451/#288 root cause is now removed.** Credits match exactly for the three Veo models; `omni_flash` differs only because the selected duration differs, which independently confirms **duration-scaled pricing**. `veo_3_1_lite_lower_priority` missed on **both** accounts, so that selector is genuinely broken rather than cohort-specific.

## Two spike bugs this run forced out

**1. The composer can be in Image mode.** There the popover shows five aspect tabs (16:9, 4:3, 1:1, 3:4, 9:16) and **no video model picker**, so every model lookup misses. The first denon82 run reported 5/5 picker misses purely for that reason — not a cohort difference. The spike now selects the Video tab first, as production does via `switch_to_video_mode`.

Keyed on the **`videocam` ligature, not the tab text** — which reads `videocamVídeo` on this account.

**2. Locale-tolerant credit extraction.** The English-only `/Generating will use N credits/` regex returns `null` on pt-BR, which reads as "no cost shown" — a silent wrong answer, the worst kind. Now matches a number adjacent to a `cr[ée]dito?s?|credits?` stem, and the raw menu text + `page_lang` are captured so a locale miss is *visible*.

Picker misses now record the rendered tabs, page lang and menu items instead of a bare `PICKER MISS`. That diagnostic is exactly what identified bug 1.

## Live re-confirmation of the ligature rule (#56)

pt-BR video tabs render as `crop_freeFrames`, `chrome_extensionElementos` (Ingredients → "Elementos"), `crop_9_169:16`, `crop_16_916:9`. **Text localizes; the Material Symbols ligature does not**, and ligature-keyed selection worked unchanged across both locales. The composer chip reads `Vídeo · 8scrop_16_9x1` — localized word, embedded ligature, so any chip matcher must strip ligatures *and* not assume the word "Video".

## Safety

Unchanged: navigation + popover reads only. No prompt typed, no Generate click, **zero credits**, on both accounts.

## Test plan

- [x] Matrix reproduced on 2 accounts / 2 locales
- [x] `ruff check` + `format` clean on the script
- [x] hygiene (753), doc links (29)
- [x] No `src/` changes

Refs #451, Refs #288