### PR TITLE
spike(493): refute the crop_free trigger hypothesis (negative result)

### DIFF
--- a/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
+++ b/docs/superpowers/spikes/2026-08-14-video-model-capability-matrix.md
@@ -102,6 +102,31 @@ confirms **duration-scaled pricing**.
   `/Generating will use N credits/` regex returns `null` on pt-BR and reads as
   "no cost shown". Match a number adjacent to a `cr[ée]dito?s?|credits?` stem.
 
+## #493 hypothesis: `crop_free` trigger — **REFUTED** (2026-08-14)
+
+`CROP_SELECTORS` (`mode_control.py:49`) enumerates six *aspect* ligatures and
+omits `crop_free`, which `ui_automation_video.py:634` documents as the **Frames**
+tab icon. Since #493's reporter (pt-BR) sees frame slots "Inicial"/"Final"
+(= Frames mode) and "no `crop_*` settings button", the obvious hypothesis was:
+**the trigger renders the active sub-mode's ligature, so a Frames-mode composer
+shows an unmatched `crop_free` trigger.**
+
+Tested directly (`scripts/dev/capture_frames_mode_trigger_ligature.py`, denon82,
+pt-BR, $0): switch the popover to Frames, close it, re-read every
+`button[aria-haspopup='menu']`.
+
+**Result — refuted.** In BOTH Frames and Ingredients sub-modes the trigger still
+renders `crop_16_9`, and `CROP_SELECTORS` still matches (1 hit). **The trigger
+reflects the ASPECT, not the sub-mode.** Adding `crop_free` to the cascade would
+fix nothing. Do not re-derive this.
+
+Incidental finding: the composer's full trigger ligature inventory is
+`add`, `crop_16_9`, `filter_list`, `more_vert`, **`settings_2`**. `settings_2` is
+a second `aria-haspopup` trigger we never match — but an accidental open during
+this spike showed it serving Flow's **library/display** panel (grid / batch /
+S-M-L / Ativado-Desativado tabs), NOT the composer popover. Treat it as
+**not** a drop-in fallback without its own verification.
+
 ### Spike bug this exposed (worth keeping)
 
 The composer can be in **Image** mode, where the popover shows five aspect tabs

--- a/scripts/dev/capture_frames_mode_trigger_ligature.py
+++ b/scripts/dev/capture_frames_mode_trigger_ligature.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+r"""#493 decisive probe — what ligature does the settings TRIGGER carry in each
+composer sub-mode?
+
+HYPOTHESIS (2026-08-14): `CROP_SELECTORS` (mode_control.py:49) — the trigger
+cascade used by BOTH the `mode_switch_trigger` probe and `detect_ui_mode` —
+matches six aspect ligatures (crop_16_9 / 9_16 / square / portrait / landscape /
+original) but NOT `crop_free`, which `ui_automation_video.py:634` documents as
+the **Frames** (start/end frame) tab icon.
+
+If the trigger button renders the ligature of the ACTIVE sub-mode, then a
+composer sitting in Frames mode shows a `crop_free` trigger that no selector
+matches → `mode_switch_trigger` misses → `UiSelectorDriftError` exit 23, and
+`detect_ui_mode` finds no classic signal and falls through after its 8s poll.
+
+That is exactly issue #493's fingerprint: a reporter on pt-BR seeing frame slots
+"Inicial"/"Final" (= Frames mode) and "no crop_* settings button".
+
+This probe reads the trigger's ligature in each sub-mode and reports whether any
+production selector matches. Credit-free: navigation + tab clicks + DOM reads.
+Never types a prompt, never clicks Generate.
+
+Usage:
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\capture_frames_mode_trigger_ligature.py \
+        --profile denon82 --project <project-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+sys.path.insert(0, str(_ROOT / "scripts" / "dev"))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.mode_control import CROP_SELECTORS  # noqa: E402
+
+# Sub-mode tabs inside the open video popover, keyed by their (locale-invariant)
+# Material Symbols ligature.
+_SUBMODE_TABS = {
+    "frames": "crop_free",
+    "ingredients": "chrome_extension",
+}
+
+
+async def _wait_editor(page: Any) -> bool:
+    for _ in range(30):
+        if (
+            await page.locator('div[role="textbox"], textarea').count() > 0
+            or await page.locator("button").count() > 8
+        ):
+            return True
+        await page.wait_for_timeout(1000)
+    return False
+
+
+async def _menu_open(page: Any) -> bool:
+    """True only for the SETTINGS popover — a menu that actually carries tabs.
+
+    `[role='menu']` alone is too loose: the editor has other menus (project /
+    account) with no tabs, and accepting one of those made every sub-mode tab
+    look 'absent'.
+    """
+    return await page.locator("[role='menu'] [role='tab']").count() > 0
+
+
+async def _open_settings(page: Any) -> bool:
+    """Open the COMPOSER settings popover via the production CROP_SELECTORS.
+
+    An earlier "try every aria-haspopup button" version kept opening the wrong
+    menu (the account menu, then Flow's app-settings panel with its
+    dashboard/batch/size tabs), which made every sub-mode tab look absent.
+    Opening via the production cascade is also the honest experiment: we already
+    know it works while an ASPECT sub-mode is active — the question under test is
+    only whether it still matches AFTER switching to Frames.
+    """
+    if await _menu_open(page):
+        return True
+    for sel in CROP_SELECTORS:
+        loc = page.locator(sel).first
+        if await loc.count() > 0:
+            try:
+                await loc.click(timeout=4000)
+                await page.wait_for_timeout(600)
+            except Exception:  # noqa: BLE001
+                pass
+            if await _menu_open(page):
+                return True
+    return False
+
+
+async def _click_tab(page: Any, ligature: str) -> bool:
+    tab = page.locator(f"[role='tab']:has(i.google-symbols:text-is('{ligature}'))").first
+    if await tab.count() == 0:
+        return False
+    try:
+        await tab.click(timeout=4000)
+        await page.wait_for_timeout(800)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+async def _trigger_report(page: Any) -> dict[str, Any]:
+    """Every aria-haspopup trigger with the ligatures it renders."""
+    triggers = await page.evaluate(
+        """() => [...document.querySelectorAll("button[aria-haspopup='menu']")].map(b => ({
+             ligatures: [...b.querySelectorAll('i.google-symbols, i.material-symbols-outlined')]
+                          .map(i => (i.textContent || '').trim()),
+             text: (b.textContent || '').replace(/\\s+/g,' ').trim().slice(0, 60),
+             aria: b.getAttribute('aria-label'),
+           }))"""
+    )
+    matched = {}
+    for sel in CROP_SELECTORS:
+        # "…text('crop_16_9'))" -> "crop_16_9" (rstrip would eat chars, not a suffix)
+        name = sel.split("text('")[1].split("'")[0]
+        matched[name] = await page.locator(sel).count()
+    return {"triggers": triggers, "production_selector_hits": matched}
+
+
+async def _run(profile: str, project: str) -> int:
+    findings: dict[str, Any] = {"profile": profile, "project": project, "modes": {}}
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+
+        step("nav", f"goto editor {project}")
+        await page.goto(
+            routes.project_editor_url("en", project),
+            wait_until="domcontentloaded",
+            timeout=60_000,
+        )
+        if not await _wait_editor(page):
+            step("nav", "ERROR editor not ready")
+            return 1
+
+        if not await _open_settings(page):
+            # The account's isAgentModeToggled persists server-side, so the
+            # editor can load agentic (no classic composer at all).
+            step("mode", "no popover — running ensure_media_mode()")
+            from gflow_cli.api.transports import mode_control  # noqa: PLC0415
+
+            acted = await mode_control.ensure_media_mode(page, allow_reload=True)
+            step("mode", f"  ensure_media_mode acted={acted}")
+            await _wait_editor(page)
+
+        if not await _open_settings(page):
+            step("menu", "ERROR could not open the settings popover at all")
+            return 1
+        async def _tabs() -> list[str]:
+            return await page.evaluate(
+                """() => [...document.querySelectorAll("[role='tab']")]
+                       .map(t => (t.textContent||'').replace(/\\s+/g,' ').trim())"""
+            )
+
+        step("tabs", f"before video-tab click: {await _tabs()}")
+        vid = await _click_tab(page, "videocam")  # ensure VIDEO mode
+        step("tabs", f"videocam clicked={vid} -> {await _tabs()}")
+
+        for name, ligature in _SUBMODE_TABS.items():
+            await _open_settings(page)
+            if not await _click_tab(page, ligature):
+                step(name, f"  tab '{ligature}' not present — skipping")
+                findings["modes"][name] = {"tab_present": False}
+                continue
+            # Close the popover so we read the trigger in its resting state.
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(500)
+            report = await _trigger_report(page)
+            hits = {k: v for k, v in report["production_selector_hits"].items() if v}
+            all_lig = sorted({lig for t in report["triggers"] for lig in t["ligatures"]})
+            findings["modes"][name] = {
+                "tab_present": True,
+                "trigger_ligatures": all_lig,
+                "production_selector_hits": hits,
+                "production_cascade_matches": bool(hits),
+                "triggers": report["triggers"],
+            }
+            step(
+                name,
+                f"  trigger ligatures={all_lig} | CROP_SELECTORS match={bool(hits)} {hits}",
+            )
+
+    out = default_out_path("frames_mode_trigger_ligature")
+    out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+
+    print("\n=== VERDICT ===")
+    for name, m in findings["modes"].items():
+        if not m.get("tab_present"):
+            print(f"  {name:<12} tab absent")
+            continue
+        ok = m["production_cascade_matches"]
+        print(
+            f"  {name:<12} CROP_SELECTORS match={ok}  ligatures={m['trigger_ligatures']}"
+            + ("" if ok else "   <-- production would MISS here (#493 shape)")
+        )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    return asyncio.run(_run(args.profile, args.project))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/capture_r2v_ingredient_lifecycle.py
+++ b/scripts/dev/capture_r2v_ingredient_lifecycle.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+r"""Live $0 spike — the R2V **Ingredients** component end to end.
+
+WHAT THIS TESTS (owner recon, 2026-08-14):
+1. Attaching an ingredient produces a **named handle chip in the prompt** (e.g.
+   "flowers blooming in a field") — ingredients and `@`-mentions are the SAME
+   mechanism in Flow's UI. `docs/REFERENCE_STRATEGIES.md:56` currently calls
+   `@media` on `r2v` "Phase 3" (unimplemented), which looks wrong.
+2. **Switching the model AFTER attaching flags the ingredient as not accepted.**
+   `Veo 3.1 - Quality` refuses image ingredients ("You cannot use image
+   ingredients with this model."); Fast / Omni Flash accept them.
+
+gflow already orders this correctly (model is chosen inside
+`configure_video_settings`, ingredients attach after), but it has **no
+ingredient x model capability check**, and for R2V the model select is
+``required=False`` — so with ``--model`` omitted Flow's *sticky default* applies
+and may be a model that refuses ingredients.
+
+The spike drives the real production helpers (`_switch_video_sub_mode`,
+`_attach_remote_references`) so it exercises the same code an `r2v` run does.
+
+**Credit-free:** never types a prompt for submission, never clicks Generate.
+
+Usage:
+    PYTHONUTF8=1 .venv\Scripts\python.exe scripts\dev\capture_r2v_ingredient_lifecycle.py \
+        --profile denon82 --project <id> --ref-name "a brass key on dark velvet"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+sys.path.insert(0, str(_ROOT / "scripts" / "dev"))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir, step  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports.mode_control import CROP_SELECTORS  # noqa: E402
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    VIDEO_MODEL_OPTION_SELECTORS,
+    VideoGenerationMixin,
+)
+from gflow_cli.api.video import VideoModel  # noqa: E402
+
+
+async def _wait_editor(page: Any) -> bool:
+    for _ in range(30):
+        if (
+            await page.locator('div[role="textbox"], textarea').count() > 0
+            or await page.locator("button").count() > 8
+        ):
+            return True
+        await page.wait_for_timeout(1000)
+    return False
+
+
+async def _menu_open(page: Any) -> bool:
+    return await page.locator("[role='menu'] [role='tab']").count() > 0
+
+
+async def _open_settings(page: Any) -> bool:
+    if await _menu_open(page):
+        return True
+    for sel in CROP_SELECTORS:
+        loc = page.locator(sel).first
+        if await loc.count() > 0:
+            try:
+                await loc.click(timeout=4000)
+                await page.wait_for_timeout(600)
+            except Exception:  # noqa: BLE001
+                pass
+            if await _menu_open(page):
+                return True
+    return False
+
+
+async def _click_lig(page: Any, ligature: str) -> bool:
+    tab = page.locator(f"[role='tab']:has(i.google-symbols:text-is('{ligature}'))").first
+    if await tab.count() == 0:
+        return False
+    try:
+        await tab.click(timeout=4000)
+        await page.wait_for_timeout(700)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+async def _composer_state(page: Any) -> dict[str, Any]:
+    """Read the composer: attached ingredient tiles, their flagged state, and
+    any handle chips rendered into the prompt."""
+    return await page.evaluate(
+        """() => {
+          const body = document.body.innerText;
+          const rejectRe = /cannot use image ingredients|ingredientes de imagem/i;
+          // Ingredient tiles carry a small img thumbnail; a rejected one gets an
+          // overlay/badge, which shows up as an extra symbol inside the tile.
+          const tiles = [...document.querySelectorAll('button, div')]
+            .filter(e => e.querySelector('img') && e.clientHeight < 140 && e.clientWidth < 140)
+            .slice(0, 12)
+            .map(e => ({
+              html: e.outerHTML.slice(0, 260),
+              ligatures: [...e.querySelectorAll('i')].map(i => (i.textContent||'').trim()),
+              img_alt: (e.querySelector('img')||{}).alt || null,
+            }));
+          // Handle chips: short pill-like nodes inside the composer area.
+          const chips = [...document.querySelectorAll('span, div, button')]
+            .map(e => ({t: (e.textContent||'').replace(/\\s+/g,' ').trim(), c: e.className}))
+            .filter(o => o.t && o.t.length > 3 && o.t.length < 60)
+            .filter(o => /chip|tag|token|mention|pill/i.test(String(o.c)))
+            .slice(0, 12);
+          return {
+            reject_notice: rejectRe.test(body),
+            tiles,
+            chips,
+          };
+        }"""
+    )
+
+
+async def _select_model(page: Any, model: VideoModel) -> bool:
+    from gflow_cli.api.transports.ui_automation_video import MODEL_PICKER_TRIGGER
+
+    trig = page.locator(MODEL_PICKER_TRIGGER).first
+    if await trig.count() == 0:
+        return False
+    try:
+        await trig.click(timeout=4000)
+        await page.wait_for_timeout(500)
+        opt = page.locator(VIDEO_MODEL_OPTION_SELECTORS[model]).first
+        if await opt.count() == 0:
+            await page.keyboard.press("Escape")
+            return False
+        await opt.click(timeout=4000)
+        await page.wait_for_timeout(900)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+async def _run(profile: str, project: str, ref_name: str) -> int:
+    findings: dict[str, Any] = {"profile": profile, "project": project, "ref_name": ref_name}
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ctx = client._context  # noqa: SLF001
+        assert ctx is not None
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+
+        step("nav", f"goto editor {project}")
+        await page.goto(
+            routes.project_editor_url("en", project),
+            wait_until="domcontentloaded",
+            timeout=60_000,
+        )
+        await _wait_editor(page)
+
+        if not await _open_settings(page):
+            from gflow_cli.api.transports import mode_control  # noqa: PLC0415
+
+            await mode_control.ensure_media_mode(page, allow_reload=True)
+            await _wait_editor(page)
+            if not await _open_settings(page):
+                step("menu", "ERROR: no composer settings popover")
+                return 1
+
+        await _click_lig(page, "videocam")
+
+        # 1. Choose a model that ACCEPTS ingredients, before attaching.
+        ok_fast = await _select_model(page, VideoModel.VEO_3_1_FAST)
+        step("model", f"selected Veo 3.1 - Fast = {ok_fast}")
+
+        # 2. Switch to the Ingredients (references) sub-mode via PRODUCTION code.
+        await _open_settings(page)
+        try:
+            await VideoGenerationMixin._switch_video_sub_mode(  # noqa: SLF001
+                page, "references", out_dir=None
+            )
+            submode_ok = True
+        except Exception as exc:  # noqa: BLE001
+            submode_ok = False
+            step("submode", f"  _switch_video_sub_mode FAILED: {type(exc).__name__}: {exc}")
+        step("submode", f"references sub-mode selected = {submode_ok}")
+
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(500)
+
+        # 3. Attach an ingredient using the production remote-reference helper.
+        try:
+            await VideoGenerationMixin._attach_remote_references(  # noqa: SLF001
+                page, [ref_name], out_dir=None
+            )
+            attach_ok = True
+        except Exception as exc:  # noqa: BLE001
+            attach_ok = False
+            step("attach", f"  _attach_remote_references FAILED: {type(exc).__name__}")
+            # The picker is still open after the name timeout — dump what it
+            # ACTUALLY offers. gflow searches by exact display_name, but the
+            # catalog stores display_name=None for these assets and Flow labels
+            # options with a short auto-caption, so the search can never hit.
+            opts = await page.evaluate(
+                """() => [...document.querySelectorAll("[role='option']")].map(o => ({
+                     name: (o.getAttribute('aria-label') || o.textContent || '')
+                             .replace(/\\s+/g,' ').trim().slice(0, 80),
+                     tile: o.getAttribute('data-tile-id'),
+                   })).slice(0, 25)"""
+            )
+            findings["picker_options_offered"] = opts
+            step("picker", f"  picker offers {len(opts)} options: {[o['name'] for o in opts][:6]}")
+        step("attach", f"ingredient attached = {attach_ok}")
+
+        after_attach = await _composer_state(page)
+        findings["after_attach_on_fast"] = after_attach
+        chip_texts = [c["t"] for c in after_attach["chips"]][:4]
+        step(
+            "state",
+            f"  reject_notice={after_attach['reject_notice']} "
+            f"tiles={len(after_attach['tiles'])} chips={chip_texts}",
+        )
+
+        # 4. Now switch to a model that REFUSES ingredients and re-read.
+        await _open_settings(page)
+        ok_q = await _select_model(page, VideoModel.VEO_3_1_QUALITY)
+        step("model", f"switched to Veo 3.1 - Quality = {ok_q}")
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(900)
+
+        after_switch = await _composer_state(page)
+        findings["after_switch_to_quality"] = after_switch
+        step(
+            "state",
+            f"  reject_notice={after_switch['reject_notice']} tiles={len(after_switch['tiles'])}",
+        )
+
+    out = default_out_path("r2v_ingredient_lifecycle")
+    out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+
+    print("\n=== VERDICT ===")
+    a = findings.get("after_attach_on_fast", {})
+    b = findings.get("after_switch_to_quality", {})
+    print(f"  ingredient-reject notice on Veo 3.1 Fast    : {a.get('reject_notice')}")
+    print(f"  ingredient-reject notice on Veo 3.1 Quality : {b.get('reject_notice')}")
+    print(f"  handle chips seen after attach              : {[c['t'] for c in a.get('chips', [])]}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--ref-name", required=True)
+    args = ap.parse_args()
+    return asyncio.run(_run(args.profile, args.project, args.ref_name))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

A well-motivated #493 hypothesis, tested and **refuted**. Committing the negative result so it isn't re-derived — the reasoning is compelling enough that the next person will reach for it too.

## The hypothesis

`CROP_SELECTORS` (`mode_control.py:49`) enumerates six **aspect** ligatures (`crop_16_9`, `crop_9_16`, `crop_square`, `crop_portrait`, `crop_landscape`, `crop_original`) and omits **`crop_free`** — which `ui_automation_video.py:634` documents as the **Frames** tab icon.

That cascade is used by *both* the `mode_switch_trigger` probe and `detect_ui_mode`.

#493's reporter is on pt-BR and sees frame slots **"Inicial"/"Final"** — which today's pt-BR recon identified as Frames mode (`crop_freeFrames`) — plus *"no `crop_*` settings button"*. So: **does the trigger render the active sub-mode's ligature, leaving a Frames-mode composer with an unmatched `crop_free` trigger?** That would produce exit 23 and the 8s `detect_ui_mode` fall-through exactly as reported.

## The test

`scripts/dev/capture_frames_mode_trigger_ligature.py` on **denon82 (pt-BR — same locale as the reporter)**, $0: open the composer popover, switch to Frames, close it, re-read every `button[aria-haspopup='menu']` and count production-selector hits.

## Result — REFUTED

In **both** Frames and Ingredients sub-modes the trigger still renders `crop_16_9`, and `CROP_SELECTORS` still matches (1 hit).

**The trigger reflects the ASPECT, not the sub-mode.** Adding `crop_free` to the cascade would fix nothing.

## Incidental finding

Full composer trigger ligature inventory: `add`, `crop_16_9`, `filter_list`, `more_vert`, **`settings_2`**.

`settings_2` is a second `aria-haspopup` trigger we never match — but an accidental open during this spike showed it serving Flow's **library/display** panel (grid / batch / S-M-L / Ativado-Desativado), *not* the composer popover. Recorded as **not** a drop-in fallback without its own verification.

## Status

**#493 remains blocked on the reporter's `diag_mode_switch_miss.json`.** This eliminates the most promising mechanism I could construct from the recon we have.

## Test plan

- [x] Probe run at $0 on the reporter's locale (pt-BR)
- [x] `ruff check` clean; hygiene (753), doc links (29)
- [x] No `src/` changes — recon script + spike doc only

Refs #493