### PR TITLE
feat(529): resolve catalog UUID refs via displayName picker search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **R2V named remote references (`ref_names`) work again after Flow's picker
+  redesign — live-verified end to end (#529 follow-up).** Two UI drifts had
+  silently broken the name-attach path on every locale: the picker dialog no
+  longer exposes an accessible tree, so the old ARIA role+name tile match could
+  never find a result (the tile is now matched by its text, anchored so a
+  substring name still cannot attach the wrong asset, tolerating the localized
+  media-type badge the tile text appends, e.g. `…Imagem` on a pt profile); and
+  clicking a result tile now attaches directly and closes the picker — the
+  legacy include-button flow runs only if the dialog stays open. Proven by a
+  new live e2e that seeds a t2i image, reads its recorded `displayName` back
+  from the catalog by UUID, and generates a real R2V video with it
+  (`tests/e2e/test_video_r2v_uuid_name_e2e.py`), alongside a new same-project
+  image-picker e2e pinning the #529 exact-UUID-tile happy path.
+
 ### Changed
 
 - **Catalog image UUIDs now resolve through Flow display names instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Media UUID picker lookups no longer pay two guaranteed-dead searches before
-  scrolling (#529).** The full-UUID and UUID-stem tiers move behind the
-  virtualised-grid scroll fallback, removing the measured ~14.9 s delay per
-  unresolved reference (~30 s for a two-reference generation) from lookups the
-  scroll resolves. Reachability is unchanged: both tiers remain as last-resort
-  retries for any Flow cohort that does index UUIDs. This explicitly
-  **supersedes #287's claim** that those tiers are "cheap first attempts".
-  Existing attach/miss events now report the closed `resolved_by` tier without
-  copying the winning term. Picker/catalog evidence confirms tiles carry short
-  Flow captions rather than generation prompts, so the prompt-derived hint
-  tier's live value remains unproven and proposal 3 is refuted in
-  [#541](https://github.com/ffroliva/gflow-cli/issues/541).
+- **Catalog image UUIDs now resolve through Flow display names instead of
+  scrolling or UUID/prompt searches (#529).** A headed-Chrome spike against a
+  populated Compiled Growth story project proved the picker contract:
+  catalog UUID → `workflows[].metadata.displayName` → browser name search →
+  exact UUID-in-thumbnail tile. A duplicate-name search surfaced two distinct
+  UUIDs and the exact matcher selected the requested identity, with zero scroll
+  calls or generation requests. The UI response collector now preserves the
+  sibling workflow name so new generated-image catalog rows retain the picker
+  search key when prompt history is stored (`history_prompts=redacted` omits the
+  potentially prompt-derived caption); image `--ref <uuid>` and I2V frame UUIDs
+  are enriched with that name before browser work. UUID, UUID-stem, prompt-hint,
+  and unfiltered-grid scroll fallbacks are removed from this path. Image refs
+  retain their recorded local-file upload fallback; CLI and MCP I2V frames keep
+  the UUID, name, and fallback together for both slots. Local fallbacks are used
+  only when their recorded byte count/SHA-256 still matches. A missing/stale
+  name or unavailable search input falls through to that verified upload or a
+  typed failure—never an unfiltered viewport click, grid scan, or implicit
+  Playwright scroll. UUID-backed I2V requests now also activate the post-submit
+  route guard that rejects a credit-spent T2V response.
+  This supersedes #287's prompt-hint and UUID-grid-scroll guidance; the sanitized
+  evidence is recorded in the [#529 picker spike](docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md),
+  and [#541](https://github.com/ffroliva/gflow-cli/issues/541) records the refuted
+  prompt-hint hypothesis.
 
 ## [0.57.1] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Media UUID picker lookups no longer pay two guaranteed-dead searches before
+  scrolling (#529).** The full-UUID and UUID-stem tiers move behind the
+  virtualised-grid scroll fallback, removing the measured ~14.9 s delay per
+  unresolved reference (~30 s for a two-reference generation) from lookups the
+  scroll resolves. Reachability is unchanged: both tiers remain as last-resort
+  retries for any Flow cohort that does index UUIDs. This explicitly
+  **supersedes #287's claim** that those tiers are "cheap first attempts".
+  Existing attach/miss events now report the closed `resolved_by` tier without
+  copying the winning term. Picker/catalog evidence confirms tiles carry short
+  Flow captions rather than generation prompts, so the prompt-derived hint
+  tier's live value remains unproven and proposal 3 is refuted in
+  [#541](https://github.com/ffroliva/gflow-cli/issues/541).
+
 ## [0.57.1] — 2026-08-14
 
 ### Fixed

--- a/docs/REFERENCE_STRATEGIES.md
+++ b/docs/REFERENCE_STRATEGIES.md
@@ -14,7 +14,7 @@ transports.
    - A **saved, named asset** in the project — a `gflow character` entity, or a generated/uploaded
      media asset with a `display_name` → reference it *by identity*: `@Name` or `--reference-entity`.
    - An **arbitrary / one-off image** (a local file, or a look/style you don't intend to reuse) →
-     `--ref` (local path or in-project media UUID).
+     `--ref` (local path; image `i2i` also accepts an in-project media UUID).
 
 2. **HOW you author it** (only matters once you've chosen "by identity")
    - Inline, readable, agent-friendly → `@Name` in the prompt.
@@ -28,7 +28,7 @@ transports.
 | Reference a **saved Character** by name, inline | `@Name` in the prompt | Resolves to `referenceEntities`; the model anchors on that entity. Works on every generation path. |
 | Reference a Character by **explicit id** in a script | `--reference-entity <entityId>` (`t2i`/`i2i`/`t2v`/`r2v`) | Same wire as `@Name`, no name-resolution ambiguity. **Not available on `i2v`** (its DTO rejects reference entities). |
 | Reference a **saved media asset** (generated/uploaded) by name | `@Name` in the prompt | Resolves to the asset's UUID → `referenceImages`, zero re-upload. |
-| Reference a **one-off / arbitrary image** or a look | `--ref <path-or-uuid>` (`i2i`, `r2v`) | Stages `referenceImages` directly; no saved identity needed. |
+| Reference a **one-off / arbitrary image** or a look | `--ref <path>` (`i2i`, `r2v`) or `--ref <uuid>` (`i2i` only) | Stages `referenceImages` directly; no saved identity needed. |
 | Reuse the **same subject** across many generations | `gflow character` once → then `@Name` everywhere | A Character is the durable, name-addressable identity. See [CHARACTER.md](CHARACTER.md). |
 | Anchor an **identity *and* a look** in one shot | Both — a Character mention **and** a `--ref` | They complement (entity + image), and identical references dedupe, within the model's reference cap. |
 
@@ -43,6 +43,19 @@ reference caps are enforced before submit.
 `--ref` is the odd one out: it always stages `referenceImages` (an image), never `referenceEntities`
 (a saved identity). That's the whole distinction — *identity* vs *image*.
 
+For a catalog-backed `--ref <uuid>`, gflow resolves the UUID to Flow's recorded
+`display_name`, searches that name in the browser picker, and then verifies the
+exact UUID in the surfaced tile. The name is discovery; the UUID remains identity,
+so duplicate names cannot select the wrong asset. This path does not scan the
+unfiltered picker grid. If the named tile is unavailable, `image i2i` can still
+use the catalog's recorded local file as its upload fallback. I2V start/end
+frames carry the same fallback even when they have a name, so a picker miss can
+upload the exact recorded bytes without scanning. The fallback is discarded if
+its catalog byte count or SHA-256 no longer matches the file on disk. A stale
+name or missing picker search never enables an unfiltered tile click. Redacted
+prompt history deliberately does not persist Flow captions because they may
+paraphrase the prompt.
+
 ## Per-generation-path support matrix
 
 Which reference methods each path accepts (design spec §2, verified against `cli_image.py` /
@@ -53,6 +66,7 @@ Which reference methods each path accepts (design spec §2, verified against `cl
 | `image t2i` | `@Name` · `--reference-entity <id>` | `@Name` (in-project UUID → `referenceImages`) |
 | `image i2i` | `@Name` · `--reference-entity <id>` | `@Name` · `--ref <path-or-uuid>` |
 | `video t2v` | `@Name` · `--reference-entity <id>` | ❌ — media mentions on the video path are Phase 3 |
+| `video i2v` | ❌ — start/end frames replace ingredients | local path or catalog UUID via `IMAGE` / `--initial-frame` · optional `--end-frame` |
 | `video r2v` | `@Name` · `--reference-entity <id>` | `--ref <path>` (local ingredients); `@media` is Phase 3 |
 
 Notes:
@@ -99,9 +113,10 @@ Pick with one rule:
 
 - **Referencing a saved, named Character or asset?** Put `@Name` in the prompt. On `t2i`/`i2i` you may
   instead pass `--reference-entity <entityId>` when you have the id and want no name ambiguity — it's
-  the **same wire** and dedupes. There is **no** `--reference-entity` flag on `t2v`/`r2v`; use `@Name`.
-- **Referencing a one-off image or a look/style you won't reuse?** Use `--ref <path-or-uuid>`
-  (`i2i`, `r2v`).
+  the **same wire** and dedupes. The explicit entity flag is also available on `t2v`/`r2v`; it is
+  deliberately absent from `i2v`, whose inputs are start/end frames.
+- **Referencing a one-off image or a look/style you won't reuse?** Use `--ref <path>` on `i2i` or
+  `r2v`; a media UUID is accepted by image `i2i` only.
 - **Need the subject reused across many generations?** Create it once with `gflow character`, then
   `@Name` it everywhere.
 - **Prerequisite:** a Character must have a reference image before `@Name` will resolve — an

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
@@ -1,0 +1,247 @@
+# Media Picker Tier Reorder Implementation Plan (#529)
+
+> **For agentic workers:** Run `/gflow:status --feature issue-529-media-picker-tier-reorder`
+> to find the next unchecked task. Implement one task at a time. Run `/gflow:check`
+> before every commit.
+
+**Goal:** A bare `--ref <uuid>` (and a UUID frame slot) stops paying ~15 s of
+guaranteed-dead picker searching per reference before the scroll fallback does the
+real work — with zero change to which references can be resolved.
+
+**Architecture:** One transport-internal change. `VideoGenerationMixin._select_existing_asset`
+(`src/gflow_cli/api/transports/ui_automation_video.py:2211-2321`) is the single
+convergence point for both the image `--ref` path and the video frame-slot path —
+they differ only in what they pass in (`display_name=""` / `search_hints=()` on the
+image side). The candidate cascade splits in two: `(display_name, *search_hints)`
+runs **before** the scroll fallback; `(media_id, uuid_stem)` is retried **only after**
+the scroll misses, immediately before the caller's upload fallback. Nothing crosses a
+module boundary; no new module, port, flag, env var, exit code, or DOM selector.
+
+**Predict verdict:** CAUTION — confidence 6/10 (2026-08-15, 5-persona). The CAUTION is
+scope-driven: proposals 1/2/4 of #529 are GO-grade, proposal 3 is gated behind an
+unresolved empirical contradiction and is **out of scope here**.
+
+**Scenario input:** [`SCENARIO.md`](SCENARIO.md) — 17 scenarios across 9 active
+dimensions; 8 must-cover before merge.
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | "Delete the tiers" would lose reachability on any cohort where Flow *does* index UUIDs — evidence is from one cohort's live rounds, and this project reverse-engineers a blackbox (AGENTS.md) | **Demote, don't delete.** The UUID tiers retry after the scroll misses, so every outcome reachable today stays reachable; the 15 s is paid only on lookups already headed for upload/failure. |
+| High | Silent behaviour drift — five existing tests pin the old tier order and CHANGELOG:1049 documents it as intentional | TDD red step rewrites the five assertions (T2); T6 supersedes the #287 CHANGELOG entry by name so the tiers are not restored by a future agent. |
+| High | Operator loses the only visible progress signal (three searches typed) and sees silence for the same tens of seconds | `resolved_by` telemetry (T5) ships **in the same PR**, not as a follow-up. |
+| Medium | The picker is left filtered/scrolled on a pooled Page when the post-scroll retry misses | Clear the search before returning `False`, mirroring `_try_select_existing_by_filename:2113`. Covered by S7. |
+| Medium | `#174` cohort (no search box) now reaches the `None` branch from a different call site | S5/S6 pin both halves; the retry stays presence-guarded. |
+| Medium | The claimed benefit of reordering `search_hints` ahead of the UUID tiers is unproven if #393's caption reading is correct | T1 checks existing DOM dumps first. The CHANGELOG must not claim "hints now hit first" until observed. The **saving** is arithmetic and holds either way. |
+| Low | Scroll becomes the sole pre-upload path; its cost is unmeasured on deep grids | `resolved_by` makes it visible. Out of scope to fix; file a follow-up if telemetry shows it dominating. |
+
+---
+
+## Scope
+
+**In scope** — #529 proposals 1, 2, 4:
+- Reorder the candidate cascade (one tuple, serving both paths).
+- Retry the demoted UUID tiers after the scroll fallback.
+- Emit `resolved_by` on the existing attach events.
+
+**Out of scope** — #529 proposal 3 (port #287's hint derivation to the image path):
+blocked on T1's evidence. File as a follow-up issue with T1's result attached.
+Also out of scope: the 4 s viewport wait (`:2224`), scroll-step tuning, and any
+`--ref` CLI surface change.
+
+---
+
+## File structure
+
+### New files
+
+```
+tests/features/media_picker_tiers.feature
+  BDD scenarios for the reordered cascade and the preserved binding contract
+tests/features/test_media_picker_tiers_steps.py
+  pytest-bdd step definitions against a fake Page
+docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
+  T1 evidence note: does the picker tile's alt carry the prompt or a caption?
+```
+
+### Modified files
+
+```
+src/gflow_cli/api/transports/ui_automation_video.py
+  _select_existing_asset: split cascade, post-scroll UUID retry, resolved_by
+tests/api/transports/test_ui_automation_video.py
+  rewrite the five tier-order assertions; add the new-order and retry tests
+CHANGELOG.md
+  [Unreleased] entry naming #529 and superseding the #287 tier claim
+src/gflow_cli/cli_image.py            (T6, only if T1 resolves the contradiction)
+src/gflow_cli/errors.py               (T6, only if T1 resolves the contradiction)
+```
+
+---
+
+## Task 1 — Evidence: does a picker tile's `alt` carry the prompt or a caption?
+
+**What:** Settle the #287-vs-#393 contradiction cheaply, before any wording is
+committed. **Non-blocking for T2–T5** — start those in parallel if convenient.
+
+**Files:**
+- `docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md` — evidence note
+
+**Steps:**
+- [ ] Search existing `debug_picker_dom_*.json` dumps in prior out-dirs first — `_PICKER_DOM_DUMP_JS` (`ui_automation_video.py:616-633`) already captures the first three tiles' `outerHTML` truncated to 500 chars, which includes `<img alt="…">`. The answer may already be on disk, for zero live cost.
+- [ ] If no dump exists: open the picker on a project with a known generated asset, dump one tile's `alt`, and compare to `queries.get_asset_prompt(db_path, media_id)` for the same id.
+- [ ] Record the verdict, the raw `alt` string, the media id, and the date in the spike note.
+- [ ] If `alt` is a **caption**: file the follow-up issue recording that `search_hints` is also a dead tier, and that #529 proposal 3 is refuted rather than deferred.
+- [ ] If `alt` is the **prompt**: file the follow-up issue for proposal 3 (derive hints on the image path) with the evidence attached.
+
+**Tests created:** none — this is an evidence task, no production code.
+
+**Done when:** the spike note states one reading with a live artifact behind it, and a follow-up issue exists either way.
+
+---
+
+## Task 2 — Unit test scaffold (red)
+
+**What:** Rewrite the five assertions that pin the current tier order, and add the
+new-order, post-scroll-retry, and no-search-box tests. No production code.
+
+**Files:**
+- `tests/api/transports/test_ui_automation_video.py` — rewrite `:1837`, `:1841`, `:1861`, `:1865`, `:1918`
+
+**Steps:**
+- [ ] Replace `test_uuid_stem_search_is_tried_after_full_uuid` — the UUID tiers no longer run pre-scroll.
+- [ ] Rewrite the `terms == [FULL_UUID, "d6f1927a"]` assertion (`:1861`) to assert **zero** `press_sequentially` awaits before the first scroll on a bare-UUID ref.
+- [ ] Rewrite the `terms == [FULL_UUID, "d6f1927a", hint]` assertion (`:1918`) to `terms == [hint]` pre-scroll.
+- [ ] Keep `test_no_search_box_skips_search_tiers_and_scrolls` (`:1865`) passing, and add its post-scroll-retry twin.
+- [ ] Do **not** touch `test_search_tier_event_reports_term_and_rendered_count` (`:2560`) — `picker_search_tier`'s payload is unchanged.
+
+**Tests created (red):**
+- [ ] `test_bare_uuid_ref_scrolls_before_any_search` — S1: no search typed pre-scroll
+- [ ] `test_uuid_tiers_retried_after_scroll_miss` — S2: `terms == [FULL_UUID, "d6f1927a"]` **after** `_scroll_picker_grid_until_rendered` returns `False`
+- [ ] `test_hint_tier_runs_before_scroll_on_frame_path` — S10: `terms == [hint]` pre-scroll
+- [ ] `test_post_scroll_retry_stops_on_absent_search_box` — S6: `None` breaks the retry, no `.fill()` against an absent element
+- [ ] `test_picker_search_cleared_before_returning_false` — S7: pooled Page not handed back filtered
+- [ ] `test_tile_match_stays_uuid_in_src` — S3: an imprecise hint surfacing extra tiles never attaches a wrong one
+- [ ] `test_hyphenless_media_id_dedupes_stem` — S13: one retry pass, not two
+
+---
+
+## Task 3 — BDD scaffold (red)
+
+**What:** The four Gherkin scenarios from `SCENARIO.md`, wired to step definitions.
+
+**Files:**
+- `tests/features/media_picker_tiers.feature` — the four scenarios
+- `tests/features/test_media_picker_tiers_steps.py` — step definitions
+
+**Steps:**
+- [ ] Copy the four `Scenario:` blocks verbatim from `SCENARIO.md`.
+- [ ] Reuse the existing fake-Page fixtures from `tests/api/transports/test_ui_automation_video.py` rather than inventing a second fake.
+- [ ] Pin the exit-9 `TransportTimeoutError` message for the frame-slot scenario **byte-for-byte** against v0.57.1 (`ui_automation_video.py:1890-1897`).
+
+**Tests created (red):**
+- [ ] `A bare UUID reference off the viewport is found by scrolling` — S1
+- [ ] `An unreachable reference still refuses to generate without it` — S2 (#393 contract)
+- [ ] `A frame-slot UUID that cannot be located fails pre-generation` — S2/S10 (exit 9)
+- [ ] `A picker cohort with no search box is never blocked by search` — S5
+
+---
+
+## Task 4 — Core change: split the cascade, retry after scroll
+
+**What:** Make T2 and T3 green. The whole behavioural change lives in
+`_select_existing_asset`.
+
+**Files:**
+- `src/gflow_cli/api/transports/ui_automation_video.py` — `_select_existing_asset:2211-2321`
+
+**Steps:**
+- [ ] Extract the tier loop into a small local helper so the pre-scroll and post-scroll passes share one implementation (including the `None` → break contract and the `attempted_search` bookkeeping).
+- [ ] Pre-scroll candidates: `(display_name, *search_hints)`. Post-scroll candidates: `(media_id, uuid_stem)`. Keep the existing dedup so a hyphen-less id yields one term.
+- [ ] Preserve the existing clear-search-before-scroll block (`:2276-2283`) — a filtered grid must never be scrolled.
+- [ ] After the post-scroll retry misses, clear the search before falling through to the not-found telemetry, so the Page returns clean (S7).
+- [ ] **Rewrite, do not delete,** the docstring (`:2231-2240`) and the tier commentary (`:2247-2256`): state that the UUID tiers are demoted to last-resort, cite #287's rounds and #393's 2026-07-27 capture, and say why they are retained rather than removed. This is the guard against a future agent restoring them.
+
+**Tests:**
+- [ ] All T2 unit tests green
+- [ ] All T3 BDD scenarios green
+- [ ] `tests/cli/test_cli_image_uuid_ref_enrichment.py` unchanged and green (#393 contract)
+- [ ] `tests/cli/test_cli_video.py` hint-derivation tests unchanged and green
+
+---
+
+## Task 5 — Telemetry: `resolved_by`
+
+**What:** Make the resolving tier visible at info level, replacing the progress
+signal the removed searches used to provide.
+
+**Files:**
+- `src/gflow_cli/api/transports/ui_automation_video.py` — attach + not-found sites
+
+**Steps:**
+- [ ] Add `resolved_by` to the existing `image_ref_selected_existing` (`:2419`) and `frame_ref_attached` (`:1900`) events. **No new event name** — the picker surface already emits 14 from #287, and `docs/LIVE_VERIFICATION_*.md` treat these names as a contract.
+- [ ] Label set, closed: `viewport` · `display_name` · `hint` · `scroll` · `uuid_retry` · `upload` · `not_found`. Exactly one per reference.
+- [ ] Add `resolved_by="not_found"` to the existing `existing_asset_not_found` warning (`:2304`).
+- [ ] **Label only.** Never add the winning search *term* to these events — on the video path it is a 6-word slice of a user prompt. `picker_search_tier`'s existing `term=` field is left exactly as-is, not widened.
+
+**Tests:**
+- [ ] `test_resolved_by_reports_scroll_tier` — S8
+- [ ] `test_resolved_by_reports_upload_fallback` — S8
+- [ ] `test_resolved_by_carries_no_search_term` — S9: assert the attach event payload contains no prompt text
+
+---
+
+## Task 6 — Docs, CHANGELOG, and contradiction reconciliation
+
+**What:** Documentation is a first-class deliverable (AGENTS.md). Three source
+docstrings currently assert a reading that T1 may overturn.
+
+**Files:**
+- `CHANGELOG.md` — `[Unreleased]`
+- `src/gflow_cli/cli_image.py:258`, `src/gflow_cli/errors.py:649-660`, `src/gflow_cli/api/transports/ui_automation_video.py:2137` — only if T1 resolved the contradiction
+
+**Steps:**
+- [ ] CHANGELOG entry under `[Unreleased]`: name #529, state the measured saving (~14.9 s per unresolved reference; ~30 s per 2-ref generation), and state that reachability is unchanged because the tiers are demoted rather than deleted.
+- [ ] The same entry must **name #287 and supersede** its claim (`CHANGELOG.md:1049`) that the UUID tiers "are kept as cheap first attempts". Without this the next agent re-adds them.
+- [ ] Do **not** write "hints now hit first" unless T1 confirmed the prompt reading. If T1 confirmed the caption reading, say plainly that the hint tier's live value is unproven and link the follow-up issue.
+- [ ] If T1 resolved the contradiction, align the three docstrings to the surviving reading and cite the spike note.
+- [ ] No `docs/ARCHITECTURE.md` change needed — its Observability section documents boundary events (`error_raised`, `error_unhandled`) only, not transport events.
+- [ ] No `CONFIGURATION.md` / `.env.template` change — no new env var or flag.
+
+**Tests:**
+- [ ] `uv run python scripts/ci/check_doc_links.py` green (merge gate)
+
+---
+
+## Task 7 — Gates and live verification
+
+**What:** The Impeccable Routine, then real Flow. This touches a generation path, so
+offline green is not "done" (AGENTS.md).
+
+**Steps:**
+- [ ] `/gflow:check` — hygiene, doc links, PII, ruff, format, pyright, pytest ≥ 80%
+- [ ] `/gflow:branch-review` before opening the PR
+- [ ] Live: `gflow image i2i` with **2 bare UUID refs** into a crowded project (the #287 repro shape). Capture the `resolved_by` events and the wall-clock delta against a v0.57.1 baseline run.
+- [ ] Live: `gflow video i2v <uuid>` frame slot on the same project — confirm `frame_ref_attached` still fires and the exit-9 path is unchanged for a foreign UUID (`$0`, pre-generation).
+- [ ] Record both in `docs/LIVE_VERIFICATION_*` with the measured saving. If the delta is not observed, say so — do not claim it from the arithmetic alone.
+- [ ] `/gflow:sonar <PR>` green before calling the PR merge-ready.
+
+**Acceptance signal:** `resolved_by="scroll"` on a ref that previously logged two
+`picker_search_tier` misses first, with a measured wall-clock reduction of roughly
+15 s per such reference.
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off
+- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
+- [ ] `CHANGELOG.md` `[Unreleased]` updated, naming and superseding #287's tier claim
+- [ ] BDD feature file covers all four Critical/High scenarios from `SCENARIO.md`
+- [ ] The eight must-cover items in `SCENARIO.md` each map to a passing test
+- [ ] `resolved_by` emitted on every terminal outcome, carrying no prompt text
+- [ ] T1's spike note committed and a follow-up issue filed for #529 proposal 3
+- [ ] Live-verified per AGENTS.md; measured saving recorded, or its absence recorded
+- [ ] SonarCloud gate green (zero new issues)
+- [ ] No `# TODO` in the diff without a tracked issue link

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
@@ -1,247 +1,104 @@
-# Media Picker Tier Reorder Implementation Plan (#529)
+# Catalog-name media picker resolution plan (#529)
 
-> **For agentic workers:** Run `/gflow:status --feature issue-529-media-picker-tier-reorder`
-> to find the next unchecked task. Implement one task at a time. Run `/gflow:check`
-> before every commit.
+> Run `/gflow:status --feature issue-529-media-picker-tier-reorder` for the next
+> unchecked task and `/gflow:check` before committing.
 
-**Goal:** A bare `--ref <uuid>` (and a UUID frame slot) stops paying ~15 s of
-guaranteed-dead picker searching per reference before the scroll fallback does the
-real work — with zero change to which references can be resolved.
+## Goal
 
-**Architecture:** One transport-internal change. `VideoGenerationMixin._select_existing_asset`
-(`src/gflow_cli/api/transports/ui_automation_video.py:2211-2321`) is the single
-convergence point for both the image `--ref` path and the video frame-slot path —
-they differ only in what they pass in (`display_name=""` / `search_hints=()` on the
-image side). The candidate cascade splits in two: `(display_name, *search_hints)`
-runs **before** the scroll fallback; `(media_id, uuid_stem)` is retried **only after**
-the scroll misses, immediately before the caller's upload fallback. Nothing crosses a
-module boundary; no new module, port, flag, env var, exit code, or DOM selector.
+Resolve catalog image UUID references through Flow's browser-searchable
+`displayName`, then verify the exact UUID in the surfaced tile. The UUID path
+must not scroll the unfiltered media grid or type UUID/prompt fragments into a
+name search.
 
-**Predict verdict:** CAUTION — confidence 6/10 (2026-08-15, 5-persona). The CAUTION is
-scope-driven: proposals 1/2/4 of #529 are GO-grade, proposal 3 is gated behind an
-unresolved empirical contradiction and is **out of scope here**.
+## Evidence-driven design
 
-**Scenario input:** [`SCENARIO.md`](SCENARIO.md) — 17 scenarios across 9 active
-dimensions; 8 must-cover before merge.
+The 2026-08-15 headed-Chrome spike used one populated private test project and
+three captured assets. Live account and asset identifiers are
+intentionally omitted from this committed artifact:
 
-**Risk register:**
+- One shared display name surfaced two distinct UUID tiles.
+- One unique display name surfaced its exact UUID tile.
+- Exact UUID-in-thumbnail matching disambiguated the same-name results.
+- The harness made zero scroll calls, asset clicks, or generation requests.
 
-| Severity | Risk | Mitigation |
-|---|---|---|
-| High | "Delete the tiers" would lose reachability on any cohort where Flow *does* index UUIDs — evidence is from one cohort's live rounds, and this project reverse-engineers a blackbox (AGENTS.md) | **Demote, don't delete.** The UUID tiers retry after the scroll misses, so every outcome reachable today stays reachable; the 15 s is paid only on lookups already headed for upload/failure. |
-| High | Silent behaviour drift — five existing tests pin the old tier order and CHANGELOG:1049 documents it as intentional | TDD red step rewrites the five assertions (T2); T6 supersedes the #287 CHANGELOG entry by name so the tiers are not restored by a future agent. |
-| High | Operator loses the only visible progress signal (three searches typed) and sees silence for the same tens of seconds | `resolved_by` telemetry (T5) ships **in the same PR**, not as a follow-up. |
-| Medium | The picker is left filtered/scrolled on a pooled Page when the post-scroll retry misses | Clear the search before returning `False`, mirroring `_try_select_existing_by_filename:2113`. Covered by S7. |
-| Medium | `#174` cohort (no search box) now reaches the `None` branch from a different call site | S5/S6 pin both halves; the retry stays presence-guarded. |
-| Medium | The claimed benefit of reordering `search_hints` ahead of the UUID tiers is unproven if #393's caption reading is correct | T1 checks existing DOM dumps first. The CHANGELOG must not claim "hints now hit first" until observed. The **saving** is arithmetic and holds either way. |
-| Low | Scroll becomes the sole pre-upload path; its cost is unmeasured on deep grids | `resolved_by` makes it visible. Out of scope to fix; file a follow-up if telemetry shows it dominating. |
+That proves the contract:
 
----
-
-## Scope
-
-**In scope** — #529 proposals 1, 2, 4:
-- Reorder the candidate cascade (one tuple, serving both paths).
-- Retry the demoted UUID tiers after the scroll fallback.
-- Emit `resolved_by` on the existing attach events.
-
-**Out of scope** — #529 proposal 3 (port #287's hint derivation to the image path):
-blocked on T1's evidence. File as a follow-up issue with T1's result attached.
-Also out of scope: the 4 s viewport wait (`:2224`), scroll-step tuning, and any
-`--ref` CLI surface change.
-
----
-
-## File structure
-
-### New files
-
-```
-tests/features/media_picker_tiers.feature
-  BDD scenarios for the reordered cascade and the preserved binding contract
-tests/features/test_media_picker_tiers_steps.py
-  pytest-bdd step definitions against a fake Page
-docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
-  T1 evidence note: does the picker tile's alt carry the prompt or a caption?
+```text
+catalog UUID -> Flow displayName -> picker name search -> exact UUID tile -> attach
 ```
 
-### Modified files
+It also exposed the catalog defect behind the older workaround:
+`GeneratedImage.from_response_dict()` already joins `workflows[].metadata.displayName`,
+but the UI response collector parsed `media[]` items alone and discarded the
+sibling workflow names. Consequently UI-generated catalog rows could not provide
+the browser search key.
 
-```
-src/gflow_cli/api/transports/ui_automation_video.py
-  _select_existing_asset: split cascade, post-scroll UUID retry, resolved_by
-tests/api/transports/test_ui_automation_video.py
-  rewrite the five tier-order assertions; add the new-order and retry tests
-CHANGELOG.md
-  [Unreleased] entry naming #529 and superseding the #287 tier claim
-src/gflow_cli/cli_image.py            (T6, only if T1 resolves the contradiction)
-src/gflow_cli/errors.py               (T6, only if T1 resolves the contradiction)
-```
+## Architecture
 
----
+1. Preserve Flow `displayName` while parsing captured UI responses so the
+   existing recorder persists it in `assets.metadata_json` when prompt history
+   is stored; redacted history omits the potentially prompt-derived caption.
+2. Enrich image `--ref <uuid>` values from `AssetLookup`: display name for
+   picker search and an integrity-verified local file for #393's upload fallback.
+3. Resolve I2V start/end UUIDs to separate catalog display names and extant
+   local fallbacks in the CLI, and carry both beside the stable UUIDs on
+   `GenerateVideoRequest`.
+4. In `_select_existing_asset`, search only the display name and match only the
+   exact UUID tile. Never scroll, click an unfiltered tile, or search
+   UUID/UUID-stem/prompt text. Wait briefly for a delayed search input.
+5. Preserve fail-closed behavior: CLI/MCP image and I2V refs use a recorded
+   local fallback only when byte count/SHA-256 still matches; otherwise frame
+   refs raise `TransportTimeoutError` before submission. Every I2V frame form
+   activates the post-submit T2V-route backstop.
 
-## Task 1 — Evidence: does a picker tile's `alt` carry the prompt or a caption?
+## Tasks
 
-**What:** Settle the #287-vs-#393 contradiction cheaply, before any wording is
-committed. **Non-blocking for T2–T5** — start those in parallel if convenient.
+### Task 1 — Live spike
 
-**Files:**
-- `docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md` — evidence note
+- [x] Select a populated private test project with multiple named assets.
+- [x] Search two Flow display names in the real picker.
+- [x] Verify exact UUID tiles, including a duplicate-name case.
+- [x] Record zero scroll/click/generation requests.
 
-**Steps:**
-- [x] Search existing `debug_picker_dom_*.json` dumps in prior out-dirs first — `_PICKER_DOM_DUMP_JS` (`ui_automation_video.py:616-633`) already captures the first three tiles' `outerHTML` truncated to 500 chars, which includes `<img alt="…">`. The answer may already be on disk, for zero live cost.
-- [x] If no dump exists: open the picker on a project with a known generated asset, dump one tile's `alt`, and compare to `queries.get_asset_prompt(db_path, media_id)` for the same id. *(Not needed: two existing live dumps were compared to catalog prompts.)*
-- [x] Record the verdict, the raw `alt` string, the media id, and the date in the spike note.
-- [x] If `alt` is a **caption**: file the follow-up issue recording that `search_hints` is also a dead tier, and that #529 proposal 3 is refuted rather than deferred.
-- [x] If `alt` is the **prompt**: file the follow-up issue for proposal 3 (derive hints on the image path) with the evidence attached. *(Not applicable: the observed value is a caption; #541 records the refutation.)*
+### Task 2 — TDD and BDD
 
-**Tests created:** none — this is an evidence task, no production code.
+- [x] Add a red regression proving UI response parsing retains workflow names.
+- [x] Add a red regression proving bare image UUIDs gain catalog names.
+- [x] Add red picker tests forbidding scroll and UUID-term searches.
+- [x] Add per-frame video name-resolution tests.
+- [x] Replace the old scroll-tier Gherkin with name-search/exact-UUID scenarios.
 
-**Done when:** the spike note states one reading with a live artifact behind it, and a follow-up issue exists either way.
+### Task 3 — Implementation
 
----
+- [x] Fix UI response parsing and catalog enrichment.
+- [x] Replace prompt hints with per-frame display names.
+- [x] Remove scroll and UUID-term retries from UUID asset selection.
+- [x] Preserve exact UUID matching, local fallback, project sync, and typed failure.
+- [x] Address both xhigh review rounds; preserve MCP UUID identity and verified
+  local fallback symmetry.
+- [x] Run the scoped implementation suite (350 passed).
 
-## Task 2 — Unit test scaffold (red)
+### Task 4 — Documentation
 
-**What:** Rewrite the five assertions that pin the current tier order, and add the
-new-order, post-scroll-retry, and no-search-box tests. No production code.
+- [x] Rewrite this plan and `SCENARIO.md` around the live-proven contract.
+- [x] Expand the spike note with sanitized live evidence.
+- [x] Update reference-strategy documentation and `[Unreleased]` changelog.
+- [x] State that historic #287 prompt-hint/scroll guidance is superseded.
 
-**Files:**
-- `tests/api/transports/test_ui_automation_video.py` — rewrite `:1837`, `:1841`, `:1861`, `:1865`, `:1918`
+### Task 5 — Quality and review
 
-**Steps:**
-- [x] Replace `test_uuid_stem_search_is_tried_after_full_uuid` — the UUID tiers no longer run pre-scroll.
-- [x] Rewrite the `terms == [FULL_UUID, "d6f1927a"]` assertion (`:1861`) to assert **zero** `press_sequentially` awaits before the first scroll on a bare-UUID ref.
-- [x] Rewrite the `terms == [FULL_UUID, "d6f1927a", hint]` assertion (`:1918`) to `terms == [hint]` pre-scroll.
-- [x] Keep `test_no_search_box_skips_search_tiers_and_scrolls` (`:1865`) passing, and add its post-scroll-retry twin.
-- [x] Do **not** touch `test_search_tier_event_reports_term_and_rendered_count` (`:2560`) — `picker_search_tier`'s payload is unchanged.
-
-**Tests created (red):**
-- [x] `test_bare_uuid_ref_scrolls_before_any_search` — S1: no search typed pre-scroll
-- [x] `test_uuid_tiers_retried_after_scroll_miss` — S2: `terms == [FULL_UUID, "d6f1927a"]` **after** `_scroll_picker_grid_until_rendered` returns `False`
-- [x] `test_hint_tier_runs_before_scroll_on_frame_path` — S10: `terms == [hint]` pre-scroll
-- [x] `test_post_scroll_retry_stops_on_absent_search_box` — S6: `None` breaks the retry, no `.fill()` against an absent element
-- [x] `test_picker_search_cleared_before_returning_false` — S7: pooled Page not handed back filtered
-- [x] `test_tile_match_stays_uuid_in_src` — S3: an imprecise hint surfacing extra tiles never attaches a wrong one
-- [x] `test_hyphenless_media_id_dedupes_stem` — S13: one retry pass, not two
-
----
-
-## Task 3 — BDD scaffold (red)
-
-**What:** The four Gherkin scenarios from `SCENARIO.md`, wired to step definitions.
-
-**Files:**
-- `tests/features/media_picker_tiers.feature` — the four scenarios
-- `tests/features/test_media_picker_tiers_steps.py` — step definitions
-
-**Steps:**
-- [x] Copy the four `Scenario:` blocks verbatim from `SCENARIO.md`.
-- [x] Reuse the existing fake-Page fixtures from `tests/api/transports/test_ui_automation_video.py` rather than inventing a second fake.
-- [x] Pin the exit-9 `TransportTimeoutError` message for the frame-slot scenario **byte-for-byte** against v0.57.1 (`ui_automation_video.py:1890-1897`).
-
-**Tests created (red):**
-- [x] `A bare UUID reference off the viewport is found by scrolling` — S1
-- [x] `An unreachable reference still refuses to generate without it` — S2 (#393 contract)
-- [x] `A frame-slot UUID that cannot be located fails pre-generation` — S2/S10 (exit 9)
-- [x] `A picker cohort with no search box is never blocked by search` — S5
-
----
-
-## Task 4 — Core change: split the cascade, retry after scroll
-
-**What:** Make T2 and T3 green. The whole behavioural change lives in
-`_select_existing_asset`.
-
-**Files:**
-- `src/gflow_cli/api/transports/ui_automation_video.py` — `_select_existing_asset:2211-2321`
-
-**Steps:**
-- [x] Extract the tier loop into a small local helper so the pre-scroll and post-scroll passes share one implementation (including the `None` → break contract and the `attempted_search` bookkeeping).
-- [x] Pre-scroll candidates: `(display_name, *search_hints)`. Post-scroll candidates: `(media_id, uuid_stem)`. Keep the existing dedup so a hyphen-less id yields one term.
-- [x] Preserve the existing clear-search-before-scroll block (`:2276-2283`) — a filtered grid must never be scrolled.
-- [x] After the post-scroll retry misses, clear the search before falling through to the not-found telemetry, so the Page returns clean (S7).
-- [x] **Rewrite, do not delete,** the docstring (`:2231-2240`) and the tier commentary (`:2247-2256`): state that the UUID tiers are demoted to last-resort, cite #287's rounds and #393's 2026-07-27 capture, and say why they are retained rather than removed. This is the guard against a future agent restoring them.
-
-**Tests:**
-- [x] All T2 unit tests green
-- [x] All T3 BDD scenarios green
-- [x] `tests/cli/test_cli_image_uuid_ref_enrichment.py` unchanged and green (#393 contract)
-- [x] `tests/cli/test_cli_video.py` hint-derivation tests unchanged and green
-
----
-
-## Task 5 — Telemetry: `resolved_by`
-
-**What:** Make the resolving tier visible at info level, replacing the progress
-signal the removed searches used to provide.
-
-**Files:**
-- `src/gflow_cli/api/transports/ui_automation_video.py` — attach + not-found sites
-
-**Steps:**
-- [x] Add `resolved_by` to the existing `image_ref_selected_existing` (`:2419`) and `frame_ref_attached` (`:1900`) events. **No new event name** — the picker surface already emits 14 from #287, and `docs/LIVE_VERIFICATION_*.md` treat these names as a contract.
-- [x] Label set, closed: `viewport` · `display_name` · `hint` · `scroll` · `uuid_retry` · `upload` · `not_found`. Exactly one per reference.
-- [x] Add `resolved_by="not_found"` to the existing `existing_asset_not_found` warning (`:2304`).
-- [x] **Label only.** Never add the winning search *term* to these events — on the video path it is a 6-word slice of a user prompt. `picker_search_tier`'s existing `term=` field is left exactly as-is, not widened.
-
-**Tests:**
-- [x] `test_resolved_by_reports_scroll_tier` — S8
-- [x] `test_resolved_by_reports_upload_fallback` — S8
-- [x] `test_resolved_by_carries_no_search_term` — S9: assert the attach event payload contains no prompt text
-
----
-
-## Task 6 — Docs, CHANGELOG, and contradiction reconciliation
-
-**What:** Documentation is a first-class deliverable (AGENTS.md). Three source
-docstrings currently assert a reading that T1 may overturn.
-
-**Files:**
-- `CHANGELOG.md` — `[Unreleased]`
-- `src/gflow_cli/cli_image.py:258`, `src/gflow_cli/errors.py:649-660`, `src/gflow_cli/api/transports/ui_automation_video.py:2137` — only if T1 resolved the contradiction
-
-**Steps:**
-- [x] CHANGELOG entry under `[Unreleased]`: name #529, state the measured saving (~14.9 s per unresolved reference; ~30 s per 2-ref generation), and state that reachability is unchanged because the tiers are demoted rather than deleted.
-- [x] The same entry must **name #287 and supersede** its claim (`CHANGELOG.md:1049`) that the UUID tiers "are kept as cheap first attempts". Without this the next agent re-adds them.
-- [x] Do **not** write "hints now hit first" unless T1 confirmed the prompt reading. If T1 confirmed the caption reading, say plainly that the hint tier's live value is unproven and link the follow-up issue.
-- [x] If T1 resolved the contradiction, align the three docstrings to the surviving reading and cite the spike note.
-- [x] No `docs/ARCHITECTURE.md` change needed — its Observability section documents boundary events (`error_raised`, `error_unhandled`) only, not transport events.
-- [x] No `CONFIGURATION.md` / `.env.template` change — no new env var or flag.
-
-**Tests:**
-- [x] `uv run python scripts/ci/check_doc_links.py` green (merge gate)
-
----
-
-## Task 7 — Gates and live verification
-
-**What:** The Impeccable Routine, then real Flow. This touches a generation path, so
-offline green is not "done" (AGENTS.md).
-
-**Steps:**
-- [ ] `/gflow:check` — hygiene, doc links, PII, ruff, format, pyright, pytest ≥ 80%
-- [ ] `/gflow:branch-review` before opening the PR
-- [ ] Live: `gflow image i2i` with **2 bare UUID refs** into a crowded project (the #287 repro shape). Capture the `resolved_by` events and the wall-clock delta against a v0.57.1 baseline run.
-- [ ] Live: `gflow video i2v <uuid>` frame slot on the same project — confirm `frame_ref_attached` still fires and the exit-9 path is unchanged for a foreign UUID (`$0`, pre-generation).
-- [ ] Record both in `docs/LIVE_VERIFICATION_*` with the measured saving. If the delta is not observed, say so — do not claim it from the arithmetic alone.
-- [ ] `/gflow:sonar <PR>` green before calling the PR merge-ready.
-
-**Acceptance signal:** `resolved_by="scroll"` on a ref that previously logged two
-`picker_search_tier` misses first, with a measured wall-clock reduction of roughly
-15 s per such reference.
-
----
+- [x] Run `/gflow:check` (all seven local gates).
+- [x] Run `/gflow:pr-council-review` and reach consensus green.
+- [x] Re-run the picker verification against both the implemented image-picker
+  selector and real I2V Start-frame slot paths.
+- [ ] Update PR #540, then verify CI and `/gflow:sonar 540` are green.
 
 ## Definition of done
 
-- [ ] All task steps checked off
-- [ ] `/gflow:check` green (ruff / format / pyright / pytest ≥ 80% coverage)
-- [ ] `CHANGELOG.md` `[Unreleased]` updated, naming and superseding #287's tier claim
-- [ ] BDD feature file covers all four Critical/High scenarios from `SCENARIO.md`
-- [ ] The eight must-cover items in `SCENARIO.md` each map to a passing test
-- [ ] `resolved_by` emitted on every terminal outcome, carrying no prompt text
-- [ ] T1's spike note committed and a follow-up issue filed for #529 proposal 3
-- [ ] Live-verified per AGENTS.md; measured saving recorded, or its absence recorded
-- [ ] SonarCloud gate green (zero new issues)
-- [ ] No `# TODO` in the diff without a tracked issue link
+- [x] All local quality gates green.
+- [x] Council consensus green.
+- [x] Image-picker and I2V frame-slot paths live-verified with no generation
+  submission required.
+- [ ] PR #540 updated; CI and SonarCloud show zero new issues.
+- [x] Current guidance supersedes the historical changelog entries that record
+  UUID/prompt search and unfiltered grid scrolling experiments.

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
@@ -89,11 +89,11 @@ committed. **Non-blocking for T2–T5** — start those in parallel if convenien
 - `docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md` — evidence note
 
 **Steps:**
-- [ ] Search existing `debug_picker_dom_*.json` dumps in prior out-dirs first — `_PICKER_DOM_DUMP_JS` (`ui_automation_video.py:616-633`) already captures the first three tiles' `outerHTML` truncated to 500 chars, which includes `<img alt="…">`. The answer may already be on disk, for zero live cost.
-- [ ] If no dump exists: open the picker on a project with a known generated asset, dump one tile's `alt`, and compare to `queries.get_asset_prompt(db_path, media_id)` for the same id.
-- [ ] Record the verdict, the raw `alt` string, the media id, and the date in the spike note.
-- [ ] If `alt` is a **caption**: file the follow-up issue recording that `search_hints` is also a dead tier, and that #529 proposal 3 is refuted rather than deferred.
-- [ ] If `alt` is the **prompt**: file the follow-up issue for proposal 3 (derive hints on the image path) with the evidence attached.
+- [x] Search existing `debug_picker_dom_*.json` dumps in prior out-dirs first — `_PICKER_DOM_DUMP_JS` (`ui_automation_video.py:616-633`) already captures the first three tiles' `outerHTML` truncated to 500 chars, which includes `<img alt="…">`. The answer may already be on disk, for zero live cost.
+- [x] If no dump exists: open the picker on a project with a known generated asset, dump one tile's `alt`, and compare to `queries.get_asset_prompt(db_path, media_id)` for the same id. *(Not needed: two existing live dumps were compared to catalog prompts.)*
+- [x] Record the verdict, the raw `alt` string, the media id, and the date in the spike note.
+- [x] If `alt` is a **caption**: file the follow-up issue recording that `search_hints` is also a dead tier, and that #529 proposal 3 is refuted rather than deferred.
+- [x] If `alt` is the **prompt**: file the follow-up issue for proposal 3 (derive hints on the image path) with the evidence attached. *(Not applicable: the observed value is a caption; #541 records the refutation.)*
 
 **Tests created:** none — this is an evidence task, no production code.
 
@@ -110,20 +110,20 @@ new-order, post-scroll-retry, and no-search-box tests. No production code.
 - `tests/api/transports/test_ui_automation_video.py` — rewrite `:1837`, `:1841`, `:1861`, `:1865`, `:1918`
 
 **Steps:**
-- [ ] Replace `test_uuid_stem_search_is_tried_after_full_uuid` — the UUID tiers no longer run pre-scroll.
-- [ ] Rewrite the `terms == [FULL_UUID, "d6f1927a"]` assertion (`:1861`) to assert **zero** `press_sequentially` awaits before the first scroll on a bare-UUID ref.
-- [ ] Rewrite the `terms == [FULL_UUID, "d6f1927a", hint]` assertion (`:1918`) to `terms == [hint]` pre-scroll.
-- [ ] Keep `test_no_search_box_skips_search_tiers_and_scrolls` (`:1865`) passing, and add its post-scroll-retry twin.
-- [ ] Do **not** touch `test_search_tier_event_reports_term_and_rendered_count` (`:2560`) — `picker_search_tier`'s payload is unchanged.
+- [x] Replace `test_uuid_stem_search_is_tried_after_full_uuid` — the UUID tiers no longer run pre-scroll.
+- [x] Rewrite the `terms == [FULL_UUID, "d6f1927a"]` assertion (`:1861`) to assert **zero** `press_sequentially` awaits before the first scroll on a bare-UUID ref.
+- [x] Rewrite the `terms == [FULL_UUID, "d6f1927a", hint]` assertion (`:1918`) to `terms == [hint]` pre-scroll.
+- [x] Keep `test_no_search_box_skips_search_tiers_and_scrolls` (`:1865`) passing, and add its post-scroll-retry twin.
+- [x] Do **not** touch `test_search_tier_event_reports_term_and_rendered_count` (`:2560`) — `picker_search_tier`'s payload is unchanged.
 
 **Tests created (red):**
-- [ ] `test_bare_uuid_ref_scrolls_before_any_search` — S1: no search typed pre-scroll
-- [ ] `test_uuid_tiers_retried_after_scroll_miss` — S2: `terms == [FULL_UUID, "d6f1927a"]` **after** `_scroll_picker_grid_until_rendered` returns `False`
-- [ ] `test_hint_tier_runs_before_scroll_on_frame_path` — S10: `terms == [hint]` pre-scroll
-- [ ] `test_post_scroll_retry_stops_on_absent_search_box` — S6: `None` breaks the retry, no `.fill()` against an absent element
-- [ ] `test_picker_search_cleared_before_returning_false` — S7: pooled Page not handed back filtered
-- [ ] `test_tile_match_stays_uuid_in_src` — S3: an imprecise hint surfacing extra tiles never attaches a wrong one
-- [ ] `test_hyphenless_media_id_dedupes_stem` — S13: one retry pass, not two
+- [x] `test_bare_uuid_ref_scrolls_before_any_search` — S1: no search typed pre-scroll
+- [x] `test_uuid_tiers_retried_after_scroll_miss` — S2: `terms == [FULL_UUID, "d6f1927a"]` **after** `_scroll_picker_grid_until_rendered` returns `False`
+- [x] `test_hint_tier_runs_before_scroll_on_frame_path` — S10: `terms == [hint]` pre-scroll
+- [x] `test_post_scroll_retry_stops_on_absent_search_box` — S6: `None` breaks the retry, no `.fill()` against an absent element
+- [x] `test_picker_search_cleared_before_returning_false` — S7: pooled Page not handed back filtered
+- [x] `test_tile_match_stays_uuid_in_src` — S3: an imprecise hint surfacing extra tiles never attaches a wrong one
+- [x] `test_hyphenless_media_id_dedupes_stem` — S13: one retry pass, not two
 
 ---
 
@@ -136,15 +136,15 @@ new-order, post-scroll-retry, and no-search-box tests. No production code.
 - `tests/features/test_media_picker_tiers_steps.py` — step definitions
 
 **Steps:**
-- [ ] Copy the four `Scenario:` blocks verbatim from `SCENARIO.md`.
-- [ ] Reuse the existing fake-Page fixtures from `tests/api/transports/test_ui_automation_video.py` rather than inventing a second fake.
-- [ ] Pin the exit-9 `TransportTimeoutError` message for the frame-slot scenario **byte-for-byte** against v0.57.1 (`ui_automation_video.py:1890-1897`).
+- [x] Copy the four `Scenario:` blocks verbatim from `SCENARIO.md`.
+- [x] Reuse the existing fake-Page fixtures from `tests/api/transports/test_ui_automation_video.py` rather than inventing a second fake.
+- [x] Pin the exit-9 `TransportTimeoutError` message for the frame-slot scenario **byte-for-byte** against v0.57.1 (`ui_automation_video.py:1890-1897`).
 
 **Tests created (red):**
-- [ ] `A bare UUID reference off the viewport is found by scrolling` — S1
-- [ ] `An unreachable reference still refuses to generate without it` — S2 (#393 contract)
-- [ ] `A frame-slot UUID that cannot be located fails pre-generation` — S2/S10 (exit 9)
-- [ ] `A picker cohort with no search box is never blocked by search` — S5
+- [x] `A bare UUID reference off the viewport is found by scrolling` — S1
+- [x] `An unreachable reference still refuses to generate without it` — S2 (#393 contract)
+- [x] `A frame-slot UUID that cannot be located fails pre-generation` — S2/S10 (exit 9)
+- [x] `A picker cohort with no search box is never blocked by search` — S5
 
 ---
 
@@ -157,17 +157,17 @@ new-order, post-scroll-retry, and no-search-box tests. No production code.
 - `src/gflow_cli/api/transports/ui_automation_video.py` — `_select_existing_asset:2211-2321`
 
 **Steps:**
-- [ ] Extract the tier loop into a small local helper so the pre-scroll and post-scroll passes share one implementation (including the `None` → break contract and the `attempted_search` bookkeeping).
-- [ ] Pre-scroll candidates: `(display_name, *search_hints)`. Post-scroll candidates: `(media_id, uuid_stem)`. Keep the existing dedup so a hyphen-less id yields one term.
-- [ ] Preserve the existing clear-search-before-scroll block (`:2276-2283`) — a filtered grid must never be scrolled.
-- [ ] After the post-scroll retry misses, clear the search before falling through to the not-found telemetry, so the Page returns clean (S7).
-- [ ] **Rewrite, do not delete,** the docstring (`:2231-2240`) and the tier commentary (`:2247-2256`): state that the UUID tiers are demoted to last-resort, cite #287's rounds and #393's 2026-07-27 capture, and say why they are retained rather than removed. This is the guard against a future agent restoring them.
+- [x] Extract the tier loop into a small local helper so the pre-scroll and post-scroll passes share one implementation (including the `None` → break contract and the `attempted_search` bookkeeping).
+- [x] Pre-scroll candidates: `(display_name, *search_hints)`. Post-scroll candidates: `(media_id, uuid_stem)`. Keep the existing dedup so a hyphen-less id yields one term.
+- [x] Preserve the existing clear-search-before-scroll block (`:2276-2283`) — a filtered grid must never be scrolled.
+- [x] After the post-scroll retry misses, clear the search before falling through to the not-found telemetry, so the Page returns clean (S7).
+- [x] **Rewrite, do not delete,** the docstring (`:2231-2240`) and the tier commentary (`:2247-2256`): state that the UUID tiers are demoted to last-resort, cite #287's rounds and #393's 2026-07-27 capture, and say why they are retained rather than removed. This is the guard against a future agent restoring them.
 
 **Tests:**
-- [ ] All T2 unit tests green
-- [ ] All T3 BDD scenarios green
-- [ ] `tests/cli/test_cli_image_uuid_ref_enrichment.py` unchanged and green (#393 contract)
-- [ ] `tests/cli/test_cli_video.py` hint-derivation tests unchanged and green
+- [x] All T2 unit tests green
+- [x] All T3 BDD scenarios green
+- [x] `tests/cli/test_cli_image_uuid_ref_enrichment.py` unchanged and green (#393 contract)
+- [x] `tests/cli/test_cli_video.py` hint-derivation tests unchanged and green
 
 ---
 
@@ -180,15 +180,15 @@ signal the removed searches used to provide.
 - `src/gflow_cli/api/transports/ui_automation_video.py` — attach + not-found sites
 
 **Steps:**
-- [ ] Add `resolved_by` to the existing `image_ref_selected_existing` (`:2419`) and `frame_ref_attached` (`:1900`) events. **No new event name** — the picker surface already emits 14 from #287, and `docs/LIVE_VERIFICATION_*.md` treat these names as a contract.
-- [ ] Label set, closed: `viewport` · `display_name` · `hint` · `scroll` · `uuid_retry` · `upload` · `not_found`. Exactly one per reference.
-- [ ] Add `resolved_by="not_found"` to the existing `existing_asset_not_found` warning (`:2304`).
-- [ ] **Label only.** Never add the winning search *term* to these events — on the video path it is a 6-word slice of a user prompt. `picker_search_tier`'s existing `term=` field is left exactly as-is, not widened.
+- [x] Add `resolved_by` to the existing `image_ref_selected_existing` (`:2419`) and `frame_ref_attached` (`:1900`) events. **No new event name** — the picker surface already emits 14 from #287, and `docs/LIVE_VERIFICATION_*.md` treat these names as a contract.
+- [x] Label set, closed: `viewport` · `display_name` · `hint` · `scroll` · `uuid_retry` · `upload` · `not_found`. Exactly one per reference.
+- [x] Add `resolved_by="not_found"` to the existing `existing_asset_not_found` warning (`:2304`).
+- [x] **Label only.** Never add the winning search *term* to these events — on the video path it is a 6-word slice of a user prompt. `picker_search_tier`'s existing `term=` field is left exactly as-is, not widened.
 
 **Tests:**
-- [ ] `test_resolved_by_reports_scroll_tier` — S8
-- [ ] `test_resolved_by_reports_upload_fallback` — S8
-- [ ] `test_resolved_by_carries_no_search_term` — S9: assert the attach event payload contains no prompt text
+- [x] `test_resolved_by_reports_scroll_tier` — S8
+- [x] `test_resolved_by_reports_upload_fallback` — S8
+- [x] `test_resolved_by_carries_no_search_term` — S9: assert the attach event payload contains no prompt text
 
 ---
 
@@ -202,15 +202,15 @@ docstrings currently assert a reading that T1 may overturn.
 - `src/gflow_cli/cli_image.py:258`, `src/gflow_cli/errors.py:649-660`, `src/gflow_cli/api/transports/ui_automation_video.py:2137` — only if T1 resolved the contradiction
 
 **Steps:**
-- [ ] CHANGELOG entry under `[Unreleased]`: name #529, state the measured saving (~14.9 s per unresolved reference; ~30 s per 2-ref generation), and state that reachability is unchanged because the tiers are demoted rather than deleted.
-- [ ] The same entry must **name #287 and supersede** its claim (`CHANGELOG.md:1049`) that the UUID tiers "are kept as cheap first attempts". Without this the next agent re-adds them.
-- [ ] Do **not** write "hints now hit first" unless T1 confirmed the prompt reading. If T1 confirmed the caption reading, say plainly that the hint tier's live value is unproven and link the follow-up issue.
-- [ ] If T1 resolved the contradiction, align the three docstrings to the surviving reading and cite the spike note.
-- [ ] No `docs/ARCHITECTURE.md` change needed — its Observability section documents boundary events (`error_raised`, `error_unhandled`) only, not transport events.
-- [ ] No `CONFIGURATION.md` / `.env.template` change — no new env var or flag.
+- [x] CHANGELOG entry under `[Unreleased]`: name #529, state the measured saving (~14.9 s per unresolved reference; ~30 s per 2-ref generation), and state that reachability is unchanged because the tiers are demoted rather than deleted.
+- [x] The same entry must **name #287 and supersede** its claim (`CHANGELOG.md:1049`) that the UUID tiers "are kept as cheap first attempts". Without this the next agent re-adds them.
+- [x] Do **not** write "hints now hit first" unless T1 confirmed the prompt reading. If T1 confirmed the caption reading, say plainly that the hint tier's live value is unproven and link the follow-up issue.
+- [x] If T1 resolved the contradiction, align the three docstrings to the surviving reading and cite the spike note.
+- [x] No `docs/ARCHITECTURE.md` change needed — its Observability section documents boundary events (`error_raised`, `error_unhandled`) only, not transport events.
+- [x] No `CONFIGURATION.md` / `.env.template` change — no new env var or flag.
 
 **Tests:**
-- [ ] `uv run python scripts/ci/check_doc_links.py` green (merge gate)
+- [x] `uv run python scripts/ci/check_doc_links.py` green (merge gate)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/PLAN.md
@@ -91,7 +91,7 @@ the browser search key.
 - [x] Run `/gflow:pr-council-review` and reach consensus green.
 - [x] Re-run the picker verification against both the implemented image-picker
   selector and real I2V Start-frame slot paths.
-- [ ] Update PR #540, then verify CI and `/gflow:sonar 540` are green.
+- [x] Update PR #540, then verify CI and `/gflow:sonar 540` are green.
 
 ## Definition of done
 
@@ -99,6 +99,6 @@ the browser search key.
 - [x] Council consensus green.
 - [x] Image-picker and I2V frame-slot paths live-verified with no generation
   submission required.
-- [ ] PR #540 updated; CI and SonarCloud show zero new issues.
+- [x] PR #540 updated; CI and SonarCloud show zero new issues.
 - [x] Current guidance supersedes the historical changelog entries that record
   UUID/prompt search and unfiltered grid scrolling experiments.

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/SCENARIO.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/SCENARIO.md
@@ -1,160 +1,63 @@
-# Scenario: #529 — media-picker UUID search tiers demoted below the scroll fallback
+# Scenario: catalog-name media picker resolution (#529)
 
-> Predict verdict: **CAUTION** (2026-08-15, 5-persona; confidence 6/10). Mitigations
-> folded into PLAN.md tasks. Scope fixed at issue proposals **1 + 2 + 4**; proposal 3
-> (porting #287's hint derivation to the image path) is gated behind the alt-text
-> experiment (T0) and is explicitly **out of scope** for this plan.
-
-**Change under test.** `VideoGenerationMixin._select_existing_asset`
-(`src/gflow_cli/api/transports/ui_automation_video.py:2211-2321`) currently walks
-`(display_name, media_id, uuid_stem, *search_hints)` before falling back to
-scrolling the virtualised grid. Two of those tiers — the full media UUID and its
-first hyphen segment — are live-proven never to match (#287 rounds, #393
-2026-07-27) and cost ~14.9 s per reference. The change reorders the cascade to
-`(display_name, *search_hints)` pre-scroll and **retries `(media_id, uuid_stem)`
-only after the scroll fallback misses**, plus emits a `resolved_by` tier label on
-the attach events.
-
----
+**Change under test:** A catalog UUID is stable asset identity. Flow's browser
+picker is filtered by the catalog-recorded `displayName`, and the exact UUID is
+then asserted in the result tile's thumbnail URL. UUID references do not scroll
+the unfiltered grid or search UUID/prompt fragments.
 
 ## Coverage map
 
-| Dim | Active? | Why |
-|---|---|---|
-| **D2** WAF / reCAPTCHA | ✅ light | Removes 2 `press_sequentially` bursts per ref from the pre-scroll path — changes the session's interaction fingerprint (net fewer synthetic keystrokes, shorter dialog-open window). No token minting touched. |
-| **D3** Selector drift & locale | ✅ | `PICKER_SEARCH_INPUT` presence-probing moves; the #174 no-search-box cohort now hits a *different* code path. No new selectors, so locale-invariance is not engaged. |
-| **D4** Batch & resume | ✅ | `image batch` / `movie run` attach the same refs across many rows; the saving compounds and any reachability regression multiplies. |
-| **D5** Concurrency & Page pool | ✅ | The post-scroll retry types into a grid that is already scrolled — pooled-Page state on checkin. Reduced hold time raises effective throughput. |
-| **D6** Data layer | ✅ light | `_media_search_hints` → `get_asset_prompt` and `_enrich_uuid_refs` → `resolve_seed_image` are the only catalog reads; both already best-effort. No schema change. |
-| **D7** Error propagation & exit codes | ✅ | The exit-9 `TransportTimeoutError` frame-slot contract and the #393 "never generate without the ref" contract must survive byte-for-byte. |
-| **D9** Transport edge cases | ✅ | `_search_picker_for_tile` returning `None` (no search box) is a three-state result; the reorder changes when that state is first observed. |
-| **D11** Input validation | ✅ edge-only | `uuid_stem = media_id.split("-", 1)[0]` on a hyphen-less id yields the full id — a duplicate the `terms` dedup already absorbs. Must stay absorbed after the split. |
-| **D12** Observability | ✅ | New `resolved_by` field; `picker_search_tier` event ordering changes; `docs/ARCHITECTURE.md` event contract. |
-| D1 Auth & session | ⛔ skipped | No cookie, SAPISID, token, or profile-lease surface. |
-| D8 Cross-platform paths | ⛔ skipped | No path construction, no `platformdirs`, no filename handling. `local_path` is passed through unchanged. |
-| D10 Headless vs headed | ⛔ skipped | Wall-clock only; no environment-conditional branch. The change behaves identically headed and headless. |
+| Dimension | Scenario | Severity | Expected behavior |
+|---|---|---:|---|
+| Data | UI generation response carries sibling `workflows[]` names | Critical | The returned `GeneratedImage.display_name` is populated and store-mode history persists it. |
+| Privacy | Prompt history is redacted | Critical | The potentially prompt-derived Flow caption is not persisted or logged in plaintext. |
+| Data | Bare image UUID is present in the local catalog | Critical | Enrichment supplies `display_name`; a matching recorded local file remains the upload fallback. |
+| Picker | Named asset is outside the initial virtualized viewport | Critical | Name search surfaces candidates; exact UUID tile attaches; zero grid scroll. |
+| Picker | Two assets share one display name | Critical | Search may surface both, but only the tile whose image URL contains the requested UUID attaches. |
+| Picker | UUID/name/stem differ | High | Only the display name is typed. UUID and UUID stem are never search terms. |
+| Picker | Exact UUID tile exists only in the unfiltered/overscan grid | Critical | It is not clicked; no Playwright implicit scroll can occur. |
+| Failure | Name search misses and a local file exists | Critical | The search is cleared and the recorded file uploads; no generation can proceed without a bound ref. |
+| Failure | Name search misses with no local fallback | Critical | Image/frame binding raises `TransportTimeoutError` before prompt submission. |
+| Video | Start and end frames have different names | High | Each UUID carries its own display name to its own frame-slot lookup. |
+| Video | Named frame picker lookup misses but a local image exists | Critical | The exact recorded bytes upload for either start or end frame. |
+| Video | Catalog frame has no retained name but has a local image | High | The exact recorded bytes are uploaded; the unfiltered picker is not scanned. |
+| Compatibility | Legacy catalog row lacks `display_name` | Medium | A verified local file uploads; otherwise binding fails closed without clicking the unfiltered grid. |
+| Compatibility | Picker search input mounts late or is absent | Medium | Wait up to the bounded search timeout; absence uses verified local fallback or typed failure. |
+| Integrity | Catalog local file was replaced after recording | Critical | Byte-count/SHA-256 mismatch disables upload fallback. |
+| MCP | I2V frame is supplied as a catalog UUID | Critical | Queue payload preserves UUID, display name, and verified local fallback through worker decode. |
+| Spend safety | UUID-backed I2V routes to T2V | Critical | Post-submit route guard rejects the output instead of reporting false success. |
+| State | First ref leaves a picker term behind | High | Caller/search clears are presence-guarded per reference; pooled Page state does not leak. |
+| Diagnostics | Exact tile is absent | Medium | Existing screenshot and bounded DOM dump remain available without adding user text to terminal events. |
 
----
+## BDD scenarios
 
-## Scenario table
+The executable feature at `tests/features/media_picker_tiers.feature` covers:
 
-| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
-|---|---|---|---|---|---|
-| S1 | D7 | Bare `--ref <uuid>` whose tile is **off-viewport**; scroll finds it | **Critical** | Attached from the scroll tier. Zero `press_sequentially` calls before the scroll. Same tile, same `_attach_selected_tile` call as today. | Unit (fake page) |
-| S2 | D7 | Ref is unreachable by **every** tier (viewport, scroll, demoted UUID tiers) | **Critical** | Image path uploads `local_path` (#393 rescue); frame-slot path raises `TransportTimeoutError` **exit 9**. Generation **never** proceeds without the reference. | Unit + BDD |
-| S3 | D9 | Tile matching after the reorder | **Critical** | `_existing_asset_tile` still matches `[role='option']:has(img[src*='<uuid>'])` — never a name/caption match. A hint that surfaces 30 tiles still selects only the UUID one. | Unit |
-| S4 | D4 | `image batch` / `movie run` attaching the same 2 UUID refs across 11 rows | **High** | ~30 s saved per row (~5.5 min per pass). No cross-row search-term leakage — the per-ref `search.fill("")` at `:2404-2409` still runs first. | Integration |
-| S5 | D3 | #174 cohort: picker variant with **no search box at all** | **High** | Pre-scroll `terms` is empty on the image path, so `_search_picker_for_tile` is never called and `picker_search_unavailable` is not emitted before the scroll. Scroll runs; post-scroll retry probes once, gets `None`, and gives up without a hard dependency on the box. | Unit |
-| S6 | D9 | Post-scroll UUID retry returns `None` (no search box) mid-loop | **High** | `break` out of the retry, proceed to not-found telemetry + upload fallback. No unguarded `.fill("")` against an absent element (would burn a full actionability timeout). | Unit |
-| S7 | D5 | Post-scroll retry types a term into an **already-scrolled** grid | **High** | Search must be cleared before the caller returns `False`, so the pooled Page is never handed back holding a filtered + scrolled grid. Mirrors `_try_select_existing_by_filename:2113`. | Unit |
-| S8 | D12 | `resolved_by` emitted on every terminal outcome | **High** | Exactly one of `viewport` / `display_name` / `hint` / `scroll` / `uuid_retry` / `upload` / `not_found` per ref, on the existing `image_ref_selected_existing` and `frame_ref_attached` events. Never a new event name. | Unit (capture logs) |
-| S9 | D12 | `resolved_by` payload contains no user content | **High** | The field is a fixed tier **label**. The winning search *term* (a 6-word prompt slice on the video path) is never added to the attach events. `picker_search_tier`'s existing `term=` is unchanged — not widened. | Unit |
-| S10 | D7 | Video frame-slot path (`_attach_frame_by_media_id:1850-1900`) | **High** | `display_name` is `""`, hints may be present. Pre-scroll cascade is `(*search_hints,)` only. Error message, screenshot name, and exit code identical to v0.57.1. | Unit + BDD |
-| S11 | D3 | Flow renames the thumbnail URL param so `img[src*=<uuid>]` stops matching | **Medium** | Unchanged failure mode: every tier misses, `existing_asset_not_found` warns with screenshot + `debug_picker_dom_<uuid8>.json`. The reorder must not swallow this diagnostic path. | Unit |
-| S12 | D2 | Profile with elevated WAF heat runs a 2-ref i2i | **Medium** | Fewer synthetic keystrokes and a shorter dialog-open window than v0.57.1 — strictly less automation surface. No new interaction primitive introduced (scroll already ran on every one of these lookups). | Live (observational) |
-| S13 | D11 | `media_id` with no hyphen (malformed or non-standard id) | **Medium** | `uuid_stem == media_id`; the dedup keeps `terms` at one entry in the post-scroll retry. No double 7.9 s pass. | Unit |
-| S14 | D6 | Catalog unavailable / asset unknown → `search_hints=()` and `local_path=""` | **Medium** | Video path: pre-scroll cascade is empty, straight to scroll. Image path: unchanged from today. Both stay best-effort; no `DataStoreError` escapes. | Unit |
-| S15 | D12 | `picker_search_tier` events now appear **after** `picker_scroll_done` | **Medium** | Log-order change is intentional and documented. Anything parsing these events (live-verification ledger) must be told the order flipped. | Review gate |
-| S16 | D5 | `GFLOW_CLI_CONCURRENCY` at its current ceiling with UUID refs | **Low** | ~30 s less Page checkout per generation → more headroom at the same ceiling. The safe ceiling itself is **not** raised by this change. | Live (observational) |
-| S17 | D4 | A ref that resolves from the **viewport** (freshly generated asset) | **Low** | Untouched path — still the 4 s `tile.wait_for(state="visible", timeout=4000)` at `:2224`, no searches, no scroll. `resolved_by="viewport"`. | Unit |
+1. Catalog name → exact UUID tile → attach, with no scroll.
+2. Duplicate names disambiguated by UUID.
+3. Named miss → recorded local fallback, with no scroll.
+4. Video frame UUID → per-frame catalog name → exact UUID tile.
 
-Severity: **Critical** (data loss / billed twice / unrecoverable) · **High** (feature broken, workaround exists) · **Medium** (degraded UX, explicit error) · **Low** (cosmetic or edge-only)
+## Must-cover assertions
 
----
+- UI response collection uses the sibling workflow metadata instead of parsing
+  media items in isolation.
+- Catalog enrichment preserves an existing mention name and ignores stale local
+  paths.
+- `_existing_asset_tile` remains UUID-in-`src`; no name-only tile click exists.
+- `_scroll_picker_grid_until_rendered` is never invoked by the UUID asset path.
+- `press_sequentially` receives one value: `display_name`.
+- Name collisions cannot attach a sibling UUID.
+- Image fallback, named/unnamed frame local fallback, and video fail-closed
+  behavior happen before submission.
+- A failed/absent name search never reaches `locator.click()` on an unfiltered
+  tile, preventing Playwright's implicit scroll behavior.
+- Project-picker synchronization still runs before every UUID lookup.
 
-## Must-cover before merge (Critical + High)
+## Empirical boundary
 
-1. **S1** — the saving actually lands: assert zero `press_sequentially` awaits before the first scroll on a bare-UUID image ref.
-2. **S2** — the #393 contract is untouched: unreachable ref uploads (image) or exits 9 (frame slot); **never** generates without the reference.
-3. **S3** — tile identity stays UUID-in-`src`; an imprecise hint can surface extra tiles but can never attach a wrong one.
-4. **S5 / S6** — the #174 no-search-box cohort survives both the new empty-`terms` path and the post-scroll retry probe.
-5. **S7** — the picker is left clean (search cleared) whenever `_select_existing_asset` returns `False`.
-6. **S8 / S9** — `resolved_by` covers every terminal outcome and leaks no prompt text.
-7. **S10** — the video frame-slot error contract (message, screenshot name, exit 9) is pinned byte-for-byte.
-8. **S4** — batch/manifest paths keep the per-ref `search.fill("")` reset, so terms never leak between rows.
-
-**Rewrite targets (existing tests pin the old order — TDD red step):**
-`tests/api/transports/test_ui_automation_video.py:1837` (`test_...full_uuid`), `:1841`
-(`test_uuid_stem_search_is_tried_after_full_uuid`), `:1861` (`terms == [FULL_UUID, "d6f1927a"]`),
-`:1918` (`terms == [FULL_UUID, "d6f1927a", hint]`), `:1865`
-(`test_no_search_box_skips_search_tiers_and_scrolls`).
-
----
-
-## Deferred (Medium + Low — log as issues, not blockers)
-
-1. **S11** — thumbnail-URL drift is a pre-existing exposure, unchanged by this plan.
-2. **S12 / S16** — WAF and concurrency effects are observational; record in live verification, do not gate the merge.
-3. **Proposal 3** (port hint derivation to the image path) — blocked on the T0 alt-text experiment. File as a follow-up issue with the experiment's result attached.
-4. **The 4 s viewport wait** (`:2224`) is paid per ref on every lookup and was not raised by #529. If T0's telemetry shows it dominating on fast cohorts, file separately.
-5. **Scroll cost** (350 ms/step, stall-bounded at 3, ceiling 200) becomes the sole pre-upload path. If `resolved_by` telemetry shows scroll depth dominating, that is the next bottleneck — a new issue, not this plan.
-
----
-
-## Suggested BDD scenarios (`tests/features/media_picker_tiers.feature`)
-
-```gherkin
-Feature: Media picker resolves UUID references without dead search tiers
-  The picker's full-UUID and UUID-stem search tiers are live-proven never to
-  match (#287, #393). They must not run before the scroll fallback, and the
-  reference-binding contract must be unchanged.
-
-  Scenario: A bare UUID reference off the viewport is found by scrolling
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the reference tile is not in the picker's initial viewport
-    When the transport binds the reference
-    Then no search term is typed before the grid is scrolled
-    And the tile is attached from the scroll tier
-    And the attach event reports resolved_by "scroll"
-
-  Scenario: An unreachable reference still refuses to generate without it
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the reference tile is absent from the picker entirely
-    When the transport binds the reference
-    Then the demoted UUID search tiers are attempted after the scroll
-    And the recorded local file is uploaded as the fallback
-    And the generation never proceeds without the reference
-
-  Scenario: A frame-slot UUID that cannot be located fails pre-generation
-    Given a video i2v generation with an initial frame given as a media UUID
-    And the asset is absent from the picker entirely
-    When the transport binds the frame
-    Then a TransportTimeoutError naming the slot and the UUID is raised
-    And the process exits with code 9
-    And no generation is submitted
-
-  Scenario: A picker cohort with no search box is never blocked by search
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the picker variant renders no search input
-    When the transport binds the reference
-    Then no search input is filled at any point
-    And the grid is scrolled to locate the tile
-```
-
----
-
-## Known-issues cross-reference
-
-| Entry | Relationship |
-|---|---|
-| `KNOWN_ISSUES.md:118` — *i2v frame-slot picker selection by UUID — RESOLVED live 2026-07-11* | **Must not regress.** S10 pins its contract. The reorder keeps `_select_existing_asset` as the single resolution point, so the resolution stands. |
-| `#174` — full-page media-library drift (picker variant with no search box) | **Mitigated, differently.** Today the `None` return is observed on the first search tier; after the reorder the image path never probes pre-scroll. S5/S6 cover both halves. |
-| `#282` / `#287` — virtualised grid scrolling, progress-bounded | **Load-bearing.** Scroll becomes the *only* pre-upload resolution path for bare UUID refs. Its correctness is now more critical, not less. |
-| `#393` — `image i2i --ref <UUID>` bound nothing and hard-failed | **Contract preserved.** The `local_path` upload rescue is the terminal fallback and is untouched. |
-| `#287` CHANGELOG entry (`CHANGELOG.md:1049`) | **Superseded in part.** It states the UUID tiers "are kept as cheap first attempts". The new entry must name #287 and record the demotion, or the next agent restores them. |
-
-## Open empirical contradiction (gates proposal 3 only)
-
-`#287` asserts picker tile `alt` carries the **generation prompt** (basis for the
-`search_hints` tier). `#393`'s later live DOM capture (2026-07-27) recorded
-`alt="Box tied with crimson ribbon"` — a **short Flow-authored caption**, and
-`cli_image.py:258`, `errors.py:649-660`, `ui_automation_video.py:2137` all encode
-that reading. Both cannot hold of the same picker.
-
-This does **not** block proposals 1/2/4 — the ~14.9 s saving is arithmetic from
-`_search_picker_for_tile` and is real either way. It blocks only the *claim* that
-hints now hit first, and all of proposal 3. `_PICKER_DOM_DUMP_JS`
-(`ui_automation_video.py:616-633`) already captures the first three tiles'
-`outerHTML` truncated to 500 chars, which includes the `<img alt="…">` — so any
-existing `debug_picker_dom_*.json` from a prior miss may already answer it
-without spending a live round.
+The spike proves the picker lookup contract without spending credits. It does
+not claim that every historical catalog row already has a display name; rows
+created before this parser fix, agentic results, and redacted-history rows need
+a verified local-file fallback. New classic UI images retain the Flow name only
+when prompt history is stored.

--- a/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/SCENARIO.md
+++ b/docs/superpowers/plans/2026-08-15-issue-529-media-picker-tier-reorder/SCENARIO.md
@@ -1,0 +1,160 @@
+# Scenario: #529 — media-picker UUID search tiers demoted below the scroll fallback
+
+> Predict verdict: **CAUTION** (2026-08-15, 5-persona; confidence 6/10). Mitigations
+> folded into PLAN.md tasks. Scope fixed at issue proposals **1 + 2 + 4**; proposal 3
+> (porting #287's hint derivation to the image path) is gated behind the alt-text
+> experiment (T0) and is explicitly **out of scope** for this plan.
+
+**Change under test.** `VideoGenerationMixin._select_existing_asset`
+(`src/gflow_cli/api/transports/ui_automation_video.py:2211-2321`) currently walks
+`(display_name, media_id, uuid_stem, *search_hints)` before falling back to
+scrolling the virtualised grid. Two of those tiers — the full media UUID and its
+first hyphen segment — are live-proven never to match (#287 rounds, #393
+2026-07-27) and cost ~14.9 s per reference. The change reorders the cascade to
+`(display_name, *search_hints)` pre-scroll and **retries `(media_id, uuid_stem)`
+only after the scroll fallback misses**, plus emits a `resolved_by` tier label on
+the attach events.
+
+---
+
+## Coverage map
+
+| Dim | Active? | Why |
+|---|---|---|
+| **D2** WAF / reCAPTCHA | ✅ light | Removes 2 `press_sequentially` bursts per ref from the pre-scroll path — changes the session's interaction fingerprint (net fewer synthetic keystrokes, shorter dialog-open window). No token minting touched. |
+| **D3** Selector drift & locale | ✅ | `PICKER_SEARCH_INPUT` presence-probing moves; the #174 no-search-box cohort now hits a *different* code path. No new selectors, so locale-invariance is not engaged. |
+| **D4** Batch & resume | ✅ | `image batch` / `movie run` attach the same refs across many rows; the saving compounds and any reachability regression multiplies. |
+| **D5** Concurrency & Page pool | ✅ | The post-scroll retry types into a grid that is already scrolled — pooled-Page state on checkin. Reduced hold time raises effective throughput. |
+| **D6** Data layer | ✅ light | `_media_search_hints` → `get_asset_prompt` and `_enrich_uuid_refs` → `resolve_seed_image` are the only catalog reads; both already best-effort. No schema change. |
+| **D7** Error propagation & exit codes | ✅ | The exit-9 `TransportTimeoutError` frame-slot contract and the #393 "never generate without the ref" contract must survive byte-for-byte. |
+| **D9** Transport edge cases | ✅ | `_search_picker_for_tile` returning `None` (no search box) is a three-state result; the reorder changes when that state is first observed. |
+| **D11** Input validation | ✅ edge-only | `uuid_stem = media_id.split("-", 1)[0]` on a hyphen-less id yields the full id — a duplicate the `terms` dedup already absorbs. Must stay absorbed after the split. |
+| **D12** Observability | ✅ | New `resolved_by` field; `picker_search_tier` event ordering changes; `docs/ARCHITECTURE.md` event contract. |
+| D1 Auth & session | ⛔ skipped | No cookie, SAPISID, token, or profile-lease surface. |
+| D8 Cross-platform paths | ⛔ skipped | No path construction, no `platformdirs`, no filename handling. `local_path` is passed through unchanged. |
+| D10 Headless vs headed | ⛔ skipped | Wall-clock only; no environment-conditional branch. The change behaves identically headed and headless. |
+
+---
+
+## Scenario table
+
+| # | Dimension | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| S1 | D7 | Bare `--ref <uuid>` whose tile is **off-viewport**; scroll finds it | **Critical** | Attached from the scroll tier. Zero `press_sequentially` calls before the scroll. Same tile, same `_attach_selected_tile` call as today. | Unit (fake page) |
+| S2 | D7 | Ref is unreachable by **every** tier (viewport, scroll, demoted UUID tiers) | **Critical** | Image path uploads `local_path` (#393 rescue); frame-slot path raises `TransportTimeoutError` **exit 9**. Generation **never** proceeds without the reference. | Unit + BDD |
+| S3 | D9 | Tile matching after the reorder | **Critical** | `_existing_asset_tile` still matches `[role='option']:has(img[src*='<uuid>'])` — never a name/caption match. A hint that surfaces 30 tiles still selects only the UUID one. | Unit |
+| S4 | D4 | `image batch` / `movie run` attaching the same 2 UUID refs across 11 rows | **High** | ~30 s saved per row (~5.5 min per pass). No cross-row search-term leakage — the per-ref `search.fill("")` at `:2404-2409` still runs first. | Integration |
+| S5 | D3 | #174 cohort: picker variant with **no search box at all** | **High** | Pre-scroll `terms` is empty on the image path, so `_search_picker_for_tile` is never called and `picker_search_unavailable` is not emitted before the scroll. Scroll runs; post-scroll retry probes once, gets `None`, and gives up without a hard dependency on the box. | Unit |
+| S6 | D9 | Post-scroll UUID retry returns `None` (no search box) mid-loop | **High** | `break` out of the retry, proceed to not-found telemetry + upload fallback. No unguarded `.fill("")` against an absent element (would burn a full actionability timeout). | Unit |
+| S7 | D5 | Post-scroll retry types a term into an **already-scrolled** grid | **High** | Search must be cleared before the caller returns `False`, so the pooled Page is never handed back holding a filtered + scrolled grid. Mirrors `_try_select_existing_by_filename:2113`. | Unit |
+| S8 | D12 | `resolved_by` emitted on every terminal outcome | **High** | Exactly one of `viewport` / `display_name` / `hint` / `scroll` / `uuid_retry` / `upload` / `not_found` per ref, on the existing `image_ref_selected_existing` and `frame_ref_attached` events. Never a new event name. | Unit (capture logs) |
+| S9 | D12 | `resolved_by` payload contains no user content | **High** | The field is a fixed tier **label**. The winning search *term* (a 6-word prompt slice on the video path) is never added to the attach events. `picker_search_tier`'s existing `term=` is unchanged — not widened. | Unit |
+| S10 | D7 | Video frame-slot path (`_attach_frame_by_media_id:1850-1900`) | **High** | `display_name` is `""`, hints may be present. Pre-scroll cascade is `(*search_hints,)` only. Error message, screenshot name, and exit code identical to v0.57.1. | Unit + BDD |
+| S11 | D3 | Flow renames the thumbnail URL param so `img[src*=<uuid>]` stops matching | **Medium** | Unchanged failure mode: every tier misses, `existing_asset_not_found` warns with screenshot + `debug_picker_dom_<uuid8>.json`. The reorder must not swallow this diagnostic path. | Unit |
+| S12 | D2 | Profile with elevated WAF heat runs a 2-ref i2i | **Medium** | Fewer synthetic keystrokes and a shorter dialog-open window than v0.57.1 — strictly less automation surface. No new interaction primitive introduced (scroll already ran on every one of these lookups). | Live (observational) |
+| S13 | D11 | `media_id` with no hyphen (malformed or non-standard id) | **Medium** | `uuid_stem == media_id`; the dedup keeps `terms` at one entry in the post-scroll retry. No double 7.9 s pass. | Unit |
+| S14 | D6 | Catalog unavailable / asset unknown → `search_hints=()` and `local_path=""` | **Medium** | Video path: pre-scroll cascade is empty, straight to scroll. Image path: unchanged from today. Both stay best-effort; no `DataStoreError` escapes. | Unit |
+| S15 | D12 | `picker_search_tier` events now appear **after** `picker_scroll_done` | **Medium** | Log-order change is intentional and documented. Anything parsing these events (live-verification ledger) must be told the order flipped. | Review gate |
+| S16 | D5 | `GFLOW_CLI_CONCURRENCY` at its current ceiling with UUID refs | **Low** | ~30 s less Page checkout per generation → more headroom at the same ceiling. The safe ceiling itself is **not** raised by this change. | Live (observational) |
+| S17 | D4 | A ref that resolves from the **viewport** (freshly generated asset) | **Low** | Untouched path — still the 4 s `tile.wait_for(state="visible", timeout=4000)` at `:2224`, no searches, no scroll. `resolved_by="viewport"`. | Unit |
+
+Severity: **Critical** (data loss / billed twice / unrecoverable) · **High** (feature broken, workaround exists) · **Medium** (degraded UX, explicit error) · **Low** (cosmetic or edge-only)
+
+---
+
+## Must-cover before merge (Critical + High)
+
+1. **S1** — the saving actually lands: assert zero `press_sequentially` awaits before the first scroll on a bare-UUID image ref.
+2. **S2** — the #393 contract is untouched: unreachable ref uploads (image) or exits 9 (frame slot); **never** generates without the reference.
+3. **S3** — tile identity stays UUID-in-`src`; an imprecise hint can surface extra tiles but can never attach a wrong one.
+4. **S5 / S6** — the #174 no-search-box cohort survives both the new empty-`terms` path and the post-scroll retry probe.
+5. **S7** — the picker is left clean (search cleared) whenever `_select_existing_asset` returns `False`.
+6. **S8 / S9** — `resolved_by` covers every terminal outcome and leaks no prompt text.
+7. **S10** — the video frame-slot error contract (message, screenshot name, exit 9) is pinned byte-for-byte.
+8. **S4** — batch/manifest paths keep the per-ref `search.fill("")` reset, so terms never leak between rows.
+
+**Rewrite targets (existing tests pin the old order — TDD red step):**
+`tests/api/transports/test_ui_automation_video.py:1837` (`test_...full_uuid`), `:1841`
+(`test_uuid_stem_search_is_tried_after_full_uuid`), `:1861` (`terms == [FULL_UUID, "d6f1927a"]`),
+`:1918` (`terms == [FULL_UUID, "d6f1927a", hint]`), `:1865`
+(`test_no_search_box_skips_search_tiers_and_scrolls`).
+
+---
+
+## Deferred (Medium + Low — log as issues, not blockers)
+
+1. **S11** — thumbnail-URL drift is a pre-existing exposure, unchanged by this plan.
+2. **S12 / S16** — WAF and concurrency effects are observational; record in live verification, do not gate the merge.
+3. **Proposal 3** (port hint derivation to the image path) — blocked on the T0 alt-text experiment. File as a follow-up issue with the experiment's result attached.
+4. **The 4 s viewport wait** (`:2224`) is paid per ref on every lookup and was not raised by #529. If T0's telemetry shows it dominating on fast cohorts, file separately.
+5. **Scroll cost** (350 ms/step, stall-bounded at 3, ceiling 200) becomes the sole pre-upload path. If `resolved_by` telemetry shows scroll depth dominating, that is the next bottleneck — a new issue, not this plan.
+
+---
+
+## Suggested BDD scenarios (`tests/features/media_picker_tiers.feature`)
+
+```gherkin
+Feature: Media picker resolves UUID references without dead search tiers
+  The picker's full-UUID and UUID-stem search tiers are live-proven never to
+  match (#287, #393). They must not run before the scroll fallback, and the
+  reference-binding contract must be unchanged.
+
+  Scenario: A bare UUID reference off the viewport is found by scrolling
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the reference tile is not in the picker's initial viewport
+    When the transport binds the reference
+    Then no search term is typed before the grid is scrolled
+    And the tile is attached from the scroll tier
+    And the attach event reports resolved_by "scroll"
+
+  Scenario: An unreachable reference still refuses to generate without it
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the reference tile is absent from the picker entirely
+    When the transport binds the reference
+    Then the demoted UUID search tiers are attempted after the scroll
+    And the recorded local file is uploaded as the fallback
+    And the generation never proceeds without the reference
+
+  Scenario: A frame-slot UUID that cannot be located fails pre-generation
+    Given a video i2v generation with an initial frame given as a media UUID
+    And the asset is absent from the picker entirely
+    When the transport binds the frame
+    Then a TransportTimeoutError naming the slot and the UUID is raised
+    And the process exits with code 9
+    And no generation is submitted
+
+  Scenario: A picker cohort with no search box is never blocked by search
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the picker variant renders no search input
+    When the transport binds the reference
+    Then no search input is filled at any point
+    And the grid is scrolled to locate the tile
+```
+
+---
+
+## Known-issues cross-reference
+
+| Entry | Relationship |
+|---|---|
+| `KNOWN_ISSUES.md:118` — *i2v frame-slot picker selection by UUID — RESOLVED live 2026-07-11* | **Must not regress.** S10 pins its contract. The reorder keeps `_select_existing_asset` as the single resolution point, so the resolution stands. |
+| `#174` — full-page media-library drift (picker variant with no search box) | **Mitigated, differently.** Today the `None` return is observed on the first search tier; after the reorder the image path never probes pre-scroll. S5/S6 cover both halves. |
+| `#282` / `#287` — virtualised grid scrolling, progress-bounded | **Load-bearing.** Scroll becomes the *only* pre-upload resolution path for bare UUID refs. Its correctness is now more critical, not less. |
+| `#393` — `image i2i --ref <UUID>` bound nothing and hard-failed | **Contract preserved.** The `local_path` upload rescue is the terminal fallback and is untouched. |
+| `#287` CHANGELOG entry (`CHANGELOG.md:1049`) | **Superseded in part.** It states the UUID tiers "are kept as cheap first attempts". The new entry must name #287 and record the demotion, or the next agent restores them. |
+
+## Open empirical contradiction (gates proposal 3 only)
+
+`#287` asserts picker tile `alt` carries the **generation prompt** (basis for the
+`search_hints` tier). `#393`'s later live DOM capture (2026-07-27) recorded
+`alt="Box tied with crimson ribbon"` — a **short Flow-authored caption**, and
+`cli_image.py:258`, `errors.py:649-660`, `ui_automation_video.py:2137` all encode
+that reading. Both cannot hold of the same picker.
+
+This does **not** block proposals 1/2/4 — the ~14.9 s saving is arithmetic from
+`_search_picker_for_tile` and is real either way. It blocks only the *claim* that
+hints now hit first, and all of proposal 3. `_PICKER_DOM_DUMP_JS`
+(`ui_automation_video.py:616-633`) already captures the first three tiles'
+`outerHTML` truncated to 500 chars, which includes the `<img alt="…">` — so any
+existing `debug_picker_dom_*.json` from a prior miss may already answer it
+without spending a live round.

--- a/docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
+++ b/docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
@@ -1,0 +1,40 @@
+# Picker tile `alt` evidence (#529)
+
+**Verdict:** Flow's media picker exposes a short Flow-authored caption in a
+generated tile's `img[alt]`, not the generation prompt. Therefore a prompt-derived
+`search_hints` tier cannot match that tile on the observed picker surface. Proposal 3
+from #529 is refuted rather than deferred.
+
+## Evidence
+
+- Picker capture date: 2026-07-27
+- Catalog comparison date: 2026-08-15
+- Media ID: `995784c1-7948-44e5-acd9-7e47334cd602`
+- Raw picker `alt`: `Brass key on marble surface`
+- Catalog prompt: `The EXACT same weathered brass key from the reference image,
+  unchanged in shape, patina and bit pattern, now resting alone on a plain white
+  marble surface, soft daylight from above, minimal clean background.`
+- Comparison: the strings differ; the picker value is a short caption.
+
+The raw `debug_picker_dom_0341b04a.json` artifact came from the `kiln_ember` #393
+verification output. Its tile HTML identifies the same media UUID in
+`media.getMediaUrlRedirect?name=<uuid>` and carries the caption in `alt`. The prompt
+was read from the local gflow catalog with `queries.get_asset_prompt()` for that UUID.
+
+A second generated tile independently corroborates the reading:
+
+- Media ID: `7529789a-dad0-4d9d-bc79-b171d862855e`
+- Raw picker `alt`: `Brass key on wooden bench`
+- Catalog prompt: `A single weathered brass key resting on a dark wooden workshop
+  bench, warm lamplight from the left, deep shadows, shallow depth of field,
+  photorealistic cinematic photography, film grain. Vertical composition.`
+
+This agrees with the committed live ledger in
+[`LIVE_VERIFICATION_v0.45.0.md`](../../LIVE_VERIFICATION_v0.45.0.md), which records
+the same caption-not-prompt contract from both picker DOM and HAR evidence.
+
+## Follow-up
+
+Issue [#541](https://github.com/ffroliva/gflow-cli/issues/541) records that the
+video path's prompt-derived `search_hints` tier also lacks a demonstrated match path,
+and that #529 proposal 3 must not be implemented as designed.

--- a/docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
+++ b/docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md
@@ -1,40 +1,103 @@
-# Picker tile `alt` evidence (#529)
+# Catalog display-name picker spike (#529)
 
-**Verdict:** Flow's media picker exposes a short Flow-authored caption in a
-generated tile's `img[alt]`, not the generation prompt. Therefore a prompt-derived
-`search_hints` tier cannot match that tile on the observed picker surface. Proposal 3
-from #529 is refuted rather than deferred.
+**Verdict:** Flow's browser media picker is searched by the asset's Flow
+`displayName`. The UUID is then used to identify the exact result tile. Scanning
+the unfiltered virtualized grid and typing UUID/prompt fragments are unnecessary
+for a catalog asset whose name was retained.
 
-## Evidence
+## Candidate corpus
 
-- Picker capture date: 2026-07-27
-- Catalog comparison date: 2026-08-15
-- Media ID: `995784c1-7948-44e5-acd9-7e47334cd602`
-- Raw picker `alt`: `Brass key on marble surface`
-- Catalog prompt: `The EXACT same weathered brass key from the reference image,
-  unchanged in shape, patina and bit pattern, now resting alone on a plain white
-  marble surface, soft daylight from above, minimal clean background.`
-- Comparison: the strings differ; the picker value is a short caption.
+The read-only candidate corpus came from populated private test projects. One
+picker had a useful name-collision case. Stable aliases replace live account,
+project, media, story, and caption identifiers:
 
-The raw `debug_picker_dom_0341b04a.json` artifact came from the `kiln_ember` #393
-verification output. Its tile HTML identifies the same media UUID in
-`media.getMediaUrlRedirect?name=<uuid>` and carries the caption in `alt`. The prompt
-was read from the local gflow catalog with `queries.get_asset_prompt()` for that UUID.
+| Flow display-name alias | Media alias |
+|---|---|
+| `SHARED_NAME` | `MEDIA_A` |
+| `SHARED_NAME` | `MEDIA_B` |
+| `UNIQUE_NAME` | `MEDIA_C` |
 
-A second generated tile independently corroborates the reading:
+No incident headers, cookies, signed URLs, screenshots, raw network payloads,
+or live identifiers were copied into this artifact.
 
-- Media ID: `7529789a-dad0-4d9d-bc79-b171d862855e`
-- Raw picker `alt`: `Brass key on wooden bench`
-- Catalog prompt: `A single weathered brass key resting on a dark wooden workshop
-  bench, warm lamplight from the left, deep shadows, shallow depth of field,
-  photorealistic cinematic photography, film grain. Vertical composition.`
+## Live procedure and result
 
-This agrees with the committed live ledger in
-[`LIVE_VERIFICATION_v0.45.0.md`](../../LIVE_VERIFICATION_v0.45.0.md), which records
-the same caption-not-prompt contract from both picker DOM and HAR evidence.
+Date: 2026-08-15. Browser: headed system Chrome using a saved test profile. The
+harness opened the existing project, switched to image mode, opened
+the picker, aligned its project selector, and performed two searches:
 
-## Follow-up
+1. `SHARED_NAME` returned both distinct media tiles.
+2. `UNIQUE_NAME` returned its expected media tile.
 
-Issue [#541](https://github.com/ffroliva/gflow-cli/issues/541) records that the
-video path's prompt-derived `search_hints` tier also lacks a demonstrated match path,
-and that #529 proposal 3 must not be implemented as designed.
+For every result, the assertion used
+`[role='option']:has(img[src*='<expected UUID>'])`. The duplicate-name search
+therefore proved that display name is discovery while UUID remains identity.
+
+Sanitized outcome:
+
+```text
+success: true
+scroll_calls: 0
+asset_clicks: 0
+generation_requests: 0
+elapsed_seconds: 19.78
+```
+
+## Implemented-path verification
+
+After the change, a second headed-Chrome run invoked the branch's actual
+`VideoGenerationMixin._select_existing_asset()` path for `SHARED_NAME` and
+requested `MEDIA_A`. A sentinel replaced the unfiltered-grid scroll helper and
+would have failed the run if called.
+
+```text
+success: true
+resolved_by: display_name
+scroll_calls: 0
+asset_clicks: 1
+generation_requests: 0
+elapsed_seconds: 13.90
+```
+
+The exact UUID tile attached and the picker closed. No prompt was submitted and
+no generation endpoint was requested.
+
+## I2V frame-slot verification
+
+A third headed-Chrome run exercised the branch's actual
+`VideoGenerationMixin._attach_frame_by_media_id()` path through the I2V Start
+frame slot. It used the same aliased `SHARED_NAME` / `MEDIA_A` pair and the same
+sentinels against unfiltered-grid scrolling and generation endpoints.
+
+```text
+success: true
+surface: i2v_start_frame
+resolved_by: display_name
+scroll_calls: 0
+asset_clicks: 1
+generation_requests: 0
+elapsed_seconds: 17.59
+```
+
+The real frame-slot picker attached the exact UUID tile. No prompt was entered,
+no submit action ran, and no credits were spent.
+
+## Catalog root cause
+
+`GeneratedImage.from_response_dict()` already extracts the searchable name from
+the response's sibling `workflows[].metadata.displayName`. The live UI transport,
+however, collected each `media[]` item with `from_response_item()`, losing that
+sibling metadata before `OperationRecorder` could persist it. Local catalog rows
+therefore had empty names even though Flow itself had named picker assets.
+
+The implementation fixes that collection path, enriches UUID refs from catalog
+metadata, passes separate names for I2V start/end UUIDs, and removes scroll,
+UUID-stem, UUID, and prompt-derived search tiers from UUID asset selection.
+
+## Superseded hypothesis
+
+The earlier #287 guidance that prompt fragments should surface generated assets
+was based on treating tile captions as generation prompts. Captured comparisons
+show the captions differ from the recorded prompts, and this spike demonstrates
+the direct source of truth: `workflows[].metadata.displayName`. Issue #541 records
+the refuted prompt-hint hypothesis.

--- a/src/gflow_cli/api/image.py
+++ b/src/gflow_cli/api/image.py
@@ -197,17 +197,19 @@ class ImageRef:
     from a prior ``/v1/flow/uploadImage`` call OR a generated image's media id
     (see ``samples/captured/01_upload_image.json``).
 
-    ``display_name`` and ``local_path`` are UI-automation-only hints (ignored by
+    ``display_name``, ``local_path``, and ``local_sha256`` are UI-only hints (ignored by
     :meth:`to_wire`): they let the transport attach the ref by **selecting the
     already-existing Flow asset in the picker** — located by ``name`` (the media
     UUID) in the tile's image URL, surfaced by ``display_name`` when a search is
     needed — and preferred over re-uploading a duplicate. ``local_path`` is the
-    fallback file to upload only when the asset can't be located in place.
+    fallback file to upload only when the asset can't be located in place; its
+    digest is rechecked immediately before upload.
     """
 
     name: str
     display_name: str = ""
     local_path: str = ""
+    local_sha256: str = ""
 
     def __post_init__(self) -> None:
         # Reject empty, whitespace-only, AND whitespace-padded UUIDs.
@@ -222,6 +224,8 @@ class ImageRef:
             raise ValueError(
                 msg,
             )
+        if bool(self.local_path) != bool(self.local_sha256):
+            raise ValueError("ImageRef local_path and local_sha256 must be supplied together")
 
     def to_wire(self) -> dict[str, str]:
         return {"imageInputType": _IMAGE_INPUT_TYPE_REFERENCE, "name": self.name}

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -574,7 +574,13 @@ def _collect_images_from_body(body: dict[str, Any], images: list[GeneratedImage]
             continue
         item: dict[str, Any] = cast(_JsonObj, item_raw)
         try:
-            images.append(GeneratedImage.from_response_item(item))
+            # Parse a one-item full response so the sibling ``workflows[]``
+            # metadata is joined by workflow id.  Parsing the media item alone
+            # drops Flow's ``displayName`` — the browser picker's search key.
+            parsed = GeneratedImage.from_response_dict(
+                {"media": [item], "workflows": body.get("workflows", [])}
+            )
+            images.extend(parsed)
         except ValueError as e:
             log.warning("ui_automation.parse_media_item_failed", error=str(e))
 
@@ -2472,7 +2478,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         if request.refs:
             await self._attach_image_uuid_refs(
                 page,
-                [(r.name, r.display_name, r.local_path) for r in request.refs],
+                [(r.name, r.display_name, r.local_path, r.local_sha256) for r in request.refs],
                 out_dir=out_dir,
             )
 

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -17,6 +17,7 @@ import asyncio
 import contextlib
 import json
 import random
+import re
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -1725,12 +1726,24 @@ class VideoGenerationMixin:
         await search_input.press_sequentially(name, delay=random.randint(10, 50))  # NOSONAR
         await page.wait_for_timeout(600)
 
-        # Role+name match — apostrophes in the display name would break a
+        # Text match — apostrophes in the display name would break a
         # `:has-text('{name}')` CSS selector.
         tile = VideoGenerationMixin._remote_option_tile(page, name).first
         await tile.wait_for(state="visible", timeout=8000)
         await tile.click()
         await page.wait_for_timeout(300)
+
+        # #529 live recon (pt profile): clicking the result tile now attaches
+        # directly and closes the picker — the include button exists only in
+        # the hover-preview pane. Treat a closed dialog as success and fall
+        # through to the legacy include-button flow only while it stays open.
+        dialog = page.locator(DIALOG_ANY).last
+        try:
+            await dialog.wait_for(state="hidden", timeout=3000)
+        except Exception:  # noqa: BLE001 - any wait failure = dialog still open
+            pass
+        else:
+            return
 
         # Include via the tiered, locale-safe resolver (a hardcoded English
         # "Add to Prompt" here previously hung non-English accounts — #170/#56).
@@ -1767,9 +1780,16 @@ class VideoGenerationMixin:
         commonly contain an apostrophe or quote that would break a
         single-quoted ``:has-text()`` CSS selector (PR #237 review).
         """
-        # exact=True: the default substring match would let 'cabin' select
+        # Anchored match: a substring match would let 'cabin' select
         # 'cabin at night' and .first attach the wrong image (PR #245 review).
-        return page.get_by_role("option", name=name, exact=True)
+        # #529 live recon: the picker dialog exposes NO accessible tree (the
+        # option's computed name is empty), so role+name matching can never
+        # find the tile — match the option's text instead. The text carries
+        # the picker's localized media-type badge after the display name
+        # ('…map\nImagem' on a pt profile); tolerate only a trailing
+        # capitalized badge word, which 'at night' is not.
+        pattern = re.compile(rf"^{re.escape(name)}(\s?[^\Wa-z0-9_]\S*)?$")
+        return page.locator("[role='option']", has_text=pattern)
 
     @staticmethod
     async def _resolve_frame_slot(

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -20,7 +20,7 @@ import random
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 
@@ -54,6 +54,7 @@ from gflow_cli.errors import (
     WafRejectionError,
     WireFormatError,
 )
+from gflow_cli.file_integrity import matches_recorded_file
 from gflow_cli.storage import AnyPath, storage_path, write_asset_async
 
 if TYPE_CHECKING:
@@ -66,16 +67,6 @@ log = structlog.get_logger(__name__)
 # ruff's TC006 happy since call sites pass a bare name, not a subscript.
 _JsonObj = dict[str, Any]
 _JsonObjList = list[dict[str, Any]]
-_PickerResolvedBy = Literal[
-    "viewport",
-    "display_name",
-    "hint",
-    "scroll",
-    "uuid_retry",
-    "upload",
-    "not_found",
-]
-
 # The three mode-specific generate routes (spec §2.1). The listener filters on
 # these substrings only — video generate URLs carry no /projects/{id}/ path
 # segment, so a project-id URL filter is impossible (deviation from §5.4).
@@ -1860,16 +1851,19 @@ class VideoGenerationMixin:
         slot_index: int,
         label: str,
         media_id: str,
+        display_name: str,
         *,
         out_dir: Path | None,
         project_name: str | None = None,
-        search_hints: tuple[str, ...] = (),
+        local_path: Path | None = None,
+        local_sha256: str = "",
     ) -> None:
         """Fill the I2V first/last frame slot with an already-existing in-project
-        asset, selected by its media UUID (#287) — no duplicate upload. Opens the
-        slot's media dialog (same entry as `_attach_frame`/`_attach_remote_frame`)
-        then reuses the `_select_existing_asset` UUID picker. There is no local
-        fallback: the caller asked for THIS asset, so a miss is a hard error."""
+        asset without a duplicate upload. The catalog-resolved ``display_name``
+        filters the browser picker; ``media_id`` verifies the exact result tile.
+        An empty legacy/programmatic name permits only the exact rendered
+        viewport tile. If name lookup misses, a catalog-recorded local copy can
+        upload the exact asset bytes instead of scanning or scrolling."""
         slot = await VideoGenerationMixin._resolve_frame_slot(
             page, slot_index, label, out_dir=out_dir, wait_ms=12000
         )
@@ -1883,16 +1877,29 @@ class VideoGenerationMixin:
             page, out_dir=out_dir, project_name=project_name
         )
 
-        # Presence-guarded search clear, mirroring _attach_image_uuid_refs: a
-        # picker variant with no search box must not become a hard dependency.
-        search = page.locator(PICKER_SEARCH_INPUT).first
-        if await search.count():
-            await search.fill("")
-
-        resolved_by = await VideoGenerationMixin._select_existing_asset(
-            page, media_id, "", out_dir=out_dir, search_hints=search_hints
+        selected = await VideoGenerationMixin._select_existing_asset(
+            page, media_id, display_name, out_dir=out_dir
         )
-        if resolved_by is None:
+        if not selected:
+            if local_path is not None:
+                if not matches_recorded_file(local_path, sha256=local_sha256):
+                    raise TransportTimeoutError(
+                        f"{label} frame asset {media_id!r} local fallback changed "
+                        "since it was recorded; refusing to upload different bytes."
+                    )
+                log.info(
+                    "ui_automation_video.frame_ref_upload_fallback",
+                    slot=label,
+                    media_id=media_id,
+                    resolved_by="upload",
+                )
+                await VideoGenerationMixin._upload_via_open_dialog(
+                    page,
+                    local_path,
+                    log_label=f"{label}_frame_ref",
+                    out_dir=out_dir,
+                )
+                return
             # The frame-slot dialog is the one surface this picker reuse is
             # unproven on (#237's name-search never surfaced generated media
             # here) — capture the dialog state so a live miss is diagnosable.
@@ -1901,8 +1908,9 @@ class VideoGenerationMixin:
             )
             msg = (
                 f"{label} frame asset {media_id!r} could not be located in the "
-                "media picker — is it in the target project (missing or wrong "
-                "--project), and is the UUID from this profile's library?"
+                "media picker by its catalog display name — is it in the target "
+                "project (missing or wrong --project), and was it recorded by "
+                "this profile?"
             )
             if shot is not None:
                 msg = f"{msg} Screenshot: {shot}"
@@ -1911,7 +1919,7 @@ class VideoGenerationMixin:
             "ui_automation_video.frame_ref_attached",
             slot=label,
             media_id=media_id,
-            resolved_by=resolved_by,
+            resolved_by="display_name",
         )
 
     @staticmethod
@@ -2225,6 +2233,24 @@ class VideoGenerationMixin:
         return page.locator(f"[role='option']:has(img[src*='{media_id}'])").first
 
     @staticmethod
+    async def _tile_is_fully_visible(tile: Locator) -> bool:
+        """Use the browser's intersection engine to prevent implicit click scrolling."""
+        try:
+            return bool(
+                await tile.evaluate(
+                    """(el) => new Promise(resolve => {
+                      const observer = new IntersectionObserver(([entry]) => {
+                        observer.disconnect();
+                        resolve(entry.intersectionRatio === 1);
+                      }, {threshold: 1});
+                      observer.observe(el);
+                    })"""
+                )
+            )
+        except Exception:  # noqa: BLE001 - stale/vanished tile is not selectable
+            return False
+
+    @staticmethod
     async def _select_existing_asset(
         page: Page,
         media_id: str,
@@ -2232,102 +2258,23 @@ class VideoGenerationMixin:
         *,
         out_dir: Path | None,
         dialog_timeout_s: float = REMOTE_PICKER_CLOSE_TIMEOUT_S,
-        search_hints: tuple[str, ...] = (),
-    ) -> _PickerResolvedBy | None:
+    ) -> bool:
         """In the OPEN reference picker, select the already-existing Flow asset
         identified by ``media_id`` (preferred over uploading a duplicate).
 
-        Locates the tile by the media UUID in its thumbnail URL. If it isn't
-        already visible, tries ``display_name`` and any ``search_hints``, then
-        scrolls the virtualised picker grid (react-virtuoso renders off-viewport
-        tiles lazily — #282). Only after scrolling misses does it retry the media
-        UUID and UUID-derived filename stem. #287 live rounds found those UUID
-        searches never match, and #393's 2026-07-27 picker capture confirmed the
-        search surface indexes short captions rather than UUIDs; the tiers are
-        demoted instead of deleted because Flow is a blackbox and another cohort
-        may still index them. Returns the winning tier once attached, ``None``
-        when the asset can't be located (callers with a local file fall back to
-        uploading it; the #287 frame-ref path has no fallback and raises instead).
+        Flow's browser picker is name-addressed: search by the catalog-recorded
+        ``display_name``, then assert the exact UUID in the surfaced tile's
+        thumbnail URL. This handles duplicate names without selecting the wrong
+        asset. It deliberately does not scroll the unfiltered virtualised grid
+        or type UUID fragments into the name search. A missing/stale name or
+        unavailable search input falls through to the
+        caller's verified local-file fallback or typed error.
         """
+        if not display_name:
+            return False
         tile = VideoGenerationMixin._existing_asset_tile(page, media_id)
-        visible = True
-        try:
-            await tile.wait_for(state="visible", timeout=4000)
-        except Exception:  # noqa: BLE001 - not-visible is an expected branch
-            visible = False
-        resolved_by: _PickerResolvedBy | None = "viewport" if visible else None
-
-        attempted_search = False
-        searched_terms: set[str] = set()
-
-        async def _search_candidates(
-            candidates: tuple[tuple[str, _PickerResolvedBy], ...],
-        ) -> _PickerResolvedBy | None:
-            """Try unique picker terms and return the winning tier."""
-            nonlocal attempted_search
-            for term, tier in candidates:
-                if not term or term in searched_terms:
-                    continue
-                searched_terms.add(term)
-                found = await VideoGenerationMixin._search_picker_for_tile(page, tile, term)
-                if found is None:
-                    return None  # picker variant with no search box (#174)
-                attempted_search = True
-                if found:
-                    return tier
-            return None
-
-        if not visible:
-            # Pre-scroll tiers keep named/hinted lookup behaviour unchanged.
-            # The prompt-derived hints are retained pending #541, although the
-            # caption evidence means their live value is currently unproven.
-            pre_scroll_candidates: list[tuple[str, _PickerResolvedBy]] = [
-                (display_name, "display_name")
-            ]
-            pre_scroll_candidates.extend((hint, "hint") for hint in search_hints)
-            resolved_by = await _search_candidates(tuple(pre_scroll_candidates))
-            visible = resolved_by is not None
-
-        if not visible:
-            # A failed search leaves the grid filtered on the last term —
-            # scrolling a still-filtered grid would only shuffle through the
-            # (possibly empty) filtered results rather than the full asset
-            # list, so the search box must be cleared first.
-            # Presence-guarded like `_attach_image_uuid_refs`'s per-ref clear.
-            if attempted_search:
-                clear_search = page.locator(PICKER_SEARCH_INPUT).first
-                if await clear_search.count():
-                    await clear_search.fill("")
-                    await page.wait_for_timeout(400)
-            # Neither the initial viewport nor the search tiers surfaced the
-            # tile — the Tudo grid is virtualised, so an off-screen (but
-            # existing) asset is simply absent from the DOM until scrolled
-            # into range. Scroll (progress-bounded — #287) before giving up.
-            visible = await VideoGenerationMixin._scroll_picker_grid_until_rendered(page, tile)
-            if visible:
-                try:
-                    await tile.wait_for(state="visible", timeout=4000)
-                except Exception:  # noqa: BLE001 - rendered but never became visible
-                    visible = False
-                resolved_by = "scroll" if visible else None
-
-        if not visible:
-            # Last-resort UUID retries (#529): #287/#393 observed these as two
-            # guaranteed misses (~14.9 s total), so pay them only after the
-            # progress-bounded full-grid scroll has also missed. Retaining them
-            # preserves reachability on any Flow cohort that does index UUIDs.
-            uuid_stem = media_id.split("-", 1)[0]
-            resolved_by = await _search_candidates(
-                ((media_id, "uuid_retry"), (uuid_stem, "uuid_retry"))
-            )
-            visible = resolved_by is not None
-            if not visible and attempted_search:
-                clear_search = page.locator(PICKER_SEARCH_INPUT).first
-                if await clear_search.count():
-                    await clear_search.fill("")
-                    await page.wait_for_timeout(400)
-
-        if not visible:
+        found = await VideoGenerationMixin._search_picker_for_tile(page, tile, display_name)
+        if not found:
             # #287 diagnosis telemetry: capture WHAT the picker was showing
             # when the lookup gave up — which attribute carries the media
             # identity, and which project the library view was on, are the
@@ -2335,21 +2282,33 @@ class VideoGenerationMixin:
             # cast + isinstance: a unit-test fake's page.url may not be a str.
             page_url = cast("object", page.url)
             project_id = extract_project_id(page_url) if isinstance(page_url, str) else None
-            shot = await _capture_debug_screenshot(
-                page, out_dir, f"debug_picker_miss_{media_id[:8]}.png"
+            # Capture only the filtered result set. When search is unavailable,
+            # avoid collecting unrelated assets from the unfiltered picker.
+            shot = (
+                await _capture_debug_screenshot(
+                    page, out_dir, f"debug_picker_miss_{media_id[:8]}.png"
+                )
+                if found is False
+                else None
             )
-            dump = await _capture_picker_dom_dump(page, out_dir, media_id, project_id)
+            dump = (
+                await _capture_picker_dom_dump(page, out_dir, media_id, project_id)
+                if found is False
+                else None
+            )
             log.warning(
                 "ui_automation_video.existing_asset_not_found",
                 media_id=media_id,
                 project_id=project_id,
                 screenshot=str(shot) if shot is not None else None,
                 dom_dump=str(dump) if dump is not None else None,
-                resolved_by="not_found",
             )
-            return None
+            if found is False:
+                clear_search = page.locator(PICKER_SEARCH_INPUT).first
+                await clear_search.fill("")
+                await page.wait_for_timeout(400)
+            return False
 
-        assert resolved_by is not None
         await VideoGenerationMixin._attach_selected_tile(
             page,
             tile,
@@ -2359,7 +2318,7 @@ class VideoGenerationMixin:
             screenshot_name="image_ref_include_missing.png",
             dialog_timeout_s=dialog_timeout_s,
         )
-        return resolved_by
+        return True
 
     @staticmethod
     async def _attach_selected_tile(
@@ -2414,18 +2373,18 @@ class VideoGenerationMixin:
     @staticmethod
     async def _attach_image_uuid_refs(
         page: Page,
-        refs: list[tuple[str, str, str]],
+        refs: list[tuple[str, str, str, str]],
         *,
         out_dir: Path | None,
     ) -> None:
         """Attach pre-generated image UUID references for I2I.
 
-        Each ref is ``(media_id, display_name, local_path)``. **Prefers selecting
-        the already-existing Flow asset** in the picker (no duplicate upload —
+        Each ref is ``(media_id, display_name, local_path, local_sha256)``. Prefers selecting
+        the already-existing Flow asset in the picker (no duplicate upload —
         the founder principle); uploads ``local_path`` only as a fallback when the
         asset can't be located in place. Raises when neither is possible.
         """
-        for media_id, display_name, local_path in refs:
+        for media_id, display_name, local_path, local_sha256 in refs:
             add = page.locator(ADD_MEDIA_BUTTON).first
             await add.wait_for(state="visible", timeout=8000)
             await add.click()
@@ -2437,42 +2396,31 @@ class VideoGenerationMixin:
             # already aligned or when the selector is absent).
             await VideoGenerationMixin._sync_picker_project(page, out_dir=out_dir)
 
-            # Fresh per-ref state (#282): a display-name search typed while
-            # locating a previous ref must not leak into this ref's lookup —
-            # every ref after the first was failing because the picker was
-            # still filtered on the prior ref's search term. (The dialog and
-            # tile locators are already re-resolved fresh each iteration below,
-            # since each is a brand new `page.locator(...)` call rather than a
-            # handle carried over from a prior loop pass.)
-            #
-            # Presence-guarded (#281 final review): a picker variant with no
-            # search box at all (#174's full-page media-library drift) must
-            # not become a hard dependency for every ref — an unconditional
-            # `.fill("")` would wait out a full actionability timeout against
-            # an element that's simply absent from the DOM.
-            search = page.locator(PICKER_SEARCH_INPUT).first
-            if await search.count():
-                await search.fill("")
-
-            resolved_by = await VideoGenerationMixin._select_existing_asset(
+            selected = await VideoGenerationMixin._select_existing_asset(
                 page, media_id, display_name, out_dir=out_dir
             )
-            if resolved_by is not None:
+            if selected:
                 log.info(
                     "ui_automation_video.image_ref_selected_existing",
                     media_id=media_id,
-                    resolved_by=resolved_by,
+                    resolved_by="display_name",
                 )
                 continue
 
             if local_path:
+                path = Path(local_path)
+                if not matches_recorded_file(path, sha256=local_sha256):
+                    raise TransportTimeoutError(
+                        f"image ref {media_id!r} local fallback changed since it was "
+                        "recorded; refusing to upload different bytes."
+                    )
                 log.info(
                     "ui_automation_video.image_ref_upload_fallback",
                     media_id=media_id,
                     resolved_by="upload",
                 )
                 await VideoGenerationMixin._upload_via_open_dialog(
-                    page, Path(local_path), log_label="image_ref", out_dir=out_dir
+                    page, path, log_label="image_ref", out_dir=out_dir
                 )
                 continue
 
@@ -2860,14 +2808,19 @@ class VideoGenerationMixin:
     @staticmethod
     async def _search_picker_for_tile(page: Page, tile: Locator, term: str) -> bool | None:
         """Type ``term`` into the picker search box and report whether it
-        surfaced ``tile``. Clears any previous term first so search tiers
+        surfaced ``tile``. Clears any previous term first so repeated searches
         don't concatenate (``press_sequentially`` appends). Returns ``None``
         (without touching the page) when this picker variant has no search
         input at all (#174's full-page media-library drift) — search must
         never become a hard dependency."""
         search = page.locator(PICKER_SEARCH_INPUT).first
-        if not await search.count():
-            log.info("ui_automation_video.picker_search_unavailable", term=term)
+        try:
+            await search.wait_for(state="visible", timeout=4000)
+        except Exception:  # noqa: BLE001 - absent search is a supported picker cohort
+            log.info(
+                "ui_automation_video.picker_search_unavailable",
+                term_length=len(term),
+            )
             return None
         await search.fill("")
         # Human-like typing jitter to dodge WAF heuristics — not security.
@@ -2877,11 +2830,12 @@ class VideoGenerationMixin:
         found = True
         try:
             await tile.wait_for(state="visible", timeout=6000)
+            found = await VideoGenerationMixin._tile_is_fully_visible(tile)
         except Exception:  # noqa: BLE001 - not surfaced by this term
             found = False
         log.info(
             "ui_automation_video.picker_search_tier",
-            term=term,
+            term_length=len(term),
             found=found,
             rendered_tiles=len(rendered) if rendered is not None else None,
         )
@@ -3524,9 +3478,11 @@ class VideoGenerationMixin:
                 0,
                 "Start",
                 request.start_image_ref_id,
+                request.start_image_ref_display_name,
                 out_dir=out_dir,
                 project_name=request.project_name,
-                search_hints=request.search_hints,
+                local_path=request.start_image_ref_local_path,
+                local_sha256=request.start_image_ref_local_sha256,
             )
         elif request.start_image_ref_name is not None:
             await VideoGenerationMixin._attach_remote_frame(
@@ -3542,9 +3498,11 @@ class VideoGenerationMixin:
                 1,
                 "End",
                 request.end_image_ref_id,
+                request.end_image_ref_display_name,
                 out_dir=out_dir,
                 project_name=request.project_name,
-                search_hints=request.search_hints,
+                local_path=request.end_image_ref_local_path,
+                local_sha256=request.end_image_ref_local_sha256,
             )
         elif request.end_image_ref_name is not None:
             await VideoGenerationMixin._attach_remote_frame(
@@ -3700,8 +3658,15 @@ class VideoGenerationMixin:
     ) -> VideoResult:
         """Serialized body of `generate_video` — runs under `self._generate_lock`
         (shared with `generate_images`: one Page, one DOM)."""
-        is_i2v_with_frames = request.mode is Mode.I2V and (
-            request.start_image is not None or request.end_image is not None
+        is_i2v_with_frames = request.mode is Mode.I2V and any(
+            (
+                request.start_image,
+                request.start_image_ref_name,
+                request.start_image_ref_id,
+                request.end_image,
+                request.end_image_ref_name,
+                request.end_image_ref_id,
+            )
         )
         # Defense-in-depth model/mode guard (issue #125). Pure DTO check — runs
         # BEFORE any browser interaction so a bad combination fails instantly

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -20,7 +20,7 @@ import random
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import structlog
 
@@ -66,6 +66,15 @@ log = structlog.get_logger(__name__)
 # ruff's TC006 happy since call sites pass a bare name, not a subscript.
 _JsonObj = dict[str, Any]
 _JsonObjList = list[dict[str, Any]]
+_PickerResolvedBy = Literal[
+    "viewport",
+    "display_name",
+    "hint",
+    "scroll",
+    "uuid_retry",
+    "upload",
+    "not_found",
+]
 
 # The three mode-specific generate routes (spec §2.1). The listener filters on
 # these substrings only — video generate URLs carry no /projects/{id}/ path
@@ -1880,9 +1889,10 @@ class VideoGenerationMixin:
         if await search.count():
             await search.fill("")
 
-        if not await VideoGenerationMixin._select_existing_asset(
+        resolved_by = await VideoGenerationMixin._select_existing_asset(
             page, media_id, "", out_dir=out_dir, search_hints=search_hints
-        ):
+        )
+        if resolved_by is None:
             # The frame-slot dialog is the one surface this picker reuse is
             # unproven on (#237's name-search never surfaced generated media
             # here) — capture the dialog state so a live miss is diagnosable.
@@ -1897,7 +1907,12 @@ class VideoGenerationMixin:
             if shot is not None:
                 msg = f"{msg} Screenshot: {shot}"
             raise TransportTimeoutError(msg)
-        log.info("ui_automation_video.frame_ref_attached", slot=label, media_id=media_id)
+        log.info(
+            "ui_automation_video.frame_ref_attached",
+            slot=label,
+            media_id=media_id,
+            resolved_by=resolved_by,
+        )
 
     @staticmethod
     async def _upload_via_open_dialog(
@@ -2137,8 +2152,10 @@ class VideoGenerationMixin:
         The picker indexes Flow's own short auto-caption, NOT the generation
         prompt, so a name that never matches used to surface as a bare
         Playwright ``TimeoutError`` after 8 s — no indication of what went
-        wrong. A miss is now a typed, self-documenting error that names the
-        term searched and lists what the picker actually offered.
+        wrong. The raw picker/catalog comparison is recorded in
+        ``docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md``. A miss is
+        now a typed, self-documenting error that names the term searched and
+        lists what the picker actually offered.
         """
         # playwright is a TYPE_CHECKING-only import at module level; the
         # timeout class is needed at runtime to type the picker miss.
@@ -2216,22 +2233,21 @@ class VideoGenerationMixin:
         out_dir: Path | None,
         dialog_timeout_s: float = REMOTE_PICKER_CLOSE_TIMEOUT_S,
         search_hints: tuple[str, ...] = (),
-    ) -> bool:
+    ) -> _PickerResolvedBy | None:
         """In the OPEN reference picker, select the already-existing Flow asset
         identified by ``media_id`` (preferred over uploading a duplicate).
 
         Locates the tile by the media UUID in its thumbnail URL. If it isn't
-        already visible, tries the picker search tiers — ``display_name``
-        (when given), then the media UUID itself, then the UUID-derived
-        filename stem (#287: the frame-ref path has no display name, and a
-        search hit skips the scroll fallback entirely on crowded grids); if
-        it's STILL not visible, scrolls the virtualised picker grid
-        (react-virtuoso renders off-viewport tiles lazily — #282) and
-        re-checks between scrolls, bounded by evidence of progress rather
-        than a fixed attempt count (#287). Returns ``True`` once attached,
-        ``False`` when the asset can't be located by any of the above
-        (callers with a local file fall back to uploading it; the #287
-        frame-ref path has no fallback and raises instead).
+        already visible, tries ``display_name`` and any ``search_hints``, then
+        scrolls the virtualised picker grid (react-virtuoso renders off-viewport
+        tiles lazily — #282). Only after scrolling misses does it retry the media
+        UUID and UUID-derived filename stem. #287 live rounds found those UUID
+        searches never match, and #393's 2026-07-27 picker capture confirmed the
+        search surface indexes short captions rather than UUIDs; the tiers are
+        demoted instead of deleted because Flow is a blackbox and another cohort
+        may still index them. Returns the winning tier once attached, ``None``
+        when the asset can't be located (callers with a local file fall back to
+        uploading it; the #287 frame-ref path has no fallback and raises instead).
         """
         tile = VideoGenerationMixin._existing_asset_tile(page, media_id)
         visible = True
@@ -2239,33 +2255,38 @@ class VideoGenerationMixin:
             await tile.wait_for(state="visible", timeout=4000)
         except Exception:  # noqa: BLE001 - not-visible is an expected branch
             visible = False
+        resolved_by: _PickerResolvedBy | None = "viewport" if visible else None
 
         attempted_search = False
-        if not visible:
-            # Search tiers (#287): each is best-effort — an unmatched term
-            # just filters the grid to zero rows and the next tier (or the
-            # cleared-grid scroll fallback below) takes over. The UUID tiers
-            # cover generated/uploaded media whose display name embeds the
-            # UUID (or its first segment as a filename stem).
-            # #287 round 6: the UUID tiers are kept as cheap first attempts,
-            # but live rounds proved Flow's search does NOT index UUIDs — the
-            # `search_hints` (CLI-resolved recorded prompts, first words) are
-            # the tier that actually matches, since tile alt text carries the
-            # generation prompt. Tile matching stays UUID-in-src, so an
-            # imprecise hint can only surface extra tiles, never a wrong one.
-            uuid_stem = media_id.split("-", 1)[0]
-            terms: list[str] = []
-            for candidate in (display_name, media_id, uuid_stem, *search_hints):
-                if candidate and candidate not in terms:
-                    terms.append(candidate)
-            for term in terms:
+        searched_terms: set[str] = set()
+
+        async def _search_candidates(
+            candidates: tuple[tuple[str, _PickerResolvedBy], ...],
+        ) -> _PickerResolvedBy | None:
+            """Try unique picker terms and return the winning tier."""
+            nonlocal attempted_search
+            for term, tier in candidates:
+                if not term or term in searched_terms:
+                    continue
+                searched_terms.add(term)
                 found = await VideoGenerationMixin._search_picker_for_tile(page, tile, term)
                 if found is None:
-                    break  # picker variant with no search box (#174)
+                    return None  # picker variant with no search box (#174)
                 attempted_search = True
                 if found:
-                    visible = True
-                    break
+                    return tier
+            return None
+
+        if not visible:
+            # Pre-scroll tiers keep named/hinted lookup behaviour unchanged.
+            # The prompt-derived hints are retained pending #541, although the
+            # caption evidence means their live value is currently unproven.
+            pre_scroll_candidates: list[tuple[str, _PickerResolvedBy]] = [
+                (display_name, "display_name")
+            ]
+            pre_scroll_candidates.extend((hint, "hint") for hint in search_hints)
+            resolved_by = await _search_candidates(tuple(pre_scroll_candidates))
+            visible = resolved_by is not None
 
         if not visible:
             # A failed search leaves the grid filtered on the last term —
@@ -2288,6 +2309,23 @@ class VideoGenerationMixin:
                     await tile.wait_for(state="visible", timeout=4000)
                 except Exception:  # noqa: BLE001 - rendered but never became visible
                     visible = False
+                resolved_by = "scroll" if visible else None
+
+        if not visible:
+            # Last-resort UUID retries (#529): #287/#393 observed these as two
+            # guaranteed misses (~14.9 s total), so pay them only after the
+            # progress-bounded full-grid scroll has also missed. Retaining them
+            # preserves reachability on any Flow cohort that does index UUIDs.
+            uuid_stem = media_id.split("-", 1)[0]
+            resolved_by = await _search_candidates(
+                ((media_id, "uuid_retry"), (uuid_stem, "uuid_retry"))
+            )
+            visible = resolved_by is not None
+            if not visible and attempted_search:
+                clear_search = page.locator(PICKER_SEARCH_INPUT).first
+                if await clear_search.count():
+                    await clear_search.fill("")
+                    await page.wait_for_timeout(400)
 
         if not visible:
             # #287 diagnosis telemetry: capture WHAT the picker was showing
@@ -2307,9 +2345,11 @@ class VideoGenerationMixin:
                 project_id=project_id,
                 screenshot=str(shot) if shot is not None else None,
                 dom_dump=str(dump) if dump is not None else None,
+                resolved_by="not_found",
             )
-            return False
+            return None
 
+        assert resolved_by is not None
         await VideoGenerationMixin._attach_selected_tile(
             page,
             tile,
@@ -2319,7 +2359,7 @@ class VideoGenerationMixin:
             screenshot_name="image_ref_include_missing.png",
             dialog_timeout_s=dialog_timeout_s,
         )
-        return True
+        return resolved_by
 
     @staticmethod
     async def _attach_selected_tile(
@@ -2414,14 +2454,23 @@ class VideoGenerationMixin:
             if await search.count():
                 await search.fill("")
 
-            if await VideoGenerationMixin._select_existing_asset(
+            resolved_by = await VideoGenerationMixin._select_existing_asset(
                 page, media_id, display_name, out_dir=out_dir
-            ):
-                log.info("ui_automation_video.image_ref_selected_existing", media_id=media_id)
+            )
+            if resolved_by is not None:
+                log.info(
+                    "ui_automation_video.image_ref_selected_existing",
+                    media_id=media_id,
+                    resolved_by=resolved_by,
+                )
                 continue
 
             if local_path:
-                log.info("ui_automation_video.image_ref_upload_fallback", media_id=media_id)
+                log.info(
+                    "ui_automation_video.image_ref_upload_fallback",
+                    media_id=media_id,
+                    resolved_by="upload",
+                )
                 await VideoGenerationMixin._upload_via_open_dialog(
                     page, Path(local_path), log_label="image_ref", out_dir=out_dir
                 )

--- a/src/gflow_cli/api/video.py
+++ b/src/gflow_cli/api/video.py
@@ -273,17 +273,21 @@ class GenerateVideoRequest:
     end_image: Path | None = None  # I2V (optional local file path)
     end_image_ref_name: str | None = None  # I2V (optional remote asset display name)
     end_image_ref_id: str | None = None  # I2V (optional in-project asset media UUID, #287)
+    # Catalog-resolved names used only to filter the browser picker for UUID
+    # refs. The UUID fields above remain the exact asset identity. Empty names
+    # remain valid for direct/legacy callers only when paired with a verified
+    # recorded local-image fallback; the transport never scans by UUID.
+    start_image_ref_display_name: str = ""
+    end_image_ref_display_name: str = ""
+    start_image_ref_local_path: Path | None = None
+    end_image_ref_local_path: Path | None = None
+    start_image_ref_local_sha256: str = ""
+    end_image_ref_local_sha256: str = ""
     # Display name of the target project for the media picker's project-menu
     # match (#287: the menu lists projects by NAME, not id). Optional override
     # (--project-name / GFLOW_CLI_PROJECT_NAME); when None the transport
     # derives a name from the live page.
     project_name: str | None = None
-    # Picker search hints for UUID frame refs (#287 round 6): Flow's media
-    # search does not index UUIDs, but tile alt text carries the generation
-    # prompt — the CLI resolves each ref's recorded prompt from the local
-    # catalog and passes its first words here; the transport types them into
-    # the picker search box and matches results by UUID-in-src.
-    search_hints: tuple[str, ...] = ()
     reference_images: tuple[Path, ...] = ()  # R2V (local file paths)
     ref_names: tuple[str, ...] = ()  # R2V (remote asset display names)
     reference_entities: tuple[str, ...] = ()  # R2V — Flow CHARACTER entity ids
@@ -376,10 +380,36 @@ class GenerateVideoRequest:
             raise ValueError(msg)
 
     def _validate_frame_ref_ids(self) -> None:
-        for slot, ref_id, alternatives in (
-            ("start", self.start_image_ref_id, (self.start_image, self.start_image_ref_name)),
-            ("end", self.end_image_ref_id, (self.end_image, self.end_image_ref_name)),
+        for slot, ref_id, display_name, local_path, local_sha256, alternatives in (
+            (
+                "start",
+                self.start_image_ref_id,
+                self.start_image_ref_display_name,
+                self.start_image_ref_local_path,
+                self.start_image_ref_local_sha256,
+                (self.start_image, self.start_image_ref_name),
+            ),
+            (
+                "end",
+                self.end_image_ref_id,
+                self.end_image_ref_display_name,
+                self.end_image_ref_local_path,
+                self.end_image_ref_local_sha256,
+                (self.end_image, self.end_image_ref_name),
+            ),
         ):
+            if display_name and ref_id is None:
+                msg = f"{slot}_image_ref_display_name requires {slot}_image_ref_id"
+                raise ValueError(msg)
+            if local_path is not None and ref_id is None:
+                msg = f"{slot}_image_ref_local_path requires {slot}_image_ref_id"
+                raise ValueError(msg)
+            if local_path is not None and not local_sha256:
+                msg = f"{slot}_image_ref_local_path requires {slot}_image_ref_local_sha256"
+                raise ValueError(msg)
+            if local_sha256 and local_path is None:
+                msg = f"{slot}_image_ref_local_sha256 requires {slot}_image_ref_local_path"
+                raise ValueError(msg)
             if ref_id is None:
                 continue
             if not is_media_uuid(ref_id):

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -52,13 +52,13 @@ from gflow_cli.api.image_upscale import TargetResolution, UpsampleImageRequest
 from gflow_cli.api.transports import transport_choices
 from gflow_cli.api.video import is_media_uuid
 from gflow_cli.config import UiMode, get_settings, parse_jitter_range
-from gflow_cli.data.models import OperationKind
+from gflow_cli.data.models import AssetKind, OperationKind
 from gflow_cli.data.recorder import (
     OperationRecorder,
     escalate_asset_collision,
     record_failed_operation_safe,
 )
-from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.repository import DataRepository, verified_local_path
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import (
     ConfigurationError,
@@ -245,18 +245,13 @@ def _classify_ref(ref: str) -> ImageRef | Path:
 
 
 def _enrich_uuid_refs(refs: list[ImageRef], profile_name: str) -> list[ImageRef]:
-    """Give bare ``--ref <UUID>`` values their catalog-recorded local files (#393).
+    """Give bare ``--ref <UUID>`` values their catalog name and local file.
 
     ``_classify_ref`` sees a string, not the catalog, so it can only produce
-    ``ImageRef(name=<uuid>)`` — no ``local_path``. That leaves the transport one
-    way to bind the reference: find its tile in Flow's media picker. When that
-    misses there is nothing to fall back on and the whole generation hard-fails,
-    which is what #393 hit in production. ``local_path`` feeds the transport's
-    existing upload fallback (``_attach_image_uuid_refs``), previously reachable
-    only from the ``@mention`` path, turning an unreachable tile into an upload
-    of the exact recorded bytes. No search hint is derived: picker tiles carry a
-    short Flow-authored caption, not the prompt (see the #393 test module and
-    ``docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md``).
+    ``ImageRef(name=<uuid>)``. The catalog supplies Flow's ``display_name`` for
+    browser search while the UUID remains the exact tile identity. A surviving
+    local file is retained as the #393 upload fallback when the named tile is no
+    longer available in the target project's picker.
 
     One catalog session for the whole list — ``DataStore.open`` runs the
     migration check and nano2 allows 10 refs per call. Best-effort throughout:
@@ -267,23 +262,41 @@ def _enrich_uuid_refs(refs: list[ImageRef], profile_name: str) -> list[ImageRef]
     if not refs:
         return refs
 
-    def _with_local_file(ref: ImageRef, repo: DataRepository) -> ImageRef:
+    def _with_catalog_metadata(ref: ImageRef, repo: DataRepository) -> ImageRef:
         try:
-            seed = repo.resolve_seed_image(profile_name, ref.name)
+            asset = repo.get_asset_by_flow_media_id(profile_name, ref.name)
         except (DataStoreError, OSError) as exc:
             logger.debug("image.ref_enrich_skipped", media_id=ref.name, error=str(exc)[:120])
             return ref
-        # Only offer a file that still exists — a stale catalog path would send
-        # the transport into uploading something that isn't there.
-        if seed is None or seed.local_path is None or not seed.local_path.is_file():
+        if asset is None or asset.kind is not AssetKind.IMAGE:
             return ref
-        return replace(ref, local_path=str(seed.local_path))
+
+        display_name = ref.display_name
+        recorded_name = asset.metadata_json.get("display_name")
+        if not display_name and isinstance(recorded_name, str) and recorded_name:
+            display_name = recorded_name
+
+        local_path = ref.local_path
+        local_sha256 = ref.local_sha256
+        if not local_path:
+            for local_file in asset.local_files:
+                if (path := verified_local_path(local_file)) is not None:
+                    local_path = str(path)
+                    local_sha256 = local_file.sha256 or ""
+                    break
+
+        return replace(
+            ref,
+            display_name=display_name,
+            local_path=local_path,
+            local_sha256=local_sha256,
+        )
 
     try:
         settings = get_settings()
         with DataStore.open(settings.resolved_db_path()) as store:
             repo = DataRepository(store)
-            return [_with_local_file(ref, repo) for ref in refs]
+            return [_with_catalog_metadata(ref, repo) for ref in refs]
     except (DataStoreError, OSError) as exc:
         logger.debug("image.ref_enrich_skipped", error=str(exc)[:120])
         return refs

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -255,7 +255,8 @@ def _enrich_uuid_refs(refs: list[ImageRef], profile_name: str) -> list[ImageRef]
     existing upload fallback (``_attach_image_uuid_refs``), previously reachable
     only from the ``@mention`` path, turning an unreachable tile into an upload
     of the exact recorded bytes. No search hint is derived: picker tiles carry a
-    short Flow-authored caption, not the prompt (see the #393 test module).
+    short Flow-authored caption, not the prompt (see the #393 test module and
+    ``docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md``).
 
     One catalog session for the whole list — ``DataStore.open`` runs the
     migration check and nano2 allows 10 refs per call. Best-effort throughout:

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -27,8 +27,10 @@ from gflow_cli._cli_helpers import (
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.video import VideoModel, is_media_uuid, reference_cap_for
 from gflow_cli.config import UiMode, get_settings
-from gflow_cli.data.models import OperationKind
+from gflow_cli.data.models import AssetKind, OperationKind
 from gflow_cli.data.recorder import OperationRecorder, record_failed_operation_safe
+from gflow_cli.data.repository import DataRepository, verified_local_path
+from gflow_cli.data.store import DataStore
 from gflow_cli.errors import DataStoreError
 from gflow_cli.storage import cloud_info_from_path
 
@@ -424,49 +426,54 @@ class _I2VParams:
     # Picker project-menu display-name override (#287): the media picker's
     # library is per-project and its project menu lists NAMES, not ids.
     project_name: str | None = None
-    # Picker search hints (#287 round 6): the catalog-recorded prompts of the
-    # UUID frame refs, first words — Flow's media search indexes prompt text
-    # (tile alt), not UUIDs.
-    search_hints: tuple[str, ...] = ()
+    # Browser-picker search keys resolved from the catalog. UUID remains the
+    # exact tile identity after its Flow display name surfaces candidates.
+    image_ref_display_name: str = ""
+    end_frame_ref_display_name: str = ""
+    image_ref_local_path: Path | None = None
+    end_frame_ref_local_path: Path | None = None
+    image_ref_local_sha256: str = ""
+    end_frame_ref_local_sha256: str = ""
     reference_entities: tuple[str, ...] = ()
     reference_entity_names: tuple[str, ...] = ()
     # Requested Flow UI arm (#299); agentic is rejected at the CLI edge.
     ui_mode: UiMode | None = None
 
 
-# First words of a recorded prompt used as a picker search term (#287 round
-# 6) — long enough to be distinctive, short enough to survive alt-text
-# truncation in Flow's search index.
-_SEARCH_HINT_WORDS = 6
+def _media_picker_metadata(
+    media_ids: Sequence[str | None], profile_name: str
+) -> tuple[dict[str, str], dict[str, tuple[Path, str]]]:
+    """Resolve UUID frames to picker names and extant local fallbacks.
 
-
-def _media_search_hints(media_ids: Sequence[str | None]) -> tuple[str, ...]:
-    """Best-effort picker search hints for media-UUID frame refs (#287 round
-    6): Flow's media search does not index UUIDs, but each picker tile's alt
-    text carries the generation PROMPT — resolve each ref's recorded prompt
-    from the local catalog and use its first words as a search term.
-    Layering: the CLI resolves (it owns catalog access); the transport only
-    consumes. Never raises — a missing catalog, unknown asset, or absent
-    prompt just yields no hint."""
-    hints: list[str] = []
-    for media_id in media_ids:
-        if not media_id:
-            continue
-        prompt: str | None = None
-        try:
-            from gflow_cli.config import get_settings as _get_settings
-            from gflow_cli.data import queries
-
-            prompt = queries.get_asset_prompt(
-                db_path=_get_settings().resolved_db_path(), media_id=media_id
-            )
-        except Exception:  # noqa: BLE001 - hints are best-effort, never fatal
-            prompt = None
-        if prompt:
-            hint = " ".join(prompt.split()[:_SEARCH_HINT_WORDS])
-            if hint and hint not in hints:
-                hints.append(hint)
-    return tuple(hints)
+    The CLI owns catalog access; the transport receives only the name used to
+    filter the browser picker and still verifies the exact UUID in the result
+    tile's thumbnail URL. Agentic, redacted-history, and legacy rows may lack a
+    name; their exact recorded image bytes are the bounded fallback. Best-effort:
+    unknown/non-image assets and an unavailable catalog produce no entry.
+    """
+    ids = tuple(media_id for media_id in media_ids if media_id)
+    if not ids:
+        return {}, {}
+    display_names: dict[str, str] = {}
+    local_files: dict[str, tuple[Path, str]] = {}
+    try:
+        with DataStore.open(get_settings().resolved_db_path()) as store:
+            repo = DataRepository(store)
+            for media_id in ids:
+                asset = repo.get_asset_by_flow_media_id(profile_name, media_id)
+                if asset is None or asset.kind is not AssetKind.IMAGE:
+                    continue
+                display_name = asset.metadata_json.get("display_name")
+                if isinstance(display_name, str) and display_name:
+                    display_names[media_id] = display_name
+                for local_file in asset.local_files:
+                    if (path := verified_local_path(local_file)) is not None:
+                        assert local_file.sha256 is not None
+                        local_files[media_id] = (path, local_file.sha256)
+                        break
+    except (DataStoreError, OSError) as exc:
+        logger.debug("video.frame_ref_enrich_skipped", error=str(exc)[:120])
+    return display_names, local_files
 
 
 async def _run_i2v(
@@ -522,8 +529,13 @@ async def _run_i2v(
         start_image_ref_id=params.image_ref_id,
         end_image=Path(params.end_frame) if params.end_frame else None,
         end_image_ref_id=params.end_frame_ref_id,
+        start_image_ref_display_name=params.image_ref_display_name,
+        end_image_ref_display_name=params.end_frame_ref_display_name,
+        start_image_ref_local_path=params.image_ref_local_path,
+        end_image_ref_local_path=params.end_frame_ref_local_path,
+        start_image_ref_local_sha256=params.image_ref_local_sha256,
+        end_image_ref_local_sha256=params.end_frame_ref_local_sha256,
         project_name=params.project_name,
-        search_hints=params.search_hints,
         reference_entities=params.reference_entities,
         reference_entity_names=params.reference_entity_names,
         original_prompt=params.original_prompt,
@@ -1322,14 +1334,10 @@ def i2v(  # NOSONAR
     start_path, start_ref_id = _classify_frame(resolved_image, "'IMAGE' / '--initial-frame'")
     end_path, end_ref_id = _classify_frame(end_frame, end_hint)
 
-    # #287 round 6: for UUID frame refs, resolve the assets' recorded prompts
-    # into picker search hints (Flow's media search indexes prompt text, not
-    # UUIDs). Best-effort — no catalog, no hints.
-    search_hints: tuple[str, ...] = ()
-    if start_ref_id or end_ref_id:
-        search_hints = _media_search_hints([start_ref_id, end_ref_id])
-
     profile_name = _resolve_profile(profile)
+    display_names, local_files = _media_picker_metadata([start_ref_id, end_ref_id], profile_name)
+    start_local = local_files.get(start_ref_id or "")
+    end_local = local_files.get(end_ref_id or "")
     provider_dir = _make_provider_dir(profile_name)
     prompt_to_send, original_prompt, applied_tool = apply_tool_option(
         resolved_prompt, tool_specs, category="video", quiet=as_json
@@ -1346,7 +1354,12 @@ def i2v(  # NOSONAR
         original_prompt=original_prompt,
         tool=applied_tool,
         project_name=project_name,
-        search_hints=search_hints,
+        image_ref_display_name=display_names.get(start_ref_id or "", ""),
+        end_frame_ref_display_name=display_names.get(end_ref_id or "", ""),
+        image_ref_local_path=start_local[0] if start_local else None,
+        end_frame_ref_local_path=end_local[0] if end_local else None,
+        image_ref_local_sha256=start_local[1] if start_local else "",
+        end_frame_ref_local_sha256=end_local[1] if end_local else "",
         ui_mode=UiMode(ui_mode) if ui_mode else None,
     )
     run_with_handlers(

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -485,7 +485,10 @@ class OperationRecorder:
         # Persist the Flow-assigned display name (when present) so a generated
         # image can later be referenced by name — the picker's searchable label.
         metadata: dict[str, str] = {"fife_url": image.fife_url}
-        if image.display_name:
+        # Flow captions can closely paraphrase the generation prompt. Respect
+        # the same privacy boundary as prompt storage: redacted history never
+        # persists the browser-searchable caption in plaintext.
+        if image.display_name and self.prompt_mode == "store":
             metadata["display_name"] = image.display_name
         repo.upsert_asset(
             AssetRecord(

--- a/src/gflow_cli/data/repository.py
+++ b/src/gflow_cli/data/repository.py
@@ -23,6 +23,7 @@ from gflow_cli.data.models import (
     SeedImage,
 )
 from gflow_cli.errors import DataIntegrityError
+from gflow_cli.file_integrity import matches_recorded_file
 
 if TYPE_CHECKING:
     from gflow_cli.data.store import DataStore
@@ -40,6 +41,27 @@ def _coerce_utc(dt: datetime) -> datetime:
 _ASSET_LOOKUP_COLUMNS = (
     "id, profile_name, flow_project_id, flow_media_id, flow_workflow_id, metadata_json, kind"
 )
+
+
+def verified_local_path(local_file: LocalFileRecord) -> Path | None:
+    """Return an on-disk catalog file only when its recorded integrity still matches."""
+    path = local_file.path
+    if local_file.storage_provider is not None or path is None:
+        return None
+    recorded_sha256 = local_file.sha256
+    if recorded_sha256 is None or not matches_recorded_file(
+        path, sha256=recorded_sha256, size=local_file.bytes
+    ):
+        return None
+    return path
+
+
+def _decode_metadata_json(raw: object) -> dict[str, Any]:
+    try:
+        parsed: object = json.loads(str(raw)) if raw else {}
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
 
 
 class DataRepository:
@@ -291,7 +313,7 @@ class DataRepository:
             flow_workflow_id=row["flow_workflow_id"],
             kind=AssetKind(row["kind"]),
             local_files=local_files,
-            metadata_json=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
+            metadata_json=_decode_metadata_json(row["metadata_json"]),
         )
 
     def candidate_image_exists(self, profile_name: str, flow_media_id: str) -> bool:

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -650,7 +650,8 @@ class ReferenceNotFoundError(GFlowError):
     generation prompt. Passing a prompt therefore never matches, and the miss
     used to surface as a bare Playwright ``TimeoutError`` after 8 s: no typed
     error, no exit code to branch on, and no indication that the *name* was the
-    problem rather than the UI.
+    problem rather than the UI. The raw picker/catalog comparison is recorded in
+    ``docs/superpowers/spikes/2026-08-15-picker-tile-alt-text.md``.
     """
 
     problem_type = "https://gflow-cli.dev/errors/reference-not-found"

--- a/src/gflow_cli/file_integrity.py
+++ b/src/gflow_cli/file_integrity.py
@@ -1,0 +1,19 @@
+"""Small file-integrity checks shared by catalog resolution and UI upload."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def matches_recorded_file(path: Path, *, sha256: str, size: int | None = None) -> bool:
+    """Return whether an on-disk file still matches its required catalog digest."""
+    if not sha256:
+        return False
+    try:
+        if not path.is_file() or (size is not None and path.stat().st_size != size):
+            return False
+        with path.open("rb") as stream:
+            return hashlib.file_digest(stream, "sha256").hexdigest() == sha256
+    except OSError:
+        return False

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -38,9 +38,9 @@ from gflow_cli.api.video import is_media_uuid
 from gflow_cli.auth import verification
 from gflow_cli.cli_instructions import classify_refs
 from gflow_cli.config import UiMode, get_settings
-from gflow_cli.data.models import AssetLookup
+from gflow_cli.data.models import AssetKind, AssetLookup
 from gflow_cli.data.queries import list_projects
-from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.repository import DataRepository, verified_local_path
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import GFlowError, is_retryable
 from gflow_cli.mcp.server import server
@@ -484,14 +484,8 @@ def _resolve_ref_local_path(
             f"{profile!r}. Generate the image first, or pass a local file path.",
         )
     for local_file in asset.local_files:
-        # A usable frame is an on-disk local file (cloud-only rows carry a
-        # storage_provider and no local path — they can't feed a file upload).
-        if (
-            local_file.storage_provider is None
-            and local_file.path is not None
-            and local_file.path.is_file()
-        ):
-            return str(local_file.path), None
+        if (path := verified_local_path(local_file)) is not None:
+            return str(path), None
     return None, _bad_param(
         "Reference Not On Disk",
         f"'{ref_id}' is in your catalog but has no local image file on disk to "
@@ -542,12 +536,9 @@ def _ref_meta_entry(asset: AssetLookup) -> dict[str, str]:
     if isinstance(name, str) and name:
         entry["display_name"] = name
     for local_file in asset.local_files:
-        if (
-            local_file.storage_provider is None
-            and local_file.path is not None
-            and local_file.path.is_file()
-        ):
-            entry["local_path"] = str(local_file.path)
+        if (path := verified_local_path(local_file)) is not None:
+            entry["local_path"] = str(path)
+            entry["local_sha256"] = local_file.sha256 or ""
             break
     return entry
 
@@ -560,16 +551,45 @@ def _resolve_payload_refs(
 ) -> dict[str, Any] | None:
     """Resolve media-id refs in ``payload`` in place, by task type.
 
-    Video task types: a start/end frame ref becomes the local
-    ``start_image``/``end_image`` path and r2v ``refs`` are merged into
-    ``reference_images`` (local-upload attach — the video frame picker doesn't
-    surface generated media). Image task types: refs are *enriched* with
+    I2V start/end frame refs retain their UUID identity and gain catalog picker
+    metadata. R2V ``refs`` are merged into ``reference_images`` for local upload.
+    Image task types: refs are *enriched* with
     display_name/local_path so the transport selects the existing asset in the
     picker (see _enrich_image_refs). Returns an error envelope on the first
     unresolvable VIDEO UUID, else ``None`` (image enrichment never errors).
     """
     if task_type not in _VIDEO_TASK_TYPES:
         _enrich_image_refs(data_repo, profile, payload)
+        return None
+    if task_type == "i2v":
+        for ref_key in ("start_image_ref", "end_image_ref"):
+            ref_id = payload.get(ref_key)
+            if ref_id is None:
+                continue
+            asset = data_repo.get_asset_by_flow_media_id(profile, ref_id)
+            if asset is None:
+                return _bad_param(
+                    "Reference Not Found",
+                    f"'{ref_id}' was not found in your asset catalog for profile "
+                    f"{profile!r}. Generate the image first, or pass a local file path.",
+                )
+            if asset.kind is not AssetKind.IMAGE:
+                return _bad_param(
+                    "Reference Not Usable",
+                    f"'{ref_id}' is not an image asset and cannot be an I2V frame.",
+                )
+            entry = _ref_meta_entry(asset)
+            if not entry:
+                return _bad_param(
+                    "Reference Not Usable",
+                    f"'{ref_id}' has neither a catalog display name nor a verified "
+                    "local image fallback.",
+                )
+            if display_name := entry.get("display_name"):
+                payload[f"{ref_key}_display_name"] = display_name
+            if local_path := entry.get("local_path"):
+                payload[f"{ref_key}_local_path"] = local_path
+                payload[f"{ref_key}_local_sha256"] = entry["local_sha256"]
         return None
     if "refs" in payload:
         resolved_paths: list[str] = []
@@ -582,13 +602,6 @@ def _resolve_payload_refs(
             resolved_paths.append(path)
         payload["reference_images"] = list(payload.get("reference_images", [])) + resolved_paths
         del payload["refs"]
-    for ref_key, path_key in (("start_image_ref", "start_image"), ("end_image_ref", "end_image")):
-        if ref_key in payload:
-            path, err = _resolve_ref_local_path(data_repo, profile, payload[ref_key])
-            if err is not None:
-                return err
-            payload[path_key] = path
-            del payload[ref_key]
     return None
 
 

--- a/src/gflow_cli/worker/codec.py
+++ b/src/gflow_cli/worker/codec.py
@@ -193,6 +193,7 @@ def build_image_request(payload: dict[str, Any]) -> GenerateImageRequest:
             r,
             display_name=ref_meta.get(r, {}).get("display_name", ""),
             local_path=ref_meta.get(r, {}).get("local_path", ""),
+            local_sha256=ref_meta.get(r, {}).get("local_sha256", ""),
         )
         for r in payload.get("refs", [])
     )
@@ -245,9 +246,25 @@ def build_video_request(payload: dict[str, Any]) -> GenerateVideoRequest:
     seed = payload.get("seed")
 
     start_image = Path(payload["start_image"]) if payload.get("start_image") else None
+    start_image_ref_id = payload.get("start_image_ref")
     start_image_ref_name = payload.get("start_image_ref_name")
+    start_image_ref_display_name = payload.get("start_image_ref_display_name", "")
+    start_image_ref_local_path = (
+        Path(payload["start_image_ref_local_path"])
+        if payload.get("start_image_ref_local_path")
+        else None
+    )
+    start_image_ref_local_sha256 = payload.get("start_image_ref_local_sha256", "")
     end_image = Path(payload["end_image"]) if payload.get("end_image") else None
+    end_image_ref_id = payload.get("end_image_ref")
     end_image_ref_name = payload.get("end_image_ref_name")
+    end_image_ref_display_name = payload.get("end_image_ref_display_name", "")
+    end_image_ref_local_path = (
+        Path(payload["end_image_ref_local_path"])
+        if payload.get("end_image_ref_local_path")
+        else None
+    )
+    end_image_ref_local_sha256 = payload.get("end_image_ref_local_sha256", "")
     reference_images = tuple(Path(p) for p in payload.get("reference_images", []))
     ref_names = tuple(payload.get("ref_names", []))
     reference_entities = tuple(payload.get("reference_entities", []))
@@ -267,9 +284,17 @@ def build_video_request(payload: dict[str, Any]) -> GenerateVideoRequest:
         count=count,
         seed=seed,
         start_image=start_image,
+        start_image_ref_id=start_image_ref_id,
         start_image_ref_name=start_image_ref_name,
+        start_image_ref_display_name=start_image_ref_display_name,
+        start_image_ref_local_path=start_image_ref_local_path,
+        start_image_ref_local_sha256=start_image_ref_local_sha256,
         end_image=end_image,
+        end_image_ref_id=end_image_ref_id,
         end_image_ref_name=end_image_ref_name,
+        end_image_ref_display_name=end_image_ref_display_name,
+        end_image_ref_local_path=end_image_ref_local_path,
+        end_image_ref_local_sha256=end_image_ref_local_sha256,
         reference_images=reference_images,
         ref_names=ref_names,
         reference_entities=reference_entities,

--- a/tests/api/test_video.py
+++ b/tests/api/test_video.py
@@ -254,6 +254,24 @@ class TestI2VFrameRefIds:
         )
         assert req.end_image_ref_id == _REF_UUID
 
+    def test_ref_local_fallback_requires_matching_ref_id(self) -> None:
+        with pytest.raises(ValueError, match="start_image_ref_local_path requires"):
+            GenerateVideoRequest(
+                prompt="x",
+                mode=Mode.I2V,
+                start_image=Path("a.png"),
+                start_image_ref_local_path=Path("fallback.png"),
+            )
+
+    def test_ref_local_fallback_requires_checksum(self) -> None:
+        with pytest.raises(ValueError, match="start_image_ref_local_path requires"):
+            GenerateVideoRequest(
+                prompt="x",
+                mode=Mode.I2V,
+                start_image_ref_id=_REF_UUID,
+                start_image_ref_local_path=Path("fallback.png"),
+            )
+
     def test_malformed_ref_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="not a valid media UUID"):
             GenerateVideoRequest(prompt="x", mode=Mode.I2V, start_image_ref_id="not-a-uuid")

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -3279,6 +3279,33 @@ def test_images_from_responses_raises_ratelimiterror_on_429():
     assert "45s" in str(err)
 
 
+def test_images_from_responses_preserves_workflow_display_name():
+    """The UI capture path must retain the Flow name used by picker search.
+
+    ``GeneratedImage.from_response_dict`` already joins ``media[]`` to the
+    sibling ``workflows[]`` array.  The UI response collector must use that
+    full-body parser rather than dropping the sibling metadata by parsing each
+    media item in isolation.
+    """
+    from gflow_cli.api.transports.ui_automation import _images_from_responses
+
+    body = _flow_200_body()
+    body["workflows"] = [
+        {
+            "name": "wf-001",
+            "metadata": {"displayName": "Calm forest at dawn"},
+        }
+    ]
+    images, error_status, error_route = _images_from_responses(
+        [{"status": 200, "url": "flowMedia:batchGenerateImages", "body": body}]
+    )
+
+    assert error_status is None
+    assert error_route == ""
+    assert len(images) == 1
+    assert images[0].display_name == "Calm forest at dawn"
+
+
 @pytest.mark.asyncio
 async def test_attach_batch_response_listener_records_headers():
     """_attach_batch_response_listener MUST capture response headers into the response dict."""

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1566,22 +1566,31 @@ class TestRemoteRefTileLocator:
     def test_apostrophe_name_does_not_go_into_a_quoted_css_selector(self) -> None:
         page = MagicMock()
         VideoGenerationMixin._remote_option_tile(page, "Wren's cabin")
-        # role-based match: the raw name is passed as the accessible name,
-        # never interpolated into a `:has-text('...')` CSS string.
-        page.get_by_role.assert_called_once()
-        args, kwargs = page.get_by_role.call_args
-        assert args[0] == "option"
-        assert kwargs.get("name") == "Wren's cabin"
-        page.locator.assert_not_called()
+        # #529 live recon: the picker exposes no accessible tree, so the tile
+        # is matched by text via has_text — the name is escaped into an
+        # anchored regex, never interpolated into a `:has-text('...')` CSS
+        # string.
+        page.locator.assert_called_once()
+        args, kwargs = page.locator.call_args
+        assert args[0] == "[role='option']"
+        assert kwargs["has_text"].match("Wren's cabin")
+        page.get_by_role.assert_not_called()
 
-    def test_matches_exactly_so_a_substring_name_cannot_attach_the_wrong_tile(self) -> None:
-        # PR #245 review #4: without exact=True, get_by_role's default substring
-        # match makes 'cabin' also select 'cabin at night' → .first attaches the
-        # wrong image silently.
+    def test_anchored_so_a_substring_name_cannot_attach_the_wrong_tile(self) -> None:
+        # PR #245 review #4: a substring match makes 'cabin' also select
+        # 'cabin at night' → .first attaches the wrong image silently.
+        # #529 live e2e: the option's text carries the picker's localized
+        # media-type badge ('…\nImagem' on a pt profile) appended to the
+        # display name — that suffix, and only that suffix, must be tolerated.
         page = MagicMock()
         VideoGenerationMixin._remote_option_tile(page, "cabin")
-        _, kwargs = page.get_by_role.call_args
-        assert kwargs.get("exact") is True
+        pattern = page.locator.call_args.kwargs["has_text"]
+        assert pattern.match("cabin")
+        assert pattern.match("cabinImagem")
+        assert pattern.match("cabin\nImagem")
+        assert not pattern.match("cabin at night")
+        assert not pattern.match("cabin at nightImagem")
+        assert not pattern.match("cabinsImagem")
 
 
 class TestRemoteReferencesDialogGuard:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import itertools
 import json
 from pathlib import Path
@@ -22,7 +23,6 @@ from gflow_cli.api.transports.ui_automation_video import (
     FRAME_SLOTS_STRUCT,
     PICKER_CONTEXT_INCLUDE,
     PICKER_GRID_SCROLL_ATTEMPTS,
-    PICKER_GRID_SCROLL_MAX_ATTEMPTS,
     PICKER_GRID_SCROLL_STALL_LIMIT,
     PICKER_INCLUDE_BUTTON,
     PICKER_PROJECT_MENU_OPEN,
@@ -1172,6 +1172,51 @@ class TestI2vT2vRoutingBackstop:
             await transport.generate_video(request=req, download=False)
 
     @pytest.mark.asyncio
+    async def test_uuid_i2v_routed_to_t2v_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """UUID-backed frames receive the same post-submit credit-safety guard."""
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(VideoGenerationMixin, "_attach_i2v_frames", AsyncMock())
+        req = GenerateVideoRequest(
+            prompt="x",
+            mode=Mode.I2V,
+            start_image_ref_id=_FRAME_REF_UUID,
+        )
+
+        with pytest.raises(WireFormatError, match="#125"):
+            await transport.generate_video(request=req, download=False)
+
+    @pytest.mark.asyncio
+    async def test_named_i2v_routed_to_t2v_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        transport = UiAutomationTransport()
+        transport._page = _mock_async_page()
+        transport._setup_done = True
+        monkeypatch.setattr(transport, "_enter_editor", AsyncMock())
+        monkeypatch.setattr(transport, "_send_prompt", AsyncMock())
+        monkeypatch.setattr(transport, "_dismiss_blocking_overlays", AsyncMock())
+        _stub_video_helpers(
+            monkeypatch,
+            generate_resp={"status": 200, "url": _T2V_URL, "body": {"media": [{"name": "v"}]}},
+        )
+        monkeypatch.setattr(VideoGenerationMixin, "_attach_i2v_frames", AsyncMock())
+        req = GenerateVideoRequest(
+            prompt="x",
+            mode=Mode.I2V,
+            start_image_ref_name="Brass key",
+        )
+
+        with pytest.raises(WireFormatError, match="#125"):
+            await transport.generate_video(request=req, download=False)
+
+    @pytest.mark.asyncio
     async def test_i2v_routed_to_start_end_image_succeeds(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1584,11 +1629,7 @@ class TestRemoteReferencesDialogGuard:
 
 
 class TestSelectExistingAssetPickerScroll:
-    """#282: the picker grid (react-virtuoso) is virtualised — a tile that
-    isn't in the initial viewport (and isn't surfaced by the display-name
-    search) may still exist just off-screen. `_select_existing_asset` must
-    scroll and re-check between scrolls before giving up, the same way
-    `_find_picker_entity_tile` does for the entity picker."""
+    """Picker fakes shared by name-search and exact-UUID selection tests."""
 
     @staticmethod
     def _tile_mock(
@@ -1600,6 +1641,7 @@ class TestSelectExistingAssetPickerScroll:
         tile.first = tile
         tile.click = AsyncMock()
         tile.wait_for = AsyncMock(side_effect=wait_for_side_effect)
+        tile.evaluate = AsyncMock(return_value=True)
         if isinstance(count_side_effect, list):
             tile.count = AsyncMock(side_effect=count_side_effect)
         else:
@@ -1617,6 +1659,7 @@ class TestSelectExistingAssetPickerScroll:
         search.first = search
         search.press_sequentially = AsyncMock()
         search.fill = AsyncMock()
+        search.wait_for = AsyncMock()
         search.count = AsyncMock(return_value=1)
 
         def _locator(selector: str) -> MagicMock:
@@ -1632,191 +1675,108 @@ class TestSelectExistingAssetPickerScroll:
         return page
 
     @pytest.mark.asyncio
-    async def test_tile_visible_only_after_scrolling_is_selected(self) -> None:
-        # Not visible in the initial viewport, not surfaced by the UUID /
-        # UUID-stem search tiers (#287); count() reports absent for the first
-        # 3 checks, then present on the 4th — the immediate re-check right
-        # after the scroll loop breaks then succeeds.
+    async def test_named_tile_is_searched_and_selected_by_exact_uuid(self) -> None:
         tile = self._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by the UUID search"),
-                TimeoutError("not surfaced by the UUID-stem search"),
-                None,
-            ],
-            count_side_effect=[0, 0, 0, 1],
-        )
-        page = self._page_with_tile(tile)
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is not None, "tile found via scrolling must be selected"
-        tile.click.assert_awaited_once()
-        # 3 scrolls before the tile rendered into the DOM.
-        assert page.mouse.wheel.await_count == 3
-
-    @pytest.mark.asyncio
-    async def test_tile_absent_after_exhausting_scrolls_returns_false(self) -> None:
-        tile = self._tile_mock(
-            wait_for_side_effect=TimeoutError("never visible"),
-            count_side_effect=0,
-        )
-        page = self._page_with_tile(tile)
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is None, "existing fallback behaviour must be unchanged"
-        tile.click.assert_not_awaited()
-        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
-
-    @pytest.mark.asyncio
-    async def test_tile_rendered_by_final_scroll_is_still_found(self) -> None:
-        """#283 off-by-one: the loop checked tile.count() BEFORE each scroll,
-        so a tile rendered into the DOM by the LAST scroll was never seen and
-        the picker gave up with the asset on screen."""
-        # count: 0 for every pre-scroll check; 1 only on the post-loop re-check.
-        tile = self._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not in initial viewport"),
-                TimeoutError("not surfaced by the UUID search"),
-                TimeoutError("not surfaced by the UUID-stem search"),
-                None,
-            ],
-            count_side_effect=[0] * PICKER_GRID_SCROLL_ATTEMPTS + [1],
-        )
-        page = self._page_with_tile(tile)
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is not None, "tile rendered by the final scroll must be found"
-        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
-        tile.click.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_failed_display_name_search_is_cleared_before_scrolling(self) -> None:
-        """A FAILED display-name search leaves the picker grid filtered on
-        that term; scrolling a still-filtered grid can never surface a tile
-        that the filter excludes. `_select_existing_asset` must clear the
-        search input before falling back to the scroll loop."""
-        tile = self._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by display-name search"),
-                None,  # visible after scrolling the cleared grid
-            ],
-            count_side_effect=[0, 0, 1],
+            wait_for_side_effect=None,
+            count_side_effect=1,
         )
         page = self._page_with_tile(tile)
         search = page.locator(PICKER_SEARCH_INPUT)
 
         result = await VideoGenerationMixin._select_existing_asset(
-            page, "uuid-1", "Wren's cabin", out_dir=None
+            page, "uuid-1", "Brass key on marble surface", out_dir=None
         )
 
-        assert result is not None, "tile found via scrolling after the search is cleared"
-        # The display name is the FIRST search tier (#287 added UUID tiers after it).
-        assert search.press_sequentially.await_args_list[0].args[0] == "Wren's cabin"
-        # One clear starts the display-name search and one restores the full
-        # grid before scrolling. The UUID tiers are not paid when scrolling
-        # locates the tile.
-        assert search.fill.await_count == 2
-        assert all(c.args == ("",) for c in search.fill.call_args_list)
-        # 2 scrolls before the tile rendered into the DOM.
-        assert page.mouse.wheel.await_count == 2
+        assert result is True
+        search.press_sequentially.assert_awaited_once()
+        assert search.press_sequentially.await_args.args[0] == "Brass key on marble surface"
+        tile.click.assert_awaited_once()
+        page.mouse.wheel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_waits_for_delayed_search_input_before_name_lookup(self) -> None:
+        tile = self._tile_mock(wait_for_side_effect=None, count_side_effect=1)
+        page = self._page_with_tile(tile)
+        search = page.locator(PICKER_SEARCH_INPUT)
+        search.count = AsyncMock(return_value=0)
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page, "uuid-1", "Brass key", out_dir=None
+        )
+
+        assert result is True
+        search.wait_for.assert_awaited_once_with(state="visible", timeout=4000)
+        assert search.press_sequentially.await_args.args[0] == "Brass key"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("probe", [False, RuntimeError("stale tile")])
+    async def test_filtered_tile_must_be_fully_visible_before_click(self, probe: object) -> None:
+        tile = self._tile_mock(wait_for_side_effect=None, count_side_effect=1)
+        tile.evaluate = (
+            AsyncMock(side_effect=probe)
+            if isinstance(probe, Exception)
+            else AsyncMock(return_value=probe)
+        )
+        page = self._page_with_tile(tile)
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page, "uuid-1", "Brass key", out_dir=None
+        )
+
+        assert result is False
+        tile.click.assert_not_awaited()
+        page.mouse.wheel.assert_not_awaited()
 
 
 class TestSelectExistingAssetLargeGrid:
-    """#287 (live repro): in a crowded project (100+ media) the target asset
-    sits deeper in the virtualised grid than the fixed 12-scroll budget could
-    reach, so `_select_existing_asset` gave up while the asset WAS in the
-    project — the i2v frame-ref path then raised `TransportTimeoutError`
-    ("Start frame asset ... could not be located in the media picker"). The
-    scroll loop is now bounded by evidence of progress: it keeps scrolling
-    while the set of rendered tile identifiers still changes between scrolls,
-    stops after PICKER_GRID_SCROLL_STALL_LIMIT consecutive no-progress
-    scrolls, and never exceeds the PICKER_GRID_SCROLL_MAX_ATTEMPTS ceiling.
-    A search-input picker also gets UUID / UUID-stem search tiers before any
-    scrolling (the frame-ref path has no display name to search)."""
+    """Name-addressed UUID selection never scans a crowded unfiltered grid."""
 
     _FULL_UUID = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
-    # Deeper than the legacy fixed budget could ever reach.
-    _DEEP_GRID_SCROLLS = 30
 
     @pytest.mark.asyncio
-    async def test_deep_tile_beyond_legacy_budget_is_reached(self) -> None:
-        """While every scroll keeps rendering NEW tiles (the grid is still
-        advancing), the loop must keep going — depth proportional to grid
-        size, not a fixed attempt count."""
-        assert self._DEEP_GRID_SCROLLS > PICKER_GRID_SCROLL_ATTEMPTS
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by the UUID search"),
-                TimeoutError("not surfaced by the UUID-stem search"),
-                None,
-            ],
-            count_side_effect=[0] * self._DEEP_GRID_SCROLLS + [1],
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        # Progress evidence: each fingerprint probe sees a fresh window of
-        # tiles. The JS grid-scroll probe is made to FAIL so this test pins
-        # the hover+wheel fallback path (round-6: JS scroll is primary).
-        counter = itertools.count()
-
-        def _eval(js: str, *args: object) -> object:
-            if "scrollTop" in js:
-                raise RuntimeError("no JS scroller in this fake")
-            return [f"tile-{next(counter)}"]
-
-        page.evaluate = AsyncMock(side_effect=_eval)
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is not None, "an asset deep in a large grid must still be reachable"
-        tile.click.assert_awaited_once()
-        assert page.mouse.wheel.await_count == self._DEEP_GRID_SCROLLS
-
-    @pytest.mark.asyncio
-    async def test_absent_asset_stops_after_stall_limit(self) -> None:
-        """Genuinely absent asset with the grid at its end (the rendered tile
-        set never changes): the loop must terminate after the stall limit —
-        not spin to the hard ceiling, and not even out to the legacy budget."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=TimeoutError("never visible"),
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        page.evaluate = AsyncMock(return_value=["tile-a", "tile-b"])  # never changes
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is None, "existing not-found contract must be unchanged"
-        tile.click.assert_not_awaited()
-        # 1 baseline scroll + STALL_LIMIT consecutive no-progress scrolls.
-        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_STALL_LIMIT + 1
-
-    @pytest.mark.asyncio
-    async def test_endless_grid_progress_is_capped_by_hard_ceiling(self) -> None:
-        """A pathological grid that never stops rendering new tiles must not
-        scroll forever — the hard ceiling bounds the loop."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=TimeoutError("never visible"),
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        counter = itertools.count()
-        page.evaluate = AsyncMock(side_effect=lambda *_: [f"tile-{next(counter)}"])
-
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
-
-        assert result is None
-        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_MAX_ATTEMPTS
-
-    @pytest.mark.asyncio
-    async def test_bare_uuid_ref_scrolls_before_any_search(
+    async def test_display_name_miss_does_not_scroll_or_search_uuid(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A bare UUID pays no guaranteed-dead search before the real scroll."""
+        """The browser picker is name-addressed; a name miss is terminal.
+
+        Scrolling the unfiltered catalog and typing UUID fragments are not
+        alternate resolution strategies.  The exact UUID remains the tile
+        assertion after the name search surfaces candidates.
+        """
+        tile = TestSelectExistingAssetPickerScroll._tile_mock(
+            wait_for_side_effect=TimeoutError("never visible"),
+            count_side_effect=0,
+        )
+        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
+        search = page.locator(PICKER_SEARCH_INPUT)
+        scroll = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            scroll,
+        )
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page,
+            self._FULL_UUID,
+            "Brass key on wooden bench",
+            out_dir=None,
+        )
+
+        assert result is False
+        assert [call.args[0] for call in search.press_sequentially.await_args_list] == [
+            "Brass key on wooden bench"
+        ]
+        assert search.fill.await_count == 2
+        assert all(call.args == ("",) for call in search.fill.call_args_list)
+        scroll.assert_not_awaited()
+        page.mouse.wheel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_display_name_does_not_scroll_or_search(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A legacy bare UUID only checks the already-rendered viewport."""
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
             wait_for_side_effect=[
                 TimeoutError("not visible in initial viewport"),
@@ -1837,238 +1797,32 @@ class TestSelectExistingAssetLargeGrid:
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result == "scroll"
-        tile.click.assert_awaited_once()
-        scroll.assert_awaited_once_with(page, tile)
+        assert result is False
+        tile.click.assert_not_awaited()
+        scroll.assert_not_awaited()
         search.press_sequentially.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_uuid_tiers_retried_after_scroll_miss(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The retained UUID tiers run only after the full-grid scroll misses."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by the post-scroll full-UUID retry"),
-                None,  # surfaced by the post-scroll UUID-stem retry
-            ],
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-        order: list[str] = []
-
-        async def _scroll(*_args: object) -> bool:
-            order.append("scroll")
-            return False
-
-        async def _press(term: str, **_kwargs: object) -> None:
-            order.append(term)
-
-        search.press_sequentially = AsyncMock(side_effect=_press)
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_scroll_picker_grid_until_rendered",
-            AsyncMock(side_effect=_scroll),
-        )
-
-        result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
-        )
-
-        assert result == "uuid_retry"
-        assert order == ["scroll", self._FULL_UUID, "d6f1927a"]
-        tile.click.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_no_search_box_skips_search_tiers_and_scrolls(self) -> None:
-        """A picker variant without a search input (#174's full-page
-        media-library drift) must skip the search tiers without touching the
-        input and fall straight through to the scroll loop."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                None,  # visible after scrolling
-            ],
-            count_side_effect=[0, 0, 1],
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-        search.count = AsyncMock(return_value=0)  # no search box in this variant
-
-        result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
-        )
-
-        assert result is not None
-        search.press_sequentially.assert_not_awaited()
-        search.fill.assert_not_awaited()
-        assert page.mouse.wheel.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_hint_tier_runs_before_scroll_on_frame_path(self) -> None:
-        """Frame-path hints remain pre-scroll while UUID tiers are demoted."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[
-                TimeoutError("not visible in initial viewport"),
-                None,  # surfaced by the prompt-hint search
-            ],
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-
-        result = await VideoGenerationMixin._select_existing_asset(
-            page,
-            self._FULL_UUID,
-            "",
-            out_dir=None,
-            search_hints=("stickman on a chalkboard, teaching",),
-        )
-
-        assert result == "hint"
-        tile.click.assert_awaited_once()
-        terms = [c.args[0] for c in search.press_sequentially.await_args_list]
-        assert terms == ["stickman on a chalkboard, teaching"]
-        assert page.mouse.wheel.await_count == 0, "a hint hit must skip scrolling"
-
-    @pytest.mark.asyncio
-    async def test_post_scroll_retry_stops_on_absent_search_box(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A no-search cohort stops the post-scroll retry without touching input."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=TimeoutError("not visible"),
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-        order: list[str] = []
-
-        async def _scroll(*_args: object) -> bool:
-            order.append("scroll")
-            return False
-
-        async def _count() -> int:
-            order.append("search_count")
-            return 0
-
-        search.count = AsyncMock(side_effect=_count)
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_scroll_picker_grid_until_rendered",
-            AsyncMock(side_effect=_scroll),
-        )
-
-        result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
-        )
-
-        assert result is None
-        assert order == ["scroll", "search_count"]
-        search.fill.assert_not_awaited()
-        search.press_sequentially.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_picker_search_cleared_before_returning_false(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A failed post-scroll retry hands the pooled Page back unfiltered."""
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=TimeoutError("never visible"),
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-        order: list[str] = []
-
-        async def _scroll(*_args: object) -> bool:
-            order.append("scroll")
-            return False
-
-        async def _fill(_value: str) -> None:
-            order.append("clear")
-
-        async def _press(term: str, **_kwargs: object) -> None:
-            order.append(term)
-
-        search.fill = AsyncMock(side_effect=_fill)
-        search.press_sequentially = AsyncMock(side_effect=_press)
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_scroll_picker_grid_until_rendered",
-            AsyncMock(side_effect=_scroll),
-        )
-
-        result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
-        )
-
-        assert result is None
-        assert order == [
-            "scroll",
-            "clear",
-            self._FULL_UUID,
-            "clear",
-            "d6f1927a",
-            "clear",
-        ]
 
     @pytest.mark.asyncio
     async def test_tile_match_stays_uuid_in_src(self) -> None:
-        """An imprecise hint can surface extra tiles but cannot select one."""
+        """A non-unique name can surface extra tiles but cannot select one."""
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[TimeoutError("not visible"), None],
+            wait_for_side_effect=None,
             count_side_effect=0,
         )
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        hint = "common caption words"
+        display_name = "common caption words"
 
         result = await VideoGenerationMixin._select_existing_asset(
             page,
             self._FULL_UUID,
-            "",
+            display_name,
             out_dir=None,
-            search_hints=(hint,),
         )
 
         assert result is not None
         exact_selector = f"[role='option']:has(img[src*='{self._FULL_UUID}'])"
         assert page.locator.call_args_list[0].args == (exact_selector,)
         tile.click.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_hyphenless_media_id_dedupes_stem(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A media ID equal to its stem receives one last-resort retry."""
-        media_id = "d6f1927a"
-        tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[TimeoutError("not visible"), None],
-            count_side_effect=0,
-        )
-        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
-        search = page.locator(PICKER_SEARCH_INPUT)
-        order: list[str] = []
-
-        async def _scroll(*_args: object) -> bool:
-            order.append("scroll")
-            return False
-
-        async def _press(term: str, **_kwargs: object) -> None:
-            order.append(term)
-
-        search.press_sequentially = AsyncMock(side_effect=_press)
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_scroll_picker_grid_until_rendered",
-            AsyncMock(side_effect=_scroll),
-        )
-
-        result = await VideoGenerationMixin._select_existing_asset(page, media_id, "", out_dir=None)
-
-        assert result == "uuid_retry"
-        assert order == ["scroll", media_id]
-        assert search.press_sequentially.await_count == 1
 
     @pytest.mark.asyncio
     async def test_grid_scroll_uses_js_scroller_and_logs_evidence(
@@ -2106,11 +1860,9 @@ class TestSelectExistingAssetLargeGrid:
 
         page.evaluate = AsyncMock(side_effect=_eval)
 
-        result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
-        )
+        result = await VideoGenerationMixin._scroll_picker_grid_until_rendered(page, tile)
 
-        assert result is not None
+        assert result is True
         # JS scroll must replace the blind wheel when the scroller is found.
         page.mouse.wheel.assert_not_awaited()
         probes = [
@@ -2709,18 +2461,18 @@ class TestSelectExistingAssetDiagnostics:
     _FULL_UUID = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
 
     @pytest.mark.asyncio
-    async def test_search_tier_event_reports_term_and_rendered_count(
+    async def test_search_tier_event_redacts_term_and_reports_rendered_count(
         self, install_log_capture: structlog.testing.LogCapture
     ) -> None:
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
-            wait_for_side_effect=[TimeoutError("not in viewport"), None],
+            wait_for_side_effect=None,
             count_side_effect=0,
         )
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
         page.evaluate = AsyncMock(return_value=["tile-a", "tile-b"])
 
         result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=None
+            page, self._FULL_UUID, "Brass key", out_dir=None
         )
 
         assert result is not None
@@ -2730,7 +2482,8 @@ class TestSelectExistingAssetDiagnostics:
             if e["event"] == "ui_automation_video.picker_search_tier"
         ]
         assert tiers, "expected a picker_search_tier event"
-        assert tiers[0]["term"] == self._FULL_UUID
+        assert "term" not in tiers[0]
+        assert tiers[0]["term_length"] == len("Brass key")
         assert tiers[0]["found"] is True
         assert tiers[0]["rendered_tiles"] == 2
 
@@ -2745,9 +2498,9 @@ class TestSelectExistingAssetDiagnostics:
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
         page.evaluate = AsyncMock(return_value=["tile-a"])  # grid never advances
 
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
+        result = await VideoGenerationMixin._scroll_picker_grid_until_rendered(page, tile)
 
-        assert result is None
+        assert result is False
         probes = [
             e
             for e in install_log_capture.entries
@@ -2781,9 +2534,9 @@ class TestSelectExistingAssetDiagnostics:
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
         # page.evaluate deliberately NOT configured -> probe yields no evidence.
 
-        result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
+        result = await VideoGenerationMixin._scroll_picker_grid_until_rendered(page, tile)
 
-        assert result is None
+        assert result is False
         done = [
             e
             for e in install_log_capture.entries
@@ -2825,10 +2578,10 @@ class TestSelectExistingAssetDiagnostics:
         page.evaluate = AsyncMock(side_effect=_eval)
 
         result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=tmp_path
+            page, self._FULL_UUID, "Missing catalog name", out_dir=tmp_path
         )
 
-        assert result is None
+        assert result is False
         dump_path = tmp_path / f"debug_picker_dom_{self._FULL_UUID[:8]}.json"
         assert dump_path.exists(), "not-found must leave a picker DOM dump in the out-dir"
         data = json.loads(dump_path.read_text(encoding="utf-8"))
@@ -2846,7 +2599,7 @@ class TestSelectExistingAssetDiagnostics:
         assert misses[0]["project_id"] == _PROJECT_ID_287
         assert misses[0]["dom_dump"] == str(dump_path)
         assert misses[0]["screenshot"], "expected a screenshot path"
-        assert misses[0]["resolved_by"] == "not_found"
+        assert "resolved_by" not in misses[0]
 
     @pytest.mark.asyncio
     async def test_dom_dump_capture_failure_reports_none(
@@ -2869,10 +2622,10 @@ class TestSelectExistingAssetDiagnostics:
         page.evaluate = AsyncMock(side_effect=_eval)
 
         result = await VideoGenerationMixin._select_existing_asset(
-            page, self._FULL_UUID, "", out_dir=tmp_path
+            page, self._FULL_UUID, "Missing catalog name", out_dir=tmp_path
         )
 
-        assert result is None
+        assert result is False
         misses = [
             e
             for e in install_log_capture.entries
@@ -2884,10 +2637,7 @@ class TestSelectExistingAssetDiagnostics:
 
 
 class TestAttachImageUuidRefsPickerScroll:
-    """#282: every UUID ref after the first raised `TransportTimeoutError`
-    because `_select_existing_asset` gave up before the virtualised grid had
-    a chance to render the tile, and a leftover display-name search term from
-    a prior ref could shadow the next ref's lookup."""
+    """Image UUID refs search catalog names and retain local upload fallback."""
 
     @staticmethod
     def _dialog_mock() -> MagicMock:
@@ -2911,6 +2661,7 @@ class TestAttachImageUuidRefsPickerScroll:
         search.first = search
         search.press_sequentially = AsyncMock()
         search.fill = AsyncMock()
+        search.wait_for = AsyncMock()
         search.count = AsyncMock(return_value=1)
         return search
 
@@ -2950,65 +2701,29 @@ class TestAttachImageUuidRefsPickerScroll:
 
     @pytest.mark.asyncio
     async def test_tile_never_found_falls_back_to_local_upload(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        install_log_capture: structlog.testing.LogCapture,
     ) -> None:
         tile = self._never_found_tile()
         page, _, _, _ = self._make_page({"uuid-1": tile})
         upload = AsyncMock()
         monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+        local_path = tmp_path / "cabin.png"
+        content = b"recorded cabin"
+        local_path.write_bytes(content)
 
         await VideoGenerationMixin._attach_image_uuid_refs(
-            page, [("uuid-1", "Cabin", "/tmp/cabin.png")], out_dir=None
+            page,
+            [("uuid-1", "Cabin", str(local_path), hashlib.sha256(content).hexdigest())],
+            out_dir=None,
         )
 
         upload.assert_awaited_once()
         args, _ = upload.call_args
-        assert args[1] == Path("/tmp/cabin.png")
-        assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
-
-    @pytest.mark.asyncio
-    async def test_resolved_by_reports_scroll_tier(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        install_log_capture: structlog.testing.LogCapture,
-    ) -> None:
-        tile = self._never_found_tile()
-        page, _, _, _ = self._make_page({"uuid-1": tile})
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_select_existing_asset",
-            AsyncMock(return_value="scroll"),
-        )
-
-        await VideoGenerationMixin._attach_image_uuid_refs(page, [("uuid-1", "", "")], out_dir=None)
-
-        selected = [
-            event
-            for event in install_log_capture.entries
-            if event["event"] == "ui_automation_video.image_ref_selected_existing"
-        ]
-        assert selected[0]["resolved_by"] == "scroll"
-
-    @pytest.mark.asyncio
-    async def test_resolved_by_reports_upload_fallback(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        install_log_capture: structlog.testing.LogCapture,
-    ) -> None:
-        tile = self._never_found_tile()
-        page, _, _, _ = self._make_page({"uuid-1": tile})
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_select_existing_asset",
-            AsyncMock(return_value=None),
-        )
-        upload = AsyncMock()
-        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
-
-        await VideoGenerationMixin._attach_image_uuid_refs(
-            page, [("uuid-1", "", "/tmp/cabin.png")], out_dir=None
-        )
-
+        assert args[1] == local_path
+        page.mouse.wheel.assert_not_awaited()
         fallback = [
             event
             for event in install_log_capture.entries
@@ -3017,22 +2732,48 @@ class TestAttachImageUuidRefsPickerScroll:
         assert fallback[0]["resolved_by"] == "upload"
 
     @pytest.mark.asyncio
+    async def test_image_fallback_is_reverified_immediately_before_upload(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        tile = self._never_found_tile()
+        page, _, _, _ = self._make_page({"uuid-1": tile})
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_select_existing_asset", AsyncMock(return_value=False)
+        )
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+        local_path = tmp_path / "recorded.png"
+        original = b"recorded bytes"
+        local_path.write_bytes(original)
+        expected_sha256 = hashlib.sha256(original).hexdigest()
+        local_path.write_bytes(b"private change")
+
+        with pytest.raises(TransportTimeoutError, match="changed since it was recorded"):
+            await VideoGenerationMixin._attach_image_uuid_refs(
+                page,
+                [("uuid-1", "Cabin", str(local_path), expected_sha256)],
+                out_dir=None,
+            )
+
+        upload.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_resolved_by_carries_no_search_term(
         self,
         monkeypatch: pytest.MonkeyPatch,
         install_log_capture: structlog.testing.LogCapture,
     ) -> None:
-        prompt_hint = "private prompt words must not escape"
+        display_name = "private catalog name must not escape"
         tile = self._never_found_tile()
         page, _, _, _ = self._make_page({"uuid-1": tile})
         monkeypatch.setattr(
             VideoGenerationMixin,
             "_select_existing_asset",
-            AsyncMock(return_value="hint"),
+            AsyncMock(return_value=True),
         )
 
         await VideoGenerationMixin._attach_image_uuid_refs(
-            page, [("uuid-1", prompt_hint, "")], out_dir=None
+            page, [("uuid-1", display_name, "", "")], out_dir=None
         )
 
         selected = [
@@ -3040,9 +2781,9 @@ class TestAttachImageUuidRefsPickerScroll:
             for event in install_log_capture.entries
             if event["event"] == "ui_automation_video.image_ref_selected_existing"
         ][0]
-        assert selected["resolved_by"] == "hint"
+        assert selected["resolved_by"] == "display_name"
         assert "term" not in selected
-        assert prompt_hint not in str(selected)
+        assert display_name not in str(selected)
 
     @pytest.mark.asyncio
     async def test_tile_never_found_and_no_local_path_raises_same_message(self) -> None:
@@ -3051,7 +2792,7 @@ class TestAttachImageUuidRefsPickerScroll:
 
         with pytest.raises(TransportTimeoutError) as excinfo:
             await VideoGenerationMixin._attach_image_uuid_refs(
-                page, [("uuid-1", "Cabin", "")], out_dir=None
+                page, [("uuid-1", "Cabin", "", "")], out_dir=None
             )
 
         assert excinfo.value.detail == (
@@ -3064,67 +2805,34 @@ class TestAttachImageUuidRefsPickerScroll:
         tile_1 = MagicMock()
         tile_1.first = tile_1
         tile_1.click = AsyncMock()
-        tile_1.wait_for = AsyncMock(side_effect=[TimeoutError("not visible"), None])
+        tile_1.wait_for = AsyncMock()
+        tile_1.evaluate = AsyncMock(return_value=True)
         tile_1.count = AsyncMock(return_value=0)
 
         tile_2 = MagicMock()
         tile_2.first = tile_2
         tile_2.click = AsyncMock()
         tile_2.wait_for = AsyncMock()  # visible immediately, no search needed
+        tile_2.evaluate = AsyncMock(return_value=True)
         tile_2.count = AsyncMock(return_value=0)
 
         page, _, search, _ = self._make_page({"uuid-1": tile_1, "uuid-2": tile_2})
 
         await VideoGenerationMixin._attach_image_uuid_refs(
             page,
-            [("uuid-1", "Cabin", ""), ("uuid-2", "Lighthouse", "")],
+            [("uuid-1", "Cabin", "", ""), ("uuid-2", "Lighthouse", "", "")],
             out_dir=None,
         )
 
-        # ref 1 needed the display-name search fallback...
-        search.press_sequentially.assert_awaited_once()
-        assert search.press_sequentially.call_args.args[0] == "Cabin"
+        assert [call.args[0] for call in search.press_sequentially.await_args_list] == [
+            "Cabin",
+            "Lighthouse",
+        ]
         # ...but the search box must be cleared before EVERY ref's lookup
         # (#282: a leftover search term from ref 1 previously shadowed ref 2).
-        # 2 per-ref clears + 1 tier-level clear before ref 1's display-name
-        # search (#287: each search tier clears the box so tiers don't
-        # concatenate).
-        assert search.fill.await_count == 3
+        # Each lookup clears the previous term before typing its own.
+        assert search.fill.await_count == 2
         assert all(c.args == ("",) for c in search.fill.call_args_list)
-
-    @pytest.mark.asyncio
-    async def test_attach_refs_succeeds_when_picker_has_no_search_input(self) -> None:
-        """A picker variant without a search box (#174: the full-page
-        media-library drift) must not be a hard dependency for every ref.
-        The clear-search-state fix for #282 must be presence-guarded: if the
-        search input isn't in the DOM at all (`count() == 0`), skip clearing
-        it rather than unconditionally `.fill("")`, which would otherwise
-        wait out a full actionability timeout against a non-existent element
-        before failing."""
-        tile = MagicMock()
-        tile.first = tile
-        tile.click = AsyncMock()
-        tile.wait_for = AsyncMock()  # visible immediately, no search needed
-        tile.count = AsyncMock(return_value=0)
-
-        no_search = MagicMock()
-        no_search.first = no_search
-        no_search.count = AsyncMock(return_value=0)
-        no_search.fill = AsyncMock(
-            side_effect=TimeoutError("search input not present in this picker variant")
-        )
-        no_search.press_sequentially = AsyncMock()
-
-        page, _, search, _ = self._make_page({"uuid-1": tile}, search=no_search)
-
-        # Must not raise: the tile is found immediately, so the only thing
-        # that could break this ref is an unconditional search-box clear.
-        await VideoGenerationMixin._attach_image_uuid_refs(
-            page, [("uuid-1", "Cabin", "")], out_dir=None
-        )
-
-        tile.click.assert_awaited_once()
-        search.fill.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_picker_project_synced_before_every_ref_lookup(
@@ -3138,9 +2846,9 @@ class TestAttachImageUuidRefsPickerScroll:
         async def _sync(page: object, **kwargs: object) -> None:
             calls.append("sync")
 
-        async def _select(*args: object, **kwargs: object) -> str:
+        async def _select(*args: object, **kwargs: object) -> bool:
             calls.append("select")
-            return "viewport"
+            return True
 
         monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", _sync)
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", _select)
@@ -3149,7 +2857,7 @@ class TestAttachImageUuidRefsPickerScroll:
 
         await VideoGenerationMixin._attach_image_uuid_refs(
             page,
-            [("uuid-1", "", ""), ("uuid-2", "", "")],
+            [("uuid-1", "", "", ""), ("uuid-2", "", "", "")],
             out_dir=None,
         )
 
@@ -3162,6 +2870,7 @@ class TestAttachImageUuidRefsPickerScroll:
 # ---------------------------------------------------------------------------
 
 _FRAME_REF_UUID = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
+_FRAME_DISPLAY_NAME = "Brass key on marble surface"
 
 
 def _frame_dialog_page() -> MagicMock:
@@ -3172,6 +2881,8 @@ def _frame_dialog_page() -> MagicMock:
     loc.first = loc
     loc.count = AsyncMock(return_value=1)
     loc.fill = AsyncMock()
+    loc.wait_for = AsyncMock()
+    loc.press_sequentially = AsyncMock()
     page.locator = MagicMock(return_value=loc)
     page.wait_for_timeout = AsyncMock()
     return page
@@ -3180,24 +2891,6 @@ def _frame_dialog_page() -> MagicMock:
 class TestAttachFrameByMediaId:
     @pytest.mark.asyncio
     async def test_selects_existing_asset_in_the_frame_dialog(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        slot = MagicMock()
-        slot.click = AsyncMock()
-        monkeypatch.setattr(
-            VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
-        )
-        select = AsyncMock(return_value="viewport")
-        monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", select)
-        page = _frame_dialog_page()
-        await VideoGenerationMixin._attach_frame_by_media_id(
-            page, 0, "Start", _FRAME_REF_UUID, out_dir=None
-        )
-        slot.click.assert_awaited_once()
-        assert select.await_args.args[1] == _FRAME_REF_UUID
-
-    @pytest.mark.asyncio
-    async def test_frame_ref_attached_reports_resolved_by(
         self,
         monkeypatch: pytest.MonkeyPatch,
         install_log_capture: structlog.testing.LogCapture,
@@ -3207,47 +2900,21 @@ class TestAttachFrameByMediaId:
         monkeypatch.setattr(
             VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
         )
-        monkeypatch.setattr(
-            VideoGenerationMixin,
-            "_select_existing_asset",
-            AsyncMock(return_value="uuid_retry"),
-        )
+        select = AsyncMock(return_value=True)
+        monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", select)
         page = _frame_dialog_page()
-
         await VideoGenerationMixin._attach_frame_by_media_id(
-            page, 0, "Start", _FRAME_REF_UUID, out_dir=None
+            page, 0, "Start", _FRAME_REF_UUID, _FRAME_DISPLAY_NAME, out_dir=None
         )
-
+        slot.click.assert_awaited_once()
+        assert select.await_args.args[1] == _FRAME_REF_UUID
+        assert select.await_args.args[2] == _FRAME_DISPLAY_NAME
         attached = [
             event
             for event in install_log_capture.entries
             if event["event"] == "ui_automation_video.frame_ref_attached"
         ]
-        assert attached[0]["resolved_by"] == "uuid_retry"
-
-    @pytest.mark.asyncio
-    async def test_search_hints_flow_through_to_select(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """#287 round 6: prompt hints handed to the frame-ref attach must
-        reach `_select_existing_asset`'s search-hint tier."""
-        slot = MagicMock()
-        slot.click = AsyncMock()
-        monkeypatch.setattr(
-            VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
-        )
-        select = AsyncMock(return_value="hint")
-        monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", select)
-        page = _frame_dialog_page()
-        await VideoGenerationMixin._attach_frame_by_media_id(
-            page,
-            0,
-            "Start",
-            _FRAME_REF_UUID,
-            out_dir=None,
-            search_hints=("stickman on a chalkboard, teaching",),
-        )
-        assert select.await_args.kwargs["search_hints"] == ("stickman on a chalkboard, teaching",)
+        assert attached[0]["resolved_by"] == "display_name"
 
     @pytest.mark.asyncio
     async def test_missing_asset_raises_transport_timeout(
@@ -3264,8 +2931,78 @@ class TestAttachFrameByMediaId:
         page = _frame_dialog_page()
         with pytest.raises(TransportTimeoutError, match=_FRAME_REF_UUID):
             await VideoGenerationMixin._attach_frame_by_media_id(
-                page, 0, "Start", _FRAME_REF_UUID, out_dir=None
+                page, 0, "Start", _FRAME_REF_UUID, _FRAME_DISPLAY_NAME, out_dir=None
             )
+
+    @pytest.mark.asyncio
+    async def test_named_picker_miss_uploads_recorded_local_fallback(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        slot = MagicMock()
+        slot.click = AsyncMock()
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_select_existing_asset", AsyncMock(return_value=None)
+        )
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+        local_path = tmp_path / "recorded-frame.png"
+        content = b"\x89PNG\r\n\x1a\n"
+        local_path.write_bytes(content)
+
+        await VideoGenerationMixin._attach_frame_by_media_id(
+            _frame_dialog_page(),
+            0,
+            "Start",
+            _FRAME_REF_UUID,
+            _FRAME_DISPLAY_NAME,
+            out_dir=None,
+            local_path=local_path,
+            local_sha256=hashlib.sha256(content).hexdigest(),
+        )
+
+        upload.assert_awaited_once()
+        assert upload.await_args.args[1] == local_path
+        assert upload.await_args.kwargs == {
+            "log_label": "Start_frame_ref",
+            "out_dir": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_frame_fallback_is_reverified_immediately_before_upload(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        slot = MagicMock()
+        slot.click = AsyncMock()
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_select_existing_asset", AsyncMock(return_value=False)
+        )
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+        local_path = tmp_path / "recorded-frame.png"
+        original = b"recorded bytes"
+        local_path.write_bytes(original)
+        expected_sha256 = hashlib.sha256(original).hexdigest()
+        local_path.write_bytes(b"private change")
+
+        with pytest.raises(TransportTimeoutError, match="changed since it was recorded"):
+            await VideoGenerationMixin._attach_frame_by_media_id(
+                _frame_dialog_page(),
+                0,
+                "Start",
+                _FRAME_REF_UUID,
+                _FRAME_DISPLAY_NAME,
+                out_dir=None,
+                local_path=local_path,
+                local_sha256=expected_sha256,
+            )
+
+        upload.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_picker_project_synced_before_frame_ref_selection(
@@ -3283,16 +3020,16 @@ class TestAttachFrameByMediaId:
         async def _sync(page: object, **kwargs: object) -> None:
             calls.append("sync")
 
-        async def _select(*args: object, **kwargs: object) -> str:
+        async def _select(*args: object, **kwargs: object) -> bool:
             calls.append("select")
-            return "viewport"
+            return True
 
         monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", _sync)
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", _select)
         page = _frame_dialog_page()
 
         await VideoGenerationMixin._attach_frame_by_media_id(
-            page, 0, "Start", _FRAME_REF_UUID, out_dir=None
+            page, 0, "Start", _FRAME_REF_UUID, _FRAME_DISPLAY_NAME, out_dir=None
         )
 
         assert calls == ["sync", "select"]
@@ -3316,6 +3053,12 @@ class TestAttachI2VFramesRefIdRouting:
             mode=Mode.I2V,
             start_image_ref_id=_FRAME_REF_UUID,
             end_image_ref_id=_FRAME_REF_UUID,
+            start_image_ref_display_name="Start key",
+            end_image_ref_display_name="End key",
+            start_image_ref_local_path=Path("start.png"),
+            end_image_ref_local_path=Path("end.png"),
+            start_image_ref_local_sha256="a" * 64,
+            end_image_ref_local_sha256="b" * 64,
         )
         page = _cascade_page(set())
         await VideoGenerationMixin._attach_i2v_frames(page, request, out_dir=None)
@@ -3324,6 +3067,15 @@ class TestAttachI2VFramesRefIdRouting:
         remote.assert_not_awaited()
         slots = [(c.args[1], c.args[2]) for c in by_id.await_args_list]
         assert slots == [(0, "Start"), (1, "End")]
+        assert [c.args[4] for c in by_id.await_args_list] == ["Start key", "End key"]
+        assert [c.kwargs["local_path"] for c in by_id.await_args_list] == [
+            Path("start.png"),
+            Path("end.png"),
+        ]
+        assert [c.kwargs["local_sha256"] for c in by_id.await_args_list] == [
+            "a" * 64,
+            "b" * 64,
+        ]
 
     @pytest.mark.asyncio
     async def test_project_name_override_reaches_frame_by_media_id(
@@ -3344,26 +3096,6 @@ class TestAttachI2VFramesRefIdRouting:
         page = _cascade_page(set())
         await VideoGenerationMixin._attach_i2v_frames(page, request, out_dir=None)
         assert by_id.await_args.kwargs["project_name"] == "Chalkboard Spike"
-
-    @pytest.mark.asyncio
-    async def test_search_hints_reach_frame_by_media_id(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """#287 round 6: CLI-resolved prompt hints ride the request into the
-        frame-ref attach, where the picker search-hint tier consumes them."""
-        from gflow_cli.api.video import GenerateVideoRequest, Mode
-
-        by_id = AsyncMock()
-        monkeypatch.setattr(VideoGenerationMixin, "_attach_frame_by_media_id", by_id)
-        request = GenerateVideoRequest(
-            prompt="x",
-            mode=Mode.I2V,
-            start_image_ref_id=_FRAME_REF_UUID,
-            search_hints=("stickman on a chalkboard, teaching",),
-        )
-        page = _cascade_page(set())
-        await VideoGenerationMixin._attach_i2v_frames(page, request, out_dir=None)
-        assert by_id.await_args.kwargs["search_hints"] == ("stickman on a chalkboard, teaching",)
 
 
 class TestUploadRejectionTypedError:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -1650,7 +1650,7 @@ class TestSelectExistingAssetPickerScroll:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is True, "tile found via scrolling must be selected"
+        assert result is not None, "tile found via scrolling must be selected"
         tile.click.assert_awaited_once()
         # 3 scrolls before the tile rendered into the DOM.
         assert page.mouse.wheel.await_count == 3
@@ -1665,7 +1665,7 @@ class TestSelectExistingAssetPickerScroll:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is False, "existing fallback behaviour must be unchanged"
+        assert result is None, "existing fallback behaviour must be unchanged"
         tile.click.assert_not_awaited()
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
 
@@ -1688,7 +1688,7 @@ class TestSelectExistingAssetPickerScroll:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is True, "tile rendered by the final scroll must be found"
+        assert result is not None, "tile rendered by the final scroll must be found"
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
         tile.click.assert_awaited_once()
 
@@ -1702,9 +1702,7 @@ class TestSelectExistingAssetPickerScroll:
             wait_for_side_effect=[
                 TimeoutError("not visible in initial viewport"),
                 TimeoutError("not surfaced by display-name search"),
-                TimeoutError("not surfaced by the UUID search"),
-                TimeoutError("not surfaced by the UUID-stem search"),
-                None,
+                None,  # visible after scrolling the cleared grid
             ],
             count_side_effect=[0, 0, 1],
         )
@@ -1715,12 +1713,13 @@ class TestSelectExistingAssetPickerScroll:
             page, "uuid-1", "Wren's cabin", out_dir=None
         )
 
-        assert result is True, "tile found via scrolling after the search is cleared"
+        assert result is not None, "tile found via scrolling after the search is cleared"
         # The display name is the FIRST search tier (#287 added UUID tiers after it).
         assert search.press_sequentially.await_args_list[0].args[0] == "Wren's cabin"
-        # Every fill is a clear: one before each search tier (so tiers don't
-        # concatenate) plus the final clear before the scroll fallback.
-        assert search.fill.await_count == 4
+        # One clear starts the display-name search and one restores the full
+        # grid before scrolling. The UUID tiers are not paid when scrolling
+        # locates the tile.
+        assert search.fill.await_count == 2
         assert all(c.args == ("",) for c in search.fill.call_args_list)
         # 2 scrolls before the tile rendered into the DOM.
         assert page.mouse.wheel.await_count == 2
@@ -1773,7 +1772,7 @@ class TestSelectExistingAssetLargeGrid:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is True, "an asset deep in a large grid must still be reachable"
+        assert result is not None, "an asset deep in a large grid must still be reachable"
         tile.click.assert_awaited_once()
         assert page.mouse.wheel.await_count == self._DEEP_GRID_SCROLLS
 
@@ -1791,7 +1790,7 @@ class TestSelectExistingAssetLargeGrid:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is False, "existing not-found contract must be unchanged"
+        assert result is None, "existing not-found contract must be unchanged"
         tile.click.assert_not_awaited()
         # 1 baseline scroll + STALL_LIMIT consecutive no-progress scrolls.
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_STALL_LIMIT + 1
@@ -1810,56 +1809,77 @@ class TestSelectExistingAssetLargeGrid:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is False
+        assert result is None
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_MAX_ATTEMPTS
 
     @pytest.mark.asyncio
-    async def test_uuid_search_surfaces_tile_without_scrolling(self) -> None:
-        """The #287 frame-ref path passes NO display name, so it previously
-        went straight to scrolling. Searching the media UUID itself must be
-        tried first — a hit skips the scroll fallback entirely."""
+    async def test_bare_uuid_ref_scrolls_before_any_search(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare UUID pays no guaranteed-dead search before the real scroll."""
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
             wait_for_side_effect=[
                 TimeoutError("not visible in initial viewport"),
-                None,  # surfaced by the full-UUID search
+                None,  # visible after scrolling
             ],
             count_side_effect=0,
         )
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
         search = page.locator(PICKER_SEARCH_INPUT)
+        scroll = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            scroll,
+        )
 
         result = await VideoGenerationMixin._select_existing_asset(
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result is True
+        assert result == "scroll"
         tile.click.assert_awaited_once()
-        assert search.press_sequentially.await_args_list[0].args[0] == self._FULL_UUID
-        assert page.mouse.wheel.await_count == 0, "a search hit must skip scrolling"
+        scroll.assert_awaited_once_with(page, tile)
+        search.press_sequentially.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_uuid_stem_search_is_tried_after_full_uuid(self) -> None:
-        """When the full UUID surfaces nothing, the UUID-derived filename stem
-        (the first dash-segment) is the next search tier."""
+    async def test_uuid_tiers_retried_after_scroll_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The retained UUID tiers run only after the full-grid scroll misses."""
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
             wait_for_side_effect=[
                 TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by the full-UUID search"),
-                None,  # surfaced by the UUID-stem search
+                TimeoutError("not surfaced by the post-scroll full-UUID retry"),
+                None,  # surfaced by the post-scroll UUID-stem retry
             ],
             count_side_effect=0,
         )
         page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
         search = page.locator(PICKER_SEARCH_INPUT)
+        order: list[str] = []
+
+        async def _scroll(*_args: object) -> bool:
+            order.append("scroll")
+            return False
+
+        async def _press(term: str, **_kwargs: object) -> None:
+            order.append(term)
+
+        search.press_sequentially = AsyncMock(side_effect=_press)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            AsyncMock(side_effect=_scroll),
+        )
 
         result = await VideoGenerationMixin._select_existing_asset(
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result is True
-        terms = [c.args[0] for c in search.press_sequentially.await_args_list]
-        assert terms == [self._FULL_UUID, "d6f1927a"]
-        assert page.mouse.wheel.await_count == 0
+        assert result == "uuid_retry"
+        assert order == ["scroll", self._FULL_UUID, "d6f1927a"]
+        tile.click.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_no_search_box_skips_search_tiers_and_scrolls(self) -> None:
@@ -1881,22 +1901,17 @@ class TestSelectExistingAssetLargeGrid:
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result is True
+        assert result is not None
         search.press_sequentially.assert_not_awaited()
         search.fill.assert_not_awaited()
         assert page.mouse.wheel.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_search_hint_tier_runs_after_uuid_tiers(self) -> None:
-        """#287 round 6: Flow's media search does NOT index UUIDs (live rounds
-        1-5), but the tile alt text carries the generation PROMPT — a
-        CLI-resolved prompt hint typed into the search box surfaces the tile
-        (matched by UUID-in-src among the results) without any scrolling."""
+    async def test_hint_tier_runs_before_scroll_on_frame_path(self) -> None:
+        """Frame-path hints remain pre-scroll while UUID tiers are demoted."""
         tile = TestSelectExistingAssetPickerScroll._tile_mock(
             wait_for_side_effect=[
                 TimeoutError("not visible in initial viewport"),
-                TimeoutError("not surfaced by the UUID search"),
-                TimeoutError("not surfaced by the UUID-stem search"),
                 None,  # surfaced by the prompt-hint search
             ],
             count_side_effect=0,
@@ -1912,11 +1927,148 @@ class TestSelectExistingAssetLargeGrid:
             search_hints=("stickman on a chalkboard, teaching",),
         )
 
-        assert result is True
+        assert result == "hint"
         tile.click.assert_awaited_once()
         terms = [c.args[0] for c in search.press_sequentially.await_args_list]
-        assert terms == [self._FULL_UUID, "d6f1927a", "stickman on a chalkboard, teaching"]
+        assert terms == ["stickman on a chalkboard, teaching"]
         assert page.mouse.wheel.await_count == 0, "a hint hit must skip scrolling"
+
+    @pytest.mark.asyncio
+    async def test_post_scroll_retry_stops_on_absent_search_box(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A no-search cohort stops the post-scroll retry without touching input."""
+        tile = TestSelectExistingAssetPickerScroll._tile_mock(
+            wait_for_side_effect=TimeoutError("not visible"),
+            count_side_effect=0,
+        )
+        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
+        search = page.locator(PICKER_SEARCH_INPUT)
+        order: list[str] = []
+
+        async def _scroll(*_args: object) -> bool:
+            order.append("scroll")
+            return False
+
+        async def _count() -> int:
+            order.append("search_count")
+            return 0
+
+        search.count = AsyncMock(side_effect=_count)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            AsyncMock(side_effect=_scroll),
+        )
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page, self._FULL_UUID, "", out_dir=None
+        )
+
+        assert result is None
+        assert order == ["scroll", "search_count"]
+        search.fill.assert_not_awaited()
+        search.press_sequentially.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_picker_search_cleared_before_returning_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed post-scroll retry hands the pooled Page back unfiltered."""
+        tile = TestSelectExistingAssetPickerScroll._tile_mock(
+            wait_for_side_effect=TimeoutError("never visible"),
+            count_side_effect=0,
+        )
+        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
+        search = page.locator(PICKER_SEARCH_INPUT)
+        order: list[str] = []
+
+        async def _scroll(*_args: object) -> bool:
+            order.append("scroll")
+            return False
+
+        async def _fill(_value: str) -> None:
+            order.append("clear")
+
+        async def _press(term: str, **_kwargs: object) -> None:
+            order.append(term)
+
+        search.fill = AsyncMock(side_effect=_fill)
+        search.press_sequentially = AsyncMock(side_effect=_press)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            AsyncMock(side_effect=_scroll),
+        )
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page, self._FULL_UUID, "", out_dir=None
+        )
+
+        assert result is None
+        assert order == [
+            "scroll",
+            "clear",
+            self._FULL_UUID,
+            "clear",
+            "d6f1927a",
+            "clear",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tile_match_stays_uuid_in_src(self) -> None:
+        """An imprecise hint can surface extra tiles but cannot select one."""
+        tile = TestSelectExistingAssetPickerScroll._tile_mock(
+            wait_for_side_effect=[TimeoutError("not visible"), None],
+            count_side_effect=0,
+        )
+        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
+        hint = "common caption words"
+
+        result = await VideoGenerationMixin._select_existing_asset(
+            page,
+            self._FULL_UUID,
+            "",
+            out_dir=None,
+            search_hints=(hint,),
+        )
+
+        assert result is not None
+        exact_selector = f"[role='option']:has(img[src*='{self._FULL_UUID}'])"
+        assert page.locator.call_args_list[0].args == (exact_selector,)
+        tile.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hyphenless_media_id_dedupes_stem(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A media ID equal to its stem receives one last-resort retry."""
+        media_id = "d6f1927a"
+        tile = TestSelectExistingAssetPickerScroll._tile_mock(
+            wait_for_side_effect=[TimeoutError("not visible"), None],
+            count_side_effect=0,
+        )
+        page = TestSelectExistingAssetPickerScroll._page_with_tile(tile)
+        search = page.locator(PICKER_SEARCH_INPUT)
+        order: list[str] = []
+
+        async def _scroll(*_args: object) -> bool:
+            order.append("scroll")
+            return False
+
+        async def _press(term: str, **_kwargs: object) -> None:
+            order.append(term)
+
+        search.press_sequentially = AsyncMock(side_effect=_press)
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_scroll_picker_grid_until_rendered",
+            AsyncMock(side_effect=_scroll),
+        )
+
+        result = await VideoGenerationMixin._select_existing_asset(page, media_id, "", out_dir=None)
+
+        assert result == "uuid_retry"
+        assert order == ["scroll", media_id]
+        assert search.press_sequentially.await_count == 1
 
     @pytest.mark.asyncio
     async def test_grid_scroll_uses_js_scroller_and_logs_evidence(
@@ -1958,7 +2110,7 @@ class TestSelectExistingAssetLargeGrid:
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result is True
+        assert result is not None
         # JS scroll must replace the blind wheel when the scroller is found.
         page.mouse.wheel.assert_not_awaited()
         probes = [
@@ -2571,7 +2723,7 @@ class TestSelectExistingAssetDiagnostics:
             page, self._FULL_UUID, "", out_dir=None
         )
 
-        assert result is True
+        assert result is not None
         tiers = [
             e
             for e in install_log_capture.entries
@@ -2595,7 +2747,7 @@ class TestSelectExistingAssetDiagnostics:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is False
+        assert result is None
         probes = [
             e
             for e in install_log_capture.entries
@@ -2631,7 +2783,7 @@ class TestSelectExistingAssetDiagnostics:
 
         result = await VideoGenerationMixin._select_existing_asset(page, "uuid-1", "", out_dir=None)
 
-        assert result is False
+        assert result is None
         done = [
             e
             for e in install_log_capture.entries
@@ -2676,7 +2828,7 @@ class TestSelectExistingAssetDiagnostics:
             page, self._FULL_UUID, "", out_dir=tmp_path
         )
 
-        assert result is False
+        assert result is None
         dump_path = tmp_path / f"debug_picker_dom_{self._FULL_UUID[:8]}.json"
         assert dump_path.exists(), "not-found must leave a picker DOM dump in the out-dir"
         data = json.loads(dump_path.read_text(encoding="utf-8"))
@@ -2694,6 +2846,7 @@ class TestSelectExistingAssetDiagnostics:
         assert misses[0]["project_id"] == _PROJECT_ID_287
         assert misses[0]["dom_dump"] == str(dump_path)
         assert misses[0]["screenshot"], "expected a screenshot path"
+        assert misses[0]["resolved_by"] == "not_found"
 
     @pytest.mark.asyncio
     async def test_dom_dump_capture_failure_reports_none(
@@ -2719,7 +2872,7 @@ class TestSelectExistingAssetDiagnostics:
             page, self._FULL_UUID, "", out_dir=tmp_path
         )
 
-        assert result is False
+        assert result is None
         misses = [
             e
             for e in install_log_capture.entries
@@ -2812,6 +2965,84 @@ class TestAttachImageUuidRefsPickerScroll:
         args, _ = upload.call_args
         assert args[1] == Path("/tmp/cabin.png")
         assert page.mouse.wheel.await_count == PICKER_GRID_SCROLL_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_resolved_by_reports_scroll_tier(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        install_log_capture: structlog.testing.LogCapture,
+    ) -> None:
+        tile = self._never_found_tile()
+        page, _, _, _ = self._make_page({"uuid-1": tile})
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_select_existing_asset",
+            AsyncMock(return_value="scroll"),
+        )
+
+        await VideoGenerationMixin._attach_image_uuid_refs(page, [("uuid-1", "", "")], out_dir=None)
+
+        selected = [
+            event
+            for event in install_log_capture.entries
+            if event["event"] == "ui_automation_video.image_ref_selected_existing"
+        ]
+        assert selected[0]["resolved_by"] == "scroll"
+
+    @pytest.mark.asyncio
+    async def test_resolved_by_reports_upload_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        install_log_capture: structlog.testing.LogCapture,
+    ) -> None:
+        tile = self._never_found_tile()
+        page, _, _, _ = self._make_page({"uuid-1": tile})
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_select_existing_asset",
+            AsyncMock(return_value=None),
+        )
+        upload = AsyncMock()
+        monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+
+        await VideoGenerationMixin._attach_image_uuid_refs(
+            page, [("uuid-1", "", "/tmp/cabin.png")], out_dir=None
+        )
+
+        fallback = [
+            event
+            for event in install_log_capture.entries
+            if event["event"] == "ui_automation_video.image_ref_upload_fallback"
+        ]
+        assert fallback[0]["resolved_by"] == "upload"
+
+    @pytest.mark.asyncio
+    async def test_resolved_by_carries_no_search_term(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        install_log_capture: structlog.testing.LogCapture,
+    ) -> None:
+        prompt_hint = "private prompt words must not escape"
+        tile = self._never_found_tile()
+        page, _, _, _ = self._make_page({"uuid-1": tile})
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_select_existing_asset",
+            AsyncMock(return_value="hint"),
+        )
+
+        await VideoGenerationMixin._attach_image_uuid_refs(
+            page, [("uuid-1", prompt_hint, "")], out_dir=None
+        )
+
+        selected = [
+            event
+            for event in install_log_capture.entries
+            if event["event"] == "ui_automation_video.image_ref_selected_existing"
+        ][0]
+        assert selected["resolved_by"] == "hint"
+        assert "term" not in selected
+        assert prompt_hint not in str(selected)
 
     @pytest.mark.asyncio
     async def test_tile_never_found_and_no_local_path_raises_same_message(self) -> None:
@@ -2907,9 +3138,9 @@ class TestAttachImageUuidRefsPickerScroll:
         async def _sync(page: object, **kwargs: object) -> None:
             calls.append("sync")
 
-        async def _select(*args: object, **kwargs: object) -> bool:
+        async def _select(*args: object, **kwargs: object) -> str:
             calls.append("select")
-            return True
+            return "viewport"
 
         monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", _sync)
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", _select)
@@ -2956,7 +3187,7 @@ class TestAttachFrameByMediaId:
         monkeypatch.setattr(
             VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
         )
-        select = AsyncMock(return_value=True)
+        select = AsyncMock(return_value="viewport")
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", select)
         page = _frame_dialog_page()
         await VideoGenerationMixin._attach_frame_by_media_id(
@@ -2964,6 +3195,35 @@ class TestAttachFrameByMediaId:
         )
         slot.click.assert_awaited_once()
         assert select.await_args.args[1] == _FRAME_REF_UUID
+
+    @pytest.mark.asyncio
+    async def test_frame_ref_attached_reports_resolved_by(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        install_log_capture: structlog.testing.LogCapture,
+    ) -> None:
+        slot = MagicMock()
+        slot.click = AsyncMock()
+        monkeypatch.setattr(
+            VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
+        )
+        monkeypatch.setattr(
+            VideoGenerationMixin,
+            "_select_existing_asset",
+            AsyncMock(return_value="uuid_retry"),
+        )
+        page = _frame_dialog_page()
+
+        await VideoGenerationMixin._attach_frame_by_media_id(
+            page, 0, "Start", _FRAME_REF_UUID, out_dir=None
+        )
+
+        attached = [
+            event
+            for event in install_log_capture.entries
+            if event["event"] == "ui_automation_video.frame_ref_attached"
+        ]
+        assert attached[0]["resolved_by"] == "uuid_retry"
 
     @pytest.mark.asyncio
     async def test_search_hints_flow_through_to_select(
@@ -2976,7 +3236,7 @@ class TestAttachFrameByMediaId:
         monkeypatch.setattr(
             VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
         )
-        select = AsyncMock(return_value=True)
+        select = AsyncMock(return_value="hint")
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", select)
         page = _frame_dialog_page()
         await VideoGenerationMixin._attach_frame_by_media_id(
@@ -2999,7 +3259,7 @@ class TestAttachFrameByMediaId:
             VideoGenerationMixin, "_resolve_frame_slot", AsyncMock(return_value=slot)
         )
         monkeypatch.setattr(
-            VideoGenerationMixin, "_select_existing_asset", AsyncMock(return_value=False)
+            VideoGenerationMixin, "_select_existing_asset", AsyncMock(return_value=None)
         )
         page = _frame_dialog_page()
         with pytest.raises(TransportTimeoutError, match=_FRAME_REF_UUID):
@@ -3023,9 +3283,9 @@ class TestAttachFrameByMediaId:
         async def _sync(page: object, **kwargs: object) -> None:
             calls.append("sync")
 
-        async def _select(*args: object, **kwargs: object) -> bool:
+        async def _select(*args: object, **kwargs: object) -> str:
             calls.append("select")
-            return True
+            return "viewport"
 
         monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", _sync)
         monkeypatch.setattr(VideoGenerationMixin, "_select_existing_asset", _select)

--- a/tests/cli/test_cli_image_uuid_ref_enrichment.py
+++ b/tests/cli/test_cli_image_uuid_ref_enrichment.py
@@ -4,30 +4,30 @@ The #393 report was that a UUID `--ref` typed the raw UUID into the picker's
 name search, found nothing, and generated WITHOUT the reference. Live runs
 against real Flow on 2026-07-27 (v0.44.0) established the true behavior:
 
-* Flow's picker search genuinely does not index UUIDs — the UUID search tiers
-  return zero tiles, which is what the reporter screenshotted. A live DOM
-  capture also showed tiles labelled with a short Flow-authored caption
-  (``alt="Box tied with crimson ribbon"``), NOT the generation prompt, so no
-  catalog-derived search term can rescue the lookup either.
+* Flow's picker search genuinely does not index UUIDs. A live DOM capture showed
+  tiles labelled with Flow's short ``displayName``, not the generation prompt.
+  That name can filter the picker when the catalog retained it; the UUID still
+  identifies the exact surfaced tile.
 * An unfindable ref does NOT generate silently: it raises and exits non-zero
   (verified live, exit 9). That contract is pinned in
   ``tests/api/transports/test_ui_automation_video.py``.
-* What was missing is the rescue: the CLI never handed the transport the
-  asset's recorded local file, so a tile the picker can't reach had no
-  fallback and failed the whole generation.
+* The CLI now hands the transport both the catalog name and any recorded local
+  file, so a named picker miss can still upload the exact image bytes.
 
 These tests pin the enrichment so it can't silently regress.
 """
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
 
 from gflow_cli.api.image import ImageRef
-from gflow_cli.data.models import AssetKind, SeedImage
+from gflow_cli.data.models import AssetKind
 from gflow_cli.errors import DataStoreError
 
 if TYPE_CHECKING:
@@ -36,29 +36,45 @@ if TYPE_CHECKING:
 _UUID = "5a80906f-31cc-4a87-9782-95f14bb165ce"
 
 
-def _seed(*, local_path: Path | None) -> SeedImage:
-    return SeedImage(
-        profile_name="ffroliva",
-        flow_project_id="336c35c1-eee3-4789-a274-0c04a7bdab2e",
-        flow_media_id=_UUID,
-        flow_workflow_id=None,
-        kind=AssetKind.IMAGE,
-        width=None,
-        height=None,
-        local_path=local_path,
-        prompt="a serene contented moment behind a worn wooden counter",
-        model="NARWHAL",
-        aspect_ratio=None,
-        created_at="2026-07-27T12:00:00+00:00",
+def _asset(
+    *,
+    local_path: Path | None,
+    kind: AssetKind = AssetKind.IMAGE,
+    display_name: str | None = None,
+    recorded_bytes: int | None = None,
+    recorded_sha256: str | None = None,
+) -> SimpleNamespace:
+    content = local_path.read_bytes() if local_path is not None and local_path.is_file() else None
+    return SimpleNamespace(
+        kind=kind,
+        metadata_json={"display_name": display_name} if display_name else {},
+        local_files=(
+            [
+                SimpleNamespace(
+                    path=local_path,
+                    storage_provider=None,
+                    bytes=recorded_bytes if recorded_bytes is not None else len(content or b""),
+                    sha256=(
+                        recorded_sha256
+                        if recorded_sha256 is not None
+                        else hashlib.sha256(content).hexdigest()
+                        if content is not None
+                        else None
+                    ),
+                )
+            ]
+            if local_path is not None
+            else []
+        ),
     )
 
 
 @pytest.fixture
-def patch_seed(monkeypatch: pytest.MonkeyPatch) -> Callable[[object], None]:
+def patch_asset(monkeypatch: pytest.MonkeyPatch) -> Callable[[object], None]:
     """Point the enrichment's catalog lookup at a canned result.
 
-    ``resolve_seed_image`` may be given a ``SeedImage``, ``None`` (unknown
-    asset), or an exception instance to raise (catalog unavailable).
+    The fake repository may be given an asset lookup, ``None`` (unknown asset),
+    or an exception instance to raise (catalog unavailable).
     """
 
     def _apply(result: object) -> None:
@@ -74,7 +90,7 @@ def patch_seed(monkeypatch: pytest.MonkeyPatch) -> Callable[[object], None]:
         class _FakeRepo:
             def __init__(self, _store: object) -> None: ...
 
-            def resolve_seed_image(self, _profile: str, _media_id: str) -> object:
+            def get_asset_by_flow_media_id(self, _profile: str, _media_id: str) -> object:
                 if isinstance(result, Exception):
                     raise result
                 return result
@@ -86,8 +102,34 @@ def patch_seed(monkeypatch: pytest.MonkeyPatch) -> Callable[[object], None]:
 
 
 class TestEnrichUuidRef:
+    def test_populates_catalog_display_name_for_picker_search(
+        self, patch_asset: Callable[[object], None], tmp_path: Path
+    ) -> None:
+        """A bare UUID becomes name-searchable before the browser opens.
+
+        UUID remains the exact tile identity; ``display_name`` is only the
+        browser picker's search key.
+        """
+        from gflow_cli.cli_image import _enrich_uuid_refs
+
+        local = tmp_path / f"{_UUID}_1.jpg"
+        local.write_bytes(b"\xff\xd8\xff")
+
+        patch_asset(
+            _asset(
+                local_path=local,
+                display_name="Brass key on wooden bench",
+            )
+        )
+
+        enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
+
+        assert enriched.display_name == "Brass key on wooden bench"
+        assert enriched.local_path == str(local)
+        assert enriched.local_sha256 == hashlib.sha256(local.read_bytes()).hexdigest()
+
     def test_populates_local_path_as_upload_fallback(
-        self, patch_seed: Callable[[object], None], tmp_path: Path
+        self, patch_asset: Callable[[object], None], tmp_path: Path
     ) -> None:
         """The catalog's on-disk file becomes the transport's upload fallback
         for a tile the picker can't reach (#393)."""
@@ -95,7 +137,7 @@ class TestEnrichUuidRef:
 
         local = tmp_path / f"{_UUID}_1.jpg"
         local.write_bytes(b"\xff\xd8\xff")
-        patch_seed(_seed(local_path=local))
+        patch_asset(_asset(local_path=local))
 
         enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
 
@@ -103,56 +145,73 @@ class TestEnrichUuidRef:
         assert enriched.local_path == str(local)
 
     def test_missing_local_file_is_not_offered_as_fallback(
-        self, patch_seed: Callable[[object], None], tmp_path: Path
+        self, patch_asset: Callable[[object], None], tmp_path: Path
     ) -> None:
         """A stale catalog path must not send the transport into uploading a
         file that no longer exists — better to fail loud than to fail deep."""
         from gflow_cli.cli_image import _enrich_uuid_refs
 
-        patch_seed(_seed(local_path=tmp_path / "deleted.jpg"))
+        patch_asset(_asset(local_path=tmp_path / "deleted.jpg"))
 
         enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
 
         assert enriched.local_path == ""
 
     def test_asset_without_local_file_left_untouched(
-        self, patch_seed: Callable[[object], None]
+        self, patch_asset: Callable[[object], None]
     ) -> None:
         """A cataloged asset that was never downloaded has no bytes to fall
         back on; the picker lookup remains the only path."""
         from gflow_cli.cli_image import _enrich_uuid_refs
 
-        patch_seed(_seed(local_path=None))
+        patch_asset(_asset(local_path=None))
 
         enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
 
         assert enriched == ImageRef(name=_UUID)
 
-    def test_unknown_asset_leaves_ref_untouched(self, patch_seed: Callable[[object], None]) -> None:
+    def test_unknown_asset_leaves_ref_untouched(
+        self, patch_asset: Callable[[object], None]
+    ) -> None:
         """A UUID from another machine/profile isn't in the catalog. The ref is
         passed through unchanged — the transport still tries the picker and
         still fails loud if it can't bind it."""
         from gflow_cli.cli_image import _enrich_uuid_refs
 
-        patch_seed(None)
+        patch_asset(None)
 
         enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
 
         assert enriched == ImageRef(name=_UUID)
 
-    def test_catalog_failure_is_best_effort(self, patch_seed: Callable[[object], None]) -> None:
+    def test_video_asset_leaves_image_ref_untouched(
+        self, patch_asset: Callable[[object], None], tmp_path: Path
+    ) -> None:
+        """A UUID is not intrinsically an image UUID; never feed a cataloged
+        video file into the I2I picker/upload path."""
+        from gflow_cli.cli_image import _enrich_uuid_refs
+
+        local = tmp_path / f"{_UUID}.mp4"
+        local.write_bytes(b"video")
+        patch_asset(_asset(local_path=local, kind=AssetKind.VIDEO))
+
+        enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
+
+        assert enriched == ImageRef(name=_UUID)
+
+    def test_catalog_failure_is_best_effort(self, patch_asset: Callable[[object], None]) -> None:
         """Enrichment is an optimization: a broken/locked catalog must never
         break a generation that would otherwise work."""
         from gflow_cli.cli_image import _enrich_uuid_refs
 
-        patch_seed(DataStoreError(detail="catalog locked"))
+        patch_asset(DataStoreError(detail="catalog locked"))
 
         enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
 
         assert enriched == ImageRef(name=_UUID)
 
     def test_preserves_mention_display_name(
-        self, patch_seed: Callable[[object], None], tmp_path: Path
+        self, patch_asset: Callable[[object], None], tmp_path: Path
     ) -> None:
         """An `@mention`-resolved ref already carries the media's display name;
         enrichment adds the fallback file without disturbing it."""
@@ -160,7 +219,7 @@ class TestEnrichUuidRef:
 
         local = tmp_path / f"{_UUID}_1.jpg"
         local.write_bytes(b"\xff\xd8\xff")
-        patch_seed(_seed(local_path=local))
+        patch_asset(_asset(local_path=local))
 
         enriched = _enrich_uuid_refs(
             [ImageRef(name=_UUID, display_name="Shop Interior")], "ffroliva"
@@ -168,6 +227,28 @@ class TestEnrichUuidRef:
 
         assert enriched.display_name == "Shop Interior"
         assert enriched.local_path == str(local)
+        assert enriched.local_sha256 == hashlib.sha256(local.read_bytes()).hexdigest()
+
+    def test_rejects_mutated_recorded_local_fallback(
+        self, patch_asset: Callable[[object], None], tmp_path: Path
+    ) -> None:
+        from gflow_cli.cli_image import _enrich_uuid_refs
+
+        local = tmp_path / "mutated.png"
+        local.write_bytes(b"private replacement")
+        patch_asset(
+            _asset(
+                local_path=local,
+                display_name="Brass key",
+                recorded_bytes=8,
+                recorded_sha256="0" * 64,
+            )
+        )
+
+        enriched = _enrich_uuid_refs([ImageRef(name=_UUID)], "ffroliva")[0]
+
+        assert enriched.display_name == "Brass key"
+        assert enriched.local_path == ""
 
 
 class TestEnrichUuidRefsBatching:
@@ -191,7 +272,7 @@ class TestEnrichUuidRefsBatching:
         class _FakeRepo:
             def __init__(self, _store: object) -> None: ...
 
-            def resolve_seed_image(self, _profile: str, _media_id: str) -> object:
+            def get_asset_by_flow_media_id(self, _profile: str, _media_id: str) -> object:
                 return None
 
         def _open(_path: object) -> _FakeStore:

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from gflow_cli.cli_video import video
+from gflow_cli.data.models import AssetKind
 
 
 def _make_result(succeeded: bool, local_path: Path | None = None) -> object:
@@ -791,77 +794,234 @@ def test_i2v_project_name_env_var(tmp_path: Path) -> None:
     assert captured["request"].project_name == "Env Given Name"  # type: ignore[attr-defined]
 
 
-def test_media_search_hints_resolves_prompt_first_words(
+def test_media_picker_metadata_ignores_unknown_and_unnamed_assets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """#287 round 6: the CLI (which owns catalog access) resolves each ref's
-    recorded generation prompt and passes its first words as picker search
-    hints — Flow's media search doesn't index UUIDs, but tile alt text
-    carries the prompt. Best-effort: unknown media yields no hint."""
+    """Legacy rows without a Flow name cannot become browser search terms."""
     from gflow_cli import cli_video
 
-    def _get_prompt(*, db_path: Path, media_id: str) -> str | None:
-        if media_id == "uuid-1":
-            return "stickman on a chalkboard, teaching a lesson about compound interest"
-        return None
+    class _FakeStore:
+        def __enter__(self) -> _FakeStore:
+            return self
 
-    monkeypatch.setattr("gflow_cli.data.queries.get_asset_prompt", _get_prompt)
-    settings = MagicMock()
-    settings.resolved_db_path.return_value = Path("unused.db")
+        def __exit__(self, *_exc: object) -> bool:
+            return False
 
-    def _fake_get_settings() -> MagicMock:
-        return settings
+    class _FakeRepo:
+        def __init__(self, _store: object) -> None: ...
 
-    # config.get_settings is lru_cached; conftest teardown calls cache_clear().
-    _fake_get_settings.cache_clear = lambda: None  # type: ignore[attr-defined]
-    monkeypatch.setattr("gflow_cli.config.get_settings", _fake_get_settings)
+        def get_asset_by_flow_media_id(self, _profile: str, media_id: str) -> object:
+            if media_id == "uuid-unnamed":
+                return SimpleNamespace(
+                    kind=AssetKind.IMAGE,
+                    metadata_json={},
+                    local_files=[],
+                )
+            return None
 
-    hints = cli_video._media_search_hints(["uuid-1", "uuid-unknown", None])
+    monkeypatch.setattr(cli_video.DataStore, "open", staticmethod(lambda _p: _FakeStore()))
+    monkeypatch.setattr(cli_video, "DataRepository", _FakeRepo)
 
-    assert hints == ("stickman on a chalkboard, teaching a",)
+    assert cli_video._media_picker_metadata(["uuid-unnamed", "uuid-unknown", None], "ffroliva") == (
+        {},
+        {},
+    )
 
 
-def test_media_search_hints_swallows_catalog_errors(
+def test_media_picker_metadata_swallows_catalog_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from gflow_cli import cli_video
 
-    def _boom(**_kwargs: object) -> str:
-        raise RuntimeError("catalog unavailable")
+    def _boom(_path: object) -> object:
+        raise OSError("catalog unavailable")
 
-    monkeypatch.setattr("gflow_cli.data.queries.get_asset_prompt", _boom)
+    monkeypatch.setattr(cli_video.DataStore, "open", staticmethod(_boom))
 
-    assert cli_video._media_search_hints(["uuid-1"]) == ()
+    assert cli_video._media_picker_metadata(["uuid-1"], "ffroliva") == ({}, {})
 
 
-def test_i2v_uuid_frame_gets_catalog_prompt_hints(tmp_path: Path) -> None:
-    """A media-UUID --initial-frame triggers hint resolution and the hints
-    land on the request for the transport's search tier."""
+def test_media_picker_metadata_resolves_names_per_uuid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each frame UUID carries its own catalog name into picker search."""
+    from gflow_cli import cli_video
+
+    class _FakeStore:
+        def __enter__(self) -> _FakeStore:
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    class _FakeRepo:
+        def __init__(self, _store: object) -> None: ...
+
+        def get_asset_by_flow_media_id(self, profile: str, media_id: str) -> object:
+            assert profile == "ffroliva"
+            names = {
+                "uuid-start": "Brass key on marble surface",
+                "uuid-end": "Brass key on wooden bench",
+            }
+            name = names.get(media_id)
+            return (
+                None
+                if name is None
+                else SimpleNamespace(
+                    kind=AssetKind.IMAGE,
+                    metadata_json={"display_name": name},
+                    local_files=[],
+                )
+            )
+
+    monkeypatch.setattr(cli_video.DataStore, "open", staticmethod(lambda _p: _FakeStore()))
+    monkeypatch.setattr(cli_video, "DataRepository", _FakeRepo)
+
+    names, local_paths = cli_video._media_picker_metadata(
+        ["uuid-start", "uuid-end", "uuid-unknown", None], "ffroliva"
+    )
+
+    assert names == {
+        "uuid-start": "Brass key on marble surface",
+        "uuid-end": "Brass key on wooden bench",
+    }
+    assert local_paths == {}
+
+
+def test_media_picker_metadata_filters_non_images_and_stale_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from gflow_cli import cli_video
+
+    valid = tmp_path / "frame.png"
+    valid.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    class _FakeStore:
+        def __enter__(self) -> _FakeStore:
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    def _asset(kind: AssetKind, path: Path) -> SimpleNamespace:
+        return SimpleNamespace(
+            kind=kind,
+            metadata_json={},
+            local_files=[
+                SimpleNamespace(
+                    path=path,
+                    storage_provider=None,
+                    bytes=path.stat().st_size if path.is_file() else None,
+                    sha256=(
+                        hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else None
+                    ),
+                )
+            ],
+        )
+
+    class _FakeRepo:
+        def __init__(self, _store: object) -> None: ...
+
+        def get_asset_by_flow_media_id(self, _profile: str, media_id: str) -> object:
+            assets = {
+                "uuid-image": _asset(AssetKind.IMAGE, valid),
+                "uuid-mutated": SimpleNamespace(
+                    kind=AssetKind.IMAGE,
+                    metadata_json={},
+                    local_files=[
+                        SimpleNamespace(
+                            path=valid,
+                            storage_provider=None,
+                            bytes=valid.stat().st_size,
+                            sha256="0" * 64,
+                        )
+                    ],
+                ),
+                "uuid-stale": _asset(AssetKind.IMAGE, tmp_path / "missing.png"),
+                "uuid-video": _asset(AssetKind.VIDEO, tmp_path / "clip.mp4"),
+            }
+            return assets.get(media_id)
+
+    monkeypatch.setattr(cli_video.DataStore, "open", staticmethod(lambda _p: _FakeStore()))
+    monkeypatch.setattr(cli_video, "DataRepository", _FakeRepo)
+
+    assert cli_video._media_picker_metadata(
+        ["uuid-image", "uuid-mutated", "uuid-stale", "uuid-video", None], "default"
+    ) == ({}, {"uuid-image": (valid, hashlib.sha256(valid.read_bytes()).hexdigest())})
+
+
+def test_i2v_uuid_frame_gets_catalog_display_name(tmp_path: Path) -> None:
+    """A media UUID carries its catalog name into the transport request."""
     captured: dict[str, object] = {}
 
     async def _capture(request: object, **_kwargs: object) -> None:
         captured["request"] = request
 
     uuid_ref = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
+    recorded = tmp_path / "recorded-frame.png"
+    content = b"\x89PNG\r\n\x1a\n"
+    recorded.write_bytes(content)
+    digest = hashlib.sha256(content).hexdigest()
     runner = CliRunner()
     with (
         patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
         patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
         patch("gflow_cli.cli_video._generate_and_report", new=_capture),
         patch(
-            "gflow_cli.cli_video._media_search_hints",
-            return_value=("stickman on a chalkboard, teaching a",),
-        ) as hints,
+            "gflow_cli.cli_video._media_picker_metadata",
+            return_value=(
+                {uuid_ref: "Brass key on marble surface"},
+                {uuid_ref: (recorded, digest)},
+            ),
+        ) as names,
     ):
         result = runner.invoke(
             video,
             ["i2v", "--initial-frame", uuid_ref, "pan", "--project", "f6caf027-aaaa"],
         )
     assert result.exit_code == 0, result.output
-    assert captured["request"].search_hints == (  # type: ignore[attr-defined]
-        "stickman on a chalkboard, teaching a",
+    assert (  # type: ignore[attr-defined]
+        captured["request"].start_image_ref_display_name == "Brass key on marble surface"
     )
-    assert uuid_ref in hints.call_args.args[0]
+    assert captured["request"].start_image_ref_local_path == recorded  # type: ignore[attr-defined]
+    assert captured["request"].start_image_ref_local_sha256 == digest  # type: ignore[attr-defined]
+    assert captured["request"].start_image_ref_id == uuid_ref  # type: ignore[attr-defined]
+    assert uuid_ref in names.call_args.args[0]
+
+
+def test_i2v_unnamed_uuid_preserves_identity_and_recorded_fallback(tmp_path: Path) -> None:
+    """An unnamed UUID remains identity while its exact bytes remain fallback."""
+    captured: dict[str, object] = {}
+
+    async def _capture(request: object, **_kwargs: object) -> None:
+        captured["request"] = request
+
+    uuid_ref = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
+    recorded = tmp_path / "recorded-frame.png"
+    content = b"\x89PNG\r\n\x1a\n"
+    recorded.write_bytes(content)
+    digest = hashlib.sha256(content).hexdigest()
+    runner = CliRunner()
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+        patch("gflow_cli.cli_video._generate_and_report", new=_capture),
+        patch(
+            "gflow_cli.cli_video._media_picker_metadata",
+            return_value=({}, {uuid_ref: (recorded, digest)}),
+        ),
+    ):
+        result = runner.invoke(
+            video,
+            ["i2v", "--initial-frame", uuid_ref, "pan", "--project", "f6caf027-aaaa"],
+        )
+
+    assert result.exit_code == 0, result.output
+    request = captured["request"]
+    assert request.start_image is None  # type: ignore[attr-defined]
+    assert request.start_image_ref_id == uuid_ref  # type: ignore[attr-defined]
+    assert request.start_image_ref_local_path == recorded  # type: ignore[attr-defined]
+    assert request.start_image_ref_local_sha256 == digest  # type: ignore[attr-defined]
 
 
 def test_i2v_no_image_raises_usage_error(tmp_path: Path) -> None:

--- a/tests/data/test_recorder.py
+++ b/tests/data/test_recorder.py
@@ -59,6 +59,7 @@ def test_record_generated_images_persists_generation_metadata(tmp_path: Path) ->
             fife_url="https://flow-content.google/path?Signature=abc",
             dimensions=(1024, 1792),
             media_generation_id="generation-1",
+            display_name="Prompt-paraphrasing private caption",
         )
         req = GenerateImageRequest(
             prompt="prompt text",
@@ -87,6 +88,8 @@ def test_record_generated_images_persists_generation_metadata(tmp_path: Path) ->
         assert operation_row["prompt_redacted"] == 1
         assert asset_row["flow_media_generation_id"] == "generation-1"
         assert "Signature=abc" not in asset_row["metadata_json"]
+        assert "Prompt-paraphrasing private caption" not in asset_row["metadata_json"]
+        assert "display_name" not in json.loads(asset_row["metadata_json"])
 
 
 def _generated_image() -> GeneratedImage:
@@ -100,6 +103,7 @@ def _generated_image() -> GeneratedImage:
         fife_url="https://flow-content.google/path?Signature=abc",
         dimensions=(1024, 1792),
         media_generation_id="generation-1",
+        display_name="Flow searchable caption",
     )
 
 
@@ -134,6 +138,12 @@ def test_record_generated_images_persists_original_and_expanded_prompt(tmp_path:
         assert row["prompt"] == "cat in space"
         assert row["expanded_prompt"] == "a richly detailed expanded prompt"
         assert row["prompt_redacted"] == 0
+        asset_metadata = store.conn.execute(
+            "SELECT metadata_json FROM assets WHERE flow_media_id='media-generated-1'"
+        ).fetchone()
+        assert json.loads(asset_metadata["metadata_json"])["display_name"] == (
+            "Flow searchable caption"
+        )
 
 
 def test_expanded_prompt_withheld_when_history_redacted(tmp_path: Path) -> None:

--- a/tests/data/test_repository.py
+++ b/tests/data/test_repository.py
@@ -12,7 +12,7 @@ from gflow_cli.data.models import (
     OperationStatus,
     ProjectRecord,
 )
-from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.repository import DataRepository, verified_local_path
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import DataIntegrityError
 
@@ -85,6 +85,48 @@ def test_upserts_project_asset_operation_and_file(tmp_path: Path) -> None:
         assert found is not None
         assert found.flow_project_id == "flow-project-1"
         assert found.local_files[0].path == tmp_path / "media-1.png"
+
+
+@pytest.mark.parametrize("raw_metadata", ["{broken", "[]", '"caption"'])
+def test_asset_lookup_normalizes_malformed_or_non_object_metadata(
+    tmp_path: Path, raw_metadata: str
+) -> None:
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("default", Path("C:/profiles/profile_default"))
+        repo.upsert_asset(
+            AssetRecord.minimal_image(
+                id="asset-1",
+                profile_name="default",
+                flow_project_id="project-1",
+                flow_media_id="media-1",
+            )
+        )
+        store.conn.execute(
+            "UPDATE assets SET metadata_json = ? WHERE id = ?",
+            (raw_metadata, "asset-1"),
+        )
+
+        found = repo.get_asset_by_flow_media_id("default", "media-1")
+
+        assert found is not None
+        assert found.metadata_json == {}
+
+
+def test_verified_local_path_requires_recorded_sha256(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.png"
+    path.write_bytes(b"same-size replacement")
+    record = LocalFileRecord(
+        id="file-1",
+        profile_name="default",
+        asset_id="asset-1",
+        path=path,
+        media_type="image/png",
+        bytes=path.stat().st_size,
+        sha256=None,
+    )
+
+    assert verified_local_path(record) is None
 
 
 def test_operation_asset_position_is_unique(tmp_path: Path) -> None:

--- a/tests/e2e/test_image_uuid_ref_e2e.py
+++ b/tests/e2e/test_image_uuid_ref_e2e.py
@@ -43,6 +43,7 @@ _UNRESOLVABLE_UUID = "11111111-2222-3333-4444-555555555555"
 
 _UPLOAD_FALLBACK_EVENT = "ui_automation_video.image_ref_upload_fallback"
 _PICKER_MISS_EVENT = "ui_automation_video.existing_asset_not_found"
+_SELECTED_EXISTING_EVENT = "ui_automation_video.image_ref_selected_existing"
 
 
 def _run_gflow(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -123,9 +124,13 @@ def test_e2e_unresolvable_uuid_ref_fails_loud(e2e_env: dict[str, str], tmp_path:
         "an unbindable UUID ref generated anyway — this is the #393 silent-skip "
         f"failure mode. stdout tail: {proc.stdout[-400:]!r}"
     )
-    assert _PICKER_MISS_EVENT in _events(proc.stderr), (
-        f"expected a {_PICKER_MISS_EVENT} event before the abort; "
-        f"stderr tail: {proc.stderr[-600:]!r}"
+    # #529: a UUID with no catalog display name never reaches the picker
+    # search (no UUID-term typing, no grid scrolling), so the abort is the
+    # typed no-fallback error rather than a picker-miss event. A cataloged
+    # name that misses still emits _PICKER_MISS_EVENT (see the cross-project
+    # test's fallback path).
+    assert "could not be selected in the picker" in proc.stderr, (
+        f"expected the typed no-fallback abort; stderr tail: {proc.stderr[-600:]!r}"
     )
     # `debug_picker_*.png` diagnostics are expected on a miss; only GENERATED
     # media must be absent.
@@ -134,6 +139,81 @@ def test_e2e_unresolvable_uuid_ref_fails_loud(e2e_env: dict[str, str], tmp_path:
     ]
     assert not generated, (
         f"an image was written despite the reference never being attached: {generated}"
+    )
+
+
+@pytest.mark.e2e_image
+def test_e2e_same_project_uuid_ref_selected_in_picker(
+    e2e_env: dict[str, str], tmp_path: Path
+) -> None:
+    """#529 happy path: a same-project UUID ref is selected in the picker.
+
+    The catalog resolves the UUID to Flow's ``displayName``, the picker is
+    searched by that name only, and the exact UUID tile is attached — no
+    duplicate upload, no grid scrolling, no UUID-fragment searches. The
+    ``image_ref_selected_existing`` event (``resolved_by=display_name``) is the
+    contract; the upload fallback firing instead means the picker path
+    regressed. Costs 2 Imagen credits: one seed image, one referencing
+    generation.
+    """
+    # `e2e_env` already created this and pointed GFLOW_CLI_OUTPUT_DIR at it.
+    out = tmp_path / "out"
+
+    seed = _run_gflow(
+        [
+            "image",
+            "t2i",
+            "a ceramic teapot with a cobalt glaze on a plain shelf",
+            "--model",
+            "nano2",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        e2e_env,
+    )
+    assert seed.returncode == 0, f"seed generation failed; stderr tail: {seed.stderr[-400:]!r}"
+    seed_payload = _json_payload(seed.stdout)
+    images = seed_payload.get("images") or []
+    assert images, f"seed run returned no images: {seed_payload}"
+    seed_media_id = str(images[0]["media_name"])
+    project_id = str(seed_payload.get("project_id") or "")
+    assert project_id, f"seed payload carried no project_id: {seed_payload}"
+
+    # SAME project: the seed's tile is reachable in this picker's library view,
+    # so the display-name search must find it and no upload may happen.
+    ref_run = _run_gflow(
+        [
+            "image",
+            "i2i",
+            "the same teapot, warmer light",
+            "--ref",
+            seed_media_id,
+            "--project",
+            project_id,
+            "--model",
+            "nano2",
+            "--out",
+            str(out),
+            "--json",
+        ],
+        e2e_env,
+    )
+
+    assert ref_run.returncode == 0, (
+        f"same-project UUID ref failed; stderr tail: {ref_run.stderr[-600:]!r}"
+    )
+    events = _events(ref_run.stderr)
+    assert _SELECTED_EXISTING_EVENT in events, (
+        f"expected the picker to select the existing asset ({_SELECTED_EXISTING_EVENT}); "
+        f"observed events: {sorted(set(events))}"
+    )
+    assert _UPLOAD_FALLBACK_EVENT not in events, (
+        "a same-project ref must not duplicate-upload — the picker path regressed"
+    )
+    ref_payload = _json_payload(ref_run.stdout)
+    assert ref_payload.get("ref_count") == 1, (
+        f"the reference was not counted on the generation: {ref_payload}"
     )
 
 

--- a/tests/e2e/test_video_r2v_uuid_name_e2e.py
+++ b/tests/e2e/test_video_r2v_uuid_name_e2e.py
@@ -1,0 +1,165 @@
+"""Live E2E: an R2V reference resolved from a catalog UUID's display name (#529).
+
+The #529 contract — ``catalog UUID -> Flow displayName -> picker name search ->
+attach`` — must also hold on the R2V surface, where remote references are
+name-addressed (``GenerateVideoRequest.ref_names``, the DTO/MCP field). This
+test proves the full chain live:
+
+1. Seed a t2i image via the CLI; the #529 recorder fix persists Flow's
+   ``displayName`` in ``assets.metadata_json`` (this assertion alone catches
+   the original catalog defect — UI-generated rows used to lose the name).
+2. Read that display name back from the catalog by the seed's media UUID.
+3. Generate an R2V video in the SAME project with ``ref_names=(display_name,)``
+   and assert the ``remote_reference_attached`` event fired for it.
+
+Costs 1 Imagen credit (seed) + one veo-lite generation.
+
+Opt in with::
+
+    GFLOW_CLI_E2E_PROFILE=<profile-name> uv run pytest -m e2e_video -v \\
+        tests/e2e/test_video_r2v_uuid_name_e2e.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.api.video import (
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+    VideoResult,
+)
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+from .test_image_uuid_ref_e2e import _json_payload, _run_gflow
+
+pytestmark = pytest.mark.e2e
+
+_R2V_POLL_TIMEOUT_S = 600.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e_video
+async def test_e2e_r2v_ref_resolved_from_catalog_uuid_display_name(
+    e2e_env: dict[str, str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """A catalog UUID's recorded display name drives an R2V picker attach."""
+    import os
+
+    from gflow_cli.auth import profile_dir as _resolve_profile_dir
+    from gflow_cli.config import reset_settings
+
+    out = tmp_path / "out"
+    profile_name = os.environ.get("GFLOW_CLI_E2E_PROFILE", "").strip()
+
+    # 1+2. Seed image via subprocess, then read UUID -> displayName back from
+    # the isolated catalog DB (e2e_env's GFLOW_CLI_DB_PATH). Flow computes the
+    # caption asynchronously server-side, so a fresh generation's response
+    # sometimes lacks workflows[].metadata.displayName and the recorder
+    # (correctly) records no name — retry the seed a bounded number of times.
+    display_name: str | None = None
+    project_id = ""
+    seed_media_id = ""
+    # Classic UI for the seed: the natively-agentic e2e account's agent
+    # sometimes answers a t2i with a video (WireFormatError).
+    seed_env = {**e2e_env, "GFLOW_CLI_PREFER_CLASSIC": "1"}
+    for attempt in range(3):
+        seed = _run_gflow(
+            [
+                "image",
+                "t2i",
+                f"a brass compass on a weathered map, take {attempt}",
+                "--model",
+                "nano2",
+                "--out",
+                str(out),
+                "--json",
+            ],
+            seed_env,
+        )
+        if seed.returncode != 0:
+            continue  # transient seed failure — retry within the bounded loop
+        seed_payload = _json_payload(seed.stdout)
+        images = seed_payload.get("images") or []
+        assert images, f"seed run returned no images: {seed_payload}"
+        seed_media_id = str(images[0]["media_name"])
+        project_id = str(seed_payload.get("project_id") or "")
+        assert project_id, f"seed payload carried no project_id: {seed_payload}"
+
+        with DataStore.open(Path(e2e_env["GFLOW_CLI_DB_PATH"])) as store:
+            asset = DataRepository(store).get_asset_by_flow_media_id(profile_name, seed_media_id)
+        assert asset is not None, f"seed asset {seed_media_id} missing from the catalog"
+        name = asset.metadata_json.get("display_name")
+        if isinstance(name, str) and name:
+            display_name = name
+            break
+
+    if display_name is None:
+        pytest.skip(
+            "no usable seed with a recorded displayName after 3 attempts — the "
+            "caption is computed asynchronously server-side (or the seed "
+            "generation failed transiently); nothing to name-search."
+        )
+
+    # 3. R2V in the SAME project, referencing the seed by its catalog name.
+    # Undo the autouse `_isolate_settings` fixture so profile lookup resolves
+    # to the real platformdirs path where the live session lives.
+    monkeypatch.delenv("GFLOW_CLI_HOME", raising=False)
+    monkeypatch.delenv("GFLOW_CLI_DB_PATH", raising=False)
+    reset_settings()
+    e2e_profile_dir = _resolve_profile_dir(profile_name)
+    if not e2e_profile_dir.exists():
+        pytest.skip(f"profile dir not found: {e2e_profile_dir}")
+
+    req = GenerateVideoRequest(
+        prompt="the compass needle spins, cinematic close-up",
+        mode=Mode.R2V,
+        aspect=Aspect.PORTRAIT,
+        model=VideoModel.VEO_3_1_LITE,
+        duration=None,  # #537: Veo 3.1 models expose no duration control
+        count=1,
+        ref_names=(display_name,),
+    )
+
+    transport = UiAutomationTransport()
+    try:
+        await transport.setup(e2e_profile_dir)
+        result: VideoResult = await transport.generate_video(
+            request=req,
+            project_id=project_id,
+            out_dir=tmp_path,
+            poll_timeout_s=_R2V_POLL_TIMEOUT_S,
+        )
+    finally:
+        await transport.teardown()
+
+    assert result.status.is_terminal and result.status.succeeded, (
+        f"Expected SUCCESSFUL terminal status, got {result.status.status!r}; "
+        f"failure_reasons={result.status.failure_reasons!r}"
+    )
+    assert result.local_path is not None and result.local_path.exists(), (
+        f"VideoResult.local_path must point to a downloaded mp4; got {result.local_path!r}"
+    )
+    head = result.local_path.read_bytes()[:32]
+    assert b"ftyp" in head, f"mp4 magic bytes not found in {result.local_path}: {head!r}"
+
+    attached = [
+        e
+        for e in install_log_capture.entries
+        if e["event"] == "ui_automation_video.remote_reference_attached"
+        and e.get("display_name") == display_name
+    ]
+    assert attached, (
+        f"expected remote_reference_attached for {display_name!r}; events: "
+        f"{sorted({e['event'] for e in install_log_capture.entries})}"
+    )

--- a/tests/features/media_picker_tiers.feature
+++ b/tests/features/media_picker_tiers.feature
@@ -1,0 +1,35 @@
+Feature: Media picker resolves UUID references without dead search tiers
+  The picker's full-UUID and UUID-stem search tiers are live-proven never to
+  match (#287, #393). They must not run before the scroll fallback, and the
+  reference-binding contract must be unchanged.
+
+  Scenario: A bare UUID reference off the viewport is found by scrolling
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the reference tile is not in the picker's initial viewport
+    When the transport binds the reference
+    Then no search term is typed before the grid is scrolled
+    And the tile is attached from the scroll tier
+    And the attach event reports resolved_by "scroll"
+
+  Scenario: An unreachable reference still refuses to generate without it
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the reference tile is absent from the picker entirely
+    When the transport binds the reference
+    Then the demoted UUID search tiers are attempted after the scroll
+    And the recorded local file is uploaded as the fallback
+    And the generation never proceeds without the reference
+
+  Scenario: A frame-slot UUID that cannot be located fails pre-generation
+    Given a video i2v generation with an initial frame given as a media UUID
+    And the asset is absent from the picker entirely
+    When the transport binds the frame
+    Then a TransportTimeoutError naming the slot and the UUID is raised
+    And the process exits with code 9
+    And no generation is submitted
+
+  Scenario: A picker cohort with no search box is never blocked by search
+    Given an image i2i generation with one bare "--ref <uuid>"
+    And the picker variant renders no search input
+    When the transport binds the reference
+    Then no search input is filled at any point
+    And the grid is scrolled to locate the tile

--- a/tests/features/media_picker_tiers.feature
+++ b/tests/features/media_picker_tiers.feature
@@ -1,35 +1,38 @@
-Feature: Media picker resolves UUID references without dead search tiers
-  The picker's full-UUID and UUID-stem search tiers are live-proven never to
-  match (#287, #393). They must not run before the scroll fallback, and the
-  reference-binding contract must be unchanged.
+Feature: Media picker resolves catalog UUIDs through Flow display names
+  A catalog UUID is stable identity, while Flow's browser picker is searched
+  by the asset's recorded display name. The surfaced tile must still match the
+  exact UUID, and the UUID path must not scan the unfiltered grid.
 
-  Scenario: A bare UUID reference off the viewport is found by scrolling
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the reference tile is not in the picker's initial viewport
-    When the transport binds the reference
-    Then no search term is typed before the grid is scrolled
-    And the tile is attached from the scroll tier
-    And the attach event reports resolved_by "scroll"
+  Scenario: A catalog name surfaces the exact UUID without scrolling
+    Given an image UUID reference named "Unique catalog caption"
+    And picker search surfaces the exact UUID tile
+    When the transport binds the image reference
+    Then only the catalog display name is typed into picker search
+    And the exact UUID tile is attached
+    And no grid scroll is attempted
 
-  Scenario: An unreachable reference still refuses to generate without it
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the reference tile is absent from the picker entirely
-    When the transport binds the reference
-    Then the demoted UUID search tiers are attempted after the scroll
-    And the recorded local file is uploaded as the fallback
-    And the generation never proceeds without the reference
+  Scenario: Duplicate display names are disambiguated by UUID
+    Given an image UUID reference named "Shared catalog caption"
+    And another picker tile has the same display name
+    And picker search surfaces the exact UUID tile
+    When the transport binds the image reference
+    Then the target locator contains the requested UUID
+    And the other same-name tile is not attached
+    And no grid scroll is attempted
 
-  Scenario: A frame-slot UUID that cannot be located fails pre-generation
-    Given a video i2v generation with an initial frame given as a media UUID
-    And the asset is absent from the picker entirely
-    When the transport binds the frame
-    Then a TransportTimeoutError naming the slot and the UUID is raised
-    And the process exits with code 9
-    And no generation is submitted
+  Scenario: A named picker miss uses the recorded local fallback
+    Given an image UUID reference named "Missing catalog image"
+    And the exact UUID tile is absent from the picker
+    And the catalog has a recorded local fallback
+    When the transport binds the image reference
+    Then only the catalog display name is typed into picker search
+    And the recorded local file is uploaded
+    And no grid scroll is attempted
 
-  Scenario: A picker cohort with no search box is never blocked by search
-    Given an image i2i generation with one bare "--ref <uuid>"
-    And the picker variant renders no search input
-    When the transport binds the reference
-    Then no search input is filled at any point
-    And the grid is scrolled to locate the tile
+  Scenario: A video frame uses its catalog name and exact UUID
+    Given a video frame UUID named "Shared catalog caption"
+    And picker search surfaces the exact UUID tile
+    When the transport binds the video frame
+    Then only the catalog display name is typed into picker search
+    And the exact UUID tile is attached
+    And no grid scroll is attempted

--- a/tests/features/test_media_picker_tiers_steps.py
+++ b/tests/features/test_media_picker_tiers_steps.py
@@ -1,0 +1,275 @@
+"""BDD steps for the #529 media-picker tier reorder."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import structlog
+from pytest_bdd import given, scenarios, then, when
+
+from gflow_cli.api.transports.ui_automation_video import (
+    ADD_MEDIA_BUTTON,
+    DIALOG_ANY,
+    PICKER_SEARCH_INPUT,
+    VideoGenerationMixin,
+)
+from gflow_cli.errors import TransportTimeoutError
+from gflow_cli.json_output import exit_code_for
+from tests.api.transports.test_ui_automation_video import (
+    TestSelectExistingAssetPickerScroll as _PickerFake,
+)
+
+scenarios("media_picker_tiers.feature")
+
+
+_MEDIA_ID = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
+
+
+@pytest.fixture
+def picker_state() -> dict[str, Any]:
+    return {
+        "media_id": _MEDIA_ID,
+        "display_name": "",
+        "local_path": "",
+        "order": [],
+        "exception": None,
+        "generation_submitted": False,
+    }
+
+
+def _image_page(tile: MagicMock) -> tuple[MagicMock, MagicMock]:
+    """Reuse the transport unit suite's fake Page, adding the caller's add button."""
+    page = _PickerFake._page_with_tile(tile)
+    search = page.locator(PICKER_SEARCH_INPUT)
+    dialog = page.locator(DIALOG_ANY)
+    add = MagicMock()
+    add.first = add
+    add.wait_for = AsyncMock()
+    add.click = AsyncMock()
+
+    def _locator(selector: str) -> MagicMock:
+        if selector == ADD_MEDIA_BUTTON:
+            return add
+        if selector == PICKER_SEARCH_INPUT:
+            return search
+        if selector == DIALOG_ANY:
+            return dialog
+        return tile
+
+    page.locator = MagicMock(side_effect=_locator)
+    return page, search
+
+
+def _install_scroll(
+    monkeypatch: pytest.MonkeyPatch,
+    picker_state: dict[str, Any],
+    *,
+    found: bool,
+) -> None:
+    async def _scroll(*_args: object) -> bool:
+        picker_state["order"].append("scroll")
+        return found
+
+    monkeypatch.setattr(
+        VideoGenerationMixin,
+        "_scroll_picker_grid_until_rendered",
+        AsyncMock(side_effect=_scroll),
+    )
+
+
+@given('an image i2i generation with one bare "--ref <uuid>"')
+def _given_image_ref(picker_state: dict[str, Any]) -> None:
+    picker_state["media_id"] = _MEDIA_ID
+
+
+@given("the reference tile is not in the picker's initial viewport")
+def _given_off_viewport(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    tile = _PickerFake._tile_mock(
+        wait_for_side_effect=[TimeoutError("not initially visible"), None],
+        count_side_effect=0,
+    )
+    page, search = _image_page(tile)
+
+    async def _press(term: str, **_kwargs: object) -> None:
+        picker_state["order"].append(f"search:{term}")
+
+    search.press_sequentially = AsyncMock(side_effect=_press)
+    picker_state.update(page=page, search=search, tile=tile)
+    _install_scroll(monkeypatch, picker_state, found=True)
+
+
+@given("the reference tile is absent from the picker entirely")
+def _given_absent_ref(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    tile = _PickerFake._tile_mock(
+        wait_for_side_effect=TimeoutError("never visible"),
+        count_side_effect=0,
+    )
+    page, search = _image_page(tile)
+
+    async def _press(term: str, **_kwargs: object) -> None:
+        picker_state["order"].append(f"search:{term}")
+
+    search.press_sequentially = AsyncMock(side_effect=_press)
+    upload = AsyncMock()
+    monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
+    picker_state.update(
+        page=page,
+        search=search,
+        tile=tile,
+        upload=upload,
+        local_path="recorded-ref.png",
+    )
+    _install_scroll(monkeypatch, picker_state, found=False)
+
+
+@given("a video i2v generation with an initial frame given as a media UUID")
+def _given_frame_ref(picker_state: dict[str, Any]) -> None:
+    picker_state["slot"] = "Start"
+
+
+@given("the asset is absent from the picker entirely")
+def _given_absent_frame(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    tile = _PickerFake._tile_mock(
+        wait_for_side_effect=TimeoutError("never visible"),
+        count_side_effect=0,
+    )
+    page, _search = _image_page(tile)
+    slot = MagicMock()
+    slot.click = AsyncMock()
+    monkeypatch.setattr(
+        VideoGenerationMixin,
+        "_resolve_frame_slot",
+        AsyncMock(return_value=slot),
+    )
+    monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", AsyncMock())
+    monkeypatch.setattr(
+        VideoGenerationMixin,
+        "_select_existing_asset",
+        AsyncMock(return_value=None),
+    )
+    picker_state.update(page=page, tile=tile, frame_slot=slot)
+
+
+@given("the picker variant renders no search input")
+def _given_no_search(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    tile = _PickerFake._tile_mock(
+        wait_for_side_effect=[TimeoutError("not initially visible"), None],
+        count_side_effect=0,
+    )
+    page, search = _image_page(tile)
+    search.count = AsyncMock(return_value=0)
+    picker_state.update(page=page, search=search, tile=tile)
+    _install_scroll(monkeypatch, picker_state, found=True)
+
+
+@when("the transport binds the reference")
+def _bind_reference(
+    picker_state: dict[str, Any],
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    asyncio.run(
+        VideoGenerationMixin._attach_image_uuid_refs(
+            picker_state["page"],
+            [
+                (
+                    picker_state["media_id"],
+                    picker_state["display_name"],
+                    picker_state["local_path"],
+                )
+            ],
+            out_dir=None,
+        )
+    )
+    picker_state["logs"] = list(install_log_capture.entries)
+
+
+@when("the transport binds the frame")
+def _bind_frame(picker_state: dict[str, Any]) -> None:
+    try:
+        asyncio.run(
+            VideoGenerationMixin._attach_frame_by_media_id(
+                picker_state["page"],
+                0,
+                picker_state["slot"],
+                picker_state["media_id"],
+                out_dir=None,
+            )
+        )
+    except TransportTimeoutError as exc:
+        picker_state["exception"] = exc
+
+
+@then("no search term is typed before the grid is scrolled")
+def _then_scroll_precedes_search(picker_state: dict[str, Any]) -> None:
+    assert picker_state["order"] and picker_state["order"][0] == "scroll"
+
+
+@then("the tile is attached from the scroll tier")
+def _then_attached_from_scroll(picker_state: dict[str, Any]) -> None:
+    assert picker_state["order"][0] == "scroll"
+    picker_state["tile"].click.assert_awaited_once()
+
+
+@then('the attach event reports resolved_by "scroll"')
+def _then_scroll_event(picker_state: dict[str, Any]) -> None:
+    attach_events = [
+        event
+        for event in picker_state["logs"]
+        if event["event"] == "ui_automation_video.image_ref_selected_existing"
+    ]
+    assert attach_events and attach_events[0]["resolved_by"] == "scroll"
+
+
+@then("the demoted UUID search tiers are attempted after the scroll")
+def _then_uuid_retry_after_scroll(picker_state: dict[str, Any]) -> None:
+    assert picker_state["order"] == [
+        "scroll",
+        f"search:{_MEDIA_ID}",
+        "search:d6f1927a",
+    ]
+
+
+@then("the recorded local file is uploaded as the fallback")
+def _then_uploaded(picker_state: dict[str, Any]) -> None:
+    picker_state["upload"].assert_awaited_once()
+
+
+@then("the generation never proceeds without the reference")
+def _then_image_not_submitted(picker_state: dict[str, Any]) -> None:
+    assert picker_state["generation_submitted"] is False
+
+
+@then("a TransportTimeoutError naming the slot and the UUID is raised")
+def _then_frame_error(picker_state: dict[str, Any]) -> None:
+    exc = picker_state["exception"]
+    assert isinstance(exc, TransportTimeoutError)
+    assert exc.detail == (
+        f"Start frame asset {_MEDIA_ID!r} could not be located in the media picker — "
+        "is it in the target project (missing or wrong --project), and is the UUID "
+        "from this profile's library?"
+    )
+
+
+@then("the process exits with code 9")
+def _then_exit_9(picker_state: dict[str, Any]) -> None:
+    assert exit_code_for(picker_state["exception"]) == 9
+
+
+@then("no generation is submitted")
+def _then_video_not_submitted(picker_state: dict[str, Any]) -> None:
+    assert picker_state["generation_submitted"] is False
+
+
+@then("no search input is filled at any point")
+def _then_no_search_fill(picker_state: dict[str, Any]) -> None:
+    picker_state["search"].fill.assert_not_awaited()
+    picker_state["search"].press_sequentially.assert_not_awaited()
+
+
+@then("the grid is scrolled to locate the tile")
+def _then_grid_scrolled(picker_state: dict[str, Any]) -> None:
+    assert picker_state["order"] == ["scroll"]
+    picker_state["tile"].click.assert_awaited_once()

--- a/tests/features/test_media_picker_tiers_steps.py
+++ b/tests/features/test_media_picker_tiers_steps.py
@@ -1,14 +1,15 @@
-"""BDD steps for the #529 media-picker tier reorder."""
+"""BDD steps for catalog-name media-picker resolution (#529)."""
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import structlog
-from pytest_bdd import given, scenarios, then, when
+from pytest_bdd import given, parsers, scenarios, then, when
 
 from gflow_cli.api.transports.ui_automation_video import (
     ADD_MEDIA_BUTTON,
@@ -16,39 +17,62 @@ from gflow_cli.api.transports.ui_automation_video import (
     PICKER_SEARCH_INPUT,
     VideoGenerationMixin,
 )
-from gflow_cli.errors import TransportTimeoutError
-from gflow_cli.json_output import exit_code_for
-from tests.api.transports.test_ui_automation_video import (
-    TestSelectExistingAssetPickerScroll as _PickerFake,
-)
 
 scenarios("media_picker_tiers.feature")
 
 
-_MEDIA_ID = "d6f1927a-3eae-4626-bc90-9a6ea7637bab"
+_MEDIA_ID = "11111111-2222-4333-8444-555555555555"
+
+
+def _tile_mock() -> MagicMock:
+    tile = MagicMock()
+    tile.first = tile
+    tile.click = AsyncMock()
+    tile.wait_for = AsyncMock()
+    tile.evaluate = AsyncMock(return_value=True)
+    tile.count = AsyncMock(return_value=1)
+    return tile
+
+
+def _page_with_tile(tile: MagicMock) -> MagicMock:
+    page = MagicMock()
+    page.wait_for_timeout = AsyncMock()
+    page.mouse = MagicMock()
+    page.mouse.wheel = AsyncMock()
+    dialog = MagicMock()
+    dialog.last = dialog
+    dialog.hover = AsyncMock()
+    dialog.wait_for = AsyncMock()
+    search = MagicMock()
+    search.first = search
+    search.press_sequentially = AsyncMock()
+    search.fill = AsyncMock()
+    search.wait_for = AsyncMock()
+    search.count = AsyncMock(return_value=1)
+
+    def _locator(selector: str) -> MagicMock:
+        if selector == DIALOG_ANY:
+            return dialog
+        if selector == PICKER_SEARCH_INPUT:
+            return search
+        return tile
+
+    page.locator = MagicMock(side_effect=_locator)
+    return page
 
 
 @pytest.fixture
-def picker_state() -> dict[str, Any]:
-    return {
-        "media_id": _MEDIA_ID,
-        "display_name": "",
-        "local_path": "",
-        "order": [],
-        "exception": None,
-        "generation_submitted": False,
-    }
-
-
-def _image_page(tile: MagicMock) -> tuple[MagicMock, MagicMock]:
-    """Reuse the transport unit suite's fake Page, adding the caller's add button."""
-    page = _PickerFake._page_with_tile(tile)
+def picker_state(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    tile = _tile_mock()
+    page = _page_with_tile(tile)
     search = page.locator(PICKER_SEARCH_INPUT)
     dialog = page.locator(DIALOG_ANY)
     add = MagicMock()
     add.first = add
     add.wait_for = AsyncMock()
     add.click = AsyncMock()
+
+    base_locator = page.locator
 
     def _locator(selector: str) -> MagicMock:
         if selector == ADD_MEDIA_BUTTON:
@@ -57,86 +81,44 @@ def _image_page(tile: MagicMock) -> tuple[MagicMock, MagicMock]:
             return search
         if selector == DIALOG_ANY:
             return dialog
-        return tile
+        return base_locator(selector)
 
     page.locator = MagicMock(side_effect=_locator)
-    return page, search
-
-
-def _install_scroll(
-    monkeypatch: pytest.MonkeyPatch,
-    picker_state: dict[str, Any],
-    *,
-    found: bool,
-) -> None:
-    async def _scroll(*_args: object) -> bool:
-        picker_state["order"].append("scroll")
-        return found
-
+    scroll = AsyncMock(return_value=False)
     monkeypatch.setattr(
         VideoGenerationMixin,
         "_scroll_picker_grid_until_rendered",
-        AsyncMock(side_effect=_scroll),
+        scroll,
     )
-
-
-@given('an image i2i generation with one bare "--ref <uuid>"')
-def _given_image_ref(picker_state: dict[str, Any]) -> None:
-    picker_state["media_id"] = _MEDIA_ID
-
-
-@given("the reference tile is not in the picker's initial viewport")
-def _given_off_viewport(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
-    tile = _PickerFake._tile_mock(
-        wait_for_side_effect=[TimeoutError("not initially visible"), None],
-        count_side_effect=0,
-    )
-    page, search = _image_page(tile)
-
-    async def _press(term: str, **_kwargs: object) -> None:
-        picker_state["order"].append(f"search:{term}")
-
-    search.press_sequentially = AsyncMock(side_effect=_press)
-    picker_state.update(page=page, search=search, tile=tile)
-    _install_scroll(monkeypatch, picker_state, found=True)
-
-
-@given("the reference tile is absent from the picker entirely")
-def _given_absent_ref(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
-    tile = _PickerFake._tile_mock(
-        wait_for_side_effect=TimeoutError("never visible"),
-        count_side_effect=0,
-    )
-    page, search = _image_page(tile)
-
-    async def _press(term: str, **_kwargs: object) -> None:
-        picker_state["order"].append(f"search:{term}")
-
-    search.press_sequentially = AsyncMock(side_effect=_press)
     upload = AsyncMock()
     monkeypatch.setattr(VideoGenerationMixin, "_upload_via_open_dialog", upload)
-    picker_state.update(
-        page=page,
-        search=search,
-        tile=tile,
-        upload=upload,
-        local_path="recorded-ref.png",
-    )
-    _install_scroll(monkeypatch, picker_state, found=False)
+    return {
+        "media_id": _MEDIA_ID,
+        "display_name": "",
+        "local_path": "",
+        "local_sha256": "",
+        "page": page,
+        "tile": tile,
+        "search": search,
+        "scroll": scroll,
+        "upload": upload,
+        "other_tile": None,
+        "mode": "image",
+    }
 
 
-@given("a video i2v generation with an initial frame given as a media UUID")
-def _given_frame_ref(picker_state: dict[str, Any]) -> None:
-    picker_state["slot"] = "Start"
+@given(parsers.parse('an image UUID reference named "{display_name}"'))
+def _given_image_ref(picker_state: dict[str, Any], display_name: str) -> None:
+    picker_state["display_name"] = display_name
+    picker_state["mode"] = "image"
 
 
-@given("the asset is absent from the picker entirely")
-def _given_absent_frame(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
-    tile = _PickerFake._tile_mock(
-        wait_for_side_effect=TimeoutError("never visible"),
-        count_side_effect=0,
-    )
-    page, _search = _image_page(tile)
+@given(parsers.parse('a video frame UUID named "{display_name}"'))
+def _given_video_ref(
+    picker_state: dict[str, Any], display_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    picker_state["display_name"] = display_name
+    picker_state["mode"] = "video"
     slot = MagicMock()
     slot.click = AsyncMock()
     monkeypatch.setattr(
@@ -145,31 +127,36 @@ def _given_absent_frame(picker_state: dict[str, Any], monkeypatch: pytest.Monkey
         AsyncMock(return_value=slot),
     )
     monkeypatch.setattr(VideoGenerationMixin, "_sync_picker_project", AsyncMock())
-    monkeypatch.setattr(
-        VideoGenerationMixin,
-        "_select_existing_asset",
-        AsyncMock(return_value=None),
-    )
-    picker_state.update(page=page, tile=tile, frame_slot=slot)
 
 
-@given("the picker variant renders no search input")
-def _given_no_search(picker_state: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
-    tile = _PickerFake._tile_mock(
-        wait_for_side_effect=[TimeoutError("not initially visible"), None],
-        count_side_effect=0,
-    )
-    page, search = _image_page(tile)
-    search.count = AsyncMock(return_value=0)
-    picker_state.update(page=page, search=search, tile=tile)
-    _install_scroll(monkeypatch, picker_state, found=True)
+@given("picker search surfaces the exact UUID tile")
+def _given_exact_tile(picker_state: dict[str, Any]) -> None:
+    picker_state["tile"].wait_for = AsyncMock()
 
 
-@when("the transport binds the reference")
-def _bind_reference(
-    picker_state: dict[str, Any],
-    install_log_capture: structlog.testing.LogCapture,
-) -> None:
+@given("another picker tile has the same display name")
+def _given_name_collision(picker_state: dict[str, Any]) -> None:
+    other = MagicMock()
+    other.click = AsyncMock()
+    picker_state["other_tile"] = other
+
+
+@given("the exact UUID tile is absent from the picker")
+def _given_missing_tile(picker_state: dict[str, Any]) -> None:
+    picker_state["tile"].wait_for = AsyncMock(side_effect=TimeoutError("not found"))
+
+
+@given("the catalog has a recorded local fallback")
+def _given_local_fallback(picker_state: dict[str, Any], tmp_path: Path) -> None:
+    path = tmp_path / "recorded-ref.png"
+    content = b"recorded image"
+    path.write_bytes(content)
+    picker_state["local_path"] = str(path)
+    picker_state["local_sha256"] = hashlib.sha256(content).hexdigest()
+
+
+@when("the transport binds the image reference")
+def _bind_image(picker_state: dict[str, Any]) -> None:
     asyncio.run(
         VideoGenerationMixin._attach_image_uuid_refs(
             picker_state["page"],
@@ -178,98 +165,58 @@ def _bind_reference(
                     picker_state["media_id"],
                     picker_state["display_name"],
                     picker_state["local_path"],
+                    picker_state["local_sha256"],
                 )
             ],
             out_dir=None,
         )
     )
-    picker_state["logs"] = list(install_log_capture.entries)
 
 
-@when("the transport binds the frame")
-def _bind_frame(picker_state: dict[str, Any]) -> None:
-    try:
-        asyncio.run(
-            VideoGenerationMixin._attach_frame_by_media_id(
-                picker_state["page"],
-                0,
-                picker_state["slot"],
-                picker_state["media_id"],
-                out_dir=None,
-            )
+@when("the transport binds the video frame")
+def _bind_video(picker_state: dict[str, Any]) -> None:
+    asyncio.run(
+        VideoGenerationMixin._attach_frame_by_media_id(
+            picker_state["page"],
+            0,
+            "Start",
+            picker_state["media_id"],
+            picker_state["display_name"],
+            out_dir=None,
         )
-    except TransportTimeoutError as exc:
-        picker_state["exception"] = exc
-
-
-@then("no search term is typed before the grid is scrolled")
-def _then_scroll_precedes_search(picker_state: dict[str, Any]) -> None:
-    assert picker_state["order"] and picker_state["order"][0] == "scroll"
-
-
-@then("the tile is attached from the scroll tier")
-def _then_attached_from_scroll(picker_state: dict[str, Any]) -> None:
-    assert picker_state["order"][0] == "scroll"
-    picker_state["tile"].click.assert_awaited_once()
-
-
-@then('the attach event reports resolved_by "scroll"')
-def _then_scroll_event(picker_state: dict[str, Any]) -> None:
-    attach_events = [
-        event
-        for event in picker_state["logs"]
-        if event["event"] == "ui_automation_video.image_ref_selected_existing"
-    ]
-    assert attach_events and attach_events[0]["resolved_by"] == "scroll"
-
-
-@then("the demoted UUID search tiers are attempted after the scroll")
-def _then_uuid_retry_after_scroll(picker_state: dict[str, Any]) -> None:
-    assert picker_state["order"] == [
-        "scroll",
-        f"search:{_MEDIA_ID}",
-        "search:d6f1927a",
-    ]
-
-
-@then("the recorded local file is uploaded as the fallback")
-def _then_uploaded(picker_state: dict[str, Any]) -> None:
-    picker_state["upload"].assert_awaited_once()
-
-
-@then("the generation never proceeds without the reference")
-def _then_image_not_submitted(picker_state: dict[str, Any]) -> None:
-    assert picker_state["generation_submitted"] is False
-
-
-@then("a TransportTimeoutError naming the slot and the UUID is raised")
-def _then_frame_error(picker_state: dict[str, Any]) -> None:
-    exc = picker_state["exception"]
-    assert isinstance(exc, TransportTimeoutError)
-    assert exc.detail == (
-        f"Start frame asset {_MEDIA_ID!r} could not be located in the media picker — "
-        "is it in the target project (missing or wrong --project), and is the UUID "
-        "from this profile's library?"
     )
 
 
-@then("the process exits with code 9")
-def _then_exit_9(picker_state: dict[str, Any]) -> None:
-    assert exit_code_for(picker_state["exception"]) == 9
+@then("only the catalog display name is typed into picker search")
+def _then_name_only(picker_state: dict[str, Any]) -> None:
+    assert [call.args[0] for call in picker_state["search"].press_sequentially.await_args_list] == [
+        picker_state["display_name"]
+    ]
 
 
-@then("no generation is submitted")
-def _then_video_not_submitted(picker_state: dict[str, Any]) -> None:
-    assert picker_state["generation_submitted"] is False
-
-
-@then("no search input is filled at any point")
-def _then_no_search_fill(picker_state: dict[str, Any]) -> None:
-    picker_state["search"].fill.assert_not_awaited()
-    picker_state["search"].press_sequentially.assert_not_awaited()
-
-
-@then("the grid is scrolled to locate the tile")
-def _then_grid_scrolled(picker_state: dict[str, Any]) -> None:
-    assert picker_state["order"] == ["scroll"]
+@then("the exact UUID tile is attached")
+def _then_exact_tile_attached(picker_state: dict[str, Any]) -> None:
     picker_state["tile"].click.assert_awaited_once()
+
+
+@then("no grid scroll is attempted")
+def _then_no_scroll(picker_state: dict[str, Any]) -> None:
+    picker_state["scroll"].assert_not_awaited()
+    picker_state["page"].mouse.wheel.assert_not_awaited()
+
+
+@then("the target locator contains the requested UUID")
+def _then_uuid_locator(picker_state: dict[str, Any]) -> None:
+    expected = f"[role='option']:has(img[src*='{picker_state['media_id']}'])"
+    assert any(call.args == (expected,) for call in picker_state["page"].locator.call_args_list)
+
+
+@then("the other same-name tile is not attached")
+def _then_other_not_attached(picker_state: dict[str, Any]) -> None:
+    picker_state["other_tile"].click.assert_not_awaited()
+
+
+@then("the recorded local file is uploaded")
+def _then_uploaded(picker_state: dict[str, Any]) -> None:
+    picker_state["upload"].assert_awaited_once()
+    assert picker_state["upload"].await_args.args[1] == Path(picker_state["local_path"])

--- a/tests/mcp/test_tools_helpers.py
+++ b/tests/mcp/test_tools_helpers.py
@@ -8,8 +8,10 @@ i2v/r2v/mutual-exclusion/path branches are exercised without a worker round-trip
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
+from gflow_cli.data.models import AssetKind
 from gflow_cli.mcp.tools import (
     _bad_param,
     _build_video_media_inputs,
@@ -155,13 +157,23 @@ class _LocalFile:
     def __init__(self, path, storage_provider=None):
         self.path = path
         self.storage_provider = storage_provider
+        content = path.read_bytes() if path is not None and path.is_file() else None
+        self.bytes = len(content) if content is not None else None
+        self.sha256 = hashlib.sha256(content).hexdigest() if content is not None else None
 
 
 class _Asset:
-    def __init__(self, local_files, flow_media_id="m", metadata_json=None):
+    def __init__(
+        self,
+        local_files,
+        flow_media_id="m",
+        metadata_json=None,
+        kind: AssetKind = AssetKind.IMAGE,
+    ):
         self.local_files = list(local_files)
         self.flow_media_id = flow_media_id
         self.metadata_json = metadata_json or {}
+        self.kind = kind
 
 
 class _FakeRepo:
@@ -171,6 +183,9 @@ class _FakeRepo:
         self._asset = asset
 
     def get_asset_by_any_id(self, profile, ref_id):
+        return self._asset
+
+    def get_asset_by_flow_media_id(self, profile, ref_id):
         return self._asset
 
 
@@ -231,20 +246,39 @@ def test_resolve_ref_local_path_skips_cloud_only_files(tmp_path: Path) -> None:
     assert path == str(img)
 
 
-def test_resolve_payload_refs_i2v_frames_become_local_paths(tmp_path: Path) -> None:
-    """i2v: a start/end frame UUID is replaced by its local path (not a *_ref_name),
-    so the existing local-upload attach runs and no picker search is attempted."""
+def test_resolve_payload_refs_i2v_preserves_uuid_name_and_fallback(tmp_path: Path) -> None:
+    """MCP I2V preserves UUID identity and adds name/local picker metadata."""
     from gflow_cli.mcp.tools import _resolve_payload_refs
 
     start = tmp_path / "start.png"
     start.write_bytes(b"\x89PNG\r\n\x1a\n")
-    repo = _FakeRepo(asset=_Asset([_LocalFile(start)]))
-    payload = {"start_image_ref": _A_UUID}
+    repo = _FakeRepo(asset=_Asset([_LocalFile(start)], metadata_json={"display_name": "Brass key"}))
+    payload = {"start_image_ref": _A_UUID, "end_image_ref": _A_UUID}
     err = _resolve_payload_refs(repo, "default", payload, task_type="i2v")
     assert err is None
-    assert payload["start_image"] == str(start)
-    assert "start_image_ref" not in payload
-    assert "start_image_ref_name" not in payload
+    assert payload["start_image_ref"] == _A_UUID
+    assert payload["start_image_ref_display_name"] == "Brass key"
+    assert payload["start_image_ref_local_path"] == str(start)
+    assert payload["start_image_ref_local_sha256"] == hashlib.sha256(start.read_bytes()).hexdigest()
+    assert payload["end_image_ref"] == _A_UUID
+    assert payload["end_image_ref_display_name"] == "Brass key"
+    assert payload["end_image_ref_local_path"] == str(start)
+    assert payload["end_image_ref_local_sha256"] == hashlib.sha256(start.read_bytes()).hexdigest()
+    assert "start_image" not in payload
+
+
+def test_resolve_payload_refs_i2v_rejects_non_image_asset(tmp_path: Path) -> None:
+    from gflow_cli.mcp.tools import _resolve_payload_refs
+
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"video")
+    repo = _FakeRepo(asset=_Asset([_LocalFile(clip)], kind=AssetKind.VIDEO))
+    payload = {"start_image_ref": _A_UUID}
+
+    err = _resolve_payload_refs(repo, "default", payload, task_type="i2v")
+
+    assert err is not None
+    assert err["error"]["title"] == "Reference Not Usable"
 
 
 def test_resolve_payload_refs_r2v_refs_merge_into_reference_images(tmp_path: Path) -> None:
@@ -297,7 +331,13 @@ def test_resolve_payload_refs_image_enriches_found_ref(tmp_path: Path) -> None:
     err = _resolve_payload_refs(repo, "default", payload, task_type="i2i")
     assert err is None
     assert payload["refs"] == [_A_UUID]  # not rewritten
-    assert payload["ref_meta"] == {_A_UUID: {"display_name": "Cozy cabin", "local_path": str(img)}}
+    assert payload["ref_meta"] == {
+        _A_UUID: {
+            "display_name": "Cozy cabin",
+            "local_path": str(img),
+            "local_sha256": hashlib.sha256(img.read_bytes()).hexdigest(),
+        }
+    }
 
 
 def test_resolve_payload_refs_image_enrich_partial_meta_only() -> None:

--- a/tests/worker/test_codec.py
+++ b/tests/worker/test_codec.py
@@ -11,6 +11,8 @@ exercising those DTOs' own validation, wrapped into one stable error type.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from gflow_cli.api.image import GenerateImageRequest
@@ -50,6 +52,34 @@ def test_video_payload_decodes_to_typed_request() -> None:
     assert decoded.schema_version == 0
     assert isinstance(decoded.request, GenerateVideoRequest)
     assert decoded.request.prompt == "a river flows"
+
+
+def test_i2v_uuid_picker_metadata_decodes_to_typed_request() -> None:
+    decoded = decode_payload(
+        "i2v",
+        {
+            "prompt": "pan",
+            "mode": "i2v",
+            "start_image_ref": "550e8400-e29b-41d4-a716-446655440000",
+            "start_image_ref_display_name": "Brass key",
+            "start_image_ref_local_path": "recorded.png",
+            "start_image_ref_local_sha256": "a" * 64,
+            "end_image_ref": "650e8400-e29b-41d4-a716-446655440000",
+            "end_image_ref_display_name": "Wooden bench",
+            "end_image_ref_local_path": "recorded-end.png",
+            "end_image_ref_local_sha256": "b" * 64,
+        },
+    )
+    request = decoded.request
+    assert isinstance(request, GenerateVideoRequest)
+    assert request.start_image_ref_id == "550e8400-e29b-41d4-a716-446655440000"
+    assert request.start_image_ref_display_name == "Brass key"
+    assert request.start_image_ref_local_path == Path("recorded.png")
+    assert request.start_image_ref_local_sha256 == "a" * 64
+    assert request.end_image_ref_id == "650e8400-e29b-41d4-a716-446655440000"
+    assert request.end_image_ref_display_name == "Wooden bench"
+    assert request.end_image_ref_local_path == Path("recorded-end.png")
+    assert request.end_image_ref_local_sha256 == "b" * 64
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preserve Flow `displayName` while parsing captured UI responses so the recorder persists it in `assets.metadata_json` (redacted history omits the prompt-derived caption)
- Enrich image `--ref <uuid>` and I2V start/end frame UUIDs with catalog display names and SHA-256/byte-count-verified local fallbacks (#393 symmetry)
- `_select_existing_asset` now searches only the display name and matches only the exact UUID tile — never scrolls the unfiltered grid, never types UUID/prompt fragments
- Fail-closed: frame refs raise `TransportTimeoutError` before submission when no verified fallback exists; every I2V frame form keeps the post-submit T2V-route backstop
- Supersedes the historic #287 prompt-hint/scroll guidance in docs and changelog

Live-proven contract (2026-08-15 headed-Chrome spike, zero scroll/click/generation calls):
`catalog UUID -> Flow displayName -> picker name search -> exact UUID tile -> attach`

Closes #529

## Test plan

- [x] `/gflow:check` — hygiene, ruff check/format, pyright 0 errors, dup proxy clean on touched code
- [x] Scoped suites: 2058 passed, 3 skipped
- [x] Council consensus green (`/gflow:pr-council-review`)
- [x] Image-picker and I2V frame-slot paths live-verified, no generation submitted
- [ ] CI + `/gflow:sonar 540` green on this push

🤖 Generated with [Claude Code](https://claude.com/claude-code)