### PR TITLE
fix(autopilot): resolve council memory dir per host via XDG, not a hardcoded path

### DIFF
--- a/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
+++ b/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
@@ -16,6 +16,7 @@ The autopilot orchestrator (`scripts/autopilot/pr_triage_autopilot.py`) runs as 
 | `TELEGRAM_USER_ID` | Autopilot orchestrator (host) | The chat ID to receive triage alert messages. |
 | `PR_TRIAGE_ENGINE` | Autopilot orchestrator (host), optional | Review engine selector. Default `council-claude`; any other value exits at startup (`council-multi-cli` is reserved backlog). |
 | `HERMES_OPS_DIR` | Autopilot orchestrator (host), optional | Location of the hermes-ops checkout hosting the Resend email notifier. Default `/opt/hermes-ops`. |
+| `GFLOW_TRIAGE_MEMORY_DIR` | Autopilot orchestrator (host), optional | Council memory directory mounted read-only for D5. Set it only to override the XDG default (`$XDG_DATA_HOME/gflow-cli/memory`, i.e. `~/.local/share/gflow-cli/memory`). **Never put a machine-specific path in the cron line** — see §2. |
 | `RESEND_API_KEY` | Email notifier (hermes-ops) | Resend API key consumed by `$HERMES_OPS_DIR/scripts/notify/email_notify.py`. |
 | `HERMES_NOTIFY_EMAIL_TO` | Email notifier (hermes-ops) | Recipient address for high-signal triage emails. |
 | `HERMES_NOTIFY_EMAIL_FROM` | Email notifier (hermes-ops) | Verified sender address for the Resend account. |
@@ -28,8 +29,19 @@ The autopilot orchestrator (`scripts/autopilot/pr_triage_autopilot.py`) runs as 
 
 Deploy the following layout on the VPS:
 - `/opt/gflow-cli`: Dedicated git repository checkout representing the active branch.
-- `/opt/experience-vault`: Host experience vault directory structure.
-- `/opt/experience-vault/projects/C--development-github-gflow-cli/memory`: The project-specific memory namespace to mount.
+- `~hermes/.local/share/gflow-cli/memory`: Council memory namespace, mounted read-only into the sandbox for dimension D5.
+
+Create the memory directory once, as the user the cron runs under:
+
+```bash
+sudo -u hermes mkdir -p ~hermes/.local/share/gflow-cli/memory
+```
+
+An **empty** directory is a valid deployment — D5 then reports that no memory is available, and the other 13 dimensions run normally. Populate it only if you want the council to consult durable project memory.
+
+> **The memory path is resolved by the orchestrator, never hardcoded.** Precedence is `--memory-dir` > `$GFLOW_TRIAGE_MEMORY_DIR` > `$XDG_DATA_HOME/gflow-cli/memory` (XDG default, falling back to `~/.local/share`). `XDG_DATA_HOME` is the correct slot per the XDG Base Directory Specification: council memory is durable knowledge that should be backed up, not regenerable cache or throwaway state.
+>
+> This replaces a hardcoded `/opt/experience-vault/projects/C--development-github-gflow-cli/memory` in the cron line, which spliced a VPS repo root onto a Claude-internal project-slug layout and therefore existed on no machine. It failed every review from deployment until 2026-08-17 — silently, because nothing validated the path before the container started. The orchestrator now refuses to start with an actionable error instead.
 
 ---
 
@@ -51,7 +63,7 @@ Ensure `iptables` is installed on the host VPS. If `iptables` permissions are wi
 Configure a cron job checking every hour on the hour under the `hermes` system user:
 
 ```cron
-0 * * * * set -a; . /opt/hermes/.env 2>/dev/null; set +a; cd /opt/gflow-cli && uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli --memory-dir /opt/experience-vault/projects/C--development-github-gflow-cli/memory >> /var/log/hermes/pr_triage.log 2>&1
+0 * * * * set -a; . /opt/hermes/.env 2>/dev/null; set +a; cd /opt/gflow-cli && uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli >> /var/log/hermes/pr_triage.log 2>&1
 ```
 
 Sourcing `/opt/hermes/.env` first (`set -a` exports everything it defines) is what delivers `GH_COMMENT_TOKEN`, `TELEGRAM_*`, and the `RESEND_API_KEY` / `HERMES_NOTIFY_EMAIL_*` vars to the process. Without it the email channel silently disables itself, and without `GH_COMMENT_TOKEN` the run exits 1.
@@ -110,5 +122,5 @@ If a PR enters the `FAILED_PERMANENT` state in `pr_triage_ledger.jsonl` due to 3
 2. Fix the underlying environmental or syntax issue.
 3. To trigger a re-review, delete or edit the `FAILED_PERMANENT` entries for that PR number/SHA in `pr_triage_ledger.jsonl`, then run the script manually:
    ```bash
-   uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli --memory-dir /opt/experience-vault/projects/C--development-github-gflow-cli/memory
+   uv run python scripts/autopilot/pr_triage_autopilot.py --repo-dir /opt/gflow-cli
    ```

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -50,6 +50,21 @@ DEFAULT_ENGINE = SUPPORTED_ENGINES[0]
 # 16 days with nothing reporting it.
 CLAUDE_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 
+# Council memory directory (D5 reads this tree read-only inside the sandbox).
+#
+# RESOLVED per host, never hardcoded. A literal path in the cron line is what
+# broke every review from deployment until 2026-08-17: it named
+# /opt/experience-vault/projects/C--development-github-gflow-cli/memory, which
+# spliced a VPS repo root onto a Claude-internal project-slug layout and so
+# existed on no machine. Resolution belongs in code that can see its own
+# environment; the cron line must not carry a machine-specific path.
+#
+# XDG_DATA_HOME (not STATE or CACHE): council memory is durable curated
+# knowledge meant to outlive the machine and be backed up, which is exactly the
+# data slot in the XDG Base Directory Specification.
+MEMORY_DIR_ENV = "GFLOW_TRIAGE_MEMORY_DIR"
+MEMORY_XDG_SUBDIR = "gflow-cli/memory"
+
 
 def check_claude_auth() -> str | None:
     """Return an error string when Claude auth is unusable, else None.
@@ -305,6 +320,34 @@ def resolve_engine() -> str:
     if engine not in SUPPORTED_ENGINES:
         raise SystemExit(f"Unsupported PR_TRIAGE_ENGINE={engine!r}; supported: {SUPPORTED_ENGINES}")
     return engine
+
+
+def resolve_memory_dir(cli_value: str | None = None) -> Path:
+    """Return the council memory directory for THIS host; refuse a missing one.
+
+    Precedence: ``--memory-dir`` > ``$GFLOW_TRIAGE_MEMORY_DIR`` > XDG default.
+    Checked on the HOST before the container starts, for the same reason
+    ``check_claude_auth`` is: an unresolvable path otherwise surfaces as an
+    opaque "Docker sandbox failed (exit 1)" from a ``cd`` deep inside the
+    wrapper script, after the lock is taken and a ledger failure is recorded.
+    """
+    if cli_value:
+        memory_dir, source = Path(cli_value), "--memory-dir"
+    elif os.environ.get(MEMORY_DIR_ENV):
+        memory_dir, source = Path(os.environ[MEMORY_DIR_ENV]), f"${MEMORY_DIR_ENV}"
+    else:
+        data_home = Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".local" / "share")
+        memory_dir, source = data_home / MEMORY_XDG_SUBDIR, "XDG default"
+
+    memory_dir = memory_dir.expanduser().resolve()
+    if not memory_dir.is_dir():
+        raise SystemExit(
+            f"Council memory directory does not exist: {memory_dir} (resolved from {source}).\n"
+            f"  Create it:            mkdir -p {memory_dir}\n"
+            f"  Or point elsewhere:   --memory-dir <path>  |  export {MEMORY_DIR_ENV}=<path>\n"
+            "An empty directory is valid — D5 then reports that no memory is available."
+        )
+    return memory_dir
 
 
 def run_review(
@@ -563,7 +606,14 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Main Host Orchestrator for PR-Triage Autopilot.")
     ap.add_argument("--repo", default="ffroliva/gflow-cli", help="owner/repo name")
     ap.add_argument("--repo-dir", required=True, help="path to local host clone")
-    ap.add_argument("--memory-dir", required=True, help="path to project-specific memory directory")
+    ap.add_argument(
+        "--memory-dir",
+        default=None,
+        help=(
+            f"council memory directory; defaults to ${MEMORY_DIR_ENV}, "
+            f"else $XDG_DATA_HOME/{MEMORY_XDG_SUBDIR}"
+        ),
+    )
     args = ap.parse_args(argv)
 
     # Validate required credentials
@@ -590,7 +640,7 @@ def main(argv: list[str] | None = None) -> int:
     engine = resolve_engine()
 
     repo_dir = Path(args.repo_dir).resolve()
-    memory_dir = Path(args.memory_dir).resolve()
+    memory_dir = resolve_memory_dir(args.memory_dir)
     ledger_path = repo_dir / LEDGER_FILE
 
     # Acquire lock

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -48,7 +48,10 @@ if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   exit 1
 fi
 
-# Ensure absolute paths
+# Ensure absolute paths. Guarded first: a bare `cd` reports only the path, so a
+# bad argument reads as a mystery filesystem error rather than a named flag.
+[ -d "$HOST_REPO" ] || { echo "Error: --repo is not a directory: $HOST_REPO"; exit 1; }
+[ -d "$HOST_MEMORY" ] || { echo "Error: --memory is not a directory: $HOST_MEMORY"; exit 1; }
 HOST_REPO=$(cd "$HOST_REPO" && pwd)
 HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
 

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -419,6 +419,74 @@ def test_present_token_passes(monkeypatch):
     assert pr_triage_autopilot.check_claude_auth() is None
 
 
+def test_memory_dir_cli_arg_wins_over_env(monkeypatch, tmp_path):
+    env_dir = tmp_path / "from-env"
+    cli_dir = tmp_path / "from-cli"
+    env_dir.mkdir()
+    cli_dir.mkdir()
+    monkeypatch.setenv(pr_triage_autopilot.MEMORY_DIR_ENV, str(env_dir))
+    assert pr_triage_autopilot.resolve_memory_dir(str(cli_dir)) == cli_dir.resolve()
+
+
+def test_memory_dir_falls_back_to_env(monkeypatch, tmp_path):
+    env_dir = tmp_path / "from-env"
+    env_dir.mkdir()
+    monkeypatch.setenv(pr_triage_autopilot.MEMORY_DIR_ENV, str(env_dir))
+    assert pr_triage_autopilot.resolve_memory_dir(None) == env_dir.resolve()
+
+
+def test_memory_dir_falls_back_to_xdg_data_home(monkeypatch, tmp_path):
+    monkeypatch.delenv(pr_triage_autopilot.MEMORY_DIR_ENV, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    expected = tmp_path / "gflow-cli" / "memory"
+    expected.mkdir(parents=True)
+    assert pr_triage_autopilot.resolve_memory_dir(None) == expected.resolve()
+
+
+def test_memory_dir_missing_exits_naming_the_path_and_overrides(monkeypatch, tmp_path):
+    monkeypatch.delenv(pr_triage_autopilot.MEMORY_DIR_ENV, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    with pytest.raises(SystemExit) as exc:
+        pr_triage_autopilot.resolve_memory_dir(None)
+    message = str(exc.value)
+    assert "gflow-cli" in message and "memory" in message
+    assert "mkdir -p" in message
+    assert pr_triage_autopilot.MEMORY_DIR_ENV in message
+
+
+def test_main_resolves_memory_from_environment_without_cli_flag(monkeypatch, tmp_path):
+    """main() must reach run_triage_cycle with the resolved dir when no flag is passed.
+
+    The cron line carries no --memory-dir, so this is the path production uses.
+    """
+    memory = tmp_path / "xdg" / "gflow-cli" / "memory"
+    memory.mkdir(parents=True)
+    monkeypatch.delenv(pr_triage_autopilot.MEMORY_DIR_ENV, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "sk-ant-oat01-xxx")
+
+    with patch("pr_triage_autopilot.run_triage_cycle") as m_cycle:
+        ret = pr_triage_autopilot.main(["--repo-dir", str(tmp_path)])
+
+    assert ret == 0
+    assert m_cycle.call_args[0][2] == memory.resolve()
+
+
+def test_main_exits_when_resolved_memory_dir_is_absent(monkeypatch, tmp_path):
+    """A missing memory dir must abort before the lock and the container."""
+    monkeypatch.delenv(pr_triage_autopilot.MEMORY_DIR_ENV, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "empty"))
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "sk-ant-oat01-xxx")
+
+    with patch("pr_triage_autopilot.run_triage_cycle") as m_cycle:
+        with pytest.raises(SystemExit):
+            pr_triage_autopilot.main(["--repo-dir", str(tmp_path)])
+
+    assert m_cycle.call_count == 0
+
+
 def test_main_sends_telegram_alert_on_missing_token(monkeypatch, tmp_path):
     monkeypatch.delenv("GH_COMMENT_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)


### PR DESCRIPTION
## Summary

Resolve the council memory directory per host instead of hardcoding it in the cron line.

Precedence: `--memory-dir` > `$GFLOW_TRIAGE_MEMORY_DIR` > `$XDG_DATA_HOME/gflow-cli/memory` (falling back to `~/.local/share`). `XDG_DATA_HOME` is the correct slot per the XDG Base Directory Specification — this is durable knowledge that should be backed up, not regenerable cache.

The orchestrator now validates the resolved directory on the host and exits with an actionable error if it is missing, rather than failing later inside the container. The wrapper script gained the same guard so a direct invocation names the offending flag.

## Test plan

- [x] 6 tests, written test-first and confirmed failing before implementation
- [x] Precedence chain covered: CLI over env, env over XDG, XDG default, and missing-directory exit
- [x] Integration tests over `main()` for the no-flag path
- [x] Full suite, lint, format, doc links, repo hygiene
