### PR TITLE
fix(autopilot): read-only sandbox token + reclaim the resources each run leaks

### DIFF
--- a/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
+++ b/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
@@ -16,6 +16,7 @@ The autopilot orchestrator (`scripts/autopilot/pr_triage_autopilot.py`) runs as 
 | `TELEGRAM_USER_ID` | Autopilot orchestrator (host) | The chat ID to receive triage alert messages. |
 | `PR_TRIAGE_ENGINE` | Autopilot orchestrator (host), optional | Review engine selector. Default `council-claude`; any other value exits at startup (`council-multi-cli` is reserved backlog). |
 | `HERMES_OPS_DIR` | Autopilot orchestrator (host), optional | Location of the hermes-ops checkout hosting the Resend email notifier. Default `/opt/hermes-ops`. |
+| `GH_SANDBOX_TOKEN` | Review **container** | Fine-grained **read-only** PAT for the repo under review. The container only reads the PR; the host posts the comment. If unset the orchestrator falls back and raises an alert rather than degrading silently. Stored in the SOPS secret store. |
 | `GFLOW_TRIAGE_MEMORY_DIR` | Autopilot orchestrator (host), optional | Council memory directory mounted read-only for D5. Set it only to override the XDG default (`$XDG_DATA_HOME/gflow-cli/memory`, i.e. `~/.local/share/gflow-cli/memory`). **Never put a machine-specific path in the cron line** — see §2. |
 | `RESEND_API_KEY` | Email notifier (hermes-ops) | Resend API key consumed by `$HERMES_OPS_DIR/scripts/notify/email_notify.py`. |
 | `HERMES_NOTIFY_EMAIL_TO` | Email notifier (hermes-ops) | Recipient address for high-signal triage emails. |
@@ -41,7 +42,7 @@ An **empty** directory is a valid deployment — D5 then reports that no memory 
 
 > **The memory path is resolved by the orchestrator, never hardcoded.** Precedence is `--memory-dir` > `$GFLOW_TRIAGE_MEMORY_DIR` > `$XDG_DATA_HOME/gflow-cli/memory` (XDG default, falling back to `~/.local/share`). `XDG_DATA_HOME` is the correct slot per the XDG Base Directory Specification: council memory is durable knowledge that should be backed up, not regenerable cache or throwaway state.
 >
-> This replaces a hardcoded `/opt/experience-vault/projects/C--development-github-gflow-cli/memory` in the cron line, which spliced a VPS repo root onto a Claude-internal project-slug layout and therefore existed on no machine. It failed every review from deployment until 2026-08-17 — silently, because nothing validated the path before the container started. The orchestrator now refuses to start with an actionable error instead.
+> The orchestrator validates the resolved path on the host and refuses to start with an actionable error if it is missing, rather than failing later inside the container.
 
 ---
 
@@ -94,6 +95,17 @@ Do **NOT** register the orchestrator directly via `hermes cron create --script p
 
 - **(a) Plain crontab** — the line above, under the `hermes` system user.
 - **(b) Thin shim in `HERMES_HOME/scripts/`** — a script that does `cd /opt/gflow-cli && exec uv run python scripts/autopilot/pr_triage_autopilot.py "$@"` (mirrors the existing EV ops-health shim pattern), registered with `hermes cron create "1h" --no-agent --script <shim> --deliver telegram`.
+
+### Log rotation
+
+`pr_triage.log` grows without bound otherwise. Install once, as root:
+
+```bash
+install -m 644 /opt/gflow-cli/deploy/logrotate-pr-triage /etc/logrotate.d/pr-triage
+logrotate --debug /etc/logrotate.d/pr-triage    # dry-run
+```
+
+Scoped to `pr_triage.log` alone — the rest of `/var/log/hermes/` belongs to hermes-ops, and two packages rotating one glob is how logs get silently truncated.
 
 ### Check Logs & Status
 - **Log Location**: `/var/log/hermes/pr_triage.log`

--- a/deploy/logrotate-pr-triage
+++ b/deploy/logrotate-pr-triage
@@ -1,0 +1,21 @@
+# logrotate config for the PR-Triage Autopilot log.
+#
+# Install on the VPS as root:
+#   install -m 644 /opt/gflow-cli/deploy/logrotate-pr-triage /etc/logrotate.d/pr-triage
+#   logrotate --debug /etc/logrotate.d/pr-triage   # dry-run to verify
+#
+# Scoped to pr_triage.log alone, not /var/log/hermes/*.log: the rest of that
+# directory belongs to hermes-ops, and two packages rotating the same glob is
+# how you get silently truncated logs.
+/var/log/hermes/pr_triage.log {
+    weekly
+    rotate 8
+    compress
+    delaycompress
+    missingok
+    notifempty
+    # The hourly cron reopens the file on each tick, but copytruncate keeps
+    # rotation safe if the orchestrator is ever run as a long-lived process.
+    copytruncate
+    su hermes hermes
+}

--- a/scripts/autopilot/Dockerfile.triage
+++ b/scripts/autopilot/Dockerfile.triage
@@ -2,6 +2,10 @@
 # docker ecosystem keeps the digest fresh.
 FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503
 
+# Scopes `docker image prune --filter label=app=gflow-triage` in
+# run_sandboxed_review.sh to our own orphaned builds on a shared host.
+LABEL app=gflow-triage
+
 # Install system dependencies: git, python3, curl, gnupg, etc.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -52,18 +52,17 @@ CLAUDE_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 
 # Council memory directory (D5 reads this tree read-only inside the sandbox).
 #
-# RESOLVED per host, never hardcoded. A literal path in the cron line is what
-# broke every review from deployment until 2026-08-17: it named
-# /opt/experience-vault/projects/C--development-github-gflow-cli/memory, which
-# spliced a VPS repo root onto a Claude-internal project-slug layout and so
-# existed on no machine. Resolution belongs in code that can see its own
-# environment; the cron line must not carry a machine-specific path.
-#
-# XDG_DATA_HOME (not STATE or CACHE): council memory is durable curated
-# knowledge meant to outlive the machine and be backed up, which is exactly the
-# data slot in the XDG Base Directory Specification.
+# Resolved per host, never hardcoded -- a machine-specific path in a cron line
+# is not portable and cannot be validated. XDG_DATA_HOME (not STATE or CACHE):
+# this is durable curated knowledge meant to be backed up, which is the data
+# slot in the XDG Base Directory Specification.
 MEMORY_DIR_ENV = "GFLOW_TRIAGE_MEMORY_DIR"
 MEMORY_XDG_SUBDIR = "gflow-cli/memory"
+
+# Read-only GitHub token handed to the review container (see
+# resolve_sandbox_token). Provisioned in hermes-ops SOPS, rendered into
+# /opt/hermes/.env, delivered by the cron line that sources it.
+SANDBOX_TOKEN_ENV = "GH_SANDBOX_TOKEN"
 
 
 def check_claude_auth() -> str | None:
@@ -174,13 +173,42 @@ def _gh_json(args: list[str], repo: str) -> any:
     return json.loads(proc.stdout)
 
 
-def post_gh_comment(pr_num: int, body: str, repo: str) -> None:
-    """Post comment back to PR using GitHub CLI."""
+def resolve_sandbox_token(write_token: str) -> str:
+    """Return the read-only token handed to the review container.
+
+    The container only reads the PR; the host posts the comment. Least
+    privilege: no write credential belongs in the container.
+
+    Falls back to the write token so a missing secret never takes the
+    pipeline down, but alerts rather than degrading silently.
+    """
+    sandbox_token = os.environ.get(SANDBOX_TOKEN_ENV)
+    if sandbox_token:
+        return sandbox_token
+    logger.warning(
+        "Sandbox token missing; falling back to the write-scoped token",
+        env_var=SANDBOX_TOKEN_ENV,
+    )
+    send_telegram_alert(
+        f"⚠️ {SANDBOX_TOKEN_ENV} is not set — the review sandbox is running with a "
+        "WRITE-scoped GitHub token. Restore the read-only token in hermes-ops SOPS."
+    )
+    return write_token
+
+
+def post_gh_comment(pr_num: int, body: str, repo: str, token: str | None = None) -> None:
+    """Post comment back to PR using GitHub CLI.
+
+    The token is passed explicitly rather than inherited from ambient env, so
+    the intended credential is always the one used.
+    """
+    env = {**os.environ, "GH_TOKEN": token} if token else None
     proc = subprocess.run(
         ["gh", "pr", "comment", str(pr_num), "--body", body, "--repo", repo],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
     if proc.returncode != 0:
         raise RuntimeError(f"Failed to post comment to PR #{pr_num}: {proc.stderr.strip()}")
@@ -262,10 +290,24 @@ def fetch_and_checkout_pr(pr_num: int, repo_dir: Path) -> str:
     return head_sha
 
 
-def restore_repo_branch(repo_dir: Path) -> None:
-    """Restore host clone repository back to develop branch."""
+def restore_repo_branch(repo_dir: Path, pr_num: int | None = None) -> None:
+    """Restore the host clone to develop and drop the fetched PR branch.
+
+    Deleting matters: ``fetch_and_checkout_pr`` creates ``pr-<N>-review`` on
+    every review and nothing ever removed it, so the clone accumulated one
+    branch per PR forever (``pr-549-review`` was still present on the VPS
+    weeks later). Best-effort -- a run that failed before fetching has no
+    branch to drop, and cleanup must never mask the original error.
+    """
     logger.info("Restoring repository to develop branch")
     subprocess.run(["git", "checkout", "develop"], cwd=repo_dir, capture_output=True, check=True)
+    if pr_num is not None:
+        branch = f"pr-{pr_num}-review"
+        proc = subprocess.run(
+            ["git", "branch", "-D", branch], cwd=repo_dir, capture_output=True, check=False
+        )
+        if proc.returncode == 0:
+            logger.info("Deleted PR review branch", branch=branch)
 
 
 def run_docker_sandbox(pr_num: int, repo_dir: Path, memory_dir: Path, gh_token: str) -> str:
@@ -456,7 +498,7 @@ def run_triage_cycle(
                 f"Reason: {reasons_str}"
             )
             try:
-                post_gh_comment(pr_num, comment_body, repo)
+                post_gh_comment(pr_num, comment_body, repo, token=gh_token)
             except Exception as exc:
                 logger.error("Failed to post comment to flagged PR", pr=pr_num, error=str(exc))
 
@@ -510,7 +552,10 @@ def run_triage_cycle(
                 continue
 
             # Run Stage 1 Pre-eval & Full sandboxed review
-            output = run_review(engine, pr_num, repo_dir, memory_dir, gh_token)
+            # Read-only token into the sandbox; the write token stays on the host.
+            output = run_review(
+                engine, pr_num, repo_dir, memory_dir, resolve_sandbox_token(gh_token)
+            )
 
             # Parse verdict & MUST-FIX count
             parsed_verdict, must_fixes = parse_summary_verdict(output)
@@ -530,7 +575,7 @@ def run_triage_cycle(
                 f"{output}\n</details>"
             )
 
-            post_gh_comment(pr_num, comment_body, repo)
+            post_gh_comment(pr_num, comment_body, repo, token=gh_token)
 
             # Record completed in ledger
             append_ledger_entry(
@@ -599,7 +644,7 @@ def run_triage_cycle(
                 send_telegram_alert(f"⚠️ PR #{pr_num} review attempt {failures} failed: {exc}")
 
         finally:
-            restore_repo_branch(repo_dir)
+            restore_repo_branch(repo_dir, pr_num=pr_num)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -6,7 +6,9 @@ set -eo pipefail
 
 # Print usage
 usage() {
-  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_token>"
+  echo "Usage: $0 --pr <num> --repo <path> --memory <path> --token <gh_read_token>"
+  echo "  --token MUST be read-only (GH_SANDBOX_TOKEN). The container reads the PR;"
+  echo "  the host orchestrator posts the comment with the write-scoped token."
   echo "  Claude auth comes from CLAUDE_CODE_OAUTH_TOKEN in the environment."
   exit 1
 }
@@ -55,9 +57,22 @@ fi
 HOST_REPO=$(cd "$HOST_REPO" && pwd)
 HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
 
+# Self-heal before we start. The cleanup trap below fires on EXIT, which a
+# SIGKILL (OOM, hard reboot) skips entirely -- stranding that run's network.
+# `docker network rm` refuses a network with attached containers, so this can
+# never disturb a concurrent review.
+for stale_net in $(docker network ls --filter "name=triage-net-" --format '{{.Name}}' 2>/dev/null); do
+  docker network rm "$stale_net" &>/dev/null && echo "Swept stale network $stale_net" || true
+done
+
 echo "Building Docker sandbox image..."
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 docker build -t gflow-triage:latest -f "$SCRIPT_DIR/Dockerfile.triage" "$SCRIPT_DIR"
+
+# The build reuses one tag, so whenever the Dockerfile or its context changes
+# the previous ~1GB image is orphaned as dangling. The label filter keeps this
+# scoped to our own images -- never other projects' on a shared host.
+docker image prune -f --filter "label=app=gflow-triage" &>/dev/null || true
 
 NET_NAME="triage-net-$PR_NUM"
 echo "Creating network $NET_NAME..."

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -82,7 +82,12 @@ def test_run_triage_cycle_success(
     mock_post_comment,
     mock_telegram,
     tmp_path,
+    monkeypatch,
 ):
+    # The deployed shape: a dedicated read-only token exists, so the container
+    # must receive THAT, never the write-scoped token used to post comments.
+    monkeypatch.setenv("GH_SANDBOX_TOKEN", "ro-token")
+
     # Mock Open PRs
     mock_gh_json.return_value = [
         {
@@ -125,9 +130,12 @@ def test_run_triage_cycle_success(
 
     # Assertions
     mock_fetch.assert_called_once_with(101, repo_dir)
-    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, "token-test")
+    # read-only token into the sandbox, NOT the write-scoped "token-test"
+    mock_sandbox.assert_called_once_with(101, repo_dir, memory_dir, "ro-token")
+    assert mock_post_comment.call_args.kwargs["token"] == "token-test"
     mock_post_comment.assert_called_once()
-    mock_restore.assert_called_once_with(repo_dir)
+    # pr_num is passed so the fetched pr-<N>-review branch is deleted, not left behind
+    mock_restore.assert_called_once_with(repo_dir, pr_num=101)
     mock_append_ledger.assert_called_once()
     mock_telegram.assert_called_once()
 
@@ -417,6 +425,88 @@ def test_empty_token_is_reported(monkeypatch):
 def test_present_token_passes(monkeypatch):
     monkeypatch.setenv(pr_triage_autopilot.CLAUDE_TOKEN_ENV, "sk-ant-oat01-xxx")
     assert pr_triage_autopilot.check_claude_auth() is None
+
+
+def test_sandbox_token_prefers_the_dedicated_readonly_token(monkeypatch):
+    monkeypatch.setenv("GH_SANDBOX_TOKEN", "github_pat_readonly")
+    with patch("pr_triage_autopilot.send_telegram_alert") as m_alert:
+        assert pr_triage_autopilot.resolve_sandbox_token("write-token") == "github_pat_readonly"
+    assert m_alert.call_count == 0
+
+
+def test_sandbox_token_falls_back_loudly_when_unset(monkeypatch):
+    """Absent secret must degrade noisily, never silently re-grant write access."""
+    monkeypatch.delenv("GH_SANDBOX_TOKEN", raising=False)
+    with patch("pr_triage_autopilot.send_telegram_alert") as m_alert:
+        assert pr_triage_autopilot.resolve_sandbox_token("write-token") == "write-token"
+    assert m_alert.call_count == 1
+    assert "GH_SANDBOX_TOKEN" in m_alert.call_args[0][0]
+
+
+def test_post_gh_comment_passes_the_write_token_explicitly():
+    """Must not rely on ambient GH_TOKEN — the host env carries several tokens."""
+    with patch("pr_triage_autopilot.subprocess.run") as m_run:
+        m_run.return_value.returncode = 0
+        pr_triage_autopilot.post_gh_comment(7, "body", "o/r", token="write-token")
+    assert m_run.call_args.kwargs["env"]["GH_TOKEN"] == "write-token"
+
+
+def _git(repo, *args):
+    import subprocess
+
+    subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
+
+
+def _make_repo(tmp_path):
+    """A real repo on develop with a pr-999-review branch checked out."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "develop")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "init")
+    _git(repo, "branch", "pr-999-review")
+    _git(repo, "checkout", "-q", "pr-999-review")
+    return repo
+
+
+def _branches(repo):
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "branch", "--format=%(refname:short)"], cwd=repo, capture_output=True, text=True
+    )
+    return set(out.stdout.split())
+
+
+def test_restore_repo_branch_deletes_the_pr_branch(tmp_path):
+    """The fetched pr-<N>-review branch must not outlive the review."""
+    repo = _make_repo(tmp_path)
+    assert "pr-999-review" in _branches(repo)
+
+    pr_triage_autopilot.restore_repo_branch(repo, pr_num=999)
+
+    assert "pr-999-review" not in _branches(repo)
+    assert _branches(repo) == {"develop"}
+
+
+def test_restore_repo_branch_tolerates_absent_pr_branch(tmp_path):
+    """A run that failed before fetching leaves no branch; cleanup must not raise."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "-q", "develop")
+    _git(repo, "branch", "-D", "pr-999-review")
+
+    pr_triage_autopilot.restore_repo_branch(repo, pr_num=999)
+
+    assert _branches(repo) == {"develop"}
+
+
+def test_restore_repo_branch_without_pr_num_still_restores_develop(tmp_path):
+    repo = _make_repo(tmp_path)
+    pr_triage_autopilot.restore_repo_branch(repo)
+    assert "pr-999-review" in _branches(repo)
 
 
 def test_memory_dir_cli_arg_wins_over_env(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- The review container now receives a **read-only** GitHub token. The host keeps the write-scoped token for posting comments. Both call sites pass their token explicitly rather than relying on ambient environment.
- Per-run cleanup, so each review stops leaving residue behind:
  - delete the fetched `pr-<N>-review` branch after the review
  - sweep stale triage networks at startup so an interrupted run self-heals
  - prune superseded triage images, scoped by label to our own builds
  - add a logrotate config for the triage log

## Test plan

- [x] 6 new tests, written test-first and confirmed failing before implementation
- [x] Branch-cleanup tests use a real temporary git repo and assert branch state
- [x] 35 tests pass
- [x] `ruff check` / `ruff format --check`, doc links, repo hygiene, `bash -n` on the wrapper

## Deploy

The read-only token is already provisioned. After merge, pull on the host and install the logrotate config (see the runbook).
