### PR TITLE
fix(autopilot): mount council memory where the reviewer actually looks

### DIFF
--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -122,10 +122,15 @@ else
 fi
 
 echo "Launching sandboxed review for PR $PR_NUM..."
+# The council memory mount target is not arbitrary: SKILL.md D5 tells the
+# reviewer to inspect ~/.claude/projects/<slug>/memory, and $HOME in the image
+# is /home/nonroot. It was /memory until 2026-08-18, so the reviewer read a
+# path that did not exist and the council ran with no memory at all while the
+# mount looked perfectly healthy from the host.
 docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \
-  -v "$HOST_MEMORY:/memory:ro" \
+  -v "$HOST_MEMORY:/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory:ro" \
   -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -596,3 +597,40 @@ def test_main_sends_telegram_alert_on_auth_error(monkeypatch, tmp_path):
         assert ret == 1
         assert m_alert.call_count == 1
         assert "Claude authentication unusable" in m_alert.call_args[0][0]
+
+
+# --- council memory reaches the reviewer inside the sandbox -------------------
+# The mount target and the path SKILL.md tells reviewers to read are two halves
+# of one contract, held in two files that nothing linked. They disagreed: the
+# sandbox mounted /memory while D5 was instructed to inspect
+# ~/.claude/projects/<slug>/memory, which does not exist in the container. The
+# council therefore found no memory even once the host tree was populated.
+
+SANDBOX_SH = ROOT / "scripts" / "autopilot" / "run_sandboxed_review.sh"
+COUNCIL_SKILL = ROOT / "skills" / "pr-council-review" / "SKILL.md"
+CONTAINER_HOME = "/home/nonroot"
+
+
+def _skill_memory_path() -> str:
+    """The memory path SKILL.md § D5 instructs a reviewer to inspect."""
+    match = re.search(
+        r"Inspect `~(/\.claude/projects/[^`]+?)/?`", COUNCIL_SKILL.read_text(encoding="utf-8")
+    )
+    assert match, "SKILL.md no longer states a D5 memory path in the expected form"
+    return CONTAINER_HOME + match.group(1)
+
+
+def test_sandbox_mounts_memory_where_the_skill_looks_for_it():
+    expected = _skill_memory_path()
+    mounts = re.findall(r'-v "\$HOST_MEMORY:([^:]+):ro"', SANDBOX_SH.read_text(encoding="utf-8"))
+    assert mounts == [expected], (
+        f"sandbox mounts council memory at {mounts}, but SKILL.md tells the reviewer "
+        f"to read {expected} — the reviewer will find no memory"
+    )
+
+
+def test_sandbox_mounts_memory_read_only():
+    assert '-v "$HOST_MEMORY:' in SANDBOX_SH.read_text(encoding="utf-8")
+    assert re.search(r'-v "\$HOST_MEMORY:[^"]+:ro"', SANDBOX_SH.read_text(encoding="utf-8")), (
+        "council memory must be mounted read-only; the container only reads it"
+    )


### PR DESCRIPTION
## Summary

The PR-triage sandbox mounted the council memory tree at `/memory`, but `skills/pr-council-review/SKILL.md` D5 instructs the reviewer to inspect `~/.claude/projects/C--development-github-gflow-cli/memory/`. `$HOME` in `Dockerfile.triage` is `/home/nonroot`, and nothing bridges the two — so that path never existed inside the container.

Consequence: the council found **no memory regardless of what the host tree contained**, while the mount looked perfectly healthy from the host. This is separate from, and downstream of, the empty-memory-dir issue left open by #552/#553 — populating the host tree alone would not have fixed anything.

Memory is not only D5's input. `SKILL.md` § 2 maps each touched path to mandatory slugs consumed by D1, D3, D4, D6, D7, D9, D10 and D13, so an unreadable tree degrades 9 of 14 dimensions, not one.

## Changes

- `run_sandboxed_review.sh` mounts the tree at the path the skill names, still read-only.
- Two tests parse the expected path out of `SKILL.md` and assert the shell script agrees. The mount target and the documented path are two halves of one contract living in two files that nothing linked; the next edit to either now fails loudly instead of silently disarming D5.

## Test plan

- [x] `uv run pytest tests/autopilot/` — 37 passed (35 existing + 2 new)
- [x] New test verified failing before the fix: `sandbox mounts council memory at ['/memory'], but SKILL.md tells the reviewer to read /home/nonroot/.claude/projects/...`
- [x] `bash -n run_sandboxed_review.sh` clean
- [x] `ruff check` / `ruff format` clean
- [ ] End-to-end: container `ls` of the mounted path on the VPS (pending, this branch deployed)