### PR TITLE
fix(autopilot): grant the sandboxed reviewer access to the memory it mounts

### DIFF
--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -122,17 +122,22 @@ else
 fi
 
 echo "Launching sandboxed review for PR $PR_NUM..."
+COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory"
 # The council memory mount target is not arbitrary: SKILL.md D5 tells the
 # reviewer to inspect ~/.claude/projects/<slug>/memory, and $HOME in the image
 # is /home/nonroot. It was /memory until 2026-08-18, so the reviewer read a
 # path that did not exist and the council ran with no memory at all while the
 # mount looked perfectly healthy from the host.
+# --add-dir is the other half: the tree sits outside the /workspace cwd, so
+# without it the agent is permission-denied and reports no memory at all.
+# It must follow the positional prompt -- it is variadic and swallows it.
 docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \
-  -v "$HOST_MEMORY:/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory:ro" \
+  -v "$HOST_MEMORY:$COUNCIL_MEMORY_DIR:ro" \
   -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
   -e GH_TOKEN="$GH_TOKEN" \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \
-  claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md."
+  claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md." \
+  --add-dir "$COUNCIL_MEMORY_DIR"

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -620,17 +620,49 @@ def _skill_memory_path() -> str:
     return CONTAINER_HOME + match.group(1)
 
 
+def _sandbox_memory_dir() -> str:
+    """The container path run_sandboxed_review.sh mounts council memory at."""
+    match = re.search(r'COUNCIL_MEMORY_DIR="([^"]+)"', SANDBOX_SH.read_text(encoding="utf-8"))
+    assert match, "run_sandboxed_review.sh no longer declares COUNCIL_MEMORY_DIR"
+    return match.group(1)
+
+
 def test_sandbox_mounts_memory_where_the_skill_looks_for_it():
-    expected = _skill_memory_path()
-    mounts = re.findall(r'-v "\$HOST_MEMORY:([^:]+):ro"', SANDBOX_SH.read_text(encoding="utf-8"))
-    assert mounts == [expected], (
-        f"sandbox mounts council memory at {mounts}, but SKILL.md tells the reviewer "
-        f"to read {expected} — the reviewer will find no memory"
+    assert _sandbox_memory_dir() == _skill_memory_path(), (
+        "the sandbox mounts council memory somewhere the reviewer is not told to look; "
+        "D5 will report no memory no matter what the host tree contains"
     )
 
 
 def test_sandbox_mounts_memory_read_only():
-    assert '-v "$HOST_MEMORY:' in SANDBOX_SH.read_text(encoding="utf-8")
-    assert re.search(r'-v "\$HOST_MEMORY:[^"]+:ro"', SANDBOX_SH.read_text(encoding="utf-8")), (
-        "council memory must be mounted read-only; the container only reads it"
+    sh = SANDBOX_SH.read_text(encoding="utf-8")
+    assert '-v "$HOST_MEMORY:$COUNCIL_MEMORY_DIR:ro"' in sh, (
+        "council memory must be mounted read-only; the container only ever reads it"
     )
+
+
+def test_sandbox_grants_the_agent_access_to_the_memory_dir():
+    """The mount is necessary but not sufficient.
+
+    The tree is outside the agent's /workspace cwd, so without --add-dir Claude
+    Code refuses to read it ("I don't have permission to read that file") and
+    the council silently reviews with no memory.
+    """
+    sh = SANDBOX_SH.read_text(encoding="utf-8")
+    assert '--add-dir "$COUNCIL_MEMORY_DIR"' in sh, (
+        "sandbox mounts council memory but never grants the agent access to it"
+    )
+
+
+def test_add_dir_follows_the_positional_prompt():
+    """--add-dir is variadic: placed before the prompt it consumes it.
+
+    Symptom is not a permission error but a hard start-up failure:
+    "Input must be provided either through stdin or as a prompt argument".
+    """
+    sh = SANDBOX_SH.read_text(encoding="utf-8")
+    prompt = re.search(r'claude -p "(?P<body>[^"]+)"', sh)
+    assert prompt, "could not locate the claude -p invocation"
+    # match the flag as used, not the word: the surrounding comment mentions it too
+    flag = sh.index('--add-dir "$COUNCIL_MEMORY_DIR"')
+    assert flag > prompt.end(), "--add-dir precedes the positional prompt and will swallow it"


### PR DESCRIPTION
## Summary

Follow-up to #554, found by verifying that one on the ops VPS instead of trusting it.

#554 made the mount land where `SKILL.md` D5 tells the reviewer to look. That was necessary but **not sufficient**: the tree sits outside the agent's `/workspace` cwd, so Claude Code refuses to read it. Run against the real `gflow-triage` image with the correct mount and real auth, the agent replied:

> I don't have permission to read that file — the request was denied.

With `--add-dir` it reads the tree and returns content only obtainable from the host copy.

`--add-dir` must follow the positional prompt. Placed before it, it is variadic and swallows the prompt, and the run dies at start-up with `Input must be provided either through stdin or as a prompt argument` — a failure that says nothing about memory.

## Changes

- `--add-dir "$COUNCIL_MEMORY_DIR"` on the `claude -p` invocation, after the prompt.
- Container path extracted to `COUNCIL_MEMORY_DIR` now that it is referenced twice.
- Two more contract tests: the agent is granted access to what is mounted, and the flag stays after the prompt.

## Test plan

- [x] `uv run pytest tests/autopilot/` — 39 passed
- [x] All four contract tests verified failing against the pre-fix script (`git stash` on the shell script alone)
- [x] `bash -n` clean, `ruff check`/`format` clean
- [x] Live on the VPS: mount-only → permission denied; with `--add-dir` → agent returned `LAST=[Promo Assets & Catalog]`, matching the real `MEMORY.md` final bullet exactly