### PR TITLE
fix(autopilot): resolve firewall hosts as IPv4 only, so the review can start

### DIFF
--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -85,10 +85,10 @@ cleanup() {
   echo "Cleaning up network rules and Docker network..."
   if [ -n "$SUBNET" ] && command -v iptables &> /dev/null; then
     sudo iptables -D FORWARD -s "$SUBNET" -j DROP &>/dev/null || true
-    for ip in $(getent ahosts github.com | awk '{print $1}' | sort -u); do
+    for ip in $(getent ahostsv4 github.com | awk '{print $1}' | sort -u); do
       sudo iptables -D FORWARD -s "$SUBNET" -d "$ip" -p tcp --dport 443 -j ACCEPT &>/dev/null || true
     done
-    for ip in $(getent ahosts api.anthropic.com | awk '{print $1}' | sort -u); do
+    for ip in $(getent ahostsv4 api.anthropic.com | awk '{print $1}' | sort -u); do
       sudo iptables -D FORWARD -s "$SUBNET" -d "$ip" -p tcp --dport 443 -j ACCEPT &>/dev/null || true
     done
     sudo iptables -D FORWARD -s "$SUBNET" -p tcp --dport 53 -j ACCEPT &>/dev/null || true
@@ -105,13 +105,19 @@ if [ -n "$SUBNET" ] && command -v iptables &> /dev/null; then
   sudo iptables -I FORWARD -s "$SUBNET" -p udp --dport 53 -j ACCEPT
   sudo iptables -I FORWARD -s "$SUBNET" -p tcp --dport 53 -j ACCEPT
   
+  # ahostsv4, not ahosts: api.anthropic.com also resolves to an AAAA record,
+  # and iptables (v4) rejects an IPv6 destination outright --
+  #   iptables v1.8.10 (nf_tables): host/network '2607:6bc0::10' not found
+  # Under `set -e` that aborted the whole script before `docker run`, so every
+  # review died during firewall setup. The bridge network is IPv4-only
+  # (no --ipv6 on `docker network create`), so v4 rules cover all its egress.
   # Allow api.anthropic.com
-  for ip in $(getent ahosts api.anthropic.com | awk '{print $1}' | sort -u); do
+  for ip in $(getent ahostsv4 api.anthropic.com | awk '{print $1}' | sort -u); do
     sudo iptables -I FORWARD -s "$SUBNET" -d "$ip" -p tcp --dport 443 -j ACCEPT
   done
   
   # Allow github.com
-  for ip in $(getent ahosts github.com | awk '{print $1}' | sort -u); do
+  for ip in $(getent ahostsv4 github.com | awk '{print $1}' | sort -u); do
     sudo iptables -I FORWARD -s "$SUBNET" -d "$ip" -p tcp --dport 443 -j ACCEPT
   done
   

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -666,3 +666,20 @@ def test_add_dir_follows_the_positional_prompt():
     # match the flag as used, not the word: the surrounding comment mentions it too
     flag = sh.index('--add-dir "$COUNCIL_MEMORY_DIR"')
     assert flag > prompt.end(), "--add-dir precedes the positional prompt and will swallow it"
+
+
+def test_firewall_resolves_only_ipv4_addresses():
+    """iptables is v4-only and errors out on an AAAA result.
+
+    api.anthropic.com publishes both an A and an AAAA record. Feeding the AAAA
+    to `iptables -d` fails, and under `set -e` that killed the run before
+    `docker run` was ever reached -- observed on the ops VPS 2026-08-18.
+    """
+    sh = SANDBOX_SH.read_text(encoding="utf-8")
+    assert "getent ahosts " not in sh, (
+        "firewall setup resolves AAAA records; iptables rejects them and set -e "
+        "aborts the review before the container starts. Use `getent ahostsv4`."
+    )
+    assert sh.count("getent ahostsv4 ") == 4, (
+        "expected all four host lookups (2 setup, 2 cleanup) to be IPv4-only"
+    )


### PR DESCRIPTION
## Summary

Found by executing a real council review on the ops VPS. The run never reached `docker run`.

`api.anthropic.com` publishes an AAAA record alongside its A record, `getent ahosts` returns both, and `iptables` is v4-only:

```
Hardening network isolation for subnet 172.20.0.0/16 via iptables...
iptables v1.8.10 (nf_tables): host/network '2607:6bc0::10' not found
Cleaning up network rules and Docker network...
```

Under `set -eo pipefail` that aborts the script mid-hardening; the cleanup trap tears the network down and the whole thing exits non-zero with no reviewer output — indistinguishable from the opaque `Docker sandbox failed (exit 1)` already in the ledger. `github.com` resolves v4-only on this host, which is why the loop just above it survived and hid the pattern.

Measured on the VPS:

| host | `getent ahosts` | `getent ahostsv4` |
|---|---|---|
| github.com | 140.82.121.4 | 140.82.121.4 |
| api.anthropic.com | 160.79.104.10, **2607:6bc0::10** | 160.79.104.10 |

## Changes

- All four host lookups (2 in setup, 2 in the cleanup trap) use `getent ahostsv4`.
- One test asserting no bare `getent ahosts` survives and all four sites are v4.

The bridge network is created without `--ipv6`, so v4 rules cover all of its egress — nothing becomes unfiltered.

## Test plan

- [x] `uv run pytest tests/autopilot/` — 40 passed
- [x] New test verified red against the pre-fix script
- [x] `bash -n` clean, `ruff` clean
- [ ] Re-run the full council on the VPS (next step, this branch deployed)