### PR TITLE
fix(autopilot): let the sandboxed reviewer actually use its tools

### DIFF
--- a/scripts/autopilot/entrypoint.sh
+++ b/scripts/autopilot/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
 
-# Setup writable project memory via symlink to the mounted read-only memory dir
-mkdir -p /tmp/claude/projects/C--development-github-gflow-cli
-ln -sf /memory /tmp/claude/projects/C--development-github-gflow-cli/memory
+# No memory symlink here: council memory is bind-mounted straight to the path
+# SKILL.md D5 reads. This used to link /memory into CLAUDE_CONFIG_DIR, which
+# resolved to nothing -- Claude derives its project slug from the cwd
+# (/workspace), never from the workstation slug this path was named after.
 
 # Execute the passed command
 exec "$@"

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -128,7 +128,7 @@ else
 fi
 
 echo "Launching sandboxed review for PR $PR_NUM..."
-COUNCIL_TOOLS="Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checks:*) Bash(gh pr list:*) Bash(git show:*) Bash(git log:*) Bash(git diff:*) Read Grep Glob Task TodoWrite"
+COUNCIL_TOOLS="Bash(gh auth status:*) Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checks:*) Bash(gh pr list:*) Bash(git show:*) Bash(git rev-parse:*) Bash(git diff:*) Bash(git log:*) Bash(git ls-remote:*) Bash(grep:*) Bash(sort:*) Bash(head:*) Bash(tail:*) Bash(wc:*) Bash(awk:*) Bash(jq:*) Bash(cat:*) Bash(ls:*) Bash(comm:*) Bash(cut:*) Bash(uniq:*) Bash(tr:*) Read Grep Glob Task TodoWrite"
 COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory"
 # The council memory mount target is not arbitrary: SKILL.md D5 tells the
 # reviewer to inspect ~/.claude/projects/<slug>/memory, and $HOME in the image
@@ -151,8 +151,14 @@ COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-c
 # unrestricted tool surface in here is a confused-deputy path, not a sandbox
 # escape. Raised by the council reviewing PR #557 against itself.
 #
+# The list is enumerated from SKILL.md's own invocations, read-only subcommands
+# only. Deliberately absent: gh pr merge/review/ready/comment/close and gh auth
+# login, git push/stash/tag/worktree/branch. The host posts the review comment
+# with the write-scoped token; the container's PAT 403s on POST regardless.
+#
 # Widen only with evidence: a missing entry shows up as the reviewer stalling on
-# a denied tool, never as a wrong verdict.
+# a denied tool (`gh auth status` was the first, found by running it), never as
+# a wrong verdict.
 docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -128,6 +128,7 @@ else
 fi
 
 echo "Launching sandboxed review for PR $PR_NUM..."
+COUNCIL_TOOLS="Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checks:*) Bash(gh pr list:*) Bash(git show:*) Bash(git log:*) Bash(git diff:*) Read Grep Glob Task TodoWrite"
 COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory"
 # The council memory mount target is not arbitrary: SKILL.md D5 tells the
 # reviewer to inspect ~/.claude/projects/<slug>/memory, and $HOME in the image
@@ -137,13 +138,21 @@ COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-c
 # --add-dir is the other half: the tree sits outside the /workspace cwd, so
 # without it the agent is permission-denied and reports no memory at all.
 # It must follow the positional prompt -- it is variadic and swallows it.
-# --dangerously-skip-permissions: in -p mode there is no one to answer a
-# permission prompt, so every `gh` call auto-denies and the reviewer stops to
-# ask a question nobody reads. The container is the security boundary, not
-# Claude's prompt: non-root uid 1001, read-only repo and memory mounts, a
-# read-only GitHub PAT, iptables egress limited to github.com,
-# api.anthropic.com and DNS, and --rm. Requires a non-root user; the flag is
-# refused when running as root.
+# COUNCIL_TOOLS: in -p mode a permission prompt is an auto-deny, not a pause --
+# every `gh` call came back "This command requires approval" and the reviewer
+# halted to ask a question nobody reads. The gate still has to go, but only for
+# the reads the protocol actually makes.
+#
+# Deliberately NOT --dangerously-skip-permissions. That would also unlock Write,
+# Edit and arbitrary Bash, and the permission gate is the only technical
+# enforcement of SKILL.md section 9's no-write-tools rule. The container bounds a
+# different threat (host and repo compromise) than that rule does: the agent
+# ingests PR diffs and comments an external contributor controls, so an
+# unrestricted tool surface in here is a confused-deputy path, not a sandbox
+# escape. Raised by the council reviewing PR #557 against itself.
+#
+# Widen only with evidence: a missing entry shows up as the reviewer stalling on
+# a denied tool, never as a wrong verdict.
 docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \
@@ -154,4 +163,4 @@ docker run --rm \
   gflow-triage:latest \
   claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md." \
   --add-dir "$COUNCIL_MEMORY_DIR" \
-  --dangerously-skip-permissions
+  --allowedTools "$COUNCIL_TOOLS"

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -137,6 +137,13 @@ COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-c
 # --add-dir is the other half: the tree sits outside the /workspace cwd, so
 # without it the agent is permission-denied and reports no memory at all.
 # It must follow the positional prompt -- it is variadic and swallows it.
+# --dangerously-skip-permissions: in -p mode there is no one to answer a
+# permission prompt, so every `gh` call auto-denies and the reviewer stops to
+# ask a question nobody reads. The container is the security boundary, not
+# Claude's prompt: non-root uid 1001, read-only repo and memory mounts, a
+# read-only GitHub PAT, iptables egress limited to github.com,
+# api.anthropic.com and DNS, and --rm. Requires a non-root user; the flag is
+# refused when running as root.
 docker run --rm \
   --net "$NET_NAME" \
   -v "$HOST_REPO:/workspace:ro" \
@@ -146,4 +153,5 @@ docker run --rm \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \
   claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md." \
-  --add-dir "$COUNCIL_MEMORY_DIR"
+  --add-dir "$COUNCIL_MEMORY_DIR" \
+  --dangerously-skip-permissions

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -683,3 +683,26 @@ def test_firewall_resolves_only_ipv4_addresses():
     assert sh.count("getent ahostsv4 ") == 4, (
         "expected all four host lookups (2 setup, 2 cleanup) to be IPv4-only"
     )
+
+
+def test_sandbox_runs_the_agent_without_interactive_permission_prompts():
+    """In -p mode a permission prompt is an auto-deny, not a pause.
+
+    Observed on the ops VPS 2026-08-18: every `gh` call came back "This command
+    requires approval" and the reviewer halted to ask a question no one would
+    read. The container is the boundary (non-root, ro mounts, read-only PAT,
+    egress firewall, --rm), so the in-container prompt only blocks work.
+    """
+    sh = SANDBOX_SH.read_text(encoding="utf-8")
+    assert "--dangerously-skip-permissions" in sh, (
+        "the sandboxed reviewer cannot run gh without this; it will auto-deny and stall"
+    )
+
+
+def test_entrypoint_has_no_dangling_memory_symlink():
+    """The old symlink pointed at /memory, which is no longer a mount target."""
+    ep = (ROOT / "scripts" / "autopilot" / "entrypoint.sh").read_text(encoding="utf-8")
+    assert "ln -sf /memory" not in ep, (
+        "entrypoint still links /memory, which nothing mounts since the memory tree "
+        "moved to the path SKILL.md reads"
+    )

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -685,18 +685,64 @@ def test_firewall_resolves_only_ipv4_addresses():
     )
 
 
-def test_sandbox_runs_the_agent_without_interactive_permission_prompts():
-    """In -p mode a permission prompt is an auto-deny, not a pause.
-
-    Observed on the ops VPS 2026-08-18: every `gh` call came back "This command
-    requires approval" and the reviewer halted to ask a question no one would
-    read. The container is the boundary (non-root, ro mounts, read-only PAT,
-    egress firewall, --rm), so the in-container prompt only blocks work.
-    """
-    sh = SANDBOX_SH.read_text(encoding="utf-8")
-    assert "--dangerously-skip-permissions" in sh, (
-        "the sandboxed reviewer cannot run gh without this; it will auto-deny and stall"
+def _sandbox_code() -> str:
+    """The script with comment lines stripped, so prose cannot satisfy a check."""
+    return "\n".join(
+        line
+        for line in SANDBOX_SH.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
     )
+
+
+def test_sandbox_grants_tools_without_disabling_the_permission_system():
+    """In -p mode a permission prompt is an auto-deny, so some grant is required.
+
+    It must stay scoped. --dangerously-skip-permissions would also unlock Write,
+    Edit and arbitrary Bash, and that gate is the only technical enforcement of
+    SKILL.md section 9's no-write-tools rule for an agent that reads
+    contributor-controlled PR content.
+    """
+    code = _sandbox_code()
+    assert '--allowedTools "$COUNCIL_TOOLS"' in code, (
+        "the sandboxed reviewer cannot run gh without a tool grant; it auto-denies and stalls"
+    )
+    assert "--dangerously-skip-permissions" not in code, (
+        "blanket bypass unlocks Write/Edit/Bash for an agent ingesting attacker-influenced "
+        "PR content; grant only the reads the protocol makes"
+    )
+
+
+def test_council_tool_grant_carries_no_write_capable_tools():
+    """A write tool in the allowlist would reintroduce exactly what it prevents."""
+    grant = re.search(r'COUNCIL_TOOLS="([^"]+)"', _sandbox_code())
+    assert grant, "run_sandboxed_review.sh no longer declares COUNCIL_TOOLS"
+
+    # split on the top level: "Bash(gh pr view:*)" is one entry despite its spaces
+    tools, depth, current = [], 0, ""
+    for ch in grant.group(1):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == " " and depth == 0:
+            if current:
+                tools.append(current)
+            current = ""
+        else:
+            current += ch
+    if current:
+        tools.append(current)
+
+    # exact names, so TodoWrite is not mistaken for Write
+    for forbidden in ("Write", "Edit", "NotebookEdit", "WebFetch", "Bash"):
+        assert forbidden not in tools, f"{forbidden} must not be granted to the reviewer"
+
+    bash_grants = [x for x in tools if x.startswith("Bash")]
+    assert bash_grants, "the reviewer needs at least the gh reads"
+    for g in bash_grants:
+        assert g.startswith("Bash(") and g.endswith(")"), (
+            f"{g} is not a scoped Bash grant; Bash must be granted per read-only subcommand"
+        )
 
 
 def test_entrypoint_has_no_dangling_memory_symlink():

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -744,6 +744,34 @@ def test_council_tool_grant_carries_no_write_capable_tools():
             f"{g} is not a scoped Bash grant; Bash must be granted per read-only subcommand"
         )
 
+    # the mutating subcommands SKILL.md also mentions must never be granted:
+    # the host posts the review comment, the container only ever reads
+    granted = " ".join(bash_grants)
+    for mutation in (
+        "gh pr merge",
+        "gh pr review",
+        "gh pr ready",
+        "gh pr comment",
+        "gh pr close",
+        "gh auth login",
+        "git push",
+        "git stash",
+        "git tag",
+    ):
+        assert mutation not in granted, f"{mutation!r} mutates state and must stay denied"
+
+
+def test_council_tool_grant_covers_the_protocol_preflight():
+    """SKILL.md section 0 runs `gh auth status` before anything else.
+
+    Omitting it stalled a real run on the VPS: the reviewer stopped to ask for
+    approval of `gh auth status` and the council never started.
+    """
+    grant = re.search(r'COUNCIL_TOOLS="([^"]+)"', _sandbox_code())
+    assert grant, "run_sandboxed_review.sh no longer declares COUNCIL_TOOLS"
+    for required in ("gh auth status", "gh pr view", "gh pr diff", "gh pr checks", "git show"):
+        assert required in grant.group(1), f"protocol calls {required!r} but it is not granted"
+
 
 def test_entrypoint_has_no_dangling_memory_symlink():
     """The old symlink pointed at /memory, which is no longer a mount target."""


### PR DESCRIPTION
## Summary

Fifth defect found by running the council for real on the ops VPS. The review started, reached its pre-flight, and then halted:

```
GitHub CLI access (`gh`) is being blocked at the permission layer in this session —
every `gh` invocation (even a no-op like `gh auth status`) returns
"This command requires approval" without pausing for an actual approve/deny
```

In `-p` mode a permission prompt is an **auto-deny, not a pause**. The agent then stopped to ask which of two remedies the operator preferred — into a log no one reads. `SKILL.md` § 0 pre-flight hard-requires `gh` for auth, PR metadata, diff and checks, with no fallback path.

The container is the security boundary here, not Claude's in-container prompt:

| control | state |
|---|---|
| user | non-root, uid 1001 |
| repo + memory mounts | read-only |
| GitHub token | read-only PAT — `POST issues/comments` → **403** verified live |
| egress | iptables: github.com, api.anthropic.com, DNS only; everything else DROP |
| lifetime | `--rm`, ephemeral network per run |

The flag is also refused when running as root, which this image never does.

## Also: three memory paths collapse to one

`entrypoint.sh` linked `/memory` into `CLAUDE_CONFIG_DIR`. That has been dangling since #554 moved the tree — but it never resolved to anything anyway: Claude derives its project slug from the cwd (`/workspace`), never from the workstation slug the path was named after. Removed, with the reason recorded where the next reader will look.

## Test plan

- [x] `uv run pytest tests/autopilot/` — 42 passed
- [x] Both new tests verified red against the pre-fix scripts
- [x] `bash -n` clean on both shell scripts, `ruff` clean
- [ ] Re-run the full council on the VPS (next step)