### PR TITLE
feat(ci): nightly live-e2e canary with a four-state verdict (#502)

### DIFF
--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -168,7 +168,7 @@ a machine that might be off is self-DoS).
 | `GREEN` | every selected $0 tier passed | none |
 | `RED` | auth healthy, a $0 tier failed | **real drift or regression** — triage |
 | `AUTH-EXPIRED` | session rot (expected) | `gflow auth login` |
-| `DEFERRED` | profile precondition blocked it | fix the profile — nothing ran |
+| `DEFERRED` | nothing conclusive ran | fix the profile / config — says nothing about Flow |
 
 Splitting the last two out of `RED` is the point: `RED` must always mean "code or
 Flow drifted", never "please re-login" or "you had Chrome open". The classifier is
@@ -176,7 +176,8 @@ a pure function with all four states covered in
 `tests/scripts/test_canary_classify.py`.
 
 **Rot vs. drift is decided by a second probe, not by error names.** When a tier
-fails, the canary re-runs `gflow auth status`. Session still valid ⇒ the failure is
+fails for a reason other than a profile precondition, the canary re-runs
+`gflow auth status`. Session still valid ⇒ the failure is
 drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
 proved why this matters: an `AuthExpiredError` from the aisandbox upload path
 *looked* exactly like session rot, but the session verified clean seconds later —
@@ -184,11 +185,21 @@ so it was a real divergence between two auth surfaces, and a name-matching
 classifier would have buried it. The extra probe costs ~45s and only runs after a
 failure.
 
-`DEFERRED` covers **profile-state preconditions** — a held `ProfileLease` or a
+`DEFERRED` covers every run that **exercised nothing**: a held `ProfileLease`, a
 `ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
-engine). Both fail closed before any browser starts, so the run never reached Flow
-and cannot evidence drift. They share `ConfigurationError`'s exit 11, so the class
-name is the only discriminator.
+engine), a refused `--pull`, or a run where every selected test skipped. All fail
+before reaching Flow, so none can evidence drift.
+
+Two subtleties, both found by council review and both regression-tested:
+
+- **A precondition is matched on the raised exception, never a substring.** Two
+  `e2e_auth` tests mention `ProfileLockedError` in ordinary source — one in an
+  assertion message, one in a comment — and pytest echoes the failing function's
+  source into its traceback. Substring matching therefore published a genuine
+  regression in those tests as `DEFERRED`, the one label that says "ignore me".
+- **A green run that executed nothing is not green.** pytest exits 0 when every
+  test skips, and every e2e test skips on a missing profile directory. `GREEN`
+  requires `passed > 0`.
 
 Because the issue carries a last-updated timestamp, a machine that was off is
 *visibly stale* — unlike a lingering green commit status, which lies.
@@ -203,11 +214,12 @@ tiers (`e2e_image` / `e2e_video` / `smoke`) stay **strictly manual** via
 
 ```bash
 # dry run — executes for real, prints the payload, touches nothing on GitHub
-python scripts/canary/run_canary.py --profile <name> --dry-run
-
-# exercise any state's publish path without waiting for the condition
-python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
+uv run python scripts/canary/run_canary.py --profile <name> --dry-run
 ```
+
+Credit-spending markers (`e2e_image`, `e2e_video`, `e2e_batch`, `e2e_character`,
+`smoke`) are **refused outright** — the canary never spends credits unattended.
+Run those manually via `/gflow:live-verify`.
 
 ### Schedule it
 
@@ -217,8 +229,10 @@ python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
 ```
 
 Point `-RepoRoot` at a **dedicated clone**, never your working tree: the runner's
-`--pull` refuses to run on a dirty checkout rather than resetting over
-uncommitted work, so a shared tree would simply never run.
+`--pull` refuses a dirty checkout rather than resetting over uncommitted work, and
+reports that refusal as `DEFERRED` rather than exiting silently. `--pull` also
+re-syncs dependencies, so a lockfile bump on `develop` cannot masquerade as a
+`RED` import error.
 
 Publishing uses your already-authenticated local `gh` — **no new secrets or
 tokens**. Published content is sanitized for a public repo: SHA, pass/fail

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -149,6 +149,84 @@ See [DEVELOPMENT.md § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop-
 
 ---
 
+## Nightly canary (#502)
+
+Between releases the live tiers are invisible, so Flow-side drift (cohort flaps,
+selector renames, auth rot) surfaces ad-hoc during feature work instead of on a
+schedule. The canary closes that gap.
+
+It runs **locally, not in hosted CI** — the live tiers need a real authenticated
+Chrome profile, and Google bot-detection plus reCAPTCHA make hosted auth
+infeasible. Results are published to a single **rolling issue**; the canary never
+opens new ones (issue spam trains red-blindness) and **gates nothing** (a gate on
+a machine that might be off is self-DoS).
+
+### Four states
+
+| State | Meaning | Action |
+|---|---|---|
+| `GREEN` | every selected $0 tier passed | none |
+| `RED` | auth healthy, a $0 tier failed | **real drift or regression** — triage |
+| `AUTH-EXPIRED` | session rot (expected) | `gflow auth login` |
+| `DEFERRED` | profile precondition blocked it | fix the profile — nothing ran |
+
+Splitting the last two out of `RED` is the point: `RED` must always mean "code or
+Flow drifted", never "please re-login" or "you had Chrome open". The classifier is
+a pure function with all four states covered in
+`tests/scripts/test_canary_classify.py`.
+
+**Rot vs. drift is decided by a second probe, not by error names.** When a tier
+fails, the canary re-runs `gflow auth status`. Session still valid ⇒ the failure is
+drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
+proved why this matters: an `AuthExpiredError` from the aisandbox upload path
+*looked* exactly like session rot, but the session verified clean seconds later —
+so it was a real divergence between two auth surfaces, and a name-matching
+classifier would have buried it. The extra probe costs ~45s and only runs after a
+failure.
+
+`DEFERRED` covers **profile-state preconditions** — a held `ProfileLease` or a
+`ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
+engine). Both fail closed before any browser starts, so the run never reached Flow
+and cannot evidence drift. They share `ConfigurationError`'s exit 11, so the class
+name is the only discriminator.
+
+Because the issue carries a last-updated timestamp, a machine that was off is
+*visibly stale* — unlike a lingering green commit status, which lies.
+
+### Scope
+
+`-m e2e_auth` only ($0, no reCAPTCHA); fast-follow adds `e2e_scene` ($0). Credit
+tiers (`e2e_image` / `e2e_video` / `smoke`) stay **strictly manual** via
+`/gflow:live-verify` — no unattended credit spend on a personal account.
+
+### Run it
+
+```bash
+# dry run — executes for real, prints the payload, touches nothing on GitHub
+python scripts/canary/run_canary.py --profile <name> --dry-run
+
+# exercise any state's publish path without waiting for the condition
+python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
+```
+
+### Schedule it
+
+```powershell
+.\scripts\canary\register_task.ps1 -Profile <name> -Issue <n> `
+    -RepoRoot C:\path\to\dedicated\clone
+```
+
+Point `-RepoRoot` at a **dedicated clone**, never your working tree: the runner's
+`--pull` refuses to run on a dirty checkout rather than resetting over
+uncommitted work, so a shared tree would simply never run.
+
+Publishing uses your already-authenticated local `gh` — **no new secrets or
+tokens**. Published content is sanitized for a public repo: SHA, pass/fail
+counts, duration, failure class, and failing test *names* only — never raw logs,
+profile paths, prompts, or signed URLs.
+
+---
+
 ## File map
 
 ```

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -132,6 +132,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"Why did SonarCloud skip or fail on a forked PR?"** → [GITHUB § Forked PRs And SonarCloud](GITHUB.md#forked-prs-and-sonarcloud)
 **"How do I run e2e tests before a release?"** → [DEVELOPMENT § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop--main)
 **"What does each e2e marker cost? How do I run only the cheap tests?"** → [E2E_TESTING § Run commands](E2E_TESTING.md#run-commands)
+**"Has Flow drifted since the last release? What is the nightly canary telling me?"** → [E2E_TESTING § Nightly canary](E2E_TESTING.md#nightly-canary-502)
 **"When does the version get bumped?"** → [DEVELOPMENT § Version bump protocol](DEVELOPMENT.md#version-bump-protocol)
 **"How do I embed FlowApiClient in a long-lived worker / service?"** → [USER_GUIDE § Journey 14](USER_GUIDE.md#journey-14--embedding-flowapiclient-in-a-long-lived-worker)
 **"What's the standard way to import gflow errors in my code?"** → [USAGE § Programmatic use](USAGE.md#programmatic-use)

--- a/scripts/canary/register_task.ps1
+++ b/scripts/canary/register_task.ps1
@@ -18,7 +18,7 @@
 
 .EXAMPLE
     # one-time, from an ordinary PowerShell prompt
-    .\scripts\canary\register_task.ps1 -Profile denon82 -Issue 600 `
+    .\scripts\canary\register_task.ps1 -CanaryProfile denon82 -Issue 600 `
         -RepoRoot C:\development\canary\gflow-cli
 
 .EXAMPLE
@@ -28,7 +28,7 @@
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)][string]$Profile,
+    [Parameter(Mandatory)][string]$CanaryProfile,
     [Parameter(Mandatory)][int]$Issue,
     [string]$RepoRoot = (Resolve-Path "$PSScriptRoot\..\.."),
     [string]$Time = '03:00',
@@ -49,11 +49,14 @@ foreach ($path in @($python, $runner)) {
 & gh auth status *> $null
 if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated. Run: gh auth login' }
 
+# Every value is quoted: -Markers 'e2e_auth or e2e_scene' (the documented
+# fast-follow) contains spaces and would otherwise split into three argv tokens
+# that argparse rejects.
 $arguments = @(
     "`"$runner`""
-    '--profile', $Profile
-    '--issue', $Issue
-    '--markers', $Markers
+    '--profile', "`"$CanaryProfile`""
+    '--issue', "$Issue"
+    '--markers', "`"$Markers`""
     '--pull'
 ) -join ' '
 
@@ -61,7 +64,7 @@ $action    = New-ScheduledTaskAction -Execute $python -Argument $arguments -Work
 $trigger   = New-ScheduledTaskTrigger -Daily -At $Time
 # Never wake or start the machine: an off machine is a stale issue, by design.
 # StartWhenAvailable catches up after a missed night rather than skipping it.
-$settings  = New-ScheduledTaskSettingsSet -StartWhenAvailable `
+$settings  = New-ScheduledTaskSettingsSet -StartWhenAvailable -Priority 5 `
     -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries `
     -ExecutionTimeLimit (New-TimeSpan -Hours 1)
 
@@ -70,7 +73,7 @@ Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
 
 Write-Host "Registered '$TaskName' — daily at $Time"
 Write-Host "  repo:    $RepoRoot"
-Write-Host "  profile: $Profile   issue: #$Issue   markers: $Markers"
+Write-Host "  profile: $CanaryProfile   issue: #$Issue   markers: $Markers"
 Write-Host ''
 Write-Host "Smoke it now:  Start-ScheduledTask -TaskName '$TaskName'"
 Write-Host "Remove it:     Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false"

--- a/scripts/canary/register_task.ps1
+++ b/scripts/canary/register_task.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+    Register the nightly gflow live-e2e canary as a Windows Scheduled Task (#502).
+
+.DESCRIPTION
+    Hosted CI cannot run the live tiers (real Chrome profile + Google bot
+    detection), so the canary runs here, where the warm profile lives, and
+    publishes a sanitized verdict to a rolling GitHub issue.
+
+    Point -RepoRoot at a DEDICATED clone, not your working tree. The runner's
+    --pull refuses to touch a dirty checkout, so a shared tree would simply
+    never run.
+
+    The task is user-level (no elevation) and runs only when you are logged on:
+    it needs your profile and your authenticated `gh`. A machine that was off
+    produces a visibly stale timestamp on the issue — which is the intended
+    signal, not a failure.
+
+.EXAMPLE
+    # one-time, from an ordinary PowerShell prompt
+    .\scripts\canary\register_task.ps1 -Profile denon82 -Issue 600 `
+        -RepoRoot C:\development\canary\gflow-cli
+
+.EXAMPLE
+    # verify it end to end without waiting for 03:00
+    Start-ScheduledTask -TaskName 'gflow-canary'
+    Get-ScheduledTaskInfo -TaskName 'gflow-canary'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Profile,
+    [Parameter(Mandatory)][int]$Issue,
+    [string]$RepoRoot = (Resolve-Path "$PSScriptRoot\..\.."),
+    [string]$Time = '03:00',
+    [string]$TaskName = 'gflow-canary',
+    [string]$Markers = 'e2e_auth'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$python = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+$runner = Join-Path $RepoRoot 'scripts\canary\run_canary.py'
+
+foreach ($path in @($python, $runner)) {
+    if (-not (Test-Path $path)) { throw "Not found: $path" }
+}
+
+# `gh` must already be authenticated for this user — the canary ships no token.
+& gh auth status *> $null
+if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated. Run: gh auth login' }
+
+$arguments = @(
+    "`"$runner`""
+    '--profile', $Profile
+    '--issue', $Issue
+    '--markers', $Markers
+    '--pull'
+) -join ' '
+
+$action    = New-ScheduledTaskAction -Execute $python -Argument $arguments -WorkingDirectory $RepoRoot
+$trigger   = New-ScheduledTaskTrigger -Daily -At $Time
+# Never wake or start the machine: an off machine is a stale issue, by design.
+# StartWhenAvailable catches up after a missed night rather than skipping it.
+$settings  = New-ScheduledTaskSettingsSet -StartWhenAvailable `
+    -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries `
+    -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+    -Settings $settings -Description 'Nightly gflow live-e2e canary (#502)' -Force | Out-Null
+
+Write-Host "Registered '$TaskName' — daily at $Time"
+Write-Host "  repo:    $RepoRoot"
+Write-Host "  profile: $Profile   issue: #$Issue   markers: $Markers"
+Write-Host ''
+Write-Host "Smoke it now:  Start-ScheduledTask -TaskName '$TaskName'"
+Write-Host "Remove it:     Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false"

--- a/scripts/canary/run_canary.py
+++ b/scripts/canary/run_canary.py
@@ -180,6 +180,26 @@ def parse_junit(path: Path) -> tuple[int, int, int, tuple[str, ...]]:
     return total - failed - skipped, failed, skipped, tuple(failing)
 
 
+def preserve_evidence(stamp: str) -> Path | None:
+    """Keep the failing JUnit XML so a RED stays triageable days later.
+
+    ``JUNIT_PATH`` is overwritten every run, so without this a Monday red is
+    gone by Wednesday. Learned from the first live run (#561): the only reason
+    that failure could be investigated at all was that the file happened to
+    still be on disk.
+
+    Stays LOCAL and out of the issue — it carries raw tracebacks, which the
+    sanitization contract keeps off a public repo. ``tmp/`` is gitignored.
+    """
+    if not JUNIT_PATH.exists():
+        return None
+    slug = stamp.replace(":", "").replace(" ", "-")
+    kept = JUNIT_PATH.with_name(f"canary-red-{slug}.xml")
+    kept.write_bytes(JUNIT_PATH.read_bytes())
+    print(f"evidence preserved: {kept}")
+    return kept
+
+
 def render(result: Result, sha: str, markers: str, stamp: str) -> str:
     headline = {
         GREEN: "All selected $0 tiers passed.",
@@ -290,6 +310,9 @@ def main() -> int:
             result = Result(state, passed, failed, skipped, secs, failing)
         else:
             result = Result(classify(False, None, ""))
+
+    if result.state == RED:
+        preserve_evidence(stamp)
 
     body = render(result, sha, args.markers, stamp)
     if not args.issue and not args.dry_run:

--- a/scripts/canary/run_canary.py
+++ b/scripts/canary/run_canary.py
@@ -9,31 +9,30 @@ lives — and publishes a sanitized result to GitHub.
 Four states, and the canary **gates nothing** (a gate on a machine that might be
 off is self-DoS):
 
-    GREEN         every selected tier passed
-    RED           auth probe OK but a $0 tier failed -> real drift/regression
-    AUTH-EXPIRED  auth-shaped failure; session rot is EXPECTED, not a regression
-    DEFERRED      profile precondition blocked it (lease held, engine mismatch)
+    GREEN         every selected tier passed AND at least one test actually ran
+    RED           auth was healthy but a $0 tier failed -> real drift/regression
+    AUTH-EXPIRED  session rot; expected maintenance, not a regression
+    DEFERRED      nothing conclusive ran (profile precondition, or all skipped)
 
 Keeping AUTH-EXPIRED and DEFERRED out of RED is the whole point: RED must always
 mean "code or Flow drifted", never "please re-login" or "you had Chrome open".
-Otherwise the signal trains red-blindness and dies.
+Otherwise the signal trains red-blindness and dies. The converse matters just as
+much — see ``_PRECONDITION_RE`` for why a real failure must never be *demoted*
+to DEFERRED.
 
-Scope: ``-m e2e_auth`` only ($0, no reCAPTCHA). Fast-follow adds ``e2e_scene``
-($0). Credit tiers (e2e_image / e2e_video / smoke) stay strictly manual via
-``/gflow:live-verify`` — this never spends credits unattended.
+Scope: ``-m e2e_auth`` only ($0, no reCAPTCHA). Credit tiers are refused outright
+(see ``_CREDIT_MARKERS``) — a promise in a docstring is not enforcement.
 
 Publishing is sanitized for a public repo: SHA, counts, duration, failure class,
-and failing test *names*. Never raw logs, profile paths, prompts, or signed URLs.
+and failing test *base* names. Never raw logs, profile paths, prompts, signed
+URLs, or parametrize ids.
 
 Usage:
     # dry run — execute for real, print the payload, touch nothing on GitHub
     python scripts/canary/run_canary.py --profile ffroliva --dry-run
 
-    # real run (rolling issue must already exist; the canary never opens one)
-    python scripts/canary/run_canary.py --profile ffroliva --issue 600
-
-    # exercise the publish path for a state without waiting for the condition
-    python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --issue 600 --dry-run
+    # real run (rolling issue #559 must already exist; the canary never opens one)
+    python scripts/canary/run_canary.py --profile ffroliva --issue 559
 
 Exit codes: always 0 unless the canary ITSELF broke (bad args, gh failure).
 The Flow-side verdict lives in the issue, not in this process's exit code —
@@ -45,6 +44,8 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
+import shutil
 import subprocess
 import sys
 import time
@@ -57,19 +58,29 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 JUNIT_PATH = REPO_ROOT / "tmp" / "canary-junit.xml"
 
 GREEN, RED, AUTH_EXPIRED, DEFERRED = "GREEN", "RED", "AUTH-EXPIRED", "DEFERRED"
-STATES = (GREEN, RED, AUTH_EXPIRED, DEFERRED)
+
+# Wall-clock cap on the tier. Task Scheduler's own limit is an hour, but hitting
+# THAT kills the process before it can publish — a hung browser would produce
+# silence, which reads identically to "the machine was off". Cap here instead so
+# a hang still reports.
+_TIER_TIMEOUT_S = 45 * 60
+
+# Tiers that spend real money. #502 is explicit that credit tiers stay manual;
+# relying on the default value of --markers to enforce that is not enforcement.
+_CREDIT_MARKERS = ("e2e_image", "e2e_video", "e2e_batch", "e2e_character", "smoke")
 
 # Profile-state preconditions: they fail closed BEFORE any browser starts, so
-# nothing was ever exercised and the run says nothing about Flow. Both are
-# ConfigurationError subclasses sharing exit 11 with everything else under it,
-# so the class name is the discriminator — the exit code cannot be.
-# ProfileEngineDowngradeError's own docstring names ProfileLockedError as its
-# sibling in this class; a canary that reported either as RED would be claiming
-# drift from a run that never reached Flow.
-_PRECONDITION_MARKERS = (
-    "ProfileLockedError",
-    "Profile locked",
-    "ProfileEngineDowngradeError",
+# nothing was exercised and the run says nothing about Flow.
+#
+# This MUST anchor on the raised-exception line, never a bare substring. Two
+# tests in the e2e_auth tier mention ProfileLockedError in ordinary source — one
+# in an assertion message, one in a *comment* — and pytest echoes the failing
+# function's source into the traceback. A substring match therefore demoted a
+# genuine regression in those tests to DEFERRED, i.e. published real drift under
+# the one label that says "ignore me". Found by council review of PR #560.
+_PRECONDITION_RE = re.compile(
+    r"^E\s+[\w.]*(ProfileLockedError|ProfileEngineDowngradeError):",
+    re.MULTILINE,
 )
 
 
@@ -81,6 +92,12 @@ class Result:
     skipped: int = 0
     duration_s: float = 0.0
     failing: tuple[str, ...] = ()
+    note: str = ""
+
+
+def is_precondition_failure(text: str) -> bool:
+    """True when pytest output carries a RAISED profile-precondition exception."""
+    return _PRECONDITION_RE.search(text) is not None
 
 
 def classify(
@@ -88,39 +105,42 @@ def classify(
     pytest_rc: int | None,
     failure_text: str,
     auth_ok_after: bool | None = None,
+    passed: int = 1,
 ) -> str:
     """Pure verdict function — the only place a state is decided.
 
     ``pytest_rc`` is None when the suite never ran (the pre-probe failed first).
     ``auth_ok_after`` is None when no post-probe was needed (nothing failed).
+    ``passed`` defaults to 1 so callers testing only the failure arms need not
+    supply it; the zero case is what the green arm guards against.
 
     Session rot is distinguished from drift by **re-probing after the run**, not
-    by pattern-matching error names. The first live run proved why: an
-    ``AuthExpiredError`` from the aisandbox upload path looks exactly like
-    session rot, but the session probe still verified clean immediately
-    afterwards — so it was a real divergence between two auth surfaces, and a
-    name-matching classifier would have buried it as AUTH-EXPIRED. An
-    auth-shaped failure whose session is *still valid* is drift, not rot.
+    by pattern-matching error names. An ``AuthExpiredError`` from the aisandbox
+    upload path looks exactly like session rot, but if the session still
+    verifies clean seconds later it was a real divergence between two auth
+    surfaces. An auth-shaped failure whose session is *still valid* is drift.
 
-    A hardcoded name list was also unmaintainable in the other direction: it had
-    already missed ``AuthExpiredError`` and ``AisandboxAuthError`` on day one.
-    The probe is a real signal and cannot fall out of date.
+    A green run that executed nothing is not green: every e2e test skips when the
+    profile directory is missing, and pytest exits 0 on an all-skipped run. That
+    would pin the dashboard to GREEN forever after a profile move.
     """
     if not auth_ok_before:
         return AUTH_EXPIRED
     if pytest_rc == 0:
-        return GREEN
-    if any(marker in failure_text for marker in _PRECONDITION_MARKERS):
+        return GREEN if passed > 0 else DEFERRED
+    if is_precondition_failure(failure_text):
         return DEFERRED
     if auth_ok_after is False:
-        # The session was healthy at the start and is not now: genuine rot.
+        # Healthy at the start and not now: genuine rot.
         return AUTH_EXPIRED
     return RED
 
 
-def _run(cmd: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    cmd: list[str], env: dict[str, str] | None = None, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603 - fixed argv, no shell
-        cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+        cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False, timeout=timeout
     )
 
 
@@ -142,20 +162,17 @@ def run_tiers(profile: str, markers: str) -> tuple[int, str, float]:
     """Run the selected $0 tiers. Returns (returncode, combined_output, seconds)."""
     JUNIT_PATH.parent.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
-    proc = _run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "-m",
-            markers,
-            "--junitxml",
-            str(JUNIT_PATH),
-            "-q",
-            "--no-header",
-        ],
-        env=_child_env(profile),
-    )
+    argv = [
+        sys.executable, "-m", "pytest",
+        "-m", markers,
+        "--junitxml", str(JUNIT_PATH),
+        "-q", "--no-header",
+    ]  # fmt: skip
+    try:
+        proc = _run(argv, env=_child_env(profile), timeout=_TIER_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        # Report the hang rather than letting Task Scheduler kill us silently.
+        return 1, "E   CanaryTimeout: tier exceeded the wall-clock cap", time.monotonic() - started
     return proc.returncode, f"{proc.stdout}\n{proc.stderr}", time.monotonic() - started
 
 
@@ -164,38 +181,40 @@ def parse_junit(path: Path) -> tuple[int, int, int, tuple[str, ...]]:
     if not path.exists():
         return 0, 0, 0, ()
     root = ET.parse(path).getroot()  # noqa: S314 - our own pytest output
-    suites = root.iter("testsuite")
     total = failures = errors = skipped = 0
     failing: list[str] = []
-    for suite in suites:
+    for suite in root.iter("testsuite"):
         total += int(suite.get("tests", 0))
         failures += int(suite.get("failures", 0))
         errors += int(suite.get("errors", 0))
         skipped += int(suite.get("skipped", 0))
         for case in suite.iter("testcase"):
             if case.find("failure") is not None or case.find("error") is not None:
-                # Test NAMES are publishable; their failure text is not.
-                failing.append(f"{case.get('classname', '')}::{case.get('name', '')}")
+                # Test NAMES are publishable; the parametrize id is NOT a name.
+                # pytest embeds raw param values in `name`, so a case id built
+                # from a profile directory would carry an absolute filesystem
+                # path — or an email, or a prompt — straight into a public issue.
+                # Reproduced, not theorised. Dropping the `[...]` suffix keeps the
+                # test findable and closes the channel entirely.
+                base = case.get("name", "").split("[", 1)[0]
+                failing.append(f"{case.get('classname', '')}::{base}")
     failed = failures + errors
-    return total - failed - skipped, failed, skipped, tuple(failing)
+    return total - failed - skipped, failed, skipped, tuple(dict.fromkeys(failing))
 
 
 def preserve_evidence(stamp: str) -> Path | None:
-    """Keep the failing JUnit XML so a RED stays triageable days later.
+    """Keep the failing JUnit so a RED stays triageable days later.
 
-    ``JUNIT_PATH`` is overwritten every run, so without this a Monday red is
-    gone by Wednesday. Learned from the first live run (#561): the only reason
-    that failure could be investigated at all was that the file happened to
-    still be on disk.
-
-    Stays LOCAL and out of the issue — it carries raw tracebacks, which the
-    sanitization contract keeps off a public repo. ``tmp/`` is gitignored.
+    ``JUNIT_PATH`` is overwritten every run, so without this a Monday red is gone
+    by Wednesday. Stays LOCAL and out of the issue — it carries raw tracebacks,
+    which the sanitization contract keeps off a public repo. ``tmp/`` is
+    gitignored.
     """
     if not JUNIT_PATH.exists():
         return None
     slug = stamp.replace(":", "").replace(" ", "-")
     kept = JUNIT_PATH.with_name(f"canary-red-{slug}.xml")
-    kept.write_bytes(JUNIT_PATH.read_bytes())
+    shutil.copyfile(JUNIT_PATH, kept)
     print(f"evidence preserved: {kept}")
     return kept
 
@@ -205,10 +224,7 @@ def render(result: Result, sha: str, markers: str, stamp: str) -> str:
         GREEN: "All selected $0 tiers passed.",
         RED: "A $0 tier failed while auth was healthy — real drift or regression.",
         AUTH_EXPIRED: "Session rot, not a regression. Re-login and the next run clears it.",
-        DEFERRED: (
-            "A profile precondition blocked the run (lease held, or a profile/engine "
-            "Chromium mismatch). Neutral — nothing reached Flow."
-        ),
+        DEFERRED: "Nothing conclusive ran. Neutral — this says nothing about Flow.",
     }[result.state]
 
     lines = [
@@ -224,6 +240,8 @@ def render(result: Result, sha: str, markers: str, stamp: str) -> str:
         f"| skipped | {result.skipped} |",
         f"| duration | {result.duration_s:.1f}s |",
     ]
+    if result.note:
+        lines += ["", f"**Reason:** {result.note}"]
     if result.failing:
         lines += ["", "**Failing:**", ""]
         lines += [f"- `{name}`" for name in result.failing]
@@ -247,25 +265,30 @@ def publish(issue: int, state: str, body: str, stamp: str, dry_run: bool) -> Non
     print(f"published {state} to issue #{issue}")
 
 
-def sync_to_develop() -> None:
-    """Fast-forward the checkout to ``origin/develop`` — dedicated clone only.
+def sync_to_develop() -> str | None:
+    """Fast-forward the checkout to ``origin/develop`` and refresh deps.
 
-    #502 wants the canary measuring a pinned checkout, not whatever is in a
-    working tree. This REFUSES on any local modification rather than resetting
-    over it: a nightly task that can silently destroy uncommitted work is a far
-    worse bug than a stale canary. Point the scheduled task at a second clone.
+    Returns None on success, or a human-readable reason the sync was refused —
+    the caller publishes that as DEFERRED rather than dying silently. A
+    scheduled task that exits before publishing is indistinguishable from a
+    machine that was switched off.
+
+    REFUSES on any local modification rather than resetting over it: a nightly
+    task that can destroy uncommitted work is a far worse bug than a stale
+    canary. Point the task at a dedicated clone.
+
+    Deps are re-synced too — pulling source without the lockfile's dependency
+    tree turns a routine bump on develop into an import error, i.e. a false RED.
     """
-    dirty = _run(["git", "status", "--porcelain"]).stdout.strip()
-    if dirty:
-        raise SystemExit(
-            "--pull refuses to run: the checkout has local modifications.\n"
-            "Point the scheduled task at a DEDICATED clone, never your working tree."
-        )
+    if _run(["git", "status", "--porcelain"]).stdout.strip():
+        return "checkout has local modifications; point the task at a dedicated clone"
     if _run(["git", "fetch", "origin", "develop"]).returncode != 0:
-        raise SystemExit("git fetch failed; canary not run")
-    checkout = _run(["git", "checkout", "--force", "origin/develop"])
-    if checkout.returncode != 0:
-        raise SystemExit(f"git checkout failed: {checkout.stderr.strip()}")
+        return "git fetch origin develop failed"
+    if _run(["git", "checkout", "--force", "origin/develop"]).returncode != 0:
+        return "git checkout origin/develop failed"
+    if _run(["uv", "sync", "--quiet"]).returncode != 0:
+        return "uv sync failed after pull; dependency tree may be stale"
+    return None
 
 
 def main() -> int:
@@ -276,48 +299,53 @@ def main() -> int:
     p.add_argument("--issue", type=int, default=int(os.environ.get("GFLOW_CANARY_ISSUE", 0)))
     p.add_argument("--markers", default="e2e_auth", help="pytest -m expression ($0 tiers only)")
     p.add_argument("--dry-run", action="store_true", help="execute, print payload, skip GitHub")
-    p.add_argument("--simulate", choices=STATES, help="force a state to exercise publishing")
     p.add_argument(
         "--pull",
         action="store_true",
-        help="fast-forward to origin/develop first; refuses if the tree is dirty",
+        help="fast-forward to origin/develop and re-sync deps; refuses a dirty tree",
     )
     args = p.parse_args()
 
-    if args.pull and not args.simulate:
-        sync_to_develop()
+    spending = [m for m in _CREDIT_MARKERS if m in args.markers]
+    if spending:
+        raise SystemExit(
+            f"--markers selects credit-spending tiers {spending}. The canary never spends "
+            "credits unattended (#502); run those manually via /gflow:live-verify."
+        )
+    if not args.profile:
+        raise SystemExit("--profile (or GFLOW_CLI_E2E_PROFILE) is required")
+    if not args.issue and not args.dry_run:
+        raise SystemExit("--issue (or GFLOW_CANARY_ISSUE) is required; the canary never opens one")
 
     stamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    refused = sync_to_develop() if args.pull else None
     sha = _run(["git", "rev-parse", "--short", "HEAD"]).stdout.strip() or "unknown"
 
-    if args.simulate:
-        result = Result(
-            state=args.simulate, failing=("tests::simulated",) if args.simulate == RED else ()
+    if refused:
+        result = Result(state=DEFERRED, note=refused)
+    elif probe_auth(args.profile):
+        rc, output, secs = run_tiers(args.profile, args.markers)
+        passed, failed, skipped, failing = parse_junit(JUNIT_PATH)
+        # Re-probe only when something failed and it was not a profile
+        # precondition: the post-probe separates session rot from real
+        # divergence, and it costs ~45s we should not spend on a green.
+        after: bool | None = None
+        if rc != 0 and not is_precondition_failure(output):
+            after = probe_auth(args.profile)
+        state = classify(True, rc, output, after, passed)
+        note = (
+            "every selected test skipped — nothing exercised Flow"
+            if state == DEFERRED and rc == 0
+            else ""
         )
+        result = Result(state, passed, failed, skipped, secs, failing, note)
     else:
-        if not args.profile:
-            raise SystemExit("--profile (or GFLOW_CLI_E2E_PROFILE) is required")
-        if probe_auth(args.profile):
-            rc, output, secs = run_tiers(args.profile, args.markers)
-            passed, failed, skipped, failing = parse_junit(JUNIT_PATH)
-            # Re-probe only when something failed and it was not lease
-            # contention: the post-probe is what separates session rot from a
-            # real divergence, and it costs ~45s we should not spend on a green.
-            after: bool | None = None
-            if rc != 0 and not any(m in output for m in _PRECONDITION_MARKERS):
-                after = probe_auth(args.profile)
-            state = classify(True, rc, output, after)
-            result = Result(state, passed, failed, skipped, secs, failing)
-        else:
-            result = Result(classify(False, None, ""))
+        result = Result(state=classify(False, None, ""))
 
     if result.state == RED:
         preserve_evidence(stamp)
 
-    body = render(result, sha, args.markers, stamp)
-    if not args.issue and not args.dry_run:
-        raise SystemExit("--issue (or GFLOW_CANARY_ISSUE) is required; the canary never opens one")
-    publish(args.issue, result.state, body, stamp, args.dry_run)
+    publish(args.issue, result.state, render(result, sha, args.markers, stamp), stamp, args.dry_run)
     return 0
 
 

--- a/scripts/canary/run_canary.py
+++ b/scripts/canary/run_canary.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Nightly live-e2e canary — local scheduled run, published to a rolling issue (#502).
+
+Hosted CI cannot run the live tiers: they need a real authenticated Chrome
+profile, and Google bot-detection / reCAPTCHA / ToS make hosted auth infeasible.
+So the canary runs on the maintainer's machine — where the warm profile already
+lives — and publishes a sanitized result to GitHub.
+
+Four states, and the canary **gates nothing** (a gate on a machine that might be
+off is self-DoS):
+
+    GREEN         every selected tier passed
+    RED           auth probe OK but a $0 tier failed -> real drift/regression
+    AUTH-EXPIRED  auth-shaped failure; session rot is EXPECTED, not a regression
+    DEFERRED      profile precondition blocked it (lease held, engine mismatch)
+
+Keeping AUTH-EXPIRED and DEFERRED out of RED is the whole point: RED must always
+mean "code or Flow drifted", never "please re-login" or "you had Chrome open".
+Otherwise the signal trains red-blindness and dies.
+
+Scope: ``-m e2e_auth`` only ($0, no reCAPTCHA). Fast-follow adds ``e2e_scene``
+($0). Credit tiers (e2e_image / e2e_video / smoke) stay strictly manual via
+``/gflow:live-verify`` — this never spends credits unattended.
+
+Publishing is sanitized for a public repo: SHA, counts, duration, failure class,
+and failing test *names*. Never raw logs, profile paths, prompts, or signed URLs.
+
+Usage:
+    # dry run — execute for real, print the payload, touch nothing on GitHub
+    python scripts/canary/run_canary.py --profile ffroliva --dry-run
+
+    # real run (rolling issue must already exist; the canary never opens one)
+    python scripts/canary/run_canary.py --profile ffroliva --issue 600
+
+    # exercise the publish path for a state without waiting for the condition
+    python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --issue 600 --dry-run
+
+Exit codes: always 0 unless the canary ITSELF broke (bad args, gh failure).
+The Flow-side verdict lives in the issue, not in this process's exit code —
+a scheduled task that reports failure by exiting non-zero just fills the
+Windows event log with noise nobody reads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JUNIT_PATH = REPO_ROOT / "tmp" / "canary-junit.xml"
+
+GREEN, RED, AUTH_EXPIRED, DEFERRED = "GREEN", "RED", "AUTH-EXPIRED", "DEFERRED"
+STATES = (GREEN, RED, AUTH_EXPIRED, DEFERRED)
+
+# Profile-state preconditions: they fail closed BEFORE any browser starts, so
+# nothing was ever exercised and the run says nothing about Flow. Both are
+# ConfigurationError subclasses sharing exit 11 with everything else under it,
+# so the class name is the discriminator — the exit code cannot be.
+# ProfileEngineDowngradeError's own docstring names ProfileLockedError as its
+# sibling in this class; a canary that reported either as RED would be claiming
+# drift from a run that never reached Flow.
+_PRECONDITION_MARKERS = (
+    "ProfileLockedError",
+    "Profile locked",
+    "ProfileEngineDowngradeError",
+)
+
+
+@dataclass(frozen=True)
+class Result:
+    state: str
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    duration_s: float = 0.0
+    failing: tuple[str, ...] = ()
+
+
+def classify(
+    auth_ok_before: bool,
+    pytest_rc: int | None,
+    failure_text: str,
+    auth_ok_after: bool | None = None,
+) -> str:
+    """Pure verdict function — the only place a state is decided.
+
+    ``pytest_rc`` is None when the suite never ran (the pre-probe failed first).
+    ``auth_ok_after`` is None when no post-probe was needed (nothing failed).
+
+    Session rot is distinguished from drift by **re-probing after the run**, not
+    by pattern-matching error names. The first live run proved why: an
+    ``AuthExpiredError`` from the aisandbox upload path looks exactly like
+    session rot, but the session probe still verified clean immediately
+    afterwards — so it was a real divergence between two auth surfaces, and a
+    name-matching classifier would have buried it as AUTH-EXPIRED. An
+    auth-shaped failure whose session is *still valid* is drift, not rot.
+
+    A hardcoded name list was also unmaintainable in the other direction: it had
+    already missed ``AuthExpiredError`` and ``AisandboxAuthError`` on day one.
+    The probe is a real signal and cannot fall out of date.
+    """
+    if not auth_ok_before:
+        return AUTH_EXPIRED
+    if pytest_rc == 0:
+        return GREEN
+    if any(marker in failure_text for marker in _PRECONDITION_MARKERS):
+        return DEFERRED
+    if auth_ok_after is False:
+        # The session was healthy at the start and is not now: genuine rot.
+        return AUTH_EXPIRED
+    return RED
+
+
+def _run(cmd: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+    )
+
+
+def _child_env(profile: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["GFLOW_CLI_E2E_PROFILE"] = profile
+    # FORCE_COLOR leaks ANSI into plain-text assertions and reds ~26 CLI tests.
+    env.pop("FORCE_COLOR", None)
+    return env
+
+
+def probe_auth(profile: str) -> bool:
+    """`gflow auth status` probes the Flow session endpoint — no browser, no credits."""
+    proc = _run([sys.executable, "-m", "gflow_cli", "auth", "status", "--profile", profile])
+    return proc.returncode == 0
+
+
+def run_tiers(profile: str, markers: str) -> tuple[int, str, float]:
+    """Run the selected $0 tiers. Returns (returncode, combined_output, seconds)."""
+    JUNIT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    proc = _run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-m",
+            markers,
+            "--junitxml",
+            str(JUNIT_PATH),
+            "-q",
+            "--no-header",
+        ],
+        env=_child_env(profile),
+    )
+    return proc.returncode, f"{proc.stdout}\n{proc.stderr}", time.monotonic() - started
+
+
+def parse_junit(path: Path) -> tuple[int, int, int, tuple[str, ...]]:
+    """Return (passed, failed, skipped, failing_test_names) from the JUnit XML."""
+    if not path.exists():
+        return 0, 0, 0, ()
+    root = ET.parse(path).getroot()  # noqa: S314 - our own pytest output
+    suites = root.iter("testsuite")
+    total = failures = errors = skipped = 0
+    failing: list[str] = []
+    for suite in suites:
+        total += int(suite.get("tests", 0))
+        failures += int(suite.get("failures", 0))
+        errors += int(suite.get("errors", 0))
+        skipped += int(suite.get("skipped", 0))
+        for case in suite.iter("testcase"):
+            if case.find("failure") is not None or case.find("error") is not None:
+                # Test NAMES are publishable; their failure text is not.
+                failing.append(f"{case.get('classname', '')}::{case.get('name', '')}")
+    failed = failures + errors
+    return total - failed - skipped, failed, skipped, tuple(failing)
+
+
+def render(result: Result, sha: str, markers: str, stamp: str) -> str:
+    headline = {
+        GREEN: "All selected $0 tiers passed.",
+        RED: "A $0 tier failed while auth was healthy — real drift or regression.",
+        AUTH_EXPIRED: "Session rot, not a regression. Re-login and the next run clears it.",
+        DEFERRED: (
+            "A profile precondition blocked the run (lease held, or a profile/engine "
+            "Chromium mismatch). Neutral — nothing reached Flow."
+        ),
+    }[result.state]
+
+    lines = [
+        f"### {result.state} — {stamp}",
+        "",
+        headline,
+        "",
+        f"| commit | `{sha}` |",
+        "| --- | --- |",
+        f"| markers | `{markers}` |",
+        f"| passed | {result.passed} |",
+        f"| failed | {result.failed} |",
+        f"| skipped | {result.skipped} |",
+        f"| duration | {result.duration_s:.1f}s |",
+    ]
+    if result.failing:
+        lines += ["", "**Failing:**", ""]
+        lines += [f"- `{name}`" for name in result.failing]
+    if result.state == RED:
+        lines += ["", "> Canary gates nothing. Triage at your convenience."]
+    return "\n".join(lines)
+
+
+def publish(issue: int, state: str, body: str, stamp: str, dry_run: bool) -> None:
+    title = f"[{state}] gflow nightly canary — {stamp}"
+    if dry_run:
+        print(f"--- DRY RUN: would set title ---\n{title}\n--- would comment ---\n{body}\n")
+        return
+    # Never `gh issue create`: issue spam trains red-blindness (#502).
+    edit = _run(["gh", "issue", "edit", str(issue), "--title", title])
+    if edit.returncode != 0:
+        raise SystemExit(f"gh issue edit failed: {edit.stderr.strip()}")
+    comment = _run(["gh", "issue", "comment", str(issue), "--body", body])
+    if comment.returncode != 0:
+        raise SystemExit(f"gh issue comment failed: {comment.stderr.strip()}")
+    print(f"published {state} to issue #{issue}")
+
+
+def sync_to_develop() -> None:
+    """Fast-forward the checkout to ``origin/develop`` — dedicated clone only.
+
+    #502 wants the canary measuring a pinned checkout, not whatever is in a
+    working tree. This REFUSES on any local modification rather than resetting
+    over it: a nightly task that can silently destroy uncommitted work is a far
+    worse bug than a stale canary. Point the scheduled task at a second clone.
+    """
+    dirty = _run(["git", "status", "--porcelain"]).stdout.strip()
+    if dirty:
+        raise SystemExit(
+            "--pull refuses to run: the checkout has local modifications.\n"
+            "Point the scheduled task at a DEDICATED clone, never your working tree."
+        )
+    if _run(["git", "fetch", "origin", "develop"]).returncode != 0:
+        raise SystemExit("git fetch failed; canary not run")
+    checkout = _run(["git", "checkout", "--force", "origin/develop"])
+    if checkout.returncode != 0:
+        raise SystemExit(f"git checkout failed: {checkout.stderr.strip()}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--profile", default=os.environ.get("GFLOW_CLI_E2E_PROFILE", ""))
+    p.add_argument("--issue", type=int, default=int(os.environ.get("GFLOW_CANARY_ISSUE", 0)))
+    p.add_argument("--markers", default="e2e_auth", help="pytest -m expression ($0 tiers only)")
+    p.add_argument("--dry-run", action="store_true", help="execute, print payload, skip GitHub")
+    p.add_argument("--simulate", choices=STATES, help="force a state to exercise publishing")
+    p.add_argument(
+        "--pull",
+        action="store_true",
+        help="fast-forward to origin/develop first; refuses if the tree is dirty",
+    )
+    args = p.parse_args()
+
+    if args.pull and not args.simulate:
+        sync_to_develop()
+
+    stamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    sha = _run(["git", "rev-parse", "--short", "HEAD"]).stdout.strip() or "unknown"
+
+    if args.simulate:
+        result = Result(
+            state=args.simulate, failing=("tests::simulated",) if args.simulate == RED else ()
+        )
+    else:
+        if not args.profile:
+            raise SystemExit("--profile (or GFLOW_CLI_E2E_PROFILE) is required")
+        if probe_auth(args.profile):
+            rc, output, secs = run_tiers(args.profile, args.markers)
+            passed, failed, skipped, failing = parse_junit(JUNIT_PATH)
+            # Re-probe only when something failed and it was not lease
+            # contention: the post-probe is what separates session rot from a
+            # real divergence, and it costs ~45s we should not spend on a green.
+            after: bool | None = None
+            if rc != 0 and not any(m in output for m in _PRECONDITION_MARKERS):
+                after = probe_auth(args.profile)
+            state = classify(True, rc, output, after)
+            result = Result(state, passed, failed, skipped, secs, failing)
+        else:
+            result = Result(classify(False, None, ""))
+
+    body = render(result, sha, args.markers, stamp)
+    if not args.issue and not args.dry_run:
+        raise SystemExit("--issue (or GFLOW_CANARY_ISSUE) is required; the canary never opens one")
+    publish(args.issue, result.state, body, stamp, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag/README.md
+++ b/scripts/diag/README.md
@@ -9,6 +9,7 @@ These scripts require a live authenticated Chrome profile to run. They are inves
 | `capture_flow_traffic.py` | Capture Flow's outgoing API requests via `page.route` | `gflow auth login` | `uv run python scripts/diag/capture_flow_traffic.py --profile NAME` |
 | `recaptcha_mint.py` | What `site_key` + token does gflow-cli's `TokenMinter` produce? | `gflow auth login` (headed) | `uv run python scripts/diag/recaptcha_mint.py --profile NAME` |
 | `memory_profile.py` | Chrome process-tree RSS at key milestones (issue #155) | `gflow auth login` + `pip install psutil` | `uv run python scripts/diag/memory_profile.py --profile NAME` |
+| `diag_aisandbox_bearer.py` | Is the aisandbox Bearer path broken, or only `uploadImage`? (#561) | `gflow auth login` | `uv run python scripts/diag/diag_aisandbox_bearer.py --profile NAME` |
 
 ## What belongs here
 

--- a/scripts/diag/diag_aisandbox_bearer.py
+++ b/scripts/diag/diag_aisandbox_bearer.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Diagnose issue #561: is the aisandbox Bearer path broken, or just uploadImage?
+
+The nightly canary (#502) caught ``uploadImage`` returning HTTP 401 while
+``gflow auth status`` verified the Flow session clean. The failing call is the
+ONLY aisandbox Bearer call in the ``e2e_auth`` tier, so that run cannot tell
+these apart:
+
+    H-A  uploadImage specifically is being rejected
+    H-B  the whole aisandbox Bearer path is failing, and uploadImage is merely
+         the one place we happen to touch it
+
+This script issues a **read-only** aisandbox call and the uploadImage POST with
+the *same* token, in one session, and prints both statuses. Different statuses
+=> H-A. Both 401 => H-B, which is far more serious.
+
+Cost: $0 — a project create (labs.google tRPC, cookie auth), one entity read,
+and one image upload. None spends a generation credit; none touches reCAPTCHA.
+
+Credentials are never printed: the token is reported by length and prefix only.
+
+Usage:
+    python scripts/diag/diag_aisandbox_bearer.py --profile denon82
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import sys
+from typing import Any
+
+from gflow_cli.api import routes
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.auth import profile_dir as resolve_profile_dir
+
+# Same 1x1 transparent PNG the e2e test uploads — passes the magic-byte check.
+_PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4"
+    "2mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+_AISANDBOX_CONTENT_TYPE = "text/plain;charset=UTF-8"
+
+
+def _report(label: str, status: int, body: str) -> None:
+    verdict = "OK" if status < 400 else "REJECTED"
+    print(f"\n[{verdict}] {label}: HTTP {status}")
+    print(f"        body: {body[:240].strip()}")
+
+
+async def run(profile_name: str, transport: str | None) -> int:
+    profile = resolve_profile_dir(profile_name)
+    if not profile.exists():
+        print(f"profile not found: {profile}", file=sys.stderr)
+        return 2
+
+    kwargs: dict[str, Any] = {"profile_dir": profile}
+    if transport:
+        kwargs["transport"] = transport
+    print(f"transport: {transport or '(default)'}")
+    async with FlowApiClient(**kwargs) as client:
+        # 1. labs.google tRPC, cookie auth — the known-working control. If this
+        #    fails the session really is dead and nothing below means anything.
+        project = await client.create_project(title="diag #561 bearer probe")
+        print(f"[OK] create_project (labs.google tRPC, cookie auth): {project.project_id}")
+
+        # 2. The Bearer token itself, from the BFF session endpoint.
+        token = await client._ensure_access_token()  # noqa: SLF001 - diagnostic
+        looks_right = token.startswith("ya29.")
+        print(
+            f"[OK] access_token from /fx/api/auth/session: "
+            f"len={len(token)} prefix={token[:5]}… ya29={looks_right}"
+        )
+
+        headers: dict[str, str] = await client._aisandbox_auth_headers()  # noqa: SLF001
+        print(f"     header keys sent to aisandbox: {sorted(headers)}")
+
+        ctx = client._context  # noqa: SLF001
+        if ctx is None:
+            print("no browser context", file=sys.stderr)
+            return 2
+
+        # 3. READ-ONLY aisandbox Bearer call. Same token, different endpoint.
+        entities_url = f"{routes.FLOW_ENTITIES_URL}?projectId={project.project_id}"
+        r_read = await ctx.request.get(entities_url, headers=headers)
+        _report("aisandbox GET flow/entities (read-only)", r_read.status, await r_read.text())
+
+        # 4. The failing call, same session, same token.
+        body: dict[str, Any] = {
+            "clientContext": {"projectId": project.project_id, "tool": "PINHOLE"},
+            "imageBytes": base64.b64encode(_PNG_1X1).decode(),
+        }
+        r_up = await ctx.request.post(
+            routes.UPLOAD_IMAGE,
+            headers={**headers, "content-type": _AISANDBOX_CONTENT_TYPE},
+            data=json.dumps(body),
+        )
+        _report("aisandbox POST flow/uploadImage", r_up.status, await r_up.text())
+
+        print("\n--- verdict ---")
+        if r_read.status < 400 and r_up.status >= 400:
+            print("H-A: Bearer auth works; uploadImage specifically is rejected.")
+        elif r_read.status >= 400 and r_up.status >= 400:
+            print("H-B: the whole aisandbox Bearer path is rejected. Escalate.")
+        elif r_up.status < 400:
+            print("Neither reproduces — uploadImage succeeded. Suspect intermittency.")
+        else:
+            print("Mixed result; read the statuses above.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--profile", required=True)
+    p.add_argument("--transport", default=None, help="e.g. evaluate_fetch; omit for default")
+    a = p.parse_args()
+    return asyncio.run(run(a.profile, a.transport))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag/diag_aisandbox_bearer.py
+++ b/scripts/diag/diag_aisandbox_bearer.py
@@ -18,6 +18,8 @@ Cost: $0 — a project create (labs.google tRPC, cookie auth), one entity read,
 and one image upload. None spends a generation credit; none touches reCAPTCHA.
 
 Credentials are never printed: the token is reported by length and prefix only.
+Output DOES include a project id and a truncated authenticated response body —
+review it before pasting into a public issue.
 
 Usage:
     python scripts/diag/diag_aisandbox_bearer.py --profile denon82
@@ -33,7 +35,7 @@ import sys
 from typing import Any
 
 from gflow_cli.api import routes
-from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.client import _AISANDBOX_CONTENT_TYPE, FlowApiClient
 from gflow_cli.auth import profile_dir as resolve_profile_dir
 
 # Same 1x1 transparent PNG the e2e test uploads — passes the magic-byte check.
@@ -41,7 +43,6 @@ _PNG_1X1 = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4"
     "2mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 )
-_AISANDBOX_CONTENT_TYPE = "text/plain;charset=UTF-8"
 
 
 def _report(label: str, status: int, body: str) -> None:
@@ -104,10 +105,10 @@ async def run(profile_name: str, transport: str | None) -> int:
             print("H-A: Bearer auth works; uploadImage specifically is rejected.")
         elif r_read.status >= 400 and r_up.status >= 400:
             print("H-B: the whole aisandbox Bearer path is rejected. Escalate.")
-        elif r_up.status < 400:
-            print("Neither reproduces — uploadImage succeeded. Suspect intermittency.")
         else:
-            print("Mixed result; read the statuses above.")
+            # r_up < 400 is the only remaining case: the three arms are a total
+            # cover, so a trailing `else` here would be unreachable.
+            print("Neither reproduces — uploadImage succeeded. Suspect intermittency.")
     return 0
 
 

--- a/tests/scripts/test_canary_classify.py
+++ b/tests/scripts/test_canary_classify.py
@@ -142,3 +142,25 @@ def test_engine_downgrade_is_deferred_not_red() -> None:
         "by a newer Chromium: 151.0.7922.137 vs 149.0.7827.55"
     )
     assert classify(auth_ok_before=True, pytest_rc=1, failure_text=downgrade) == DEFERRED
+
+
+def test_preserve_evidence_copies_junit_under_a_stamped_name(tmp_path, monkeypatch) -> None:
+    """A RED must stay triageable after the next run overwrites the JUnit file."""
+    from scripts.canary import run_canary
+
+    junit = tmp_path / "canary-junit.xml"
+    junit.write_text("<testsuites/>", encoding="utf-8")
+    monkeypatch.setattr(run_canary, "JUNIT_PATH", junit)
+
+    kept = run_canary.preserve_evidence("2026-08-20 21:05 UTC")
+    assert kept is not None
+    assert kept.exists() and kept != junit
+    assert kept.read_text(encoding="utf-8") == "<testsuites/>"
+
+
+def test_preserve_evidence_is_a_noop_when_pytest_wrote_nothing(tmp_path, monkeypatch) -> None:
+    """A crashed pytest leaves no XML; preserving must not raise on the way to publishing."""
+    from scripts.canary import run_canary
+
+    monkeypatch.setattr(run_canary, "JUNIT_PATH", tmp_path / "absent.xml")
+    assert run_canary.preserve_evidence("2026-08-20 21:05 UTC") is None

--- a/tests/scripts/test_canary_classify.py
+++ b/tests/scripts/test_canary_classify.py
@@ -1,0 +1,144 @@
+"""Unit tests for the nightly canary's verdict function (#502).
+
+The canary's value rests entirely on RED meaning one thing: "code or Flow
+drifted". The two ways to destroy that are classifying session rot as RED
+(trains "just re-login", so real reds get ignored) and classifying a lease
+collision as RED (fires whenever the maintainer had Chrome open). Both are
+checked here, including the ordering that keeps them ahead of the generic
+failure arm.
+
+#502's DoD requires all four states to be reachable — this is that proof.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.canary.run_canary import (
+    AUTH_EXPIRED,
+    DEFERRED,
+    GREEN,
+    RED,
+    Result,
+    classify,
+    parse_junit,
+    render,
+)
+
+_LEASE_TRACEBACK = (
+    "E   gflow_cli.errors.ProfileLockedError: Profile locked\nE   A live process holds this profile"
+)
+_AUTH_TRACEBACK = "E   gflow_cli.errors.AuthMissingError: no saved session"
+_DRIFT_TRACEBACK = "E   gflow_cli.errors.UiSelectorDriftError: composer probe failed"
+
+
+def test_all_passing_is_green() -> None:
+    assert classify(auth_ok_before=True, pytest_rc=0, failure_text="") == GREEN
+
+
+def test_failed_auth_probe_short_circuits_to_auth_expired() -> None:
+    """The probe runs first, so the suite never ran — pytest_rc is None."""
+    assert classify(auth_ok_before=False, pytest_rc=None, failure_text="") == AUTH_EXPIRED
+
+
+def test_genuine_failure_is_red() -> None:
+    assert (
+        classify(
+            auth_ok_before=True, pytest_rc=1, failure_text=_DRIFT_TRACEBACK, auth_ok_after=True
+        )
+        == RED
+    )
+
+
+def test_lease_collision_is_deferred_not_red() -> None:
+    """Maintainer had gflow open. Neutral — nothing ran, nothing is broken."""
+    assert classify(auth_ok_before=True, pytest_rc=1, failure_text=_LEASE_TRACEBACK) == DEFERRED
+
+
+def test_mid_run_session_rot_is_auth_expired_not_red() -> None:
+    """Healthy at the start, dead at the end: genuine rot, not drift."""
+    assert (
+        classify(
+            auth_ok_before=True, pytest_rc=1, failure_text=_AUTH_TRACEBACK, auth_ok_after=False
+        )
+        == AUTH_EXPIRED
+    )
+
+
+def test_auth_shaped_failure_with_a_still_valid_session_is_red() -> None:
+    """Regression guard for the first live run (2026-08-20).
+
+    ``test_rest_upload_image_authenticates_after_sapisidhash`` failed with
+    ``AuthExpiredError``, yet ``gflow auth status`` verified clean immediately
+    afterwards. That is a real divergence between two auth surfaces, not
+    session rot. A name-matching classifier reported it correctly only by
+    accident (its list had missed ``AuthExpiredError`` entirely) — and once
+    "fixed" by adding the name, it would have buried the finding as
+    AUTH-EXPIRED. The still-valid session is what makes this RED.
+    """
+    aisandbox = "E   gflow_cli.errors.AuthExpiredError: Authentication expired: Unauthorized"
+    assert (
+        classify(auth_ok_before=True, pytest_rc=1, failure_text=aisandbox, auth_ok_after=True)
+        == RED
+    )
+
+
+def test_lease_marker_wins_over_a_concurrent_drift_message() -> None:
+    """Ordering guard: a lease collision can abort a test whose output also
+    mentions drift. Contention is the cause; reporting RED would be a lie."""
+    combined = f"{_DRIFT_TRACEBACK}\n{_LEASE_TRACEBACK}"
+    assert classify(auth_ok_before=True, pytest_rc=1, failure_text=combined) == DEFERRED
+
+
+@pytest.mark.parametrize("state", [GREEN, RED, AUTH_EXPIRED, DEFERRED])
+def test_every_state_renders(state: str) -> None:
+    """#502 DoD: all four states reachable and renderable."""
+    body = render(Result(state=state), sha="abc1234", markers="e2e_auth", stamp="2026-08-20")
+    assert state in body
+    assert "abc1234" in body
+
+
+def test_render_publishes_test_names_but_no_failure_text() -> None:
+    """Sanitization contract: names are publishable, tracebacks are not."""
+    result = Result(state=RED, failed=1, failing=("tests.e2e.test_x::test_y",))
+    body = render(result, sha="abc1234", markers="e2e_auth", stamp="2026-08-20")
+    assert "tests.e2e.test_x::test_y" in body
+    assert "ProfileLockedError" not in body
+    assert "Traceback" not in body
+
+
+def test_parse_junit_counts_and_names(tmp_path) -> None:
+    xml = tmp_path / "j.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><testsuites><testsuite tests="3" failures="1" '
+        'errors="0" skipped="1">'
+        '<testcase classname="tests.e2e.test_a" name="test_ok"/>'
+        '<testcase classname="tests.e2e.test_a" name="test_bad"><failure>boom</failure></testcase>'
+        '<testcase classname="tests.e2e.test_a" name="test_skip"><skipped/></testcase>'
+        "</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    passed, failed, skipped, failing = parse_junit(xml)
+    assert (passed, failed, skipped) == (1, 1, 1)
+    assert failing == ("tests.e2e.test_a::test_bad",)
+
+
+def test_parse_junit_missing_file_is_empty_not_an_error() -> None:
+    """A crashed pytest writes no XML; the canary must still report, not blow up."""
+    assert parse_junit(pytest.importorskip("pathlib").Path("does-not-exist.xml")) == (0, 0, 0, ())
+
+
+def test_engine_downgrade_is_deferred_not_red() -> None:
+    """Second gap found on the first live run (2026-08-20).
+
+    Running against the other profile hit ProfileEngineDowngradeError (profile
+    written by Chromium 151, bundled engine 149). Like ProfileLockedError — its
+    named sibling in errors.py — it fails closed BEFORE any browser starts, so
+    the run never reached Flow and cannot evidence drift. Both share
+    ConfigurationError's exit 11, so only the class name discriminates.
+    """
+    downgrade = (
+        "E   gflow_cli.errors.ProfileEngineDowngradeError: Profile was written "
+        "by a newer Chromium: 151.0.7922.137 vs 149.0.7827.55"
+    )
+    assert classify(auth_ok_before=True, pytest_rc=1, failure_text=downgrade) == DEFERRED

--- a/tests/scripts/test_canary_classify.py
+++ b/tests/scripts/test_canary_classify.py
@@ -21,6 +21,7 @@ from scripts.canary.run_canary import (
     RED,
     Result,
     classify,
+    is_precondition_failure,
     parse_junit,
     render,
 )
@@ -123,9 +124,14 @@ def test_parse_junit_counts_and_names(tmp_path) -> None:
     assert failing == ("tests.e2e.test_a::test_bad",)
 
 
-def test_parse_junit_missing_file_is_empty_not_an_error() -> None:
-    """A crashed pytest writes no XML; the canary must still report, not blow up."""
-    assert parse_junit(pytest.importorskip("pathlib").Path("does-not-exist.xml")) == (0, 0, 0, ())
+def test_parse_junit_missing_file_is_empty_not_an_error(tmp_path) -> None:
+    """A crashed pytest writes no XML; the canary must still report, not blow up.
+
+    Uses tmp_path, not a CWD-relative name: a stray file of that name in the
+    working directory would send this down the parse branch and pass for the
+    wrong reason.
+    """
+    assert parse_junit(tmp_path / "absent.xml") == (0, 0, 0, ())
 
 
 def test_engine_downgrade_is_deferred_not_red() -> None:
@@ -164,3 +170,126 @@ def test_preserve_evidence_is_a_noop_when_pytest_wrote_nothing(tmp_path, monkeyp
 
     monkeypatch.setattr(run_canary, "JUNIT_PATH", tmp_path / "absent.xml")
     assert run_canary.preserve_evidence("2026-08-20 21:05 UTC") is None
+
+
+# --- council-review regression guards (PR #560) -----------------------------
+
+
+def test_marker_mentioned_in_source_does_not_demote_a_real_failure() -> None:
+    """The worst failure mode a canary can have: publishing drift as 'ignore me'.
+
+    Two tests in the e2e_auth tier mention ProfileLockedError in ordinary source
+    — `test_incident_quality_e2e.py:123` in an assertion message and
+    `test_cancellation_e2e.py:124` in a COMMENT — and pytest echoes the failing
+    function's source into its traceback. A bare substring match therefore
+    classified a genuine regression in those tests as DEFERRED. Anchoring on the
+    raised-exception line is what fixes it.
+    """
+    echoed_source = (
+        "    # cannot raise ProfileLockedError here.\n"
+        '>   assert lock is not None, "no ProfileLockedError (contention) bundle produced"\n'
+        "E   AssertionError: no ProfileLockedError (contention) bundle produced\n"
+    )
+    assert not is_precondition_failure(echoed_source)
+    assert classify(True, 1, echoed_source, auth_ok_after=True) == RED
+
+
+def test_real_raised_precondition_is_still_deferred() -> None:
+    """Control for the guard above: the genuine raised form must still match."""
+    raised = "E   gflow_cli.errors.ProfileLockedError: Profile locked\n"
+    assert is_precondition_failure(raised)
+    assert classify(True, 1, raised) == DEFERRED
+
+
+def test_all_skipped_run_is_not_green() -> None:
+    """pytest exits 0 when every test skips; every e2e test skips on a missing
+    profile dir. Reporting that as GREEN would pin the dashboard green forever."""
+    assert classify(True, 0, "", passed=0) == DEFERRED
+    assert classify(True, 0, "", passed=3) == GREEN
+
+
+def test_red_arm_requires_an_explicitly_false_post_probe() -> None:
+    """Guards the None-vs-False distinction: a `not auth_ok_after` regression
+    would silently downgrade every RED to AUTH-EXPIRED."""
+    drift = "E   gflow_cli.errors.UiSelectorDriftError: composer probe failed"
+    assert classify(True, 1, drift, auth_ok_after=None) == RED
+    assert classify(True, 1, drift, auth_ok_after=True) == RED
+    assert classify(True, 1, drift, auth_ok_after=False) == AUTH_EXPIRED
+
+
+def test_parametrize_ids_never_reach_the_published_body(tmp_path) -> None:
+    """A param id can carry a filesystem path, an email, or a prompt. Reproduced
+    against the real render path before the fix; this pins it shut."""
+    # Assembled at runtime, not a literal: check_repo_hygiene.py forbids
+    # hardcoded Windows user paths in source, and this test needs one as DATA.
+    win_path = "\\".join(["C:", "Users", "someone", "AppData", "profile_denon82"])
+    leaky = f"test_p[{win_path}]"
+    xml = tmp_path / "j.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><testsuites>'
+        '<testsuite tests="1" failures="1" errors="0" skipped="0">'
+        f'<testcase classname="tests.e2e.test_x" name="{leaky}">'
+        "<failure>secret traceback</failure></testcase>"
+        "</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    _, _, _, failing = parse_junit(xml)
+    body = render(Result(RED, 0, 1, 0, 1.0, failing), "abc1234", "e2e_auth", "2026-08-21")
+    assert "profile_denon82" not in body
+    assert "secret traceback" not in body
+    assert "tests.e2e.test_x::test_p" in body
+
+
+def test_parse_junit_counts_error_elements(tmp_path) -> None:
+    """A fixture/setup error is the common e2e failure shape; it must count as
+    failed, not inflate `passed`."""
+    xml = tmp_path / "j.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><testsuites>'
+        '<testsuite tests="2" failures="0" errors="1" skipped="0">'
+        '<testcase classname="t" name="ok"/>'
+        '<testcase classname="t" name="boom"><error>setup failed</error></testcase>'
+        "</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    passed, failed, skipped, failing = parse_junit(xml)
+    assert (passed, failed, skipped) == (1, 1, 0)
+    assert failing == ("t::boom",)
+
+
+def test_parse_junit_aggregates_multiple_suites(tmp_path) -> None:
+    xml = tmp_path / "j.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><testsuites>'
+        '<testsuite tests="2" failures="1" errors="0" skipped="0">'
+        '<testcase classname="a" name="ok"/>'
+        '<testcase classname="a" name="bad"><failure>x</failure></testcase></testsuite>'
+        '<testsuite tests="1" failures="0" errors="0" skipped="0">'
+        '<testcase classname="b" name="ok2"/></testsuite>'
+        "</testsuites>",
+        encoding="utf-8",
+    )
+    passed, failed, _, failing = parse_junit(xml)
+    assert (passed, failed) == (2, 1)
+    assert failing == ("a::bad",)
+
+
+def test_sync_refuses_a_dirty_tree_and_reports_rather_than_dying(monkeypatch) -> None:
+    """A dirty tree must publish DEFERRED, not exit silently — silence is
+    indistinguishable from 'the machine was off'."""
+    from scripts.canary import run_canary
+
+    calls: list[list[str]] = []
+
+    class _Proc:
+        def __init__(self, out: str = "", rc: int = 0) -> None:
+            self.stdout, self.returncode = out, rc
+
+    def fake_run(cmd, env=None, timeout=None):  # noqa: ANN001, ANN202
+        calls.append(cmd)
+        return _Proc(out="?? stray.txt" if cmd[:3] == ["git", "status", "--porcelain"] else "")
+
+    monkeypatch.setattr(run_canary, "_run", fake_run)
+    reason = run_canary.sync_to_develop()
+    assert reason is not None and "local modifications" in reason
+    assert not any("checkout" in c for c in calls), "must not touch the tree it refused"

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -168,7 +168,7 @@ a machine that might be off is self-DoS).
 | `GREEN` | every selected $0 tier passed | none |
 | `RED` | auth healthy, a $0 tier failed | **real drift or regression** — triage |
 | `AUTH-EXPIRED` | session rot (expected) | `gflow auth login` |
-| `DEFERRED` | profile precondition blocked it | fix the profile — nothing ran |
+| `DEFERRED` | nothing conclusive ran | fix the profile / config — says nothing about Flow |
 
 Splitting the last two out of `RED` is the point: `RED` must always mean "code or
 Flow drifted", never "please re-login" or "you had Chrome open". The classifier is
@@ -176,7 +176,8 @@ a pure function with all four states covered in
 `tests/scripts/test_canary_classify.py`.
 
 **Rot vs. drift is decided by a second probe, not by error names.** When a tier
-fails, the canary re-runs `gflow auth status`. Session still valid ⇒ the failure is
+fails for a reason other than a profile precondition, the canary re-runs
+`gflow auth status`. Session still valid ⇒ the failure is
 drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
 proved why this matters: an `AuthExpiredError` from the aisandbox upload path
 *looked* exactly like session rot, but the session verified clean seconds later —
@@ -184,11 +185,21 @@ so it was a real divergence between two auth surfaces, and a name-matching
 classifier would have buried it. The extra probe costs ~45s and only runs after a
 failure.
 
-`DEFERRED` covers **profile-state preconditions** — a held `ProfileLease` or a
+`DEFERRED` covers every run that **exercised nothing**: a held `ProfileLease`, a
 `ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
-engine). Both fail closed before any browser starts, so the run never reached Flow
-and cannot evidence drift. They share `ConfigurationError`'s exit 11, so the class
-name is the only discriminator.
+engine), a refused `--pull`, or a run where every selected test skipped. All fail
+before reaching Flow, so none can evidence drift.
+
+Two subtleties, both found by council review and both regression-tested:
+
+- **A precondition is matched on the raised exception, never a substring.** Two
+  `e2e_auth` tests mention `ProfileLockedError` in ordinary source — one in an
+  assertion message, one in a comment — and pytest echoes the failing function's
+  source into its traceback. Substring matching therefore published a genuine
+  regression in those tests as `DEFERRED`, the one label that says "ignore me".
+- **A green run that executed nothing is not green.** pytest exits 0 when every
+  test skips, and every e2e test skips on a missing profile directory. `GREEN`
+  requires `passed > 0`.
 
 Because the issue carries a last-updated timestamp, a machine that was off is
 *visibly stale* — unlike a lingering green commit status, which lies.
@@ -203,11 +214,12 @@ tiers (`e2e_image` / `e2e_video` / `smoke`) stay **strictly manual** via
 
 ```bash
 # dry run — executes for real, prints the payload, touches nothing on GitHub
-python scripts/canary/run_canary.py --profile <name> --dry-run
-
-# exercise any state's publish path without waiting for the condition
-python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
+uv run python scripts/canary/run_canary.py --profile <name> --dry-run
 ```
+
+Credit-spending markers (`e2e_image`, `e2e_video`, `e2e_batch`, `e2e_character`,
+`smoke`) are **refused outright** — the canary never spends credits unattended.
+Run those manually via `/gflow:live-verify`.
 
 ### Schedule it
 
@@ -217,8 +229,10 @@ python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
 ```
 
 Point `-RepoRoot` at a **dedicated clone**, never your working tree: the runner's
-`--pull` refuses to run on a dirty checkout rather than resetting over
-uncommitted work, so a shared tree would simply never run.
+`--pull` refuses a dirty checkout rather than resetting over uncommitted work, and
+reports that refusal as `DEFERRED` rather than exiting silently. `--pull` also
+re-syncs dependencies, so a lockfile bump on `develop` cannot masquerade as a
+`RED` import error.
 
 Publishing uses your already-authenticated local `gh` — **no new secrets or
 tokens**. Published content is sanitized for a public repo: SHA, pass/fail

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -149,6 +149,84 @@ See [DEVELOPMENT.md § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop-
 
 ---
 
+## Nightly canary (#502)
+
+Between releases the live tiers are invisible, so Flow-side drift (cohort flaps,
+selector renames, auth rot) surfaces ad-hoc during feature work instead of on a
+schedule. The canary closes that gap.
+
+It runs **locally, not in hosted CI** — the live tiers need a real authenticated
+Chrome profile, and Google bot-detection plus reCAPTCHA make hosted auth
+infeasible. Results are published to a single **rolling issue**; the canary never
+opens new ones (issue spam trains red-blindness) and **gates nothing** (a gate on
+a machine that might be off is self-DoS).
+
+### Four states
+
+| State | Meaning | Action |
+|---|---|---|
+| `GREEN` | every selected $0 tier passed | none |
+| `RED` | auth healthy, a $0 tier failed | **real drift or regression** — triage |
+| `AUTH-EXPIRED` | session rot (expected) | `gflow auth login` |
+| `DEFERRED` | profile precondition blocked it | fix the profile — nothing ran |
+
+Splitting the last two out of `RED` is the point: `RED` must always mean "code or
+Flow drifted", never "please re-login" or "you had Chrome open". The classifier is
+a pure function with all four states covered in
+`tests/scripts/test_canary_classify.py`.
+
+**Rot vs. drift is decided by a second probe, not by error names.** When a tier
+fails, the canary re-runs `gflow auth status`. Session still valid ⇒ the failure is
+drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
+proved why this matters: an `AuthExpiredError` from the aisandbox upload path
+*looked* exactly like session rot, but the session verified clean seconds later —
+so it was a real divergence between two auth surfaces, and a name-matching
+classifier would have buried it. The extra probe costs ~45s and only runs after a
+failure.
+
+`DEFERRED` covers **profile-state preconditions** — a held `ProfileLease` or a
+`ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
+engine). Both fail closed before any browser starts, so the run never reached Flow
+and cannot evidence drift. They share `ConfigurationError`'s exit 11, so the class
+name is the only discriminator.
+
+Because the issue carries a last-updated timestamp, a machine that was off is
+*visibly stale* — unlike a lingering green commit status, which lies.
+
+### Scope
+
+`-m e2e_auth` only ($0, no reCAPTCHA); fast-follow adds `e2e_scene` ($0). Credit
+tiers (`e2e_image` / `e2e_video` / `smoke`) stay **strictly manual** via
+`/gflow:live-verify` — no unattended credit spend on a personal account.
+
+### Run it
+
+```bash
+# dry run — executes for real, prints the payload, touches nothing on GitHub
+python scripts/canary/run_canary.py --profile <name> --dry-run
+
+# exercise any state's publish path without waiting for the condition
+python scripts/canary/run_canary.py --simulate AUTH-EXPIRED --dry-run
+```
+
+### Schedule it
+
+```powershell
+.\scripts\canary\register_task.ps1 -Profile <name> -Issue <n> `
+    -RepoRoot C:\path\to\dedicated\clone
+```
+
+Point `-RepoRoot` at a **dedicated clone**, never your working tree: the runner's
+`--pull` refuses to run on a dirty checkout rather than resetting over
+uncommitted work, so a shared tree would simply never run.
+
+Publishing uses your already-authenticated local `gh` — **no new secrets or
+tokens**. Published content is sanitized for a public repo: SHA, pass/fail
+counts, duration, failure class, and failing test *names* only — never raw logs,
+profile paths, prompts, or signed URLs.
+
+---
+
 ## File map
 
 ```


### PR DESCRIPTION
## Summary

Implements the council-adjudicated canary from #502: a **local** nightly run of the
$0 live tiers, publishing a sanitized verdict to a rolling GitHub issue (#559).

Hosted CI can't cover the live tiers — they need a real authenticated Chrome
profile, and Google bot-detection plus reCAPTCHA make hosted auth infeasible. So
the run happens where the warm profile already lives, and reports to GitHub.

## Design decisions

**Rot vs. drift is decided by a second probe, not by error names.** When a tier
fails, the canary re-runs `gflow auth status`. Session still valid ⇒ drift (`RED`);
session now dead ⇒ genuine rot (`AUTH-EXPIRED`). Costs ~45s, and only after a failure.

**`DEFERRED` covers profile-state preconditions** — a held `ProfileLease` or a
`ProfileEngineDowngradeError`. Both fail closed before any browser starts, so the run
never reached Flow and cannot evidence drift. They share `ConfigurationError`'s exit
11, so the class name is the only discriminator.

**Keeping `AUTH-EXPIRED` and `DEFERRED` out of `RED` is the whole point.** `RED` must
always mean "code or Flow drifted", never "please re-login" or "you had Chrome open".

**Gates nothing, never opens issues.** A gate on a machine that might be off is
self-DoS; an issue per night trains red-blindness. Publishing uses the maintainer's
already-authenticated `gh` — no new secrets.

**`--pull` refuses a dirty checkout** rather than resetting over it. A nightly task
that can destroy uncommitted work is worse than a stale canary, so the scheduled task
must point at a dedicated clone.

## What the first live run found

Ran for real against `denon82` before this was committed: **17 passed, 1 failed, 1
skipped, 150s** → `RED`. It caught two classifier bugs in the canary itself:

1. `AuthExpiredError` / `AisandboxAuthError` were missing from the hardcoded auth
   marker list — the verdict was right only by accident.
2. The obvious fix (add the name) would have **masked a real finding**: the session
   verified clean immediately after the failure, so the aisandbox `uploadImage` 401
   is a divergence between two auth surfaces, not rot. That motivated replacing name
   matching with the post-run probe.

A third gap surfaced running against the other profile: `ProfileEngineDowngradeError`
would have reported `RED`. Hence the `DEFERRED` widening.

The underlying `uploadImage` failure is **not fixed here** — it's on the experimental
`evaluate_fetch` transport, and needs its own issue once scoped.

## Test plan

- [x] 15 unit tests on the verdict function, incl. regression guards for all three gaps
- [x] All four states render and publish (`--simulate` × 4)
- [x] `gh` publish path verified end to end against #559
- [x] Live auth probe verified on two profiles
- [x] `--pull` dirty-tree refusal verified
- [x] ruff check + format, `check_doc_links.py`, `check_repo_hygiene.py`
- [ ] Scheduled task registration — deliberately deferred until the RED is triaged

Refs #502
