### PR TITLE
docs: selector registry + drift probe — design and implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -31,7 +31,7 @@
 
 **Interfaces:**
 - Consumes: `gflow_cli.config.UiMode`; the existing constants in `mode_control` / `ui_automation`.
-- Produces: `Surface`, `Selector`, `Grade`, `Outcome`, `grade(...)`, `SURFACES`, `SELECTORS`, `by_key()`, `for_surface()`.
+- Produces: `Surface`, `Selector`, `Grade`, `Outcome`, `grade(...)`, `SURFACES`, `SELECTORS`, `for_surface()`.
 
 - [ ] **Step 1: Write the failing model + grading tests**
 
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import pytest
 
-from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors.model import Selector, Surface
 
 
@@ -305,19 +304,16 @@ def test_state_gated_families_are_deliberately_absent() -> None:
 
 
 def test_incident_families_are_registered() -> None:
-    for key in ("editor.composer.input", "editor.composer.submit",
-                "editor.agent_toggle", "editor.crop_control"):
-        registry.by_key(key)  # raises KeyError if missing
+    keys = {s.key for s in registry.SELECTORS}
+    assert keys >= {"editor.composer.input", "editor.composer.submit",
+                    "editor.agent_toggle", "editor.crop_control"}
 
 
-def test_by_key_raises_for_unknown() -> None:
-    with pytest.raises(KeyError):
-        registry.by_key("editor.nope")
-
-
-def test_for_surface_filters_by_mode() -> None:
-    agentic = {s.key for s in registry.for_surface("editor", mode=UiMode.AGENTIC)}
-    assert "editor.crop_control" not in agentic
+def test_for_surface_returns_every_entry_including_mode_scoped_ones() -> None:
+    """Mode belongs to grading, not selection — a mode-scoped entry must still
+    reach the report as EXPECTED_ABSENT rather than vanishing from it."""
+    keys = {s.key for s in registry.for_surface("editor")}
+    assert "editor.crop_control" in keys
 
 
 ```
@@ -359,7 +355,9 @@ SELECTORS: tuple[Selector, ...] = (
         key="editor.composer.submit",
         surface="editor",
         candidates=tuple(ui_automation.SUBMIT_BUTTON_SELECTORS),
-        expect_unique=True,
+        note="NOT expect_unique: scripts/dev/capture_i2v_post_bind_state.py "
+        "exists because this can legitimately match a top-level submit, an "
+        "in-panel submit and a Send-to-Agent submit at once.",
     ),
     Selector(
         key="editor.agent_toggle",
@@ -379,19 +377,15 @@ SELECTORS: tuple[Selector, ...] = (
     ),
 )
 
-_BY_KEY = {s.key: s for s in SELECTORS}
+def for_surface(surface_key: str) -> tuple[Selector, ...]:
+    """Every entry on a surface, in registry order.
 
-
-def by_key(key: str) -> Selector:
-    return _BY_KEY[key]
-
-
-def for_surface(surface_key: str, mode: UiMode | None = None) -> tuple[Selector, ...]:
-    return tuple(
-        s
-        for s in SELECTORS
-        if s.surface == surface_key and (mode is None or s.mode is None or s.mode == mode)
-    )
+    Deliberately does NOT filter by mode. Mode belongs to grading, not
+    selection: a mode-scoped entry absent on the other arm must still appear in
+    the report as EXPECTED_ABSENT, or the report silently shrinks and nobody
+    notices coverage was skipped.
+    """
+    return tuple(s for s in SELECTORS if s.surface == surface_key)
 ```
 
 - [ ] **Step 8: Run the whole suite, lint, commit**
@@ -418,14 +412,19 @@ Refs #404 #493 #313"
 ### Task 2: CI probe
 
 **Files:**
-- Create: `src/gflow_cli/flow_selectors/check.py`
 - Create: `scripts/probe/run_probe.py`
 - Create: `.github/workflows/selector-probe.yml`
 - Test: `tests/flow_selectors/test_report.py`
 
 **Interfaces:**
 - Consumes: `registry`, `grade`, `Outcome`.
-- Produces: `async check_html(html, entries, observed_mode) -> list[Outcome]`; `render_report(outcomes) -> str`.
+- Produces: `render_report(outcomes) -> str`; `async resolve(page, entries, mode) -> list[Outcome]`.
+
+> **No `check_html` / no static re-parse.** An earlier draft closed the live page,
+> launched a *second* chromium and re-parsed `page.content()` through
+> `set_content()` — which drops external CSS/JS and shadow roots, making it
+> strictly lower fidelity than the live page it had just discarded. It was
+> residue from the cut snapshot layer. Resolve against the live `page`.
 
 - [ ] **Step 1: Write the failing report test** (pure — no browser, so it is safe in the default suite)
 
@@ -455,6 +454,15 @@ def test_ambiguous_is_reported_as_a_failure() -> None:
     assert "1 need" in body
 
 
+def test_alternate_state_names_are_stable_report_vocabulary() -> None:
+    """R8: the two known zero-click states must be enumerable, or an executor
+    cannot tell 'panel covering the composer' from 'Google moved it'."""
+    from scripts.probe.run_probe import _ALTERNATE_STATE_INDICATORS
+
+    labels = {label for label, _ in _ALTERNATE_STATE_INDICATORS}
+    assert labels == {"expanded chat sidebar", "agent chat panel"}
+
+
 def test_expected_absent_is_visible_but_not_a_failure() -> None:
     """A mode-scoped entry absent on the other arm must still appear, or the
     report silently shrinks and nobody notices coverage was skipped."""
@@ -468,51 +476,7 @@ def test_expected_absent_is_visible_but_not_a_failure() -> None:
 Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_report.py -v`
 Expected: FAIL — `No module named 'scripts.probe.run_probe'`
 
-- [ ] **Step 3: Implement check + probe**
-
-```python
-# src/gflow_cli/flow_selectors/check.py
-"""Resolve registry candidates against DOM text and grade them.
-
-Needs a headless chromium only for Playwright's selector engines; no network,
-auth or credits. Asserts STRUCTURAL PRESENCE only — set_content() drops
-external CSS/JS and page.content() omits shadow roots, so visible/enabled is
-out of scope for both callers.
-"""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-
-from playwright.async_api import async_playwright
-
-from gflow_cli.config import UiMode
-from gflow_cli.flow_selectors.grading import Outcome, grade
-from gflow_cli.flow_selectors.model import Selector
-
-
-async def check_html(
-    html: str, entries: Sequence[Selector], observed_mode: UiMode | None = None
-) -> list[Outcome]:
-    results: list[Outcome] = []
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch(headless=True)
-        try:
-            page = await browser.new_page()
-            await page.set_content(html)
-            for entry in entries:
-                index: int | None = None
-                count = 0
-                for i, candidate in enumerate(entry.candidates):
-                    count = await page.locator(candidate).count()
-                    if count:
-                        index = i
-                        break
-                results.append(grade(entry, index, count, observed_mode))
-        finally:
-            await browser.close()
-    return results
-```
+- [ ] **Step 3: Implement the probe**
 
 ```python
 # scripts/probe/run_probe.py
@@ -531,15 +495,17 @@ import argparse
 import asyncio
 import os
 import sys
+from collections.abc import Sequence
 
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright
 
+from gflow_cli.api.transports import mode_control, ui_automation_video
 from gflow_cli.api.transports.drivers import factory
 from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors import registry
-from gflow_cli.flow_selectors.check import check_html
-from gflow_cli.flow_selectors.grading import Grade, Outcome
+from gflow_cli.flow_selectors.grading import Grade, Outcome, grade
+from gflow_cli.flow_selectors.model import Selector
 
 SESSION_COOKIE = "__Secure-next-auth.session-token"
 _LABEL = {
@@ -558,6 +524,53 @@ def render_report(outcomes: list[Outcome]) -> str:
     bad = [o.selector_key for o in outcomes if o.is_failure]
     lines += ["", f"**{len(bad)} need attention**" if bad else "**0 need attention.**"]
     return "\n".join(lines)
+
+
+# Known ZERO-CLICK alternate states. Neither is drift, and both hide the
+# composer, so grading through them would report drift that did not happen.
+#   mode_control.py:66-84  — an expanded chat sidebar "removes the classic
+#                            composer entirely... no crop_* trigger AND no Agent pill"
+#   ui_automation_video.py:149-153 — a chat panel "appears on some project opens
+#                            and not others"; while up "the in-composer pill is
+#                            NOT in the DOM at all"
+_ALTERNATE_STATE_INDICATORS: tuple[tuple[str, str], ...] = (
+    ("expanded chat sidebar", mode_control.SIDEBAR_CLOSE_SELECTOR),
+    ("agent chat panel", ui_automation_video.AGENT_CHAT_PANEL_CLOSE_SELECTOR),
+)
+
+
+async def alternate_state(page: object) -> str | None:
+    """Name the known alternate state the editor is in, if any.
+
+    This is the difference between "the composer is gone because Google moved
+    it" (drift, exit 1) and "the composer is gone because a panel is covering
+    it" (inconclusive, exit 2). Three of the four registered selectors are
+    absent in these states, so without this gate a cohort flap reads as drift.
+    """
+    for label, selector in _ALTERNATE_STATE_INDICATORS:
+        if await page.locator(selector).count():  # type: ignore[attr-defined]
+            return label
+    return None
+
+
+async def resolve(page: object, entries: Sequence[Selector], mode: UiMode) -> list[Outcome]:
+    """Resolve each entry against the LIVE page and grade it.
+
+    Against the live page, not a re-parsed copy: set_content() drops external
+    CSS/JS and page.content() omits shadow roots, so a static round-trip is
+    strictly lower fidelity than the page already open here.
+    """
+    results: list[Outcome] = []
+    for entry in entries:
+        index: int | None = None
+        count = 0
+        for i, candidate in enumerate(entry.candidates):
+            count = await page.locator(candidate).count()  # type: ignore[attr-defined]
+            if count:
+                index = i
+                break
+        results.append(grade(entry, index, count, mode))
+    return results
 
 
 async def run(token: str, project_id: str, surface_key: str) -> int:
@@ -600,11 +613,15 @@ async def run(token: str, project_id: str, surface_key: str) -> int:
                 if await factory._any_present(page, factory._CLASSIC_CROP_SELECTORS)  # noqa: SLF001
                 else UiMode.AGENTIC
             )
-            html = await page.content()
+            blocked = await alternate_state(page)
+            if blocked is not None:
+                # NOT drift: a known cohort/load state hides the composer.
+                print(f"::warning::editor is in a known alternate state ({blocked})")
+                return 2
+            outcomes = await resolve(page, registry.for_surface(surface_key), mode)
         finally:
             await browser.close()
 
-    outcomes = await check_html(html, registry.for_surface(surface_key), mode)
     print(f"observed mode: {mode.value}")
     print(render_report(outcomes))
     return 1 if any(o.is_failure for o in outcomes) else 0
@@ -673,7 +690,7 @@ code. Never use `pull_request_target`.
 .venv/Scripts/python.exe -m ruff format --check src tests
 .venv/Scripts/python.exe scripts/ci/check_repo_hygiene.py
 .venv/Scripts/python.exe -m pytest tests/flow_selectors tests/scripts -v
-git add src/gflow_cli/flow_selectors/check.py scripts/probe/run_probe.py .github/workflows/selector-probe.yml tests/flow_selectors/test_report.py
+git add scripts/probe/run_probe.py .github/workflows/selector-probe.yml tests/flow_selectors/test_report.py
 git commit -m "feat(probe): CI selector-drift probe on a single session cookie
 
 Exit 2 (infrastructure) stays distinct from exit 1 (drift): an expired token or

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -1,0 +1,1197 @@
+# Selector Registry + Drift Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn gflow's scattered Flow DOM selectors into a structured, enumerable registry that a $0 probe can walk, so drift is *named* rather than inferred from a failing test.
+
+**Architecture:** A pure-data registry (`Surface` + `Selector`) with a pure grading function. Capture (navigate → `page.content()`) is separated from check (`html + entries → HIT/FALLBACK/MISS`), so the same grader runs against a committed snapshot in CI and a fresh capture in the nightly probe.
+
+**Tech Stack:** Python 3.11+, Playwright (already a dep), pytest, ruff, GitHub Actions.
+
+**Spec:** [`docs/superpowers/specs/2026-08-21-selector-registry-design.md`](../specs/2026-08-21-selector-registry-design.md)
+
+## Global Constraints
+
+- **Windows dev:** use `.venv/Scripts/python.exe -m pytest`, never `uv run pytest` (broken here).
+- **Never `-m pytest ... | tail`** — piping masks the exit code.
+- **$0 invariant:** reach steps MUST be non-mutating and credit-free. Navigation and panel-opening qualify; submitting does not.
+- **Locale-invariant selectors only** — Material Symbols ligatures, never display text. Locale is account-driven: `project_editor_url("en", …)` still served `/fx/pt/`.
+- **Every DOM probe carries a positive control in the same run** and creates-or-verifies its own project. A stale project id renders an error shell (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall.
+- **Secrets:** `__Secure-next-auth.session-token` only. Never log or publish a cookie value.
+- **`Plan` is a NEW enum** (Free/Pro/Ultra). Do NOT name it `Tier` — `api/video.py:35` already defines `Tier` as video quality.
+- CI lints `src` and `tests` only; `scripts/` is not in `ruff check src tests` scope but keep it clean anyway.
+
+---
+
+### Task 1: Registry types and the pure grader
+
+**Files:**
+- Create: `src/gflow_cli/ui/selectors/__init__.py`
+- Create: `src/gflow_cli/ui/selectors/model.py`
+- Create: `src/gflow_cli/ui/selectors/grading.py`
+- Test: `tests/ui/selectors/test_model.py`, `tests/ui/selectors/test_grading.py`
+
+**Interfaces:**
+- Consumes: `gflow_cli.config.UiMode` (AUTO/CLASSIC/AGENTIC).
+- Produces: `Surface`, `Selector`, `Plan`, `Grade`, `Outcome`, `grade(entry, resolved_index) -> Outcome`.
+
+> **Deliberate narrowing of the spec.** §3.1 specifies `reach: Reach` — a URL builder
+> *or* a parent surface plus a non-mutating action, because panels like the media
+> picker are reached by clicking. This plan ships only URL-reachable surfaces, so
+> `Surface` carries a plain `url_template`. `Reach` arrives with the first panel
+> surface in the follow-up plan. Do not build the union type speculatively.
+
+- [ ] **Step 1: Write the failing test for the model**
+
+```python
+# tests/ui/selectors/test_model.py
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors.model import Plan, Selector, Surface
+
+
+def test_selector_requires_at_least_one_candidate() -> None:
+    with pytest.raises(ValueError, match="at least one candidate"):
+        Selector(key="editor.x", surface="editor", candidates=())
+
+
+def test_selector_key_must_be_dotted_lowercase() -> None:
+    """Keys are a public promise: they appear in exit-23 messages, canary
+    reports and the env override. Enforce one shape so they stay scriptable."""
+    with pytest.raises(ValueError, match="dotted lower_snake"):
+        Selector(key="Editor Composer", surface="editor", candidates=("div",))
+
+
+def test_selector_defaults_are_the_permissive_ones() -> None:
+    sel = Selector(key="editor.composer.input", surface="editor", candidates=("div",))
+    assert sel.mode is None          # present in every arm
+    assert sel.min_plan is None      # present on every plan
+    assert sel.required is True      # drift is exit 23 unless stated otherwise
+    assert sel.features == ()
+
+
+def test_surface_declares_the_modes_it_can_present() -> None:
+    s = Surface(key="editor", url_template="/project/{project_id}",
+                modes=(UiMode.CLASSIC, UiMode.AGENTIC))
+    assert UiMode.CLASSIC in s.modes
+
+
+def test_plan_is_ordered_so_min_plan_comparisons_work() -> None:
+    assert Plan.FREE < Plan.PRO < Plan.ULTRA
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gflow_cli.ui.selectors'`
+
+- [ ] **Step 3: Implement the model**
+
+```python
+# src/gflow_cli/ui/selectors/model.py
+"""Structured inventory of the Flow DOM elements gflow depends on.
+
+A selector without its page is unfindable, and a MISS without its mode is
+unattributable — CROP_SELECTORS[0] legitimately misses on the agentic arm
+because it IS the classic-mode indicator (factory.py:116). Context is data here,
+not a naming convention.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+from gflow_cli.config import UiMode
+
+_SEG = r"[a-z0-9]+(?:_[a-z0-9]+)*"
+_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})+$")          # selectors: always dotted
+_SURFACE_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})*$")   # surfaces: dot optional
+
+
+class Plan(IntEnum):
+    """Flow subscription plan. Ordered so ``min_plan`` comparisons work.
+
+    Deliberately NOT named ``Tier``: ``api/video.py`` already defines ``Tier``
+    as a video-quality enum. #171 (UpscaleUnavailableError, exit 22) is the
+    reason this exists — 4K upscale needs Ultra, so on a lesser plan the
+    control is legitimately absent and must not read as drift.
+    """
+
+    FREE = 0
+    PRO = 1
+    ULTRA = 2
+
+
+@dataclass(frozen=True)
+class Surface:
+    """A navigable UI context that selectors belong to."""
+
+    key: str
+    url_template: str
+    modes: tuple[UiMode, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Surface keys may be single-segment ("editor") or dotted
+        # ("editor.media_picker"); selector keys must always be dotted.
+        if not _SURFACE_KEY_RE.match(self.key):
+            msg = f"surface key must be lower_snake, optionally dotted: {self.key!r}"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class Selector:
+    """One DOM dependency, with the context that makes a MISS interpretable."""
+
+    key: str
+    surface: str
+    candidates: tuple[str, ...]
+    mode: UiMode | None = None
+    min_plan: Plan | None = None
+    features: tuple[str, ...] = field(default_factory=tuple)
+    required: bool = True
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.candidates:
+            msg = f"{self.key}: needs at least one candidate"
+            raise ValueError(msg)
+        if not _KEY_RE.match(self.key):
+            msg = f"selector key must be dotted lower_snake: {self.key!r}"
+            raise ValueError(msg)
+```
+
+- [ ] **Step 4: Run the model tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_model.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Write the failing grader test**
+
+```python
+# tests/ui/selectors/test_grading.py
+from __future__ import annotations
+
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors.grading import Grade, grade
+from gflow_cli.ui.selectors.model import Plan, Selector
+
+SEL = Selector(key="editor.count_tabs", surface="editor",
+               candidates=("[role=tab]:text-is('x2')", "[role=tab]:text-is('2x')"))
+
+
+def test_first_candidate_resolving_is_a_hit() -> None:
+    assert grade(SEL, resolved_index=0).grade is Grade.HIT
+
+
+def test_later_candidate_resolving_is_fallback_not_failure() -> None:
+    """#493's actual outcome: the scoped close missed, the unscoped fallback
+    held. Reporting that as failure is how a canary trains red-blindness."""
+    out = grade(SEL, resolved_index=1)
+    assert out.grade is Grade.FALLBACK
+    assert out.is_failure is False
+
+
+def test_no_candidate_resolving_on_a_required_selector_is_drift() -> None:
+    out = grade(SEL, resolved_index=None)
+    assert out.grade is Grade.MISS
+    assert out.is_failure is True
+
+
+def test_optional_selector_missing_is_not_a_failure() -> None:
+    optional = Selector(key="editor.hint", surface="editor",
+                        candidates=("div",), required=False)
+    assert grade(optional, resolved_index=None).is_failure is False
+
+
+def test_wrong_mode_makes_a_miss_expected_not_drift() -> None:
+    """The CROP_SELECTORS lesson: absent on the agentic arm means 'classic
+    indicator', not 'Google moved it'."""
+    classic_only = Selector(key="editor.crop", surface="editor",
+                            candidates=("button",), mode=UiMode.CLASSIC)
+    out = grade(classic_only, resolved_index=None, observed_mode=UiMode.AGENTIC)
+    assert out.grade is Grade.EXPECTED_ABSENT
+    assert out.is_failure is False
+
+
+def test_plan_gated_selector_missing_below_min_plan_is_expected() -> None:
+    ultra = Selector(key="editor.upscale_4k", surface="editor",
+                     candidates=("button",), min_plan=Plan.ULTRA)
+    out = grade(ultra, resolved_index=None, observed_plan=Plan.FREE)
+    assert out.grade is Grade.EXPECTED_ABSENT
+
+
+def test_plan_gated_selector_missing_at_or_above_min_plan_is_drift() -> None:
+    ultra = Selector(key="editor.upscale_4k", surface="editor",
+                     candidates=("button",), min_plan=Plan.ULTRA)
+    assert grade(ultra, resolved_index=None, observed_plan=Plan.ULTRA).is_failure is True
+```
+
+- [ ] **Step 6: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_grading.py -v`
+Expected: FAIL — `No module named 'gflow_cli.ui.selectors.grading'`
+
+- [ ] **Step 7: Implement the grader**
+
+```python
+# src/gflow_cli/ui/selectors/grading.py
+"""Pure grading of a probe result. No browser, no IO — the same function grades
+a live capture and a committed snapshot, so the two layers cannot disagree."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors.model import Plan, Selector
+
+
+class Grade(Enum):
+    HIT = "hit"                        # candidates[0] resolved
+    FALLBACK = "fallback"              # a later candidate resolved — warn, do not fail
+    MISS = "miss"                      # nothing resolved and it should have
+    EXPECTED_ABSENT = "expected_absent"  # mode/plan says it should not be here
+
+
+@dataclass(frozen=True)
+class Outcome:
+    selector_key: str
+    grade: Grade
+    resolved_index: int | None
+
+    @property
+    def is_failure(self) -> bool:
+        return self.grade is Grade.MISS
+
+
+def grade(
+    selector: Selector,
+    resolved_index: int | None,
+    observed_mode: UiMode | None = None,
+    observed_plan: Plan | None = None,
+) -> Outcome:
+    """Grade one selector against which candidate (if any) resolved."""
+    if resolved_index is not None:
+        g = Grade.HIT if resolved_index == 0 else Grade.FALLBACK
+        return Outcome(selector.key, g, resolved_index)
+
+    if selector.mode is not None and observed_mode is not None and selector.mode != observed_mode:
+        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
+    if (
+        selector.min_plan is not None
+        and observed_plan is not None
+        and observed_plan < selector.min_plan
+    ):
+        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
+    if not selector.required:
+        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
+    return Outcome(selector.key, Grade.MISS, None)
+```
+
+- [ ] **Step 8: Run both test files**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/ -v`
+Expected: PASS (12 tests)
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check src/gflow_cli/ui/selectors tests/ui/selectors
+.venv/Scripts/python.exe -m ruff format src/gflow_cli/ui/selectors tests/ui/selectors
+git add src/gflow_cli/ui/selectors tests/ui/selectors
+git commit -m "feat(selectors): registry model and pure grading function
+
+A MISS is only interpretable with its context: CROP_SELECTORS[0] legitimately
+misses on the agentic arm because it IS the classic-mode indicator. mode,
+min_plan and ordered candidates make that attributable instead of ambiguous.
+
+Refs #502"
+```
+
+---
+
+### Task 2: Populate the registry with the drift-prone families
+
+**Files:**
+- Create: `src/gflow_cli/ui/selectors/registry.py`
+- Test: `tests/ui/selectors/test_registry.py`
+
+**Interfaces:**
+- Consumes: `Surface`, `Selector`, `Plan` from Task 1.
+- Produces: `SURFACES: dict[str, Surface]`, `SELECTORS: tuple[Selector, ...]`, `by_key(key) -> Selector`, `for_surface(surface_key, mode) -> tuple[Selector, ...]`.
+
+Only the families with incident history land here. Everything else migrates in Task 6.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ui/selectors/test_registry.py
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors import registry
+
+
+def test_every_selector_points_at_a_declared_surface() -> None:
+    for sel in registry.SELECTORS:
+        assert sel.surface in registry.SURFACES, f"{sel.key} -> unknown surface {sel.surface}"
+
+
+def test_keys_are_unique() -> None:
+    keys = [s.key for s in registry.SELECTORS]
+    assert len(keys) == len(set(keys))
+
+
+def test_no_candidate_depends_on_display_text() -> None:
+    """Locale is ACCOUNT-driven: project_editor_url("en", ...) still served
+    /fx/pt/ in Portuguese. Text-matching selectors break for any non-English
+    account, so candidates must key on Material Symbols ligatures or structure.
+    ``:text-is('crop_16_9')`` is a LIGATURE (icon name), not display copy."""
+    banned = ("Generate", "New project", "Sign in", "Create")
+    for sel in registry.SELECTORS:
+        for cand in sel.candidates:
+            for word in banned:
+                assert word not in cand, f"{sel.key} matches display text: {word!r}"
+
+
+def test_incident_families_are_present() -> None:
+    for key in (
+        "editor.composer.input",
+        "editor.composer.submit",
+        "editor.agent_toggle",
+        "editor.sidebar.close",
+        "editor.crop_control",
+    ):
+        assert registry.by_key(key) is not None
+
+
+def test_by_key_raises_for_unknown() -> None:
+    with pytest.raises(KeyError):
+        registry.by_key("editor.nope")
+
+
+def test_for_surface_filters_by_mode() -> None:
+    classic = registry.for_surface("editor", mode=UiMode.CLASSIC)
+    keys = {s.key for s in classic}
+    assert "editor.crop_control" in keys          # classic-only indicator
+    agentic = {s.key for s in registry.for_surface("editor", mode=UiMode.AGENTIC)}
+    assert "editor.crop_control" not in agentic
+
+
+def test_sidebar_close_keeps_its_fallback_ordered() -> None:
+    """#493: the edit_square-scoped close was the single point of failure; the
+    unscoped fallback is what recovered it. Order encodes preference."""
+    sel = registry.by_key("editor.sidebar.close")
+    assert len(sel.candidates) >= 2
+    assert "edit_square" in sel.candidates[0]
+    assert "edit_square" not in sel.candidates[1]
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_registry.py -v`
+Expected: FAIL — `No module named 'gflow_cli.ui.selectors.registry'`
+
+- [ ] **Step 3: Implement the registry**
+
+Copy the candidate strings verbatim from their current homes — do not retype them. Read `src/gflow_cli/api/transports/mode_control.py:43,49,61,79` and `ui_automation.py:198,209` first.
+
+```python
+# src/gflow_cli/ui/selectors/registry.py
+"""The selectors gflow depends on, with the context that makes drift readable.
+
+Scope: the families with incident history (#404, #493, #174, #313). The rest
+migrate later — a partial registry that is USED beats a complete one that is not.
+"""
+
+from __future__ import annotations
+
+from gflow_cli.api.transports import mode_control, ui_automation
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors.model import Selector, Surface
+
+SURFACES: dict[str, Surface] = {
+    "editor": Surface(
+        key="editor",
+        url_template="https://labs.google/fx/{locale}/tools/flow/project/{project_id}",
+        modes=(UiMode.CLASSIC, UiMode.AGENTIC),
+    ),
+}
+
+SELECTORS: tuple[Selector, ...] = (
+    Selector(
+        key="editor.composer.input",
+        surface="editor",
+        candidates=tuple(ui_automation.PROMPT_INPUT_SELECTORS),
+        features=("image", "video"),
+        note="#493 — the expanded chat sidebar hid this entirely.",
+    ),
+    Selector(
+        key="editor.composer.submit",
+        surface="editor",
+        candidates=tuple(ui_automation.SUBMIT_BUTTON_SELECTORS),
+        features=("image", "video"),
+    ),
+    Selector(
+        key="editor.agent_toggle",
+        surface="editor",
+        candidates=(mode_control.AGENT_TOGGLE_SELECTOR,),
+        features=("image", "video"),
+        note="#313 — agent settings panel became sticky.",
+    ),
+    Selector(
+        key="editor.sidebar.close",
+        surface="editor",
+        candidates=(
+            mode_control.SIDEBAR_CLOSE_SELECTOR,
+            mode_control.SIDEBAR_CLOSE_FALLBACK_SELECTOR,
+        ),
+        note="#493 — the edit_square-scoped close was the SPOF; the unscoped "
+        "fallback is the recovery. Order is preference, not decoration.",
+    ),
+    Selector(
+        key="editor.crop_control",
+        surface="editor",
+        candidates=tuple(mode_control.CROP_SELECTORS),
+        mode=UiMode.CLASSIC,
+        note="Classic-mode INDICATOR (factory.py:116). Absent on the agentic "
+        "arm by design — probing one of its six ratio variants and calling the "
+        "miss 'drift' is the exact error this registry prevents.",
+    ),
+)
+
+_BY_KEY = {s.key: s for s in SELECTORS}
+
+
+def by_key(key: str) -> Selector:
+    """Look up one selector. Raises KeyError for an unknown key."""
+    return _BY_KEY[key]
+
+
+def for_surface(surface_key: str, mode: UiMode | None = None) -> tuple[Selector, ...]:
+    """Selectors expected on a surface, optionally narrowed to one arm."""
+    return tuple(
+        s
+        for s in SELECTORS
+        if s.surface == surface_key and (mode is None or s.mode is None or s.mode == mode)
+    )
+```
+
+- [ ] **Step 4: Run the registry tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_registry.py -v`
+Expected: PASS (7 tests).
+
+If `test_no_candidate_depends_on_display_text` fails, check whether the match is a Material Symbols **ligature** or real display copy. `:text('arrow_forward')` in `SUBMIT_BUTTON_SELECTORS` is a ligature — the icon's name, identical in every locale — and is fine. Actual UI copy is not. If you hit real copy, that is a pre-existing locale bug: raise it rather than weakening the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check src/gflow_cli/ui/selectors tests/ui/selectors
+git add src/gflow_cli/ui/selectors/registry.py tests/ui/selectors/test_registry.py
+git commit -m "feat(selectors): register the drift-prone families
+
+Imports the existing constants rather than copying their values, so the
+registry cannot silently diverge from the code that uses them today.
+
+Refs #404 #493 #313"
+```
+
+---
+
+### Task 3: Offline check against a committed DOM snapshot
+
+**Files:**
+- Create: `src/gflow_cli/ui/selectors/check.py`
+- Create: `tests/ui/selectors/fixtures/editor_classic.html` (generated in Task 4; use a hand-written stub until then)
+- Test: `tests/ui/selectors/test_check.py`
+
+**Interfaces:**
+- Consumes: `registry`, `grade`, `Outcome`.
+- Produces: `async check_html(html: str, entries: Sequence[Selector], **ctx) -> list[Outcome]`.
+
+Verified mechanism: Playwright's `set_content()` resolves `:has()` / `:text-is()` offline — no network, no auth, no credits.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ui/selectors/test_check.py
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.ui.selectors.check import check_html
+from gflow_cli.ui.selectors.grading import Grade
+from gflow_cli.ui.selectors.model import Selector
+
+HTML = """<html><body>
+  <div role="textbox" data-slate-editor="true">prompt</div>
+  <button><i class="google-symbols">close</i></button>
+</body></html>"""
+
+
+async def test_resolving_first_candidate_reports_hit() -> None:
+    sel = Selector(key="editor.composer.input", surface="editor",
+                   candidates=('div[role="textbox"][data-slate-editor="true"]',))
+    (out,) = await check_html(HTML, [sel])
+    assert out.grade is Grade.HIT
+
+
+async def test_falls_through_to_a_later_candidate() -> None:
+    sel = Selector(key="editor.sidebar.close", surface="editor",
+                   candidates=("button.does-not-exist",
+                               "button:has(i.google-symbols:text-is('close'))"))
+    (out,) = await check_html(HTML, [sel])
+    assert out.grade is Grade.FALLBACK
+    assert out.resolved_index == 1
+
+
+async def test_absent_required_selector_reports_miss() -> None:
+    sel = Selector(key="editor.gone", surface="editor", candidates=("#nope",))
+    (out,) = await check_html(HTML, [sel])
+    assert out.grade is Grade.MISS
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_check.py -v`
+Expected: FAIL — `No module named 'gflow_cli.ui.selectors.check'`
+
+- [ ] **Step 3: Implement the checker**
+
+```python
+# src/gflow_cli/ui/selectors/check.py
+"""Grade selectors against DOM text. No network, no auth, no credits.
+
+A headless chromium is needed only to run Playwright's selector engines
+(``:has()``, ``:text-is()``) — verified working against static HTML via
+``set_content()``. This is the same function the live probe uses, so an
+offline snapshot check and a live capture check can never disagree.
+
+Limitation: ``set_content()`` drops external CSS/JS, so visibility and
+enabled-state are NOT reliable here. This layer asserts structural presence;
+the live probe additionally asserts visible/enabled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from playwright.async_api import async_playwright
+
+from gflow_cli.config import UiMode
+from gflow_cli.ui.selectors.grading import Outcome, grade
+from gflow_cli.ui.selectors.model import Plan, Selector
+
+
+async def check_html(
+    html: str,
+    entries: Sequence[Selector],
+    observed_mode: UiMode | None = None,
+    observed_plan: Plan | None = None,
+) -> list[Outcome]:
+    """Resolve each entry's candidates against ``html`` and grade the result."""
+    results: list[Outcome] = []
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            page = await browser.new_page()
+            await page.set_content(html)
+            for entry in entries:
+                index: int | None = None
+                for i, candidate in enumerate(entry.candidates):
+                    if await page.locator(candidate).count():
+                        index = i
+                        break
+                results.append(grade(entry, index, observed_mode, observed_plan))
+        finally:
+            await browser.close()
+    return results
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_check.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gflow_cli/ui/selectors/check.py tests/ui/selectors/test_check.py
+git commit -m "feat(selectors): offline DOM check, no network or credentials
+
+Same grader for snapshots and live captures, so the layers cannot drift apart.
+set_content() loses CSS/JS, so this asserts structural presence only."
+```
+
+---
+
+### Task 4: Capture command
+
+**Files:**
+- Create: `scripts/probe/capture_surface.py`
+- Test: `tests/scripts/test_capture_surface.py`
+
+**Interfaces:**
+- Consumes: `registry.SURFACES`, `FlowApiClient`.
+- Produces: `scrub(html) -> str`; CLI writing `tests/ui/selectors/fixtures/<surface>_<mode>.html`.
+
+- [ ] **Step 1: Write the failing scrub test**
+
+```python
+# tests/scripts/test_capture_surface.py
+from __future__ import annotations
+
+from scripts.probe.capture_surface import scrub
+
+
+def test_scrub_removes_uuids() -> None:
+    out = scrub('<a href="/project/edf7fefa-c143-436b-b224-b19ec238e753">x</a>')
+    assert "edf7fefa" not in out
+    assert "REDACTED-UUID" in out
+
+
+def test_scrub_removes_emails() -> None:
+    assert "@" not in scrub("<span>someone@example.com</span>")
+
+
+def test_scrub_removes_signed_urls() -> None:
+    html = '<img src="https://cdn.example/x.png?Expires=1&Signature=abc">'
+    assert "Signature=abc" not in scrub(html)
+
+
+def test_scrub_is_idempotent() -> None:
+    once = scrub('<a href="/project/edf7fefa-c143-436b-b224-b19ec238e753">x</a>')
+    assert scrub(once) == once
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture_surface.py -v`
+Expected: FAIL — `No module named 'scripts.probe'`
+
+- [ ] **Step 3: Implement capture + scrub**
+
+```python
+# scripts/probe/capture_surface.py
+"""Capture a Flow surface's DOM for offline selector checking. $0 — navigation
+and DOM read only; never submits.
+
+Carries a positive control by construction: it CREATES its project rather than
+trusting a stored id. A stale project renders an error shell (~441KB, 3 buttons,
+0 icons) that is indistinguishable from an auth wall, and that confound voided
+three spike runs before it was caught.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.auth import profile_dir as resolve_profile
+from gflow_cli.ui.selectors import registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "ui" / "selectors" / "fixtures"
+
+_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+_EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
+_SIGNED = re.compile(r"(Signature|X-Goog-Signature|Expires)=[^&\"'\s]+", re.I)
+
+
+def scrub(html: str) -> str:
+    """Strip identifiers before a DOM snapshot enters a public repo."""
+    html = _UUID.sub("REDACTED-UUID", html)
+    html = _EMAIL.sub("REDACTED-EMAIL", html)
+    return _SIGNED.sub(r"\1=REDACTED", html)
+
+
+async def capture(profile: str, surface_key: str) -> Path:
+    surface = registry.SURFACES[surface_key]
+    async with FlowApiClient(profile_dir=resolve_profile(profile), headless=True) as client:
+        project = await client.create_project(title="selector-probe capture")
+        page = client._page or client._context.pages[0]  # noqa: SLF001
+        url = surface.url_template.format(locale="en", project_id=project.project_id)
+        await page.goto(url, wait_until="domcontentloaded", timeout=90_000)
+        for _ in range(25):
+            if await page.locator("i.google-symbols").count():
+                break
+            await page.wait_for_timeout(1000)
+        else:
+            msg = "surface never hydrated — capture aborted rather than saving an error shell"
+            raise SystemExit(msg)
+        html = scrub(await page.content())
+
+    FIXTURES.mkdir(parents=True, exist_ok=True)
+    out = FIXTURES / f"{surface_key}.html"
+    out.write_text(html, encoding="utf-8")
+    print(f"captured {len(html):,} bytes -> {out}")
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--profile", required=True)
+    p.add_argument("--surface", default="editor")
+    args = p.parse_args()
+    asyncio.run(capture(args.profile, args.surface))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the scrub tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture_surface.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Capture the real fixture and add the snapshot test**
+
+```bash
+.venv/Scripts/python.exe scripts/probe/capture_surface.py --profile denon82 --surface editor
+```
+
+```python
+# append to tests/ui/selectors/test_check.py
+from pathlib import Path
+from gflow_cli.ui.selectors import registry
+
+FIXTURE = Path(__file__).parent / "fixtures" / "editor.html"
+
+
+async def test_committed_snapshot_still_satisfies_every_editor_selector() -> None:
+    """Catches OUR regressions on every PR. It can never detect Google changing
+    the page — the snapshot is frozen. That is the live probe's job."""
+    html = FIXTURE.read_text(encoding="utf-8")
+    outcomes = await check_html(html, registry.for_surface("editor"))
+    failures = [o.selector_key for o in outcomes if o.is_failure]
+    assert not failures, f"snapshot no longer satisfies: {failures}"
+```
+
+- [ ] **Step 6: Verify the fixture is clean before committing it**
+
+Run: `grep -ciE "[0-9a-f]{8}-[0-9a-f]{4}|@[a-z-]+\.[a-z]" tests/ui/selectors/fixtures/editor.html`
+Expected: `0`. Non-zero means `scrub()` missed a pattern — fix `scrub`, re-capture, re-check.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/probe tests/scripts/test_capture_surface.py tests/ui/selectors/
+git commit -m "feat(probe): DOM capture with scrubbing, plus the snapshot check
+
+Capture creates its own project: a stale id renders an error shell that reads
+exactly like an auth wall, which voided three spike runs before it was caught."
+```
+
+---
+
+### Task 5: CI probe workflow
+
+**Files:**
+- Create: `scripts/probe/run_probe.py`
+- Create: `.github/workflows/selector-probe.yml`
+- Test: `tests/scripts/test_run_probe.py`
+
+**Interfaces:**
+- Consumes: `check_html`, `registry`, `scrub`.
+- Produces: `render_report(outcomes) -> str`; exit 0 clean / 1 drift / 2 infrastructure.
+
+Evidence: a bundled headless chromium carrying only `__Secure-next-auth.session-token` (1088 chars, 30-day expiry) renders the editor identically to a full real-Chrome profile — six-arm matrix, all identical.
+
+- [ ] **Step 1: Write the failing report test**
+
+```python
+# tests/scripts/test_run_probe.py
+from __future__ import annotations
+
+from gflow_cli.ui.selectors.grading import Grade, Outcome
+from scripts.probe.run_probe import render_report
+
+
+def test_report_names_the_drifted_selector() -> None:
+    body = render_report([Outcome("editor.count_tabs", Grade.MISS, None)])
+    assert "editor.count_tabs" in body
+    assert "DRIFT" in body
+
+
+def test_fallback_is_reported_as_a_warning_not_drift() -> None:
+    body = render_report([Outcome("editor.sidebar.close", Grade.FALLBACK, 1)])
+    assert "FALLBACK" in body
+    assert "DRIFT" not in body
+
+
+def test_report_never_contains_a_raw_selector() -> None:
+    """Keys are publication-safe; raw selectors and paths are not."""
+    body = render_report([Outcome("editor.composer.input", Grade.MISS, None)])
+    assert "div[role=" not in body
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_run_probe.py -v`
+Expected: FAIL — `No module named 'scripts.probe.run_probe'`
+
+- [ ] **Step 3: Implement the probe runner**
+
+```python
+# scripts/probe/run_probe.py
+"""Probe live Flow for selector drift. $0 — navigate and read only.
+
+Auth is ONE cookie: __Secure-next-auth.session-token (30-day life, scoped to
+labs.google). Measured: a bundled headless chromium with only that cookie
+renders the editor identically to a full real-Chrome profile.
+
+Exit: 0 no drift · 1 drift found · 2 infrastructure failure (never confuse them).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from playwright.async_api import async_playwright
+
+from gflow_cli.ui.selectors import registry
+from gflow_cli.ui.selectors.check import check_html
+from gflow_cli.ui.selectors.grading import Grade, Outcome
+
+SESSION_COOKIE = "__Secure-next-auth.session-token"
+_LABEL = {
+    Grade.HIT: "ok",
+    Grade.FALLBACK: "FALLBACK",
+    Grade.MISS: "DRIFT",
+    Grade.EXPECTED_ABSENT: "n/a",
+}
+
+
+def render_report(outcomes: list[Outcome]) -> str:
+    """Publication-safe: keys only, never raw selectors or paths."""
+    lines = ["| selector | result |", "| --- | --- |"]
+    lines += [f"| `{o.selector_key}` | {_LABEL[o.grade]} |" for o in outcomes]
+    drift = [o.selector_key for o in outcomes if o.is_failure]
+    lines += ["", f"**{len(drift)} drifted**" if drift else "**No drift.**"]
+    return "\n".join(lines)
+
+
+async def run(token: str, project_id: str, surface_key: str) -> int:
+    surface = registry.SURFACES[surface_key]
+    url = surface.url_template.format(locale="en", project_id=project_id)
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            ctx = await browser.new_context()
+            await ctx.add_cookies([{
+                "name": SESSION_COOKIE, "value": token,
+                "domain": "labs.google", "path": "/",
+                "httpOnly": True, "secure": True, "sameSite": "Lax",
+            }])
+            page = await ctx.new_page()
+            await page.goto(url, wait_until="domcontentloaded", timeout=90_000)
+            for _ in range(25):
+                if await page.locator("i.google-symbols").count():
+                    break
+                await page.wait_for_timeout(1000)
+            else:
+                # Positive control: an un-hydrated surface means the token expired
+                # or the project is gone. That is NOT drift — never report it as such.
+                print("::error::surface never hydrated (expired token or missing project)")
+                return 2
+            html = await page.content()
+        finally:
+            await browser.close()
+
+    outcomes = await check_html(html, registry.for_surface(surface_key))
+    print(render_report(outcomes))
+    return 1 if any(o.is_failure for o in outcomes) else 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--surface", default="editor")
+    args = p.parse_args()
+    token = os.environ.get("GFLOW_CI_SESSION_TOKEN", "")
+    project = os.environ.get("GFLOW_CI_PROJECT_ID", "")
+    if not token or not project:
+        print("::error::GFLOW_CI_SESSION_TOKEN and GFLOW_CI_PROJECT_ID are required")
+        return 2
+    return asyncio.run(run(token, project, args.surface))
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the report tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_run_probe.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Add the workflow**
+
+```yaml
+# .github/workflows/selector-probe.yml
+name: Selector drift probe
+
+on:
+  schedule:
+    - cron: "0 5 * * *"      # 05:00 UTC, before the maintainer's local canary
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ffroliva/gflow-cli'
+    steps:
+      - uses: actions/checkout@v4
+        with: { persist-credentials: false }
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync --frozen
+      - run: uv run playwright install chromium --with-deps
+      - name: Probe
+        env:
+          GFLOW_CI_SESSION_TOKEN: ${{ secrets.GFLOW_CI_SESSION_TOKEN }}
+          GFLOW_CI_PROJECT_ID: ${{ secrets.GFLOW_CI_PROJECT_ID }}
+        run: uv run python scripts/probe/run_probe.py --surface editor
+```
+
+Start on `schedule` + `workflow_dispatch` only. Do **not** add `pull_request` until R1 (datacenter-IP behaviour) is answered by a first real run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/probe/run_probe.py .github/workflows/selector-probe.yml tests/scripts/test_run_probe.py
+git commit -m "feat(probe): CI selector-drift probe on a single session cookie
+
+Exit 2 (infrastructure) is kept distinct from exit 1 (drift): an expired token
+or a deleted project must never be reported as Google changing the page."
+```
+
+---
+
+### Task 6: AST guardrail, error key, and env override
+
+**Files:**
+- Create: `tests/api/transports/test_selectors_only_in_registry.py`
+- Modify: `src/gflow_cli/errors.py` (`UiSelectorDriftError`)
+- Create: `src/gflow_cli/ui/selectors/overrides.py`
+- Test: `tests/ui/selectors/test_overrides.py`
+
+**Interfaces:**
+- Consumes: `registry`, `Selector`.
+- Produces: `apply_overrides(entries) -> tuple[Selector, ...]`; `UiSelectorDriftError(selector_key=...)`.
+
+- [ ] **Step 1: Write the failing override test**
+
+```python
+# tests/ui/selectors/test_overrides.py
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.ui.selectors.model import Selector
+from gflow_cli.ui.selectors.overrides import apply_overrides
+
+BASE = (Selector(key="editor.count_tabs", surface="editor", candidates=("[role=tab]",)),)
+
+
+def test_no_env_leaves_entries_untouched(monkeypatch) -> None:
+    monkeypatch.delenv("GFLOW_CLI_SELECTOR_OVERRIDE", raising=False)
+    assert apply_overrides(BASE) == BASE
+
+
+def test_override_replaces_the_candidate_list(monkeypatch) -> None:
+    """A user hit by a #404-class rename patches it and keeps working, instead
+    of waiting for a release."""
+    monkeypatch.setenv("GFLOW_CLI_SELECTOR_OVERRIDE", "editor.count_tabs=[role=tab].new")
+    (sel,) = apply_overrides(BASE)
+    assert sel.candidates == ("[role=tab].new",)
+
+
+def test_unknown_key_is_rejected_loudly(monkeypatch) -> None:
+    monkeypatch.setenv("GFLOW_CLI_SELECTOR_OVERRIDE", "editor.nope=div")
+    with pytest.raises(ValueError, match="unknown selector key"):
+        apply_overrides(BASE)
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_overrides.py -v`
+Expected: FAIL — `No module named 'gflow_cli.ui.selectors.overrides'`
+
+- [ ] **Step 3: Implement overrides**
+
+```python
+# src/gflow_cli/ui/selectors/overrides.py
+"""Operator escape hatch: patch a drifted selector without waiting for a release.
+
+    GFLOW_CLI_SELECTOR_OVERRIDE='editor.count_tabs=<css>;editor.composer.input=<css>'
+
+Keys are a public promise — renaming one is a breaking change.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from collections.abc import Sequence
+
+from gflow_cli.ui.selectors.model import Selector
+
+ENV_VAR = "GFLOW_CLI_SELECTOR_OVERRIDE"
+
+
+def _parse(raw: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for chunk in raw.split(";"):
+        if not chunk.strip():
+            continue
+        key, sep, value = chunk.partition("=")
+        if not sep or not value.strip():
+            msg = f"malformed {ENV_VAR} entry: {chunk!r} (expected key=selector)"
+            raise ValueError(msg)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def apply_overrides(entries: Sequence[Selector]) -> tuple[Selector, ...]:
+    """Return entries with any env-supplied candidates substituted."""
+    raw = os.environ.get(ENV_VAR, "").strip()
+    if not raw:
+        return tuple(entries)
+    wanted = _parse(raw)
+    known = {e.key for e in entries}
+    unknown = sorted(set(wanted) - known)
+    if unknown:
+        msg = f"{ENV_VAR}: unknown selector key(s) {unknown}"
+        raise ValueError(msg)
+    return tuple(
+        dataclasses.replace(e, candidates=(wanted[e.key],)) if e.key in wanted else e
+        for e in entries
+    )
+```
+
+- [ ] **Step 4: Run the override tests**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_overrides.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Add `selector_key` to the drift error**
+
+`UiSelectorDriftError` is an RFC 9457 Problem Details class (`errors.py:70`): class-level identity, instance-level extensions. Add `selector_key` as an extension alongside `route`, so exit 23 names what moved.
+
+```python
+# in src/gflow_cli/errors.py, inside UiSelectorDriftError
+    selector_key: str | None = None
+```
+
+Add a test in `tests/test_error_contract.py`:
+
+```python
+def test_ui_selector_drift_carries_a_registry_key() -> None:
+    err = UiSelectorDriftError(detail="probe missed", selector_key="editor.count_tabs")
+    assert err.selector_key == "editor.count_tabs"
+    assert "editor.count_tabs" not in str(err.to_problem_details().get("detail", ""))
+```
+
+- [ ] **Step 6: Add the AST guardrail**
+
+```python
+# tests/api/transports/test_selectors_only_in_registry.py
+"""Guard: registered selector strings live only in the registry.
+
+Sibling of test_selector_symmetry.py, which already locks the agentic
+indicators to one source. This widens the same principle: once a selector is in
+the registry, no transport may carry its literal, or the two silently diverge —
+which is exactly what happened to the agentic probes before #183.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.ui.selectors import registry
+
+SRC = Path(__file__).resolve().parents[3] / "src" / "gflow_cli"
+REGISTRY_DIR = SRC / "ui" / "selectors"
+# mode_control/ui_automation still DEFINE the constants the registry imports;
+# they are the migration source and are exempt until Task 7 inverts the flow.
+EXEMPT = {
+    SRC / "api" / "transports" / "mode_control.py",
+    SRC / "api" / "transports" / "ui_automation.py",
+}
+
+pytestmark = pytest.mark.repo_lint
+
+
+def _registered_literals() -> set[str]:
+    return {c for s in registry.SELECTORS for c in s.candidates}
+
+
+def test_no_module_outside_the_registry_hardcodes_a_registered_selector() -> None:
+    registered = _registered_literals()
+    offenders: list[str] = []
+    for path in SRC.rglob("*.py"):
+        if path in EXEMPT or REGISTRY_DIR in path.parents:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and node.value in registered:
+                offenders.append(f"{path.relative_to(SRC)}:{node.lineno}")
+    assert not offenders, (
+        "registered selectors must come from the registry, not literals: " + ", ".join(offenders)
+    )
+```
+
+- [ ] **Step 7: Run the whole selector suite**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors tests/scripts tests/api/transports/test_selectors_only_in_registry.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Full gate and commit**
+
+```bash
+.venv/Scripts/python.exe -m ruff check src tests
+.venv/Scripts/python.exe -m ruff format --check src tests
+.venv/Scripts/python.exe scripts/ci/check_repo_hygiene.py
+.venv/Scripts/python.exe scripts/ci/check_doc_links.py
+git add -A
+git commit -m "feat(selectors): AST guardrail, drift-error key, and env override
+
+Users hit by a rename can now patch it via GFLOW_CLI_SELECTOR_OVERRIDE instead
+of waiting for a release, and exit 23 names the registry key that moved."
+```
+
+---
+
+## Deferred to a follow-up plan
+
+- Migrating the remaining ~35 selectors and **inverting** the import direction so `mode_control`/`ui_automation` read *from* the registry (removes the `EXEMPT` set in Task 6).
+- Additional surfaces: `editor.media_picker`, `character_editor`, timeline.
+- Splitting `ui_automation.py` (3,557 lines) and `ui_automation_video.py` (3,814).
+- Wiring the nightly canary to publish CI-token expiry (spec R2).
+
+## Open question for the first real run
+
+**R1 — datacenter IP.** Every measurement came from a residential connection. No local test can predict how Google treats a GitHub runner. Run the workflow once via `workflow_dispatch` and read the result before considering a `pull_request` trigger.

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -270,9 +270,6 @@ Expected: PASS (11 tests: 5 model + 6 grading)
 # tests/flow_selectors/test_registry.py
 from __future__ import annotations
 
-import pytest
-
-from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors import registry
 
 
@@ -535,7 +532,7 @@ def render_report(outcomes: list[Outcome]) -> str:
 
 # Known ZERO-CLICK alternate states. Neither is drift, and both hide the
 # composer, so grading through them would report drift that did not happen.
-#   mode_control.py:66-84  — an expanded chat sidebar "removes the classic
+#   mode_control.py:61-84  — an expanded chat sidebar "removes the classic
 #                            composer entirely... no crop_* trigger AND no Agent pill"
 #   ui_automation_video.py:149-153 — a chat panel "appears on some project opens
 #                            and not others"; while up "the in-composer pill is

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Turn gflow's scattered Flow DOM selectors into a structured, enumerable registry that a $0 probe can walk, so drift is *named* rather than inferred from a failing test.
+**Goal:** Turn gflow's scattered Flow DOM selectors into a structured, enumerable registry that a $0 CI probe walks nightly, so drift is *named* rather than inferred from a failing test.
 
-**Architecture:** A pure-data registry (`Surface` + `Selector`) with a pure grading function. Capture (navigate → `page.content()`) is separated from check (`html + entries → HIT/FALLBACK/MISS`), so the same grader runs against a committed snapshot in CI and a fresh capture in the nightly probe.
+**Architecture:** A pure-data registry (`Surface` + `Selector`) and a pure grader. Capture (navigate at a pinned viewport → `page.content()` + a mode sidecar) is separate from check (`html + entries + observed → grade`), so the probe's evidence and its verdict are independently inspectable.
 
 **Tech Stack:** Python 3.11+, Playwright (already a dep), pytest, ruff, GitHub Actions.
 
@@ -12,45 +12,37 @@
 
 ## Global Constraints
 
-- **Windows dev:** use `.venv/Scripts/python.exe -m pytest`, never `uv run pytest` (broken here).
-- **Never `-m pytest ... | tail`** — piping masks the exit code.
-- **$0 invariant:** reach steps MUST be non-mutating and credit-free. Navigation and panel-opening qualify; submitting does not.
-- **Locale-invariant selectors only** — Material Symbols ligatures, never display text. Locale is account-driven: `project_editor_url("en", …)` still served `/fx/pt/`.
-- **Every DOM probe carries a positive control in the same run** and creates-or-verifies its own project. A stale project id renders an error shell (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall.
-- **Secrets:** `__Secure-next-auth.session-token` only. Never log or publish a cookie value.
-- **`Plan` is a NEW enum** (Free/Pro/Ultra). Do NOT name it `Tier` — `api/video.py:35` already defines `Tier` as video quality.
-- CI lints `src` and `tests` only; `scripts/` is not in `ruff check src tests` scope but keep it clean anyway.
+- **Windows dev:** `.venv/Scripts/python.exe -m pytest`, never `uv run pytest` (broken here). Never pipe pytest to `tail` — it masks the exit code.
+- **$0 invariant:** reach steps MUST be non-mutating and credit-free. Never submit.
+- **Pin the viewport to 1920×1080.** `ui_automation.py:117-124`: smaller *"would cross the responsive breakpoint and drift the selectors"*. `FlowApiClient` (1280×720) and Playwright's default (1280×720) are both **below** it.
+- **`observed_mode` is a capture-time sidecar, never inferred at check time** — inferring it is circular, because the mode detector IS the crop probe.
+- **Every DOM probe creates-or-verifies its project.** A stale id renders an error shell (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall.
+- **No default-suite test may launch a real browser.** `ci.yml:165` runs plain pytest and **no workflow installs Playwright**. Browser-touching tests live in the probe workflow, which installs chromium itself.
+- **Secrets:** `__Secure-next-auth.session-token` only, from a dedicated throwaway account. Never log a cookie value. For any published output reuse `src/gflow_cli/data/redaction.py` — it already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token` and signed queries.
+- **Package name:** `gflow_cli.flow_selectors`, NOT `gflow_cli.ui` — `src/gflow_cli/ui/` already means gflow's own UI (`app.py`, `server.py`).
 
 ---
 
-### Task 1: Registry types and the pure grader
+### Task 1: Registry model, grader, and entries
 
 **Files:**
-- Create: `src/gflow_cli/ui/selectors/__init__.py`
-- Create: `src/gflow_cli/ui/selectors/model.py`
-- Create: `src/gflow_cli/ui/selectors/grading.py`
-- Test: `tests/ui/selectors/test_model.py`, `tests/ui/selectors/test_grading.py`
+- Create: `src/gflow_cli/flow_selectors/__init__.py`, `model.py`, `grading.py`, `registry.py`
+- Test: `tests/flow_selectors/__init__.py`, `test_model.py`, `test_grading.py`, `test_registry.py`
 
 **Interfaces:**
-- Consumes: `gflow_cli.config.UiMode` (AUTO/CLASSIC/AGENTIC).
-- Produces: `Surface`, `Selector`, `Plan`, `Grade`, `Outcome`, `grade(entry, resolved_index) -> Outcome`.
+- Consumes: `gflow_cli.config.UiMode`; the existing constants in `mode_control` / `ui_automation`.
+- Produces: `Surface`, `Selector`, `Grade`, `Outcome`, `grade(...)`, `SURFACES`, `SELECTORS`, `by_key()`, `for_surface()`.
 
-> **Deliberate narrowing of the spec.** §3.1 specifies `reach: Reach` — a URL builder
-> *or* a parent surface plus a non-mutating action, because panels like the media
-> picker are reached by clicking. This plan ships only URL-reachable surfaces, so
-> `Surface` carries a plain `url_template`. `Reach` arrives with the first panel
-> surface in the follow-up plan. Do not build the union type speculatively.
-
-- [ ] **Step 1: Write the failing test for the model**
+- [ ] **Step 1: Write the failing model + grading tests**
 
 ```python
-# tests/ui/selectors/test_model.py
+# tests/flow_selectors/test_model.py
 from __future__ import annotations
 
 import pytest
 
 from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors.model import Plan, Selector, Surface
+from gflow_cli.flow_selectors.model import Selector, Surface
 
 
 def test_selector_requires_at_least_one_candidate() -> None:
@@ -58,102 +50,142 @@ def test_selector_requires_at_least_one_candidate() -> None:
         Selector(key="editor.x", surface="editor", candidates=())
 
 
-def test_selector_key_must_be_dotted_lowercase() -> None:
-    """Keys are a public promise: they appear in exit-23 messages, canary
-    reports and the env override. Enforce one shape so they stay scriptable."""
+def test_selector_key_must_be_dotted_lower_snake() -> None:
     with pytest.raises(ValueError, match="dotted lower_snake"):
         Selector(key="Editor Composer", surface="editor", candidates=("div",))
 
 
-def test_selector_defaults_are_the_permissive_ones() -> None:
-    sel = Selector(key="editor.composer.input", surface="editor", candidates=("div",))
-    assert sel.mode is None          # present in every arm
-    assert sel.min_plan is None      # present on every plan
-    assert sel.required is True      # drift is exit 23 unless stated otherwise
-    assert sel.features == ()
+def test_surface_pins_a_viewport_at_or_above_the_breakpoint() -> None:
+    """ui_automation.py:117-124 — below 1920x1080 crosses Flow's responsive
+    breakpoint and drifts the selectors. A probe that forgets this reports
+    false drift, so the model refuses to let it be forgotten."""
+    with pytest.raises(ValueError, match="breakpoint"):
+        Surface(key="editor", url_template="/x", viewport=(1280, 720),
+                modes=(UiMode.CLASSIC,))
 
 
-def test_surface_declares_the_modes_it_can_present() -> None:
-    s = Surface(key="editor", url_template="/project/{project_id}",
+def test_surface_accepts_the_production_viewport() -> None:
+    s = Surface(key="editor", url_template="/x", viewport=(1920, 1080),
                 modes=(UiMode.CLASSIC, UiMode.AGENTIC))
-    assert UiMode.CLASSIC in s.modes
-
-
-def test_plan_is_ordered_so_min_plan_comparisons_work() -> None:
-    assert Plan.FREE < Plan.PRO < Plan.ULTRA
+    assert s.viewport == (1920, 1080)
 ```
 
-- [ ] **Step 2: Run it to confirm it fails**
+```python
+# tests/flow_selectors/test_grading.py
+from __future__ import annotations
 
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_model.py -v`
-Expected: FAIL — `ModuleNotFoundError: No module named 'gflow_cli.ui.selectors'`
+from gflow_cli.config import UiMode
+from gflow_cli.flow_selectors.grading import Grade, grade
+from gflow_cli.flow_selectors.model import Selector
+
+SEL = Selector(key="editor.count_tabs", surface="editor",
+               candidates=("[role=tab]:text-is('x2')", "[role=tab]:text-is('2x')"))
+
+
+def test_first_candidate_is_a_hit() -> None:
+    assert grade(SEL, resolved_index=0, match_count=1).grade is Grade.HIT
+
+
+def test_later_candidate_is_fallback_not_failure() -> None:
+    out = grade(SEL, resolved_index=1, match_count=1)
+    assert out.grade is Grade.FALLBACK
+    assert out.is_failure is False
+
+
+def test_multiple_matches_on_a_unique_selector_is_ambiguous() -> None:
+    """Drivers call .first, so a second match means gflow clicks the WRONG
+    element while a count-based check reports success. SIDEBAR_CLOSE_FALLBACK
+    is deliberately unscoped and is the standing candidate for this."""
+    unique = Selector(key="editor.sidebar.close", surface="editor",
+                      candidates=("button",), expect_unique=True)
+    out = grade(unique, resolved_index=0, match_count=2)
+    assert out.grade is Grade.AMBIGUOUS
+    assert out.is_failure is True
+
+
+def test_nothing_resolving_is_drift() -> None:
+    assert grade(SEL, resolved_index=None, match_count=0).is_failure is True
+
+
+def test_wrong_mode_makes_a_miss_expected() -> None:
+    classic = Selector(key="editor.crop_control", surface="editor",
+                       candidates=("button",), mode=UiMode.CLASSIC)
+    out = grade(classic, resolved_index=None, match_count=0,
+                observed_mode=UiMode.AGENTIC)
+    assert out.grade is Grade.EXPECTED_ABSENT
+    assert out.is_failure is False
+
+
+def test_missing_sidecar_mode_does_not_silently_pass_a_mode_scoped_miss() -> None:
+    """Without observed_mode the grader CANNOT know whether an absent
+    classic-only control is drift or the wrong arm. It must say so rather than
+    guess — guessing MISS is what produced a guaranteed false DRIFT in the
+    first draft of this plan."""
+    classic = Selector(key="editor.crop_control", surface="editor",
+                       candidates=("button",), mode=UiMode.CLASSIC)
+    out = grade(classic, resolved_index=None, match_count=0, observed_mode=None)
+    assert out.grade is Grade.UNKNOWN_CONTEXT
+    assert out.is_failure is False
+```
+
+- [ ] **Step 2: Run both to confirm they fail**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gflow_cli.flow_selectors'`
 
 - [ ] **Step 3: Implement the model**
 
 ```python
-# src/gflow_cli/ui/selectors/model.py
+# src/gflow_cli/flow_selectors/model.py
 """Structured inventory of the Flow DOM elements gflow depends on.
 
-A selector without its page is unfindable, and a MISS without its mode is
-unattributable — CROP_SELECTORS[0] legitimately misses on the agentic arm
-because it IS the classic-mode indicator (factory.py:116). Context is data here,
-not a naming convention.
+A selector without its page is unfindable; a MISS without its mode is
+unattributable. CROP_SELECTORS[0] legitimately misses on the agentic arm
+because it IS the classic-mode indicator (factory.py:116). Context is data.
 """
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
-from enum import IntEnum
+from dataclasses import dataclass
 
 from gflow_cli.config import UiMode
 
 _SEG = r"[a-z0-9]+(?:_[a-z0-9]+)*"
-_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})+$")          # selectors: always dotted
-_SURFACE_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})*$")   # surfaces: dot optional
+_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})+$")
+_SURFACE_KEY_RE = re.compile(rf"^{_SEG}(?:\.{_SEG})*$")
 
-
-class Plan(IntEnum):
-    """Flow subscription plan. Ordered so ``min_plan`` comparisons work.
-
-    Deliberately NOT named ``Tier``: ``api/video.py`` already defines ``Tier``
-    as a video-quality enum. #171 (UpscaleUnavailableError, exit 22) is the
-    reason this exists — 4K upscale needs Ultra, so on a lesser plan the
-    control is legitimately absent and must not read as drift.
-    """
-
-    FREE = 0
-    PRO = 1
-    ULTRA = 2
+# ui_automation.py:117-124 — below this, Flow crosses its responsive breakpoint
+# and the selectors drift. A probe rendering smaller reports drift that is not there.
+MIN_VIEWPORT = (1920, 1080)
 
 
 @dataclass(frozen=True)
 class Surface:
-    """A navigable UI context that selectors belong to."""
-
     key: str
     url_template: str
+    viewport: tuple[int, int]
     modes: tuple[UiMode, ...] = ()
 
     def __post_init__(self) -> None:
-        # Surface keys may be single-segment ("editor") or dotted
-        # ("editor.media_picker"); selector keys must always be dotted.
         if not _SURFACE_KEY_RE.match(self.key):
             msg = f"surface key must be lower_snake, optionally dotted: {self.key!r}"
+            raise ValueError(msg)
+        if self.viewport < MIN_VIEWPORT:
+            msg = (
+                f"{self.key}: viewport {self.viewport} is below Flow's responsive "
+                f"breakpoint {MIN_VIEWPORT}; selectors drift below it"
+            )
             raise ValueError(msg)
 
 
 @dataclass(frozen=True)
 class Selector:
-    """One DOM dependency, with the context that makes a MISS interpretable."""
-
     key: str
     surface: str
     candidates: tuple[str, ...]
     mode: UiMode | None = None
-    min_plan: Plan | None = None
-    features: tuple[str, ...] = field(default_factory=tuple)
-    required: bool = True
+    expect_unique: bool = False
     note: str = ""
 
     def __post_init__(self) -> None:
@@ -165,83 +197,11 @@ class Selector:
             raise ValueError(msg)
 ```
 
-- [ ] **Step 4: Run the model tests**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_model.py -v`
-Expected: PASS (5 tests)
-
-- [ ] **Step 5: Write the failing grader test**
+- [ ] **Step 4: Implement the grader**
 
 ```python
-# tests/ui/selectors/test_grading.py
-from __future__ import annotations
-
-from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors.grading import Grade, grade
-from gflow_cli.ui.selectors.model import Plan, Selector
-
-SEL = Selector(key="editor.count_tabs", surface="editor",
-               candidates=("[role=tab]:text-is('x2')", "[role=tab]:text-is('2x')"))
-
-
-def test_first_candidate_resolving_is_a_hit() -> None:
-    assert grade(SEL, resolved_index=0).grade is Grade.HIT
-
-
-def test_later_candidate_resolving_is_fallback_not_failure() -> None:
-    """#493's actual outcome: the scoped close missed, the unscoped fallback
-    held. Reporting that as failure is how a canary trains red-blindness."""
-    out = grade(SEL, resolved_index=1)
-    assert out.grade is Grade.FALLBACK
-    assert out.is_failure is False
-
-
-def test_no_candidate_resolving_on_a_required_selector_is_drift() -> None:
-    out = grade(SEL, resolved_index=None)
-    assert out.grade is Grade.MISS
-    assert out.is_failure is True
-
-
-def test_optional_selector_missing_is_not_a_failure() -> None:
-    optional = Selector(key="editor.hint", surface="editor",
-                        candidates=("div",), required=False)
-    assert grade(optional, resolved_index=None).is_failure is False
-
-
-def test_wrong_mode_makes_a_miss_expected_not_drift() -> None:
-    """The CROP_SELECTORS lesson: absent on the agentic arm means 'classic
-    indicator', not 'Google moved it'."""
-    classic_only = Selector(key="editor.crop", surface="editor",
-                            candidates=("button",), mode=UiMode.CLASSIC)
-    out = grade(classic_only, resolved_index=None, observed_mode=UiMode.AGENTIC)
-    assert out.grade is Grade.EXPECTED_ABSENT
-    assert out.is_failure is False
-
-
-def test_plan_gated_selector_missing_below_min_plan_is_expected() -> None:
-    ultra = Selector(key="editor.upscale_4k", surface="editor",
-                     candidates=("button",), min_plan=Plan.ULTRA)
-    out = grade(ultra, resolved_index=None, observed_plan=Plan.FREE)
-    assert out.grade is Grade.EXPECTED_ABSENT
-
-
-def test_plan_gated_selector_missing_at_or_above_min_plan_is_drift() -> None:
-    ultra = Selector(key="editor.upscale_4k", surface="editor",
-                     candidates=("button",), min_plan=Plan.ULTRA)
-    assert grade(ultra, resolved_index=None, observed_plan=Plan.ULTRA).is_failure is True
-```
-
-- [ ] **Step 6: Run it to confirm it fails**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_grading.py -v`
-Expected: FAIL — `No module named 'gflow_cli.ui.selectors.grading'`
-
-- [ ] **Step 7: Implement the grader**
-
-```python
-# src/gflow_cli/ui/selectors/grading.py
-"""Pure grading of a probe result. No browser, no IO — the same function grades
-a live capture and a committed snapshot, so the two layers cannot disagree."""
+# src/gflow_cli/flow_selectors/grading.py
+"""Pure grading. No browser, no IO."""
 
 from __future__ import annotations
 
@@ -249,14 +209,16 @@ from dataclasses import dataclass
 from enum import Enum
 
 from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors.model import Plan, Selector
+from gflow_cli.flow_selectors.model import Selector
 
 
 class Grade(Enum):
-    HIT = "hit"                        # candidates[0] resolved
-    FALLBACK = "fallback"              # a later candidate resolved — warn, do not fail
-    MISS = "miss"                      # nothing resolved and it should have
-    EXPECTED_ABSENT = "expected_absent"  # mode/plan says it should not be here
+    HIT = "hit"
+    FALLBACK = "fallback"              # a later candidate held — warn, do not fail
+    AMBIGUOUS = "ambiguous"            # >1 match; drivers use .first, so this misclicks
+    MISS = "miss"
+    EXPECTED_ABSENT = "expected_absent"
+    UNKNOWN_CONTEXT = "unknown_context"  # mode-scoped, but no sidecar mode to judge against
 
 
 @dataclass(frozen=True)
@@ -267,82 +229,50 @@ class Outcome:
 
     @property
     def is_failure(self) -> bool:
-        return self.grade is Grade.MISS
+        return self.grade in (Grade.MISS, Grade.AMBIGUOUS)
 
 
 def grade(
     selector: Selector,
     resolved_index: int | None,
+    match_count: int,
     observed_mode: UiMode | None = None,
-    observed_plan: Plan | None = None,
 ) -> Outcome:
-    """Grade one selector against which candidate (if any) resolved."""
     if resolved_index is not None:
+        if selector.expect_unique and match_count > 1:
+            return Outcome(selector.key, Grade.AMBIGUOUS, resolved_index)
         g = Grade.HIT if resolved_index == 0 else Grade.FALLBACK
         return Outcome(selector.key, g, resolved_index)
 
-    if selector.mode is not None and observed_mode is not None and selector.mode != observed_mode:
-        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
-    if (
-        selector.min_plan is not None
-        and observed_plan is not None
-        and observed_plan < selector.min_plan
-    ):
-        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
-    if not selector.required:
-        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
+    if selector.mode is not None:
+        if observed_mode is None:
+            # Never guess: guessing MISS here is a guaranteed false DRIFT.
+            return Outcome(selector.key, Grade.UNKNOWN_CONTEXT, None)
+        if selector.mode != observed_mode:
+            return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
     return Outcome(selector.key, Grade.MISS, None)
 ```
 
-- [ ] **Step 8: Run both test files**
+- [ ] **Step 5: Run model + grading tests**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/ -v`
-Expected: PASS (12 tests)
+Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_model.py tests/flow_selectors/test_grading.py -v`
+Expected: PASS (11 tests)
 
-- [ ] **Step 9: Lint and commit**
-
-```bash
-.venv/Scripts/python.exe -m ruff check src/gflow_cli/ui/selectors tests/ui/selectors
-.venv/Scripts/python.exe -m ruff format src/gflow_cli/ui/selectors tests/ui/selectors
-git add src/gflow_cli/ui/selectors tests/ui/selectors
-git commit -m "feat(selectors): registry model and pure grading function
-
-A MISS is only interpretable with its context: CROP_SELECTORS[0] legitimately
-misses on the agentic arm because it IS the classic-mode indicator. mode,
-min_plan and ordered candidates make that attributable instead of ambiguous.
-
-Refs #502"
-```
-
----
-
-### Task 2: Populate the registry with the drift-prone families
-
-**Files:**
-- Create: `src/gflow_cli/ui/selectors/registry.py`
-- Test: `tests/ui/selectors/test_registry.py`
-
-**Interfaces:**
-- Consumes: `Surface`, `Selector`, `Plan` from Task 1.
-- Produces: `SURFACES: dict[str, Surface]`, `SELECTORS: tuple[Selector, ...]`, `by_key(key) -> Selector`, `for_surface(surface_key, mode) -> tuple[Selector, ...]`.
-
-Only the families with incident history land here. Everything else migrates in Task 6.
-
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 6: Write the failing registry test**
 
 ```python
-# tests/ui/selectors/test_registry.py
+# tests/flow_selectors/test_registry.py
 from __future__ import annotations
 
 import pytest
 
 from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors import registry
+from gflow_cli.flow_selectors import registry
 
 
 def test_every_selector_points_at_a_declared_surface() -> None:
     for sel in registry.SELECTORS:
-        assert sel.surface in registry.SURFACES, f"{sel.key} -> unknown surface {sel.surface}"
+        assert sel.surface in registry.SURFACES
 
 
 def test_keys_are_unique() -> None:
@@ -350,27 +280,17 @@ def test_keys_are_unique() -> None:
     assert len(keys) == len(set(keys))
 
 
-def test_no_candidate_depends_on_display_text() -> None:
-    """Locale is ACCOUNT-driven: project_editor_url("en", ...) still served
-    /fx/pt/ in Portuguese. Text-matching selectors break for any non-English
-    account, so candidates must key on Material Symbols ligatures or structure.
-    ``:text-is('crop_16_9')`` is a LIGATURE (icon name), not display copy."""
-    banned = ("Generate", "New project", "Sign in", "Create")
-    for sel in registry.SELECTORS:
-        for cand in sel.candidates:
-            for word in banned:
-                assert word not in cand, f"{sel.key} matches display text: {word!r}"
+def test_the_404_family_is_registered() -> None:
+    """#404 (1x -> x2 rename) is the most-cited incident in the spec; the first
+    draft of this plan tested editor.count_tabs nine times without defining it."""
+    sel = registry.by_key("editor.count_tabs")
+    assert len(sel.candidates) >= 2, "must match BOTH cohorts, picking by digit"
 
 
-def test_incident_families_are_present() -> None:
-    for key in (
-        "editor.composer.input",
-        "editor.composer.submit",
-        "editor.agent_toggle",
-        "editor.sidebar.close",
-        "editor.crop_control",
-    ):
-        assert registry.by_key(key) is not None
+def test_incident_families_are_registered() -> None:
+    for key in ("editor.composer.input", "editor.composer.submit",
+                "editor.agent_toggle", "editor.crop_control"):
+        registry.by_key(key)  # raises KeyError if missing
 
 
 def test_by_key_raises_for_unknown() -> None:
@@ -379,49 +299,40 @@ def test_by_key_raises_for_unknown() -> None:
 
 
 def test_for_surface_filters_by_mode() -> None:
-    classic = registry.for_surface("editor", mode=UiMode.CLASSIC)
-    keys = {s.key for s in classic}
-    assert "editor.crop_control" in keys          # classic-only indicator
     agentic = {s.key for s in registry.for_surface("editor", mode=UiMode.AGENTIC)}
     assert "editor.crop_control" not in agentic
 
 
-def test_sidebar_close_keeps_its_fallback_ordered() -> None:
-    """#493: the edit_square-scoped close was the single point of failure; the
-    unscoped fallback is what recovered it. Order encodes preference."""
-    sel = registry.by_key("editor.sidebar.close")
-    assert len(sel.candidates) >= 2
-    assert "edit_square" in sel.candidates[0]
-    assert "edit_square" not in sel.candidates[1]
+def test_no_state_gated_selector_is_registered_yet() -> None:
+    """R4: SIDEBAR_CLOSE only exists while the sidebar is EXPANDED. On a
+    freshly-loaded editor it is legitimately absent, so registering it now
+    would grade MISS on every clean capture. It waits for Reach."""
+    assert "editor.sidebar.close" not in {s.key for s in registry.SELECTORS}
 ```
 
-- [ ] **Step 2: Run it to confirm it fails**
+- [ ] **Step 7: Implement the registry**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_registry.py -v`
-Expected: FAIL — `No module named 'gflow_cli.ui.selectors.registry'`
-
-- [ ] **Step 3: Implement the registry**
-
-Copy the candidate strings verbatim from their current homes — do not retype them. Read `src/gflow_cli/api/transports/mode_control.py:43,49,61,79` and `ui_automation.py:198,209` first.
+Read `mode_control.py:43,49` and `ui_automation.py:198,209` first; import the constants, never retype their values.
 
 ```python
-# src/gflow_cli/ui/selectors/registry.py
-"""The selectors gflow depends on, with the context that makes drift readable.
+# src/gflow_cli/flow_selectors/registry.py
+"""The Flow DOM elements gflow depends on, with the context that makes drift readable.
 
-Scope: the families with incident history (#404, #493, #174, #313). The rest
-migrate later — a partial registry that is USED beats a complete one that is not.
+Scope: families with incident history, present on a FRESHLY LOADED editor.
+State-gated entries (sidebar close) wait for `Reach` — see spec R4.
 """
 
 from __future__ import annotations
 
 from gflow_cli.api.transports import mode_control, ui_automation
 from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors.model import Selector, Surface
+from gflow_cli.flow_selectors.model import Selector, Surface
 
 SURFACES: dict[str, Surface] = {
     "editor": Surface(
         key="editor",
         url_template="https://labs.google/fx/{locale}/tools/flow/project/{project_id}",
+        viewport=(1920, 1080),
         modes=(UiMode.CLASSIC, UiMode.AGENTIC),
     ),
 }
@@ -431,40 +342,36 @@ SELECTORS: tuple[Selector, ...] = (
         key="editor.composer.input",
         surface="editor",
         candidates=tuple(ui_automation.PROMPT_INPUT_SELECTORS),
-        features=("image", "video"),
         note="#493 — the expanded chat sidebar hid this entirely.",
     ),
     Selector(
         key="editor.composer.submit",
         surface="editor",
         candidates=tuple(ui_automation.SUBMIT_BUTTON_SELECTORS),
-        features=("image", "video"),
+        expect_unique=True,
     ),
     Selector(
         key="editor.agent_toggle",
         surface="editor",
         candidates=(mode_control.AGENT_TOGGLE_SELECTOR,),
-        features=("image", "video"),
+        expect_unique=True,
         note="#313 — agent settings panel became sticky.",
     ),
     Selector(
-        key="editor.sidebar.close",
+        key="editor.count_tabs",
         surface="editor",
-        candidates=(
-            mode_control.SIDEBAR_CLOSE_SELECTOR,
-            mode_control.SIDEBAR_CLOSE_FALLBACK_SELECTOR,
-        ),
-        note="#493 — the edit_square-scoped close was the SPOF; the unscoped "
-        "fallback is the recovery. Order is preference, not decoration.",
+        candidates=("[role=tab]:text-is('x1')", "[role=tab]:text-is('1x')"),
+        note="#404 — Google renamed 1x -> x1. BOTH cohorts must match, and the "
+        "driver picks by DIGIT, never by position.",
     ),
     Selector(
         key="editor.crop_control",
         surface="editor",
         candidates=tuple(mode_control.CROP_SELECTORS),
         mode=UiMode.CLASSIC,
-        note="Classic-mode INDICATOR (factory.py:116). Absent on the agentic "
-        "arm by design — probing one of its six ratio variants and calling the "
-        "miss 'drift' is the exact error this registry prevents.",
+        note="Classic-mode INDICATOR (factory.py:116). Absent on the agentic arm "
+        "by design — grading that MISS as drift is the error this registry exists "
+        "to prevent, which is why an absent sidecar mode yields UNKNOWN_CONTEXT.",
     ),
 )
 
@@ -472,12 +379,10 @@ _BY_KEY = {s.key: s for s in SELECTORS}
 
 
 def by_key(key: str) -> Selector:
-    """Look up one selector. Raises KeyError for an unknown key."""
     return _BY_KEY[key]
 
 
 def for_surface(surface_key: str, mode: UiMode | None = None) -> tuple[Selector, ...]:
-    """Selectors expected on a surface, optionally narrowed to one arm."""
     return tuple(
         s
         for s in SELECTORS
@@ -485,260 +390,140 @@ def for_surface(surface_key: str, mode: UiMode | None = None) -> tuple[Selector,
     )
 ```
 
-- [ ] **Step 4: Run the registry tests**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_registry.py -v`
-Expected: PASS (7 tests).
-
-If `test_no_candidate_depends_on_display_text` fails, check whether the match is a Material Symbols **ligature** or real display copy. `:text('arrow_forward')` in `SUBMIT_BUTTON_SELECTORS` is a ligature — the icon's name, identical in every locale — and is fine. Actual UI copy is not. If you hit real copy, that is a pre-existing locale bug: raise it rather than weakening the test.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 8: Run the whole suite, lint, commit**
 
 ```bash
-.venv/Scripts/python.exe -m ruff check src/gflow_cli/ui/selectors tests/ui/selectors
-git add src/gflow_cli/ui/selectors/registry.py tests/ui/selectors/test_registry.py
-git commit -m "feat(selectors): register the drift-prone families
+.venv/Scripts/python.exe -m pytest tests/flow_selectors -v
+.venv/Scripts/python.exe -m ruff check src/gflow_cli/flow_selectors tests/flow_selectors
+.venv/Scripts/python.exe -m ruff format src/gflow_cli/flow_selectors tests/flow_selectors
+git add src/gflow_cli/flow_selectors tests/flow_selectors
+git commit -m "feat(selectors): registry model, grader, and the incident families
 
-Imports the existing constants rather than copying their values, so the
-registry cannot silently diverge from the code that uses them today.
+Surface pins 1920x1080: below Flow's responsive breakpoint the selectors drift,
+so a probe that forgets the viewport reports drift that is not there.
+
+A mode-scoped selector with no sidecar mode grades UNKNOWN_CONTEXT, never MISS.
+Guessing MISS there is a guaranteed false DRIFT on every agentic capture.
 
 Refs #404 #493 #313"
 ```
 
 ---
 
-### Task 3: Offline check against a committed DOM snapshot
+### Task 2: Capture with sidecar
 
 **Files:**
-- Create: `src/gflow_cli/ui/selectors/check.py`
-- Create: `tests/ui/selectors/fixtures/editor_classic.html` (generated in Task 4; use a hand-written stub until then)
-- Test: `tests/ui/selectors/test_check.py`
-
-**Interfaces:**
-- Consumes: `registry`, `grade`, `Outcome`.
-- Produces: `async check_html(html: str, entries: Sequence[Selector], **ctx) -> list[Outcome]`.
-
-Verified mechanism: Playwright's `set_content()` resolves `:has()` / `:text-is()` offline — no network, no auth, no credits.
-
-- [ ] **Step 1: Write the failing test**
-
-```python
-# tests/ui/selectors/test_check.py
-from __future__ import annotations
-
-import pytest
-
-from gflow_cli.ui.selectors.check import check_html
-from gflow_cli.ui.selectors.grading import Grade
-from gflow_cli.ui.selectors.model import Selector
-
-HTML = """<html><body>
-  <div role="textbox" data-slate-editor="true">prompt</div>
-  <button><i class="google-symbols">close</i></button>
-</body></html>"""
-
-
-async def test_resolving_first_candidate_reports_hit() -> None:
-    sel = Selector(key="editor.composer.input", surface="editor",
-                   candidates=('div[role="textbox"][data-slate-editor="true"]',))
-    (out,) = await check_html(HTML, [sel])
-    assert out.grade is Grade.HIT
-
-
-async def test_falls_through_to_a_later_candidate() -> None:
-    sel = Selector(key="editor.sidebar.close", surface="editor",
-                   candidates=("button.does-not-exist",
-                               "button:has(i.google-symbols:text-is('close'))"))
-    (out,) = await check_html(HTML, [sel])
-    assert out.grade is Grade.FALLBACK
-    assert out.resolved_index == 1
-
-
-async def test_absent_required_selector_reports_miss() -> None:
-    sel = Selector(key="editor.gone", surface="editor", candidates=("#nope",))
-    (out,) = await check_html(HTML, [sel])
-    assert out.grade is Grade.MISS
-```
-
-- [ ] **Step 2: Run it to confirm it fails**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_check.py -v`
-Expected: FAIL — `No module named 'gflow_cli.ui.selectors.check'`
-
-- [ ] **Step 3: Implement the checker**
-
-```python
-# src/gflow_cli/ui/selectors/check.py
-"""Grade selectors against DOM text. No network, no auth, no credits.
-
-A headless chromium is needed only to run Playwright's selector engines
-(``:has()``, ``:text-is()``) — verified working against static HTML via
-``set_content()``. This is the same function the live probe uses, so an
-offline snapshot check and a live capture check can never disagree.
-
-Limitation: ``set_content()`` drops external CSS/JS, so visibility and
-enabled-state are NOT reliable here. This layer asserts structural presence;
-the live probe additionally asserts visible/enabled.
-"""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-
-from playwright.async_api import async_playwright
-
-from gflow_cli.config import UiMode
-from gflow_cli.ui.selectors.grading import Outcome, grade
-from gflow_cli.ui.selectors.model import Plan, Selector
-
-
-async def check_html(
-    html: str,
-    entries: Sequence[Selector],
-    observed_mode: UiMode | None = None,
-    observed_plan: Plan | None = None,
-) -> list[Outcome]:
-    """Resolve each entry's candidates against ``html`` and grade the result."""
-    results: list[Outcome] = []
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch(headless=True)
-        try:
-            page = await browser.new_page()
-            await page.set_content(html)
-            for entry in entries:
-                index: int | None = None
-                for i, candidate in enumerate(entry.candidates):
-                    if await page.locator(candidate).count():
-                        index = i
-                        break
-                results.append(grade(entry, index, observed_mode, observed_plan))
-        finally:
-            await browser.close()
-    return results
-```
-
-- [ ] **Step 4: Run the tests**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_check.py -v`
-Expected: PASS (3 tests)
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/gflow_cli/ui/selectors/check.py tests/ui/selectors/test_check.py
-git commit -m "feat(selectors): offline DOM check, no network or credentials
-
-Same grader for snapshots and live captures, so the layers cannot drift apart.
-set_content() loses CSS/JS, so this asserts structural presence only."
-```
-
----
-
-### Task 4: Capture command
-
-**Files:**
-- Create: `scripts/probe/capture_surface.py`
-- Test: `tests/scripts/test_capture_surface.py`
+- Create: `scripts/probe/capture.py`
+- Test: `tests/scripts/test_capture.py`
 
 **Interfaces:**
 - Consumes: `registry.SURFACES`, `FlowApiClient`.
-- Produces: `scrub(html) -> str`; CLI writing `tests/ui/selectors/fixtures/<surface>_<mode>.html`.
+- Produces: `detect_mode(page) -> UiMode`; `async capture(profile, surface_key) -> tuple[str, dict]`.
 
-- [ ] **Step 1: Write the failing scrub test**
+- [ ] **Step 1: Write the failing sidecar test**
 
 ```python
-# tests/scripts/test_capture_surface.py
+# tests/scripts/test_capture.py
 from __future__ import annotations
 
-from scripts.probe.capture_surface import scrub
+from gflow_cli.config import UiMode
+from scripts.probe.capture import build_sidecar
 
 
-def test_scrub_removes_uuids() -> None:
-    out = scrub('<a href="/project/edf7fefa-c143-436b-b224-b19ec238e753">x</a>')
-    assert "edf7fefa" not in out
-    assert "REDACTED-UUID" in out
+def test_sidecar_records_the_context_the_grader_needs() -> None:
+    car = build_sidecar(mode=UiMode.AGENTIC, viewport=(1920, 1080),
+                        captured_at="2026-08-21T12:00:00Z", surface="editor")
+    assert car["mode"] == "agentic"
+    assert car["viewport"] == [1920, 1080]
+    assert car["surface"] == "editor"
 
 
-def test_scrub_removes_emails() -> None:
-    assert "@" not in scrub("<span>someone@example.com</span>")
-
-
-def test_scrub_removes_signed_urls() -> None:
-    html = '<img src="https://cdn.example/x.png?Expires=1&Signature=abc">'
-    assert "Signature=abc" not in scrub(html)
-
-
-def test_scrub_is_idempotent() -> None:
-    once = scrub('<a href="/project/edf7fefa-c143-436b-b224-b19ec238e753">x</a>')
-    assert scrub(once) == once
+def test_sidecar_never_carries_identifiers() -> None:
+    """The sidecar may be published alongside a drift report; keep it to
+    context, never project ids, accounts or URLs."""
+    car = build_sidecar(mode=UiMode.CLASSIC, viewport=(1920, 1080),
+                        captured_at="2026-08-21T12:00:00Z", surface="editor")
+    assert set(car) == {"mode", "viewport", "captured_at", "surface"}
 ```
 
 - [ ] **Step 2: Run it to confirm it fails**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture_surface.py -v`
-Expected: FAIL — `No module named 'scripts.probe'`
+Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture.py -v`
+Expected: FAIL — `No module named 'scripts.probe.capture'`
 
-- [ ] **Step 3: Implement capture + scrub**
+- [ ] **Step 3: Implement capture**
 
 ```python
-# scripts/probe/capture_surface.py
-"""Capture a Flow surface's DOM for offline selector checking. $0 — navigation
-and DOM read only; never submits.
+# scripts/probe/capture.py
+"""Capture a Flow surface's DOM plus the context needed to grade it. $0.
 
-Carries a positive control by construction: it CREATES its project rather than
-trusting a stored id. A stale project renders an error shell (~441KB, 3 buttons,
-0 icons) that is indistinguishable from an auth wall, and that confound voided
-three spike runs before it was caught.
+Creates its own project: a stale id renders an error shell (~441KB, 3 buttons,
+0 icons) indistinguishable from an auth wall, a confound that voided three
+spike runs before a positive control caught it.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
-import re
-import sys
-from pathlib import Path
+from datetime import UTC, datetime
 
 from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.drivers import factory
 from gflow_cli.auth import profile_dir as resolve_profile
-from gflow_cli.ui.selectors import registry
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-FIXTURES = REPO_ROOT / "tests" / "ui" / "selectors" / "fixtures"
-
-_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
-_EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
-_SIGNED = re.compile(r"(Signature|X-Goog-Signature|Expires)=[^&\"'\s]+", re.I)
+from gflow_cli.config import UiMode
+from gflow_cli.flow_selectors import registry
 
 
-def scrub(html: str) -> str:
-    """Strip identifiers before a DOM snapshot enters a public repo."""
-    html = _UUID.sub("REDACTED-UUID", html)
-    html = _EMAIL.sub("REDACTED-EMAIL", html)
-    return _SIGNED.sub(r"\1=REDACTED", html)
+def build_sidecar(
+    mode: UiMode, viewport: tuple[int, int], captured_at: str, surface: str
+) -> dict[str, object]:
+    """Context the grader needs. Deliberately carries no identifiers."""
+    return {
+        "mode": mode.value,
+        "viewport": [viewport[0], viewport[1]],
+        "captured_at": captured_at,
+        "surface": surface,
+    }
 
 
-async def capture(profile: str, surface_key: str) -> Path:
+async def detect_mode(page: object) -> UiMode:
+    """Which arm is rendered. Uses the SAME probe the drivers use, so the
+    sidecar cannot disagree with production (factory.py:116)."""
+    return (
+        UiMode.CLASSIC
+        if await factory._any_present(page, factory._CLASSIC_CROP_SELECTORS)  # noqa: SLF001
+        else UiMode.AGENTIC
+    )
+
+
+async def capture(profile: str, surface_key: str) -> tuple[str, dict[str, object]]:
     surface = registry.SURFACES[surface_key]
-    async with FlowApiClient(profile_dir=resolve_profile(profile), headless=True) as client:
+    async with FlowApiClient(
+        profile_dir=resolve_profile(profile), headless=True
+    ) as client:
         project = await client.create_project(title="selector-probe capture")
         page = client._page or client._context.pages[0]  # noqa: SLF001
-        url = surface.url_template.format(locale="en", project_id=project.project_id)
-        await page.goto(url, wait_until="domcontentloaded", timeout=90_000)
+        await page.set_viewport_size(
+            {"width": surface.viewport[0], "height": surface.viewport[1]}
+        )
+        await page.goto(
+            surface.url_template.format(locale="en", project_id=project.project_id),
+            wait_until="domcontentloaded",
+            timeout=90_000,
+        )
         for _ in range(25):
             if await page.locator("i.google-symbols").count():
                 break
             await page.wait_for_timeout(1000)
         else:
-            msg = "surface never hydrated — capture aborted rather than saving an error shell"
+            msg = "surface never hydrated — refusing to save an error shell"
             raise SystemExit(msg)
-        html = scrub(await page.content())
+        mode = await detect_mode(page)
+        html = await page.content()
 
-    FIXTURES.mkdir(parents=True, exist_ok=True)
-    out = FIXTURES / f"{surface_key}.html"
-    out.write_text(html, encoding="utf-8")
-    print(f"captured {len(html):,} bytes -> {out}")
-    return out
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return html, build_sidecar(mode, surface.viewport, stamp, surface_key)
 
 
 def main() -> int:
@@ -746,79 +531,52 @@ def main() -> int:
     p.add_argument("--profile", required=True)
     p.add_argument("--surface", default="editor")
     args = p.parse_args()
-    asyncio.run(capture(args.profile, args.surface))
+    html, sidecar = asyncio.run(capture(args.profile, args.surface))
+    print(f"captured {len(html):,} bytes; context={sidecar}")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())
 ```
 
-- [ ] **Step 4: Run the scrub tests**
+- [ ] **Step 4: Verify `_any_present` and `_CLASSIC_CROP_SELECTORS` exist**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture_surface.py -v`
-Expected: PASS (4 tests)
+Run: `grep -n "_any_present\|_CLASSIC_CROP_SELECTORS" src/gflow_cli/api/transports/drivers/factory.py`
+Expected: both present (seen at `factory.py:52,116`). If either is renamed, use the current name — do not reimplement mode detection, or the sidecar can disagree with production.
 
-- [ ] **Step 5: Capture the real fixture and add the snapshot test**
+- [ ] **Step 5: Run tests and commit**
 
 ```bash
-.venv/Scripts/python.exe scripts/probe/capture_surface.py --profile denon82 --surface editor
-```
+.venv/Scripts/python.exe -m pytest tests/scripts/test_capture.py -v
+git add scripts/probe/capture.py tests/scripts/test_capture.py
+git commit -m "feat(probe): DOM capture with a mode sidecar at the pinned viewport
 
-```python
-# append to tests/ui/selectors/test_check.py
-from pathlib import Path
-from gflow_cli.ui.selectors import registry
-
-FIXTURE = Path(__file__).parent / "fixtures" / "editor.html"
-
-
-async def test_committed_snapshot_still_satisfies_every_editor_selector() -> None:
-    """Catches OUR regressions on every PR. It can never detect Google changing
-    the page — the snapshot is frozen. That is the live probe's job."""
-    html = FIXTURE.read_text(encoding="utf-8")
-    outcomes = await check_html(html, registry.for_surface("editor"))
-    failures = [o.selector_key for o in outcomes if o.is_failure]
-    assert not failures, f"snapshot no longer satisfies: {failures}"
-```
-
-- [ ] **Step 6: Verify the fixture is clean before committing it**
-
-Run: `grep -ciE "[0-9a-f]{8}-[0-9a-f]{4}|@[a-z-]+\.[a-z]" tests/ui/selectors/fixtures/editor.html`
-Expected: `0`. Non-zero means `scrub()` missed a pattern — fix `scrub`, re-capture, re-check.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add scripts/probe tests/scripts/test_capture_surface.py tests/ui/selectors/
-git commit -m "feat(probe): DOM capture with scrubbing, plus the snapshot check
-
-Capture creates its own project: a stale id renders an error shell that reads
-exactly like an auth wall, which voided three spike runs before it was caught."
+Mode is detected with the drivers' own probe, so the sidecar cannot disagree
+with production. Inferring it at check time would be circular."
 ```
 
 ---
 
-### Task 5: CI probe workflow
+### Task 3: CI probe
 
 **Files:**
+- Create: `src/gflow_cli/flow_selectors/check.py`
 - Create: `scripts/probe/run_probe.py`
 - Create: `.github/workflows/selector-probe.yml`
-- Test: `tests/scripts/test_run_probe.py`
+- Test: `tests/flow_selectors/test_report.py`
 
 **Interfaces:**
-- Consumes: `check_html`, `registry`, `scrub`.
-- Produces: `render_report(outcomes) -> str`; exit 0 clean / 1 drift / 2 infrastructure.
+- Consumes: `registry`, `grade`, `Outcome`.
+- Produces: `async check_html(html, entries, observed_mode) -> list[Outcome]`; `render_report(outcomes) -> str`.
 
-Evidence: a bundled headless chromium carrying only `__Secure-next-auth.session-token` (1088 chars, 30-day expiry) renders the editor identically to a full real-Chrome profile — six-arm matrix, all identical.
-
-- [ ] **Step 1: Write the failing report test**
+- [ ] **Step 1: Write the failing report test** (pure — no browser, so it is safe in the default suite)
 
 ```python
-# tests/scripts/test_run_probe.py
+# tests/flow_selectors/test_report.py
 from __future__ import annotations
 
-from gflow_cli.ui.selectors.grading import Grade, Outcome
+from gflow_cli.flow_selectors.grading import Grade, Outcome
 from scripts.probe.run_probe import render_report
 
 
@@ -828,34 +586,86 @@ def test_report_names_the_drifted_selector() -> None:
     assert "DRIFT" in body
 
 
-def test_fallback_is_reported_as_a_warning_not_drift() -> None:
+def test_fallback_is_a_warning_not_drift() -> None:
     body = render_report([Outcome("editor.sidebar.close", Grade.FALLBACK, 1)])
     assert "FALLBACK" in body
     assert "DRIFT" not in body
 
 
-def test_report_never_contains_a_raw_selector() -> None:
-    """Keys are publication-safe; raw selectors and paths are not."""
-    body = render_report([Outcome("editor.composer.input", Grade.MISS, None)])
-    assert "div[role=" not in body
+def test_ambiguous_is_reported_as_a_failure() -> None:
+    body = render_report([Outcome("editor.agent_toggle", Grade.AMBIGUOUS, 0)])
+    assert "AMBIGUOUS" in body
+    assert "1 need" in body
+
+
+def test_unknown_context_is_visible_but_not_a_failure() -> None:
+    """Silence here would hide that the probe could not judge a mode-scoped
+    entry at all."""
+    body = render_report([Outcome("editor.crop_control", Grade.UNKNOWN_CONTEXT, None)])
+    assert "UNKNOWN" in body
+    assert "0 need" in body
 ```
 
 - [ ] **Step 2: Run it to confirm it fails**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_run_probe.py -v`
+Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_report.py -v`
 Expected: FAIL — `No module named 'scripts.probe.run_probe'`
 
-- [ ] **Step 3: Implement the probe runner**
+- [ ] **Step 3: Implement check + probe**
+
+```python
+# src/gflow_cli/flow_selectors/check.py
+"""Resolve registry candidates against DOM text and grade them.
+
+Needs a headless chromium only for Playwright's selector engines; no network,
+auth or credits. Asserts STRUCTURAL PRESENCE only — set_content() drops
+external CSS/JS and page.content() omits shadow roots, so visible/enabled is
+out of scope for both callers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from playwright.async_api import async_playwright
+
+from gflow_cli.config import UiMode
+from gflow_cli.flow_selectors.grading import Outcome, grade
+from gflow_cli.flow_selectors.model import Selector
+
+
+async def check_html(
+    html: str, entries: Sequence[Selector], observed_mode: UiMode | None = None
+) -> list[Outcome]:
+    results: list[Outcome] = []
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            page = await browser.new_page()
+            await page.set_content(html)
+            for entry in entries:
+                index: int | None = None
+                count = 0
+                for i, candidate in enumerate(entry.candidates):
+                    count = await page.locator(candidate).count()
+                    if count:
+                        index = i
+                        break
+                results.append(grade(entry, index, count, observed_mode))
+        finally:
+            await browser.close()
+    return results
+```
 
 ```python
 # scripts/probe/run_probe.py
 """Probe live Flow for selector drift. $0 — navigate and read only.
 
-Auth is ONE cookie: __Secure-next-auth.session-token (30-day life, scoped to
-labs.google). Measured: a bundled headless chromium with only that cookie
-renders the editor identically to a full real-Chrome profile.
+Auth is ONE cookie: __Secure-next-auth.session-token. Measured sufficient AT
+MINT TIME; an aged token is unverified (spec §2.2), so exit 2 exists to keep an
+expired credential from ever being reported as drift.
 
-Exit: 0 no drift · 1 drift found · 2 infrastructure failure (never confuse them).
+Exit: 0 clean · 1 drift · 2 infrastructure.
 """
 
 from __future__ import annotations
@@ -867,56 +677,68 @@ import sys
 
 from playwright.async_api import async_playwright
 
-from gflow_cli.ui.selectors import registry
-from gflow_cli.ui.selectors.check import check_html
-from gflow_cli.ui.selectors.grading import Grade, Outcome
+from gflow_cli.config import UiMode
+from gflow_cli.flow_selectors import registry
+from gflow_cli.flow_selectors.check import check_html
+from gflow_cli.flow_selectors.grading import Grade, Outcome
 
 SESSION_COOKIE = "__Secure-next-auth.session-token"
 _LABEL = {
     Grade.HIT: "ok",
     Grade.FALLBACK: "FALLBACK",
+    Grade.AMBIGUOUS: "AMBIGUOUS",
     Grade.MISS: "DRIFT",
     Grade.EXPECTED_ABSENT: "n/a",
+    Grade.UNKNOWN_CONTEXT: "UNKNOWN",
 }
 
 
 def render_report(outcomes: list[Outcome]) -> str:
-    """Publication-safe: keys only, never raw selectors or paths."""
+    """Publication-safe: keys and grades only, never selectors or DOM."""
     lines = ["| selector | result |", "| --- | --- |"]
     lines += [f"| `{o.selector_key}` | {_LABEL[o.grade]} |" for o in outcomes]
-    drift = [o.selector_key for o in outcomes if o.is_failure]
-    lines += ["", f"**{len(drift)} drifted**" if drift else "**No drift.**"]
+    bad = [o.selector_key for o in outcomes if o.is_failure]
+    lines += ["", f"**{len(bad)} need attention**" if bad else "**0 need attention.**"]
     return "\n".join(lines)
 
 
 async def run(token: str, project_id: str, surface_key: str) -> int:
     surface = registry.SURFACES[surface_key]
-    url = surface.url_template.format(locale="en", project_id=project_id)
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(headless=True)
         try:
-            ctx = await browser.new_context()
+            ctx = await browser.new_context(
+                viewport={"width": surface.viewport[0], "height": surface.viewport[1]}
+            )
             await ctx.add_cookies([{
                 "name": SESSION_COOKIE, "value": token,
                 "domain": "labs.google", "path": "/",
                 "httpOnly": True, "secure": True, "sameSite": "Lax",
             }])
             page = await ctx.new_page()
-            await page.goto(url, wait_until="domcontentloaded", timeout=90_000)
+            await page.goto(
+                surface.url_template.format(locale="en", project_id=project_id),
+                wait_until="domcontentloaded", timeout=90_000,
+            )
             for _ in range(25):
                 if await page.locator("i.google-symbols").count():
                     break
                 await page.wait_for_timeout(1000)
             else:
-                # Positive control: an un-hydrated surface means the token expired
-                # or the project is gone. That is NOT drift — never report it as such.
+                # Expired token or missing project — NOT drift. Never conflate them.
                 print("::error::surface never hydrated (expired token or missing project)")
                 return 2
+            mode = (
+                UiMode.CLASSIC
+                if await page.locator(registry.by_key("editor.crop_control").candidates[0]).count()
+                else UiMode.AGENTIC
+            )
             html = await page.content()
         finally:
             await browser.close()
 
-    outcomes = await check_html(html, registry.for_surface(surface_key))
+    outcomes = await check_html(html, registry.for_surface(surface_key), mode)
+    print(f"observed mode: {mode.value}")
     print(render_report(outcomes))
     return 1 if any(o.is_failure for o in outcomes) else 0
 
@@ -939,8 +761,8 @@ if __name__ == "__main__":
 
 - [ ] **Step 4: Run the report tests**
 
-Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_run_probe.py -v`
-Expected: PASS (3 tests)
+Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_report.py -v`
+Expected: PASS (4 tests)
 
 - [ ] **Step 5: Add the workflow**
 
@@ -950,7 +772,7 @@ name: Selector drift probe
 
 on:
   schedule:
-    - cron: "0 5 * * *"      # 05:00 UTC, before the maintainer's local canary
+    - cron: "0 5 * * *"
   workflow_dispatch:
 
 permissions:
@@ -973,225 +795,38 @@ jobs:
         run: uv run python scripts/probe/run_probe.py --surface editor
 ```
 
-Start on `schedule` + `workflow_dispatch` only. Do **not** add `pull_request` until R1 (datacenter-IP behaviour) is answered by a first real run.
+**Never add `pull_request`.** Fork PRs are safe (GitHub withholds secrets), but
+**same-repo branch PRs do receive them** while checking out attacker-editable probe
+code. Never use `pull_request_target`.
 
-- [ ] **Step 6: Commit**
-
-```bash
-git add scripts/probe/run_probe.py .github/workflows/selector-probe.yml tests/scripts/test_run_probe.py
-git commit -m "feat(probe): CI selector-drift probe on a single session cookie
-
-Exit 2 (infrastructure) is kept distinct from exit 1 (drift): an expired token
-or a deleted project must never be reported as Google changing the page."
-```
-
----
-
-### Task 6: AST guardrail, error key, and env override
-
-**Files:**
-- Create: `tests/api/transports/test_selectors_only_in_registry.py`
-- Modify: `src/gflow_cli/errors.py` (`UiSelectorDriftError`)
-- Create: `src/gflow_cli/ui/selectors/overrides.py`
-- Test: `tests/ui/selectors/test_overrides.py`
-
-**Interfaces:**
-- Consumes: `registry`, `Selector`.
-- Produces: `apply_overrides(entries) -> tuple[Selector, ...]`; `UiSelectorDriftError(selector_key=...)`.
-
-- [ ] **Step 1: Write the failing override test**
-
-```python
-# tests/ui/selectors/test_overrides.py
-from __future__ import annotations
-
-import pytest
-
-from gflow_cli.ui.selectors.model import Selector
-from gflow_cli.ui.selectors.overrides import apply_overrides
-
-BASE = (Selector(key="editor.count_tabs", surface="editor", candidates=("[role=tab]",)),)
-
-
-def test_no_env_leaves_entries_untouched(monkeypatch) -> None:
-    monkeypatch.delenv("GFLOW_CLI_SELECTOR_OVERRIDE", raising=False)
-    assert apply_overrides(BASE) == BASE
-
-
-def test_override_replaces_the_candidate_list(monkeypatch) -> None:
-    """A user hit by a #404-class rename patches it and keeps working, instead
-    of waiting for a release."""
-    monkeypatch.setenv("GFLOW_CLI_SELECTOR_OVERRIDE", "editor.count_tabs=[role=tab].new")
-    (sel,) = apply_overrides(BASE)
-    assert sel.candidates == ("[role=tab].new",)
-
-
-def test_unknown_key_is_rejected_loudly(monkeypatch) -> None:
-    monkeypatch.setenv("GFLOW_CLI_SELECTOR_OVERRIDE", "editor.nope=div")
-    with pytest.raises(ValueError, match="unknown selector key"):
-        apply_overrides(BASE)
-```
-
-- [ ] **Step 2: Run it to confirm it fails**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_overrides.py -v`
-Expected: FAIL — `No module named 'gflow_cli.ui.selectors.overrides'`
-
-- [ ] **Step 3: Implement overrides**
-
-```python
-# src/gflow_cli/ui/selectors/overrides.py
-"""Operator escape hatch: patch a drifted selector without waiting for a release.
-
-    GFLOW_CLI_SELECTOR_OVERRIDE='editor.count_tabs=<css>;editor.composer.input=<css>'
-
-Keys are a public promise — renaming one is a breaking change.
-"""
-
-from __future__ import annotations
-
-import dataclasses
-import os
-from collections.abc import Sequence
-
-from gflow_cli.ui.selectors.model import Selector
-
-ENV_VAR = "GFLOW_CLI_SELECTOR_OVERRIDE"
-
-
-def _parse(raw: str) -> dict[str, str]:
-    out: dict[str, str] = {}
-    for chunk in raw.split(";"):
-        if not chunk.strip():
-            continue
-        key, sep, value = chunk.partition("=")
-        if not sep or not value.strip():
-            msg = f"malformed {ENV_VAR} entry: {chunk!r} (expected key=selector)"
-            raise ValueError(msg)
-        out[key.strip()] = value.strip()
-    return out
-
-
-def apply_overrides(entries: Sequence[Selector]) -> tuple[Selector, ...]:
-    """Return entries with any env-supplied candidates substituted."""
-    raw = os.environ.get(ENV_VAR, "").strip()
-    if not raw:
-        return tuple(entries)
-    wanted = _parse(raw)
-    known = {e.key for e in entries}
-    unknown = sorted(set(wanted) - known)
-    if unknown:
-        msg = f"{ENV_VAR}: unknown selector key(s) {unknown}"
-        raise ValueError(msg)
-    return tuple(
-        dataclasses.replace(e, candidates=(wanted[e.key],)) if e.key in wanted else e
-        for e in entries
-    )
-```
-
-- [ ] **Step 4: Run the override tests**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors/test_overrides.py -v`
-Expected: PASS (3 tests)
-
-- [ ] **Step 5: Add `selector_key` to the drift error**
-
-`UiSelectorDriftError` is an RFC 9457 Problem Details class (`errors.py:70`): class-level identity, instance-level extensions. Add `selector_key` as an extension alongside `route`, so exit 23 names what moved.
-
-```python
-# in src/gflow_cli/errors.py, inside UiSelectorDriftError
-    selector_key: str | None = None
-```
-
-Add a test in `tests/test_error_contract.py`:
-
-```python
-def test_ui_selector_drift_carries_a_registry_key() -> None:
-    err = UiSelectorDriftError(detail="probe missed", selector_key="editor.count_tabs")
-    assert err.selector_key == "editor.count_tabs"
-    assert "editor.count_tabs" not in str(err.to_problem_details().get("detail", ""))
-```
-
-- [ ] **Step 6: Add the AST guardrail**
-
-```python
-# tests/api/transports/test_selectors_only_in_registry.py
-"""Guard: registered selector strings live only in the registry.
-
-Sibling of test_selector_symmetry.py, which already locks the agentic
-indicators to one source. This widens the same principle: once a selector is in
-the registry, no transport may carry its literal, or the two silently diverge —
-which is exactly what happened to the agentic probes before #183.
-"""
-
-from __future__ import annotations
-
-import ast
-from pathlib import Path
-
-import pytest
-
-from gflow_cli.ui.selectors import registry
-
-SRC = Path(__file__).resolve().parents[3] / "src" / "gflow_cli"
-REGISTRY_DIR = SRC / "ui" / "selectors"
-# mode_control/ui_automation still DEFINE the constants the registry imports;
-# they are the migration source and are exempt until Task 7 inverts the flow.
-EXEMPT = {
-    SRC / "api" / "transports" / "mode_control.py",
-    SRC / "api" / "transports" / "ui_automation.py",
-}
-
-pytestmark = pytest.mark.repo_lint
-
-
-def _registered_literals() -> set[str]:
-    return {c for s in registry.SELECTORS for c in s.candidates}
-
-
-def test_no_module_outside_the_registry_hardcodes_a_registered_selector() -> None:
-    registered = _registered_literals()
-    offenders: list[str] = []
-    for path in SRC.rglob("*.py"):
-        if path in EXEMPT or REGISTRY_DIR in path.parents:
-            continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Constant) and node.value in registered:
-                offenders.append(f"{path.relative_to(SRC)}:{node.lineno}")
-    assert not offenders, (
-        "registered selectors must come from the registry, not literals: " + ", ".join(offenders)
-    )
-```
-
-- [ ] **Step 7: Run the whole selector suite**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/ui/selectors tests/scripts tests/api/transports/test_selectors_only_in_registry.py -v`
-Expected: PASS
-
-- [ ] **Step 8: Full gate and commit**
+- [ ] **Step 6: Full gate and commit**
 
 ```bash
 .venv/Scripts/python.exe -m ruff check src tests
 .venv/Scripts/python.exe -m ruff format --check src tests
 .venv/Scripts/python.exe scripts/ci/check_repo_hygiene.py
-.venv/Scripts/python.exe scripts/ci/check_doc_links.py
-git add -A
-git commit -m "feat(selectors): AST guardrail, drift-error key, and env override
+.venv/Scripts/python.exe -m pytest tests/flow_selectors tests/scripts -v
+git add src/gflow_cli/flow_selectors/check.py scripts/probe .github/workflows/selector-probe.yml tests/
+git commit -m "feat(probe): CI selector-drift probe on a single session cookie
 
-Users hit by a rename can now patch it via GFLOW_CLI_SELECTOR_OVERRIDE instead
-of waiting for a release, and exit 23 names the registry key that moved."
+Exit 2 (infrastructure) stays distinct from exit 1 (drift): an expired token or
+a deleted project must never be published as Google changing the page.
+
+schedule + workflow_dispatch only. pull_request would hand the secret to
+same-repo branch PRs alongside attacker-editable probe code."
 ```
 
 ---
 
+## First run checklist (R1)
+
+1. Create the throwaway account, sign in once, capture its session token.
+2. `gh secret set GFLOW_CI_SESSION_TOKEN` and `GFLOW_CI_PROJECT_ID`.
+3. `workflow_dispatch` once. **Datacenter-IP behaviour is unmeasured** — all evidence is from a residential IP.
+4. **Re-run on day 7.** §2.2 establishes the cookie only at mint time; an aged token is unverified, and §2.7 says it hard-dies at day 30 with no rotation and therefore no warning.
+
 ## Deferred to a follow-up plan
 
-- Migrating the remaining ~35 selectors and **inverting** the import direction so `mode_control`/`ui_automation` read *from* the registry (removes the `EXEMPT` set in Task 6).
-- Additional surfaces: `editor.media_picker`, `character_editor`, timeline.
-- Splitting `ui_automation.py` (3,557 lines) and `ui_automation_video.py` (3,814).
-- Wiring the nightly canary to publish CI-token expiry (spec R2).
-
-## Open question for the first real run
-
-**R1 — datacenter IP.** Every measurement came from a residential connection. No local test can predict how Google treats a GitHub runner. Run the workflow once via `workflow_dispatch` and read the result before considering a `pull_request` trigger.
+- **AST guardrail.** It flags **9 real offenders today** (`ui_automation_video.py:91-96,162`, `agentic.py:62`, `diagnostics.py:1738`), so it reds on arrival while its own migration is deferred.
+- **`selector_key` on `UiSelectorDriftError` and `GFLOW_CLI_SELECTOR_OVERRIDE`** — blocked on a scope decision (spec §3.5). Both need the drivers to read from the registry; `GFlowError.__init__` also takes a fixed kwarg list, so `selector_key` is not a one-line addition.
+- Remaining ~35 selectors, inverting the import direction, `Reach` for state-gated surfaces, additional surfaces.

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -738,5 +738,6 @@ same-repo branch PRs alongside attacker-editable probe code."
 ## Deferred to a follow-up plan
 
 - **AST guardrail.** It flags **9 real offenders today** (`ui_automation_video.py:91-96,162`, `agentic.py:62`, `diagnostics.py:1738`), so it reds on arrival while its own migration is deferred.
-- **`selector_key` on `UiSelectorDriftError` and `GFLOW_CLI_SELECTOR_OVERRIDE`** — blocked on a scope decision (spec §3.5). Both need the drivers to read from the registry; `GFlowError.__init__` also takes a fixed kwarg list, so `selector_key` is not a one-line addition.
+- **`selector_key` on `UiSelectorDriftError`** — needs the drivers to read from the registry (all 7 raise sites are in `ui_automation*`), and `GFlowError.__init__` takes a fixed kwarg list, so it is not a one-line addition. Lands with the import inversion.
+- **`GFLOW_CLI_SELECTOR_OVERRIDE` is NOT deferred — it is rejected.** See spec §3.5: an env var injecting arbitrary DOM selectors into production automation is a hack, and the probe already delivers the half that matters by reporting drift by key.
 - Remaining ~35 selectors, inverting the import direction, `Reach` for state-gated surfaces, additional surfaces.

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -16,7 +16,7 @@
 - **$0 invariant:** reach steps MUST be non-mutating and credit-free. Never submit.
 - **Pin the viewport to 1920×1080.** `ui_automation.py:117-124`: smaller *"would cross the responsive breakpoint and drift the selectors"*. `FlowApiClient` (1280×720) and Playwright's default (1280×720) are both **below** it.
 - **`observed_mode` is REQUIRED by the grader**, and must come from production's own detector: `factory._any_present(page, _CLASSIC_CROP_SELECTORS)` over **all six** ratio variants. Checking only `candidates[0]` is a silent-pass hole — a classic editor on a 9:16 project reads AGENTIC, so a drifted `crop_control` grades EXPECTED_ABSENT and hides permanently.
-- **Every DOM probe creates-or-verifies its project.** A stale id renders an error shell (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall.
+- **A stale project renders an error shell** (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall. The probe must therefore be able to say *"the surface did not load"* (exit 2) rather than *"a selector drifted"* (exit 1). It does **not** create projects — that would be a mutating operation against the $0 invariant.
 - **No default-suite test may launch a real browser.** `ci.yml:165` runs plain pytest and **no workflow installs Playwright**. Browser-touching tests live in the probe workflow, which installs chromium itself.
 - **Secrets:** `__Secure-next-auth.session-token` only, from a dedicated throwaway account. Never log a cookie value. For any published output reuse `src/gflow_cli/data/redaction.py` — it already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token` and signed queries.
 - **Package name:** `gflow_cli.flow_selectors`, NOT `gflow_cli.ui` — `src/gflow_cli/ui/` already means gflow's own UI (`app.py`, `server.py`).
@@ -454,13 +454,20 @@ def test_ambiguous_is_reported_as_a_failure() -> None:
     assert "1 need" in body
 
 
-def test_alternate_state_names_are_stable_report_vocabulary() -> None:
-    """R8: the two known zero-click states must be enumerable, or an executor
-    cannot tell 'panel covering the composer' from 'Google moved it'."""
-    from scripts.probe.run_probe import _ALTERNATE_STATE_INDICATORS
+def test_alternate_state_gate_has_a_scoped_and_an_unscoped_candidate() -> None:
+    """R8. Two guards in one test:
 
-    labels = {label for label, _ in _ALTERNATE_STATE_INDICATORS}
-    assert labels == {"expanded chat sidebar", "agent chat panel"}
+    - the gate must not rely on the edit_square scoping alone — that was #493's
+      single point of failure, and a drifted scope would silently disable it
+    - the candidates must be DISTINCT. SIDEBAR_CLOSE_SELECTOR and
+      AGENT_CHAT_PANEL_CLOSE_SELECTOR are byte-equal aliases, so an earlier
+      draft listed one selector twice and certified a label it could not emit.
+    """
+    from scripts.probe.run_probe import _ALTERNATE_STATE_CANDIDATES
+
+    assert len(set(_ALTERNATE_STATE_CANDIDATES)) == len(_ALTERNATE_STATE_CANDIDATES)
+    assert any("edit_square" in c for c in _ALTERNATE_STATE_CANDIDATES)
+    assert any("edit_square" not in c for c in _ALTERNATE_STATE_CANDIDATES)
 
 
 def test_expected_absent_is_visible_but_not_a_failure() -> None:
@@ -500,7 +507,7 @@ from collections.abc import Sequence
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright
 
-from gflow_cli.api.transports import mode_control, ui_automation_video
+from gflow_cli.api.transports import mode_control
 from gflow_cli.api.transports.drivers import factory
 from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors import registry
@@ -533,10 +540,17 @@ def render_report(outcomes: list[Outcome]) -> str:
 #   ui_automation_video.py:149-153 — a chat panel "appears on some project opens
 #                            and not others"; while up "the in-composer pill is
 #                            NOT in the DOM at all"
-_ALTERNATE_STATE_INDICATORS: tuple[tuple[str, str], ...] = (
-    ("expanded chat sidebar", mode_control.SIDEBAR_CLOSE_SELECTOR),
-    ("agent chat panel", ui_automation_video.AGENT_CHAT_PANEL_CLOSE_SELECTOR),
+# NOTE: mode_control.SIDEBAR_CLOSE_SELECTOR and
+# ui_automation_video.AGENT_CHAT_PANEL_CLOSE_SELECTOR are BYTE-EQUAL — two names
+# for one selector. Listing both would make the second entry unreachable. One
+# scoped candidate plus the genuinely-different unscoped fallback, mirroring
+# production's two-tier close: the edit_square scoping was #493's single point
+# of failure, so relying on it alone would let a drifted scope disable this gate.
+_ALTERNATE_STATE_CANDIDATES: tuple[str, ...] = (
+    mode_control.SIDEBAR_CLOSE_SELECTOR,
+    mode_control.SIDEBAR_CLOSE_FALLBACK_SELECTOR,
 )
+_ALTERNATE_STATE_LABEL = "expanded chat sidebar / agent chat panel"
 
 
 async def alternate_state(page: object) -> str | None:
@@ -547,9 +561,9 @@ async def alternate_state(page: object) -> str | None:
     it" (inconclusive, exit 2). Three of the four registered selectors are
     absent in these states, so without this gate a cohort flap reads as drift.
     """
-    for label, selector in _ALTERNATE_STATE_INDICATORS:
+    for selector in _ALTERNATE_STATE_CANDIDATES:
         if await page.locator(selector).count():  # type: ignore[attr-defined]
-            return label
+            return _ALTERNATE_STATE_LABEL
     return None
 
 
@@ -646,7 +660,7 @@ if __name__ == "__main__":
 - [ ] **Step 4: Run the report tests**
 
 Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_report.py -v`
-Expected: PASS (4 tests)
+Expected: PASS (5 tests)
 
 - [ ] **Step 5: Add the workflow**
 

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -4,7 +4,7 @@
 
 **Goal:** Turn gflow's scattered Flow DOM selectors into a structured, enumerable registry that a $0 CI probe walks nightly, so drift is *named* rather than inferred from a failing test.
 
-**Architecture:** A pure-data registry (`Surface` + `Selector`) and a pure grader. Capture (navigate at a pinned viewport → `page.content()` + a mode sidecar) is separate from check (`html + entries + observed → grade`), so the probe's evidence and its verdict are independently inspectable.
+**Architecture:** A pure-data registry (`Surface` + `Selector`) and a pure grader, driven by one CI probe: navigate at a pinned viewport, detect the UI arm with production's own detector, read the DOM once, grade.
 
 **Tech Stack:** Python 3.11+, Playwright (already a dep), pytest, ruff, GitHub Actions.
 
@@ -15,7 +15,7 @@
 - **Windows dev:** `.venv/Scripts/python.exe -m pytest`, never `uv run pytest` (broken here). Never pipe pytest to `tail` — it masks the exit code.
 - **$0 invariant:** reach steps MUST be non-mutating and credit-free. Never submit.
 - **Pin the viewport to 1920×1080.** `ui_automation.py:117-124`: smaller *"would cross the responsive breakpoint and drift the selectors"*. `FlowApiClient` (1280×720) and Playwright's default (1280×720) are both **below** it.
-- **`observed_mode` is a capture-time sidecar, never inferred at check time** — inferring it is circular, because the mode detector IS the crop probe.
+- **`observed_mode` is REQUIRED by the grader**, and must come from production's own detector: `factory._any_present(page, _CLASSIC_CROP_SELECTORS)` over **all six** ratio variants. Checking only `candidates[0]` is a silent-pass hole — a classic editor on a 9:16 project reads AGENTIC, so a drifted `crop_control` grades EXPECTED_ABSENT and hides permanently.
 - **Every DOM probe creates-or-verifies its project.** A stale id renders an error shell (~441KB, 3 buttons, 0 icons) indistinguishable from an auth wall.
 - **No default-suite test may launch a real browser.** `ci.yml:165` runs plain pytest and **no workflow installs Playwright**. Browser-touching tests live in the probe workflow, which installs chromium itself.
 - **Secrets:** `__Secure-next-auth.session-token` only, from a dedicated throwaway account. Never log a cookie value. For any published output reuse `src/gflow_cli/data/redaction.py` — it already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token` and signed queries.
@@ -60,34 +60,43 @@ def test_surface_pins_a_viewport_at_or_above_the_breakpoint() -> None:
     breakpoint and drifts the selectors. A probe that forgets this reports
     false drift, so the model refuses to let it be forgotten."""
     with pytest.raises(ValueError, match="breakpoint"):
-        Surface(key="editor", url_template="/x", viewport=(1280, 720),
-                modes=(UiMode.CLASSIC,))
+        Surface(key="editor", url_template="/x", viewport=(1280, 720))
 
 
 def test_surface_accepts_the_production_viewport() -> None:
-    s = Surface(key="editor", url_template="/x", viewport=(1920, 1080),
-                modes=(UiMode.CLASSIC, UiMode.AGENTIC))
-    assert s.viewport == (1920, 1080)
+    assert Surface(key="editor", url_template="/x", viewport=(1920, 1080)).viewport == (
+        1920,
+        1080,
+    )
+
+
+def test_a_wide_but_short_viewport_is_still_rejected() -> None:
+    """Tuple comparison would ACCEPT (2560, 720): lexicographically 2560 > 1920
+    ends the comparison before height is considered. Verified by execution."""
+    with pytest.raises(ValueError, match="breakpoint"):
+        Surface(key="editor", url_template="/x", viewport=(2560, 720))
 ```
 
 ```python
 # tests/flow_selectors/test_grading.py
 from __future__ import annotations
 
+import pytest
+
 from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors.grading import Grade, grade
 from gflow_cli.flow_selectors.model import Selector
 
-SEL = Selector(key="editor.count_tabs", surface="editor",
-               candidates=("[role=tab]:text-is('x2')", "[role=tab]:text-is('2x')"))
+SEL = Selector(key="editor.composer.input", surface="editor",
+               candidates=("div[data-slate-editor]", "div[role=textbox]"))
 
 
 def test_first_candidate_is_a_hit() -> None:
-    assert grade(SEL, resolved_index=0, match_count=1).grade is Grade.HIT
+    assert grade(SEL, 0, match_count=1, observed_mode=UiMode.CLASSIC).grade is Grade.HIT
 
 
 def test_later_candidate_is_fallback_not_failure() -> None:
-    out = grade(SEL, resolved_index=1, match_count=1)
+    out = grade(SEL, 1, match_count=1, observed_mode=UiMode.CLASSIC)
     assert out.grade is Grade.FALLBACK
     assert out.is_failure is False
 
@@ -98,34 +107,30 @@ def test_multiple_matches_on_a_unique_selector_is_ambiguous() -> None:
     is deliberately unscoped and is the standing candidate for this."""
     unique = Selector(key="editor.sidebar.close", surface="editor",
                       candidates=("button",), expect_unique=True)
-    out = grade(unique, resolved_index=0, match_count=2)
+    out = grade(unique, 0, match_count=2, observed_mode=UiMode.CLASSIC)
     assert out.grade is Grade.AMBIGUOUS
     assert out.is_failure is True
 
 
 def test_nothing_resolving_is_drift() -> None:
-    assert grade(SEL, resolved_index=None, match_count=0).is_failure is True
+    assert grade(SEL, None, match_count=0, observed_mode=UiMode.CLASSIC).is_failure is True
 
 
 def test_wrong_mode_makes_a_miss_expected() -> None:
     classic = Selector(key="editor.crop_control", surface="editor",
                        candidates=("button",), mode=UiMode.CLASSIC)
-    out = grade(classic, resolved_index=None, match_count=0,
-                observed_mode=UiMode.AGENTIC)
+    out = grade(classic, None, match_count=0, observed_mode=UiMode.AGENTIC)
     assert out.grade is Grade.EXPECTED_ABSENT
     assert out.is_failure is False
 
 
-def test_missing_sidecar_mode_does_not_silently_pass_a_mode_scoped_miss() -> None:
-    """Without observed_mode the grader CANNOT know whether an absent
-    classic-only control is drift or the wrong arm. It must say so rather than
-    guess — guessing MISS is what produced a guaranteed false DRIFT in the
-    first draft of this plan."""
+def test_grade_cannot_be_called_without_a_mode() -> None:
+    """The false-DRIFT guarantee is enforced by the signature, not a sentinel
+    grade: omitting observed_mode is a TypeError, not a silent misgrade."""
     classic = Selector(key="editor.crop_control", surface="editor",
                        candidates=("button",), mode=UiMode.CLASSIC)
-    out = grade(classic, resolved_index=None, match_count=0, observed_mode=None)
-    assert out.grade is Grade.UNKNOWN_CONTEXT
-    assert out.is_failure is False
+    with pytest.raises(TypeError):
+        grade(classic, None, match_count=0)  # type: ignore[call-arg]
 ```
 
 - [ ] **Step 2: Run both to confirm they fail**
@@ -165,13 +170,14 @@ class Surface:
     key: str
     url_template: str
     viewport: tuple[int, int]
-    modes: tuple[UiMode, ...] = ()
 
     def __post_init__(self) -> None:
         if not _SURFACE_KEY_RE.match(self.key):
             msg = f"surface key must be lower_snake, optionally dotted: {self.key!r}"
             raise ValueError(msg)
-        if self.viewport < MIN_VIEWPORT:
+        # Per-AXIS, not tuple comparison: (2560, 720) < (1920, 1080) is False
+        # lexicographically, so a 720px-tall surface would slip the guard.
+        if self.viewport[0] < MIN_VIEWPORT[0] or self.viewport[1] < MIN_VIEWPORT[1]:
             msg = (
                 f"{self.key}: viewport {self.viewport} is below Flow's responsive "
                 f"breakpoint {MIN_VIEWPORT}; selectors drift below it"
@@ -218,7 +224,6 @@ class Grade(Enum):
     AMBIGUOUS = "ambiguous"            # >1 match; drivers use .first, so this misclicks
     MISS = "miss"
     EXPECTED_ABSENT = "expected_absent"
-    UNKNOWN_CONTEXT = "unknown_context"  # mode-scoped, but no sidecar mode to judge against
 
 
 @dataclass(frozen=True)
@@ -236,27 +241,29 @@ def grade(
     selector: Selector,
     resolved_index: int | None,
     match_count: int,
-    observed_mode: UiMode | None = None,
+    observed_mode: UiMode,
 ) -> Outcome:
+    """``observed_mode`` is REQUIRED, deliberately.
+
+    Defaulting it to None let a mode-scoped selector be graded with no context,
+    which produced a guaranteed false DRIFT on every agentic capture. Requiring
+    it moves that guarantee to the type level — the caller cannot forget.
+    """
     if resolved_index is not None:
         if selector.expect_unique and match_count > 1:
             return Outcome(selector.key, Grade.AMBIGUOUS, resolved_index)
         g = Grade.HIT if resolved_index == 0 else Grade.FALLBACK
         return Outcome(selector.key, g, resolved_index)
 
-    if selector.mode is not None:
-        if observed_mode is None:
-            # Never guess: guessing MISS here is a guaranteed false DRIFT.
-            return Outcome(selector.key, Grade.UNKNOWN_CONTEXT, None)
-        if selector.mode != observed_mode:
-            return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
+    if selector.mode is not None and selector.mode != observed_mode:
+        return Outcome(selector.key, Grade.EXPECTED_ABSENT, None)
     return Outcome(selector.key, Grade.MISS, None)
 ```
 
 - [ ] **Step 5: Run model + grading tests**
 
 Run: `.venv/Scripts/python.exe -m pytest tests/flow_selectors/test_model.py tests/flow_selectors/test_grading.py -v`
-Expected: PASS (11 tests)
+Expected: PASS (11 tests: 5 model + 6 grading)
 
 - [ ] **Step 6: Write the failing registry test**
 
@@ -280,11 +287,21 @@ def test_keys_are_unique() -> None:
     assert len(keys) == len(set(keys))
 
 
-def test_the_404_family_is_registered() -> None:
-    """#404 (1x -> x2 rename) is the most-cited incident in the spec; the first
-    draft of this plan tested editor.count_tabs nine times without defining it."""
-    sel = registry.by_key("editor.count_tabs")
-    assert len(sel.candidates) >= 2, "must match BOTH cohorts, picking by digit"
+def test_state_gated_families_are_deliberately_absent() -> None:
+    """Two incident families CANNOT live on a URL-only surface:
+
+    - sidebar close needs the sidebar EXPANDED
+    - #404's count tabs sit inside the generation-settings panel, which must be
+      clicked open (`_open_gen_settings_panel`; `_is_settings_panel_open` exists
+      because it is normally closed)
+
+    Registering either grades MISS on every clean capture. That #404 — the
+    incident this design leans on hardest — needs `Reach` is the argument FOR
+    prioritising Reach, not for registering a selector that reds nightly.
+    """
+    keys = {s.key for s in registry.SELECTORS}
+    assert "editor.sidebar.close" not in keys
+    assert "editor.count_tabs" not in keys
 
 
 def test_incident_families_are_registered() -> None:
@@ -303,11 +320,6 @@ def test_for_surface_filters_by_mode() -> None:
     assert "editor.crop_control" not in agentic
 
 
-def test_no_state_gated_selector_is_registered_yet() -> None:
-    """R4: SIDEBAR_CLOSE only exists while the sidebar is EXPANDED. On a
-    freshly-loaded editor it is legitimately absent, so registering it now
-    would grade MISS on every clean capture. It waits for Reach."""
-    assert "editor.sidebar.close" not in {s.key for s in registry.SELECTORS}
 ```
 
 - [ ] **Step 7: Implement the registry**
@@ -333,7 +345,6 @@ SURFACES: dict[str, Surface] = {
         key="editor",
         url_template="https://labs.google/fx/{locale}/tools/flow/project/{project_id}",
         viewport=(1920, 1080),
-        modes=(UiMode.CLASSIC, UiMode.AGENTIC),
     ),
 }
 
@@ -358,20 +369,13 @@ SELECTORS: tuple[Selector, ...] = (
         note="#313 — agent settings panel became sticky.",
     ),
     Selector(
-        key="editor.count_tabs",
-        surface="editor",
-        candidates=("[role=tab]:text-is('x1')", "[role=tab]:text-is('1x')"),
-        note="#404 — Google renamed 1x -> x1. BOTH cohorts must match, and the "
-        "driver picks by DIGIT, never by position.",
-    ),
-    Selector(
         key="editor.crop_control",
         surface="editor",
         candidates=tuple(mode_control.CROP_SELECTORS),
         mode=UiMode.CLASSIC,
         note="Classic-mode INDICATOR (factory.py:116). Absent on the agentic arm "
         "by design — grading that MISS as drift is the error this registry exists "
-        "to prevent, which is why an absent sidecar mode yields UNKNOWN_CONTEXT.",
+        "to prevent — which is why observed_mode is a REQUIRED grader argument.",
     ),
 )
 
@@ -402,163 +406,16 @@ git commit -m "feat(selectors): registry model, grader, and the incident familie
 Surface pins 1920x1080: below Flow's responsive breakpoint the selectors drift,
 so a probe that forgets the viewport reports drift that is not there.
 
-A mode-scoped selector with no sidecar mode grades UNKNOWN_CONTEXT, never MISS.
-Guessing MISS there is a guaranteed false DRIFT on every agentic capture.
+observed_mode is a REQUIRED grader argument: defaulting it let a mode-scoped
+selector be graded with no context, a guaranteed false DRIFT on every agentic
+capture. The signature now enforces it.
 
 Refs #404 #493 #313"
 ```
 
 ---
 
-### Task 2: Capture with sidecar
-
-**Files:**
-- Create: `scripts/probe/capture.py`
-- Test: `tests/scripts/test_capture.py`
-
-**Interfaces:**
-- Consumes: `registry.SURFACES`, `FlowApiClient`.
-- Produces: `detect_mode(page) -> UiMode`; `async capture(profile, surface_key) -> tuple[str, dict]`.
-
-- [ ] **Step 1: Write the failing sidecar test**
-
-```python
-# tests/scripts/test_capture.py
-from __future__ import annotations
-
-from gflow_cli.config import UiMode
-from scripts.probe.capture import build_sidecar
-
-
-def test_sidecar_records_the_context_the_grader_needs() -> None:
-    car = build_sidecar(mode=UiMode.AGENTIC, viewport=(1920, 1080),
-                        captured_at="2026-08-21T12:00:00Z", surface="editor")
-    assert car["mode"] == "agentic"
-    assert car["viewport"] == [1920, 1080]
-    assert car["surface"] == "editor"
-
-
-def test_sidecar_never_carries_identifiers() -> None:
-    """The sidecar may be published alongside a drift report; keep it to
-    context, never project ids, accounts or URLs."""
-    car = build_sidecar(mode=UiMode.CLASSIC, viewport=(1920, 1080),
-                        captured_at="2026-08-21T12:00:00Z", surface="editor")
-    assert set(car) == {"mode", "viewport", "captured_at", "surface"}
-```
-
-- [ ] **Step 2: Run it to confirm it fails**
-
-Run: `.venv/Scripts/python.exe -m pytest tests/scripts/test_capture.py -v`
-Expected: FAIL — `No module named 'scripts.probe.capture'`
-
-- [ ] **Step 3: Implement capture**
-
-```python
-# scripts/probe/capture.py
-"""Capture a Flow surface's DOM plus the context needed to grade it. $0.
-
-Creates its own project: a stale id renders an error shell (~441KB, 3 buttons,
-0 icons) indistinguishable from an auth wall, a confound that voided three
-spike runs before a positive control caught it.
-"""
-
-from __future__ import annotations
-
-import argparse
-import asyncio
-from datetime import UTC, datetime
-
-from gflow_cli.api.client import FlowApiClient
-from gflow_cli.api.transports.drivers import factory
-from gflow_cli.auth import profile_dir as resolve_profile
-from gflow_cli.config import UiMode
-from gflow_cli.flow_selectors import registry
-
-
-def build_sidecar(
-    mode: UiMode, viewport: tuple[int, int], captured_at: str, surface: str
-) -> dict[str, object]:
-    """Context the grader needs. Deliberately carries no identifiers."""
-    return {
-        "mode": mode.value,
-        "viewport": [viewport[0], viewport[1]],
-        "captured_at": captured_at,
-        "surface": surface,
-    }
-
-
-async def detect_mode(page: object) -> UiMode:
-    """Which arm is rendered. Uses the SAME probe the drivers use, so the
-    sidecar cannot disagree with production (factory.py:116)."""
-    return (
-        UiMode.CLASSIC
-        if await factory._any_present(page, factory._CLASSIC_CROP_SELECTORS)  # noqa: SLF001
-        else UiMode.AGENTIC
-    )
-
-
-async def capture(profile: str, surface_key: str) -> tuple[str, dict[str, object]]:
-    surface = registry.SURFACES[surface_key]
-    async with FlowApiClient(
-        profile_dir=resolve_profile(profile), headless=True
-    ) as client:
-        project = await client.create_project(title="selector-probe capture")
-        page = client._page or client._context.pages[0]  # noqa: SLF001
-        await page.set_viewport_size(
-            {"width": surface.viewport[0], "height": surface.viewport[1]}
-        )
-        await page.goto(
-            surface.url_template.format(locale="en", project_id=project.project_id),
-            wait_until="domcontentloaded",
-            timeout=90_000,
-        )
-        for _ in range(25):
-            if await page.locator("i.google-symbols").count():
-                break
-            await page.wait_for_timeout(1000)
-        else:
-            msg = "surface never hydrated — refusing to save an error shell"
-            raise SystemExit(msg)
-        mode = await detect_mode(page)
-        html = await page.content()
-
-    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return html, build_sidecar(mode, surface.viewport, stamp, surface_key)
-
-
-def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--profile", required=True)
-    p.add_argument("--surface", default="editor")
-    args = p.parse_args()
-    html, sidecar = asyncio.run(capture(args.profile, args.surface))
-    print(f"captured {len(html):,} bytes; context={sidecar}")
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
-```
-
-- [ ] **Step 4: Verify `_any_present` and `_CLASSIC_CROP_SELECTORS` exist**
-
-Run: `grep -n "_any_present\|_CLASSIC_CROP_SELECTORS" src/gflow_cli/api/transports/drivers/factory.py`
-Expected: both present (seen at `factory.py:52,116`). If either is renamed, use the current name — do not reimplement mode detection, or the sidecar can disagree with production.
-
-- [ ] **Step 5: Run tests and commit**
-
-```bash
-.venv/Scripts/python.exe -m pytest tests/scripts/test_capture.py -v
-git add scripts/probe/capture.py tests/scripts/test_capture.py
-git commit -m "feat(probe): DOM capture with a mode sidecar at the pinned viewport
-
-Mode is detected with the drivers' own probe, so the sidecar cannot disagree
-with production. Inferring it at check time would be circular."
-```
-
----
-
-### Task 3: CI probe
+### Task 2: CI probe
 
 **Files:**
 - Create: `src/gflow_cli/flow_selectors/check.py`
@@ -581,8 +438,8 @@ from scripts.probe.run_probe import render_report
 
 
 def test_report_names_the_drifted_selector() -> None:
-    body = render_report([Outcome("editor.count_tabs", Grade.MISS, None)])
-    assert "editor.count_tabs" in body
+    body = render_report([Outcome("editor.composer.input", Grade.MISS, None)])
+    assert "editor.composer.input" in body
     assert "DRIFT" in body
 
 
@@ -598,11 +455,11 @@ def test_ambiguous_is_reported_as_a_failure() -> None:
     assert "1 need" in body
 
 
-def test_unknown_context_is_visible_but_not_a_failure() -> None:
-    """Silence here would hide that the probe could not judge a mode-scoped
-    entry at all."""
-    body = render_report([Outcome("editor.crop_control", Grade.UNKNOWN_CONTEXT, None)])
-    assert "UNKNOWN" in body
+def test_expected_absent_is_visible_but_not_a_failure() -> None:
+    """A mode-scoped entry absent on the other arm must still appear, or the
+    report silently shrinks and nobody notices coverage was skipped."""
+    body = render_report([Outcome("editor.crop_control", Grade.EXPECTED_ABSENT, None)])
+    assert "editor.crop_control" in body
     assert "0 need" in body
 ```
 
@@ -675,8 +532,10 @@ import asyncio
 import os
 import sys
 
+from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright
 
+from gflow_cli.api.transports.drivers import factory
 from gflow_cli.config import UiMode
 from gflow_cli.flow_selectors import registry
 from gflow_cli.flow_selectors.check import check_html
@@ -689,7 +548,6 @@ _LABEL = {
     Grade.AMBIGUOUS: "AMBIGUOUS",
     Grade.MISS: "DRIFT",
     Grade.EXPECTED_ABSENT: "n/a",
-    Grade.UNKNOWN_CONTEXT: "UNKNOWN",
 }
 
 
@@ -716,10 +574,16 @@ async def run(token: str, project_id: str, surface_key: str) -> int:
                 "httpOnly": True, "secure": True, "sameSite": "Lax",
             }])
             page = await ctx.new_page()
-            await page.goto(
-                surface.url_template.format(locale="en", project_id=project_id),
-                wait_until="domcontentloaded", timeout=90_000,
-            )
+            try:
+                await page.goto(
+                    surface.url_template.format(locale="en", project_id=project_id),
+                    wait_until="domcontentloaded", timeout=90_000,
+                )
+            except PlaywrightError as exc:
+                # A raw traceback is neither exit 1 nor exit 2, and its message
+                # embeds the project id. Keep the contract intact.
+                print(f"::error::navigation failed: {type(exc).__name__}")
+                return 2
             for _ in range(25):
                 if await page.locator("i.google-symbols").count():
                     break
@@ -728,9 +592,12 @@ async def run(token: str, project_id: str, surface_key: str) -> int:
                 # Expired token or missing project — NOT drift. Never conflate them.
                 print("::error::surface never hydrated (expired token or missing project)")
                 return 2
+            # Production's OWN detector, over all six ratio variants. Checking
+            # candidates[0] alone misreads a 9:16 classic editor as agentic, and a
+            # drifted crop_control then grades EXPECTED_ABSENT — hidden forever.
             mode = (
                 UiMode.CLASSIC
-                if await page.locator(registry.by_key("editor.crop_control").candidates[0]).count()
+                if await factory._any_present(page, factory._CLASSIC_CROP_SELECTORS)  # noqa: SLF001
                 else UiMode.AGENTIC
             )
             html = await page.content()
@@ -806,7 +673,7 @@ code. Never use `pull_request_target`.
 .venv/Scripts/python.exe -m ruff format --check src tests
 .venv/Scripts/python.exe scripts/ci/check_repo_hygiene.py
 .venv/Scripts/python.exe -m pytest tests/flow_selectors tests/scripts -v
-git add src/gflow_cli/flow_selectors/check.py scripts/probe .github/workflows/selector-probe.yml tests/
+git add src/gflow_cli/flow_selectors/check.py scripts/probe/run_probe.py .github/workflows/selector-probe.yml tests/flow_selectors/test_report.py
 git commit -m "feat(probe): CI selector-drift probe on a single session cookie
 
 Exit 2 (infrastructure) stays distinct from exit 1 (drift): an expired token or

--- a/docs/superpowers/plans/2026-08-21-selector-registry.md
+++ b/docs/superpowers/plans/2026-08-21-selector-registry.md
@@ -439,9 +439,11 @@ def test_report_names_the_drifted_selector() -> None:
     assert "DRIFT" in body
 
 
-def test_fallback_is_a_warning_not_drift() -> None:
-    body = render_report([Outcome("editor.sidebar.close", Grade.FALLBACK, 1)])
-    assert "FALLBACK" in body
+def test_fallback_names_which_candidate_held() -> None:
+    """crop_control has six candidates; "a later one held" is not actionable
+    without knowing how far down the cascade the page has drifted."""
+    body = render_report([Outcome("editor.crop_control", Grade.FALLBACK, 3)])
+    assert "FALLBACK[3]" in body
     assert "DRIFT" not in body
 
 
@@ -521,10 +523,23 @@ _LABEL = {
 }
 
 
+def _cell(outcome: Outcome) -> str:
+    """FALLBACK names WHICH candidate held.
+
+    `crop_control` carries six candidates; "a later one held" is not actionable
+    without the index, and the index is what says how far down the cascade the
+    page has drifted. Safe to publish — it is an ordinal, not a selector.
+    """
+    label = _LABEL[outcome.grade]
+    if outcome.grade is Grade.FALLBACK:
+        return f"{label}[{outcome.resolved_index}]"
+    return label
+
+
 def render_report(outcomes: list[Outcome]) -> str:
-    """Publication-safe: keys and grades only, never selectors or DOM."""
+    """Publication-safe: keys, grades and candidate ordinals — never selectors or DOM."""
     lines = ["| selector | result |", "| --- | --- |"]
-    lines += [f"| `{o.selector_key}` | {_LABEL[o.grade]} |" for o in outcomes]
+    lines += [f"| `{o.selector_key}` | {_cell(o)} |" for o in outcomes]
     bad = [o.selector_key for o in outcomes if o.is_failure]
     lines += ["", f"**{len(bad)} need attention**" if bad else "**0 need attention.**"]
     return "\n".join(lines)

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -93,9 +93,12 @@ Replicated independently (arm N2: 431KB / 3 buttons / 0 icons, single variable).
 established, not merely plausible.**
 
 > **Binding consequence:** any probe navigating to a fixed project id can produce a
-> convincing false negative. Every DOM probe MUST carry a positive control in the same
-> run and MUST create-or-verify its project. §2.2 shows the same rule applies in the
-> other direction: an all-HIT matrix without a falsifying arm proves nothing either.
+> convincing false negative. A DOM probe MUST therefore be able to tell "the surface
+> did not load" from "a selector drifted", and report the former as inconclusive
+> (exit 2) rather than as drift. The CI probe does this with its hydration gate — it
+> does **not** create projects, which would be a mutating operation against the $0
+> invariant. §2.2 shows the same rule applies in the other direction: an all-HIT
+> matrix without a falsifying arm proves nothing either.
 
 ### 2.4 Locale is account-driven
 
@@ -161,7 +164,7 @@ class Selector:
 
 **Keys are a public promise** — they appear in canary reports and any future override.
 
-### 3.2 Capture / check split, and the mode sidecar
+### 3.2 One pass: navigate, detect, resolve, grade
 
 ```
 CAPTURE  navigate (viewport-pinned) → page.content() + observed context → HTML + JSON
@@ -258,6 +261,7 @@ surfaces, and §3.5 if the maintainer keeps it.
 | R4 | **State-gated selectors.** `SIDEBAR_CLOSE` needs an expanded sidebar; **count tabs need the generation-settings panel opened**. A URL-only surface grades both MISS. | Phase 1 registers only selectors present on a freshly-loaded editor. Both wait for `Reach` — including #404's family (§4). |
 | R5 | **CI has no browser.** `ci.yml:165` runs plain pytest; no workflow installs Playwright. | Probe workflow installs chromium itself. No default-suite test may require a real browser. |
 | R6 | **Secrets in a public repo.** | Dedicated throwaway account, never the maintainer's. Reuse `src/gflow_cli/data/redaction.py` (already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token`, signed queries) for any published output — do not write a fourth redactor. |
+| R8 | **Known zero-click alternate states.** `mode_control.py:66-84` — an expanded chat sidebar "removes the classic composer entirely… no `crop_*` trigger AND no Agent pill". `ui_automation_video.py:149-153` — a chat panel "appears on some project opens and not others", and while up "the in-composer pill is NOT in the DOM at all". Both are load states, no clicks. Three of the four registered selectors would MISS there and report drift that did not happen. | The probe checks a **base-state precondition** before grading: if a known alternate-state indicator is present, absence is *explained* → exit 2 (inconclusive), never exit 1. If no indicator is present and the composer is still gone, that is real drift. Reuses production's own detectors. |
 | R7 | **Same-repo branch PRs would receive the secret** while checking out attacker-editable probe code. Fork PRs are safe (GitHub withholds secrets). | Never add `pull_request`; never `pull_request_target`. |
 
 ---

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -145,7 +145,7 @@ class Surface:
 
 @dataclass(frozen=True)
 class Selector:
-    key: str                     # "editor.composer.input" — stable, public, in errors
+    key: str                     # "editor.composer.input" — stable, public, in reports
     surface: str                 # → Surface.key
     candidates: tuple[str, ...]  # ORDERED: [0] preferred, then cohort variants / fallbacks
     mode: UiMode | None          # None = every mode of that surface
@@ -213,7 +213,10 @@ same regression class far more cheaply.
   Drivers call `.first`, so a second match means gflow clicks the wrong thing while a
   count-based check reports success. `SIDEBAR_CLOSE_FALLBACK_SELECTOR` is deliberately
   unscoped and is the standing candidate for this.
-- **MISS** — nothing resolved → drift → exit 23.
+- **MISS** — nothing resolved → drift. The **probe** exits 1 (exit 2 is reserved for
+  inconclusive: expired token, dead project, alternate base state). Exit 23 is
+  production's `UiSelectorDriftError`, which the probe does not raise — wiring the two
+  together is part of the deferred §3.5.
 - **EXPECTED_ABSENT** — the observed `mode` says it should not be here.
 
 ### 3.5 Error contract — BLOCKED, pending a scope decision

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -1,6 +1,6 @@
 # Selector Registry + Drift Probe — Design
 
-**Status:** Draft, pending council review
+**Status:** Draft, council round 1 applied (5 dimensions, all YELLOW)
 **Date:** 2026-08-21
 **Related:** #502 (nightly canary, shipped), #404, #493, #174, #299, #313, #171
 
@@ -19,10 +19,8 @@ working. Every incident below is a selector that moved:
 | #174 | library UI A/B flip |
 | #313 | agent settings panel became sticky |
 
-Two structural problems make each one worse than it needs to be.
-
-**No inventory.** Selectors are scattered across four modules, some as inline literals,
-some as module-private constants ~2,900 lines into a 3,557-line file:
+**No inventory.** Selectors are scattered across four modules, some inline, some
+module-private ~2,900 lines into a 3,557-line file:
 
 ```
 mode_control.py:43,49,61,79        factory.py:52,58,60
@@ -35,11 +33,7 @@ Nobody — human or agent — can answer *"what parts of Flow's page does gflow 
 The nightly canary (#502) can therefore only report *"a test failed"*, never *"this
 selector moved"*.
 
-**No user recourse.** A selector is compiled in. When Google renames a control, every user
-is broken until a release ships. `notebooklm-py`'s users patch a drifted value with an env
-var and keep working; gflow's cannot.
-
-**Context is encoded in file paths.** `SIDEBAR_CLOSE_SELECTOR` and
+**Context lives in file paths, not data.** `SIDEBAR_CLOSE_SELECTOR` and
 `SIDEBAR_CLOSE_FALLBACK_SELECTOR` are related only by naming convention.
 `UiSelectorDriftError` carries "the probe label" as free text. None of it is queryable.
 
@@ -47,57 +41,91 @@ var and keep working; gflow's cannot.
 
 ## 2. Evidence
 
-Everything in §3 rests on measurements taken 2026-08-21, not assumptions. Two of these
-overturned conclusions this design previously held.
+Measurements taken 2026-08-21. Independently replicated during council review; the
+replication is recorded here because two claims changed as a result.
 
 ### 2.1 Offline selector checking works
 
 Playwright's `set_content()` plus its locator engines (`:has()`, `:text-is()`) resolve
-gflow's real selectors against static HTML — no network, no auth, no credits. Cohort
-variants correctly report MISS.
+gflow's real selectors against static HTML — no network, auth, or credits.
 
-### 2.2 CI can capture the live DOM — one cookie is sufficient
+### 2.2 One cookie is sufficient — *at mint time*
 
-Six-arm isolation matrix, positive control in the same run, one variable at a time:
+Six-arm matrix, positive control in-run, one variable at a time — **plus the negative
+control the first write-up lacked**. Reproduce with `scripts/probe/spike_auth_matrix.py`.
 
-| Arm | Browser | Cookies | composer | icons |
-|---|---|---|---|---|
-| CONTROL | real Chrome + full profile | profile (63) | 1 | 17 |
-| D | real Chrome, fresh ctx | labs.google (7) | 1 | 17 |
-| E | real Chrome, fresh ctx | all 63 | 1 | 17 |
-| F | bundled chromium, fresh ctx | all 63 | 1 | 17 |
-| G | bundled chromium, fresh ctx | labs.google (7) | 1 | 17 |
-| **H** | **bundled chromium, fresh ctx** | **session-token only (1)** | **1** | **17** |
+| Arm | Browser | Cookie | project | composer | icons | buttons |
+|---|---|---|---|---|---|---|
+| CONTROL | real Chrome + full profile | profile (63) | real | 1 | 17 | — |
+| D | real Chrome, fresh ctx | labs.google (7) | real | 1 | 17 | — |
+| E | real Chrome, fresh ctx | all 63 | real | 1 | 17 | — |
+| F | bundled chromium | all 63 | real | 1 | 17 | — |
+| G | bundled chromium | labs.google (7) | real | 1 | 17 | — |
+| **H** | **bundled chromium** | **session-token only** | real | **1** | 17 | — |
+| **N1** | bundled chromium | **none** | real | **0** | 9 | 67 |
+| **N3** | bundled chromium | **value replaced with `xxx…`** | real | **0** | 9 | 67 |
+| N2 | bundled chromium | valid | **bogus** | 0 | **0** | **3** |
 
-**All six identical.** `__Secure-next-auth.session-token` (1088 chars, **30-day** expiry,
-scoped to `labs.google`) is sufficient on its own. No profile, no real Chrome, no
-`.google.com` cookies, no master token, no OAuth bounce.
+`__Secure-next-auth.session-token` (1088 chars, scoped to `labs.google`) is sufficient
+alone. **N1/N3 are what make this falsifiable**: without the cookie, or with its value
+corrupted, the app does not render. The cookie's *value* does the work, not its presence.
+
+The discriminator is **`composer ≥ 1` and `icons ≫ 0`**, not the literal cell values —
+those drift run to run (icons 17→18, jar 63→65).
 
 This is decisive because the blocker assumed for CI auth — `__Secure-1PSIDTS` rotating
 every ~10 minutes — is a **Google** cookie. Flow does not authenticate on it.
 
+**Scope limit — the token under test was ~9 minutes old.** Its sibling
+`__Secure-next-auth.pkce.code_verifier` / `.state` cookies show a full OAuth bounce
+minutes before measurement. The matrix therefore establishes sufficiency **at mint
+time**, never for an aged token — which is precisely the CI condition. R1 must include
+a day-7 re-run before this is relied on.
+
 ### 2.3 The confound that voided three earlier runs
 
 Three runs reused a hard-coded project id. A stale/deleted project renders an error shell
-— **~441KB, 3 buttons, 0 icons** — which is indistinguishable from an auth wall by every
-metric being measured. Those runs produced the false conclusions *"CI-without-auth is
-dead"* and *"DOM auth and API auth are separate gates."* Both are retracted.
+— **~441KB, 3 buttons, 0 icons** — indistinguishable from an auth wall by every metric
+measured. Those runs produced the false conclusions *"CI-without-auth is dead"* and
+*"DOM auth and API auth are separate gates."* Both retracted.
+
+Replicated independently (arm N2: 431KB / 3 buttons / 0 icons, single variable). **Cause
+established, not merely plausible.**
 
 > **Binding consequence:** any probe navigating to a fixed project id can produce a
 > convincing false negative. Every DOM probe MUST carry a positive control in the same
-> run, and MUST create or verify its project rather than trust a stored id.
+> run and MUST create-or-verify its project. §2.2 shows the same rule applies in the
+> other direction: an all-HIT matrix without a falsifying arm proves nothing either.
 
-### 2.4 Other measurements
+### 2.4 Locale is account-driven
 
-- **Headless is not bot-blocked** from a residential IP; unauthenticated it serves a 552KB
-  marketing page with none of the app.
-- **Locale is account-driven, not URL-driven.** Passing `locale="en"` to
-  `project_editor_url()` still redirected to `/fx/pt/` and served Portuguese. Selectors
-  MUST stay locale-invariant (Material Symbols ligatures, never display text).
-- **`CROP_SELECTORS[0]` MISSes on the agentic arm.** It is the *classic-mode indicator*
-  (`factory.py:116`), and only 1 of its 6 ratio variants was probed. Without `mode` and
-  ordered `candidates`, that MISS is unattributable — the exact ambiguity this design exists
-  to remove.
+Passing `locale="en"` to `project_editor_url()` still served `/fx/pt/` in Portuguese.
+The *evidence* for account-attribution is the authed/unauthed contrast at identical
+`Accept-Language` and IP: **authed → `pt`, unauthed → `en`, cookie the only variable**
+(N0/N2 vs N1/N3).
+
+**Corollary worth its own ticket:** `client.py:416`'s `locale="en-US"` and
+`ui_automation.py:77`'s comment that *"`?hl=en` locks locale"* are both **ineffective**.
+Selectors MUST be locale-invariant (Material Symbols ligatures, never display text).
+
+### 2.5 Viewport is selector-affecting
+
+`ui_automation.py:117-124` pins `_VIEWPORT = {1920, 1080}` and states that smaller
+*"would cross the responsive breakpoint and **drift the selectors**"*. `FlowApiClient`
+uses 1280×720 and Playwright's default context is 1280×720 — **both below the
+breakpoint**. Any probe not pinning 1920×1080 reports false drift.
+
+### 2.6 Headless is not bot-blocked
+
+Confirmed on the **authenticated full app** (arm N0), from one residential IP. The
+earlier unauthenticated observation was of a marketing page and does not support the
+claim. Says nothing about datacenter IPs — see R1.
+
+### 2.7 The session token does not rotate on use
+
+`last_update_utc == creation_utc` to the microsecond across a 30-day-old token. A CI
+secret is therefore **stable until it hard-dies at day 30** — preferable to a silently
+rotating credential, but it fails abruptly rather than degrading.
 
 ---
 
@@ -108,130 +136,128 @@ dead"* and *"DOM auth and API auth are separate gates."* Both are retracted.
 ```python
 @dataclass(frozen=True)
 class Surface:
-    key: str                     # "editor", "editor.media_picker", "character_editor"
-    reach: Reach                 # URL builder | (parent surface + non-mutating action)
-    modes: tuple[UiMode, ...]    # which arms this surface can present
+    key: str                     # "editor"
+    url_template: str
+    viewport: tuple[int, int]    # (1920, 1080) — below the breakpoint drifts selectors (§2.5)
+    modes: tuple[UiMode, ...]
 
 @dataclass(frozen=True)
 class Selector:
     key: str                     # "editor.composer.input" — stable, public, in errors
     surface: str                 # → Surface.key
-    mode: UiMode | None          # None = every mode of that surface
-    min_plan: Plan | None        # None = every plan; gated controls are expected-absent below it
     candidates: tuple[str, ...]  # ORDERED: [0] preferred, then cohort variants / fallbacks
-    features: tuple[str, ...]    # ("image", "video") — dependent commands
-    required: bool               # True → drift is exit 23; False → degraded but survivable
+    mode: UiMode | None          # None = every mode of that surface
+    expect_unique: bool          # True = >1 match is AMBIGUOUS, not HIT (§3.4)
     note: str                    # why fallbacks exist; incident refs
 ```
 
-Every field is justified by §2 or by a listed incident. `min_plan` exists because #171
-(`UpscaleUnavailableError`, exit 22) is plan-gated — `errors.py:508` says 4K upscale
-"requires a Flow Ultra subscription". On a free CI account those controls are legitimately
-absent, and that must not read as drift.
+**Dropped after council review** (each verified to have zero consumers):
 
-> **New type required.** `Plan` (Free / Pro / Ultra) does **not** exist in the codebase and
-> must be introduced by this work. It is deliberately NOT named `Tier`: `api/video.py:35`
-> already defines `Tier` as a *video quality* enum, and reusing the name would collide.
+| Field | Why cut |
+|---|---|
+| `min_plan` / `Plan` enum | No plan-gated selector is in the initial registry. Add the day one is — 4 lines then. |
+| `features` | Nothing reads it; `surface` + `note` already carry the context. |
+| `required` | All entries defaulted `True`, and its `False` branch returned the same grade as the mode branch. Two encodings, one outcome. |
 
-**Keys are a public promise.** They surface in exit-23 messages, canary reports, and the
-env override. Renaming one is a breaking change — which is why the override ships last.
+**Keys are a public promise** — they appear in canary reports and any future override.
 
-**Deliberately excluded:** timeouts, retry counts, screenshot-on-miss. Those are behaviour
-and belong at the call site; including them would make this a config framework rather than
-an inventory.
-
-### 3.2 Capture / check split
+### 3.2 Capture / check split, and the mode sidecar
 
 ```
-CAPTURE   navigate to surface → page.content() → HTML     [browser + 1 cookie, $0]
-CHECK     (html, entries) → HIT | FALLBACK | MISS         [pure; needs a browser only
-                                                           for the selector engine]
+CAPTURE  navigate (viewport-pinned) → page.content() + observed context → HTML + JSON
+CHECK    (html, entries, observed) → HIT | FALLBACK | AMBIGUOUS | MISS | EXPECTED_ABSENT
 ```
 
-The check is a pure function, so the *same code* grades a fresh capture and a committed
-snapshot. The layers cannot disagree.
+**`observed_mode` must be a capture-time sidecar, not inferred at check time.** Inferring
+it from the DOM is circular: the mode detector *is* `factory.py:116`'s crop/ligature
+probe. Without the sidecar, `editor.crop_control` (`mode=CLASSIC`) grades MISS = drift on
+every agentic capture — the exact error this design exists to prevent. Capture writes
+`{"mode": "agentic", "viewport": [1920,1080], "captured_at": "..."}` beside the HTML.
 
-**Invariant:** reach steps MUST be non-mutating and credit-free. Opening a panel qualifies;
-clicking Generate does not. This is what makes "$0" true by construction rather than by
-hope, and it is reviewable.
+**Correction to an earlier claim.** This does *not* mean snapshot and live checks "cannot
+disagree". `set_content()` drops external CSS/JS and re-executes inline scripts, and
+`page.content()` omits shadow roots. Both layers assert **structural presence only**;
+neither asserts visible/enabled today.
+
+**Invariant:** reach steps MUST be non-mutating and credit-free.
 
 ### 3.3 Where each layer runs
 
 | Layer | Trigger | Credential | Detects |
 |---|---|---|---|
-| **CI probe** | schedule + label (cadence open, see R1/§5) | `GFLOW_CI_SESSION_TOKEN` + project id | Google changed the page |
-| **Nightly canary** | 03:00 local | maintainer profile | drift on the maintainer's cohort/tier/IP |
-| **Snapshot tests** | every PR, offline | none | *we* broke a selector |
+| **CI probe** | `schedule` + `workflow_dispatch` | `GFLOW_CI_SESSION_TOKEN` + project id | Google changed the page |
+| **Nightly canary** | 03:00 local | maintainer profile | drift on the maintainer's cohort and IP |
 
-The nightly canary keeps a distinct role even with CI probing: a different account sits on
-a different **A/B cohort** and a different **plan**, and runs from a residential IP.
-Divergence between CI and nightly is *data*, not a bug — `mode`/`min_plan` make it attributable.
+**Snapshot fixtures are cut.** With CI probing live, a frozen snapshot only ever detects
+*our* regressions, while costing a second capture path, a PII-scrubbing pipeline, and a
+committed authenticated DOM in a public repo. The AST guardrail (deferred, §4) covers the
+same regression class far more cheaply.
 
 ### 3.4 Grading
 
-- **HIT** — `candidates[0]` resolved.
-- **FALLBACK HELD** — `[0]` missed, a later candidate resolved. **Warning, not failure**;
-  this is #493's actual outcome and the difference between a canary that gets read and one
-  that gets ignored.
-- **MISS (required)** — no candidate resolved → drift → `UiSelectorDriftError` (exit 23)
-  carrying the key.
-- **MISS (expected)** — `mode` or `min_plan` says it should be absent → informational.
+- **HIT** — `candidates[0]` resolved (uniquely, when `expect_unique`).
+- **FALLBACK HELD** — `[0]` missed, a later candidate resolved. Warning, not failure; #493's actual outcome.
+- **AMBIGUOUS** — resolved, but matched **>1** element on an `expect_unique` selector.
+  Drivers call `.first`, so a second match means gflow clicks the wrong thing while a
+  count-based check reports success. `SIDEBAR_CLOSE_FALLBACK_SELECTOR` is deliberately
+  unscoped and is the standing candidate for this.
+- **MISS** — nothing resolved → drift → exit 23.
+- **EXPECTED_ABSENT** — the sidecar's `mode` says it should not be here.
 
-### 3.5 Error contract and override
+### 3.5 Error contract — BLOCKED, pending a scope decision
 
-`UiSelectorDriftError` gains a structured `selector_key` alongside its free-text detail. The
-key is publication-safe for a public issue (unlike a raw selector or a path).
+Adding `selector_key` to `UiSelectorDriftError` and shipping
+`GFLOW_CLI_SELECTOR_OVERRIDE` both require the **drivers** to read from the registry.
+Today all 7 `UiSelectorDriftError(` raise sites are in `ui_automation.py` (2) and
+`ui_automation_video.py` (5), and nothing in those modules consumes the registry — so
+`selector_key` would stay `None` in production and an override would change what is
+*checked*, never what is *clicked*.
 
-Env override, **last phase only**:
+That makes §6's non-goal *"not replacing the driver code"* incompatible with this section.
+Three independent findings say cut: no user has requested an override
+(`gh issue list --state all --search "selector override"` → none), it does not work as
+specified, and making it work means inverting imports across two 3,800-line modules.
 
-```
-GFLOW_CLI_SELECTOR_OVERRIDE='editor.count_tabs=<css>;editor.composer.input=<css>'
-```
-
-A user hit by a #404-class rename patches it and keeps working; the proper fix ships at its
-own pace.
+**Deferred, not deleted** — the scope call belongs to the maintainer.
 
 ---
 
 ## 4. Migration
 
-Incremental, no phase requiring the 3,800-line module split up front.
+1. **Registry + grader** — drift-prone families only (composer, submit, agent toggle,
+   sidebar close, crop control, **count tabs**). #404 must be registered; the first draft
+   tested `editor.count_tabs` nine times without ever defining it.
+2. **Capture** — viewport-pinned, creates its own project, writes the mode sidecar.
+3. **CI probe workflow** — `schedule` + `workflow_dispatch` only.
 
-1. **Registry + surfaces for the drift-prone families only** — composer, mode switch, count
-   tabs, sidebar close. These carry the incident history.
-2. **Snapshot fixtures + offline check** — commit scrubbed DOM per surface; CI grades every PR.
-3. **CI probe workflow** — live capture, grading, report.
-4. **AST guardrail** — selector literals forbidden outside the registry (pattern:
-   `test_rpc_method_ids_only_in_types.py`).
-5. **Remaining selectors**, then the env override once keys have proven stable.
-
-Steps 1–3 deliver value independently. The AST lint lands only after (5) is reachable,
-otherwise it blocks its own migration.
+**Deferred to a follow-up plan:** the AST guardrail (it flags **9 real offenders** today —
+`ui_automation_video.py:91-96,162`, `agentic.py:62`, `diagnostics.py:1738` — so it reds on
+arrival while its migration is still deferred), inverting the import direction, additional
+surfaces, and §3.5 if the maintainer keeps it.
 
 ---
 
-## 5. Risks and open questions
+## 5. Risks
 
 | # | Risk | Resolution |
 |---|---|---|
-| R1 | **Datacenter IP.** Every measurement was from a residential IP; Google may treat a GitHub runner differently. | Unresolvable locally. Put the secret in, run once, look. Cheap and definitive. |
-| R2 | **30-day secret rotation.** CI fails on day 31 with a confusing auth error. | Nightly canary reads cookie expiry locally and warns on the dashboard below 7 days. |
-| R3 | **Project validity** (§2.3). | CI creates or verifies its project per run; never trusts a stored id blindly. |
-| R4 | **Free-plan CI account** cannot render plan-gated controls. | `min_plan` field; expected-absent ≠ drift. Requires introducing a `Plan` enum. |
-| R5 | **Snapshots rot** into always-passing. | They only ever detect *our* regressions; the live probe is the drift authority. Re-record on every confirmed drift. |
-| R6 | **DOM snapshots carry PII** — project ids, asset URLs, possibly email. | Scrubbing required before commit, enforced by a guardrail test (pattern: `test_cassettes_clean.py`). |
-| R7 | Static snapshots lose CSS/JS, so **visibility/enabled state is unverifiable offline**. | Snapshot layer asserts structural presence only; live probe additionally asserts visible/enabled. |
-
-**Open question:** should CI probe on every PR, or on a schedule plus label? Every-PR gives
-the fastest signal but hammers one account; the answer likely depends on R1.
+| R1 | **Datacenter IP** — all measurements from a residential IP. | Unresolvable locally. `workflow_dispatch` once and read the result. Must also include a **day-7 token re-run** (§2.2 scope limit). |
+| R2 | **Token hard-dies at day 30** (§2.7 — no rotation, so no warning). | Nightly canary reports remaining life. It MUST pin the profile path — two `profile_denon82` trees exist on the maintainer's machine and the orphaned one reports "expired 38 days ago". |
+| R3 | **Project validity** (§2.3). | Probe creates-or-verifies per run. |
+| R4 | **State-gated selectors.** `SIDEBAR_CLOSE` exists only while the sidebar is expanded, so a URL-only surface grades it MISS. | Phase 1 registers only selectors present on a freshly-loaded editor. State-gated entries wait for `Reach`. |
+| R5 | **CI has no browser.** `ci.yml:165` runs plain pytest; no workflow installs Playwright. | Probe workflow installs chromium itself. No default-suite test may require a real browser. |
+| R6 | **Secrets in a public repo.** | Dedicated throwaway account, never the maintainer's. Reuse `src/gflow_cli/data/redaction.py` (already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token`, signed queries) for any published output — do not write a fourth redactor. |
+| R7 | **Same-repo branch PRs would receive the secret** while checking out attacker-editable probe code. Fork PRs are safe (GitHub withholds secrets). | Never add `pull_request`; never `pull_request_target`. |
 
 ---
 
 ## 6. Non-goals
 
-- **Not** replacing the driver code. The registry owns data; clicking stays where it is.
-- **Not** a Page Object Model rewrite. POM hides selectors inside classes; enumerability is
-  the whole point here.
-- **Not** the master token. §2.2 makes it unnecessary — see `[[master-token-tier0-deferred]]`.
+- **Not** replacing the driver code *in this phase*. §3.5 is deferred precisely because it
+  would require that; the two cannot both hold.
+- **Not** a Page Object Model rewrite — POM hides selectors inside classes; enumerability
+  is the point.
+- **Not** the master token — §2.2 makes it unnecessary. See `[[master-token-tier0-deferred]]`.
 - **Not** generation testing. The probe never submits, never spends credits.
-- **Not** splitting `ui_automation*.py` in this work. Desirable, separately scoped.
+- **Not** committed DOM snapshots (§3.3).
+- **Not** splitting `ui_automation*.py`. Desirable, separately scoped.

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -167,9 +167,13 @@ class Selector:
 ### 3.2 One pass: navigate, detect, resolve, grade
 
 ```
-CAPTURE  navigate (viewport-pinned) → page.content() + observed context → HTML + JSON
-CHECK    (html, entries, observed) → HIT | FALLBACK | AMBIGUOUS | MISS | EXPECTED_ABSENT
+navigate (viewport-pinned) → detect arm → base-state gate → resolve against the
+LIVE page → HIT | FALLBACK | AMBIGUOUS | MISS | EXPECTED_ABSENT
 ```
+
+Resolution runs against the live page, never a re-parsed copy: `set_content()` drops
+external CSS/JS and `page.content()` omits shadow roots, so a static round-trip is
+strictly lower fidelity than the page already open.
 
 **`observed_mode` is a REQUIRED argument to the grader.** Without it,
 `editor.crop_control` (`mode=CLASSIC`) grades MISS = drift on every agentic capture — the
@@ -241,8 +245,9 @@ specified, and making it work means inverting imports across two 3,800-line modu
    closed). Registering them would grade MISS on every clean capture. The incident this
    design leans on hardest therefore needs `Reach` — which is the strongest argument for
    prioritising `Reach` in the follow-up, not for registering a selector that reds nightly.
-2. **Capture** — viewport-pinned, creates its own project, writes the mode sidecar.
-3. **CI probe workflow** — `schedule` + `workflow_dispatch` only.
+2. **CI probe** — viewport-pinned, detects the arm with production's detector,
+   gates on base state, resolves against the live page. `schedule` +
+   `workflow_dispatch` only.
 
 **Deferred to a follow-up plan:** the AST guardrail (it flags **9 real offenders** today —
 `ui_automation_video.py:91-96,162`, `agentic.py:62`, `diagnostics.py:1738` — so it reds on
@@ -257,7 +262,7 @@ surfaces, and §3.5 if the maintainer keeps it.
 |---|---|---|
 | R1 | **Datacenter IP** — all measurements from a residential IP. | Unresolvable locally. `workflow_dispatch` once and read the result. Must also include a **day-7 token re-run** (§2.2 scope limit). |
 | R2 | **Token hard-dies at day 30** (§2.7 — no rotation, so no warning). | Nightly canary reports remaining life. It MUST pin the profile path — two `profile_denon82` trees exist on the maintainer's machine and the orphaned one reports "expired 38 days ago". |
-| R3 | **Project validity** (§2.3). | Probe creates-or-verifies per run. |
+| R3 | **Project validity** (§2.3). | The hydration gate reports exit 2 (inconclusive) when the surface never renders, so a dead project can never be published as drift. The probe does not create projects — that would be mutating. |
 | R4 | **State-gated selectors.** `SIDEBAR_CLOSE` needs an expanded sidebar; **count tabs need the generation-settings panel opened**. A URL-only surface grades both MISS. | Phase 1 registers only selectors present on a freshly-loaded editor. Both wait for `Reach` — including #404's family (§4). |
 | R5 | **CI has no browser.** `ci.yml:165` runs plain pytest; no workflow installs Playwright. | Probe workflow installs chromium itself. No default-suite test may require a real browser. |
 | R6 | **Secrets in a public repo.** | Dedicated throwaway account, never the maintainer's. Reuse `src/gflow_cli/data/redaction.py` (already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token`, signed queries) for any published output — do not write a fourth redactor. |

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -139,7 +139,6 @@ class Surface:
     key: str                     # "editor"
     url_template: str
     viewport: tuple[int, int]    # (1920, 1080) — below the breakpoint drifts selectors (§2.5)
-    modes: tuple[UiMode, ...]
 
 @dataclass(frozen=True)
 class Selector:
@@ -158,6 +157,7 @@ class Selector:
 | `min_plan` / `Plan` enum | No plan-gated selector is in the initial registry. Add the day one is — 4 lines then. |
 | `features` | Nothing reads it; `surface` + `note` already carry the context. |
 | `required` | All entries defaulted `True`, and its `False` branch returned the same grade as the mode branch. Two encodings, one outcome. |
+| `Surface.modes` | Never read — `for_surface()` filters on `Selector.mode`. Same category as `features`, cut in the same review that added it. |
 
 **Keys are a public promise** — they appear in canary reports and any future override.
 
@@ -168,11 +168,16 @@ CAPTURE  navigate (viewport-pinned) → page.content() + observed context → HT
 CHECK    (html, entries, observed) → HIT | FALLBACK | AMBIGUOUS | MISS | EXPECTED_ABSENT
 ```
 
-**`observed_mode` must be a capture-time sidecar, not inferred at check time.** Inferring
-it from the DOM is circular: the mode detector *is* `factory.py:116`'s crop/ligature
-probe. Without the sidecar, `editor.crop_control` (`mode=CLASSIC`) grades MISS = drift on
-every agentic capture — the exact error this design exists to prevent. Capture writes
-`{"mode": "agentic", "viewport": [1920,1080], "captured_at": "..."}` beside the HTML.
+**`observed_mode` is a REQUIRED argument to the grader.** Without it,
+`editor.crop_control` (`mode=CLASSIC`) grades MISS = drift on every agentic capture — the
+exact error this design exists to prevent. Making it required enforces that at the type
+level, which is cheaper and stricter than a sentinel grade for "no context".
+
+**Mode detection must reuse production's detector**, never a reimplementation:
+`factory._any_present(page, _CLASSIC_CROP_SELECTORS)` over **all six** ratio variants.
+Checking only `candidates[0]` (`crop_16_9`) is a silent-pass hole: a classic editor on a
+9:16 project reads as AGENTIC, so `crop_control` grades EXPECTED_ABSENT and real drift
+hides permanently. That is the same one-of-six error §2.4 documents.
 
 **Correction to an earlier claim.** This does *not* mean snapshot and live checks "cannot
 disagree". `set_content()` drops external CSS/JS and re-executes inline scripts, and
@@ -202,7 +207,7 @@ same regression class far more cheaply.
   count-based check reports success. `SIDEBAR_CLOSE_FALLBACK_SELECTOR` is deliberately
   unscoped and is the standing candidate for this.
 - **MISS** — nothing resolved → drift → exit 23.
-- **EXPECTED_ABSENT** — the sidecar's `mode` says it should not be here.
+- **EXPECTED_ABSENT** — the observed `mode` says it should not be here.
 
 ### 3.5 Error contract — BLOCKED, pending a scope decision
 
@@ -224,9 +229,15 @@ specified, and making it work means inverting imports across two 3,800-line modu
 
 ## 4. Migration
 
-1. **Registry + grader** — drift-prone families only (composer, submit, agent toggle,
-   sidebar close, crop control, **count tabs**). #404 must be registered; the first draft
-   tested `editor.count_tabs` nine times without ever defining it.
+1. **Registry + grader** — only selectors present on a **freshly-loaded** editor:
+   composer input, composer submit, agent toggle, crop control.
+
+   **#404's count tabs are NOT registerable yet, and that is worth stating plainly.**
+   They live inside the generation-settings panel, which must be clicked open
+   (`_open_gen_settings_panel`; `_is_settings_panel_open` exists because it is normally
+   closed). Registering them would grade MISS on every clean capture. The incident this
+   design leans on hardest therefore needs `Reach` — which is the strongest argument for
+   prioritising `Reach` in the follow-up, not for registering a selector that reds nightly.
 2. **Capture** — viewport-pinned, creates its own project, writes the mode sidecar.
 3. **CI probe workflow** — `schedule` + `workflow_dispatch` only.
 
@@ -244,7 +255,7 @@ surfaces, and §3.5 if the maintainer keeps it.
 | R1 | **Datacenter IP** — all measurements from a residential IP. | Unresolvable locally. `workflow_dispatch` once and read the result. Must also include a **day-7 token re-run** (§2.2 scope limit). |
 | R2 | **Token hard-dies at day 30** (§2.7 — no rotation, so no warning). | Nightly canary reports remaining life. It MUST pin the profile path — two `profile_denon82` trees exist on the maintainer's machine and the orphaned one reports "expired 38 days ago". |
 | R3 | **Project validity** (§2.3). | Probe creates-or-verifies per run. |
-| R4 | **State-gated selectors.** `SIDEBAR_CLOSE` exists only while the sidebar is expanded, so a URL-only surface grades it MISS. | Phase 1 registers only selectors present on a freshly-loaded editor. State-gated entries wait for `Reach`. |
+| R4 | **State-gated selectors.** `SIDEBAR_CLOSE` needs an expanded sidebar; **count tabs need the generation-settings panel opened**. A URL-only surface grades both MISS. | Phase 1 registers only selectors present on a freshly-loaded editor. Both wait for `Reach` — including #404's family (§4). |
 | R5 | **CI has no browser.** `ci.yml:165` runs plain pytest; no workflow installs Playwright. | Probe workflow installs chromium itself. No default-suite test may require a real browser. |
 | R6 | **Secrets in a public repo.** | Dedicated throwaway account, never the maintainer's. Reuse `src/gflow_cli/data/redaction.py` (already covers `Bearer`, `SAPISIDHASH`, `__Secure-next-auth.session-token`, signed queries) for any published output — do not write a fourth redactor. |
 | R7 | **Same-repo branch PRs would receive the secret** while checking out attacker-editable probe code. Fork PRs are safe (GitHub withholds secrets). | Never add `pull_request`; never `pull_request_target`. |

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -162,7 +162,7 @@ class Selector:
 | `required` | All entries defaulted `True`, and its `False` branch returned the same grade as the mode branch. Two encodings, one outcome. |
 | `Surface.modes` | Never read — `for_surface()` filters on `Selector.mode`. Same category as `features`, cut in the same review that added it. |
 
-**Keys are a public promise** — they appear in canary reports and any future override.
+**Keys are a public promise** — they appear in probe reports, and eventually in exit-23 messages.
 
 ### 3.2 One pass: navigate, detect, resolve, grade
 
@@ -219,21 +219,38 @@ same regression class far more cheaply.
   together is part of the deferred §3.5.
 - **EXPECTED_ABSENT** — the observed `mode` says it should not be here.
 
-### 3.5 Error contract — BLOCKED, pending a scope decision
+### 3.5 Rejected: an operator selector override
 
-Adding `selector_key` to `UiSelectorDriftError` and shipping
-`GFLOW_CLI_SELECTOR_OVERRIDE` both require the **drivers** to read from the registry.
-Today all 7 `UiSelectorDriftError(` raise sites are in `ui_automation.py` (2) and
-`ui_automation_video.py` (5), and nothing in those modules consumes the registry — so
-`selector_key` would stay `None` in production and an override would change what is
-*checked*, never what is *clicked*.
+An earlier draft proposed `GFLOW_CLI_SELECTOR_OVERRIDE`, letting a user patch a drifted
+selector from the environment instead of waiting for a release:
 
-That makes §6's non-goal *"not replacing the driver code"* incompatible with this section.
-Three independent findings say cut: no user has requested an override
-(`gh issue list --state all --search "selector override"` → none), it does not work as
-specified, and making it work means inverting imports across two 3,800-line modules.
+```
+GFLOW_CLI_SELECTOR_OVERRIDE='editor.count_tabs=[role=tab]:text-is("x1")'
+```
 
-**Deferred, not deleted** — the scope call belongs to the maintainer.
+**Rejected — recorded here so it is not re-proposed.**
+
+It is a hack: an env var that injects arbitrary DOM selectors into production automation,
+papering over the real problem rather than fixing it. The real fix for a rename is a
+registry edit and a release; the real fix for *not knowing about the rename* is the probe
+this document specifies. An override addresses neither and adds a permanently-supported
+public surface whose values nobody can validate.
+
+Three supporting findings, each verified:
+
+- **No demand.** `gh issue list --state all --search "selector override"` → nobody has
+  asked, ever.
+- **It did not work as specified.** It was wired into the probe, so it would change what
+  gflow *checks* and leave what gflow *clicks* untouched — the user stays broken.
+- **The borrowed precedent does not transfer.** `notebooklm-py` ships an override for RPC
+  method IDs: 6-character strings copied from a network tab, which any user can do.
+  Authoring a Playwright selector with `:has()` and Material Symbols ligature matching for
+  a React app is a different skill. The only person who could use it is the maintainer,
+  who can edit the registry instead.
+
+**What replaces it:** nothing. The probe already reports drift *by key*
+(`editor.composer.input DRIFT`), which is the half that carries the value — you learn what
+moved the morning it moves.
 
 ---
 
@@ -252,7 +269,8 @@ specified, and making it work means inverting imports across two 3,800-line modu
    gates on base state, resolves against the live page. `schedule` +
    `workflow_dispatch` only.
 
-**Deferred to a follow-up plan:** the AST guardrail (it flags **9 real offenders** today —
+**Deferred to a follow-up plan:** `selector_key` on `UiSelectorDriftError`, the AST
+guardrail (it flags **9 real offenders** today —
 `ui_automation_video.py:91-96,162`, `agentic.py:62`, `diagnostics.py:1738` — so it reds on
 arrival while its migration is still deferred), inverting the import direction, additional
 surfaces, and §3.5 if the maintainer keeps it.
@@ -276,8 +294,11 @@ surfaces, and §3.5 if the maintainer keeps it.
 
 ## 6. Non-goals
 
-- **Not** replacing the driver code *in this phase*. §3.5 is deferred precisely because it
-  would require that; the two cannot both hold.
+- **Not** replacing the driver code in this phase. `selector_key` on
+  `UiSelectorDriftError` needs it (all 7 raise sites live in `ui_automation*`, and
+  `GFlowError.__init__` takes a fixed kwarg list), so that stays deferred to the
+  follow-up, where the drivers start reading from the registry anyway.
+- **Not** an operator selector override, ever — see §3.5.
 - **Not** a Page Object Model rewrite — POM hides selectors inside classes; enumerability
   is the point.
 - **Not** the master token — §2.2 makes it unnecessary. See `[[master-token-tier0-deferred]]`.

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -1,0 +1,237 @@
+# Selector Registry + Drift Probe — Design
+
+**Status:** Draft, pending council review
+**Date:** 2026-08-21
+**Related:** #502 (nightly canary, shipped), #404, #493, #174, #299, #313, #171
+
+---
+
+## 1. Problem
+
+gflow drives Flow by locating DOM elements. Those locators — **selectors** — are the
+project's #1 breakage class: Google changes the page without notice and gflow stops
+working. Every incident below is a selector that moved:
+
+| Incident | What Google did |
+|---|---|
+| #404 | renamed video count tabs `1x` → `x1` |
+| #493 | expanded sidebar removed the classic composer |
+| #174 | library UI A/B flip |
+| #313 | agent settings panel became sticky |
+
+Two structural problems make each one worse than it needs to be.
+
+**No inventory.** Selectors are scattered across four modules, some as inline literals,
+some as module-private constants ~2,900 lines into a 3,557-line file:
+
+```
+mode_control.py:43,49,61,79        factory.py:52,58,60
+agentic.py:62,210                  (inline literals)
+ui_automation.py:97…460, 2924, 2952, 2961, 2964
+ui_automation_video.py:90,103,144
+```
+
+Nobody — human or agent — can answer *"what parts of Flow's page does gflow depend on?"*
+The nightly canary (#502) can therefore only report *"a test failed"*, never *"this
+selector moved"*.
+
+**No user recourse.** A selector is compiled in. When Google renames a control, every user
+is broken until a release ships. `notebooklm-py`'s users patch a drifted value with an env
+var and keep working; gflow's cannot.
+
+**Context is encoded in file paths.** `SIDEBAR_CLOSE_SELECTOR` and
+`SIDEBAR_CLOSE_FALLBACK_SELECTOR` are related only by naming convention.
+`UiSelectorDriftError` carries "the probe label" as free text. None of it is queryable.
+
+---
+
+## 2. Evidence
+
+Everything in §3 rests on measurements taken 2026-08-21, not assumptions. Two of these
+overturned conclusions this design previously held.
+
+### 2.1 Offline selector checking works
+
+Playwright's `set_content()` plus its locator engines (`:has()`, `:text-is()`) resolve
+gflow's real selectors against static HTML — no network, no auth, no credits. Cohort
+variants correctly report MISS.
+
+### 2.2 CI can capture the live DOM — one cookie is sufficient
+
+Six-arm isolation matrix, positive control in the same run, one variable at a time:
+
+| Arm | Browser | Cookies | composer | icons |
+|---|---|---|---|---|
+| CONTROL | real Chrome + full profile | profile (63) | 1 | 17 |
+| D | real Chrome, fresh ctx | labs.google (7) | 1 | 17 |
+| E | real Chrome, fresh ctx | all 63 | 1 | 17 |
+| F | bundled chromium, fresh ctx | all 63 | 1 | 17 |
+| G | bundled chromium, fresh ctx | labs.google (7) | 1 | 17 |
+| **H** | **bundled chromium, fresh ctx** | **session-token only (1)** | **1** | **17** |
+
+**All six identical.** `__Secure-next-auth.session-token` (1088 chars, **30-day** expiry,
+scoped to `labs.google`) is sufficient on its own. No profile, no real Chrome, no
+`.google.com` cookies, no master token, no OAuth bounce.
+
+This is decisive because the blocker assumed for CI auth — `__Secure-1PSIDTS` rotating
+every ~10 minutes — is a **Google** cookie. Flow does not authenticate on it.
+
+### 2.3 The confound that voided three earlier runs
+
+Three runs reused a hard-coded project id. A stale/deleted project renders an error shell
+— **~441KB, 3 buttons, 0 icons** — which is indistinguishable from an auth wall by every
+metric being measured. Those runs produced the false conclusions *"CI-without-auth is
+dead"* and *"DOM auth and API auth are separate gates."* Both are retracted.
+
+> **Binding consequence:** any probe navigating to a fixed project id can produce a
+> convincing false negative. Every DOM probe MUST carry a positive control in the same
+> run, and MUST create or verify its project rather than trust a stored id.
+
+### 2.4 Other measurements
+
+- **Headless is not bot-blocked** from a residential IP; unauthenticated it serves a 552KB
+  marketing page with none of the app.
+- **Locale is account-driven, not URL-driven.** Passing `locale="en"` to
+  `project_editor_url()` still redirected to `/fx/pt/` and served Portuguese. Selectors
+  MUST stay locale-invariant (Material Symbols ligatures, never display text).
+- **`CROP_SELECTORS[0]` MISSes on the agentic arm.** It is the *classic-mode indicator*
+  (`factory.py:116`), and only 1 of its 6 ratio variants was probed. Without `mode` and
+  ordered `candidates`, that MISS is unattributable — the exact ambiguity this design exists
+  to remove.
+
+---
+
+## 3. Design
+
+### 3.1 Data model
+
+```python
+@dataclass(frozen=True)
+class Surface:
+    key: str                     # "editor", "editor.media_picker", "character_editor"
+    reach: Reach                 # URL builder | (parent surface + non-mutating action)
+    modes: tuple[UiMode, ...]    # which arms this surface can present
+
+@dataclass(frozen=True)
+class Selector:
+    key: str                     # "editor.composer.input" — stable, public, in errors
+    surface: str                 # → Surface.key
+    mode: UiMode | None          # None = every mode of that surface
+    min_plan: Plan | None        # None = every plan; gated controls are expected-absent below it
+    candidates: tuple[str, ...]  # ORDERED: [0] preferred, then cohort variants / fallbacks
+    features: tuple[str, ...]    # ("image", "video") — dependent commands
+    required: bool               # True → drift is exit 23; False → degraded but survivable
+    note: str                    # why fallbacks exist; incident refs
+```
+
+Every field is justified by §2 or by a listed incident. `min_plan` exists because #171
+(`UpscaleUnavailableError`, exit 22) is plan-gated — `errors.py:508` says 4K upscale
+"requires a Flow Ultra subscription". On a free CI account those controls are legitimately
+absent, and that must not read as drift.
+
+> **New type required.** `Plan` (Free / Pro / Ultra) does **not** exist in the codebase and
+> must be introduced by this work. It is deliberately NOT named `Tier`: `api/video.py:35`
+> already defines `Tier` as a *video quality* enum, and reusing the name would collide.
+
+**Keys are a public promise.** They surface in exit-23 messages, canary reports, and the
+env override. Renaming one is a breaking change — which is why the override ships last.
+
+**Deliberately excluded:** timeouts, retry counts, screenshot-on-miss. Those are behaviour
+and belong at the call site; including them would make this a config framework rather than
+an inventory.
+
+### 3.2 Capture / check split
+
+```
+CAPTURE   navigate to surface → page.content() → HTML     [browser + 1 cookie, $0]
+CHECK     (html, entries) → HIT | FALLBACK | MISS         [pure; needs a browser only
+                                                           for the selector engine]
+```
+
+The check is a pure function, so the *same code* grades a fresh capture and a committed
+snapshot. The layers cannot disagree.
+
+**Invariant:** reach steps MUST be non-mutating and credit-free. Opening a panel qualifies;
+clicking Generate does not. This is what makes "$0" true by construction rather than by
+hope, and it is reviewable.
+
+### 3.3 Where each layer runs
+
+| Layer | Trigger | Credential | Detects |
+|---|---|---|---|
+| **CI probe** | schedule + label (cadence open, see R1/§5) | `GFLOW_CI_SESSION_TOKEN` + project id | Google changed the page |
+| **Nightly canary** | 03:00 local | maintainer profile | drift on the maintainer's cohort/tier/IP |
+| **Snapshot tests** | every PR, offline | none | *we* broke a selector |
+
+The nightly canary keeps a distinct role even with CI probing: a different account sits on
+a different **A/B cohort** and a different **plan**, and runs from a residential IP.
+Divergence between CI and nightly is *data*, not a bug — `mode`/`min_plan` make it attributable.
+
+### 3.4 Grading
+
+- **HIT** — `candidates[0]` resolved.
+- **FALLBACK HELD** — `[0]` missed, a later candidate resolved. **Warning, not failure**;
+  this is #493's actual outcome and the difference between a canary that gets read and one
+  that gets ignored.
+- **MISS (required)** — no candidate resolved → drift → `UiSelectorDriftError` (exit 23)
+  carrying the key.
+- **MISS (expected)** — `mode` or `min_plan` says it should be absent → informational.
+
+### 3.5 Error contract and override
+
+`UiSelectorDriftError` gains a structured `selector_key` alongside its free-text detail. The
+key is publication-safe for a public issue (unlike a raw selector or a path).
+
+Env override, **last phase only**:
+
+```
+GFLOW_CLI_SELECTOR_OVERRIDE='editor.count_tabs=<css>;editor.composer.input=<css>'
+```
+
+A user hit by a #404-class rename patches it and keeps working; the proper fix ships at its
+own pace.
+
+---
+
+## 4. Migration
+
+Incremental, no phase requiring the 3,800-line module split up front.
+
+1. **Registry + surfaces for the drift-prone families only** — composer, mode switch, count
+   tabs, sidebar close. These carry the incident history.
+2. **Snapshot fixtures + offline check** — commit scrubbed DOM per surface; CI grades every PR.
+3. **CI probe workflow** — live capture, grading, report.
+4. **AST guardrail** — selector literals forbidden outside the registry (pattern:
+   `test_rpc_method_ids_only_in_types.py`).
+5. **Remaining selectors**, then the env override once keys have proven stable.
+
+Steps 1–3 deliver value independently. The AST lint lands only after (5) is reachable,
+otherwise it blocks its own migration.
+
+---
+
+## 5. Risks and open questions
+
+| # | Risk | Resolution |
+|---|---|---|
+| R1 | **Datacenter IP.** Every measurement was from a residential IP; Google may treat a GitHub runner differently. | Unresolvable locally. Put the secret in, run once, look. Cheap and definitive. |
+| R2 | **30-day secret rotation.** CI fails on day 31 with a confusing auth error. | Nightly canary reads cookie expiry locally and warns on the dashboard below 7 days. |
+| R3 | **Project validity** (§2.3). | CI creates or verifies its project per run; never trusts a stored id blindly. |
+| R4 | **Free-plan CI account** cannot render plan-gated controls. | `min_plan` field; expected-absent ≠ drift. Requires introducing a `Plan` enum. |
+| R5 | **Snapshots rot** into always-passing. | They only ever detect *our* regressions; the live probe is the drift authority. Re-record on every confirmed drift. |
+| R6 | **DOM snapshots carry PII** — project ids, asset URLs, possibly email. | Scrubbing required before commit, enforced by a guardrail test (pattern: `test_cassettes_clean.py`). |
+| R7 | Static snapshots lose CSS/JS, so **visibility/enabled state is unverifiable offline**. | Snapshot layer asserts structural presence only; live probe additionally asserts visible/enabled. |
+
+**Open question:** should CI probe on every PR, or on a schedule plus label? Every-PR gives
+the fastest signal but hammers one account; the answer likely depends on R1.
+
+---
+
+## 6. Non-goals
+
+- **Not** replacing the driver code. The registry owns data; clicking stays where it is.
+- **Not** a Page Object Model rewrite. POM hides selectors inside classes; enumerability is
+  the whole point here.
+- **Not** the master token. §2.2 makes it unnecessary — see `[[master-token-tier0-deferred]]`.
+- **Not** generation testing. The probe never submits, never spends credits.
+- **Not** splitting `ui_automation*.py` in this work. Desirable, separately scoped.

--- a/scripts/probe/spike_auth_matrix.py
+++ b/scripts/probe/spike_auth_matrix.py
@@ -1,0 +1,131 @@
+"""THROWAWAY SPIKE — isolate WHY a profile-less browser cannot render Flow's editor.
+
+The previous run changed two variables at once (bundled chromium AND cookie
+injection instead of a profile), so it could not attribute the failure. This
+varies ONE thing at a time and carries a positive control in the same run, so a
+Flow outage or a stale selector cannot be mistaken for a negative result.
+
+    CONTROL  real Chrome + full profile          expect HIT (proves setup valid NOW)
+    D        real Chrome, fresh ctx, labs jar    browser? or cookies?
+    E        real Chrome, fresh ctx, FULL jar    do .google.com cookies fix it?
+    F        bundled chromium, fresh ctx, FULL   does the browser binary matter?
+
+Reading:
+    D HIT              -> cause was the browser binary; CI runners HAVE Chrome -> viable
+    D miss, E HIT      -> cause is Google cookies -> ~10min PSIDTS rotation -> blocked
+    E miss, F miss     -> profile state (localStorage/IndexedDB) required -> blocked
+
+$0 throughout: navigation and DOM reads only. Cookie values never printed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+sys.path.insert(0, r"C:\development\github\gflow-cli\src")
+sys.path.insert(0, r"C:\development\github\gflow-cli")
+
+from playwright.async_api import async_playwright  # noqa: E402
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.api.transports.mode_control import AGENT_TOGGLE_SELECTOR  # noqa: E402
+from gflow_cli.api.transports.ui_automation import PROMPT_INPUT_SELECTORS  # noqa: E402
+from gflow_cli.auth import profile_dir as resolve  # noqa: E402
+
+# Set at runtime from a FRESH project. A stale/deleted id renders an error shell
+# that looks exactly like an auth wall (~441KB, 3 buttons, 0 icons) — which is
+# what voided the first matrix run.
+URL = ""
+FIELDS = ("name", "value", "domain", "path", "expires", "httpOnly", "secure", "sameSite")
+
+PROBES = {
+    "composer": PROMPT_INPUT_SELECTORS[0],
+    "agent_toggle": AGENT_TOGGLE_SELECTOR,
+    "icons": "i.google-symbols",
+    "slate": "[data-slate-editor]",
+}
+RESULTS: list[tuple[str, str, dict[str, int]]] = []
+
+
+async def measure(page, arm: str, note: str) -> None:
+    await page.goto(URL, wait_until="domcontentloaded", timeout=90_000)
+    # Wait for the SPA to hydrate rather than guessing: poll for icons, cap at 25s.
+    for _ in range(25):
+        if await page.locator("i.google-symbols").count():
+            break
+        await page.wait_for_timeout(1000)
+    counts = {k: await page.locator(s).count() for k, s in PROBES.items()}
+    RESULTS.append((arm, note, counts))
+    print(f"  {arm:9} {note:34} {counts}")
+
+
+async def control_and_harvest() -> list[dict]:
+    """Positive control on the real profile, and harvest the FULL cookie jar.
+
+    ctx.cookies() is called with NO url filter: filtering by url silently drops
+    subpath-scoped cookies (issue #222/#230).
+    """
+    global URL
+    async with FlowApiClient(profile_dir=resolve("denon82"), headless=True) as c:
+        proj = await c.create_project(title="ci-matrix control")  # $0, and guarantees it EXISTS
+        URL = routes.project_editor_url("en", proj.project_id)
+        print(f"  (fresh project {proj.project_id})")
+        page = c._page or c._context.pages[0]  # noqa: SLF001
+        await measure(page, "CONTROL", "real Chrome + full profile")
+        return list(await c._context.cookies())  # noqa: SLF001 - unfiltered, all domains
+
+
+async def arm(label: str, note: str, channel: str | None, cookies: list[dict]) -> None:
+    async with async_playwright() as pw:
+        kwargs = {"headless": True}
+        if channel:
+            kwargs["channel"] = channel
+        try:
+            browser = await pw.chromium.launch(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {label:9} LAUNCH FAILED: {type(exc).__name__}")
+            return
+        try:
+            ctx = await browser.new_context()
+            await ctx.add_cookies([{k: ck[k] for k in FIELDS} for ck in cookies])
+            await measure(await ctx.new_page(), label, note)
+        finally:
+            await browser.close()
+
+
+async def main() -> None:
+    print("arm       setup                              counts")
+    jar = await control_and_harvest()
+    labs = [c for c in jar if "labs.google" in c["domain"]]
+    print(f"\n  (harvested {len(jar)} cookies total, {len(labs)} on labs.google)\n")
+
+    await arm("D", "real Chrome, fresh ctx, labs jar", "chrome", labs)
+    await arm("E", "real Chrome, fresh ctx, FULL jar", "chrome", jar)
+    await arm("F", "bundled chromium, fresh, FULL jar", None, jar)
+    # G is the EXACT CI shape: no real Chrome, no Google cookies, no profile.
+    await arm("G", "bundled chromium, labs jar ONLY", None, labs)
+    # H: is the single session cookie sufficient on its own?
+    only = [c for c in labs if c["name"] == "__Secure-next-auth.session-token"]
+    await arm("H", "bundled chromium, session cookie ONLY", None, only)
+
+    print("\n--- verdict ---")
+    by = {a: c for a, _, c in RESULTS}
+    ctrl = by.get("CONTROL", {})
+    if not ctrl.get("composer"):
+        print("CONTROL FAILED — result is VOID (Flow down, or selector already drifted).")
+        return
+    if by.get("H", {}).get("composer"):
+        print("H HIT -> ONE 30-day cookie + bundled chromium is enough. CI capture VIABLE.")
+    elif by.get("G", {}).get("composer"):
+        print("G HIT -> labs.google jar + bundled chromium is enough. CI capture VIABLE.")
+    elif by.get("D", {}).get("composer"):
+        print("D HIT -> needs real Chrome. Runners ship Chrome, so still viable.")
+    elif by.get("E", {}).get("composer"):
+        print("E HIT -> needs .google.com cookies -> PSIDTS rotates ~10min -> CI BLOCKED.")
+    else:
+        print("D+E miss -> profile state beyond cookies is required -> CI BLOCKED.")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

Design spec + implementation plan for the selector registry — the highest-value item from the `notebooklm-py` comparative audit, and what lets the nightly canary (#502) report **which selector drifted** instead of *"a test failed"*.

Docs only. No product code.

**Council-reviewed to consensus: 5 rounds, 5 dimensions, all GREEN.**

## Why

Selector drift is gflow's #1 breakage class — #404 (`1x`→`x1`), #493 (sidebar hid the composer), #174 (library A/B), #313 (sticky settings panel). Today selectors are scattered across four modules with no inventory, so nobody can answer *"what does gflow depend on?"* and the canary can only say *"something broke"*.

## The headline finding

A six-arm isolation matrix — **with a negative control** — established that a bundled headless chromium carrying **one cookie** (`__Secure-next-auth.session-token`, 1088 chars, 30-day expiry, scoped to `labs.google`) renders Flow's editor identically to a full real-Chrome profile. Without the cookie, or with its value corrupted, it does not render.

**So CI can capture the live DOM.** No master token, no `gpsoauth`, no OAuth bounce, no real Chrome, no Google cookies. The blocker everyone assumed — `__Secure-1PSIDTS` rotating every ~10 min — is a *Google* cookie Flow does not authenticate on.

Scope limit recorded honestly: the tested token was ~9 minutes old, so sufficiency is established **at mint time**, not for an aged one. R1 requires a day-7 re-run.

## What the council changed

| Round | Finding |
|---|---|
| 1 | The headline feature **couldn't work** — no driver reads the registry, so `selector_key` ships `None` and an override changes what's *checked*, never what's *clicked* |
| 1 | §2.2 had **no negative control** — an all-HIT matrix repeating the very error §2.3 documents |
| 2 | Capture *and* probe rendered **below Flow's responsive breakpoint**, reporting drift that wasn't there |
| 2 | Cutting snapshots **orphaned their producer** — a whole task nothing imported |
| 3 | `check_html` re-parsed the DOM in a **second browser** at lower fidelity than the live page it discarded |
| 3 | **3 of 4 registered selectors red on a known cohort flap** → new base-state gate |
| 4 | Two constants I treated as distinct are **byte-identical** — the gate certified a label it could never emit |

Scope: **6 tasks → 2** · 5 registry entries → 4 · 6 `Grade` members → 5 · one `src/` module deleted. Verified by extraction: **21 tests pass** from the plan's own code blocks.

## Maintainer decision applied

`GFLOW_CLI_SELECTOR_OVERRIDE` is **rejected outright**, not deferred — recorded in §3.5 so it isn't re-proposed. An env var injecting arbitrary DOM selectors into production automation papers over the problem instead of fixing it, and the borrowed precedent doesn't transfer: notebooklm-py's override patches 6-char RPC ids anyone can copy from a network tab, not Playwright selectors for a React app.

`selector_key` stays deferred separately — it's diagnosis, not a hack, and lands with the import inversion.

## Open risk

**R1 — datacenter IP.** Every measurement came from a residential connection; no local test predicts how Google treats a GitHub runner. The workflow ships `schedule` + `workflow_dispatch` only, with an explicit instruction not to add `pull_request` until one real run answers it.

Refs #502
