### PR TITLE
docs: selector drift probe operator guide

### DIFF
--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -239,6 +239,55 @@ tokens**. Published content is sanitized for a public repo: SHA, pass/fail
 counts, duration, failure class, and failing test *names* only — never raw logs,
 profile paths, prompts, or signed URLs.
 
+## Selector drift probe (#563)
+
+The canary answers *"does gflow still work on the maintainer's cohort?"*; the
+probe answers *"which Flow DOM selector moved?"* — from hosted CI, with no
+maintainer machine involved. It walks the structured selector inventory in
+`gflow_cli.flow_selectors` (the incident families from #404/#493/#313) against
+a live editor at the pinned 1920×1080 viewport: navigate and read only, **$0**,
+never submits.
+
+Runs via `.github/workflows/selector-probe.yml` on `schedule` (05:00 UTC daily)
+plus `workflow_dispatch`. **Never add a `pull_request` trigger**: same-repo
+branch PRs receive repository secrets while running attacker-editable probe
+code (fork PRs are safe — GitHub withholds secrets — but the same-repo case is
+not).
+
+### Exit contract
+
+| Exit | Meaning | Action |
+|---|---|---|
+| `0` | every registered selector resolved (`ok` / `FALLBACK[n]` / `n/a`) | none |
+| `1` | **drift** — a selector graded MISS or AMBIGUOUS; the report names its key | re-derive that selector, ship a registry edit |
+| `2` | **inconclusive** — expired token, dead project, known alternate UI state, or no recognizable editor arm | fix the credential/project; says nothing about Flow |
+
+Keeping `1` and `2` apart is the whole design: an expired credential must never
+be published as "Google changed the page". The deciding gate is a poll on
+production's own arm indicators (the six `crop_*` variants ⇒ classic, the
+agentic ligatures ⇒ agentic); a page showing neither within 25 s — a sign-in
+wall renders neither — is inconclusive, not drift. Mode-scoped selectors absent
+on the observed arm grade `n/a` (`EXPECTED_ABSENT`), never drift — the probe's
+first two live runs landed on opposite arms (classic locally, agentic on the
+runner) and both graded clean.
+
+### Secrets and token care
+
+Two repository secrets, from a **dedicated throwaway Google account**, never
+the maintainer's: `GFLOW_CI_SESSION_TOKEN` (the
+`__Secure-next-auth.session-token` cookie) and `GFLOW_CI_PROJECT_ID` (any
+project that account owns — a deleted id renders an error shell the probe
+reports as exit 2).
+
+The token **re-issues on every profile open** (observed live 2026-08-21: three
+values in 15 minutes; the first CI dispatch failed exit 2 on a superseded
+snapshot). Harvest accordingly: open the throwaway profile once, read the
+cookie, close the browser, `gh secret set GFLOW_CI_SESSION_TOKEN` from stdin —
+and never reopen that profile without re-syncing the secret afterwards. The
+value also hard-dies at day 30 with no warning. Either way an aged token shows
+as a red exit-2 run, never as drift, and the nightly schedule itself is the
+aging test.
+
 ---
 
 ## File map

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -58,6 +58,8 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [docs/superpowers/plans/2026-07-19-live-verify/PLAN.md](superpowers/plans/2026-07-19-live-verify/PLAN.md) | Task-by-task implementation plan for `/gflow:live-verify` (skill file → AGENTS.md/check.md wiring → INDEX row) | Tracking task-by-task execution of the live-verify skill |
 | [docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md](superpowers/plans/2026-07-27-tier-aware-credit-confirmations/SCENARIO.md) | Edge-case matrix for replacing fixed chain/movie credit estimates with truthful pending-operation guidance | Reviewing the financial-safety, resume, dry-run, and compatibility scenarios |
 | [docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md](superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md) | TDD implementation plan for tier-aware chain/movie planning and confirmation output | Tracking the isolated runtime pricing-guidance bugfix |
+| [docs/superpowers/specs/2026-08-21-selector-registry-design.md](superpowers/specs/2026-08-21-selector-registry-design.md) | Selector registry + drift probe design spec: measured one-cookie auth evidence, data model, grading semantics, CI probe, risk register | Reviewing the registry/probe design or auditing its evidence |
+| [docs/superpowers/plans/2026-08-21-selector-registry.md](superpowers/plans/2026-08-21-selector-registry.md) | Task-by-task TDD plan for the selector registry + CI probe (executed — PR #563) | Auditing how the registry/probe was built |
 
 ## Agent commands
 
@@ -133,6 +135,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"How do I run e2e tests before a release?"** → [DEVELOPMENT § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop--main)
 **"What does each e2e marker cost? How do I run only the cheap tests?"** → [E2E_TESTING § Run commands](E2E_TESTING.md#run-commands)
 **"Has Flow drifted since the last release? What is the nightly canary telling me?"** → [E2E_TESTING § Nightly canary](E2E_TESTING.md#nightly-canary-502)
+**"Which Flow selector moved? What is the CI selector probe telling me (exit 0/1/2)?"** → [E2E_TESTING § Selector drift probe](E2E_TESTING.md#selector-drift-probe-563)
 **"When does the version get bumped?"** → [DEVELOPMENT § Version bump protocol](DEVELOPMENT.md#version-bump-protocol)
 **"How do I embed FlowApiClient in a long-lived worker / service?"** → [USER_GUIDE § Journey 14](USER_GUIDE.md#journey-14--embedding-flowapiclient-in-a-long-lived-worker)
 **"What's the standard way to import gflow errors in my code?"** → [USAGE § Programmatic use](USAGE.md#programmatic-use)

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -239,6 +239,55 @@ tokens**. Published content is sanitized for a public repo: SHA, pass/fail
 counts, duration, failure class, and failing test *names* only — never raw logs,
 profile paths, prompts, or signed URLs.
 
+## Selector drift probe (#563)
+
+The canary answers *"does gflow still work on the maintainer's cohort?"*; the
+probe answers *"which Flow DOM selector moved?"* — from hosted CI, with no
+maintainer machine involved. It walks the structured selector inventory in
+`gflow_cli.flow_selectors` (the incident families from #404/#493/#313) against
+a live editor at the pinned 1920×1080 viewport: navigate and read only, **$0**,
+never submits.
+
+Runs via `.github/workflows/selector-probe.yml` on `schedule` (05:00 UTC daily)
+plus `workflow_dispatch`. **Never add a `pull_request` trigger**: same-repo
+branch PRs receive repository secrets while running attacker-editable probe
+code (fork PRs are safe — GitHub withholds secrets — but the same-repo case is
+not).
+
+### Exit contract
+
+| Exit | Meaning | Action |
+|---|---|---|
+| `0` | every registered selector resolved (`ok` / `FALLBACK[n]` / `n/a`) | none |
+| `1` | **drift** — a selector graded MISS or AMBIGUOUS; the report names its key | re-derive that selector, ship a registry edit |
+| `2` | **inconclusive** — expired token, dead project, known alternate UI state, or no recognizable editor arm | fix the credential/project; says nothing about Flow |
+
+Keeping `1` and `2` apart is the whole design: an expired credential must never
+be published as "Google changed the page". The deciding gate is a poll on
+production's own arm indicators (the six `crop_*` variants ⇒ classic, the
+agentic ligatures ⇒ agentic); a page showing neither within 25 s — a sign-in
+wall renders neither — is inconclusive, not drift. Mode-scoped selectors absent
+on the observed arm grade `n/a` (`EXPECTED_ABSENT`), never drift — the probe's
+first two live runs landed on opposite arms (classic locally, agentic on the
+runner) and both graded clean.
+
+### Secrets and token care
+
+Two repository secrets, from a **dedicated throwaway Google account**, never
+the maintainer's: `GFLOW_CI_SESSION_TOKEN` (the
+`__Secure-next-auth.session-token` cookie) and `GFLOW_CI_PROJECT_ID` (any
+project that account owns — a deleted id renders an error shell the probe
+reports as exit 2).
+
+The token **re-issues on every profile open** (observed live 2026-08-21: three
+values in 15 minutes; the first CI dispatch failed exit 2 on a superseded
+snapshot). Harvest accordingly: open the throwaway profile once, read the
+cookie, close the browser, `gh secret set GFLOW_CI_SESSION_TOKEN` from stdin —
+and never reopen that profile without re-syncing the secret afterwards. The
+value also hard-dies at day 30 with no warning. Either way an aged token shows
+as a red exit-2 run, never as drift, and the nightly schedule itself is the
+aging test.
+
 ---
 
 ## File map


### PR DESCRIPTION
## Summary

Operator documentation for the selector drift probe shipped in #563 — currently its only prose lives in the spec/plan (deleted at release consolidation) and a PR comment.

- **E2E_TESTING.md**: new `Selector drift probe (#563)` section beside the canary it complements — scope, the never-add-pull_request rule, the exit 0/1/2 contract table, and token care (the re-issue-on-every-profile-open rule proven by the first live runs, the harvest procedure, day-30 hard death).
- **INDEX.md**: rows for the 2026-08-21 spec/plan (matching the convention for prior specs) + a topic shortcut for probe verdicts.
- **website/docs mirror**: regenerated (E2E_TESTING.md).

## Test plan

- [x] check_doc_links, generate_website_docs --check, PII guard, repo hygiene — all green locally
- [x] No secrets or account identifiers in the published docs

Refs #563