### PR TITLE
chore(ci): harden the workflow supply chain — persist-credentials, zizmor (#565)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0  # full history so gitleaks can diff against base
 
       - name: Run gitleaks
@@ -39,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Audit locked dependencies for known CVEs
@@ -57,6 +60,42 @@ jobs:
           # dependabot ecosystem — bump by hand when it drifts).
           uvx pip-audit==2.10.1 -r requirements-audit.txt
 
+  # ── Security gate: static analysis of the workflows themselves ───────────
+  # Everything else in this file audits the Python we ship. Nothing audited the
+  # CI that ships it, and CI is a supply-chain surface in its own right: it
+  # holds a repository token, it publishes to PyPI, and its inputs (branch
+  # names, PR titles, fork content) are attacker-controllable text.
+  #
+  # zizmor is what turns that into a gate. It found real defects on its first
+  # run over this repo (#565): 12 checkouts persisting the job token into the
+  # workspace, and `${{ github.base_ref }}` interpolated straight into a
+  # governance-advisory shell script. Both are fixed; this job is what stops
+  # them coming back one copy-pasted step at a time.
+  workflow-audit:
+    name: Workflow audit (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Audit workflows (zizmor)
+        # --offline: the online audits need a GH token and reach the network, so
+        #   they would make this gate non-deterministic and unrunnable on fork
+        #   PRs. Action freshness/pinning is already covered by Dependabot plus
+        #   Scorecard's Pinned-Dependencies check.
+        # --min-severity low: informational findings are advisory, not defects.
+        #   The one open today is `superfluous-actions` on
+        #   softprops/action-gh-release; rewriting the release publisher is not
+        #   a hardening change and is deliberately declined (docs/GITHUB.md).
+        # Version pinned for a reproducible gate — uvx has no Dependabot
+        # ecosystem, so bump it by hand (the pin is asserted by
+        # tests/scripts/test_workflow_hardening.py, which fails if the two drift).
+        run: uvx zizmor==1.29.0 --offline --min-severity low .github/workflows/
+
   # ── Supply-chain gate: resolve WITHOUT the lockfile ───────────────────────
   # Every other job installs via `uv sync`, which honours uv.lock. That means CI
   # never exercises the version RANGES in pyproject.toml — the exact blind spot
@@ -73,6 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -127,6 +168,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -196,6 +239,8 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -237,6 +282,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0  # shallow clones break blame / new-code detection
 
       - name: Download coverage report

--- a/.github/workflows/deps-watch.yml
+++ b/.github/workflows/deps-watch.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/external-pr-triage.yml
+++ b/.github/workflows/external-pr-triage.yml
@@ -1,7 +1,15 @@
 name: External PR Triage
 
+# `pull_request_target` is deliberate and is the reason this file is the
+# highest-risk surface in the repo: labelling a fork's PR needs a token forks
+# cannot be given, and `pull_request` does not have one. The trigger is only
+# unsafe when the workflow CHECKS OUT or EXECUTES the untrusted head — this one
+# never does: there is no `actions/checkout` step at all, every PR field is read
+# from `context.payload` inside github-script, and permissions are scoped to
+# `issues`/`pull-requests` write. Keep all three properties or drop the
+# suppression with them.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, reopened, synchronize, ready_for_review, edited]
 
 permissions:

--- a/.github/workflows/governance-advisory.yml
+++ b/.github/workflows/governance-advisory.yml
@@ -21,13 +21,21 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0 # full history so `git diff origin/<base>..HEAD` resolves
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Classify touched paths (advisory, never blocks)
+        # BASE_REF arrives through `env:`, never interpolated into the script
+        # body: a branch name is attacker-supplied text, and `${{ ... }}` is
+        # substituted before the shell ever sees it (zizmor: template-injection).
+        # The fetch is belt-and-braces — `fetch-depth: 0` above already brings
+        # the base branch down — and needs no credential on a public repo.
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch --no-tags origin "${{ github.base_ref }}" || true
+          git fetch --no-tags origin "$BASE_REF" || true
           uv run python scripts/ci/check_materiality.py \
-            --base "origin/${{ github.base_ref }}"
+            --base "origin/$BASE_REF"

--- a/.github/workflows/governance-benchmark.yml
+++ b/.github/workflows/governance-benchmark.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0 # full history — the backtest replays every commit
 
       - name: Install uv

--- a/.github/workflows/main-base-guard.yml
+++ b/.github/workflows/main-base-guard.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Verify release artifacts
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # This is the one workflow that publishes artefacts (PyPI + GitHub
+          # Release), so it must not restore a cache any other workflow can
+          # write: a poisoned entry would reach a signed release. Releases are
+          # rare; the cold resolve costs seconds (zizmor: cache-poisoning).
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CI/CD supply-chain hardening
   ([#565](https://github.com/ffroliva/gflow-cli/issues/565)).** Every
-  `actions/checkout` step now sets `persist-credentials: false` (12 steps across
-  `ci.yml`, `deps-watch.yml`, `governance-advisory.yml`,
+  `actions/checkout` step now sets `persist-credentials: false` (12 existing
+  steps fixed across `ci.yml`, `deps-watch.yml`, `governance-advisory.yml`,
   `governance-benchmark.yml`, `main-base-guard.yml`, `pages.yml` and
   `release.yml`); the default leaves the job token in `.git/config` for the rest
   of the job. No workflow needed it — releases publish over PyPI Trusted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2 inconclusive — an expired token or dead project is never published as
   drift.
 
+### Security
+
+- **CI/CD supply-chain hardening
+  ([#565](https://github.com/ffroliva/gflow-cli/issues/565)).** Every
+  `actions/checkout` step now sets `persist-credentials: false` (12 steps across
+  `ci.yml`, `deps-watch.yml`, `governance-advisory.yml`,
+  `governance-benchmark.yml`, `main-base-guard.yml`, `pages.yml` and
+  `release.yml`); the default leaves the job token in `.git/config` for the rest
+  of the job. No workflow needed it — releases publish over PyPI Trusted
+  Publishing (OIDC) and Pages deploys over `actions/deploy-pages`. A new
+  `workflow-audit` job runs [zizmor](https://github.com/zizmorcore/zizmor)
+  (pinned, `--offline`) over `.github/workflows/` on every push and PR, so the
+  class cannot come back. Its first run also caught two defects the manual pass
+  missed: `${{ github.base_ref }}` interpolated directly into a
+  `governance-advisory.yml` shell script (template injection — the value now
+  arrives through `env:`), and a shared uv cache restored by the publishing
+  release job (cache poisoning — caching is now off there). The
+  `pull_request_target` trigger in `external-pr-triage.yml` is suppressed inline
+  with its rationale, and a changelog-guard workflow was evaluated and declined
+  — both decisions recorded in
+  [docs/GITHUB.md § Workflow Security Gates](docs/GITHUB.md#workflow-security-gates).
+
 ## [0.59.0] — 2026-08-16
 
 ### Added

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -185,6 +185,85 @@ Use this rule:
 - Sonar findings are usually maintainability, reliability, security, or coverage
   signals; small findings may be cosmetic, but they still need classification
 
+## Workflow Security Gates
+
+The workflows are themselves a supply-chain surface: they hold a repository
+token, `release.yml` publishes to PyPI, and their inputs (branch names, PR
+titles, fork content) are attacker-controllable text. Two rules keep that
+surface honest, both mechanically enforced.
+
+### 1. No checkout persists the job token
+
+Every `actions/checkout` step sets `persist-credentials: false`. The action's
+default is `true`, which writes the job token into `.git/config` in the runner
+workspace, where it stays for the rest of the job — and travels into any
+artifact built from that workspace.
+
+Nothing in this repo needs the persisted credential: no workflow runs `git
+push`. `release.yml` publishes through PyPI Trusted Publishing (OIDC) and
+`softprops/action-gh-release` (its own token input); `pages.yml` deploys through
+`actions/deploy-pages` (OIDC); `governance-advisory.yml`'s `git fetch` is an
+unauthenticated read of a public repository, and is redundant with its
+`fetch-depth: 0` checkout in the first place.
+
+### 2. `zizmor` audits every workflow on every PR
+
+The `workflow-audit` job in `ci.yml` runs
+[zizmor](https://github.com/zizmorcore/zizmor), a static analyser for GitHub
+Actions. Run it locally exactly as CI does:
+
+```bash
+uvx zizmor==1.29.0 --offline --min-severity low .github/workflows/
+```
+
+`--offline` keeps the gate deterministic and fork-safe (the online audits need a
+token and network); action pinning and freshness are already covered by
+Dependabot and Scorecard's Pinned-Dependencies check. The pin is asserted by
+`tests/scripts/test_workflow_hardening.py`, so the gate and the test cannot
+drift apart silently.
+
+Two findings are deliberately not fixed, and both are documented where they
+live:
+
+| Finding | Where | Why |
+|---|---|---|
+| `dangerous-triggers` | `external-pr-triage.yml` | `pull_request_target` is required to label a fork's PR. The trigger is only unsafe when the workflow checks out or executes the untrusted head; this one never does — no `actions/checkout` at all, PR fields read from `context.payload`, scoped permissions. Suppressed inline with that rationale. |
+| `superfluous-actions` (informational) | `release.yml` | zizmor suggests replacing `softprops/action-gh-release` with `gh release`. Rewriting the release publisher is not a hardening change; declined rather than risked. Informational findings do not gate (`--min-severity low`). |
+
+### 3. Changelog guard — declined (2026-08-22, [#565](https://github.com/ffroliva/gflow-cli/issues/565))
+
+A [changelog-guard workflow](https://github.com/mvanhorn/last30days-skill/blob/main/.github/workflows/changelog-guard.yml)
+was evaluated for adoption and **declined**. Its central rule — *non-release PRs
+must not edit `CHANGELOG.md`* — is the inverse of this project's convention:
+gflow-cli follows Keep a Changelog with a live `## [Unreleased]` section that
+ordinary feature PRs are expected to update. Adopting it would block almost
+every PR the repo merges.
+
+The rest of the reference workflow is either unneeded or already mechanical
+here:
+
+- **Changelog fragments** presuppose a towncrier-style fragment directory this
+  repo does not have. The `[Unreleased]` section already serves that purpose
+  without a second source of truth to reconcile at release time.
+- **`release` label exemption** — release-ness is keyed off the branch
+  (`chore/release-*`) and base (`main`), already enforced by
+  `main-base-guard.yml`. A label would be a third and weaker signal.
+- **Version lockstep across manifests** — already enforced by
+  `scripts/ci/check_release_artifacts.py` (pyproject ↔ `__version__` ↔
+  CHANGELOG section ↔ footer links ↔ `LIVE_VERIFICATION` doc) on every PR into
+  `main`, and re-checked against the tag by `release.yml` at publish time.
+
+**Recorded gap, deliberately left open:** nothing stops a non-release PR into
+`develop` from bumping a version string — the release-artifact guard only runs
+on `main`-targeting PRs. The minimal adaptation would be a `main-base-guard.yml`
+job failing a `develop`-targeting PR that changes `version =` in
+`pyproject.toml` or `__version__`, exempting `chore/release-*` and `hotfix/*`.
+It is not built here because the `main` → `develop` back-merge PR carries
+exactly that bump legitimately, so the exemption has to be verified against a
+real back-merge before the guard can block anything — and an unverified gate on
+the release path is worse than the convention it would replace. Open a
+follow-up issue if a stray bump ever actually lands.
+
 ## Merge Rule
 
 Merge to `develop` only after:

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -190,7 +190,8 @@ Use this rule:
 The workflows are themselves a supply-chain surface: they hold a repository
 token, `release.yml` publishes to PyPI, and their inputs (branch names, PR
 titles, fork content) are attacker-controllable text. Two rules keep that
-surface honest, both mechanically enforced.
+surface honest, both mechanically enforced. A third gate was evaluated and
+declined; § 3 records that decision so it is not re-litigated.
 
 ### 1. No checkout persists the job token
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,7 +23,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | **[docs/DEVELOPMENT.md](DEVELOPMENT.md)** | Branching model, PR protocol, e2e gate, version bump protocol, AI-assisted workflow | Understanding the end-to-end dev process |
 | **[docs/E2E_TESTING.md](E2E_TESTING.md)** | Layer model, cost sub-markers, run commands, isolation patterns, roadmap to contract/replay layer | Running or extending e2e tests; cost control |
 | **[docs/AGENT_UI_E2E.md](AGENT_UI_E2E.md)** | Deterministic e2e runbook for the Agentic UI image path (force-agent trigger, validation ledger) | Live-verifying Agentic-UI features |
-| **[docs/GITHUB.md](GITHUB.md)** | Maintainer PR triage protocol, forked PR handling, SonarCloud scenarios | Reviewing or merging a GitHub PR |
+| **[docs/GITHUB.md](GITHUB.md)** | Maintainer PR triage protocol, forked PR handling, SonarCloud scenarios, workflow security gates | Reviewing or merging a GitHub PR; adding or changing a workflow |
 | [docs/sonar-cleanup-tracker.md](sonar-cleanup-tracker.md) | SonarCloud zero-smells cleanup tracker (`chore/sonar-zero-cleanup`) | Resuming or auditing the Sonar cleanup effort |
 | [docs/medium_tutorial.md](medium_tutorial.md) | Long-form tutorial article (Medium draft): Veo + Imagen from the terminal | Writing or updating outreach/tutorial content |
 | [.env.template](../.env.template) | All environment variables with defaults | Setting up a new shell or container |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -128,6 +128,7 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"What does Chrome actually use in RAM during a generation?"** → run `uv run python scripts/diag/memory_profile.py --profile NAME` (see [scripts/diag/README.md](../scripts/diag/README.md))
 **"How do I report a security issue?"** → [SECURITY § Reporting](SECURITY.md#reporting)
 **"What branch do I work on? How do I name it?"** → [DEVELOPMENT § Branching model](DEVELOPMENT.md#branching-model)
+**"What secures our GitHub Actions workflows?"** → [GITHUB § Workflow Security Gates](GITHUB.md#workflow-security-gates)
 **"How do I handle an external GitHub PR?"** → [GITHUB § Scenario Matrix](GITHUB.md#scenario-matrix)
 **"What automation runs on external PRs?"** → [GITHUB § Automated External PR Triage](GITHUB.md#automated-external-pr-triage)
 **"How do we use Copilot review on PRs?"** → [GITHUB § GitHub Copilot Code Review](GITHUB.md#github-copilot-code-review)

--- a/tests/scripts/test_workflow_hardening.py
+++ b/tests/scripts/test_workflow_hardening.py
@@ -1,0 +1,101 @@
+"""Workflow-hardening gates (#565).
+
+Offline regression locks for the CI/supply-chain hardening pass:
+
+* every ``actions/checkout`` sets ``persist-credentials: false`` — the default
+  leaves the job token in ``.git/config`` for the rest of the job (and inside
+  any artifact built from the workspace);
+* no ``run:`` block interpolates a ``${{ github.* }}`` context directly — that
+  is template injection; the value must arrive through ``env:`` instead;
+* the ``zizmor`` static analyser actually runs in CI, pinned;
+* the release job does not restore a shared uv cache (cache-poisoning surface
+  on the one workflow that publishes artefacts).
+
+These duplicate the ``workflow-audit`` CI job on purpose: the job is the
+authority, this is the copy that fails on a developer's machine — and in every
+matrix leg — before a push burns a CI cycle.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# Pinned in ci.yml. uvx has no Dependabot ecosystem, so the bump is manual and
+# this constant is what makes a drifted pin a failing test rather than a
+# silently different analyser.
+ZIZMOR_PIN = "zizmor==1.29.0"
+
+
+def _workflow_paths() -> list[Path]:
+    paths = sorted(WORKFLOWS.glob("*.yml"))
+    assert paths, f"no workflows found under {WORKFLOWS}"
+    return paths
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        step
+        for job in (doc.get("jobs") or {}).values()
+        for step in (job.get("steps") or [])
+        if isinstance(step, dict)
+    ]
+
+
+@pytest.mark.parametrize("path", _workflow_paths(), ids=lambda p: p.name)
+def test_every_checkout_disables_credential_persistence(path: Path) -> None:
+    for step in _steps(_load(path)):
+        if not str(step.get("uses", "")).startswith("actions/checkout@"):
+            continue
+        with_block = step.get("with") or {}
+        assert with_block.get("persist-credentials") is False, (
+            f"{path.name}: actions/checkout must set 'persist-credentials: false' "
+            "(the default persists the job token in .git/config)"
+        )
+
+
+@pytest.mark.parametrize("path", _workflow_paths(), ids=lambda p: p.name)
+def test_no_run_block_interpolates_a_github_context(path: Path) -> None:
+    pattern = re.compile(r"\$\{\{\s*github\.")
+    for step in _steps(_load(path)):
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        assert not pattern.search(run), (
+            f"{path.name}: run block interpolates a ${{{{ github.* }}}} context — "
+            "pass it through 'env:' and reference the shell variable instead "
+            "(template injection)"
+        )
+
+
+def test_ci_runs_the_zizmor_workflow_audit() -> None:
+    ci = _load(WORKFLOWS / "ci.yml")
+    audit = (ci.get("jobs") or {}).get("workflow-audit")
+    assert audit is not None, "ci.yml: no 'workflow-audit' job"
+
+    commands = " ".join(
+        str(step.get("run", "")) for step in audit.get("steps") or [] if isinstance(step, dict)
+    )
+    assert ZIZMOR_PIN in commands, f"ci.yml: workflow-audit must run pinned {ZIZMOR_PIN}"
+    assert ".github/workflows" in commands, "ci.yml: workflow-audit must audit .github/workflows"
+
+
+def test_release_does_not_restore_a_shared_uv_cache() -> None:
+    for step in _steps(_load(WORKFLOWS / "release.yml")):
+        if str(step.get("uses", "")).startswith("astral-sh/setup-uv@"):
+            with_block = step.get("with") or {}
+            assert with_block.get("enable-cache") is False, (
+                "release.yml: setup-uv must set 'enable-cache: false' — the publishing "
+                "workflow must not restore a cache another workflow can write"
+            )


### PR DESCRIPTION
## Summary

Closes #565 — all three acceptance items.

**1. `persist-credentials: false` on every checkout.** 12 pre-existing steps fixed, across `ci.yml` (×6), `deps-watch.yml`, `governance-advisory.yml`, `governance-benchmark.yml`, `main-base-guard.yml`, `pages.yml`, `release.yml`. `scorecard.yml` and `selector-probe.yml` were already correct. With the new `workflow-audit` job's own checkout added by this PR, the tree now holds **15 checkout steps, 15 of which set the flag** — and `tests/scripts/test_workflow_hardening.py` fails if a 16th ever lands without it.

The issue flagged `release.yml` and `pages.yml` as possibly credential-dependent. They are not: no workflow in the repo runs `git push`. `release.yml` publishes over PyPI Trusted Publishing (OIDC) and `softprops/action-gh-release` (its own token input), and its `git cat-file` tag checks are local reads; `pages.yml` deploys over `actions/deploy-pages` (OIDC). `governance-advisory.yml`'s `git fetch` is an unauthenticated read of a public repo, and is redundant with its own `fetch-depth: 0` anyway.

**2. zizmor added as a CI gate — and it found two things the manual pass missed.** New `workflow-audit` job in `ci.yml` runs `uvx zizmor==1.29.0 --offline --min-severity low .github/workflows/`.

The issue expected zizmor to be a regression guard finding nothing new. It was not. Beyond the 12 `artipacked` findings above, it reported:

| Finding | Severity | Fix |
|---|---|---|
| `template-injection` ×2 — `${{ github.base_ref }}` interpolated straight into a shell script in `governance-advisory.yml` | **High / High confidence** | Value now arrives through `env:` (the idiom `main-base-guard.yml` already uses) |
| `cache-poisoning` — `setup-uv` restores a shared cache in `release.yml`, the one workflow that publishes signed artefacts | High / Low confidence | `enable-cache: false` there; releases are rare, the cold resolve costs seconds |
| `dangerous-triggers` — `pull_request_target` in `external-pr-triage.yml` | High / Medium confidence | Suppressed inline, with the three properties that keep it safe spelled out (no checkout of untrusted head, PR data from `context.payload`, scoped permissions) |
| `superfluous-actions` — swap `action-gh-release` for `gh release` | Informational | **Declined** — rewriting the release publisher is not a hardening change. Informational findings do not gate. |

The gate is green: `No findings to report`, exit 0.

`--offline` keeps it deterministic and fork-safe (online audits need a token and network); action pinning/freshness is already covered by Dependabot and Scorecard's Pinned-Dependencies.

**3. Changelog guard — declined, decision recorded** in `docs/GITHUB.md § Workflow Security Gates`.

Its central rule (*non-release PRs must not edit `CHANGELOG.md`*) is the inverse of this repo's convention: gflow-cli keeps a live `## [Unreleased]` section that ordinary feature PRs are expected to update — #563 did exactly that. Adopting it would block almost every PR. Fragments presuppose a towncrier-style directory we do not have and do not need; the `release`-label exemption would be a third, weaker signal next to `chore/release-*` + base `main`, already enforced by `main-base-guard.yml`; and version lockstep is already mechanical via `scripts/ci/check_release_artifacts.py` plus `release.yml`'s tag↔pyproject check.

One real gap is **recorded rather than gated**: nothing stops a non-release PR into `develop` from bumping a version string. The minimal guard would false-positive on the `main` → `develop` back-merge, which carries that bump legitimately, so the exemption needs verifying against a real back-merge before it can block anything.

## Validation

- [x] Focused tests added — `tests/scripts/test_workflow_hardening.py` (24 parametrized cases), written first and confirmed **red on 10** before the fix: every checkout, no `${{ github.* }}` in any `run:` block, the zizmor pin matching `ci.yml`, and the release cache setting
- [x] Documentation updated — `docs/GITHUB.md` (new § Workflow Security Gates, incl. both declined findings and the changelog-guard decision), `docs/INDEX.md` routing entry, `CHANGELOG.md` `### Security`
- [x] `uv run python scripts/ci/check_repo_hygiene.py` — 800 files, no violations (branch-name advisory only: the `claude/` prefix is imposed by the session harness)
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved across 29 files
- [x] `uv run python scripts/ci/check_website_docs_pii.py` + `generate_website_docs.py --check` — clean, mirror in sync
- [x] `uv run ruff check src tests` / `ruff format --check` — clean
- [x] `uv run pyright src` — 0 errors
- [x] `uv run python -m pytest -q` — 3340 passed, 5 skipped, 2 failed locally (see below)
- [x] The gate itself, run exactly as CI will: `uvx zizmor==1.29.0 --offline --min-severity low .github/workflows/` → `No findings to report`, exit 0

**CI green on both commits** — 15/15 checks on `35bce08` and a green suite on `eb3f679`, including `Workflow audit (zizmor)`, `SonarCloud analysis`, the full 3.11/3.12/3.13 matrix and the three-OS ProfileLease legs. The doc-link, website-mirror, zizmor and workflow-hardening gates were re-run locally on `eb3f679` and are all green.

The two local failures — `tests/auth/test_verification.py::TestVerifyFlowSession::test_dpapi_runtime_error_triggers_playwright_fallback` and `tests/features/test_auth_steps.py::test_status_of_a_profile_with_a_live_flow_session` — **pass in CI on all three Python versions.** They were already failing on a clean tree at this base commit (proven by `git stash`), and CI proves they are specific to the Linux container this branch was developed in (`browser_cookie3`/DPAPI probe raising `SecurityError`), not a defect on `develop`. No action needed.

Two CI results are worth calling out as the real empirical checks on this diff, since both jobs run with the changed checkout behaviour: `Secret scan (gitleaks)` passed with `persist-credentials: false` and `fetch-depth: 0`, and `Materiality + traceability (advisory)` — the workflow whose shell script was rewritten to take the base ref through `env:` — resolved the base ref correctly on a real PR.

Not live-verified, and it does not need to be: this diff touches no Flow transport, selector, or generation path.

## Contribution Checklist

- [x] This PR targets `develop`
- [x] My commits use my real Git identity or GitHub noreply email
- [ ] External contribution commits include `Signed-off-by:` — n/a, internal
- [x] I did not include secrets, cookies, account tokens, signed URLs, or private captured data
- [x] I reviewed any AI-assisted changes before submitting