### PR TITLE
chore(canary): keep captured logs on a RED, and correct the 401's surface

### DIFF
--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -179,11 +179,17 @@ a pure function with all four states covered in
 fails for a reason other than a profile precondition, the canary re-runs
 `gflow auth status`. Session still valid ⇒ the failure is
 drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
-proved why this matters: an `AuthExpiredError` from the aisandbox upload path
+proved why this matters: an `AuthExpiredError` on `project.createProject`
 *looked* exactly like session rot, but the session verified clean seconds later —
 so it was a real divergence between two auth surfaces, and a name-matching
 classifier would have buried it. The extra probe costs ~45s and only runs after a
 failure.
+
+> The route is `labs.google/fx/api/trpc/project.createProject` — the NextAuth
+> **cookie** surface — not the aisandbox Bearer path. #561 originally recorded it
+> as an `uploadImage` failure because the failing test is named for an upload;
+> the traceback dies one line earlier, on the project-creation call. Corrected
+> here so the next reader does not re-investigate the wrong host.
 
 `DEFERRED` covers every run that **exercised nothing**: a held `ProfileLease`, a
 `ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
@@ -203,6 +209,18 @@ Two subtleties, both found by council review and both regression-tested:
 
 Because the issue carries a last-updated timestamp, a machine that was off is
 *visibly stale* — unlike a lingering green commit status, which lies.
+
+**A RED preserves its own evidence, logs included.** The run's JUnit is copied to
+`tmp/canary-red-<stamp>.xml` (the live one is overwritten nightly), and pytest runs
+with `-o junit_logging=all` so that copy carries the captured structlog output, not
+just a traceback. This is not optional detail: the canary's failures reproduce only
+unattended, so whatever the run does not record cannot be recovered afterwards. For
+an auth 401 the deciding line is `client.context_cookie_state` — the #222
+diagnostic, which reports whether the launched browser context actually loaded the
+Flow session cookie. That single boolean separates "the browser never got the
+cookie" from "the session was genuinely refused"; without it a 401 traceback is the
+same shape either way. The copy stays **local** — it carries raw tracebacks and
+profile paths, which the sanitization contract keeps off the public issue.
 
 ### Scope
 

--- a/scripts/canary/run_canary.py
+++ b/scripts/canary/run_canary.py
@@ -162,10 +162,19 @@ def run_tiers(profile: str, markers: str) -> tuple[int, str, float]:
     """Run the selected $0 tiers. Returns (returncode, combined_output, seconds)."""
     JUNIT_PATH.parent.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
+    # junit_logging=all folds pytest's captured stdout/log into the JUnit, so a
+    # preserved RED carries the run's structlog output and not just a traceback.
+    # An auth 401's traceback cannot say WHICH cookie carrier failed; the
+    # `client.context_cookie_state` line (the #222 diagnostic) answers exactly
+    # that and is otherwise captured and discarded. The failure only reproduces
+    # unattended, so a red that drops it is untriageable by construction
+    # (#559/#561). The JUnit already stays local — it already carries raw
+    # tracebacks — so this exposes nothing the sanitization contract covers.
     argv = [
         sys.executable, "-m", "pytest",
         "-m", markers,
         "--junitxml", str(JUNIT_PATH),
+        "-o", "junit_logging=all",
         "-q", "--no-header",
     ]  # fmt: skip
     try:

--- a/tests/scripts/test_canary_classify.py
+++ b/tests/scripts/test_canary_classify.py
@@ -293,3 +293,34 @@ def test_sync_refuses_a_dirty_tree_and_reports_rather_than_dying(monkeypatch) ->
     reason = run_canary.sync_to_develop()
     assert reason is not None and "local modifications" in reason
     assert not any("checkout" in c for c in calls), "must not touch the tree it refused"
+
+
+def test_tier_run_captures_logs_into_the_junit(monkeypatch) -> None:
+    """The tier must run pytest with ``junit_logging=all`` (#559/#561).
+
+    A RED publishes only the failing test's NAME, and the preserved JUnit
+    carries only the traceback. But the traceback of an auth 401 cannot say
+    WHICH cookie carrier failed — and the answer is already logged, by
+    ``client.context_cookie_state`` (the #222 diagnostic), which pytest
+    captures and then discards. Without this flag every overnight RED is
+    untriageable by construction: the one line that decides it is thrown away
+    at the moment it is produced, and the failure only occurs unattended.
+    """
+    from scripts.canary import run_canary
+
+    calls: list[list[str]] = []
+
+    class _Proc:
+        def __init__(self) -> None:
+            self.stdout, self.stderr, self.returncode = "", "", 0
+
+    def fake_run(cmd, env=None, timeout=None):  # noqa: ANN001, ANN202
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr(run_canary, "_run", fake_run)
+    run_canary.run_tiers("denon82", "e2e_auth")
+
+    argv = calls[0]
+    assert "-o" in argv, "no pytest -o override present"
+    assert argv[argv.index("-o") + 1] == "junit_logging=all"

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -179,11 +179,17 @@ a pure function with all four states covered in
 fails for a reason other than a profile precondition, the canary re-runs
 `gflow auth status`. Session still valid ⇒ the failure is
 drift (`RED`); session now dead ⇒ genuine rot (`AUTH-EXPIRED`). The first live run
-proved why this matters: an `AuthExpiredError` from the aisandbox upload path
+proved why this matters: an `AuthExpiredError` on `project.createProject`
 *looked* exactly like session rot, but the session verified clean seconds later —
 so it was a real divergence between two auth surfaces, and a name-matching
 classifier would have buried it. The extra probe costs ~45s and only runs after a
 failure.
+
+> The route is `labs.google/fx/api/trpc/project.createProject` — the NextAuth
+> **cookie** surface — not the aisandbox Bearer path. #561 originally recorded it
+> as an `uploadImage` failure because the failing test is named for an upload;
+> the traceback dies one line earlier, on the project-creation call. Corrected
+> here so the next reader does not re-investigate the wrong host.
 
 `DEFERRED` covers every run that **exercised nothing**: a held `ProfileLease`, a
 `ProfileEngineDowngradeError` (profile written by a newer Chromium than the bundled
@@ -203,6 +209,18 @@ Two subtleties, both found by council review and both regression-tested:
 
 Because the issue carries a last-updated timestamp, a machine that was off is
 *visibly stale* — unlike a lingering green commit status, which lies.
+
+**A RED preserves its own evidence, logs included.** The run's JUnit is copied to
+`tmp/canary-red-<stamp>.xml` (the live one is overwritten nightly), and pytest runs
+with `-o junit_logging=all` so that copy carries the captured structlog output, not
+just a traceback. This is not optional detail: the canary's failures reproduce only
+unattended, so whatever the run does not record cannot be recovered afterwards. For
+an auth 401 the deciding line is `client.context_cookie_state` — the #222
+diagnostic, which reports whether the launched browser context actually loaded the
+Flow session cookie. That single boolean separates "the browser never got the
+cookie" from "the session was genuinely refused"; without it a 401 traceback is the
+same shape either way. The copy stays **local** — it carries raw tracebacks and
+profile paths, which the sanitization contract keeps off the public issue.
 
 ### Scope
 


### PR DESCRIPTION
## Summary

Three canary REDs (2026-08-20 / 08-23 / 08-25) named the same test and preserved only a traceback. For an auth 401 that traceback is the same shape whatever the cause, and the failure reproduces **only** on the unattended overnight run — so every red so far has been untriageable by construction.

Two changes, both evidence-driven.

### 1. Keep the logs (`-o junit_logging=all`)

The line that decides this is already emitted on every run — `client.context_cookie_state`, the #222 diagnostic, which reports whether the launched browser context actually loaded the Flow session cookie:

```
client.context_cookie_state  context_cookie_count=59
                             flow_session_cookie_expired=False
                             flow_session_cookie_present=True
                             google_sapisid_present=True
```

pytest captures it and throws it away. With this flag it lands in the preserved `tmp/canary-red-*.xml`. Verified empirically before committing.

That boolean is the discriminator:
- `present=False` → the browser context never loaded the cookies. Same class as #222 (macOS), where `project.createProject` 401'd while login and verification both passed because they read cookies a different way.
- `present=True` → the context held a valid cookie and was still refused. Different cause, but the count / SAPISID / expiry come with it.

### 2. Correct which auth surface fails

The preserved JUnit from all three REDs is byte-identical:

```
tests/e2e/test_aisandbox_auth_live.py:69
    project = await client.create_project(...)
resp = <APIResponse url='https://labs.google/fx/api/trpc/project.createProject'
        status=401 status_text='Unauthorized'>
```

That is the **NextAuth cookie** surface. No Bearer token is involved — `_aisandbox_auth_headers()` is gated on `is_aisandbox` (`client.py:1256`) and never runs. The failing line is `:69` (`create_project`), not `:70` (`upload_image`).

#561 is titled for an `uploadImage` failure and its transport A/B tested a code path the failure never reaches. `docs/E2E_TESTING.md` repeated the same wording; corrected here so the next reader does not re-investigate the wrong host.

## What this PR deliberately does NOT do

No fix. The failure is not reproducible on demand — verified today against the live `denon82` profile at $0: `auth status` exit 0, the failing test **1 passed** standalone, the full tier **18 passed**. #561's own standing rule applies: no fix against a failure we cannot reproduce. This PR only makes the next occurrence readable.

## Falsified along the way

A leading hypothesis was that the canary's own pre-run `gflow auth status` caused the RED: the session probe makes labs.google issue a rotated `__Secure-next-auth.session-token` via `Set-Cookie`, which gflow-cli discards, leaving the profile on the superseded token. Measured directly — **dead**:

| arm | result |
|---|---|
| control: `createProject` with on-disk token, x2 | 200, 200 |
| after probe 1, **same old token** | 200 |
| the rotated token | 200 |
| after probe 2, old token again | 200 |

Rotation is harmless. The canary is not causing its own red.

## Test plan

- [x] `tests/scripts/test_canary_classify.py::test_tier_run_captures_logs_into_the_junit` — new, TDD (red → green)
- [x] Verified live that `client.context_cookie_state` reaches the JUnit under the flag
- [x] repo hygiene / doc links / website PII: pass
- [x] `ruff check src tests` + `ruff format --check src tests`: pass
- [x] `pyright src`: 0 errors
- [x] Full offline suite: 3342 passed, 5 skipped
- [x] `website/docs` mirror regenerated

## Timing

The canary runs from a dedicated clone that pulls `develop` before each run. This needs to be on `develop` **before 03:00 tonight** or tomorrow is another blind red.

Refs #559, #561