### PR TITLE
chore(ci): add uv.lock to the version-agreement gate, and stop CI repairing drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,15 @@ jobs:
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}
 
+      # --frozen: install from the committed uv.lock without re-resolving it.
+      # Plain `uv sync` REWRITES uv.lock in place, which would silently repair
+      # the exact version drift the hygiene gate below exists to catch.
       - name: Install deps
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
-      - name: Repo hygiene (no artefacts, no hardcoded paths)
-        run: uv run python scripts/ci/check_repo_hygiene.py
+      # --no-sync for the same reason: `uv run` re-locks before running.
+      - name: Repo hygiene (no artefacts, no hardcoded paths, version lockstep)
+        run: uv run --no-sync python scripts/ci/check_repo_hygiene.py
 
       - name: Documentation links
         run: uv run python scripts/ci/check_doc_links.py

--- a/scripts/ci/check_repo_hygiene.py
+++ b/scripts/ci/check_repo_hygiene.py
@@ -209,12 +209,17 @@ def _check_branch_name(branch: str | None) -> list[str]:
 
 
 def _check_version_agreement() -> list[str]:
-    """pyproject == __init__ == plugin.json — one version, three declarations.
+    """pyproject == __init__ == plugin.json == uv.lock — one version, four declarations.
 
-    pyproject is read with the same anchored-regex style the release gate
-    (check_release_artifacts.py) uses — deliberately NOT tomllib, which is
-    3.11+ and would silently disable this gate under an older pre-commit
-    interpreter.
+    pyproject and uv.lock are read with the same anchored-regex style the
+    release gate (check_release_artifacts.py) uses — deliberately NOT tomllib,
+    which is 3.11+ and would silently disable this gate under an older
+    pre-commit interpreter.
+
+    uv.lock carries the editable package's own version and is re-resolved on
+    every bump (/gflow:release step 9 stages it). It drifts silently when a
+    bump lands without `uv lock`, so it belongs in the same gate as the other
+    three rather than being discovered at release time.
     """
     import json
 
@@ -232,11 +237,20 @@ def _check_version_agreement() -> list[str]:
         versions["src/gflow_cli/__init__.py"] = match.group(1)
         plugin_raw = (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         versions[".codex-plugin/plugin.json"] = str(json.loads(plugin_raw)["version"])
+        lock_text = (ROOT / "uv.lock").read_text(encoding="utf-8")
+        # The editable package's own [[package]] block: `name` then `version`.
+        # Anchored on the name so the ~200 dependency versions can't match.
+        lock_match = re.search(
+            r'^name = "gflow-cli"\r?\nversion = "([^"]+)"', lock_text, re.MULTILINE
+        )
+        if lock_match is None:
+            return ['uv.lock: no [[package]] block for "gflow-cli" found']
+        versions["uv.lock"] = lock_match.group(1)
     except (OSError, KeyError, ValueError) as exc:
         return [f"version-agreement check could not read a source: {exc}"]
     if len(set(versions.values())) > 1:
         listing = ", ".join(f"{src}={ver}" for src, ver in versions.items())
-        return [f"version disagreement — {listing} (bump all three together)"]
+        return [f"version disagreement — {listing} (bump all four together)"]
     return []
 
 

--- a/tests/scripts/test_check_repo_hygiene.py
+++ b/tests/scripts/test_check_repo_hygiene.py
@@ -97,11 +97,12 @@ def test_real_tree_passes_root_doc_check() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Version agreement (chore/ci-hardening): pyproject == __init__ == plugin.json
+# Version agreement (chore/ci-hardening):
+# pyproject == __init__ == plugin.json == uv.lock
 # ---------------------------------------------------------------------------
 
 
-def _version_tree(tmp_path, pyproject: str, init: str, plugin: str):
+def _version_tree(tmp_path, pyproject: str, init: str, plugin: str, lock: str | None = None):
     import json as _json
 
     (tmp_path / "pyproject.toml").write_text(
@@ -114,6 +115,19 @@ def _version_tree(tmp_path, pyproject: str, init: str, plugin: str):
     (tmp_path / ".codex-plugin").mkdir()
     (tmp_path / ".codex-plugin" / "plugin.json").write_text(
         _json.dumps({"version": plugin}), encoding="utf-8"
+    )
+    # Realistic uv.lock: the editable package block sits among other packages
+    # whose own `version = "..."` lines must not be picked up by the gate.
+    (tmp_path / "uv.lock").write_text(
+        "[[package]]\n"
+        'name = "click"\n'
+        'version = "8.9.9"\n'
+        "\n"
+        "[[package]]\n"
+        'name = "gflow-cli"\n'
+        f'version = "{pyproject if lock is None else lock}"\n'
+        'source = { editable = "." }\n',
+        encoding="utf-8",
     )
     return tmp_path
 
@@ -129,6 +143,36 @@ def test_version_agreement_fails_on_any_disagreement(tmp_path, monkeypatch) -> N
     assert len(errors) == 1
     assert "disagreement" in errors[0]
     assert "1.2.4" in errors[0]
+
+
+def test_version_agreement_fails_when_only_uv_lock_drifts(tmp_path, monkeypatch) -> None:
+    """A bump that forgets `uv lock` is the drift this gate was added for."""
+    monkeypatch.setattr(
+        hygiene, "ROOT", _version_tree(tmp_path, "1.2.3", "1.2.3", "1.2.3", lock="1.2.2")
+    )
+    errors = hygiene._check_version_agreement()
+    assert len(errors) == 1
+    assert "uv.lock=1.2.2" in errors[0]
+
+
+def test_version_agreement_ignores_other_packages_in_uv_lock(tmp_path, monkeypatch) -> None:
+    """The gate must anchor on gflow-cli, not the first `version =` it sees."""
+    root = _version_tree(tmp_path, "1.2.3", "1.2.3", "1.2.3")
+    assert '"8.9.9"' in (root / "uv.lock").read_text(encoding="utf-8")
+    monkeypatch.setattr(hygiene, "ROOT", root)
+    assert hygiene._check_version_agreement() == []
+
+
+def test_version_agreement_flags_uv_lock_without_own_package_block(tmp_path, monkeypatch) -> None:
+    """A uv.lock missing the editable entry must fail loudly, not pass silently."""
+    root = _version_tree(tmp_path, "1.2.3", "1.2.3", "1.2.3")
+    (root / "uv.lock").write_text(
+        '[[package]]\nname = "click"\nversion = "8.9.9"\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(hygiene, "ROOT", root)
+    errors = hygiene._check_version_agreement()
+    assert len(errors) == 1
+    assert "uv.lock" in errors[0]
 
 
 def test_version_agreement_reports_missing_source_gracefully(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`uv.lock` carries the editable package's own version and is re-resolved on every bump. A bump that lands without `uv lock` leaves it silently behind — and that drift surfaced only at release time, since `/gflow:release` step 9 stages the lockfile. Whoever cut the release absorbed the surprise.

This adds it as the **fourth** declaration in the existing version-agreement gate, alongside `pyproject.toml`, `__init__.py` and `plugin.json`.

## The part that matters more than the gate

**CI could not have caught this as written.** The workflow ran:

```yaml
- run: uv sync --extra dev                                    # REWRITES uv.lock in place
- run: uv run python scripts/ci/check_repo_hygiene.py         # Provide a command or script to invoke with `uv run <command>` or `uv run <script>.py`.

The following commands are available in the environment:

- browser-cookie
- cffi-gen-src
- coverage
- coverage-3.13
- coverage3
- detect-secrets
- detect-secrets-hook
- dotenv
- f2py
- fastapi
- flow
- gflow
- httpx
- httpx2
- idna
- jsonschema
- mako-render
- markdown-it
- mcp
- nodeenv
- normalizer
- numpy-config
- playwright
- py.test
- pyav
- pydoc.bat
- pygmentize
- pyright
- pyright-langserver
- pyright-python
- pyright-python-langserver
- pytest
- pytest-bdd
- python
- pythonw
- pywin32_postinstall
- pywin32_postinstall.py
- pywin32_testall
- pywin32_testall.py
- ruff
- uvicorn
- watchfiles
- websockets
- wmitest.cmd
- wmitest.master.ini
- wmitest.py
- wmiweb.py

See `uv run --help` for more information. re-locks first
```

Both steps repair the exact drift the gate exists to detect, one step before it runs. Adding the check without pinning these would have shipped a gate that can never fire in CI — green forever, detecting nothing. Fixed with `--frozen` / `--no-sync`, each with a comment saying why, because the next person to "simplify" those flags away would silently disable the gate again.

## Implementation notes

- Read with the same anchored-regex style `check_release_artifacts.py` uses — deliberately **not** `tomllib`, which is 3.11+ and would silently disable the gate under an older pre-commit interpreter.
- The regex anchors on `^name = "gflow-cli"` followed by `version`, so the ~200 dependency version strings in the lockfile cannot match it.
- Missing `[[package]]` block for `gflow-cli` is reported explicitly rather than passing vacuously.
- `\r?\n` in the pattern so it holds on a CRLF checkout.

## Test plan

- [x] `tests/scripts/test_check_repo_hygiene.py`: 39 passed (extended for the uv.lock arm)
- [x] `scripts/ci/check_repo_hygiene.py`: 801 tracked files, no violations
- [x] doc links + website PII gates: pass
- [x] `ruff check src tests` + `format --check`: pass on **0.16.4** (rebased onto #571's bump)
- [x] `pyright src`: 0 errors
- [x] Full offline suite: 3346 passed, 5 skipped

Rebased onto `develop` at `5d10554`, after #569/#570/#571. Verified the gate still passes against the **new** `uv.lock` that #571 produced — which is the first real exercise of this check.