### PR TITLE
test(ci): close the three workflow-hardening gaps (#568)

### DIFF
--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -219,9 +219,16 @@ uvx zizmor==1.29.0 --offline --min-severity low .github/workflows/
 
 `--offline` keeps the gate deterministic and fork-safe (the online audits need a
 token and network); action pinning and freshness are already covered by
-Dependabot and Scorecard's Pinned-Dependencies check. The pin is asserted by
-`tests/scripts/test_workflow_hardening.py`, so the gate and the test cannot
-drift apart silently.
+Dependabot and Scorecard's Pinned-Dependencies check.
+
+`ci.yml` is the single source of truth for the pin.
+`tests/scripts/test_workflow_hardening.py` reads it from there and asserts that
+**the command quoted above matches** — so the gate, the test, and this
+documentation cannot drift apart silently. Bumping zizmor means editing exactly
+two places: the `run:` line in `ci.yml` and the command above. (Until #568 the
+test held its own hand-copied constant and never checked this doc, so this
+snippet could — and would — go stale while the sentence promising otherwise
+stayed put.)
 
 Two findings are deliberately not fixed, and both are documented where they
 live:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -60,6 +60,7 @@ Welcome to the `gflow-cli` documentation. This index is the routing layer: it te
 | [docs/superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md](superpowers/plans/2026-07-27-tier-aware-credit-confirmations/PLAN.md) | TDD implementation plan for tier-aware chain/movie planning and confirmation output | Tracking the isolated runtime pricing-guidance bugfix |
 | [docs/superpowers/specs/2026-08-21-selector-registry-design.md](superpowers/specs/2026-08-21-selector-registry-design.md) | Selector registry + drift probe design spec: measured one-cookie auth evidence, data model, grading semantics, CI probe, risk register | Reviewing the registry/probe design or auditing its evidence |
 | [docs/superpowers/plans/2026-08-21-selector-registry.md](superpowers/plans/2026-08-21-selector-registry.md) | Task-by-task TDD plan for the selector registry + CI probe (executed — PR #563) | Auditing how the registry/probe was built |
+| [docs/superpowers/plans/2026-08-25-workflow-hardening-gaps.md](superpowers/plans/2026-08-25-workflow-hardening-gaps.md) | Spec + decisions + TDD plan for #568 — why the pin is derived from `ci.yml`, why the injection ban stays blanket, why the property tests are kept | Bumping zizmor, or re-opening "should these tests exist" |
 
 ## Agent commands
 

--- a/docs/superpowers/plans/2026-08-25-workflow-hardening-gaps.md
+++ b/docs/superpowers/plans/2026-08-25-workflow-hardening-gaps.md
@@ -1,0 +1,171 @@
+# Workflow-hardening test — closing the three council gaps (#568)
+
+> Spec + decisions + BDD scenarios + task plan for #568, the follow-up to
+> #565 / PR #566 (`230200b`). Scope is `tests/scripts/test_workflow_hardening.py`,
+> `docs/GITHUB.md`, and nothing else. No workflow behaviour changes.
+
+## 1. Context
+
+PR #566 added two overlapping controls:
+
+| Control | Where | Required check? |
+|---|---|---|
+| `zizmor==1.29.0 --offline --min-severity low` | `ci.yml` job `workflow-audit` | on `main` only (added by #567) |
+| `tests/scripts/test_workflow_hardening.py` | `test` job | on `main` |
+
+The `/gflow:pr-council-review` council on #566 raised four items. None blocked
+the merge; all were recorded on #568 rather than dropped.
+
+Verified against the tree at `5d10554` before deciding anything:
+
+- All 11 workflows are `.yml`. **No `.yaml` exists today** — gap 1 is latent, not active.
+- `zizmor==` appears in exactly **3** places: `ci.yml:97`, `docs/GITHUB.md:217`,
+  `test_workflow_hardening.py:34`. Matches the issue.
+- Every `${{ github.* }}` in a workflow already arrives through an `env:` block
+  (`BASE_REF`, `HEAD_REF`). The blanket ban currently costs nothing.
+
+## 2. Assessment per gap
+
+### Gap 1 — `glob("*.yml")` misses `*.yaml`  → CONFIRMED
+
+`test_workflow_hardening.py:38`. GitHub honours both extensions. A future
+`.yaml` workflow escapes the persist-credentials and template-injection guards
+locally and in the `test` job. CI's zizmor job is handed the *directory*, so it
+still audits such a file — the gap is in the local guard, not total.
+
+**Decision: `glob("*.y*ml")`.**
+
+Rejected `glob("*.yml") + glob("*.yaml")`: same effect, more code. `*.y*ml` also
+matches contrived names like `x.yZZml`, which is over-inclusion — the fail-safe
+direction for a security guard. Under-inclusion is the failure mode that matters.
+
+### Gap 2 — the zizmor pin has a third, unguarded copy → CONFIRMED
+
+`ZIZMOR_PIN` locks `ci.yml` ↔ the test. `docs/GITHUB.md:217` is unguarded, while
+that same doc claims *"the gate and the test cannot drift apart silently"*.
+
+The issue offered two fixes. **Both are rejected**, and a third is taken:
+
+| Option | Verdict |
+|---|---|
+| Assert the doc copy against `ZIZMOR_PIN` | Works, but keeps a hand-maintained constant — 3 files to edit per bump. |
+| Drop `ZIZMOR_PIN`, assert `zizmor==\d+\.\d+\.\d+` | **Weaker than today.** It only proves *a* pin exists. `ci.yml` could say `1.31.0` and the doc `1.29.0` and the test would pass — the exact drift the issue is about. |
+| **Derive the pin from `ci.yml`, assert the doc matches** | Taken. |
+
+**Decision: `ci.yml` becomes the single source of truth.** A helper extracts the
+pinned version from the `workflow-audit` run command; the doc is asserted equal
+to it. This is strictly better than both options: it removes the constant *and*
+locks all three copies, so a bump touches `ci.yml` + the doc and the test follows
+on its own. Editing one file per bump instead of three, with drift impossible
+rather than merely detected.
+
+### Gap 3 — the injection regex is broader than zizmor's rule → CONFIRMED, keep as-is
+
+`r"\$\{\{\s*github\."` bans *every* `github.*` context in a `run:` block. zizmor's
+`template-injection` is context-aware, so a benign `${{ github.run_id }}` fails the
+test and passes zizmor.
+
+**Decision: keep the blanket ban; document it as deliberate.** Comment only, no
+logic change.
+
+Narrowing was considered and rejected on security grounds: the attacker-controllable
+set is long and moves (`event.*`, `head_ref`, `base_ref`, `actor`,
+`triggering_actor`, `event.issue.title`, `event.pull_request.body`, …). An
+allowlist that is wrong on one entry is a hole; a blanket ban that is
+occasionally inconvenient is not. "Always go through `env:`" is one rule a
+contributor can hold in their head, it currently costs nothing (all 11 workflows
+already comply), and the escape hatch — add an `env:` line — is trivial.
+
+### Gap 4 — keep or cut the three property tests → KEEP
+
+D14 (YAGNI) proposed cutting ~60 lines because `artipacked` / `template-injection`
+/ `cache-poisoning` duplicate zizmor rules running on the same commit. D4 (tests)
+countered that all four assertions were mutation-verified to bite, run offline in
+0.46s, and guard a property zizmor cannot check about itself.
+
+**Decision: keep — but on narrower grounds than first drafted.**
+
+Two tempting arguments were checked against the live repo and **both failed**:
+
+| Candidate argument | Checked | Verdict |
+|---|---|---|
+| "These are the only *enforced* control on `develop`" | `gh api .../branches/develop/protection` → **404, not protected** | **False.** Nothing is enforced on `develop` — not this job, not zizmor. |
+| "zizmor is skipped on some PRs, these are not" | The one `SKIPPED` check on the dependabot PRs is **SonarCloud**; `workflow-audit` has no `if:` guard | **False.** zizmor runs on every PR. |
+
+What actually survives:
+
+- **No network.** `uvx zizmor` downloads before it audits; these run offline in
+  well under a second, so they bite pre-push and in every matrix leg — where a
+  hardening slip is cheapest to fix. This is the only property zizmor cannot
+  match, and it is what the module docstring already claimed from the start.
+- **Mutation-verified.** Every assertion has been watched failing against a
+  deliberate revert.
+- `test_ci_runs_the_zizmor_workflow_audit` and the new doc-pin test were never in
+  scope for cutting — they check properties zizmor cannot check about itself.
+
+So the honest position is: in CI the three property tests **are** largely
+redundant, and they are kept for local pre-push feedback and analyser
+independence, at a cost of ~60 lines that run in 0.26s. That is a modest
+argument stated at its real strength, not an enforcement argument — which is what
+the first draft of this section wrongly claimed.
+
+## 3. BDD scenarios
+
+```gherkin
+Feature: the workflow-hardening guard covers what it claims to cover
+
+  Scenario: a .yaml workflow is not invisible to the guard
+    Given a workflows directory containing "a.yml" and "b.yaml"
+    When the guard enumerates workflow files
+    Then both files are returned
+
+  Scenario: the documented zizmor command is the one CI runs
+    Given ci.yml pins zizmor to a specific version
+    When docs/GITHUB.md quotes a zizmor invocation
+    Then the two pins are identical
+
+  Scenario: an unpinned gate is rejected
+    Given ci.yml's workflow-audit runs bare "uvx zizmor"
+    When the guard reads the pin from ci.yml
+    Then it fails, rather than silently comparing nothing
+
+  Scenario: a benign github context in a run block is still refused
+    Given a run block interpolating "${{ github.run_id }}"
+    When the template-injection guard inspects it
+    Then it fails — the blanket ban is policy, not an oversight
+```
+
+The last scenario is already covered by the existing test's behaviour; it is
+recorded here so the behaviour is understood as intended.
+
+## 4. Task plan (TDD order)
+
+Each task: failing test first, then the change, then green.
+
+- [ ] **T1** — `_workflow_paths()` finds `.yaml`.
+      Test: point the module's `WORKFLOWS` at a tmp dir holding `a.yml` + `b.yaml`,
+      assert both are returned. Red on `*.yml`. Fix: `*.y*ml`.
+- [ ] **T2** — the pin is derived from `ci.yml`, not a constant.
+      Test: `_zizmor_pin_from_ci()` returns `zizmor==<version>` for the real
+      `ci.yml`; raises/fails on an unpinned command. Fix: add the helper, delete
+      `ZIZMOR_PIN`, rewire `test_ci_runs_the_zizmor_workflow_audit`.
+- [ ] **T3** — `docs/GITHUB.md` cannot drift from `ci.yml`.
+      Test: the doc contains the pin derived in T2. Red today only if drifted —
+      so prove it bites by temporarily mutating the doc.
+- [ ] **T4** — document gap 3 and gap 4 decisions in the module docstring /
+      inline comments. No logic change.
+- [ ] **T5** — `/gflow:check` (full Impeccable Routine).
+- [ ] **T6** — self-review, then PR closing #568.
+
+**Mutation check (non-negotiable):** every new assertion must be shown to fail
+when the thing it guards is reverted. A guard that has never been seen red is
+not a guard. #566's council verified the original four this way; the new ones
+get the same treatment.
+
+## 5. Out of scope
+
+- **#567** — required status checks on `develop`. Blocked on a maintainer
+  decision (protect `develop` and route the release back-merge through a PR, vs
+  `enforce_admins: false`, vs leave it). Not a code change and not decidable here.
+- Bumping zizmor itself. `1.29.0` stays; this PR only changes how the pin is
+  guarded.

--- a/tests/scripts/test_workflow_hardening.py
+++ b/tests/scripts/test_workflow_hardening.py
@@ -14,6 +14,28 @@ Offline regression locks for the CI/supply-chain hardening pass:
 These duplicate the ``workflow-audit`` CI job on purpose: the job is the
 authority, this is the copy that fails on a developer's machine — and in every
 matrix leg — before a push burns a CI cycle.
+
+**Why the duplication is kept** (#568, decided). A council reviewer proposed
+cutting the three property tests as redundant with the zizmor rules running on
+the same commit — and in CI they largely are: ``workflow-audit`` carries no
+``if:`` guard, so it runs on every PR. Two things survive that objection:
+
+* they need **no network**. ``uvx zizmor`` downloads before it audits; these run
+  offline in well under a second, so they bite pre-push and in every matrix leg,
+  which is where a hardening slip is cheapest to fix.
+* every assertion has been **watched failing** against a deliberate revert —
+  including the ``.yaml`` enumeration gap below. A guard never seen red is not a
+  guard.
+
+``test_ci_runs_the_zizmor_workflow_audit`` and
+``test_docs_quote_the_zizmor_pin_that_ci_actually_runs`` were never in scope for
+cutting: they check properties zizmor cannot check about itself — that the gate
+exists, is pinned, and matches its own documentation.
+
+One correction worth leaving here, because the opposite is easy to assume:
+``develop`` has **no required status checks at all** (verified 2026-08-25), so on
+the default branch neither this test job nor the zizmor job blocks a merge.
+Both are required on ``main``. See #567.
 """
 
 from __future__ import annotations
@@ -28,15 +50,23 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
-# Pinned in ci.yml. uvx has no Dependabot ecosystem, so the bump is manual and
-# this constant is what makes a drifted pin a failing test rather than a
-# silently different analyser.
-ZIZMOR_PIN = "zizmor==1.29.0"
+# uvx has no Dependabot ecosystem, so the zizmor bump is manual. ci.yml is the
+# authority — it is where the gate actually runs — so the pin is DERIVED from it
+# rather than restated here. A constant would be one more copy to keep in step,
+# which is the failure this guards against (#568).
+_ZIZMOR_PIN_RE = re.compile(r"\bzizmor==\d+\.\d+\.\d+\b")
 
 
-def _workflow_paths() -> list[Path]:
-    paths = sorted(WORKFLOWS.glob("*.yml"))
-    assert paths, f"no workflows found under {WORKFLOWS}"
+def _workflow_paths(directory: Path = WORKFLOWS) -> list[Path]:
+    """Every file GitHub would treat as a workflow — ``.yml`` **and** ``.yaml``.
+
+    ``*.y*ml`` rather than one glob per extension: a workflow this enumeration
+    misses is invisible to every assertion below, so it would escape the
+    persist-credentials and template-injection guards entirely. Over-inclusion
+    (a contrived ``x.yZZml``) is the safe direction; under-inclusion is not.
+    """
+    paths = sorted(directory.glob("*.y*ml"))
+    assert paths, f"no workflows found under {directory}"
     return paths
 
 
@@ -53,6 +83,27 @@ def _steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _workflow_audit_commands() -> str:
+    """The shell commands ci.yml's ``workflow-audit`` job runs, joined."""
+    ci = _load(WORKFLOWS / "ci.yml")
+    audit = (ci.get("jobs") or {}).get("workflow-audit")
+    assert audit is not None, "ci.yml: no 'workflow-audit' job"
+    return " ".join(
+        str(step.get("run", "")) for step in audit.get("steps") or [] if isinstance(step, dict)
+    )
+
+
+def _zizmor_pin_from_ci() -> str:
+    """The exact ``zizmor==X.Y.Z`` spec ci.yml runs — the single source of truth."""
+    match = _ZIZMOR_PIN_RE.search(_workflow_audit_commands())
+    assert match is not None, (
+        "ci.yml: workflow-audit must run zizmor pinned to an exact version "
+        "(no 'zizmor==X.Y.Z' found) — an unpinned analyser silently changes "
+        "what the gate enforces between runs"
+    )
+    return match.group(0)
+
+
 @pytest.mark.parametrize("path", _workflow_paths(), ids=lambda p: p.name)
 def test_every_checkout_disables_credential_persistence(path: Path) -> None:
     for step in _steps(_load(path)):
@@ -67,6 +118,19 @@ def test_every_checkout_disables_credential_persistence(path: Path) -> None:
 
 @pytest.mark.parametrize("path", _workflow_paths(), ids=lambda p: p.name)
 def test_no_run_block_interpolates_a_github_context(path: Path) -> None:
+    """Ban EVERY ``github.*`` context in a ``run:`` block — deliberately blanket.
+
+    This is broader than zizmor's ``template-injection``, which is
+    context-aware: a benign ``${{ github.run_id }}`` passes zizmor and fails
+    here. That is the intended trade (#568). Narrowing to the
+    attacker-controllable set was considered and rejected — that set is long and
+    keeps moving (``event.*``, ``head_ref``, ``base_ref``, ``actor``,
+    ``triggering_actor``, ``event.issue.title``, ...), and an allowlist that is
+    wrong about one entry is a hole, whereas a blanket ban is at worst
+    inconvenient. "Always go through ``env:``" is one rule a contributor can
+    hold in their head, every workflow already complies, and the escape hatch is
+    a single ``env:`` line.
+    """
     pattern = re.compile(r"\$\{\{\s*github\.")
     for step in _steps(_load(path)):
         run = step.get("run")
@@ -79,16 +143,54 @@ def test_no_run_block_interpolates_a_github_context(path: Path) -> None:
         )
 
 
-def test_ci_runs_the_zizmor_workflow_audit() -> None:
-    ci = _load(WORKFLOWS / "ci.yml")
-    audit = (ci.get("jobs") or {}).get("workflow-audit")
-    assert audit is not None, "ci.yml: no 'workflow-audit' job"
+def test_workflow_enumeration_covers_the_yaml_extension(tmp_path: Path) -> None:
+    """GitHub honours ``.yaml`` too, so the guard must (#568).
 
-    commands = " ".join(
-        str(step.get("run", "")) for step in audit.get("steps") or [] if isinstance(step, dict)
+    Not hypothetical bookkeeping: a ``.yaml`` workflow the enumeration skips is
+    checked by nothing in this module — it could persist credentials or
+    interpolate an attacker-controlled context and every test here would still
+    be green. Every workflow is ``.yml`` today, which is exactly why this needs
+    a test rather than a habit.
+    """
+    (tmp_path / "a.yml").write_text("on: push\n", encoding="utf-8")
+    (tmp_path / "b.yaml").write_text("on: push\n", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("not a workflow\n", encoding="utf-8")
+
+    assert [p.name for p in _workflow_paths(tmp_path)] == ["a.yml", "b.yaml"]
+
+
+def test_an_unpinned_zizmor_command_is_not_mistaken_for_a_pin() -> None:
+    """The pin detector must reject a bare ``uvx zizmor``.
+
+    A regex matching anything containing "zizmor" would let
+    ``test_ci_runs_the_zizmor_workflow_audit`` pass on an unpinned gate — a
+    guard that cannot fail.
+    """
+    assert _ZIZMOR_PIN_RE.search("uvx zizmor --offline .github/workflows/") is None
+    assert _ZIZMOR_PIN_RE.search("uvx zizmor==1.29.0 --offline .github/workflows/") is not None
+
+
+def test_ci_runs_the_zizmor_workflow_audit() -> None:
+    commands = _workflow_audit_commands()
+    assert _ZIZMOR_PIN_RE.search(commands), (
+        "ci.yml: workflow-audit must run zizmor pinned to an exact version — "
+        "an unpinned analyser silently changes what the gate enforces"
     )
-    assert ZIZMOR_PIN in commands, f"ci.yml: workflow-audit must run pinned {ZIZMOR_PIN}"
     assert ".github/workflows" in commands, "ci.yml: workflow-audit must audit .github/workflows"
+
+
+def test_docs_quote_the_zizmor_pin_that_ci_actually_runs() -> None:
+    """``docs/GITHUB.md`` tells contributors to reproduce the gate locally, and
+    claims the gate and the test "cannot drift apart silently" (#568).
+
+    Nothing enforced that for the doc's own copy of the command. A bump to
+    ci.yml would leave the doc quoting the previous analyser, so anyone
+    following the documented command reproduces a *different* result from CI —
+    while reading a sentence promising they cannot.
+    """
+    pin = _zizmor_pin_from_ci()
+    doc = (ROOT / "docs" / "GITHUB.md").read_text(encoding="utf-8")
+    assert pin in doc, f"docs/GITHUB.md must quote the pin ci.yml runs ({pin}) — bump both together"
 
 
 def test_release_does_not_restore_a_shared_uv_cache() -> None:


### PR DESCRIPTION
Closes #568. Follow-up to #565 / PR #566 — three council-flagged gaps plus the keep-or-cut decision it deferred. Test/doc only; no workflow behaviour changes.

## 1. `glob("*.yml")` missed `*.yaml`

GitHub honours both extensions. A `.yaml` workflow was checked by **nothing** in this module — it could persist credentials or interpolate an attacker-controlled context and every test here would still be green.

Fixed with `*.y*ml`, and proved end to end rather than by inspection. Dropping a `.yaml` workflow with a credential-persisting checkout into `.github/workflows/`:

| | result |
|---|---|
| before | `28 passed` — the file is invisible |
| after | `FAILED ...[zz-probe.yaml]: actions/checkout must set 'persist-credentials: false'` |

Rejected `glob("*.yml") + glob("*.yaml")`: same effect, more code. `*.y*ml` over-includes a contrived `x.yZZml`, which is the fail-safe direction — under-inclusion is the failure mode that matters here.

## 2. The zizmor pin had a third, unguarded copy

`ZIZMOR_PIN` locked `ci.yml` ↔ the test. `docs/GITHUB.md` was unguarded — while claiming *"the gate and the test cannot drift apart silently"*.

The issue offered two fixes; **both are rejected** and a third taken:

| Option | Verdict |
|---|---|
| Assert the doc against `ZIZMOR_PIN` | Works, but keeps a hand-maintained constant — 3 files per bump. |
| Drop the constant, assert `zizmor==\d+\.\d+\.\d+` | **Weaker than today.** Only proves *a* pin exists: `ci.yml` could say 1.31.0 and the doc 1.29.0 and it passes — the exact drift being fixed. |
| **Derive the pin from `ci.yml`, assert the doc matches** | Taken. |

`ci.yml` becomes the single source of truth. A bump now touches **two** files instead of three, and drift is **impossible** rather than merely detected.

## 3. Injection regex broader than zizmor's rule → kept blanket, now documented

`r"\$\{\{\s*github\."` bans every `github.*` context in a `run:` block; zizmor's `template-injection` is context-aware, so `${{ github.run_id }}` passes zizmor and fails here.

Narrowing was rejected on security grounds: the attacker-controllable set is long and keeps moving (`event.*`, `head_ref`, `base_ref`, `actor`, `triggering_actor`, `event.issue.title`, …). An allowlist wrong about one entry is a hole; a blanket ban is at worst inconvenient. All 11 workflows already comply, and the escape hatch is one `env:` line.

## 4. Keep-or-cut the three property tests → keep, on narrower grounds than I first wrote

I drafted two justifications and **checked both against the live repo. Both were false:**

| Candidate argument | Check | Verdict |
|---|---|---|
| "the only *enforced* control on `develop`" | `gh api .../branches/develop/protection` → **404 not protected** | **False** — nothing is enforced on `develop`, not this job, not zizmor |
| "zizmor is skipped on some PRs" | the one SKIPPED check on the dependabot PRs is **SonarCloud**; `workflow-audit` has no `if:` guard | **False** — zizmor runs on every PR |

What survives is narrower, and the docstring now says so at its real strength: these need **no network**, so they bite pre-push where `uvx zizmor` must first download. In CI the three property tests **are** largely redundant. Kept for local feedback and analyser independence, at ~60 lines running in 0.26s.

The first draft of that docstring shipped the enforcement claim; it is corrected in this PR rather than left as a confident-sounding "do not re-litigate".

## Mutation verification

A guard never seen red is not a guard. Every new assertion was watched failing:

| Mutation | Result |
|---|---|
| glob reverted to `*.yml` | `1 failed` |
| docs pin drifted to 1.28.0 | `1 failed` |
| `ci.yml` zizmor unpinned | `1 failed` |
| `ci.yml` bumped to 1.31.0, doc left behind | `1 failed` |
| `.yaml` workflow with bad checkout (end-to-end) | `1 failed` |

## Considered and declined

If `ci.yml` ever ran **two** zizmor commands at different pins, `_zizmor_pin_from_ci()` takes the first, so the doc check would compare against only that one. The job has a single step and this is contrived; flagging rather than adding uniqueness handling nobody needs. Raise it if you disagree.

## Test plan

- [x] `tests/scripts/test_workflow_hardening.py`: 27 passed (was 24)
- [x] All 5 mutations above verified to bite
- [x] hygiene (802 files) / doc links / website PII: pass
- [x] `ruff check src tests` + `format --check`: pass
- [x] `pyright src`: 0 errors
- [x] Full offline suite: 3346 passed, 5 skipped
- [x] `docs/INDEX.md` row added for the plan doc; `GITHUB.md` is not website-mirrored, so no mirror regen needed

## Not in this PR

**#567 stays open** — required status checks on `develop`. It needs a maintainer decision, not code: protect `develop` and route the release back-merge through a PR (`skills/release/SKILL.md` step 15 pushes directly and would be rejected), or `enforce_admins: false`, or leave it. Documented in the plan doc.