### PR TITLE
fix(errors): classify generation-route 400s as content policy, not wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2 inconclusive — an expired token or dead project is never published as
   drift.
 
+### Fixed
+
+- **Content-policy 400s are no longer misclassified as `WireFormatError`
+  ([#528](https://github.com/ffroliva/gflow-cli/issues/528)).** An HTTP 400 from
+  `flowMedia:batchGenerateImages` or `batchAsyncGenerateVideo*` now raises
+  `ContentPolicyError` with remediation that names the levers that actually
+  work — reduce to a single face-bearing reference, replace age-explicit person
+  descriptors with relational or role nouns — and states outright that
+  shortening the prompt does not help. Previously these surfaced as "the
+  request was rejected as malformed… retry with a simpler prompt text", which
+  sends operators down a path that cannot succeed. Same defect shape as
+  [#379](https://github.com/ffroliva/gflow-cli/issues/379) (429), one status
+  over, and the self-documenting-errors goal of
+  [#380](https://github.com/ffroliva/gflow-cli/issues/380).
+- **Video generation gained the 429 branch the image path got in #379.** A
+  quota hit on `batchAsyncGenerateVideo*` raised `WireFormatError` instead of
+  `RateLimitError`, losing `Retry-After` and the retryable classification.
+- **`generate_images_batch` no longer reports a bare, remediation-free
+  `GFlowError`** when every response failed — it classifies the first error the
+  same way the single-prompt path does.
+
+### Added
+
+- **Incident bundles record what was submitted
+  ([#528](https://github.com/ffroliva/gflow-cli/issues/528)).**
+  `network.json` gains a `generation_requests` array carrying a counts-only
+  summary of each outgoing generation submit (body size, reference-entity
+  count, reference-field count). The reference shape that triggers a policy 400
+  was previously visible only in the stderr stream, so bundles attached to an
+  issue could not be diagnosed. Counts and booleans only — no key names, field
+  values, or prompt text — matching the existing §5.3 retention boundary.
+
 ### Security
 
 - **CI/CD supply-chain hardening

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -85,6 +85,7 @@ from gflow_cli.errors import (
     UpscaleUnavailableError,
     WafRejectionError,
     WireFormatError,
+    classify_content_safety,
 )
 from gflow_cli.paths import adjust_key_extension, character_output_path, looks_like_video
 from gflow_cli.profile_lease import ProfileLease
@@ -819,10 +820,16 @@ class FlowApiClient:
 
     def _build_transport_setup(self) -> TransportSetup:
         """Assemble the immutable output/storage wiring handed to the transport."""
+        rec = self._recorder
         return TransportSetup(
             out_dir=self._out_dir,
             storage_uri=self.settings.storage_uri,
             output_dir=self.settings.output_dir,
+            # #528: the transport sees request bodies the context-level network
+            # listeners cannot decode. None when capture is off.
+            record_generation_request=(
+                rec.record_generation_request if rec is not None and rec.enabled else None
+            ),
         )
 
     def _apply_transport_setup(
@@ -2770,56 +2777,6 @@ def _is_png_or_jpeg(data: bytes) -> bool:
     return data[:8] == b"\x89PNG\r\n\x1a\n" or data[:3] == b"\xff\xd8\xff"
 
 
-_CONTENT_SAFETY_REASONS: frozenset[str] = frozenset(
-    {
-        "PUBLIC_ERROR_UNSAFE_GENERATION",
-        "PUBLIC_ERROR_UNSAFE_CONTENT",
-        "PUBLIC_ERROR_UNSAFE_FACE",
-        "PUBLIC_ERROR_UNSAFE_IDENTITY",
-    }
-)
-
-
-def _classify_content_safety(body_text: str) -> str | None:
-    """Parse a Flow error body for content-safety rejection reasons.
-
-    Returns the matching ``reason`` string (e.g.
-    ``PUBLIC_ERROR_UNSAFE_GENERATION``) if the body contains a known
-    content-safety reason, or ``None`` otherwise.
-
-    Flow's HTTP 400 error shape::
-
-        {
-          "error": {
-            "code": 400,
-            "message": "Request contains an invalid argument.",
-            "status": "INVALID_ARGUMENT",
-            "details": [
-              {"@type": "...ErrorInfo", "reason": "PUBLIC_ERROR_UNSAFE_GENERATION"}
-            ]
-          }
-        }
-    """
-    try:
-        parsed: object = json.loads(body_text)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    parsed_dict = cast("JsonObject", parsed)
-    error_obj = cast("JsonObject | None", parsed_dict.get("error"))
-    if not isinstance(error_obj, dict):
-        return None
-    details_obj = cast("list[JsonObject] | None", error_obj.get("details"))
-    if not isinstance(details_obj, list):
-        return None
-    for item in details_obj:
-        reason = cast("str", item.get("reason", ""))
-        if reason in _CONTENT_SAFETY_REASONS:
-            return reason
-    return None
-
-
 def _extract_provider_error_message(body_text: str) -> str | None:
     """Extract human-readable error message from provider JSON response body if present."""
     if not body_text or not body_text.strip():
@@ -2903,7 +2860,7 @@ def _raise_for_non_retryable(resp: Any, body_text: str, *, route: str) -> None:
             route=route,
         )
     if resp.status == 400:
-        safety_reason = _classify_content_safety(body_text)
+        safety_reason = classify_content_safety(body_text)
         if safety_reason is not None:
             base_detail = (
                 f"HTTP 400: Flow refused the request on content-safety grounds "

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -20,10 +20,12 @@ from gflow_cli.data.redaction import redact_error_detail
 from gflow_cli.errors import (
     AuthExpiredError,
     ContentPolicyError,
+    FlowApiError,
     NetworkError,
     RateLimitError,
     WafRejectionError,
     WireFormatError,
+    classify_content_safety,
 )
 
 # ---------------------------------------------------------------------------
@@ -123,6 +125,58 @@ def interpret_response(strategy_name: str, resp: Any) -> list[GeneratedImage]:
 
     msg = f"{strategy_name}: unexpected HTTP status {status}: {_redacted_snippet(text)}"
     raise WireFormatError(msg)
+
+
+GENERATION_POLICY_HINT: str = (
+    "Flow refused this generation (HTTP 400 on the generation route). This is "
+    "almost always a content-policy rejection, not a malformed request — on this "
+    "path Flow's own web app composes the request body. Most common causes, in "
+    "order: (a) more than ONE face-bearing reference in the same request — reduce "
+    "to a single --reference-entity OR a single portrait --ref and carry other "
+    "people in prose; (b) an age-explicit person descriptor in the prompt ('a "
+    "young woman in her early 20s', 'a man of about thirty') — use a relational "
+    "or role noun instead ('his adult granddaughter', 'an estate agent'); (c) a "
+    "real-person likeness or a frontal close-up face. Shortening the prompt does "
+    "NOT help."
+)
+
+
+def generation_error(*, status: int, route: str, body: object) -> FlowApiError:
+    """Classify a non-2xx status on a Flow **generation** route (issue #528).
+
+    Returns the exception rather than raising it: the single-prompt paths do
+    ``raise generation_error(...)``, while ``generate_images_batch`` needs the
+    object to hand back inside a per-prompt ``BatchSubmissionResult``.
+
+    Callers reach here only after 401/403/429 have been branched off, and only
+    when no image/media survived — so this decides between "Flow refused the
+    content" and "we genuinely do not understand this response".
+
+    * 400 → :class:`ContentPolicyError`. Named ``reason`` when Flow sent one,
+      but a bare 400 counts too: on the ``ui_automation`` path the generation
+      request body is composed by Flow's own web app, so a 400 there cannot be
+      our malformation. Before #528 these surfaced as ``WireFormatError``
+      telling operators to "retry with a simpler prompt text", which never works.
+    * any other status → :class:`WireFormatError`, unchanged.
+    """
+    if status == 400:
+        reason = classify_content_safety(body)
+        detail = f"HTTP 400 on {route or 'the generation route'}: Flow refused the request " + (
+            f"on content-safety grounds (reason={reason})"
+            if reason
+            else "— no reason field returned (see remediation for the usual causes)"
+        )
+        return ContentPolicyError(
+            detail=detail,
+            status=400,
+            route=route,
+            remediation_hint=GENERATION_POLICY_HINT,
+        )
+    return WireFormatError(
+        detail=f"generation route returned HTTP {status}",
+        status=status,
+        route=route,
+    )
 
 
 def _redacted_snippet(text: str) -> str:

--- a/src/gflow_cli/api/transports/base.py
+++ b/src/gflow_cli/api/transports/base.py
@@ -19,6 +19,23 @@ if TYPE_CHECKING:
     from gflow_cli.api.video import GenerateVideoRequest, VideoResult, VideoStartedCallback
 
 
+class GenerationRequestRecorder(Protocol):
+    """Counts-only sink for outgoing generation-request summaries (issue #528).
+
+    Structural so the transports never import ``diagnostics`` (which must stay
+    leaf-level — ``FlowApiClient`` owns the ``IncidentRecorder``)."""
+
+    def __call__(
+        self,
+        *,
+        url: str,
+        body_bytes: int,
+        reference_entity_count: int,
+        reference_field_count: int,
+        mentions_reference_entities: bool,
+    ) -> None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class TransportSetup:
     """Immutable output/storage wiring the client hands a transport.
@@ -36,6 +53,13 @@ class TransportSetup:
     """Cloud-storage target for video uploads. ``None`` keeps downloads local."""
     output_dir: Path | None = None
     """Local directory video downloads land in (``settings.output_dir``)."""
+    record_generation_request: GenerationRequestRecorder | None = None
+    """Sink for counts-only generation-request summaries (issue #528).
+
+    The incident recorder's context-level listeners cannot decode a request
+    body, so the transport — which already summarises it for the #170 submit
+    backstop — hands the counts back through this callback. ``None`` (the
+    default, and whenever incident capture is off) makes the call a no-op."""
 
 
 @runtime_checkable

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -29,7 +29,7 @@ from gflow_cli.api._retry import parse_retry_after
 from gflow_cli.api.character import CHARACTER_MODELS, CharacterImageRequest
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
-from gflow_cli.api.transports._common import extract_project_id
+from gflow_cli.api.transports._common import extract_project_id, generation_error
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     from playwright.async_api import Locator, Page, ViewportSize
 
-    from gflow_cli.api.transports.base import TransportSetup
+    from gflow_cli.api.transports.base import GenerationRequestRecorder, TransportSetup
 
 # Lazy-imported at call time so ``import gflow_cli`` doesn't pay the
 # Playwright import cost when another transport is selected.
@@ -587,17 +587,22 @@ def _collect_images_from_body(body: dict[str, Any], images: list[GeneratedImage]
 
 def _images_from_responses(
     responses: list[dict[str, Any]],
-) -> tuple[list[GeneratedImage], int | None, str]:
+) -> tuple[list[GeneratedImage], int | None, str, dict[str, Any]]:
     """Process captured batchGenerateImages responses.
 
-    Returns ``(images, first_error_status, first_error_route)``. Raises
-    :class:`AuthExpiredError` on 401, :class:`WafRejectionError` on 403, and
-    :class:`RateLimitError` on 429, which the caller must surface — these are not
-    first-error candidates.
+    Returns ``(images, first_error_status, first_error_route, first_error_body)``.
+    Raises :class:`AuthExpiredError` on 401, :class:`WafRejectionError` on 403,
+    and :class:`RateLimitError` on 429, which the caller must surface — these are
+    not first-error candidates.
+
+    The error **body** rides out with the status (issue #528): the caller has to
+    tell a content-policy 400 apart from a genuinely unexpected response shape,
+    and dropping the body here left it no way to.
     """
     images: list[GeneratedImage] = []
     first_error_status: int | None = None
     first_error_route: str = ""
+    first_error_body: dict[str, Any] = {}
 
     for response in responses:
         status = response.get("status")
@@ -642,13 +647,24 @@ def _images_from_responses(
                 retry_after=retry_after,
             )
         if status != 200:
-            first_error_status = first_error_status or status
-            first_error_route = first_error_route or route_str
+            if status == 400:
+                # We still do not know Flow's real 400 shape on this route — every
+                # #528 incident bundle showed a bare `{"status": 400}`. Log it like
+                # the 403 branch above so the next occurrence settles it.
+                log.warning(
+                    "ui_automation.batch_400_body",
+                    body_prefix=str(body)[:200],
+                    route=route_str,
+                )
+            if first_error_status is None:
+                first_error_status = status
+                first_error_route = route_str
+                first_error_body = body
             continue
 
         _collect_images_from_body(body, images)
 
-    return images, first_error_status, first_error_route
+    return images, first_error_status, first_error_route, first_error_body
 
 
 _REF_VALUE_MAX_CHARS = 512
@@ -713,6 +729,29 @@ def _summarize_batch_request_body(post_data: str | None) -> dict[str, Any]:
     else:
         summary["top_keys"] = sorted(parsed_dict.keys())
     return summary
+
+
+def _reference_field_count(post_data: str | None) -> int:
+    """How many reference/entity-ish fields ride on ``requests[0]`` (issue #528).
+
+    A COUNT, never the key names: this feeds the incident bundle, which retains
+    counts and booleans only (§5.3, S02/S29). The deciding signal for a policy
+    400 is how many face-bearing references were attached, not what they were
+    called.
+    """
+    if not post_data:
+        return 0
+    try:
+        parsed: object = json.loads(post_data)
+    except (ValueError, TypeError):
+        return 0
+    if not isinstance(parsed, dict):
+        return 0
+    reqs = cast(_JsonObj, parsed).get("requests")
+    if not (isinstance(reqs, list) and reqs and isinstance(reqs[0], dict)):
+        return 0
+    first = cast(_JsonObj, reqs[0])
+    return sum(1 for k in first if "reference" in k.lower() or "entity" in k.lower())
 
 
 def _entity_ids_from_one_request(req: Any) -> set[str]:
@@ -808,6 +847,9 @@ class UiAutomationTransport(VideoGenerationMixin):
         # below are this transport's own derived state — the client no longer
         # writes them directly.
         self.setup_config: TransportSetup | None = None
+        # Counts-only incident sink for outgoing generation submits (#528).
+        # None until apply_setup runs, and whenever incident capture is off.
+        self._record_generation_request: GenerationRequestRecorder | None = None
         # Optional directory for debug screenshots — derived from the client's
         # `out_dir` constructor arg (#18). When None, the internal
         # _capture_debug_screenshot helper is a no-op.
@@ -836,6 +878,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             self._out_dir = config.out_dir
         self._storage_uri = config.storage_uri
         self._output_dir = config.output_dir
+        self._record_generation_request = config.record_generation_request
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -2175,6 +2218,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         *,
         project_id: str | None = None,
         sink: list[dict[str, Any]] | None = None,
+        record_generation_request: GenerationRequestRecorder | None = None,
     ) -> Callable[[], None]:
         """Register a ``page.on('request', ...)`` that logs a compact summary of
         each outgoing ``batchGenerateImages`` body.
@@ -2202,13 +2246,23 @@ class UiAutomationTransport(VideoGenerationMixin):
                 filter_project_id=project_id,
                 summary=_summarize_batch_request_body(post_data),
             )
+            entity_ids = _entity_ids_from_request_body(post_data)
             if sink is not None:
-                sink.append(
-                    {
-                        "url": request_obj.url,
-                        "entity_ids": _entity_ids_from_request_body(post_data),
-                    }
-                )
+                sink.append({"url": request_obj.url, "entity_ids": entity_ids})
+            # #528: persist a counts-only echo into the incident bundle. The
+            # stderr log above is richer but evaporates; the bundle is what a
+            # reporter actually attaches to an issue.
+            if record_generation_request is not None:
+                try:
+                    record_generation_request(
+                        url=request_obj.url,
+                        body_bytes=len(post_data or ""),
+                        reference_entity_count=len(entity_ids),
+                        reference_field_count=_reference_field_count(post_data),
+                        mentions_reference_entities="referenceEntit" in (post_data or ""),
+                    )
+                except Exception:  # noqa: BLE001, S110 — observation only, never break a submit
+                    pass
 
         page.on("request", on_request)
 
@@ -2527,7 +2581,10 @@ class UiAutomationTransport(VideoGenerationMixin):
             # it carries — the #170 submit backstop reads the sink after the run.
             request_bodies: list[dict[str, Any]] = []
             req_log_detach = self._attach_batch_request_logger(
-                page, project_id=nav_project_id, sink=request_bodies
+                page,
+                project_id=nav_project_id,
+                sink=request_bodies,
+                record_generation_request=self._record_generation_request,
             )
             # Record submit_time BEFORE the click so the post-submit-time filter
             # in _await_captured can distinguish this prompt's responses from any
@@ -2547,13 +2604,16 @@ class UiAutomationTransport(VideoGenerationMixin):
 
         # Collect images from ALL captured responses (Flow makes one API call
         # per image when count > 1).
-        images, first_error_status, first_error_route = _images_from_responses(responses)
+        images, first_error_status, first_error_route, first_error_body = _images_from_responses(
+            responses
+        )
 
         if first_error_status is not None and not images:
-            raise WireFormatError(
-                detail=f"batchGenerateImages returned HTTP {first_error_status}",
+            # #528: a 400 here is a content-policy rejection, not a wire problem.
+            raise generation_error(
                 status=first_error_status,
                 route=first_error_route,
+                body=first_error_body,
             )
 
         if not images:
@@ -2766,11 +2826,24 @@ class UiAutomationTransport(VideoGenerationMixin):
                 err,
             )
 
-        images, first_error_status, _ = _images_from_responses(responses)
+        images, first_error_status, first_error_route, first_error_body = _images_from_responses(
+            responses
+        )
         if not images:
-            err = GFlowError(
-                detail=f"no parseable images (first_error_status={first_error_status})",
-                route="generate_images_batch",
+            # #528: classify rather than hand back a bare GFlowError with no
+            # remediation — a policy 400 here needs the same guidance the
+            # single-prompt path gets.
+            err = (
+                generation_error(
+                    status=first_error_status,
+                    route=first_error_route or "generate_images_batch",
+                    body=first_error_body,
+                )
+                if first_error_status is not None
+                else GFlowError(
+                    detail="no parseable images (every response was 200 with no media)",
+                    route="generate_images_batch",
+                )
             )
             return (
                 BatchSubmissionResult(
@@ -3336,13 +3409,16 @@ class UiAutomationTransport(VideoGenerationMixin):
         finally:
             detach()
 
-        images, first_error_status, first_error_route = _images_from_responses(responses)
+        images, first_error_status, first_error_route, first_error_body = _images_from_responses(
+            responses
+        )
 
         if first_error_status is not None and not images:
-            raise WireFormatError(
-                detail=f"batchGenerateImages returned HTTP {first_error_status}",
+            # #528: a 400 here is a content-policy rejection, not a wire problem.
+            raise generation_error(
                 status=first_error_status,
                 route=first_error_route,
+                body=first_error_body,
             )
 
         if not images:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING, Any, cast
 import structlog
 
 from gflow_cli.api import routes
-from gflow_cli.api.transports._common import extract_project_id
+from gflow_cli.api._retry import parse_retry_after
+from gflow_cli.api.transports._common import extract_project_id, generation_error
 from gflow_cli.api.transports.drivers.factory import AGENTIC_INDICATOR_SELECTORS
 from gflow_cli.api.video import (
     I2V_DEFAULT_MODEL,
@@ -48,6 +49,7 @@ from gflow_cli.errors import (
     FlowAppError,
     MediaUploadRejectedError,
     ModelModeIncompatibilityError,
+    RateLimitError,
     ReferenceNotFoundError,
     TransportTimeoutError,
     UiSelectorDriftError,
@@ -3350,11 +3352,26 @@ class VideoGenerationMixin:
                 status=403,
                 route=route,
             )
-        if http_status != 200:
-            raise WireFormatError(
-                detail=f"batchAsyncGenerateVideo* returned HTTP {http_status}",
-                status=http_status if isinstance(http_status, int) else None,
+        if http_status == 429:
+            # #379 gave the image path a 429 branch; video never got one, so a
+            # quota hit surfaced as "unexpected response shape" (#528).
+            retry_after = parse_retry_after(generate_resp)
+            raise RateLimitError(
+                detail=(
+                    "batchAsyncGenerateVideo* returned HTTP 429 — rate limit hit."
+                    + (f" Retry after {retry_after:.0f}s." if retry_after is not None else "")
+                ),
+                status=429,
                 route=route,
+                retry_after=retry_after,
+            )
+        if http_status != 200:
+            # #528: same misclassification as the image path — a 400 here is a
+            # content-policy refusal, not a malformed request.
+            raise generation_error(
+                status=http_status if isinstance(http_status, int) else -1,
+                route=route,
+                body=generate_resp.get("body") or {},
             )
         # A video 200 ALWAYS carries media[0] (the asset slot — capture 02);
         # content rejection surfaces later as a FAILED *status*, not empty media.

--- a/src/gflow_cli/diagnostics.py
+++ b/src/gflow_cli/diagnostics.py
@@ -34,6 +34,8 @@ from urllib.parse import urlsplit
 
 import structlog
 
+from gflow_cli.errors import CONTENT_SAFETY_REASONS
+
 if sys.platform == "win32":
     import msvcrt
 else:
@@ -243,16 +245,9 @@ def text_summary(text: str, category: str) -> TextSummary:
 _KNOWN_TOP_KEYS = frozenset({"error"})
 _KNOWN_ERROR_KEYS = frozenset({"code", "message", "status", "details"})
 _STATUS_ENUM_RE = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
-# Mirrors api/client.py::_CONTENT_SAFETY_REASONS (client imports would cycle:
-# FlowApiClient owns the IncidentRecorder, so diagnostics must stay leaf-level).
-_CONTENT_SAFETY_REASONS = frozenset(
-    {
-        "PUBLIC_ERROR_UNSAFE_GENERATION",
-        "PUBLIC_ERROR_UNSAFE_CONTENT",
-        "PUBLIC_ERROR_UNSAFE_FACE",
-        "PUBLIC_ERROR_UNSAFE_IDENTITY",
-    }
-)
+# `errors` is the one module below diagnostics in the import graph (it pulls
+# IncidentRef under TYPE_CHECKING only), so CONTENT_SAFETY_REASONS is imported
+# rather than mirrored — the mirror had already drifted into a third copy by #528.
 
 
 def reduce_error_body(parsed: object) -> ErrorBodySummary:
@@ -299,7 +294,7 @@ def reduce_error_body(parsed: object) -> ErrorBodySummary:
                 if not isinstance(item, dict):
                     continue
                 reason = cast("dict[str, object]", item).get("reason")
-                if isinstance(reason, str) and reason in _CONTENT_SAFETY_REASONS:
+                if isinstance(reason, str) and reason in CONTENT_SAFETY_REASONS:
                     safety = True
                     break
     return ErrorBodySummary(
@@ -321,6 +316,7 @@ def reduce_error_body(parsed: object) -> ErrorBodySummary:
 # synchronously and never retain a Playwright Request/Response/ConsoleMessage.
 
 _NETWORK_RING_CAP = 100
+_GENERATION_REQUEST_RING_CAP = 50
 _CONSOLE_RING_CAP = 100
 _PAGE_ERROR_RING_CAP = 50
 
@@ -335,6 +331,26 @@ class NetworkRecord:
     resource_type: str
     status_or_failure: str
     duration_ms: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationRequestRecord:
+    """Counts-only shape of an outgoing generation request (issue #528).
+
+    Every #528 incident bundle carried `network.json` with `records: []`, so the
+    only proof of WHAT was submitted lived in the stderr stream — the reference
+    shape that actually triggered the policy 400 was invisible to anyone reading
+    the bundle. This record makes it visible while honouring the same §5.3
+    discipline as `reduce_error_body`: counts and booleans only, never key
+    names, field values, or prompt text (S02/S29).
+    """
+
+    ts_utc: str
+    route: str
+    body_bytes: int
+    reference_entity_count: int
+    reference_field_count: int
+    mentions_reference_entities: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -358,6 +374,7 @@ class PageErrorRecord:
 @dataclass(frozen=True, slots=True)
 class JournalSnapshot:
     network: tuple[NetworkRecord, ...]
+    generation_requests: tuple[GenerationRequestRecord, ...]
     console: tuple[ConsoleRecord, ...]
     page_errors: tuple[PageErrorRecord, ...]
 
@@ -367,10 +384,13 @@ class IncidentJournal:
     ``add_*`` afterwards is a no-op so late callbacks cannot mutate evidence
     mid-finalization (S17)."""
 
-    __slots__ = ("_console", "_frozen", "_network", "_page_errors")
+    __slots__ = ("_console", "_frozen", "_generation_requests", "_network", "_page_errors")
 
     def __init__(self) -> None:
         self._network: deque[NetworkRecord] = deque(maxlen=_NETWORK_RING_CAP)
+        self._generation_requests: deque[GenerationRequestRecord] = deque(
+            maxlen=_GENERATION_REQUEST_RING_CAP
+        )
         self._console: deque[ConsoleRecord] = deque(maxlen=_CONSOLE_RING_CAP)
         self._page_errors: deque[PageErrorRecord] = deque(maxlen=_PAGE_ERROR_RING_CAP)
         self._frozen = False
@@ -381,6 +401,10 @@ class IncidentJournal:
     def add_network(self, rec: NetworkRecord) -> None:
         if not self._frozen:
             self._network.append(rec)
+
+    def add_generation_request(self, rec: GenerationRequestRecord) -> None:
+        if not self._frozen:
+            self._generation_requests.append(rec)
 
     def add_console(self, rec: ConsoleRecord) -> None:
         if not self._frozen:
@@ -393,6 +417,7 @@ class IncidentJournal:
     def snapshot(self) -> JournalSnapshot:
         return JournalSnapshot(
             network=tuple(self._network),
+            generation_requests=tuple(self._generation_requests),
             console=tuple(self._console),
             page_errors=tuple(self._page_errors),
         )
@@ -1042,6 +1067,35 @@ class IncidentRecorder:
             )
         )
 
+    def record_generation_request(
+        self,
+        *,
+        url: str,
+        body_bytes: int,
+        reference_entity_count: int,
+        reference_field_count: int,
+        mentions_reference_entities: bool,
+    ) -> None:
+        """Journal a counts-only summary of an outgoing generation submit (#528).
+
+        Called by the ui_automation transports, which see the request body the
+        context-level listeners cannot decode. The caller passes primitives only
+        — this method never receives the body itself.
+        """
+        if self._frozen:
+            return
+        s = sanitize_url(url, self.hasher)
+        self.journal.add_generation_request(
+            GenerationRequestRecord(
+                ts_utc=datetime.now(UTC).isoformat(),
+                route=s.route,
+                body_bytes=body_bytes,
+                reference_entity_count=reference_entity_count,
+                reference_field_count=reference_field_count,
+                mentions_reference_entities=mentions_reference_entities,
+            )
+        )
+
     def record_request_failed(
         self,
         *,
@@ -1412,7 +1466,12 @@ class IncidentRecorder:
     ) -> None:
         snap = self.journal.snapshot()
         payloads = {
-            "network.json": {"records": [asdict(r) for r in snap.network]},
+            "network.json": {
+                "records": [asdict(r) for r in snap.network],
+                # #528: what was SUBMITTED, in counts only — the deciding signal
+                # for a policy 400 is "how many face-bearing references rode".
+                "generation_requests": [asdict(r) for r in snap.generation_requests],
+            },
             "browser.json": {
                 "console": [asdict(r) for r in snap.console],
                 "page_errors": [asdict(r) for r in snap.page_errors],

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 if TYPE_CHECKING:
     from gflow_cli.diagnostics import IncidentRef
 
 __all__ = [
+    "CONTENT_SAFETY_REASONS",
     "EXIT_CODE_MAP",
     "RETRYABLE_ERRORS",
     "AisandboxAuthError",
@@ -49,6 +51,7 @@ __all__ = [
     "VideoModelSelectionError",
     "WafRejectionError",
     "WireFormatError",
+    "classify_content_safety",
     "is_retryable",
 ]
 
@@ -192,6 +195,59 @@ class AisandboxAuthError(AuthExpiredError):
         "SAPISID cookie missing, expired, or unreadable. "
         "Re-run `gflow auth login --profile <name>` and retry."
     )
+
+
+CONTENT_SAFETY_REASONS: frozenset[str] = frozenset(
+    {
+        "PUBLIC_ERROR_UNSAFE_GENERATION",
+        "PUBLIC_ERROR_UNSAFE_CONTENT",
+        "PUBLIC_ERROR_UNSAFE_FACE",
+        "PUBLIC_ERROR_UNSAFE_IDENTITY",
+    }
+)
+"""Flow's content-safety ``details[].reason`` values on an HTTP 400.
+
+Lives here, next to :class:`ContentPolicyError` whose docstring documents the
+wire shape, because ``errors`` is a leaf module: ``api.client``,
+``api.transports.*`` and ``diagnostics`` can all import it, and none of them can
+import each other (``client`` imports ``transports``; ``diagnostics`` must stay
+leaf-level because ``FlowApiClient`` owns the ``IncidentRecorder``). Before #528
+this set was maintained in three places and the transports had no copy at all.
+"""
+
+
+def classify_content_safety(body: object) -> str | None:
+    """Return Flow's content-safety ``reason``, or ``None`` if the body has none.
+
+    Accepts either the raw response text (what ``api.client`` holds) or an
+    already-parsed dict (what the ``ui_automation`` response listener stores),
+    so both callers share one implementation.
+
+    Flow's HTTP 400 error shape::
+
+        {"error": {"code": 400, "message": "...", "status": "INVALID_ARGUMENT",
+                   "details": [{"reason": "PUBLIC_ERROR_UNSAFE_GENERATION"}]}}
+    """
+    parsed: object = body
+    if isinstance(parsed, str):
+        try:
+            parsed = json.loads(parsed)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if not isinstance(parsed, dict):
+        return None
+    error_obj = cast("dict[str, Any]", parsed).get("error")
+    if not isinstance(error_obj, dict):
+        return None
+    details = cast("dict[str, Any]", error_obj).get("details")
+    if not isinstance(details, list):
+        return None
+    for item in cast("list[Any]", details):
+        if isinstance(item, dict):
+            reason = cast("dict[str, Any]", item).get("reason", "")
+            if reason in CONTENT_SAFETY_REASONS:
+                return cast("str", reason)
+    return None
 
 
 class RateLimitError(FlowApiError):

--- a/tests/api/transports/test_policy_400.py
+++ b/tests/api/transports/test_policy_400.py
@@ -1,0 +1,185 @@
+"""Issue #528 — HTTP 400 on a generation route is a content-policy rejection.
+
+The `ui_automation` transports raised :class:`WireFormatError` for any non-2xx
+status they did not explicitly branch on, so Google's content-policy 400s
+arrived carrying "the request was rejected as malformed... retry with a simpler
+prompt text". That remediation is actively wrong: shortening the prompt never
+helps, and it hides the two levers that do (reference-shape and person
+descriptors).
+
+Same defect shape as #379 (429 mishandled as WireFormatError), one status over.
+"""
+
+from __future__ import annotations
+
+import pytest
+from structlog.testing import capture_logs
+
+from gflow_cli.api.transports._common import generation_error
+from gflow_cli.api.transports.ui_automation import _images_from_responses
+from gflow_cli.api.transports.ui_automation_video import VideoGenerationMixin
+from gflow_cli.errors import (
+    ContentPolicyError,
+    RateLimitError,
+    WireFormatError,
+    classify_content_safety,
+)
+
+IMAGE_ROUTE = "https://aisandbox-pa.googleapis.com/v1/projects/p1/flowMedia:batchGenerateImages"
+VIDEO_ROUTE = (
+    "https://aisandbox-pa.googleapis.com/v1/projects/p1/flowMedia:batchAsyncGenerateVideoText"
+)
+
+UNSAFE_BODY = {
+    "error": {
+        "code": 400,
+        "message": "Request contains an invalid argument.",
+        "status": "INVALID_ARGUMENT",
+        "details": [
+            {"@type": "type.googleapis.com/x.ErrorInfo", "reason": "PUBLIC_ERROR_UNSAFE_GENERATION"}
+        ],
+    }
+}
+
+# What #528's incident bundles actually captured: a bare 400 with no reason we
+# recognise. The fix must still classify it as policy, not wire format.
+BARE_400_BODY = {
+    "error": {
+        "code": 400,
+        "message": "Request contains an invalid argument.",
+        "status": "INVALID_ARGUMENT",
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# shared classifier (was triplicated: client.py, diagnostics.py, transports)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_content_safety_accepts_a_parsed_dict() -> None:
+    """The ui_automation listener stores an already-parsed body, not text."""
+    assert classify_content_safety(UNSAFE_BODY) == "PUBLIC_ERROR_UNSAFE_GENERATION"
+
+
+def test_classify_content_safety_accepts_raw_text() -> None:
+    """client.py's callers hold the undecoded response text."""
+    import json
+
+    assert classify_content_safety(json.dumps(UNSAFE_BODY)) == "PUBLIC_ERROR_UNSAFE_GENERATION"
+
+
+@pytest.mark.parametrize("body", ["not json", "", {}, None, {"error": {"details": []}}])
+def test_classify_content_safety_returns_none_when_absent(body: object) -> None:
+    assert classify_content_safety(body) is None
+
+
+# ---------------------------------------------------------------------------
+# image i2i — the path the issue was filed against
+# ---------------------------------------------------------------------------
+
+
+def test_images_from_responses_carries_the_error_body_out() -> None:
+    """The 400's body is captured by the listener and must not be dropped.
+
+    Before #528 the `status != 200` branch kept only status+route, so the
+    caller could not tell a policy rejection from a malformed request.
+    """
+    responses = [{"status": 400, "url": IMAGE_ROUTE, "body": UNSAFE_BODY}]
+
+    images, status, route, body = _images_from_responses(responses)
+
+    assert images == []
+    assert status == 400
+    assert route == IMAGE_ROUTE
+    assert body == UNSAFE_BODY
+
+
+def test_image_400_with_a_safety_reason_raises_content_policy() -> None:
+    with pytest.raises(ContentPolicyError) as exc_info:
+        raise generation_error(status=400, route=IMAGE_ROUTE, body=UNSAFE_BODY)
+
+    err = exc_info.value
+    assert "PUBLIC_ERROR_UNSAFE_GENERATION" in str(err)
+    assert err.status == 400
+
+
+def test_image_400_without_a_reason_is_still_a_policy_rejection() -> None:
+    """#528's own evidence: every bundle showed a bare 400, no reason field.
+
+    On the ui_automation path Flow's own web app composes the request body, so
+    a 400 there cannot be OUR malformation — classifying it as WireFormatError
+    is wrong regardless of whether a reason rode along.
+    """
+    with pytest.raises(ContentPolicyError):
+        raise generation_error(status=400, route=IMAGE_ROUTE, body=BARE_400_BODY)
+
+
+def test_policy_remediation_names_the_levers_that_actually_work() -> None:
+    """The whole point of #528: recover from the error text alone (#380)."""
+    with pytest.raises(ContentPolicyError) as exc_info:
+        raise generation_error(status=400, route=IMAGE_ROUTE, body=BARE_400_BODY)
+
+    hint = exc_info.value.remediation_hint.lower()
+    # (a) the reference-shape lever
+    assert "one" in hint and "face" in hint
+    assert "--reference-entity" in hint or "reference-entity" in hint
+    # (b) the person-descriptor lever
+    assert "descriptor" in hint or "age" in hint
+    # and the anti-guidance that cost three hours
+    assert "shorten" in hint
+
+
+def test_non_400_4xx_is_still_a_wire_format_error() -> None:
+    """Don't over-swing: a 404/422 on the route really is unexpected shape."""
+    with pytest.raises(WireFormatError):
+        raise generation_error(status=404, route=IMAGE_ROUTE, body={})
+
+
+def test_image_400_body_is_logged_for_discovery() -> None:
+    """We still don't know Flow's real 400 shape — log it like the 403 branch.
+
+    Uses structlog's own capture rather than capsys: the rendered stream depends
+    on whatever structlog configuration an earlier test left behind, so a stdout
+    assertion passes alone and fails in a full run.
+    """
+    responses = [{"status": 400, "url": IMAGE_ROUTE, "body": BARE_400_BODY}]
+
+    with capture_logs() as logs:
+        _images_from_responses(responses)
+
+    assert [e for e in logs if e["event"] == "ui_automation.batch_400_body"]
+
+
+# ---------------------------------------------------------------------------
+# video — identical defect at ui_automation_video.py:3353, plus no 429 branch
+# ---------------------------------------------------------------------------
+
+
+def test_video_400_raises_content_policy_not_wire_format() -> None:
+    resp = {"status": 400, "url": VIDEO_ROUTE, "body": UNSAFE_BODY}
+
+    with pytest.raises(ContentPolicyError):
+        VideoGenerationMixin._parse_generate_response(resp)
+
+
+def test_video_429_raises_rate_limit() -> None:
+    """#379 gave the image path a 429 branch; video never got one."""
+    resp = {
+        "status": 429,
+        "url": VIDEO_ROUTE,
+        "body": {"error": {"message": "Resource exhausted"}},
+        "headers": {"retry-after": "30"},
+    }
+
+    with pytest.raises(RateLimitError) as exc_info:
+        VideoGenerationMixin._parse_generate_response(resp)
+
+    assert exc_info.value.retry_after == 30.0
+
+
+def test_video_404_is_still_a_wire_format_error() -> None:
+    resp = {"status": 404, "url": VIDEO_ROUTE, "body": {}}
+
+    with pytest.raises(WireFormatError):
+        VideoGenerationMixin._parse_generate_response(resp)

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -1307,7 +1307,13 @@ class TestGenerateImages:
             reference_entity_names=("Stacky",),  # fewer names than ids on purpose
         )
 
-        def _seeding_logger(page: Any, *, project_id: Any = None, sink: Any = None) -> Any:
+        def _seeding_logger(
+            page: Any,
+            *,
+            project_id: Any = None,
+            sink: Any = None,
+            record_generation_request: Any = None,
+        ) -> Any:
             # Feed the #170 submit backstop: pretend the captured submit
             # carried both staged entities (the real logger fills the sink
             # from outgoing batchGenerateImages bodies).
@@ -1593,7 +1599,13 @@ class TestImageEntityBackstop:
             reference_entity_names=("Stacky",),
         )
 
-        def _seeding_logger(page: Any, *, project_id: Any = None, sink: Any = None) -> Any:
+        def _seeding_logger(
+            page: Any,
+            *,
+            project_id: Any = None,
+            sink: Any = None,
+            record_generation_request: Any = None,
+        ) -> Any:
             if sink is not None:
                 sink.append({"entity_ids": {"ent-1"}})
             return lambda: None
@@ -3296,12 +3308,13 @@ def test_images_from_responses_preserves_workflow_display_name():
             "metadata": {"displayName": "Calm forest at dawn"},
         }
     ]
-    images, error_status, error_route = _images_from_responses(
+    images, error_status, error_route, error_body = _images_from_responses(
         [{"status": 200, "url": "flowMedia:batchGenerateImages", "body": body}]
     )
 
     assert error_status is None
     assert error_route == ""
+    assert error_body == {}
     assert len(images) == 1
     assert images[0].display_name == "Calm forest at dawn"
 

--- a/tests/api/transports/test_ui_automation_batch.py
+++ b/tests/api/transports/test_ui_automation_batch.py
@@ -276,7 +276,7 @@ async def test_generate_images_batch_happy_path(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(
         uia_mod,
         "_images_from_responses",
-        lambda responses: ([fake_img] * len(responses), None, ""),
+        lambda responses: ([fake_img] * len(responses), None, "", {}),
     )
 
     # Mock _extract_project_id to return the URL-extracted UUID.
@@ -397,7 +397,7 @@ async def test_generate_images_batch_continue_on_error_send_fail(
         cap.append({"status": 200, "url": "https://x/batchGenerateImages", "body": {}})
 
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-X")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -474,7 +474,7 @@ async def test_generate_images_batch_fail_fast_partial_salvage(
         cap.append({"status": 200, "url": "https://x/batchGenerateImages", "body": {}})
 
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-Y")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -549,7 +549,7 @@ async def test_generate_images_batch_detach_invariant(
 
     fake_img = MagicMock()
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-Z")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -640,7 +640,7 @@ async def test_settings_fail_after_attach_calls_detach_before_continue(
 
     fake_img = MagicMock()
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-DETACH")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -721,7 +721,7 @@ async def test_await_captured_timeout_partial_list_gives_fail_result(
 
     fake_img = MagicMock()
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-TIMEOUT")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -853,7 +853,7 @@ async def test_serial_pattern_await_captured_always_called(
 
     fake_img = MagicMock()
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "PROJ-SERIAL")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())
@@ -920,7 +920,7 @@ async def test_generate_images_batch_project_id_identical_across_results(
 
     fake_img = MagicMock()
     monkeypatch.setattr(
-        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "")
+        uia_mod, "_images_from_responses", lambda r: ([fake_img] * len(r), None, "", {})
     )
     monkeypatch.setattr(uia_mod, "_extract_project_id", lambda url: "SHARED-UUID")
     monkeypatch.setattr(uia_mod.asyncio, "sleep", AsyncMock())

--- a/tests/test_errors_classification.py
+++ b/tests/test_errors_classification.py
@@ -2,12 +2,13 @@ import json
 
 import pytest
 
-from gflow_cli.api.client import _classify_content_safety, _raise_for_non_retryable
+from gflow_cli.api.client import _raise_for_non_retryable
 from gflow_cli.errors import (
     AuthExpiredError,
     ContentPolicyError,
     WafRejectionError,
     WireFormatError,
+    classify_content_safety,
 )
 
 
@@ -81,7 +82,7 @@ def test_400_content_policy_error_carries_reason_in_remediation() -> None:
 
 
 def test_400_unknown_reason_still_maps_to_wire_format() -> None:
-    """A 400 with an unknown reason (not in _CONTENT_SAFETY_REASONS) falls
+    """A 400 with an unknown reason (not in CONTENT_SAFETY_REASONS) falls
     through to WireFormatError — the safety net still works."""
     body = _flow_400_body("SOME_OTHER_REASON")
     with pytest.raises(WireFormatError):
@@ -115,24 +116,24 @@ def test_400_empty_details_still_maps_to_wire_format() -> None:
 
 def test_classify_content_safety_returns_reason_for_valid_body() -> None:
     body = _flow_400_body("PUBLIC_ERROR_UNSAFE_GENERATION")
-    assert _classify_content_safety(body) == "PUBLIC_ERROR_UNSAFE_GENERATION"
+    assert classify_content_safety(body) == "PUBLIC_ERROR_UNSAFE_GENERATION"
 
 
 def test_classify_content_safety_returns_none_for_non_content_safety_reason() -> None:
     body = _flow_400_body("SOME_OTHER_REASON")
-    assert _classify_content_safety(body) is None
+    assert classify_content_safety(body) is None
 
 
 def test_classify_content_safety_returns_none_for_non_json() -> None:
-    assert _classify_content_safety("not json") is None
+    assert classify_content_safety("not json") is None
 
 
 def test_classify_content_safety_returns_none_for_empty_string() -> None:
-    assert _classify_content_safety("") is None
+    assert classify_content_safety("") is None
 
 
 def test_classify_content_safety_returns_none_for_array_body() -> None:
-    assert _classify_content_safety("[]") is None
+    assert classify_content_safety("[]") is None
 
 
 def test_classify_content_safety_handles_multiple_details() -> None:
@@ -154,4 +155,4 @@ def test_classify_content_safety_handles_multiple_details() -> None:
             }
         }
     )
-    assert _classify_content_safety(body) == "PUBLIC_ERROR_UNSAFE_GENERATION"
+    assert classify_content_safety(body) == "PUBLIC_ERROR_UNSAFE_GENERATION"

--- a/tests/test_incident_generation_requests.py
+++ b/tests/test_incident_generation_requests.py
@@ -1,0 +1,94 @@
+"""Issue #528 proposal 4 — the incident bundle must show what was SUBMITTED.
+
+All five bundles for the failing scene carried `network.json` with
+`records: []`, so the only proof of the reference shape that triggered the
+policy 400 lived in the stderr stream. These tests pin the counts-only echo
+that now rides in the bundle — and pin that it stays counts-only, because
+`network.json` is inside the §5.3 retention boundary (S02/S29: never key names,
+field values, or prompt text).
+"""
+
+from __future__ import annotations
+
+import json
+
+from gflow_cli.api.transports.ui_automation import _reference_field_count
+from gflow_cli.diagnostics import GenerationRequestRecord, IncidentJournal
+
+BODY = json.dumps(
+    {
+        "requests": [
+            {
+                "prompt": "a portrait of his adult granddaughter on the porch",
+                "referenceEntities": [{"entityId": "ent-1"}, {"entityId": "ent-2"}],
+                "referenceImages": [{"bytes": "AAAA"}],
+                "aspectRatio": "IMAGE_ASPECT_RATIO_LANDSCAPE",
+            }
+        ]
+    }
+)
+
+
+def test_reference_field_count_counts_without_naming() -> None:
+    """referenceEntities + referenceImages = 2 reference-ish fields."""
+    assert _reference_field_count(BODY) == 2
+
+
+def test_reference_field_count_is_zero_for_unusable_input() -> None:
+    for bad in (None, "", "not json", "[]", json.dumps({"requests": []})):
+        assert _reference_field_count(bad) == 0
+
+
+def test_journal_ring_collects_generation_requests() -> None:
+    journal = IncidentJournal()
+    journal.add_generation_request(
+        GenerationRequestRecord(
+            ts_utc="2026-08-25T00:00:00+00:00",
+            route="flowMedia:batchGenerateImages",
+            body_bytes=7500,
+            reference_entity_count=2,
+            reference_field_count=2,
+            mentions_reference_entities=True,
+        )
+    )
+
+    snap = journal.snapshot()
+
+    assert len(snap.generation_requests) == 1
+    assert snap.generation_requests[0].reference_entity_count == 2
+
+
+def test_freeze_stops_late_generation_records() -> None:
+    """Same S17 discipline as the other rings — no mutation mid-finalization."""
+    journal = IncidentJournal()
+    journal.freeze()
+    journal.add_generation_request(
+        GenerationRequestRecord(
+            ts_utc="2026-08-25T00:00:00+00:00",
+            route="r",
+            body_bytes=1,
+            reference_entity_count=0,
+            reference_field_count=0,
+            mentions_reference_entities=False,
+        )
+    )
+
+    assert journal.snapshot().generation_requests == ()
+
+
+def test_record_carries_no_free_text() -> None:
+    """The retention boundary: counts, booleans, a sanitized route, a timestamp.
+
+    If someone adds a prompt, a key name, or an entity id to this record, this
+    test is the thing that should stop them.
+    """
+    allowed = {
+        "ts_utc",
+        "route",
+        "body_bytes",
+        "reference_entity_count",
+        "reference_field_count",
+        "mentions_reference_entities",
+    }
+
+    assert set(GenerationRequestRecord.__slots__) == allowed


### PR DESCRIPTION
## Summary

An HTTP 400 from `flowMedia:batchGenerateImages` was raised as `WireFormatError`, whose remediation says the request was malformed and to *"retry with a simpler prompt text"*. Every 400 in the reported incident was a Google content-policy rejection, so that guidance sent the operator down a path that cannot succeed — three hours and ~12 failed generations before controlled A/B isolation found the real triggers.

Same defect shape as #379 (429 mishandled as `WireFormatError`), one status over, and the self-documenting-errors goal of #380: recover from the error text alone.

## Root cause

`_images_from_responses` captured the 400's body from the response listener (`ui_automation.py:2122` stores `await response.json()`) and then **discarded it** at the `status != 200` branch, so the caller could only see a status and defaulted to `WireFormatError`.

The correct logic already existed in `client._raise_for_non_retryable`, but the `ui_automation` transports had no way to reach it: `CONTENT_SAFETY_REASONS` was maintained separately in `client.py` and `diagnostics.py` and was absent from the transports entirely. That duplication *is* why this bug existed.

## What changed

**Classification (proposals 1 + 2)**
- `errors.py` gains `CONTENT_SAFETY_REASONS` + `classify_content_safety` — the single definition all three call sites now share. `errors` is the one leaf module `client`, `transports`, and `diagnostics` can each import (`client` imports `transports`; `diagnostics` must stay leaf-level because `FlowApiClient` owns the `IncidentRecorder`).
- `_common.generation_error` classifies a generation-route failure. A **bare 400 counts as policy too**: on the `ui_automation` path Flow's own web app composes the request body, so a 400 there cannot be our malformation. This matters — every incident bundle showed a bare `{"status": 400}` with no reason field, so reason-only matching would have fallen straight back to `WireFormatError`. Non-400 statuses still raise `WireFormatError`.
- Remediation names the levers that actually work (one face-bearing reference; a relational or role noun instead of an age-explicit descriptor) and states outright that shortening the prompt does not help.

**Guidance stays targeted (proposal 3)** — a per-class remediation block plus the existing stable `problem_type` URL. No KNOWN_ISSUES dump at failure time.

**Incident bundle (proposal 4)** — `network.json` gains `generation_requests[]`, a counts-only summary of each outgoing submit (`body_bytes`, `reference_entity_count`, `reference_field_count`, `mentions_reference_entities`). Fed through the existing `TransportSetup` seam, so the transports still never import `diagnostics`.

> **Deliberate narrowing, please review:** the issue asked to persist the `batch_request_body` summary, but that summary returns `request0_keys` — *key names* — and `network.json` sits inside the §5.3 retention boundary (`diagnostics.py`: "never key names, message text, or raw values", S02/S29). It lands as counts and booleans only. That still answers what the incident turned on ("how many face-bearing references rode?"), and `test_record_carries_no_free_text` fails if a prompt, key name, or entity id is ever added to that record.

## Beyond the issue — same root cause, other callers

Grepping every caller of the functions being touched turned up three more:

1. **Video had the identical bug** (`ui_automation_video.py:3353`) *and had never received #379's 429 branch* — a quota hit on `batchAsyncGenerateVideo*` surfaced as "unexpected response shape", losing `Retry-After` and its retryable classification.
2. **`generate_images_batch`** built a bare `GFlowError` with **no remediation at all** when every response failed. It now classifies like the single-prompt path.
3. **Latent pairing bug**: `first_error_status`/`route` were two independent `or` guards, so a first failing response with an empty URL could have its route filled by a *later* response. Status, route, and body are now captured as one coherent triple.

The 400 body is also now logged (`ui_automation.batch_400_body`) like the 403 branch — Flow's real 400 shape on this route is still unconfirmed, and this settles it on the next occurrence.

## Verification status

- [x] `ruff format` + `ruff check` clean
- [x] `pyright src/gflow_cli` — 0 errors, 0 warnings
- [x] 21 new tests green (`tests/api/transports/test_policy_400.py`, `tests/test_incident_generation_requests.py`)
- [x] Regression sweep — **1891 passed**, 4 skipped, across `tests/api`, `tests/cli`, `tests/image_batch`, errors, and diagnostics
- [x] Fixed 13 call-site breakages the sweep exposed (3-tuple stubs in `test_ui_automation_batch.py`, `_seeding_logger` doubles, one 3-tuple unpack)
- [ ] **Not live-verified against Flow.** The classification is pure-Python and fully covered browser-free, but the empirical claim *"a 400 on this route is always policy, never malformation"* rests on the issue's A/B evidence, not on a run through this branch. The new `batch_400_body` log is what will confirm Flow's actual 400 shape.

### One pre-existing failure, not from this branch

The sweep also surfaced `tests/test_self_documenting_errors.py::test_cli_rich_error_handler_renders_remediation`. It is **order-dependent and pre-existing** — `tests/conftest.py:85`'s `install_log_capture` fixture calls `structlog.configure()` globally and never restores it, so any test using it permanently swaps structlog's processors and `emit_error_event` stops rendering to stdout.

Reproduced on clean `develop` at `b4b8a90` with zero local changes:

```
uv run pytest tests/api/test_bearer_redaction.py tests/test_self_documenting_errors.py
# 1 failed, 5 passed
```

CI is green on `develop`, so its ordering doesn't hit this. Left untouched as out of scope — worth its own issue.

Refs #528
