### PR TITLE
test: make structlog configuration test-local, and split a conflated test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,26 @@ from tests.fixtures.doctor_env import healthy_doctor_env  # noqa: F401
 
 
 @pytest.fixture(autouse=True)
+def _isolate_structlog_config() -> Iterator[None]:
+    """Give every test the structlog configuration it started with.
+
+    ``structlog.configure()`` mutates process-global state. ``install_log_capture``
+    (and the inline copies it replaced) called it and never put it back, so the
+    FIRST test to capture logs silently switched the whole rest of the session
+    from "render to stdout" to "collect into a list". Any later test asserting on
+    rendered log output then passed or failed purely on collection order — the
+    code under test behaving identically either way.
+
+    Same contract as :func:`_isolate_settings`: snapshot before, restore after, so
+    no test can inherit or leak logging configuration. A test that needs a
+    specific configuration must establish it itself.
+    """
+    saved = structlog.get_config().copy()
+    yield
+    structlog.configure(**saved)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Redirect GFLOW_CLI_HOME and GFLOW_CLI_DB_PATH to per-test tmp dirs.
 
@@ -66,7 +86,7 @@ def _isolate_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterat
 
 
 @pytest.fixture
-def install_log_capture() -> structlog.testing.LogCapture:
+def install_log_capture() -> Iterator[structlog.testing.LogCapture]:
     """Install a fresh structlog ``LogCapture`` processor + ``merge_contextvars``.
 
     Use as a fixture argument::
@@ -87,4 +107,8 @@ def install_log_capture() -> structlog.testing.LogCapture:
         processors=[structlog.contextvars.merge_contextvars, cap],
         cache_logger_on_first_use=False,
     )
-    return cap
+    yield cap
+    # Explicit teardown even though _isolate_structlog_config already restores
+    # the snapshot: a fixture that mutates global state should undo it at its own
+    # boundary, not rely on a sibling fixture's ordering.
+    structlog.reset_defaults()

--- a/tests/test_self_documenting_errors.py
+++ b/tests/test_self_documenting_errors.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import structlog
 
 from gflow_cli._cli_helpers import _handle_gflow_error
 from gflow_cli.api.client import _raise_for_non_retryable
@@ -100,15 +101,43 @@ def test_json_error_payload_carries_remediation_hint() -> None:
     assert len(payload["error"]["remediation_hint"]) > 0
 
 
-def test_cli_rich_error_handler_renders_remediation(capsys: pytest.CaptureFixture[str]) -> None:
-    """Verify that _cli_helpers renders remediation hints to stdout/stderr."""
-    exc = WireFormatError(
+def _wire_format_exc() -> WireFormatError:
+    return WireFormatError(
         detail="Invalid parameter payload",
         remediation_hint="Check request payload parameters or retry with a simpler prompt text.",
     )
-    code = _handle_gflow_error(exc, cli_command="test")
+
+
+def test_cli_rich_error_handler_renders_remediation(capsys: pytest.CaptureFixture[str]) -> None:
+    """The rich CONSOLE channel renders title, detail and remediation.
+
+    Split from the log-event assertion below. These are two channels:
+    ``_handle_gflow_error`` prints the human-facing lines through the rich
+    console (always, unconditionally) AND emits a structured ``error_raised``
+    event through structlog (whose destination is process-global config). The
+    original single test scraped stdout for both, so the half that read the log
+    event passed or failed on test ORDER — the class name appears nowhere in the
+    console output.
+    """
+    code = _handle_gflow_error(_wire_format_exc(), cli_command="test")
     captured = capsys.readouterr()
 
     assert code == 7
-    assert "WireFormatError" in captured.out
+    assert "Unexpected response shape from Flow" in captured.out
+    assert "Invalid parameter payload" in captured.out
     assert "Check request payload parameters" in captured.out
+
+
+def test_cli_error_handler_emits_error_class_event(
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """The structured LOG channel carries the concrete error class.
+
+    Asserts on the captured event dict rather than scraping rendered stdout, so
+    the result cannot depend on how structlog happens to be configured.
+    """
+    _handle_gflow_error(_wire_format_exc(), cli_command="test")
+
+    events = [e for e in install_log_capture.entries if e["event"] == "error_raised"]
+    assert events, "expected an error_raised event"
+    assert events[0]["error_class"] == "WireFormatError"


### PR DESCRIPTION
## Summary

`install_log_capture` called `structlog.configure()` — process-global state — and never restored it. The first test to capture logs switched the rest of the session from "render to stdout" to "collect into a list", so later tests asserting on rendered log output passed or failed purely on collection order, with the code under test behaving identically either way.

Reproducible on a clean tree before this branch:

```
pytest tests/api/test_bearer_redaction.py tests/test_self_documenting_errors.py   # 1 failed
pytest tests/test_self_documenting_errors.py                                      # 6 passed
```

## Three defects, not one

A restore alone would have fixed only the first.

**1. No teardown.** The fixture used `return`, so it never undid its mutation. Now `yield` + explicit reset — a fixture that mutates global state should undo it at its own boundary, not rely on a sibling fixture's ordering.

**2. No isolation guarantee.** Even with a restore, nothing structurally stopped the next fixture doing the same. `conftest.py` already had the correct pattern for the settings singleton — `_isolate_settings` is autouse and resets *before and after* every test — but logging never received the equivalent. Added `_isolate_structlog_config` with the same contract, so no test can inherit or leak logging configuration regardless of who misbehaves.

**3. Two tests fused into one.** `_handle_gflow_error` writes to two independent channels:

| Channel | Produces | Depends on global config? |
|---|---|---|
| `emit_error_event` → structlog | `error_class=WireFormatError` | **Yes** |
| `_console.print` → rich | title, detail, remediation | No — unconditional |

`test_cli_rich_error_handler_renders_remediation` scraped `capsys` stdout and asserted against **both**. `"WireFormatError"` appears nowhere in the console output (`exc.title` is `"Unexpected response shape from Flow"`), so that assertion could only ever be satisfied by the log channel. One assertion was order-dependent, the other was not, and they shared a test.

Now split:
- **console test** — asserts title, detail and remediation on stdout. Rich prints unconditionally, so there is no hidden dependency.
- **log test** — asserts `error_class` on the **captured event dict**, not scraped text.

The split matters more than the restore. Restoring config fixes this instance; asserting on structured data instead of rendered stdout removes the whole category.

## Verification

- [x] Deterministic across three orderings — poisoner-first (the order that failed before), victim-first, victim alone. All green.
- [x] Full non-e2e suite with the autouse fixture active: **3371 passed, 5 skipped, 0 failed**. Nothing was secretly relying on the leaked config — the real risk of adding an autouse fixture.
- [x] `ruff format` + `ruff check` clean

## Note on scope

Test-suite only. No `src/` changes, so nothing ships to users.

Closes #576