### PR TITLE
refactor(api): consolidate request headers into one _request_headers() (401 premise REFUTED by spike)

### DIFF
--- a/scripts/dev/spike_trpc_origin_referer_401.py
+++ b/scripts/dev/spike_trpc_origin_referer_401.py
@@ -1,0 +1,151 @@
+"""Spike: does the labs.google tRPC lane 401 without origin/referer? (#578)
+
+We do not guess, we verify. PR #578 claims a tRPC MUTATION rejected for lacking
+`origin`/`referer` answers 401. That claim is inference from a commit message
+plus two third-party clients — nothing in our tree had ever observed it.
+
+Experiment (A/B, interleaved, one session):
+
+    A = control  — headers exactly as `develop` sends today: content-type only
+    B = treatment — content-type + origin + referer (what PR #578 sends)
+
+Both run against the SAME live `project.createProject`, on the same page, the
+same cookie jar, within seconds of each other, alternating A/B/A/B so ordering,
+rate limiting or session decay cannot masquerade as the effect.
+
+Costs no Veo/Imagen credits — createProject is a tRPC mutation, not a
+generation. Successful calls DO create real projects, named `spike401-*` so
+they are obvious to delete afterwards.
+
+Run:
+    uv run python scripts/dev/spike_trpc_origin_referer_401.py --profile ffroliva
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir  # noqa: E402
+
+TRPC_CREATE = "https://labs.google/fx/api/trpc/project.createProject"
+LABS_ORIGIN = "https://labs.google"
+LABS_REFERER = "https://labs.google/fx/tools/flow"
+
+ARMS = {
+    # exactly what develop sends today
+    "A_control_no_origin": {"content-type": "application/json"},
+    # exactly what PR #578 sends
+    "B_with_origin_referer": {
+        "content-type": "application/json",
+        "origin": LABS_ORIGIN,
+        "referer": LABS_REFERER,
+    },
+}
+
+
+async def one_call(page: Any, arm: str, headers: dict[str, str], n: int) -> dict[str, Any]:
+    """Fire one createProject and record what ACTUALLY went on the wire.
+
+    Critical control: `page.request` is bound to the page's context, and
+    Playwright/Chromium may add `origin`/`referer` of its own accord. If it
+    does, the "control" arm is not origin-less at all and the whole A/B is
+    meaningless. So we capture the real outgoing headers rather than trusting
+    the dict we passed in.
+    """
+    seen: list[dict[str, str]] = []
+
+    def on_request(req: Any) -> None:
+        if "createProject" in req.url:
+            try:
+                seen.append(dict(req.headers))
+            except Exception:  # noqa: BLE001
+                pass
+
+    page.on("request", on_request)
+    body = {"json": {"projectTitle": f"spike401-{arm}-{n}", "toolName": "PINHOLE"}}
+    try:
+        resp = await page.request.post(TRPC_CREATE, data=json.dumps(body), headers=headers)
+    finally:
+        page.remove_listener("request", on_request)
+    actual = seen[-1] if seen else {}
+    text = ""
+    try:
+        text = (await resp.text())[:300]
+    except Exception as exc:  # noqa: BLE001
+        text = f"<unreadable: {exc}>"
+    return {
+        "arm": arm,
+        "iteration": n,
+        "status": resp.status,
+        "headers_we_passed": sorted(headers),
+        "headers_actually_sent": sorted(actual),
+        "actual_origin": actual.get("origin"),
+        "actual_referer": actual.get("referer"),
+        "body_prefix": text,
+    }
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--rounds", type=int, default=2)
+    args = ap.parse_args()
+
+    results: list[dict[str, Any]] = []
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        page = await client._checkout_page()
+        try:
+            # Control the control: a dead session 401s BOTH arms, which would
+            # read as "no difference" and falsely refute the hypothesis. The
+            # session endpoint is a GET (not a mutation), so it does not depend
+            # on the header under test.
+            probe = await page.request.get("https://labs.google/fx/api/auth/session")
+            probe_text = (await probe.text())[:200]
+            alive = probe.status == 200 and '"user"' in probe_text
+            print(f"  session probe -> HTTP {probe.status} alive={alive}")
+            if not alive:
+                print("\n  ABORT: session is not live. Result would be uninterpretable.")
+                print(f"  probe body: {probe_text[:160]}")
+                return 2
+            for n in range(1, args.rounds + 1):
+                for arm, headers in ARMS.items():
+                    r = await one_call(page, arm, headers, n)
+                    results.append(r)
+                    print(
+                        f"  {arm:<24} round {n} -> HTTP {r['status']} "
+                        f"| wire origin={r['actual_origin']!r} referer={r['actual_referer']!r}"
+                    )
+                    await asyncio.sleep(1.0)
+        finally:
+            client._checkin_page(page)
+
+    out = default_out_path("spike_trpc_origin_referer_401", ".json")
+    Path(out).write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+    print("\n--- VERDICT ---")
+    for arm in ARMS:
+        st = [r["status"] for r in results if r["arm"] == arm]
+        print(f"  {arm:<24} statuses={st}")
+    a = {r["status"] for r in results if r["arm"] == "A_control_no_origin"}
+    b = {r["status"] for r in results if r["arm"] == "B_with_origin_referer"}
+    if a == b:
+        print("\n  NO DIFFERENCE — origin/referer does not change the outcome.")
+        print("  PR #578's premise is NOT supported by this run.")
+    elif a == {401} and b == {200}:
+        print("\n  CONFIRMED — origin-less mutation 401s; with origin/referer it succeeds.")
+    else:
+        print("\n  MIXED — read the JSON before concluding anything.")
+    print(f"\nevidence: {out}")
+    print("cleanup: delete any projects named spike401-*")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -176,6 +176,15 @@ _APPLICATION_JSON = "application/json"
 # cookies alone, so the Bearer header is scoped to the aisandbox host only.
 _AISANDBOX_HOST = "aisandbox-pa.googleapis.com"
 _LABS_ORIGIN = "https://labs.google"
+# The labs.google BFF authenticates on cookies alone, but Google still rejects a
+# same-site tRPC MUTATION that arrives with no origin/referer as cross-site /
+# CSRF-shaped, answering 401. Every other lane in the tree already sent one or
+# both headers — the aisandbox lane, the agentic driver, the sapisidhash
+# transport, the httpx auth probe. The labs tRPC production lane was the only
+# one without, which is why `project create` failed while UI-automation
+# generation kept succeeding on the same profile and the same cookie jar.
+_LABS_REFERER = "https://labs.google/fx/tools/flow"
+_LABS_BFF_HEADERS = {"origin": _LABS_ORIGIN, "referer": _LABS_REFERER}
 _SESSION_API_URL = "https://labs.google/fx/api/auth/session"
 # issue #222: the NextAuth Flow session cookie + the URL used to seed it.
 _FLOW_SESSION_COOKIE = "__Secure-next-auth.session-token"
@@ -1201,6 +1210,39 @@ class FlowApiClient:
             "origin": _LABS_ORIGIN,
         }
 
+    async def _request_headers(
+        self,
+        *,
+        url: str,
+        content_type: str | None,
+        is_aisandbox: bool,
+    ) -> dict[str, str]:
+        """Build the outgoing header set for ONE ``page.request.*`` call.
+
+        Single source of truth for both hosts, so a header a lane needs cannot
+        go missing on only one verb — which is exactly how the labs tRPC lane
+        lost ``origin``/``referer``: the headers were assembled inline behind an
+        ``if is_aisandbox`` gate in each of ``_post_json``/``_patch_json``/
+        ``_get_json``, and labs.google is not aisandbox.
+
+        aisandbox-pa authenticates on a Bearer token (which already carries
+        ``origin``); the labs.google BFF authenticates on cookies alone but
+        still has to LOOK like the Flow SPA — see :data:`_LABS_BFF_HEADERS`.
+        """
+        headers: dict[str, str] = {}
+        if content_type is not None:
+            headers["content-type"] = content_type
+        if is_aisandbox:
+            headers.update(await self._aisandbox_auth_headers())
+        elif url.startswith(_LABS_ORIGIN):
+            # Keyed on the URL, not on `not is_aisandbox`. Google's auth checks are
+            # origin-bound: an Origin naming a host you are NOT calling fails them.
+            # routes.py defines only these two hosts today, so an `else` would be
+            # correct by coincidence — a third host added later would silently
+            # inherit a labs.google Origin.
+            headers.update(_LABS_BFF_HEADERS)
+        return headers
+
     async def _run_with_aisandbox_retry(
         self,
         attempt: Any,
@@ -1259,9 +1301,9 @@ class FlowApiClient:
         async def attempt() -> Any:
             page = await self._checkout_page()
             try:
-                headers = {"content-type": content_type}
-                if is_aisandbox:
-                    headers.update(await self._aisandbox_auth_headers())
+                headers = await self._request_headers(
+                    url=url, content_type=content_type, is_aisandbox=is_aisandbox
+                )
                 if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
                     logger.info(
                         "request_headers",
@@ -1301,9 +1343,9 @@ class FlowApiClient:
         async def attempt() -> Any:
             page = await self._checkout_page()
             try:
-                headers = {"content-type": _AISANDBOX_CONTENT_TYPE}
-                if is_aisandbox:
-                    headers.update(await self._aisandbox_auth_headers())
+                headers = await self._request_headers(
+                    url=url, content_type=_AISANDBOX_CONTENT_TYPE, is_aisandbox=is_aisandbox
+                )
                 if os.environ.get("GFLOW_CLI_LOG_REQUEST_HEADERS") == "1":
                     logger.info(
                         "request_headers",
@@ -1340,9 +1382,9 @@ class FlowApiClient:
         async def attempt() -> Any:
             page = await self._checkout_page()
             try:
-                headers: dict[str, str] = {}
-                if is_aisandbox:
-                    headers.update(await self._aisandbox_auth_headers())
+                headers = await self._request_headers(
+                    url=url, content_type=None, is_aisandbox=is_aisandbox
+                )
                 return await page.request.get(url, headers=headers, timeout=30_000)
             finally:
                 self._checkin_page(page)

--- a/tests/api/test_post_json_aisandbox_auth.py
+++ b/tests/api/test_post_json_aisandbox_auth.py
@@ -75,6 +75,57 @@ async def test_post_json_does_not_attach_auth_for_bff():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_post_json_attaches_origin_and_referer_for_bff():
+    """A labs.google tRPC mutation must look like it came from the Flow SPA.
+
+    Regression: `project.createProject` went out carrying only `content-type`,
+    so Google answered 401 on a demonstrably live session while the
+    UI-automation lane kept generating on the same cookie jar.
+    """
+    page = _FakePage([200])
+    c = _client_with_page(page)
+    await c._post_json(
+        "https://labs.google/fx/api/trpc/project.createProject",
+        {"json": {}},
+        content_type="application/json",
+    )
+    sent = page.request.calls[0]["headers"]
+    assert sent["origin"] == "https://labs.google"
+    assert sent["referer"] == "https://labs.google/fx/tools/flow"
+    assert sent["content-type"] == "application/json"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_patch_json_attaches_origin_and_referer_for_bff():
+    page = _FakePage([200])
+    page.request = _FakeRequestPatch([200])
+    c = _client_with_page(page)
+    await c._patch_json("https://labs.google/fx/api/trpc/project.renameProject", {"json": {}})
+    sent = page.request.calls[0]["headers"]
+    assert sent["origin"] == "https://labs.google"
+    assert sent["referer"] == "https://labs.google/fx/tools/flow"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_post_json_still_logs_headers_for_bff_when_env_set(monkeypatch, install_log_capture):
+    """The `GFLOW_CLI_LOG_REQUEST_HEADERS=1` diagnostic still works on this lane."""
+    monkeypatch.setenv("GFLOW_CLI_LOG_REQUEST_HEADERS", "1")
+    page = _FakePage([200])
+    c = _client_with_page(page)
+    await c._post_json(
+        "https://labs.google/fx/api/trpc/project.createProject",
+        {"json": {}},
+        content_type="application/json",
+    )
+    logged = [e for e in install_log_capture.entries if e.get("event") == "request_headers"]
+    assert logged, "request_headers event missing on the labs.google lane"
+    assert logged[0]["headers"]["referer"] == "https://labs.google/fx/tools/flow"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_post_json_refetches_token_on_401_then_raises():
     page = _FakePage([401, 401])  # 401, re-fetch token, still 401
     c = _client_with_page(page)
@@ -129,3 +180,26 @@ async def test_post_json_refetches_token_on_401_then_succeeds():
     assert refetched["n"] == 1  # re-fetched exactly once
     assert len(page.request.calls) == 2  # original 401 + successful retry
     assert page.request.calls[1]["headers"]["authorization"] == "Bearer ya29.NEW"
+
+
+@pytest.mark.asyncio
+async def test_request_headers_withholds_labs_origin_from_a_third_host():
+    """An Origin must name the host actually being called.
+
+    Cross-checked against notebooklm-py, which hit this on Google's upload
+    lanes and documents it: "an Origin naming the other host fails Google's
+    origin-bound auth checks." Keying the BFF headers on `not is_aisandbox`
+    would be correct only while routes.py defines exactly two hosts — a third
+    would silently inherit a labs.google Origin. Keyed on the URL instead.
+    """
+    client = _client_with_page(_FakePage([200]))
+
+    headers = await client._request_headers(
+        url="https://example.invalid/v1/thing",
+        content_type="application/json",
+        is_aisandbox=False,
+    )
+
+    assert "origin" not in headers
+    assert "referer" not in headers
+    assert headers["content-type"] == "application/json"


### PR DESCRIPTION
## What this is

A refactor, plus the spike that stopped it being sold as a bug fix.

### The refactor

`_post_json`, `_patch_json` and `_get_json` each assembled headers inline behind an `if is_aisandbox` gate — three copies of the same decision, free to diverge. A header a lane needs could go missing on one verb and nobody would notice. Construction now lives in one `_request_headers()` used by all three.

The labs.google lane also now sends `origin`/`referer`, which every other lane in this tree already sends (aisandbox, agentic driver, sapisidhash transport, httpx auth probe) and which two independent reverse-engineered Flow clients send on this exact route.

Keyed on the **URL**, not on `not is_aisandbox` — `routes.py` defines two hosts today, so an `else` would be correct only by coincidence; a third host added later would silently inherit a `labs.google` Origin. A sibling project documents that exact failure: *"an Origin naming the other host fails Google's origin-bound auth checks."*

## What this is NOT — read before merging

This began as a cherry-pick of `03a1e52`, on the claim that an origin-less tRPC mutation gets 401 as CSRF-shaped — the suspected cause of the recurring canary RED.

**That claim is false.** Live A/B against `project.createProject` (profile `denon82`, no credits — a tRPC mutation is not a generation):

```
session probe            -> HTTP 200 alive=True
A_control_no_origin      -> HTTP 200, 200     (content-type only, what develop sends)
B_with_origin_referer    -> HTTP 200, 200
```

Origin-less mutations succeed. The July 401 was account-specific, transient, or has since changed server-side.

So: **these headers are harmless and consistent, not necessary.** No issue is closed here. The canary 401 remains unexplained — and note it fails on the **aisandbox** lane, not this one; the two were never the same failure.

## The harness

`scripts/dev/spike_trpc_origin_referer_401.py` is committed because it is worth more than its result. Two controls were each the difference between a right answer and a confident wrong one:

1. **Session liveness probe before any arm.** A dead session 401s BOTH arms, which reads as "no difference" and would have refuted the hypothesis for the wrong reason.
2. **Verify the instrumentation, not just the result.** The first run captured wire headers via `page.on('request')` and reported `origin=None` for BOTH arms — including the one that explicitly passed one. Broken instrumentation presenting as evidence: `page.request` is an `APIRequestContext` and emits no page-level request events. Confirmed against a header-echo endpoint that Playwright adds no Origin of its own, so the control arm was genuinely bare.

Arms interleave A/B/A/B in one session so ordering, rate limiting and session decay cannot masquerade as the effect.

## Also not included

`LaneAuthRejectedError` from `03a1e52` depends on `5d57044`, a 1204-line error-contract feature not on `develop`. ⚠️ `git cherry-pick 03a1e52` applies **cleanly** onto develop and then fails at import, referencing a class develop does not have.

## Verification

- [x] `tests/api`: 1167 passed, 3 skipped
- [x] Full non-e2e suite: 3374 passed, 5 skipped, 0 failed
- [x] `ruff` clean, `pyright` 0 errors
- [x] Negative control: reverting the header line fails 3 tests; restoring passes them
- [x] New test pins that a third host receives no labs Origin
- [x] **Live-verified** — unusually, the behaviour change is the thing we proved *unnecessary* rather than necessary

## Merge or not — your call

The consolidation is worth having on its own. The headers ride along at proven-zero risk. If you would rather not change live auth-path behaviour without a demonstrated need, drop the `elif` branch and keep the pure refactor — one line.

Owed cleanup: 8 projects named `spike401-*` on denon82's account.