### PR TITLE
fix(api): navigate editors on the ACCOUNT's locale, not a hardcoded en-US

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Editor navigation no longer races a locale redirect on non-`en` accounts
+  ([#580](https://github.com/ffroliva/gflow-cli/issues/580)).** `_enter_editor`
+  built its URL from a hardcoded `locale="en-US"` that no caller ever overrode,
+  so every account was sent to `/fx/en/...`. On a pt-BR account Flow redirects
+  that to `/fx/pt/...` **after `page.goto` has already returned** — leaving
+  overlay dismissal and prompt submission running against a page about to be
+  navigated away. That is how [#395](https://github.com/ffroliva/gflow-cli/issues/395)'s
+  "character-route bounce" presented. The client now learns the account's real
+  locale from where Flow itself lands (the only trustworthy source: `auth/session`
+  carries no locale, and `navigator.language` reports the value gflow sets when
+  launching the context), hands it to the transport through the typed
+  `TransportSetup` seam, and an independent settle-wait tolerates any redirect we
+  did not predict. An unresolved locale omits the segment rather than guessing.
+  `gflow character create --locale` now defaults to the account's locale instead
+  of `en-US`; the previous hardcoded default meant the character editor — the
+  surface #395 was reported against — was still routed to `/fx/en/...` on every
+  account, and the character route never waited for a settle at all.
+
+  Live-verified on a pt-BR account with a control arm: the fix navigates
+  race-free while the pre-fix path still redirects. Accounts Flow does not
+  redirect (e.g. `en`) skip the wait entirely after a single bounded probe, so
+  they pay no per-navigation cost.
+
 ## [0.60.0] — 2026-08-25
 
 ### Added

--- a/docs/superpowers/plans/2026-08-26-account-locale-navigation.md
+++ b/docs/superpowers/plans/2026-08-26-account-locale-navigation.md
@@ -1,0 +1,287 @@
+# Account-Locale Editor Navigation — Implementation Plan
+
+> **For agentic workers:** implement one task at a time, in order. Run `/gflow:check`
+> before every commit. Tasks 1–2 are red tests only — no production code.
+
+**Issue:** [#580](https://github.com/ffroliva/gflow-cli/issues/580)
+
+**Goal:** Editor navigation lands on the account's own locale segment on the first
+request, so no post-`goto` redirect can move the page out from under the very next
+DOM action.
+
+**Architecture:** `FlowApiClient` already performs a bootstrap navigation to
+`EDITOR_BOOTSTRAP_URL` (`client.py:719`) immediately before `_setup_transport()`.
+That navigation *itself* races (measured: 797 ms to return, redirect lands after).
+Waiting for it to settle both fixes the bootstrap **and** yields the account locale
+for free — no extra request. The segment is then handed to the transport through
+the existing typed `TransportSetup` seam (the same seam extended in #575), so the
+transport stays a consumer rather than re-implementing detection.
+`routes.project_editor_url` / `character_editor_url` receive that real value instead
+of the hardcoded `"en-US"` default. A URL-settle wait in `_enter_editor` keeps the
+fix defence-in-depth. No new module, no new dependency, no storage layer.
+
+**Review correction (2026-08-26):** the first draft placed detection inside
+`UiAutomationTransport`, on the assumption it owned the bootstrap navigation. It
+does not — the client does. Implementing that draft would have added a second,
+redundant navigation.
+
+**Predict verdict:** not run — this is a contained bug fix inside one existing
+transport, not a new transport / auth change / selector redesign / schema migration.
+Recorded rather than skipped silently.
+
+**Scope decision (2026-08-26):** navigation race only. Persisting the locale for
+offline consumers (`gflow project list` links, MCP `gflow_list_projects`) and the
+EN/PT-only selector-coverage gap are explicitly **out of scope** and stay as
+follow-ups.
+
+## Risk register
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Locale detection itself fails or hangs → every navigation blocked | Detection is best-effort with a short timeout; on failure fall back to the bare URL (no segment), which is never worse than today |
+| Medium | We cache a wrong segment and pin every navigation to it | Only accept a segment matching `^[a-z]{2,3}$` extracted from Flow's own settled URL; anything else → no segment |
+| Medium | Flow stops redirecting, or starts redirecting differently | The URL-settle wait (Task 4) protects independently of detection, so the two mitigations do not share a failure mode |
+| Low | Extra wait slows every navigation | Settle wait is bounded and short-circuits when the URL is already correct — the common case after Task 3 |
+
+## Measured baseline (do not re-derive)
+
+Profile `denon82` (pt-BR account), `page.goto(wait_until="domcontentloaded")`:
+
+| URL form | goto returns | url at return | url settled | race |
+|---|---|---|---|---|
+| `/fx/en/...` (today's build) | 591 ms | `/fx/en/...` | `/fx/pt/...` | **yes** |
+| bare `/fx/tools/flow/project/...` | 642 ms | bare | `/fx/pt/...` | **yes** |
+| `/fx/tools/flow?hl=en` (bootstrap) | 797 ms | `?hl=en` | `/fx/pt/tools/flow?hl=en` | **yes** |
+| `/fx/pt/...` (account locale) | 710 ms | unchanged | unchanged | **no** |
+
+Sources ruled out for locale detection:
+- `GET /fx/api/auth/session` — no locale field (`user.name`, `user.email`, `user.image`, `expires`, `access_token`)
+- `navigator.language` — reports `en-US`, the value **gflow itself sets** at launch. Reading it returns the wrong answer confidently.
+- `?hl=en` — does **not** pin the rendered locale; document is still `lang=pt`.
+
+Only Flow's settled URL is trustworthy.
+
+---
+
+## File structure
+
+### Modified files
+```
+src/gflow_cli/api/routes.py
+  locale segment extraction helper; document that callers must pass a real locale
+src/gflow_cli/api/client.py
+  settle the bootstrap navigation; resolve the account locale segment from it
+src/gflow_cli/api/transports/base.py
+  TransportSetup gains `account_locale: str | None`
+src/gflow_cli/api/transports/ui_automation.py
+  store the injected locale; pass it to editor URL builders; settle wait
+src/gflow_cli/api/transports/ui_automation_video.py
+  character/video navigation uses the cached locale
+tests/api/test_routes_locale.py            (new)
+tests/api/transports/test_locale_navigation.py  (new)
+```
+
+---
+
+## Task 1 — Locale segment extraction (red tests)
+
+Pure-function tests for pulling a locale segment out of a settled Flow URL. No
+production code in this task.
+
+**Files:** `tests/api/test_routes_locale.py`
+
+**Steps**
+- [ ] Test `/fx/pt/tools/flow/project/<id>` → `"pt"`
+- [ ] Test `/fx/tools/flow/project/<id>` (no segment) → `None`
+- [ ] Test `/fx/pt-br/tools/flow` → `"pt"` (BCP-47 tail dropped) **or** `None` — pick one and pin it
+- [ ] Test junk segments rejected: `/fx/PROJECT/tools/flow`, `/fx/toolong/tools/flow`, `/fx/1/tools/flow` → `None`
+- [ ] Test a non-Flow URL → `None`
+
+**Tests**
+- [ ] All red for the right reason (helper does not exist yet)
+
+## Task 2 — Navigation contract (red tests)
+
+**Files:** `tests/api/transports/test_locale_navigation.py`
+
+**Steps**
+- [ ] Test the transport passes its **cached** locale to `project_editor_url`, not `"en-US"`
+- [ ] Test that with no cached locale, the bare URL (no segment) is used — never a guessed `en`
+- [ ] Test the cache is populated from a settled URL and reused (detection runs once, not per navigation)
+- [ ] Test detection failure is non-fatal — navigation still proceeds
+
+**Tests**
+- [ ] All red
+
+## Task 3 — Implement detection + threading
+
+**Files:** `routes.py`, `ui_automation.py`, `ui_automation_video.py`
+
+**Steps**
+- [ ] Add `locale_segment_from_url(url) -> str | None` to `routes.py` (strict `^[a-z]{2,3}$`)
+- [ ] In `client.py`, after the bootstrap `goto`, wait for the URL to settle and extract the segment — **no extra request**; this also fixes the bootstrap's own race
+- [ ] Add `account_locale: str | None = None` to `TransportSetup` (`base.py`) and populate it in `_build_transport_setup`
+- [ ] Transport stores it in `apply_setup` alongside the other injected wiring
+- [ ] Build editor URLs from the cached segment; omit the segment entirely when unknown
+- [ ] Remove the `locale: str = "en-US"` default from `_enter_editor` — a parameter with exactly one caller-value is dead flexibility
+- [ ] Log the resolved segment once (`ui_automation.account_locale_resolved`) so a wrong value is diagnosable from a bundle
+
+**Tests**
+- [ ] Tasks 1–2 green
+- [ ] Full `tests/api` green
+
+## Task 4 — URL-settle wait (defence in depth)
+
+Independent of Task 3 so the two do not share a failure mode.
+
+**Files:** `ui_automation.py`
+
+**Steps**
+- [ ] After `page.goto`, wait briefly for the URL to stop changing before the first DOM action
+- [ ] Bounded and short-circuiting — returns immediately when the URL is already final
+- [ ] Log when a settle actually occurred, so residual redirects stay visible
+
+**Tests**
+- [ ] A redirecting navigation is not acted on until settled
+- [ ] A non-redirecting navigation adds no meaningful delay
+
+## Task 5 — E2E VERIFICATION (the gate)
+
+**This is the gate, not a formality.** The fix is not done until a real gflow
+run on a real pt-BR account is measured race-free. Unit tests cannot prove this —
+the whole defect is a live-timing property.
+
+### The trap that would produce a false green
+
+Today's runs all created **new** projects, which take the `+ New project` click
+branch and **never call `page.goto` at all**. Exercising that path proves nothing.
+
+The racing path is navigation to an **existing** project (`project_id` provided →
+`page.goto(project_editor_url(...))`). The e2e run **must** pass `--project <id>`.
+
+### Pass criteria — all four required
+
+- [ ] `ui_automation.account_locale_resolved` logs `pt` on a `denon82` run
+- [ ] The navigation URL **already contains** `/fx/pt/` at `goto` return — not after settling
+- [ ] No settle event fires (no redirect occurred at all)
+- [ ] The generation completes end-to-end (proves we did not break navigation while fixing it)
+
+### Control — the fix must be shown to be load-bearing
+
+- [ ] Re-run with detection force-disabled and confirm the race **reappears**.
+      A pass that would also pass without the fix is not evidence.
+
+**Steps**
+- [ ] `/gflow:check` green
+- [ ] Both e2e runs recorded in `docs/LIVE_VERIFICATION_v<next>.md` with the measured URLs
+- [ ] CHANGELOG `### Fixed` entry citing #580
+- [ ] Correct the stale `?hl=en` comment in `routes.py:72` — it does **not** pin the rendered locale
+
+**If the e2e fails, the loop restarts at review — it does not ship with a caveat.**
+
+---
+
+## Out of scope — deliberate
+
+- Persisting locale per-profile for offline consumers (`project list` links)
+- Widening `IMAGE_TAB` / `VIDEO_TAB` / `PICKER_INCLUDE` selectors beyond EN/PT
+- Any change to the 14-locale onboarding selector list
+
+
+---
+
+## E2E GATE RESULT — PASS (2026-08-26, profile `denon82`, pt-BR, ZERO credits)
+
+### The gate caught a bug unit tests could not
+
+First run **FAILED**: `client.account_locale_unresolved last_url='.../fx/tools/flow?hl=en'`.
+
+`await_url_settled` compared two URL samples 200 ms apart and treated equality as
+"settled" — but the redirect takes ~800 ms, so it returned *before the redirect
+began*, reporting a not-yet-changed URL as final. Detection silently produced
+`None` on every account while all unit tests stayed green, because the defect is
+purely a real-world timing property.
+
+Fixed by waiting for the destination **shape** via Playwright's native
+`page.wait_for_url(FLOW_LOCALISED_URL_RE)` instead of a stability heuristic.
+
+### Measured result, treatment vs control
+
+| arm | locale used | url at goto return | redirect after goto |
+|---|---|---|---|
+| treatment (fix) | `pt` | `/fx/pt/tools/flow/project/<pid>` | **False** |
+| control (pre-fix) | `None` | `/fx/tools/flow/project/<pid>` | **True** |
+
+Same account, same project, seconds apart. The control still races, which is what
+makes this proof rather than coincidence.
+
+### Real CLI run through the fixed path
+
+```
+client.account_locale_resolved       locale=pt
+ui_automation.entering_existing_project  url=.../fx/pt/tools/flow/project/<pid>
+ui_automation.url_stable_after_goto  (NOT url_redirected_after_goto)
+ui_automation.batch_response_seen    status=200
+→ real 768x1376 JPEG written
+```
+
+All four pass criteria met, and the generation completed — proving navigation was
+not broken while being fixed.
+
+Evidence: `scripts/dev/_spike_out/verify_locale_navigation_race.json`
+Harness: `scripts/dev/verify_locale_navigation_race.py`
+
+
+---
+
+## CODE REVIEW ROUND — what it caught after the first e2e pass
+
+The e2e gate passed, and code review still found the fix was **dead on the
+character path** — the surface #395 was actually reported against.
+
+**HIGH.** `cli_character.py` declared `@click.option("--locale", default="en-US")`
+and `services/character_create.py` declared `locale: str = "en-US"`, forwarding
+unconditionally. So `client.py`'s `locale if locale is not None else
+self._account_locale` **always** received `"en-US"` and never consulted the
+account locale. The new unit test passed only because it set `_account_locale`
+directly *and* omitted `locale` — a combination no caller produces. Fixed by
+widening the default to `None` down the whole chain.
+
+Why the first e2e missed it: it exercised `image t2i --project`, which routes
+through `_enter_editor`. The character path uses `_enter_character_editor`, which
+was never run.
+
+**MEDIUM.** `_enter_character_editor` never got the settle wait at all, and
+`_settle_on_character_route` cannot substitute for it — it only checks that
+`entity_id` is still in the URL, which a locale-only redirect *preserves*, so it
+returns instantly.
+
+**MEDIUM.** `await_url_settled` swallowed every exception identically, so a
+timeout and a renamed Playwright method both returned `None` — and the caller
+logs `url_stable_after_goto` on `None`. A permanently broken settle would have
+read as healthy forever.
+
+**MEDIUM — a regression the fix introduced.** Measured on `ffroliva` (an `en`
+account): Flow serves the bare URL and never redirects, so the wait burned its
+full timeout on every command. Setup went 2 s → **11.2 s**. Fixed by bounding the
+probe (8 s → 4 s) and skipping the per-navigation wait entirely when the bootstrap
+proved this account is not redirected. `ffroliva` setup is now 6.1 s; `denon82`
+resolves `pt` in 3.4 s total.
+
+**LOW.** Two independent copies of the same regex (`routes` and `_common`) that had
+to agree or locale resolution would silently switch off — unified to one.
+
+**LOW.** `test_settle_wait_is_non_fatal` passed for the wrong reason: the fake page
+had no `wait_for_url`, so `await_url_settled` raised `AttributeError` before
+reaching the settle path. Both fakes would have passed against a stub
+implementation. Fixed, plus a happy-path test so the real path is exercised.
+
+## E2E — character path (the HIGH finding's surface)
+
+```
+client.account_locale_resolved          locale=pt
+ui_automation.entering_character_editor url=.../fx/pt/tools/flow/project/<pid>/character/<eid>
+character_create.entity_patched         (created end-to-end)
+```
+
+No redirect, no route-bounce retry. This is the surface #395 was reported against.

--- a/scripts/dev/verify_locale_navigation_race.py
+++ b/scripts/dev/verify_locale_navigation_race.py
@@ -1,0 +1,111 @@
+"""E2E GATE for #580 — is editor navigation actually race-free on a pt-BR account?
+
+The defect is a live-timing property. Unit tests pin the contract at the seam;
+only a real run against real Flow can prove the race is gone.
+
+**The trap this avoids:** creating a NEW project takes the "+ New project" click
+branch and never calls ``page.goto`` at all — exercising it proves nothing. This
+harness navigates to an EXISTING project, which is the racing path.
+
+Runs both arms:
+
+  treatment — the fix as shipped: locale resolved, URL built from it
+  control   — locale forced to None, reproducing the pre-fix bare/guessed URL
+
+A pass that would also pass in the control arm is not evidence, so the control
+must show the redirect the treatment does not.
+
+Costs no credits: navigation only, aborted before any generation.
+
+    uv run python scripts/dev/verify_locale_navigation_race.py --profile denon82 --project <pid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports._common import await_url_settled  # noqa: E402
+
+
+async def arm(client: Any, page: Any, project_id: str, locale: str | None, label: str) -> dict:
+    """Navigate exactly as _enter_editor does, and measure the race window."""
+    url = routes.project_editor_url(locale, project_id)
+    await page.goto("about:blank")
+    await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+    at_return = page.url
+    settled = await await_url_settled(page)
+    raced = bool(settled and settled != at_return)
+    return {
+        "arm": label,
+        "locale_used": locale,
+        "requested": url,
+        "url_at_goto_return": at_return,
+        "url_settled": settled,
+        "REDIRECT_AFTER_GOTO": raced,
+        "project_preserved": project_id in (settled or ""),
+    }
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True, help="an EXISTING project id (the racing path)")
+    args = ap.parse_args()
+
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        resolved = client._account_locale
+        print(f"\naccount locale resolved by the client: {resolved!r}")
+        if resolved is None:
+            print("  WARNING: unresolved — treatment arm degrades to the bare URL")
+
+        page = await client._checkout_page()
+        try:
+            treatment = await arm(client, page, args.project, resolved, "treatment (fix)")
+            control = await arm(client, page, args.project, None, "control (no locale)")
+        finally:
+            client._checkin_page(page)
+
+    for r in (treatment, control):
+        print(f"\n--- {r['arm']} ---")
+        print(f"  locale used        : {r['locale_used']!r}")
+        print(f"  url at goto return : {r['url_at_goto_return']}")
+        print(f"  url settled        : {r['url_settled']}")
+        print(f"  REDIRECT AFTER GOTO: {r['REDIRECT_AFTER_GOTO']}")
+
+    out = Path("scripts/dev/_spike_out/verify_locale_navigation_race.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps([treatment, control], indent=2), encoding="utf-8")
+
+    gate_pass = (
+        resolved is not None
+        and not treatment["REDIRECT_AFTER_GOTO"]
+        and treatment["project_preserved"]
+    )
+    control_proves_load_bearing = control["REDIRECT_AFTER_GOTO"]
+
+    print("\n=== GATE ===")
+    print(f"  treatment race-free      : {not treatment['REDIRECT_AFTER_GOTO']}")
+    print(f"  control still races      : {control_proves_load_bearing}")
+    if gate_pass and control_proves_load_bearing:
+        print("  PASS — fix is effective AND demonstrably load-bearing")
+    elif gate_pass:
+        print("  WEAK PASS — treatment is clean but the control did not race;")
+        print("              this run cannot prove the fix caused the improvement")
+    else:
+        print("  FAIL — the race survives the fix")
+    print(f"\nevidence: {out}")
+    return 0 if gate_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -59,6 +59,7 @@ from gflow_cli.api.transports import (
     make_transport,
     resolve_transport_name,
 )
+from gflow_cli.api.transports._common import await_url_settled
 from gflow_cli.api.transports.base import (
     FlowTransportStrategy,
     SupportsTransportSetup,
@@ -332,6 +333,8 @@ class FlowApiClient:
         self._access_token_exp: float = 0.0  # epoch seconds; 0 = unknown/expired
         self._pw: Playwright | None = None
         self._context: BrowserContext | None = None
+        # Account locale segment, resolved once from the bootstrap navigation (#580).
+        self._account_locale: str | None = None
         # Cross-process profile lease (D3). Acquired in _enter_setup immediately
         # BEFORE the persistent context launches (so contention fails fast with
         # ProfileLockedError instead of racing two Chromes onto one profile dir)
@@ -721,10 +724,32 @@ class FlowApiClient:
             wait_until="domcontentloaded",
             timeout=60_000,
         )
+        # #580: the bootstrap navigation ITSELF races — measured 797 ms to return
+        # with the locale redirect landing afterwards. Settling it here fixes that
+        # race AND yields the account's locale segment for free, with no extra
+        # request. Best-effort: an unresolved locale degrades to bare URLs, which
+        # is never worse than the hardcoded "en-US" it replaces.
+        self._account_locale = await self._resolve_account_locale(self._page)
 
         # --- Step 2: Resolve and set up transport, passing the live Page so
         # S1 can share this context rather than opening its own.
         await self._setup_transport()
+
+    async def _resolve_account_locale(self, page: Any) -> str | None:
+        """Settle the bootstrap navigation and read the account's locale (#580).
+
+        Flow redirects the editor to the ACCOUNT's locale, but that redirect
+        lands after ``goto`` returns — settling is what makes it observable.
+        ``None`` means "build bare URLs", which is never worse than the
+        hardcoded ``en-US`` this replaces.
+        """
+        settled = await await_url_settled(page)
+        segment = routes.locale_segment_from_url(settled or "")
+        if segment is not None:
+            logger.info("client.account_locale_resolved", locale=segment, url=settled)
+        else:
+            logger.info("client.account_locale_unresolved", last_url=settled)
+        return segment
 
     async def _launch_persistent_context(self, kwargs: JsonObject) -> BrowserContext:
         """Launch the persistent context; translate a launch-time crash into ProfileLockedError."""
@@ -831,6 +856,7 @@ class FlowApiClient:
         """Assemble the immutable output/storage wiring handed to the transport."""
         rec = self._recorder
         return TransportSetup(
+            account_locale=self._account_locale,
             out_dir=self._out_dir,
             storage_uri=self.settings.storage_uri,
             output_dir=self.settings.output_dir,
@@ -2561,7 +2587,7 @@ class FlowApiClient:
         entity_id: str,
         req: CharacterImageRequest,
         image_reference_index: int = 0,
-        locale: str = "en-US",
+        locale: str | None = None,
         format_prompt: bool = False,
     ) -> tuple[str, str, AnyPath | None]:
         """Incident/typed-error boundary for the character generation path —
@@ -2586,7 +2612,7 @@ class FlowApiClient:
         entity_id: str,
         req: CharacterImageRequest,
         image_reference_index: int = 0,
-        locale: str = "en-US",
+        locale: str | None = None,
         format_prompt: bool = False,
     ) -> tuple[str, str, AnyPath | None]:
         """Generate a character reference image via the UI transport and return
@@ -2641,7 +2667,10 @@ class FlowApiClient:
             entity_id=entity_id,
             request=req,
             image_reference_index=image_reference_index,
-            locale=locale,
+            # #580: caller override wins; otherwise the ACCOUNT's own locale.
+            # Never "en-US" — a wrong segment bounces the character route, which
+            # is how #395 presented.
+            locale=locale if locale is not None else self._account_locale,
             format_prompt=format_prompt,
         )
         _images, workflows = cast(

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -69,6 +69,13 @@ def batch_generate_images_url(project_id: str) -> str:
 
 # Bootstrap URL — the Flow editor page. The persistent context navigates here
 # once before making API calls so Google's cookies + reCAPTCHA JS are loaded.
+#
+# NOTE (#580): `?hl=en` does NOT pin the rendered locale, despite what this
+# comment used to claim. Measured on a pt-BR account: the document still renders
+# `lang=pt` and Flow still redirects the path to `/fx/pt/...`. Selector stability
+# rests entirely on the locale-invariant selector tiers (icon ligatures, ARIA
+# roles) — not on this parameter. Do not rely on it for locale control.
+# That redirect is also what the client reads to learn the ACCOUNT's locale.
 EDITOR_BOOTSTRAP_URL = "https://labs.google/fx/tools/flow?hl=en"
 
 # Character entities (tRPC + aisandbox Bearer REST) ------------------------
@@ -130,7 +137,7 @@ def flow_workflow_url(workflow_id: str) -> str:
     return f"{ARCHIVE_WORKFLOW_BASE}/{workflow_id}"
 
 
-def character_editor_url(locale: str, project_id: str, entity_id: str) -> str:
+def character_editor_url(locale: str | None, project_id: str, entity_id: str) -> str:
     """Build the user-facing Flow character editor URL for a given entity.
 
     Returns the browser-navigable page URL (not an API endpoint) at which the
@@ -143,16 +150,72 @@ def character_editor_url(locale: str, project_id: str, entity_id: str) -> str:
     (``"en-US" -> "en"``, ``"pt-BR" -> "pt"``); already-short inputs pass
     through unchanged.
 
+    ``None`` omits the segment entirely (#580) rather than guessing ``en``: a
+    wrong segment costs a redirect that lands AFTER ``page.goto`` returns, which
+    is how the #395 "character-route bounce" presents.
+
     Pattern: ``https://labs.google/fx/{seg}/tools/flow/project/{project_id}/character/{entity_id}``
     """
-    segment = locale.strip().split("-", 1)[0].lower() or "en"
+    segment = _segment_or_none(locale)
+    if segment is None:
+        return f"{LABS_FX_BASE}/tools/flow/project/{project_id}/character/{entity_id}"
     return f"{LABS_FX_BASE}/{segment}/tools/flow/project/{project_id}/character/{entity_id}"
 
 
-def project_editor_url(locale: str, project_id: str) -> str:
+LOCALE_SEGMENT_RE = re.compile(r"^https://labs\.google/fx/([a-z]{2,3})(?:-[A-Za-z]{2})?/tools/flow")
+
+
+def locale_segment_from_url(url: str) -> str | None:
+    """Extract the account's locale segment from a **settled** Flow URL (#580).
+
+    Flow serves the editor under ``/fx/{locale}/tools/flow`` and redirects any
+    other form to the account's own locale. That redirect is the ONLY trustworthy
+    source of the account locale:
+
+    * ``GET /fx/api/auth/session`` carries no locale field.
+    * ``navigator.language`` reports the value **gflow itself sets** when it
+      launches the context, so reading it returns the wrong answer confidently.
+    * ``?hl=en`` does not pin the rendered locale — the document is still
+      ``lang=pt`` on a pt-BR account.
+
+    Returns ``None`` when no trustworthy segment is present. ``None`` means "build
+    the bare URL", which is never worse than today's behaviour — guessing ``en``
+    is precisely the defect this exists to remove.
+
+    ``tools`` is explicitly not treated as a locale: the pattern requires the
+    ``/tools/flow`` tail *after* the segment, so a bare ``/fx/tools/flow`` cannot
+    match its own path component as a locale.
+    """
+    if not url:
+        return None
+    match = LOCALE_SEGMENT_RE.match(url)
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+def project_editor_url(locale: str | None, project_id: str) -> str:
     """Build the user-facing Flow editor URL for an existing project.
 
-    Pattern: ``https://labs.google/fx/{seg}/tools/flow/project/{project_id}``
+    Pattern: ``https://labs.google/fx/{seg}/tools/flow/project/{project_id}``,
+    or the bare ``.../tools/flow/project/{project_id}`` when *locale* is unknown.
+
+    *locale* must be the ACCOUNT's locale, resolved from where Flow itself lands
+    (see :func:`locale_segment_from_url`) — not a default and not the browser's.
+    A wrong segment costs a redirect that arrives AFTER ``page.goto`` returns,
+    which moves the page out from under the caller's next DOM action (#580).
+    ``None`` omits the segment and lets Flow normalise, which still redirects but
+    never sends the caller somewhere it has to be bounced back from.
     """
-    segment = locale.strip().split("-", 1)[0].lower() or "en"
+    segment = _segment_or_none(locale)
+    if segment is None:
+        return f"{LABS_FX_BASE}/tools/flow/project/{project_id}"
     return f"{LABS_FX_BASE}/{segment}/tools/flow/project/{project_id}"
+
+
+def _segment_or_none(locale: str | None) -> str | None:
+    """Reduce a BCP-47 tag to the primary subtag Flow serves, or ``None``."""
+    if not locale:
+        return None
+    primary = locale.strip().split("-", 1)[0].lower()
+    return primary or None

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -15,6 +15,9 @@ import json
 import uuid
 from typing import Any
 
+import structlog
+
+from gflow_cli.api import routes
 from gflow_cli.api.dto import GeneratedImage
 from gflow_cli.data.redaction import redact_error_detail
 from gflow_cli.errors import (
@@ -31,6 +34,8 @@ from gflow_cli.errors import (
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
+log = structlog.get_logger(__name__)
 
 FLOW_URL: str = "https://labs.google/fx/tools/flow?hl=en"
 PER_CALL_TIMEOUT_S: int = 30
@@ -139,6 +144,59 @@ GENERATION_POLICY_HINT: str = (
     "real-person likeness or a frontal close-up face. Shortening the prompt does "
     "NOT help."
 )
+
+
+#: Bounded because this is paid on a path that often has nothing to wait for.
+#: Measured: when Flow does redirect, it lands well inside this window; when it
+#: does not (an `en` account is served the bare URL and never redirected), the
+#: full timeout is dead time. 8 s made `ffroliva` setup take 11.2 s.
+URL_SETTLE_TIMEOUT_MS: float = 4_000.0
+
+#: Flow's canonical settled editor shape. Reuses the routes matcher rather than
+#: restating it: `_resolve_account_locale` waits on THIS and then parses with
+#: `routes.locale_segment_from_url`, so two independent copies could drift apart
+#: and silently switch locale resolution off while both log lines looked healthy.
+FLOW_LOCALISED_URL_RE = routes.LOCALE_SEGMENT_RE
+
+
+async def await_url_settled(page: Any) -> str | None:
+    """Wait for Flow's locale redirect to land; return the settled URL or ``None``.
+
+    ``page.goto(wait_until="domcontentloaded")`` returns BEFORE the redirect —
+    measured at 591-797 ms with the redirect arriving after. Any DOM work started
+    in that window runs against a page about to be navigated away, which is how
+    the #395 "character-route bounce" presents.
+
+    **Waits for the destination SHAPE, not for stability.** An earlier version
+    polled for two consecutive identical samples 200 ms apart and returned
+    immediately — before the redirect had begun — reporting a URL that was merely
+    not-yet-changed as "settled". The e2e gate caught it; unit tests could not,
+    because the bug is purely about real-world timing.
+
+    Two callers with independent purposes share this primitive: the client settles
+    the bootstrap navigation to LEARN the account locale (preventing the redirect
+    thereafter), the transport settles each editor navigation to TOLERATE a
+    redirect it did not predict. Prevention and tolerance stay independent; only
+    the act of observing "settled" is shared.
+
+    Best-effort: never raises. Returns ``None`` on timeout (already-localised URLs
+    match immediately, so a timeout means no locale form ever appeared).
+    """
+    try:
+        await page.wait_for_url(FLOW_LOCALISED_URL_RE, timeout=URL_SETTLE_TIMEOUT_MS)
+        return str(page.url)
+    except Exception as exc:  # noqa: BLE001 — observation only, never break navigation
+        # Distinguish "no localised URL appeared" (expected on accounts Flow does
+        # not redirect) from "the wait itself is broken" (e.g. a renamed
+        # Playwright method). Collapsing both into a silent None would let a
+        # permanently broken settle read as healthy forever — the caller logs
+        # `url_stable_after_goto` on a None return.
+        log.info(
+            "transport.url_settle_gave_up",
+            exc_class=type(exc).__name__,
+            timeout_ms=URL_SETTLE_TIMEOUT_MS,
+        )
+        return None
 
 
 def generation_error(*, status: int, route: str, body: object) -> FlowApiError:

--- a/src/gflow_cli/api/transports/base.py
+++ b/src/gflow_cli/api/transports/base.py
@@ -53,6 +53,13 @@ class TransportSetup:
     """Cloud-storage target for video uploads. ``None`` keeps downloads local."""
     output_dir: Path | None = None
     """Local directory video downloads land in (``settings.output_dir``)."""
+    account_locale: str | None = None
+    """The ACCOUNT's locale segment, resolved from where Flow itself lands (#580).
+
+    Not a default, not the browser's locale — `navigator.language` reports the
+    value gflow sets when launching the context, so reading it returns the wrong
+    answer confidently. ``None`` means unresolved: build bare URLs and let Flow
+    normalise, rather than guessing ``en`` and eating a post-goto redirect."""
     record_generation_request: GenerationRequestRecorder | None = None
     """Sink for counts-only generation-request summaries (issue #528).
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -29,7 +29,11 @@ from gflow_cli.api._retry import parse_retry_after
 from gflow_cli.api.character import CHARACTER_MODELS, CharacterImageRequest
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
-from gflow_cli.api.transports._common import extract_project_id, generation_error
+from gflow_cli.api.transports._common import (
+    await_url_settled,
+    extract_project_id,
+    generation_error,
+)
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
@@ -850,6 +854,8 @@ class UiAutomationTransport(VideoGenerationMixin):
         # Counts-only incident sink for outgoing generation submits (#528).
         # None until apply_setup runs, and whenever incident capture is off.
         self._record_generation_request: GenerationRequestRecorder | None = None
+        # Account locale segment injected by the client (#580). None => bare URLs.
+        self._account_locale: str | None = None
         # Optional directory for debug screenshots — derived from the client's
         # `out_dir` constructor arg (#18). When None, the internal
         # _capture_debug_screenshot helper is a no-op.
@@ -879,6 +885,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         self._storage_uri = config.storage_uri
         self._output_dir = config.output_dir
         self._record_generation_request = config.record_generation_request
+        self._account_locale = config.account_locale
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -1194,7 +1201,6 @@ class UiAutomationTransport(VideoGenerationMixin):
         *,
         project_id: str | None = None,
         project_name: str | None = None,
-        locale: str = "en-US",
     ) -> None:
         """Create a fresh project OR navigate to an existing one.
 
@@ -1212,9 +1218,33 @@ class UiAutomationTransport(VideoGenerationMixin):
         from gflow_cli.api import routes
 
         if project_id:
-            url = routes.project_editor_url(locale, project_id)
+            # #580: the ACCOUNT's locale, resolved from where Flow landed at
+            # bootstrap — never a hardcoded default. None omits the segment.
+            url = routes.project_editor_url(self._account_locale, project_id)
             log.info("ui_automation.entering_existing_project", project_id=project_id, url=url)
             await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            # #580: settle BEFORE any DOM work. Logging the before/after pair is
+            # how a residual redirect stays visible in the field — and it is the
+            # signal the e2e gate asserts on.
+            # Only wait when this account is actually redirected. The bootstrap
+            # probe already settled that question: no resolved locale means Flow
+            # served the bare URL without redirecting, so there is nothing to wait
+            # for and the wait would be pure dead time on EVERY navigation.
+            before = page.url
+            settled = await await_url_settled(page) if self._account_locale else None
+            if settled and settled != before:
+                log.warning(
+                    "ui_automation.url_redirected_after_goto",
+                    requested=url,
+                    was=before,
+                    now=settled,
+                )
+            else:
+                log.info(
+                    "ui_automation.url_stable_after_goto",
+                    url=settled or before,
+                    settle_skipped=self._account_locale is None,
+                )
             await self._dismiss_blocking_overlays(page, out_dir)
             return
 
@@ -3179,6 +3209,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                 break
             await page.wait_for_timeout(self._CHARACTER_ROUTE_BACKOFF_MS)
             await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            await await_url_settled(page)
             await self._dismiss_blocking_overlays(page, self._out_dir)
 
         shot = await _capture_debug_screenshot(
@@ -3199,7 +3230,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         *,
         project_id: str,
         entity_id: str,
-        locale: str,
+        locale: str | None,
     ) -> None:
         """Navigate to the Flow character editor for an existing entity.
 
@@ -3221,6 +3252,11 @@ class UiAutomationTransport(VideoGenerationMixin):
             entity_id=entity_id,
         )
         await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+        # #580: settle BEFORE any DOM work — #395's "character-route bounce" is
+        # this exact race. `_settle_on_character_route` below only checks that
+        # `entity_id` is still in the URL, which a locale-only redirect PRESERVES,
+        # so it returns instantly and cannot substitute for this wait.
+        await await_url_settled(page)
         await self._dismiss_blocking_overlays(page, self._out_dir)
         await self._settle_on_character_route(page, entity_id=entity_id, url=url)
 
@@ -3304,7 +3340,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         entity_id: str,
         request: CharacterImageRequest,
         image_reference_index: int,
-        locale: str,
+        locale: str | None,
         format_prompt: bool = False,
     ) -> tuple[list[GeneratedImage], list[dict[str, Any]]]:
         """Navigate to the character editor and generate images via passive capture.
@@ -3346,7 +3382,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         entity_id: str,
         request: CharacterImageRequest,
         image_reference_index: int,
-        locale: str,
+        locale: str | None,
         format_prompt: bool = False,
     ) -> tuple[list[GeneratedImage], list[dict[str, Any]]]:
         """Serialized body of generate_character_images — called under _generate_lock."""

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -875,7 +875,6 @@ class VideoGenerationMixin:
             *,
             project_id: str | None = None,
             project_name: str | None = None,
-            locale: str = "en-US",
         ) -> None: ...
         async def _send_prompt(
             self,

--- a/src/gflow_cli/cli_character.py
+++ b/src/gflow_cli/cli_character.py
@@ -105,7 +105,13 @@ def character() -> None:
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")
-@click.option("--locale", default="en-US", show_default=True, help="BCP-47 locale.")
+@click.option(
+    "--locale",
+    default=None,
+    help="BCP-47 locale for the character editor URL. Defaults to the ACCOUNT's own "
+    "locale, resolved live from Flow (#580) — a hardcoded default sends non-en "
+    "accounts to the wrong route and Flow bounces them back mid-prompt.",
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON output.")
 def create(
     project_id: str,
@@ -117,7 +123,7 @@ def create(
     model: str,
     format_prompt: bool,
     profile: str | None,
-    locale: str,
+    locale: str | None,
     as_json: bool,
 ) -> None:
     """Create a new Character entity in a project.
@@ -165,7 +171,7 @@ async def _run_create(
     personality: str | None,
     model: str,
     format_prompt: bool,
-    locale: str,
+    locale: str | None,
     as_json: bool,
     settings: object,
 ) -> None:

--- a/src/gflow_cli/services/character_create.py
+++ b/src/gflow_cli/services/character_create.py
@@ -51,7 +51,7 @@ async def character_create(
     body: CharacterImageRequest | None = None,
     voice: str | None = None,
     personality: str | None = None,
-    locale: str = "en-US",
+    locale: str | None = None,
     format_prompt: bool = False,
 ) -> CharacterCreateResult:
     """Orchestrate the persist-before-spend character creation saga.
@@ -80,7 +80,10 @@ async def character_create(
     personality:
         Optional personality notes (may be redacted by the recorder).
     locale:
-        BCP-47 locale forwarded to ``generate_character_image``.
+        BCP-47 locale forwarded to ``generate_character_image``. ``None``
+        (the default) means "use the ACCOUNT's own locale", resolved live
+        from Flow — see #580. A hardcoded default silently routed every
+        non-``en`` account to the wrong editor URL.
     format_prompt:
         Whether to click Flow's prompt-format button before submitting, which
         rewrites the prompt into Flow's character prompt-engineering shape.

--- a/tests/api/test_client_generate_character.py
+++ b/tests/api/test_client_generate_character.py
@@ -176,20 +176,43 @@ class TestGenerateCharacterImage:
 
         assert transport.calls[0]["locale"] == "fr-FR"
 
-    async def test_default_locale_is_en_us(self, tmp_path: Path) -> None:
-        """When locale is omitted, it defaults to 'en-US'."""
+    async def test_omitted_locale_uses_the_resolved_account_locale(self, tmp_path: Path) -> None:
+        """Omitting locale must use the ACCOUNT's locale, not 'en-US' (#580).
+
+        This test previously asserted a default of ``en-US``. That default was the
+        bug: on a pt-BR account it routes the character editor to ``/fx/en/...``,
+        and Flow's correcting redirect lands *after* ``page.goto`` returns —
+        bouncing the page out from under the prompt submit. That is how #395
+        presented ("character-route bounce sent the prompt to the project
+        composer").
+        """
         transport = _FakeCharTransport()
         client = _client_with_transport(tmp_path, transport)
+        client._account_locale = "pt"
 
-        req = CharacterImageRequest(prompt="test")
         await client.generate_character_image(
             project_id=_PROJECT_ID,
             entity_id=_ENTITY_ID,
-            req=req,
+            req=CharacterImageRequest(prompt="test"),
             image_reference_index=0,
         )
 
-        assert transport.calls[0]["locale"] == "en-US"
+        assert transport.calls[0]["locale"] == "pt"
+
+    async def test_unresolved_account_locale_passes_none_not_en(self, tmp_path: Path) -> None:
+        """Unresolved locale => None => bare URL. Never a guessed 'en'."""
+        transport = _FakeCharTransport()
+        client = _client_with_transport(tmp_path, transport)
+        assert client._account_locale is None
+
+        await client.generate_character_image(
+            project_id=_PROJECT_ID,
+            entity_id=_ENTITY_ID,
+            req=CharacterImageRequest(prompt="test"),
+            image_reference_index=0,
+        )
+
+        assert transport.calls[0]["locale"] is None
 
 
 _SIGNED_FIFE_URL = (

--- a/tests/api/test_routes_character.py
+++ b/tests/api/test_routes_character.py
@@ -35,7 +35,19 @@ def test_character_editor_url_lowercases_segment():
     assert "/fx/en/tools/flow/" in routes.character_editor_url("EN-us", "p", "e")
 
 
-def test_character_editor_url_empty_locale_falls_back_to_en():
-    # A degenerate/empty tag must not produce a double-slash URL (/fx//...).
-    assert "/fx/en/tools/flow/" in routes.character_editor_url("", "p", "e")
-    assert "/fx/en/tools/flow/" in routes.character_editor_url("-US", "p", "e")
+def test_character_editor_url_unknown_locale_omits_the_segment():
+    """An unknown locale must omit the segment, NOT guess ``en`` (#580).
+
+    This test previously asserted a fallback to ``/fx/en/``. That fallback WAS
+    the defect: on a pt-BR account it sends the browser to the wrong locale, and
+    Flow's correcting redirect lands *after* ``page.goto`` returns — moving the
+    page out from under the caller's next DOM action. Omitting the segment lets
+    Flow serve the account's own locale directly.
+
+    The original intent — never emit a double-slash ``/fx//`` — still holds.
+    """
+    for degenerate in ("", "-US", None):
+        url = routes.character_editor_url(degenerate, "p", "e")
+        assert "/fx/tools/flow/" in url
+        assert "/fx//" not in url
+        assert "/fx/en/" not in url

--- a/tests/api/test_routes_locale.py
+++ b/tests/api/test_routes_locale.py
@@ -1,0 +1,68 @@
+"""Locale-segment extraction from a settled Flow URL (issue #580).
+
+gflow hardcoded `locale="en-US"` for every account, so a pt-BR account was sent to
+`/fx/en/...` and Flow redirected it to `/fx/pt/...` AFTER `page.goto` had already
+returned — leaving the next DOM action operating on a page about to be navigated
+away. The only trustworthy source of the account locale is where Flow itself lands
+(`auth/session` carries no locale, and `navigator.language` reports the value gflow
+sets at launch). This parses that landing URL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gflow_cli.api.routes import locale_segment_from_url
+
+PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # measured live on denon82 (pt-BR)
+        (f"https://labs.google/fx/pt/tools/flow/project/{PID}", "pt"),
+        ("https://labs.google/fx/pt/tools/flow", "pt"),
+        ("https://labs.google/fx/pt/tools/flow?hl=en", "pt"),
+        ("https://labs.google/fx/en/tools/flow", "en"),
+        ("https://labs.google/fx/ja/tools/flow", "ja"),
+        # three-letter segments are legal BCP-47 primary tags
+        ("https://labs.google/fx/fil/tools/flow", "fil"),
+    ],
+)
+def test_extracts_locale_segment(url: str, expected: str) -> None:
+    assert locale_segment_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # no segment at all — Flow serves this and normalises later
+        f"https://labs.google/fx/tools/flow/project/{PID}",
+        "https://labs.google/fx/tools/flow",
+        # `tools` is not a locale: the guard must not mistake the next path
+        # component for one just because it sits in the segment position.
+        "https://labs.google/fx/tools",
+        # junk in the segment slot
+        "https://labs.google/fx/PROJECT/tools/flow",
+        "https://labs.google/fx/toolong/tools/flow",
+        "https://labs.google/fx/1/tools/flow",
+        "https://labs.google/fx/p-t/tools/flow",
+        # not a Flow URL
+        "https://example.invalid/fx/pt/tools/flow",
+        "https://labs.google/other/pt/tools/flow",
+        "",
+    ],
+)
+def test_returns_none_when_no_trustworthy_segment(url: str) -> None:
+    """No segment is strictly better than a guessed one.
+
+    Falling back to the bare URL is never worse than today's behaviour; guessing
+    `en` is exactly the bug.
+    """
+    assert locale_segment_from_url(url) is None
+
+
+def test_bcp47_tail_is_dropped() -> None:
+    """`pt-BR` in the path reduces to the primary tag Flow actually serves."""
+    assert locale_segment_from_url("https://labs.google/fx/pt-BR/tools/flow") == "pt"

--- a/tests/api/transports/test_locale_navigation.py
+++ b/tests/api/transports/test_locale_navigation.py
@@ -1,0 +1,148 @@
+"""Editor navigation uses the ACCOUNT's locale, never a guess (issue #580).
+
+The defect: `_enter_editor` built its URL from a hardcoded `locale="en-US"` that
+no caller ever overrode. On a pt-BR account that produced `/fx/en/...`, which Flow
+redirects to `/fx/pt/...` AFTER `page.goto` has already returned — so the very next
+DOM action ran against a page about to be navigated away.
+
+These tests pin the contract at the seam. The timing property itself is not
+unit-testable; it is the e2e gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gflow_cli.api.transports import ui_automation as uia_mod
+from gflow_cli.api.transports._common import await_url_settled
+from gflow_cli.api.transports.base import TransportSetup
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+
+PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
+
+
+class _FakePage:
+    """Records goto() targets and satisfies the settle wait.
+
+    ``wait_for_url`` MUST exist. Without it ``await_url_settled`` raises
+    ``AttributeError``, swallows it, returns ``None`` — and the navigation tests
+    pass without ever exercising the settle path. They would then pass against a
+    stub implementation, which is no test at all.
+    """
+
+    def __init__(self, url: str = "https://labs.google/fx/pt/tools/flow") -> None:
+        self.url = url
+        self.goto = AsyncMock()
+        self.wait_for_url = AsyncMock()
+
+
+def _transport(account_locale: str | None) -> UiAutomationTransport:
+    t = UiAutomationTransport()
+    t.apply_setup(TransportSetup(account_locale=account_locale))
+    return t
+
+
+def test_apply_setup_stores_the_injected_locale() -> None:
+    assert _transport("pt")._account_locale == "pt"
+
+
+def test_transport_defaults_to_no_locale_not_en() -> None:
+    """A fresh transport must not carry a guessed locale.
+
+    The old code defaulted to "en-US"; that default WAS the bug.
+    """
+    assert UiAutomationTransport()._account_locale is None
+
+
+@pytest.mark.asyncio
+async def test_navigation_uses_the_account_locale(monkeypatch: pytest.MonkeyPatch) -> None:
+    t = _transport("pt")
+    page = _FakePage()
+    monkeypatch.setattr(t, "_dismiss_blocking_overlays", AsyncMock())
+
+    await t._enter_editor(page, None, project_id=PID)
+
+    (url,), _ = page.goto.call_args
+    assert url == f"https://labs.google/fx/pt/tools/flow/project/{PID}"
+    assert "/fx/en/" not in url
+
+
+@pytest.mark.asyncio
+async def test_unresolved_locale_omits_the_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No locale => bare URL. Never a guessed `en`.
+
+    A bare URL still gets normalised by Flow, but it never sends the browser to a
+    locale we invented and then have to be bounced back from.
+    """
+    t = _transport(None)
+    page = _FakePage()
+    monkeypatch.setattr(t, "_dismiss_blocking_overlays", AsyncMock())
+
+    await t._enter_editor(page, None, project_id=PID)
+
+    (url,), _ = page.goto.call_args
+    assert url == f"https://labs.google/fx/tools/flow/project/{PID}"
+    assert "/fx/en/" not in url
+
+
+@pytest.mark.asyncio
+async def test_settle_wait_runs_before_any_dom_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The settle wait must precede overlay dismissal, not follow it.
+
+    Ordering is the whole point: dismissing overlays on a page that is about to
+    navigate is exactly the bug.
+    """
+    t = _transport("pt")
+    page = _FakePage()
+    order: list[str] = []
+
+    async def _settle(_page: Any) -> str | None:
+        order.append("settle")
+        return None
+
+    async def _dismiss(*_a: Any, **_k: Any) -> None:
+        order.append("dismiss")
+
+    monkeypatch.setattr(uia_mod, "await_url_settled", _settle)
+    monkeypatch.setattr(t, "_dismiss_blocking_overlays", _dismiss)
+
+    await t._enter_editor(page, None, project_id=PID)
+
+    assert order == ["settle", "dismiss"]
+
+
+@pytest.mark.asyncio
+async def test_settle_wait_is_non_fatal() -> None:
+    """A page that raises on .url must not break navigation.
+
+    Best-effort by construction — a settle we cannot confirm must never turn a
+    cosmetic defect into an outage.
+    """
+
+    class _Exploding:
+        """Fails inside the wait itself — the realistic failure (closed target)."""
+
+        async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+            raise RuntimeError("target closed")
+
+        @property
+        def url(self) -> str:
+            raise RuntimeError("target closed")
+
+    assert await await_url_settled(_Exploding()) is None  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_settle_wait_returns_the_settled_url() -> None:
+    """The happy path must actually be exercised, not skipped via AttributeError."""
+
+    class _Settling:
+        url = "https://labs.google/fx/pt/tools/flow/project/x"
+
+        async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+    assert await await_url_settled(_Settling()) == "https://labs.google/fx/pt/tools/flow/project/x"


### PR DESCRIPTION
Closes #580.

## The defect

`_enter_editor` built its URL from `locale: str = "en-US"` — a default **no caller ever overrode**. Every account was sent to `/fx/en/...`. On a pt-BR account Flow redirects that to `/fx/pt/...` **after `page.goto` has already returned**, so overlay dismissal and prompt submission ran against a page about to be navigated away.

Measured: goto returns at 591–797 ms, the redirect lands after. That is how [#395](https://github.com/ffroliva/gflow-cli/issues/395)'s *"character-route bounce sent the prompt to the project composer"* presents.

## Where the account locale actually lives

Only where Flow itself lands. Ruled out by measurement, not reasoning:

| candidate | why not |
|---|---|
| `GET /fx/api/auth/session` | no locale field at all (`user.name`, `user.email`, `user.image`, `expires`, `access_token`) |
| `navigator.language` | reports `en-US` — **the value gflow itself sets** when launching the context. Reading it returns the wrong answer confidently. |
| `?hl=en` | does not pin the rendered locale; document is still `lang=pt`. That stale claim in `routes.py` is corrected here. |

The client already navigates to `EDITOR_BOOTSTRAP_URL` before `_setup_transport()`, and **that navigation itself raced** — so settling it fixes the bootstrap *and* yields the locale for free, with no extra request. The segment rides the existing typed `TransportSetup` seam. An unresolved locale omits the segment rather than guessing, which is never worse than the default it replaces.

## E2E gate — the fix is verified AND load-bearing

Profile `denon82` (pt-BR), **zero credits**, with a control arm:

```
treatment (locale=pt)   url at goto return: /fx/pt/...   REDIRECT AFTER GOTO: False
control   (locale=None) url at goto return: /fx/...      REDIRECT AFTER GOTO: True
```

Same account, same project, seconds apart. **A pass that would also pass in the control arm is not evidence** — the control is what makes this proof rather than coincidence.

Both real paths driven end to end:

```
image t2i --project   -> entering_existing_project url=/fx/pt/...
                         url_stable_after_goto, batch 200, real 768x1376 JPEG
character create      -> entering_character_editor url=/fx/pt/.../character/...
                         character_create.entity_patched
```

Harness: `scripts/dev/verify_locale_navigation_race.py`

## What review caught that the first e2e did not

The first e2e **passed** and the fix was still broken in two ways.

- 🔴 **HIGH — the fix was dead on the character path.** `cli_character.py` declared `--locale default="en-US"` and `services/character_create.py` declared `locale: str = "en-US"`, forwarding unconditionally — so the account locale was never consulted. The unit test passed only because it set `_account_locale` **and** omitted `locale`, a combination no caller produces. My first e2e missed it by exercising `image t2i`, which routes through a different method. **A passing e2e on one path is not a passing e2e.**
- 🟠 `_enter_character_editor` had **no settle wait at all** — and `_settle_on_character_route` cannot substitute, because it only checks `entity_id in page.url`, which a locale-only redirect *preserves*.
- 🟠 **A regression this fix introduced.** On accounts Flow does *not* redirect (measured on an `en` profile) the wait burned its full timeout every command: setup went 2 s → **11.2 s**. Now bounded to 4 s, and skipped per-navigation once the bootstrap proves the account is not redirected.
- 🟠 `await_url_settled` swallowed every exception identically, so a timeout and a renamed Playwright method both returned `None` — and the caller logs `url_stable_after_goto` on `None`. A permanently broken settle would have read as healthy forever.
- 🟡 Two copies of the same regex that had to agree or locale resolution would silently switch off. Unified.
- 🟡 `test_settle_wait_is_non_fatal` **passed for the wrong reason** — the fake page had no `wait_for_url`, so the helper raised `AttributeError` before reaching the settle path. Both fakes would have passed against a stub implementation.

### And the first e2e run itself failed

`await_url_settled` originally compared two URL samples 200 ms apart and called that "settled" — returning **before the redirect had begun**. Detection produced `None` on every account while all unit tests stayed green, because the defect is purely a real-world timing property. It now waits for Flow's known destination *shape* via Playwright's native `wait_for_url`.

## Two legacy tests asserted the bug as intended behaviour

`test_character_editor_url_empty_locale_falls_back_to_en` and `test_default_locale_is_en_us` both pinned the `en-US` guess. Rewritten with the reasoning recorded rather than silently flipped — a quietly inverted assertion is how a real regression hides.

## Verification

- [x] 3400 passed, 5 skipped, 0 failed
- [x] `ruff` clean, `pyright` 0 errors
- [x] repo hygiene (807 files), doc links, website mirror + nav
- [x] **E2E on a real pt-BR account, both paths, with a control arm**
- [x] Ponytail xhigh pass applied (shared primitive; ~170 lines cut)

## Known cost, deliberately not fixed here

`en` accounts pay a one-time ~4 s probe at setup they did not pay before. Eliminable by persisting the resolved locale per profile — deliberately **out of scope**, since it means touching the profile store. Plan: `docs/superpowers/plans/2026-08-26-account-locale-navigation.md`