### PR TITLE
fix(canary): run the version of run_canary.py that the pull just installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The nightly canary now runs the version of itself that it just pulled
+  ([#582](https://github.com/ffroliva/gflow-cli/issues/582)).** `run_canary.py
+  --pull` fast-forwards the checkout and then keeps executing the copy Python
+  loaded at startup, so every runner change was silently one night late. This was
+  not theoretical: #572 added `-o junit_logging=all` so a preserved RED would
+  carry the structlog line that decides #561, and the next run pulled it and
+  still produced a RED with zero log output — three REDs untriageable, and the
+  failure reads as "the fix did not work". The runner now re-runs itself once
+  when a successful pull changed its own source, guarded by both an env var and
+  a content digest (either alone prevents a loop), via `subprocess.run` rather
+  than `os.execv` so Task Scheduler still sees one process and the real exit code.
+
 - **Editor navigation no longer races a locale redirect on non-`en` accounts
   ([#580](https://github.com/ffroliva/gflow-cli/issues/580)).** `_enter_editor`
   built its URL from a hardcoded `locale="en-US"` that no caller ever overrode,

--- a/docs/superpowers/plans/2026-08-26-canary-reexec-after-pull.md
+++ b/docs/superpowers/plans/2026-08-26-canary-reexec-after-pull.md
@@ -1,0 +1,102 @@
+# Canary self-update takes effect the same night — Implementation Plan
+
+**Goal:** A change to `run_canary.py` takes effect on the run that pulls it, not
+the one after.
+
+## Deconstruct
+
+`run_canary.py --pull` does:
+
+```
+1. Python loads run_canary.py into memory        <- the OLD copy
+2. sync_to_develop() fast-forwards the checkout  <- NEW copy now on disk
+3. run_tiers() uses the in-memory argv           <- still the OLD one
+```
+
+The script updates its own source and then keeps running the version it started
+with. Every runner change is silently one night late.
+
+## Evidence this is real, not theoretical
+
+#572 added `-o junit_logging=all` so a preserved RED would carry the structlog
+line that decides #561. Merged 2026-08-25 12:29 UTC. The 2026-08-26 02:00 run
+pulled it and produced a RED with **zero** log output.
+
+```
+git show 230200b:scripts/canary/run_canary.py | grep -c junit_logging   -> 0
+```
+
+`230200b` is what the clone was running when it started that night. The flag was
+on disk by the time pytest ran and was not used.
+
+Three REDs are untriageable as a direct result, and the failure mode is invisible:
+the natural reading is "#572 did not work", which would prompt rewriting a fix
+that was already correct.
+
+## Develop
+
+Re-run the script once, after a pull that actually changed it.
+
+**Windows constraint (load-bearing).** `os.execv` on Windows does not replace the
+process image the way it does on POSIX — the CRT spawns a new process and
+terminates the current one, so the PID changes. This canary runs under Task
+Scheduler, which would see the original process exit and could treat the task as
+finished. Use `subprocess.run(...)` + `sys.exit(rc)` instead: one supervising
+process, exit code propagated, Task Scheduler semantics unchanged.
+
+**Loop safety (two independent guards).** A canary that re-execs forever is worse
+than one that updates late:
+
+1. An env-var guard (`GFLOW_CANARY_REEXECED`) — set before re-running, checked
+   first. Even a broken digest cannot loop twice.
+2. A digest comparison — no content change, no re-run. This also makes the common
+   case (already current) free.
+
+Either guard alone prevents a loop; both together mean a bug in one is not enough.
+
+## Risk register
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Infinite re-exec loop starves the host | Two independent guards, either sufficient |
+| High | Task Scheduler mis-reads a replaced process | `subprocess.run` + propagate exit code; never `os.execv` |
+| Medium | Re-run doubles wall-clock if it fires spuriously | Digest gate means it fires only on a real change |
+| Low | Digest read fails (file locked) | Treat as "unchanged": update late rather than loop |
+
+## Tasks
+
+### Task 1 — red tests
+- [ ] `_script_digest` is stable across calls and changes with content
+- [ ] Guard env var set => `_maybe_rerun_after_pull` returns without re-running
+- [ ] Digest unchanged => no re-run
+- [ ] Digest changed + no guard => re-runs exactly once, with argv preserved
+- [ ] Unreadable script => no re-run (fail safe, not fail loop)
+
+### Task 2 — implement
+- [ ] Digest before `sync_to_develop()`, check after
+- [ ] `subprocess.run([sys.executable, __file__, *sys.argv[1:]], env=…)`, `sys.exit(rc)`
+- [ ] Log `canary.reexec_after_pull` with both short digests so the swap is visible
+- [ ] Never re-run when the pull was refused (`sync_to_develop` returned a reason)
+
+### Task 3 — E2E GATE
+
+Unit tests cannot prove the real sequence works. Reproduce the actual failure:
+
+- [ ] Put the canary clone on `230200b` (the pre-#572 runner), detached and clean
+- [ ] Run `run_canary.py --pull --dry-run` against `denon82`
+- [ ] **Pass criteria:**
+  - `canary.reexec_after_pull` appears
+  - the run completes exactly once (no loop)
+  - the produced JUnit contains `system-out` — proving the pulled flag was used
+  - `flow_session_cookie_present` is finally present
+- [ ] **Control:** re-run when already current => no re-exec line, still completes
+
+$0 — `e2e_auth` tier only, no credit-spending markers.
+
+### Task 4 — ship
+- [ ] `/gflow:check`, CHANGELOG, PR
+
+## Out of scope
+
+Whether the #561 401 is cookie-absent or cookie-rejected. This plan only makes
+the evidence *reachable*; reading it is the next task.

--- a/scripts/canary/run_canary.py
+++ b/scripts/canary/run_canary.py
@@ -43,6 +43,7 @@ Windows event log with noise nobody reads.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import re
 import shutil
@@ -274,6 +275,57 @@ def publish(issue: int, state: str, body: str, stamp: str, dry_run: bool) -> Non
     print(f"published {state} to issue #{issue}")
 
 
+_REEXEC_GUARD = "GFLOW_CANARY_REEXECED"
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def _script_digest(path: Path = _SCRIPT_PATH) -> str:
+    """SHA-256 of this script, or "" when it cannot be read.
+
+    Unreadable degrades to "unchanged" deliberately: updating one night late is a
+    nuisance, re-running forever is an outage.
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def _maybe_rerun_after_pull(digest_before: str, digest_now: str | None = None) -> None:
+    """Re-run this script once if the pull just changed it.
+
+    `--pull` updates this file and then keeps executing the copy Python loaded at
+    startup, so a runner change only takes effect the FOLLOWING night. #572 added
+    `-o junit_logging=all` to make a RED carry the structlog line that decides
+    #561; the next run pulled it and still produced a log-less RED, because the
+    pre-pull copy was the one running. The failure is invisible — it reads as "the
+    fix did not work".
+
+    Uses `subprocess.run`, never `os.execv`: on Windows execv does not replace the
+    process image (the CRT spawns a new process and terminates this one), so the
+    PID changes and Task Scheduler can read the task as finished. A supervising
+    process keeps the scheduler's view intact and propagates the child's code.
+
+    Two independent loop guards — either is sufficient on its own:
+      1. `_REEXEC_GUARD` in the child's env, checked first here.
+      2. The digest comparison: no content change, no re-run.
+    """
+    if os.environ.get(_REEXEC_GUARD):
+        return
+    now = _script_digest() if digest_now is None else digest_now
+    if not now or not digest_before or now == digest_before:
+        return
+    print(f"canary.reexec_after_pull: {digest_before[:12]} -> {now[:12]}")
+    child_env = dict(os.environ)
+    child_env[_REEXEC_GUARD] = "1"
+    proc = subprocess.run(  # noqa: S603 - our own script, fixed interpreter
+        [sys.executable, str(_SCRIPT_PATH), *sys.argv[1:]],
+        env=child_env,
+        check=False,
+    )
+    raise SystemExit(proc.returncode)
+
+
 def sync_to_develop() -> str | None:
     """Fast-forward the checkout to ``origin/develop`` and refresh deps.
 
@@ -327,7 +379,12 @@ def main() -> int:
         raise SystemExit("--issue (or GFLOW_CANARY_ISSUE) is required; the canary never opens one")
 
     stamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    digest_before = _script_digest() if args.pull else ""
     refused = sync_to_develop() if args.pull else None
+    if args.pull and refused is None:
+        # Only after a SUCCESSFUL pull — a refused sync changed nothing, and
+        # re-running on a refusal would just repeat the refusal.
+        _maybe_rerun_after_pull(digest_before)
     sha = _run(["git", "rev-parse", "--short", "HEAD"]).stdout.strip() or "unknown"
 
     if refused:

--- a/tests/scripts/test_canary_reexec.py
+++ b/tests/scripts/test_canary_reexec.py
@@ -1,0 +1,133 @@
+"""The canary must run the version of itself that it just pulled.
+
+`run_canary.py --pull` updates its own source and then keeps executing the copy
+Python loaded at startup, so every runner change is silently one night late.
+
+That is not theoretical: #572 added `-o junit_logging=all` so a preserved RED
+would carry the structlog line that decides #561. It merged 2026-08-25 12:29 UTC,
+the 2026-08-26 02:00 run pulled it, and that RED still had zero log output —
+because the pre-pull copy (`230200b`, no flag) was the one running. Three REDs are
+untriageable as a result, and the failure reads as "the fix did not work", which
+would prompt rewriting a fix that was already correct.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_RUNNER = Path(__file__).resolve().parents[2] / "scripts" / "canary" / "run_canary.py"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("run_canary_under_test", _RUNNER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def canary() -> Any:
+    return _load()
+
+
+def test_digest_is_stable_and_content_sensitive(canary: Any, tmp_path: Path) -> None:
+    f = tmp_path / "s.py"
+    f.write_text("one", encoding="utf-8")
+    first = canary._script_digest(f)
+    assert first == canary._script_digest(f)
+    f.write_text("two", encoding="utf-8")
+    assert canary._script_digest(f) != first
+
+
+def test_unreadable_script_does_not_trigger_a_rerun(canary: Any, tmp_path: Path) -> None:
+    """Fail SAFE, not fail LOOP.
+
+    A digest we cannot read must degrade to "unchanged" (update late) rather than
+    "changed" (re-run, possibly forever).
+    """
+    assert canary._script_digest(tmp_path / "does-not-exist.py") == ""
+
+
+def test_guard_env_var_prevents_a_second_rerun(
+    canary: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard alone must stop a loop, even if the digest logic is wrong."""
+    monkeypatch.setenv(canary._REEXEC_GUARD, "1")
+    called: list[Any] = []
+    monkeypatch.setattr(canary.subprocess, "run", lambda *a, **k: called.append(a))
+
+    canary._maybe_rerun_after_pull("digest-before", digest_now="totally-different")
+
+    assert called == []
+
+
+def test_unchanged_digest_does_not_rerun(canary: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(canary._REEXEC_GUARD, raising=False)
+    called: list[Any] = []
+    monkeypatch.setattr(canary.subprocess, "run", lambda *a, **k: called.append(a))
+
+    canary._maybe_rerun_after_pull("same", digest_now="same")
+
+    assert called == []
+
+
+def test_changed_digest_reruns_once_with_argv_preserved(
+    canary: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(canary._REEXEC_GUARD, raising=False)
+    monkeypatch.setattr(sys, "argv", ["run_canary.py", "--pull", "--profile", "denon82"])
+    seen: dict[str, Any] = {}
+
+    class _Proc:
+        returncode = 7
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        seen["cmd"] = cmd
+        seen["env"] = kwargs.get("env")
+        return _Proc()
+
+    monkeypatch.setattr(canary.subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit) as exc:
+        canary._maybe_rerun_after_pull("before", digest_now="after")
+
+    # exit code propagates so Task Scheduler still sees the real result
+    assert exc.value.code == 7
+    # the ORIGINAL flags must survive the re-run, or the second pass behaves
+    # differently from the one the operator scheduled
+    assert "--pull" in seen["cmd"]
+    assert "--profile" in seen["cmd"] and "denon82" in seen["cmd"]
+    # and the guard must be set for the child, or it re-runs forever
+    assert seen["env"][canary._REEXEC_GUARD] == "1"
+
+
+def test_rerun_uses_subprocess_not_execv(canary: Any) -> None:
+    """Windows-specific, and load-bearing.
+
+    `os.execv` on Windows does not replace the process image: the CRT spawns a new
+    process and terminates this one, so the PID changes. Under Task Scheduler that
+    can read as "the task finished". A supervising `subprocess.run` keeps one
+    process and propagates the exit code.
+
+    Checks for a CALL, not a mention — the module documents why execv is wrong,
+    so a naive substring search matches its own explanation.
+    """
+    import ast
+
+    tree = ast.parse(_RUNNER.read_text(encoding="utf-8"))
+    calls = {
+        f"{n.func.value.id}.{n.func.attr}"
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and isinstance(n.func.value, ast.Name)
+    }
+    assert not {c for c in calls if c.startswith("os.exec")}, calls
+    assert "subprocess.run" in calls


### PR DESCRIPTION
Closes #582.

## The bug

```
1. Python loads run_canary.py into memory        <- the OLD copy
2. sync_to_develop() fast-forwards the checkout  <- NEW copy now on disk
3. run_tiers() uses the in-memory argv           <- still the OLD one
```

The script updates its own source and then keeps executing the version it started with. **Every runner change was one night late**, and invisibly so.

## What it cost

#572 added `-o junit_logging=all` so a preserved RED would carry the `client.context_cookie_state` line that decides #561. Merged 2026-08-25 12:29 UTC; the 2026-08-26 02:00 run pulled it and produced a RED with **zero** log output.

```
git show 230200b:scripts/canary/run_canary.py | grep -c junit_logging   ->  0
```

Three consecutive REDs untriageable. And the failure reads as *"#572 did not work"* — I was one step from rewriting a fix that was already correct.

**Confirmed #572 is fine:** a manual run on the current runner captured 40 `system-out` entries, 11 `context_cookie_state` lines, and `flow_session_cookie_present`. The stale runner was the whole story.

## The fix

Re-run once when a successful pull changed the script's own source.

**Two independent loop guards, either sufficient alone** — a canary that re-execs forever is worse than one that updates late:
1. `GFLOW_CANARY_REEXECED` in the child env, checked first.
2. A content digest — no change, no re-run.

An unreadable digest degrades to *"unchanged"*: updating late is a nuisance, looping is an outage.

**`subprocess.run`, never `os.execv`** — and this is load-bearing on Windows. `execv` there does not replace the process image; the CRT spawns a new process and terminates this one, so the PID changes and Task Scheduler can read the task as finished. A supervising process keeps the scheduler's view intact and propagates the child's exit code. Asserted by an **AST** test, because a substring search matches the module's own explanation of why execv is wrong.

⚠️ The fix cannot help its own deployment — the first run after it lands is still the old runner. It applies from the following change onward.

## E2E gate — with a control that reproduces the original failure

Scratch clone, real profile, **$0**:

| arm | setup | result |
|---|---|---|
| **control** | clone on the pre-fix runner; pull brings the flag | no re-exec (correct — the old runner cannot know about it) · **JUnit `system-out`: 0** ← reproduces the 02:00 failure exactly |
| **treatment** | clone on the fixed runner; develop ahead with a runner change | `canary.reexec_after_pull: ffd32333cb9b -> fef66243ee51` · pulled runner in place · ran **once**, no loop · **JUnit `system-out`: 42` |

The control is the original bug, reproduced on demand. That is what makes the treatment proof rather than coincidence.

## Verification

- [x] 6 new unit tests (digest stability, both loop guards, argv preserved, exit code propagated, AST no-execv)
- [x] `tests/scripts`: 184 passed
- [x] `ruff check` + `format --check` clean on the touched files and on the canonical `src tests` gate
- [x] repo hygiene (813 files), doc links
- [x] **E2E with a reproducing control arm**

## Also learned tonight

The canary was **GREEN** when run manually at 06:06 UTC — same clone, same commit, same profile as the 02:00 RED. Combined with a manual spike returning 200 at ~20:00 UTC, the #561 401 looks **time-dependent rather than persistent**. Recorded on #561; out of scope here.