### PR TITLE
fix(api): settle the four remaining navigations before acting on the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Four more navigations settle before acting on the page
+  ([#584](https://github.com/ffroliva/gflow-cli/issues/584)).** #580 settled the
+  three sites it touched; an audit of every `page.goto` found four more with the
+  same defect. The worst is `evaluate_fetch.refresh_auth`, which re-navigates to
+  refresh page-context tokens and reported success while the page was still
+  moving. Two more (`evaluate_fetch` setup, `sapisidhash` fingerprint capture)
+  run `page.evaluate` immediately after navigating, where a mid-flight redirect
+  raises "Execution context was destroyed" rather than failing quietly. The
+  fourth (`_enter_editor`'s gallery return) ran `_bypass_onboarding` — real
+  button clicks — on a page about to navigate away. A new AST-based test pins
+  every `goto` to a following settle, so the audit does not have to be redone
+  by hand.
+
 - **The nightly canary now runs the version of itself that it just pulled
   ([#582](https://github.com/ffroliva/gflow-cli/issues/582)).** `run_canary.py
   --pull` fast-forwards the checkout and then keeps executing the copy Python

--- a/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
+++ b/src/gflow_cli/api/transports/experimental/evaluate_fetch.py
@@ -39,6 +39,7 @@ from gflow_cli.api.image import (
 from gflow_cli.api.transports._common import (
     FLOW_URL,
     PER_CALL_TIMEOUT_S,
+    await_url_settled,
     interpret_response,
     mint_batch_id,
 )
@@ -177,6 +178,10 @@ class EvaluateFetchTransport:
             new_page = await ctx.new_page()
             self._page = new_page
             await new_page.goto(FLOW_URL, wait_until="domcontentloaded", timeout=30_000)
+            # #584: this transport's whole job is `page.evaluate` fetch calls.
+            # A locale redirect landing mid-evaluate raises "Execution context
+            # was destroyed", intermittently and unattributably.
+            await await_url_settled(new_page)
             self._setup_done = True
             log.info("evaluate_fetch.setup_done", profile=str(profile_dir))
         except BaseException:
@@ -196,6 +201,9 @@ class EvaluateFetchTransport:
             raise AuthExpiredError(msg)
         try:
             await self._page.goto(FLOW_URL, wait_until="domcontentloaded", timeout=30_000)
+            # #584: do not report auth as refreshed while the page is still
+            # moving — the caller acts on that signal immediately.
+            await await_url_settled(self._page)
             log.info("evaluate_fetch.refresh_auth_done")
         except Exception as exc:
             msg = f"evaluate_fetch: refresh navigation failed: {exc}"

--- a/src/gflow_cli/api/transports/experimental/sapisidhash.py
+++ b/src/gflow_cli/api/transports/experimental/sapisidhash.py
@@ -31,6 +31,7 @@ from gflow_cli.api.image import GenerateImageRequest, _build_batch_generate_imag
 from gflow_cli.api.transports._common import (
     FLOW_URL,
     PER_CALL_TIMEOUT_S,
+    await_url_settled,
     interpret_response,
     mint_batch_id,
 )
@@ -225,6 +226,9 @@ class SapisidhashTransport:
                 try:
                     page = await ctx.new_page()
                     await page.goto(FLOW_URL, wait_until="domcontentloaded", timeout=30_000)
+                    # #584: capture_fingerprint evaluates in the page; a redirect
+                    # mid-capture destroys the execution context.
+                    await await_url_settled(page)
                     fp = await capture_fingerprint(page)
                 finally:
                     await ctx.close()

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1259,6 +1259,12 @@ class UiAutomationTransport(VideoGenerationMixin):
             # readiness gate.
             log.info("ui_automation.navigating_to_gallery", restored_url=page.url)
             await page.goto(FLOW_URL, timeout=45_000)
+            # #584: FLOW_URL is the bare form, which Flow redirects to the
+            # account's locale AFTER goto returns. `_bypass_onboarding` clicks
+            # real buttons — running it mid-redirect clicks a page that is
+            # leaving. The wait_for_timeout below would absorb it, but it comes
+            # after this call, not before.
+            await await_url_settled(page)
             await self._bypass_onboarding(page)
 
         await page.wait_for_timeout(3000)

--- a/tests/api/transports/test_navigation_settled.py
+++ b/tests/api/transports/test_navigation_settled.py
@@ -1,0 +1,94 @@
+"""Every Flow navigation settles before the next action (issues #580, #584).
+
+`page.goto(wait_until="domcontentloaded")` returns BEFORE Flow's locale redirect
+lands — measured 591-797 ms with the redirect after. Whatever runs next operates
+on a page about to be navigated away: overlay clicks land on a leaving page, and
+`page.evaluate` raises "Execution context was destroyed".
+
+#580 settled three sites. An audit found four more, including
+`evaluate_fetch.refresh_auth` — an auth path that reported success while the page
+was still moving.
+
+This test is a ratchet: it fails when a NEW unsettled navigation appears, so the
+audit does not have to be redone by hand.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_TRANSPORTS = Path(__file__).resolve().parents[3] / "src" / "gflow_cli" / "api"
+
+#: Sites whose existing wait already absorbs the redirect. `networkidle` waits for
+#: the network to go quiet, which a redirect cannot do without being observed; the
+#: bearer site additionally sleeps 5 s. Listed explicitly so the exemption is a
+#: decision on the record rather than an oversight.
+_ABSORBED_BY_EXISTING_WAIT = {
+    ("ui_automation.py", "networkidle"),
+    ("bearer.py", "networkidle"),
+}
+
+
+def _goto_calls(path: Path) -> list[tuple[int, str]]:
+    """Return (lineno, wait_until) for every `*.goto(...)` in a module."""
+    out: list[tuple[int, str]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "goto"
+        ):
+            wait = ""
+            for kw in node.keywords:
+                if kw.arg == "wait_until" and isinstance(kw.value, ast.Constant):
+                    wait = str(kw.value.value)
+            out.append((node.lineno, wait))
+    return out
+
+
+def _settle_lines(path: Path) -> set[int]:
+    """Line numbers of every `await_url_settled(...)` call."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        n.lineno
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "await_url_settled"
+    }
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        "transports/ui_automation.py",
+        "transports/experimental/evaluate_fetch.py",
+        "transports/experimental/sapisidhash.py",
+        "transports/experimental/bearer.py",
+    ],
+)
+def test_every_goto_is_followed_by_a_settle(relpath: str) -> None:
+    """A `goto` must be followed by `await_url_settled` within a few lines.
+
+    Proximity rather than exactness: the settle is the next statement in every
+    current case, and a small window tolerates an intervening log line without
+    letting an unsettled navigation hide further down the function.
+    """
+    path = _TRANSPORTS / relpath
+    settles = _settle_lines(path)
+    unsettled = [
+        (lineno, wait)
+        for lineno, wait in _goto_calls(path)
+        if (path.name, wait) not in _ABSORBED_BY_EXISTING_WAIT
+        and not any(lineno < s <= lineno + 12 for s in settles)
+    ]
+    assert not unsettled, (
+        f"{relpath}: navigation(s) at line(s) "
+        f"{[ln for ln, _ in unsettled]} are not followed by await_url_settled(). "
+        "Flow's locale redirect lands after goto returns (#580/#584); whatever "
+        "runs next operates on a page about to navigate away."
+    )


### PR DESCRIPTION
Closes #584. Follow-up to #580 — you were right that the locale issue was not fully closed.

## The audit

#580 settled the three sites it touched. Auditing **every** `page.goto` in the tree found four more with the same defect:

| site | what runs immediately after |
|---|---|
| **`evaluate_fetch.py:198` `refresh_auth`** | reports auth refreshed **mid-navigation** |
| `evaluate_fetch.py:179` setup | `page.evaluate` fetch calls |
| `sapisidhash.py:227` fingerprint | `capture_fingerprint` (evaluates) |
| `ui_automation.py:1261` gallery return | `_bypass_onboarding` — real button clicks |

## Why the transport sites are worse than the cosmetic case

A redirect landing mid-`evaluate` does not produce a subtly wrong result — it raises **"Execution context was destroyed, most likely because of a navigation"**. Intermittent, environment-dependent, and hard to attribute to a cause.

`refresh_auth` is the worst: it re-navigates to refresh page-context tokens and returns immediately, so a caller acts on "refreshed" auth while the page is still moving.

`ui_automation.py:1261` has a `wait_for_timeout(3000)` a few lines later that *would* have absorbed the redirect — but `_bypass_onboarding` runs **before** it.

## Deliberate exemptions, on the record

`ui_automation.py:992` and `bearer.py:254` already wait on `networkidle` (bearer additionally sleeps 5 s). Listed as explicit exemptions **in the test**, so this is a recorded decision rather than an oversight.

## A ratchet, so the audit is not redone by hand

New AST-based test: every `*.goto(...)` must be followed by `await_url_settled(...)` within a few lines. A new unsettled navigation now fails CI.

**Mutation-verified** — removing a single settle fails the test, and only for the affected file. (A test that passes for the wrong reason bit me twice today; this one was checked.)

## E2E — denon82 (pt-BR), zero credits

```
image t2i        -> account_locale_resolved pt
                    url_stable_after_goto settle_skipped=false
                    batch 200, real JPEG
-m e2e_auth      -> exercises all three experimental transports
```

### An important negative result

The `e2e_auth` tier failed intermittently during verification. Two runs with this change failed **two different** tests. Rather than call it flaky, I ran a **control on clean `develop`** — which failed the same way (`sidebar_recovery`) **without** this change.

| run | tree | failure |
|---|---|---|
| run 1 | this branch | `sidebar_recovery` |
| run 2 | this branch | `agent_chat_panel` |
| **control** | **clean develop** | **`sidebar_recovery`** |

**Pre-existing flakiness, not a regression from this change.** Worth knowing for canary triage: a RED in that tier is not automatically real drift. The 401 REDs remain distinguishable — they fail one specific test with `AuthExpiredError`, not a selector timeout.

## Verification

- [x] 3410 passed, 5 skipped, 0 failed
- [x] `ruff` clean, `pyright` 0 errors
- [x] New ratchet test, mutation-verified
- [x] E2E on a real pt-BR account, with a control run to rule out regression

## Still open on the locale thread

Filed in #584's body, not fixed here: the ~4 s probe `en` accounts pay, the selector-coverage asymmetry (103 locale-dependent text selectors; onboarding covers 14 locales, `IMAGE_TAB`/`VIDEO_TAB`/`PICKER_INCLUDE` cover 2–3), and `gflow project list` emitting account-correct URLs.