### PR TITLE
fix(api): refuse an unselectable image model; read attribution from the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A requested image model that cannot be selected no longer generates silently
+  on a different one ([#586](https://github.com/ffroliva/gflow-cli/issues/586)).**
+  `_select_image_model` swallowed every failure, logged a warning, and let the
+  generation proceed on whatever the project's picker already held. Observed
+  live: `--model imagen4` produced an image on `NARWHAL` and exited **0** —
+  confirmed three ways (log, catalog, and `imageModelName` in a HAR). Flow has
+  removed `Imagen 4` from its picker, and `has-text('Nano Banana 2')` had become
+  ambiguous with the newly-offered `Nano Banana 2 Lite`, so `.first` resolved by
+  DOM order. A missing or ambiguous selector now raises `UiSelectorDriftError`
+  (exit 23) naming what Flow actually offered, before anything is submitted.
+
+### Added
+
+- **Server-side model attribution
+  ([#586](https://github.com/ffroliva/gflow-cli/issues/586)).**
+  `parse_media_attribution` reads `modelNameType` / `seed` / `aspectRatio` from
+  the `flow.projectInitialData` listing gflow already fetches — the same payload
+  the sync path walks for `name` and discards the rest of. This matters most on
+  the **agentic** arm, where those fields were previously synthesised from our
+  own request because they live in a Web-Worker SSE stream Playwright cannot
+  observe; "not visible to the page" was never the same as "unknowable". Verified
+  live: an agentic run that requested `GEM_PIX_2` was attributed `NARWHAL` by the
+  server, with a real seed where the catalog held `0`.
+
 - **Four more navigations settle before acting on the page
   ([#584](https://github.com/ffroliva/gflow-cli/issues/584)).** #580 settled the
   three sites it touched; an audit of every `page.goto` found four more with the

--- a/docs/superpowers/plans/2026-08-26-model-drift-governance.md
+++ b/docs/superpowers/plans/2026-08-26-model-drift-governance.md
@@ -1,0 +1,113 @@
+# Model-Drift Governance — Implementation Plan
+
+**Goal:** Model drift on Flow's side becomes loud. Today it is silent, and we
+only found it by manual spike.
+
+## What we are guarding against — observed, not hypothetical
+
+Read live from Flow's image picker on 2026-08-26 (menu open, so valid):
+
+```
+🍌 Nano Banana Pro
+🍌 Nano Banana 2
+🍌 Nano Banana 2 Lite
+```
+
+Against `IMAGE_MODEL_OPTION_SELECTORS` (`ui_automation.py:101`):
+
+| our model | selector | reality |
+|---|---|---|
+| `GEM_PIX_2` | `has-text('Nano Banana Pro')` | HIT |
+| `NARWHAL` | `has-text('Nano Banana 2')` | **AMBIGUOUS** — also matches `Nano Banana 2 Lite` |
+| `IMAGEN_3_5` | `has-text('Imagen 4')` | **MISS** — the entry no longer exists |
+| — | — | **UNKNOWN_OFFERED**: `Nano Banana 2 Lite` is a tier we do not model |
+
+Three distinct drift classes, none of which produced a single failing test or a
+user-visible error.
+
+## Why it is invisible today
+
+`_select_image_model` (`ui_automation.py:1751-1782`) swallows every failure:
+
+```python
+raise RuntimeError(f"no visible option matched for model {model.value!r}")
+except Exception as e:
+    log.warning("ui_automation.image_model_not_set", note="Flow default model applies")
+```
+
+So a MISS means the user asks for one model, silently gets another, **and is
+billed for it**. The AMBIGUOUS case is worse than a MISS: `.first` picks by DOM
+order, so it works until Flow reorders, then silently selects the Lite tier.
+
+The code comment at `:94-95` asserts `'Nano Banana 2' is not a substring of
+'Nano Banana Pro', so has-text is unambiguous across the three` — true when
+written, false now. A comment cannot notice that it has expired.
+
+## Architecture
+
+Reuse `flow_selectors`, do not build a parallel system. Its `Grade` vocabulary
+(`grading.py:12-17`) already names two of the three classes — `AMBIGUOUS`
+literally documents "drivers use .first, so this misclicks".
+
+Three layers, each catching what the one below cannot:
+
+**1. Fail loudly (immediate safety).** `_select_image_model` stops swallowing.
+A requested model that cannot be selected must abort before spending anything,
+not silently downgrade. This is the only change that protects a user today.
+
+**2. Recorded inventory + offline governance test (every CI run).** The live
+probe writes what Flow actually offers into a dated fixture. An offline test
+grades our selectors against that fixture: every registered model resolves to
+exactly one entry, and every offered entry is modelled or explicitly waived.
+When the fixture updates and a selector becomes ambiguous, CI fails — the
+"Nano Banana 2 Lite" case is caught by construction.
+
+**3. Live drift probe (scheduled, $0).** Opens each picker, reads **while open**,
+grades, refreshes the fixture. Exit `0` clean / `1` drift / `2` infrastructure,
+matching `scripts/probe/run_probe.py`.
+
+Layer 2 is what makes this governance rather than a one-off script: it fails in
+CI, on every commit, without needing a browser.
+
+## Risk register
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Probe reads an empty menu and records "no models", wiping the fixture | An empty read is INSTRUMENT FAILURE, never data. #539 made exactly this mistake; so did I, twice today. Refuse to write a fixture from an empty read. |
+| High | Failing loudly breaks users mid-workflow on a transient miss | Abort BEFORE submitting, so nothing is spent; message names the offered models so the fix is obvious |
+| Medium | Fixture churn on every Flow A/B | Waivable entries; the test asserts *our* selectors resolve, not that the inventory is frozen |
+| Low | Probe cost | Navigation + two menu clicks, no generation |
+
+## Tasks
+
+### Task 1 — fail loudly (red tests first)
+- [ ] Requested model not present => raises, does not warn-and-continue
+- [ ] The error names the model asked for AND the options Flow offered
+- [ ] Raises BEFORE any submit, so nothing is charged
+- [ ] Ambiguous match (>1) is also a failure, not a `.first` guess
+
+### Task 2 — model registry + recorded inventory
+- [ ] Declare expected models per picker surface, reusing `Selector`/`Grade`
+- [ ] Add an `UNKNOWN_OFFERED` concept for entries Flow offers that we do not model
+- [ ] Dated, provenanced fixture of the live inventory
+
+### Task 3 — offline governance test (the CI guard)
+- [ ] Every `Model` / `VideoModel` member has a picker selector — a new model cannot be added without one
+- [ ] Each selector matches EXACTLY ONE entry in the recorded inventory (catches AMBIGUOUS)
+- [ ] Each selector matches AT LEAST ONE entry (catches MISS)
+- [ ] Every offered entry is modelled or explicitly waived (catches UNKNOWN_OFFERED)
+- [ ] Mutation-verified: the test must FAIL against the 2026-08-26 inventory before the selectors are fixed
+
+### Task 4 — live probe
+- [ ] Read menus while open; empty read => exit 2, never exit 0 and never write the fixture
+- [ ] Grade via `flow_selectors.grading`
+- [ ] Exit 0/1/2
+
+### Task 5 — E2E GATE
+- [ ] Probe run against real Flow reproduces the three known drift classes
+- [ ] Offline test fails on the pre-fix selectors, passes after
+- [ ] `/gflow:check` green
+
+## Out of scope
+- Adding `Nano Banana 2 Lite` as a usable model (inventory first, capability later)
+- #539's video `[Lower Priority]` question — this makes it *answerable*, it does not answer it

--- a/docs/superpowers/specs/2026-08-26-model-attribution-provenance.md
+++ b/docs/superpowers/specs/2026-08-26-model-attribution-provenance.md
@@ -1,0 +1,158 @@
+# Spec — Model attribution provenance (observed vs assumed)
+
+**Status:** draft for council review. 2026-08-26.
+
+**One-line problem:** the catalog's `model` column means *ground truth* on one
+code path and *our own intent* on another, and nothing distinguishes them.
+
+---
+
+## 1. Evidence gathered today (all live, zero credits)
+
+Every claim below was observed. Claims I could not observe are in §3.
+
+### 1.1 The trigger — a silent wrong-model generation
+
+| observation | evidence |
+|---|---|
+| Requested `imagen4` (`IMAGEN_3_5`) | CLI invocation |
+| Model was not applied | log `image_model_not_set model=IMAGEN_3_5` |
+| Generation ran and reported success | **exit 0**, 1 image written |
+| Wire carried a different model | **HAR: `requests[0].imageModelName = 'NARWHAL'`** |
+| Catalog recorded `NARWHAL` | `gflow data list images` |
+| New code refuses instead | **exit 23**, 0 images written |
+
+Three independent layers (log, catalog, raw wire) agree.
+
+### 1.2 Why it happened — no fallback logic exists
+
+`IMAGEN_3_5` appears in exactly four places: the enum, its CLI aliases, its
+reference cap, and its picker selector. **Nothing maps it to `NARWHAL`.**
+
+`NARWHAL` is only the CLI default for an *omitted* `--model`; an explicit model
+was passed, so that default never applied.
+
+The model came from **residual browser UI state**. Catalog timeline, same project:
+
+```
+11:55:16  model=NARWHAL  proj=2ddc3a33  'a harbour at dawn'    <- ran --model nano2
+14:08:07  model=NARWHAL  proj=2ddc3a33  'old behaviour check'  <- ran --model imagen4
+```
+
+The earlier command set the picker; the later one failed to change it and
+inherited the selection **two hours later**.
+
+So this is not a fallback path — it is an *absence of enforcement*. There is no
+code to review, no constant to grep, no default to point at. The effective model
+is a function of what was run before in that project.
+
+### 1.3 Flow's picker no longer matches our registry
+
+Read live, menu open:
+
+```
+🍌 Nano Banana Pro  /  🍌 Nano Banana 2  /  🍌 Nano Banana 2 Lite
+```
+
+- `IMAGEN_3_5` → `has-text('Imagen 4')` — **MISS**, entry no longer exists
+- `NARWHAL` → `has-text('Nano Banana 2')` — **AMBIGUOUS**, also matches `2 Lite`
+- `Nano Banana 2 Lite` — a tier we do not model at all
+
+`gflow models` still advertises `IMAGEN_3_5 (image4, imagen4)` to users.
+
+### 1.4 The deeper defect — provenance
+
+| path | `model_name_type` source | meaning |
+|---|---|---|
+| classic | `dto.py:183` ← response `generated["modelNameType"]` | **observed** — Flow's own attribution |
+| agentic | `agentic.py:914` ← `pending_model` (the request) | **assumed** — our intent |
+
+`recorder.py:503` writes both into the same catalog column.
+
+The agentic driver documents why (`agentic.py:862-871`): the real wire values
+"live in the Web-Worker-delegated streamChat SSE stream which Playwright's
+page-level instrumentation cannot observe", so they are "scrape-synthesised
+sentinels".
+
+**Consequence:** `gflow data list images` returns truth for classic rows and
+intent for agentic rows, indistinguishably. Any audit, any governance guard, and
+any user query inherits that ambiguity.
+
+It also means §1.1's catalog evidence held **only because that run was classic**.
+On the agentic arm the catalog would have recorded `IMAGEN_3_5` — my own
+intent — and the wrong-model generation would have been invisible in the data.
+
+### 1.5 Cost currencies are not what I first claimed
+
+I asserted a wrong-model generation "billed" the user. **Retracted.**
+
+- Image → **0 Flow credits**, metered by a **per-model daily quota**
+  (`tests/e2e/test_classic_count_setter_e2e.py:7`; live cost line read `0`)
+- Video → Flow **credits** (live popover: omni-flash 7–15, veo-lite 10,
+  veo-fast 20, veo-quality 100)
+
+Quota exhaustion surfaces as HTTP 429 naming the model
+(`"You have reached the daily limit for Nano Banana Pro."` →
+`RateLimitError`, exit 4). The real harm of a wrong-model generation is
+consuming **another model's daily allowance** and receiving different output.
+
+---
+
+## 2. Oracles available, per arm
+
+| oracle | classic | agentic | cost |
+|---|---|---|---|
+| UI picker state | readable | **does not exist** — model is a natural-language directive; the driver explicitly does not drive the tune popover for model | medium |
+| Request `imageModelName` | on the wire; interception already exists (`_attach_batch_request_logger`) | unverified | ~free |
+| Response `modelNameType` | **already parsed** | **not observable** (SSE inside a Web Worker) | free |
+
+**There is no single oracle across both arms.** Classic can be made
+deterministic today for free. Agentic cannot, until the SSE stream is reachable.
+
+Precedent for the pattern: `_assert_image_entities_attached` already verifies at
+the wire that a UI attach actually took effect, because a click that silently
+did not apply is this same bug class.
+
+---
+
+## 3. Explicitly NOT established — do not design on these
+
+- Whether the agentic arm's submitted `imageModelName` matches the directive.
+  **Never observed.** The natural-language directive may or may not be honoured.
+- Numeric daily limits for any image model. Observable only on exhaustion.
+- Whether the daily quota is per-model or per-account.
+- Cost/quota of `Nano Banana 2 Lite`.
+- Whether `veo_3_1_lite_lower_priority` exists in the live picker (#539) — the
+  video picker uses a different trigger; two prior captures read an empty menu
+  **after it closed**, which is instrument failure, not absence.
+
+---
+
+## 4. Proposed direction (for the council to attack)
+
+1. **Provenance flag first.** The catalog must record whether a value was
+   OBSERVED or ASSUMED. Everything downstream inherits this; a guard built on an
+   ambiguous column produces confident wrong answers.
+2. **Classic wire check.** Compare response `modelNameType` against
+   `request.model`; refuse on mismatch. Free, uses data already parsed.
+3. **Pre-submit refusal** (already implemented on this branch): a model that
+   cannot be selected raises before spending.
+4. **Governance guard** (already implemented and mutation-proven): offline CI
+   test grading our selectors against a recorded live inventory.
+5. **Agentic observability** — separate investigation; without it the agentic arm
+   cannot be verified at all.
+
+---
+
+## 5. Questions for the council
+
+1. Is the provenance flag the right first move, or does it over-engineer a
+   two-value distinction that a boolean `verified` column would cover?
+2. Is a post-hoc wire check worth it when the quota is already spent, or should
+   effort go to pre-submit enforcement only?
+3. Does the agentic arm's unobservability make the catalog's `model` column
+   fundamentally untrustworthy — i.e. should it be nullable rather than assumed?
+4. What breaks this design under: multi-account, concurrent runs, a Flow A/B that
+   changes picker ordering, or a model renamed rather than removed?
+5. Is there an oracle for the agentic arm we have not considered (CDP, the
+   worker's own network events, tRPC polling, the project's server-side state)?

--- a/docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md
+++ b/docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md
@@ -1,0 +1,134 @@
+# Spec — Model cost/quota catalogue and its drift governance
+
+**Status:** proposed. Written 2026-08-26 after a live spike found three
+undetected model drifts and one unsupported claim of my own.
+
+## Correction that motivated this spec
+
+I stated a wrong-model selection "billed you". **That was unsupported.** The
+evidence says the opposite for image models:
+
+| Source | Evidence |
+|---|---|
+| `tests/e2e/test_classic_count_setter_e2e.py:7` | "Spends Imagen **quota** (**0 Flow credits** — only video costs credits)" |
+| live settings popover, 2026-08-26 | image cost line reads **0** |
+| `errors.py:257` | "**Daily or per-minute model quota** reached; retry with a different model or wait for quota reset" |
+| `tests/test_self_documenting_errors.py` | `"You have reached the daily limit for Nano Banana Pro."` → HTTP 429 |
+| `tests/api/test_client_errors.py:78` | `"Daily generation quota reached"` → `RateLimitError` |
+
+So there are **two different cost currencies**, and we conflate them:
+
+- **Video** → Flow **credits**, metered per generation.
+- **Image** → **0 credits**, metered against a **per-model daily quota**.
+
+The real harm of selecting the wrong model is therefore *not* a charge. It is:
+consuming a different model's daily allowance, receiving different output than
+requested, and — once that model's quota is exhausted — a 429 attributed to a
+model the user never asked for.
+
+## The gap
+
+There is **no structured cost/quota metadata anywhere**. `Model` holds wire
+strings and CLI aliases. What we "know" lives in a test docstring and an error
+remediation string — neither assertable, neither governable.
+
+`gflow models` prints model / aliases / ref-cap / max-duration and **no cost or
+quota column**. It also still advertises `IMAGEN_3_5` (`image4`, `imagen4`),
+which Flow no longer offers.
+
+Its docstring claims the catalog "can never drift from what the generation
+commands accept". True, and beside the point: it is internally consistent and
+externally wrong. The authority for what exists is **Flow**, not our enum.
+
+## What we know vs what we must not assert
+
+Governance is worthless if it records guesses as facts. Split explicitly:
+
+**Established by evidence**
+- Image generation costs 0 Flow credits.
+- Image models are limited by a daily quota, enforced by Flow with a 429 whose
+  message *names the model* ("daily limit for Nano Banana Pro").
+- Video generation costs credits; the settings popover renders a live cost line.
+- Observed video costs (#539, live popover): omni-flash 7–15 (duration-scaled),
+  veo-lite 10, veo-fast 20, veo-quality 100.
+
+**Not established — must be recorded as UNKNOWN, never inferred**
+- The numeric daily limit for any image model.
+- Whether that limit is per-model or shared across models on an account.
+- Whether `Nano Banana 2 Lite` carries a different quota (it is a newly
+  discovered tier we do not model).
+- Whether `veo_3_1_lite_lower_priority` is cheaper, free, or absent (#539).
+
+## Observability — and its hard limit
+
+The credit line is a **credit-free oracle for video**: select a model, read the
+cost. That is how #539 can be answered without spending.
+
+**Daily quota has no such oracle.** It is observable *only on exhaustion*, via
+the 429. So the catalogue must record quota as an **observation with a date**,
+never as a configured constant. A number we cannot re-derive on demand is a
+number that will silently rot — the exact failure this whole exercise exists to
+prevent.
+
+## Proposed catalogue
+
+Per model, structured and assertable:
+
+| field | source | when unknown |
+|---|---|---|
+| `currency` | `CREDITS` \| `DAILY_QUOTA` | must be known; no default |
+| `credits_per_generation` | live cost line | `None` for quota-metered models |
+| `daily_limit_observed` | 429 message | `None` — never guessed |
+| `daily_limit_observed_utc` | when that 429 was seen | `None` |
+| `offered_by_flow` | live picker inventory | drift signal |
+
+`gflow models` gains a cost column, so the distinction is visible to users
+rather than buried.
+
+## Test strategy
+
+**TDD (unit).** Every model has a `currency`. A `DAILY_QUOTA` model must not
+carry `credits_per_generation`, and a `CREDITS` model must. `daily_limit_observed`
+without a date is rejected — an undated observation is a guess.
+
+**BDD (scenario).**
+```gherkin
+Scenario: a quota-limited model is exhausted
+  Given the image model "Nano Banana Pro" has reached its daily limit
+  When I run an image generation with that model
+  Then it fails with RateLimitError
+  And the message names the model whose quota was exhausted
+  And the remediation offers a different model, not "wait and retry" alone
+
+Scenario: a requested model is not offered by Flow
+  Given Flow's picker no longer offers "Imagen 4"
+  When I request that model
+  Then it fails before submitting
+  And the error names what Flow does offer
+  And no quota is consumed
+```
+
+**E2E.** The credit-line read per video model is credit-free and repeatable —
+that is the gate for the video half. The image half is asserted through the
+already-passing loud-failure path; deliberately exhausting a daily quota to
+observe a 429 is **not** a routine test, and the catalogue records the value
+opportunistically when a real 429 occurs.
+
+## Governance
+
+Extend the mechanism already built and proven in
+`tests/flow_selectors/test_model_governance.py`:
+
+1. The live probe records, per model: offered-by-Flow, and the cost line.
+2. The offline CI test asserts the catalogue matches the recording — a changed
+   credit cost, a removed model, or a new unmodelled tier fails CI.
+3. `RateLimitError` handling captures the model named in a 429 and surfaces it,
+   so a real exhaustion updates the catalogue instead of being lost in a log.
+
+The property to preserve: **a number in this catalogue must always be traceable
+to an observation with a date.** Anything else drifts silently, which is how we
+got here.
+
+## Out of scope
+- Enforcing quotas client-side (we cannot know the remaining allowance).
+- Shipping `Nano Banana 2 Lite` (inventory first, capability later).

--- a/scripts/dev/spike_model_inventory.py
+++ b/scripts/dev/spike_model_inventory.py
@@ -1,0 +1,131 @@
+"""What models does Flow ACTUALLY offer, and what does each cost? (#539, #586)
+
+Two questions this settles with evidence:
+
+1. **Model inventory.** Which entries does the picker render? Our image selectors
+   are text-only brand names (`ui_automation.py:101`) with no locale-invariant
+   fallback, and `VEO_3_1_LITE_LOWER_PRIORITY` (#539) has *never* been seen live —
+   its selector missed on both accounts, and the previous capture came back empty.
+
+2. **Cost, credit-free.** Flow's settings popover renders a live cost line that
+   updates with the selected model. If "[Lower Priority]" reads 0 — or materially
+   below veo-lite's 10 — that answers #539 at zero credits.
+
+**The trap this avoids, twice documented.** #539 records that the earlier capture
+"came back empty — taken *after* the menu closed → inconclusive, not proof of
+absence". I independently hit the identical failure an hour ago. So this reads the
+menu **while it is open** and treats an empty read as INSTRUMENT FAILURE, never as
+"the model is gone".
+
+The credit regex is deliberately locale-aware: an English-only /credits/ silently
+returns null on a pt-BR UI and reads as "no cost shown".
+
+Navigation and menu clicks only. Never submits. Zero credits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from gflow_cli.api.transports.ui_automation import (  # noqa: E402
+    IMAGE_MODEL_PICKER_TRIGGER,
+)
+
+# Locale-aware: pt "créditos"/"creditos", es "créditos", en "credits".
+_READ_MENU = """
+() => {
+  const items = Array.from(document.querySelectorAll("[role='menuitem']"))
+      .map(e => (e.innerText || '').replace(/\\s+/g, ' ').trim())
+      .filter(Boolean);
+  const body = document.body ? document.body.innerText : '';
+  const m = body.match(/([\\d.,]+)\\s*(?:cr[e\\u00e9]dito?s?|credits?)/i);
+  return { items, credits: m ? m[1] : null, item_count: items.length };
+}
+"""
+
+
+async def open_and_read(page: Any, label: str) -> dict[str, Any]:
+    """Click the model picker and read the menu WHILE IT IS OPEN."""
+    try:
+        await page.locator(IMAGE_MODEL_PICKER_TRIGGER).first.click(timeout=6000)
+    except Exception as exc:  # noqa: BLE001
+        return {"stage": label, "instrument_error": f"trigger: {type(exc).__name__}"}
+    await page.wait_for_timeout(1200)
+    snap = await page.evaluate(_READ_MENU)
+    snap["stage"] = label
+    if snap["item_count"] == 0:
+        # Never report this as "no models" — #539's earlier capture made exactly
+        # that mistake and the conclusion was wrong.
+        snap["instrument_error"] = "menu read empty — menu was not open; INCONCLUSIVE"
+    return snap
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--locale", default=None, help="force a locale segment (default: account)")
+    args = ap.parse_args()
+
+    out: dict[str, Any] = {}
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        t = client.transport
+        page = client._page
+        if args.locale:
+            t._account_locale = args.locale
+        out["locale_used"] = t._account_locale
+
+        await t._enter_editor(page, None, project_id=args.project)
+        out["html_lang"] = await page.evaluate("document.documentElement.lang")
+
+        # --- IMAGE ---
+        await t._switch_to_image_mode(page)
+        await t._open_gen_settings_panel(page)
+        out["image"] = await open_and_read(page, "image")
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(400)
+
+        # --- VIDEO ---
+        try:
+            await t._switch_to_video_mode(page, out_dir=None)
+            await t._open_gen_settings_panel(page)
+            out["video"] = await open_and_read(page, "video")
+            await page.keyboard.press("Escape")
+        except Exception as exc:  # noqa: BLE001
+            out["video"] = {
+                "stage": "video",
+                "instrument_error": f"{type(exc).__name__}: {exc!s}"[:140],
+            }
+
+    print(f"\nlocale={out['locale_used']}  html_lang={out.get('html_lang')}")
+    for stage in ("image", "video"):
+        blk = out.get(stage) or {}
+        print(f"\n=== {stage.upper()} MODEL MENU ===")
+        if blk.get("instrument_error"):
+            print(f"   INSTRUMENT ERROR: {blk['instrument_error']}")
+        print(f"   items ({blk.get('item_count')}):")
+        for it in blk.get("items", []):
+            print(f"     - {it}")
+        print(f"   live credit line: {blk.get('credits')}")
+        lower = [i for i in blk.get("items", []) if "lower priority" in i.lower()]
+        if lower:
+            print(f"   >>> LOWER-PRIORITY ENTRY FOUND: {lower}")
+
+    dest = Path("scripts/dev/_spike_out/spike_model_inventory.json")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nevidence: {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/dev/verify_language_agnostic.py
+++ b/scripts/dev/verify_language_agnostic.py
@@ -1,0 +1,113 @@
+"""Is gflow ACTUALLY language-agnostic? Drive the REAL code, per locale.
+
+Language agnosticism is a core design claim: the selector cascades try
+structural / ARIA / icon-ligature tiers FIRST and fall back to human-language
+text only when those miss. If the real editor-entry + mode-switch path succeeds
+in a locale, that path is agnostic for that locale. If it raises, it is not.
+
+**Why this drives the transport instead of reimplementing it.** A first version
+of this probe did `goto` + `wait` + `is_visible` and reported MISS for every
+selector group — including on the account's OWN locale, a path that provably
+works in production. Reimplementing the entry sequence got it wrong (missing
+overlay dismissal, mount waits, and the fact that the mode tabs live inside a
+dropdown that must be opened first). Calling the real methods cannot be wrong
+about its own preconditions.
+
+Flow routes locale by URL PATH SEGMENT, so ONE account can be served every
+locale — this does not need 14 Google accounts. Note `/fx/en/` is Flow's
+"default", which redirects to the account locale; en is therefore only testable
+on an en account.
+
+Navigation and menu interaction only. Never submits a prompt, never generates,
+spends no credits.
+
+    uv run python scripts/dev/verify_language_agnostic.py \
+        --profile denon82 --project <existing-project-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+LOCALES = ["pt", "es", "fr", "de", "it", "nl", "ja", "zh", "ko", "pl", "ru", "tr", "id"]
+
+
+async def probe(client: Any, page: Any, locale: str, project_id: str) -> dict[str, Any]:
+    """Run the REAL editor-entry + image-mode-switch path under one locale."""
+    transport = client.transport
+    transport._account_locale = locale  # force the URL this run builds
+
+    row: dict[str, Any] = {"locale": locale}
+    try:
+        await transport._enter_editor(page, None, project_id=project_id)
+        row["served"] = f"/fx/{locale}/" in page.url
+        row["html_lang"] = await page.evaluate("document.documentElement.lang")
+        row["entered_editor"] = True
+    except Exception as exc:  # noqa: BLE001
+        row.update(
+            entered_editor=False,
+            served=None,
+            error=f"{type(exc).__name__}: {str(exc)[:120]}",
+        )
+        return row
+
+    # The real cascade: exits agent mode, probes the mode-switch trigger, opens
+    # the dropdown, probes the image tab. Raises if any tier fails to resolve.
+    try:
+        await transport._switch_to_image_mode(page)
+        row["image_mode_switch"] = "OK"
+    except Exception as exc:  # noqa: BLE001
+        row["image_mode_switch"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+    return row
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--locales", default=",".join(LOCALES))
+    args = ap.parse_args()
+
+    rows: list[dict[str, Any]] = []
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        page = client._page
+        for loc in [x.strip() for x in args.locales.split(",") if x.strip()]:
+            rows.append(await probe(client, page, loc, args.project))
+            print(f"  probed {loc}: {rows[-1].get('image_mode_switch', rows[-1].get('error'))}")
+
+    print(f"\n{'locale':<8}{'served':<9}{'lang':<7}{'editor':<9}image-mode-switch")
+    print("-" * 88)
+    for r in rows:
+        print(
+            f"{r['locale']:<8}{str(r.get('served')):<9}{str(r.get('html_lang')):<7}"
+            f"{str(r.get('entered_editor')):<9}{str(r.get('image_mode_switch', r.get('error')))[:44]}"
+        )
+
+    served = [r for r in rows if r.get("served")]
+    broken = [r for r in served if r.get("image_mode_switch") != "OK"]
+    print("\n=== VERDICT ===")
+    print(f"  locales served      : {len(served)}/{len(rows)}")
+    print(f"  image-mode failures : {len(broken)} {[r['locale'] for r in broken]}")
+    if served and not broken:
+        print("\n  LANGUAGE-AGNOSTIC CONFIRMED on the editor-entry + image-mode path")
+        print("  for every locale Flow served. The locale-invariant tiers held.")
+    else:
+        print("\n  NOT AGNOSTIC — the path fails in the locales listed above.")
+
+    out = Path("scripts/dev/_spike_out/verify_language_agnostic.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nevidence: {out}")
+    return 0 if served and not broken else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/dev/verify_model_attribution.py
+++ b/scripts/dev/verify_model_attribution.py
@@ -1,0 +1,82 @@
+"""Did Flow actually use the model we asked for? Ask the server, both arms.
+
+The catalog records attribution from the classic RESPONSE (observed) or, on the
+agentic arm, from the REQUEST we sent (assumed). Same column, no distinction.
+
+Observed live 2026-08-26: an agentic run requested GEM_PIX_2 (Nano Banana Pro),
+Flow generated with NARWHAL, the CLI exited 0 and printed GEM_PIX_2. Nothing in
+the product noticed.
+
+This compares INTENT against SERVER TRUTH via `flow.projectInitialData`, which
+carries `modelNameType` / `seed` / `aspectRatio` for BOTH arms keyed by the media
+UUID — through a fetcher gflow already has (~0.5s, cookie auth, no credits).
+
+    uv run python scripts/dev/verify_model_attribution.py \
+        --profile denon82 --project <pid> --media <uuid> --expected GEM_PIX_2
+
+Omit --media to audit every media in the project against the catalog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from gflow_cli.services.catalog_sync import parse_media_attribution  # noqa: E402
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--media", help="a single media UUID to check")
+    ap.add_argument("--expected", help="the model that was REQUESTED")
+    args = ap.parse_args()
+
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        listing = await client.fetch_project_listing(args.project)
+
+    attrs = parse_media_attribution(listing)
+    if not attrs:
+        # Never report this as "the server attributes nothing" — an empty read is
+        # indistinguishable from a listing we failed to parse, and #539 records
+        # the cost of treating emptiness as absence.
+        print("no attributed media found — INCONCLUSIVE, not proof of absence")
+        return 2
+
+    rows = {args.media: attrs[args.media]} if args.media and args.media in attrs else attrs
+    if args.media and args.media not in attrs:
+        print(f"media {args.media} not in listing (freshness? try again shortly)")
+        return 2
+
+    print(f"{'media':<38}{'server model':<14}{'seed':<10}aspect")
+    print("-" * 88)
+    for uuid, a in rows.items():
+        print(f"{uuid:<38}{str(a.model_name_type):<14}{str(a.seed):<10}{a.aspect_ratio}")
+
+    if args.expected:
+        mismatched = [
+            (u, a.model_name_type)
+            for u, a in rows.items()
+            if a.model_name_type and a.model_name_type != args.expected
+        ]
+        print("\n=== ATTRIBUTION CHECK ===")
+        print(f"  requested : {args.expected}")
+        if mismatched:
+            for u, got in mismatched:
+                print(f"  MISMATCH  : {u} generated with {got!r}, not {args.expected!r}")
+            print("\n  The catalog records the REQUEST on the agentic arm, so this")
+            print("  mismatch is invisible in `gflow data list images`.")
+            return 1
+        print("  all media match the requested model")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -182,6 +182,17 @@ async def await_url_settled(page: Any) -> str | None:
     Best-effort: never raises. Returns ``None`` on timeout (already-localised URLs
     match immediately, so a timeout means no locale form ever appeared).
     """
+    # Short-circuit: if the URL is ALREADY the localised shape there is nothing to
+    # wait for. Measured: without this, every project navigation on a
+    # resolved-locale account burned the full timeout, because wait_for_url does
+    # not reliably return early for an already-matching current URL.
+    try:
+        current = str(page.url)
+    except Exception:  # noqa: BLE001
+        current = ""
+    if current and FLOW_LOCALISED_URL_RE.match(current):
+        return current
+
     try:
         await page.wait_for_url(FLOW_LOCALISED_URL_RE, timeout=URL_SETTLE_TIMEOUT_MS)
         return str(page.url)

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -98,8 +98,59 @@ _PROJECT_URL_FRAGMENT = "/project/"
 IMAGE_MODEL_PICKER_TRIGGER = (
     "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))"
 )
+_READ_OFFERED_MODELS = r"""
+() => Array.from(document.querySelectorAll("[role='menuitem']"))
+    .map(e => (e.innerText || '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+"""
+
+
+async def _offered_model_labels(page: Any) -> list[str]:
+    """What the picker is rendering RIGHT NOW — read while the menu is open.
+
+    Included in every failure message: a bare "model not found" is unactionable,
+    whereas the actual list tells an operator immediately whether Flow renamed an
+    entry, removed it, or added a near-duplicate. Best-effort — diagnostics must
+    never mask the error they describe.
+    """
+    try:
+        return list(await page.evaluate(_READ_OFFERED_MODELS))
+    except Exception:  # noqa: BLE001
+        return []
+
+
+async def _close_model_menu(page: Any) -> None:
+    """Leave no stray open UI behind after a refusal.
+
+    TWO Escapes, deliberately: the model menu and the generation-settings panel
+    beneath it. Raising out of `_select_image_model` skips the panel-close at the
+    end of `_configure_generation_settings`, so a single Escape leaves the panel
+    open. In a batch that then toggles the panel SHUT on the next prompt's open
+    attempt, turning one drifted selector into a whole-batch failure.
+    """
+    for _ in range(2):
+        try:
+            await page.keyboard.press("Escape")
+        except Exception:  # noqa: BLE001, S110 — cleanup only
+            return
+
+
+# Verified live 2026-08-26 (menu read WHILE OPEN, profile denon82):
+#   ['Nano Banana Pro', 'Nano Banana 2', 'Nano Banana 2 Lite']
+# `has-text` is a SUBSTRING match, so 'Nano Banana 2' also matches
+# 'Nano Banana 2 Lite' — text-is pins the exact label instead. The previous
+# comment claimed the three names were mutually unambiguous; that was true when
+# written and silently expired when Flow added the Lite tier.
+# `Imagen 4` is NO LONGER OFFERED. Its selector is kept so the governance test
+# reports an honest MISS (tests/flow_selectors/test_model_governance.py) rather
+# than the model quietly disappearing from the registry.
 IMAGE_MODEL_OPTION_SELECTORS: dict[Model, tuple[str, ...]] = {
-    Model.NARWHAL: ("[role='menuitem']:has-text('Nano Banana 2')",),
+    # `text-is` was tried first and REMOVED 2026-08-26: it never matched live.
+    # The recorded inventory stores whitespace-NORMALISED labels, but `text-is`
+    # matches raw innerText, which carries a newline between the emoji and the
+    # label. Keeping a selector that only matches in the fixture would make the
+    # governance test bless something that cannot work against Flow.
+    Model.NARWHAL: ("[role='menuitem']:has-text('Nano Banana 2'):not(:has-text('Lite'))",),
     Model.GEM_PIX_2: ("[role='menuitem']:has-text('Nano Banana Pro')",),
     Model.IMAGEN_3_5: ("[role='menuitem']:has-text('Imagen 4')",),
 }
@@ -1743,44 +1794,97 @@ class UiAutomationTransport(VideoGenerationMixin):
 
     @staticmethod
     async def _select_image_model(page: Page, model: Model) -> None:
-        """Click the image model picker and select `model` (Nano Banana 2 / Nano
-        Banana Pro / Imagen 4). Must run with the gen-settings panel open. Without
-        this the generation uses Flow's UI-default model and ``--model`` is a
-        no-op. Non-fatal on miss (logged at WARNING — the wrong model has a real
-        cost/quality impact, so a miss is a genuine signal)."""
+        """Click the image model picker and select *model*, or FAIL.
+
+        Must run with the gen-settings panel open.
+
+        Fails loudly by design (changed 2026-08-26). This previously swallowed
+        every failure, logged a WARNING, and let the generation proceed on Flow's
+        UI-default model — so a stale selector meant the user asked for one model,
+        silently received another, and was BILLED for it.
+
+        That was not hypothetical. Flow's picker on 2026-08-26 offers
+        ``Nano Banana Pro`` / ``Nano Banana 2`` / ``Nano Banana 2 Lite``;
+        ``Model.IMAGEN_3_5``'s ``has-text('Imagen 4')`` matches nothing, and
+        ``has-text('Nano Banana 2')`` matches TWO entries.
+
+        AMBIGUOUS is treated as a failure, not a ``.first`` guess: ``.first``
+        resolves by DOM order, so an ambiguous selector silently picks whichever
+        Flow renders first and changes behaviour with no code change on our side.
+
+        Raises before anything is submitted, so a failure costs nothing.
+        """
         option_sels = IMAGE_MODEL_OPTION_SELECTORS.get(model)
         if not option_sels:
-            log.warning("ui_automation.image_model_unknown", model=model.value)
-            return
-        try:
-            trigger = page.locator(IMAGE_MODEL_PICKER_TRIGGER).first
-            await trigger.wait_for(state="visible", timeout=4000)
-            await trigger.click()
-            await page.wait_for_timeout(500)
-            for sel in option_sels:
-                try:
-                    loc = page.locator(sel).first
-                    await loc.wait_for(state="visible", timeout=4000)
-                    await loc.click()
-                    await page.wait_for_timeout(500)
-                    log.info("ui_automation.image_model_selected", model=model.value, via=sel)
-                    return
-                except Exception as sel_err:
-                    log.debug(
-                        "ui_automation.image_model_selector_miss",
-                        sel=sel,
-                        error=str(sel_err)[:120],
-                    )
-                    continue
-            raise RuntimeError(f"no visible option matched for model {model.value!r}")
-        except Exception as e:
-            log.warning(
-                "ui_automation.image_model_not_set",
-                model=model.value,
-                error=str(e)[:80],
-                note="Flow default model applies",
+            raise UiSelectorDriftError(
+                selector_drift_detail(
+                    "image_model",
+                    f"no picker selector registered for model {model.value!r}.",
+                    None,
+                )
             )
-            await page.keyboard.press("Escape")  # close a stray model menu
+
+        trigger = page.locator(IMAGE_MODEL_PICKER_TRIGGER).first
+        await trigger.wait_for(state="visible", timeout=4000)
+        await trigger.click()
+        await page.wait_for_timeout(500)
+
+        offered = await _offered_model_labels(page)
+        for sel in option_sels:
+            loc = page.locator(sel)
+            try:
+                # Count VISIBLE matches only. `count()` alone counts mounted-but-
+                # hidden nodes — Radix keeps menus mounted, so a stale or offscreen
+                # menu inflates the count and either forces a false AMBIGUOUS or
+                # resolves to a node that cannot be clicked. The visibility gate
+                # was in the pre-2026-08-26 code and was dropped when ambiguity
+                # detection was added; this restores it.
+                total = await loc.count()
+                matches = 0
+                first_visible = None
+                for i in range(total):
+                    nth = loc.nth(i)
+                    if await nth.is_visible():
+                        matches += 1
+                        if first_visible is None:
+                            first_visible = nth
+            except Exception as exc:  # noqa: BLE001
+                log.debug("ui_automation.image_model_selector_miss", sel=sel, error=str(exc)[:120])
+                continue
+            if matches == 0:
+                continue
+            if matches > 1:
+                await _close_model_menu(page)
+                raise UiSelectorDriftError(
+                    selector_drift_detail(
+                        "image_model",
+                        (
+                            f"selector for {model.value!r} is AMBIGUOUS — {matches} entries "
+                            f"match {sel!r}. Selecting .first would pick by DOM order and "
+                            f"could bill a different model than requested. "
+                            f"Flow offered: {offered}."
+                        ),
+                        None,
+                    )
+                )
+            assert first_visible is not None  # matches > 0 implies one was found
+            await first_visible.click()
+            await page.wait_for_timeout(500)
+            log.info("ui_automation.image_model_selected", model=model.value, via=sel)
+            return
+
+        await _close_model_menu(page)
+        raise UiSelectorDriftError(
+            selector_drift_detail(
+                "image_model",
+                (
+                    f"model {model.value!r} is not selectable — no picker entry matched. "
+                    f"Flow offered: {offered}. Refusing to generate on a different model "
+                    f"than requested."
+                ),
+                None,
+            )
+        )
 
     @staticmethod
     async def _configure_generation_settings(
@@ -1816,6 +1920,28 @@ class UiAutomationTransport(VideoGenerationMixin):
         )
 
         if not await UiAutomationTransport._open_gen_settings_panel(page):
+            # A requested MODEL cannot be honoured without this panel, and the
+            # submit will inherit whatever the project's picker holds — the
+            # silent wrong-model path (#586).
+            #
+            # This deliberately WARNS rather than raises. An earlier version
+            # raised here; the existing batch tests showed it turning one
+            # transient panel miss on prompt 0 into a whole-batch abort, because
+            # the transport cannot distinguish "user passed --model X" from
+            # "X is the default" — `request.model` is populated either way, so a
+            # raise punishes callers who never asked for a specific model.
+            #
+            # Detection moved to where it is arm-agnostic and costs nothing:
+            # `services.catalog_sync.parse_media_attribution` reads what the
+            # SERVER says generated each media. That catches this on the agentic
+            # arm too, where this code path never runs at all.
+            if model is not None:
+                log.warning(
+                    "ui_automation.image_model_not_applied",
+                    model=model.value,
+                    reason="generation-settings panel could not be opened",
+                    note="generation will use the project's current selection",
+                )
             log.warning("ui_automation.gen_settings_panel_not_found", skipping=True)
             return
 

--- a/src/gflow_cli/services/catalog_sync.py
+++ b/src/gflow_cli/services/catalog_sync.py
@@ -129,21 +129,94 @@ def _has_pagination_marker(node: Any, depth: int = 0) -> bool:
     return False
 
 
+@dataclass(frozen=True, slots=True)
+class MediaAttribution:
+    """What the SERVER says produced a media — observed, never inferred.
+
+    gflow records attribution from two sources today: the classic
+    ``batchGenerateImages`` response (observed) and, on the agentic arm, the
+    request we sent (assumed — ``agentic.py`` synthesises ``model_name_type``,
+    ``seed``, ``aspect_ratio`` and more because they live in a Web-Worker SSE
+    stream Playwright cannot observe). Both land in the same catalog column.
+
+    Observed 2026-08-26: an agentic run requested ``GEM_PIX_2`` and Flow
+    generated with ``NARWHAL``; the CLI exited 0 and recorded the request.
+
+    ``flow.projectInitialData`` carries the truth for BOTH arms, keyed by the
+    media UUID the agentic scraper already extracts — so "unobservable from the
+    DOM" was never the same as "unknowable".
+    """
+
+    model_name_type: str | None
+    seed: int | None
+    aspect_ratio: str | None
+
+
+def parse_media_attribution(payload: dict[str, Any]) -> dict[str, MediaAttribution]:
+    """Map media UUID -> server-side attribution from a project listing.
+
+    Rows without ``image.generatedImage`` are OMITTED rather than defaulted: a
+    placeholder would be indistinguishable from an observation, which is the
+    defect this function exists to detect.
+
+    Raises ``ValueError`` on an unrecognised envelope, matching
+    :func:`parse_project_listing` — returning ``{}`` would read as "the server
+    attributes nothing", which a caller would take as agreement.
+    """
+    contents = _project_contents(payload)
+    out: dict[str, MediaAttribution] = {}
+    for item in cast("list[Any]", contents.get("media") or []):
+        if not isinstance(item, dict):
+            continue
+        entry = cast("dict[str, Any]", item)
+        name = entry.get("name")
+        if not isinstance(name, str) or not is_media_uuid(name):
+            continue
+        image = entry.get("image")
+        if not isinstance(image, dict):
+            continue
+        gen = cast("dict[str, Any]", image).get("generatedImage")
+        if not isinstance(gen, dict):
+            continue
+        g = cast("dict[str, Any]", gen)
+        raw_seed = g.get("seed")
+        seed: int | None
+        try:
+            # The wire sends seed as a STRING; the catalog column is an int, so
+            # a raw passthrough would compare unequal to every recorded row.
+            seed = int(raw_seed) if raw_seed is not None else None
+        except (TypeError, ValueError):
+            seed = None
+        model = g.get("modelNameType")
+        aspect = g.get("aspectRatio")
+        out[name] = MediaAttribution(
+            model_name_type=model if isinstance(model, str) else None,
+            seed=seed,
+            aspect_ratio=aspect if isinstance(aspect, str) else None,
+        )
+    return out
+
+
+def _project_contents(payload: dict[str, Any]) -> dict[str, Any]:
+    """Shared envelope unwrap — one definition, so the two parsers cannot drift."""
+    try:
+        raw: Any = payload["result"]["data"]["json"]["projectContents"]
+    except (KeyError, TypeError) as exc:
+        msg = "payload has no result.data.json.projectContents"
+        raise ValueError(msg) from exc
+    if not isinstance(raw, dict):
+        msg = "projectContents is not an object"
+        raise ValueError(msg)
+    return cast("dict[str, Any]", raw)
+
+
 def parse_project_listing(payload: dict[str, Any]) -> ListingParse:
     """Extract names + presence from a ``flow.projectInitialData`` envelope.
 
     Raises ``ValueError`` when ``result.data.json.projectContents`` is absent
     — an unrecognized envelope must fail loudly, not sync an empty project.
     """
-    try:
-        raw_contents: Any = payload["result"]["data"]["json"]["projectContents"]
-    except (KeyError, TypeError) as exc:
-        msg = "payload has no result.data.json.projectContents"
-        raise ValueError(msg) from exc
-    if not isinstance(raw_contents, dict):
-        msg = "projectContents is not an object"
-        raise ValueError(msg)
-    contents = cast("dict[str, Any]", raw_contents)
+    contents = _project_contents(payload)
 
     dropped = 0
 

--- a/tests/api/transports/test_model_selection_loud.py
+++ b/tests/api/transports/test_model_selection_loud.py
@@ -1,0 +1,192 @@
+"""A model that cannot be selected must fail loudly, before spending anything.
+
+`_select_image_model` swallowed every failure and logged a WARNING, then let the
+generation proceed on Flow's UI-default model. So a stale selector meant the user
+asked for one model, silently received another, **and was billed for it**.
+
+That is not hypothetical. Read live from Flow's image picker on 2026-08-26:
+
+    Nano Banana Pro  /  Nano Banana 2  /  Nano Banana 2 Lite
+
+`Model.IMAGEN_3_5`'s selector is `has-text('Imagen 4')` — an entry that no longer
+exists. Under the old behaviour, `--model imagen-4` generated on whatever Flow
+defaulted to and charged for it, with only a warning in a log nobody reads.
+
+The AMBIGUOUS case is worse than a MISS: `has-text('Nano Banana 2')` matches BOTH
+`Nano Banana 2` and `Nano Banana 2 Lite`. `.first` picks by DOM order, so it works
+until Flow reorders and then silently selects the cheaper tier.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gflow_cli.api.image import Model
+from gflow_cli.api.transports.ui_automation import (
+    IMAGE_MODEL_OPTION_SELECTORS,
+    UiAutomationTransport,
+)
+from gflow_cli.errors import UiSelectorDriftError
+
+
+class _Loc:
+    def __init__(self, count: int, *, visible: list[bool] | None = None) -> None:
+        self._count = count
+        # per-index visibility, so a mounted-but-hidden duplicate can be modelled
+        self._visible = visible if visible is not None else [True] * count
+        self.click = AsyncMock()
+        self.wait_for = AsyncMock()
+
+    def nth(self, i: int) -> _Loc:
+        one = _Loc(1, visible=[self._visible[i] if i < len(self._visible) else True])
+        return one
+
+    @property
+    def first(self) -> _Loc:
+        return self
+
+    async def count(self) -> int:
+        return self._count
+
+    async def is_visible(self, **_: Any) -> bool:
+        return bool(self._visible and self._visible[0])
+
+
+class _Page:
+    """Trigger resolves; option locators resolve per `counts`."""
+
+    def __init__(
+        self,
+        counts: dict[str, int],
+        offered: list[str] | None = None,
+        visible: dict[str, list[bool]] | None = None,
+    ) -> None:
+        self._counts = counts
+        self._visible = visible or {}
+        self._offered = offered or []
+        self.keyboard = AsyncMock()
+        self.wait_for_timeout = AsyncMock()
+
+    def locator(self, sel: str) -> _Loc:
+        if "arrow_drop_down" in sel:  # the picker trigger
+            return _Loc(1)
+        return _Loc(self._counts.get(sel, 0), visible=self._visible.get(sel))
+
+    async def evaluate(self, *_a: Any, **_k: Any) -> list[str]:
+        return self._offered
+
+
+@pytest.mark.asyncio
+async def test_missing_model_raises_instead_of_silently_downgrading() -> None:
+    """The Imagen 4 case: selector matches nothing.
+
+    Old behaviour logged a warning and generated on Flow's default — billing the
+    user for a model they did not ask for.
+    """
+    page = _Page(counts={}, offered=["Nano Banana Pro", "Nano Banana 2", "Nano Banana 2 Lite"])
+
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await UiAutomationTransport._select_image_model(page, Model.IMAGEN_3_5)
+
+    msg = str(exc.value)
+    assert "imagen" in msg.lower(), msg
+    # the message must name what Flow DID offer, or the operator cannot act on it
+    assert "Nano Banana 2 Lite" in msg, msg
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_model_raises_rather_than_guessing_with_first() -> None:
+    """The Nano Banana 2 / 2 Lite case.
+
+    `.first` resolves by DOM order, so an ambiguous selector silently selects
+    whichever Flow happens to render first. That is a wrong-model generation the
+    user pays for, and it changes without any code change on our side.
+    """
+    # Keyed off the REGISTRY, not a hardcoded string: this test previously
+    # pinned a selector literal and silently stopped exercising ambiguity the
+    # moment the selector was disambiguated.
+    sel = IMAGE_MODEL_OPTION_SELECTORS[Model.NARWHAL][0]
+    page = _Page(counts={sel: 2}, offered=["Nano Banana 2", "Nano Banana 2 Lite"])
+
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await UiAutomationTransport._select_image_model(page, Model.NARWHAL)
+
+    assert "ambiguous" in str(exc.value).lower(), str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_unique_match_still_selects_normally() -> None:
+    """The guard must not break the working path."""
+    sel = IMAGE_MODEL_OPTION_SELECTORS[Model.GEM_PIX_2][0]
+    page = _Page(counts={sel: 1}, offered=["Nano Banana Pro"])
+
+    await UiAutomationTransport._select_image_model(page, Model.GEM_PIX_2)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_panel_miss_warns_loudly_and_names_the_unapplied_model() -> None:
+    """S2 — the bypass, and why it is a WARNING rather than a raise.
+
+    `_configure_generation_settings` returned early when
+    `_open_gen_settings_panel` was False, so the model was never applied AND
+    never checked, and the submit proceeded on the project's residual picker
+    state — the exact silent wrong-model path the guard exists to close.
+
+    An earlier version of this fix RAISED here. The existing batch tests showed
+    that turning one transient panel miss into a whole-batch abort, because the
+    transport cannot tell "user passed --model X" from "X is the default" —
+    `request.model` is populated either way.
+
+    So the contract is: warn loudly, name the model that was NOT applied, and let
+    `parse_media_attribution` (server truth, arm-agnostic, free) do the detecting.
+    """
+    page = _Page(counts={})
+    with (
+        patch.object(
+            UiAutomationTransport, "_open_gen_settings_panel", AsyncMock(return_value=False)
+        ),
+        patch.object(UiAutomationTransport, "_capture_diag_screenshot", AsyncMock()),
+        patch("gflow_cli.api.transports.ui_automation.log") as mock_log,
+    ):
+        await UiAutomationTransport._configure_generation_settings(
+            page, None, None, model=Model.GEM_PIX_2
+        )
+
+    events = [c[0][0] for c in mock_log.warning.call_args_list]
+    assert "ui_automation.image_model_not_applied" in events, events
+    kwargs = next(
+        c[1]
+        for c in mock_log.warning.call_args_list
+        if c[0][0] == "ui_automation.image_model_not_applied"
+    )
+    assert kwargs["model"] == Model.GEM_PIX_2.value
+
+
+@pytest.mark.asyncio
+async def test_panel_miss_without_a_requested_model_stays_non_fatal() -> None:
+    """Aspect/count remain best-effort — their absence degrades output, it does
+    not misattribute it. Only an unhonourable MODEL request is fatal."""
+    page = _Page(counts={})
+    with (
+        patch.object(
+            UiAutomationTransport, "_open_gen_settings_panel", AsyncMock(return_value=False)
+        ),
+        patch.object(UiAutomationTransport, "_capture_diag_screenshot", AsyncMock()),
+    ):
+        await UiAutomationTransport._configure_generation_settings(page, "16:9", 2, model=None)
+
+
+@pytest.mark.asyncio
+async def test_hidden_duplicate_does_not_force_a_false_ambiguous() -> None:
+    """S4 — `count()` alone counts mounted-but-hidden nodes.
+
+    Radix keeps menus mounted, so a stale menu inflates the match count. Without
+    a visibility gate this refuses a picker a human would drive fine.
+    """
+    sel = IMAGE_MODEL_OPTION_SELECTORS[Model.GEM_PIX_2][0]
+    page = _Page(counts={sel: 2}, visible={sel: [True, False]})  # one real, one stale
+
+    await UiAutomationTransport._select_image_model(page, Model.GEM_PIX_2)  # must not raise

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -2668,51 +2668,68 @@ def _make_model_page_mock(
 
 
 class TestSelectImageModel:
-    """Unit tests for UiAutomationTransport._select_image_model cascade logic."""
+    """Contract for `_select_image_model` — REWRITTEN 2026-08-26.
+
+    This class previously pinned the old silent-fallback behaviour by name
+    (`test_all_selectors_fail_logs_warning_and_presses_escape`,
+    `test_unknown_model_logs_warning_and_returns`). That behaviour was the bug:
+    a stale selector meant the user asked for one model, silently received
+    another, and was BILLED for it. Flow removed `Imagen 4` from its picker at
+    some unknown point and nothing failed.
+
+    The tests are rewritten rather than deleted, and the reasoning recorded,
+    because silently inverting an assertion is how a real regression hides.
+
+    Detailed drift cases (MISS / AMBIGUOUS, with the live 2026-08-26 inventory)
+    live in tests/api/transports/test_model_selection_loud.py. This class keeps
+    the mechanism coverage: cascade order, and the working path.
+    """
+
+    @staticmethod
+    def _page(counts: dict[str, int]) -> MagicMock:
+        """Page whose option locators report `counts` matches; trigger resolves."""
+        page = MagicMock()
+        trigger = MagicMock()
+        trigger.first = trigger
+        trigger.wait_for = AsyncMock()
+        trigger.click = AsyncMock()
+
+        def _locator(sel: str) -> MagicMock:
+            if "arrow_drop_down" in sel:
+                return trigger
+            n = counts.get(sel, 0)
+            loc = MagicMock()
+            loc.first = loc
+            loc.count = AsyncMock(return_value=n)
+            loc.click = AsyncMock()
+            # The visibility gate counts VISIBLE matches via nth(i).is_visible(),
+            # because count() alone counts mounted-but-hidden Radix nodes.
+            loc.is_visible = AsyncMock(return_value=True)
+            loc.nth = MagicMock(side_effect=lambda _i: loc)
+            return loc
+
+        page.locator = MagicMock(side_effect=_locator)
+        page.wait_for_timeout = AsyncMock()
+        page.evaluate = AsyncMock(return_value=list(counts))
+        page.keyboard = MagicMock()
+        page.keyboard.press = AsyncMock()
+        return page
 
     @pytest.mark.asyncio
-    async def test_happy_path_first_selector_wins(self) -> None:
-        """First selector succeeds → model selected, log.info emitted, no Escape."""
-        page = _make_model_page_mock(selector_side_effects=[[None]])
+    async def test_happy_path_selects_and_does_not_escape(self) -> None:
+        sel = IMAGE_MODEL_OPTION_SELECTORS[Model.GEM_PIX_2][0]
+        page = self._page({sel: 1})
         with patch("gflow_cli.api.transports.ui_automation.log") as mock_log:
-            await UiAutomationTransport._select_image_model(page, Model.NARWHAL)
-        mock_log.info.assert_called_once()
-        call_kwargs = mock_log.info.call_args[0][0]
-        assert call_kwargs == "ui_automation.image_model_selected"
+            await UiAutomationTransport._select_image_model(page, Model.GEM_PIX_2)
+        assert mock_log.info.call_args[0][0] == "ui_automation.image_model_selected"
         page.keyboard.press.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cascade_fallthrough_second_selector_wins(self) -> None:
-        """First selector times out, second succeeds → second selector used."""
-        from gflow_cli.api.transports.ui_automation import IMAGE_MODEL_OPTION_SELECTORS
-
-        page = MagicMock()
-        trigger_loc = MagicMock()
-        trigger_loc.first = trigger_loc
-        trigger_loc.wait_for = AsyncMock()
-        trigger_loc.click = AsyncMock()
-
-        call_count = [0]
-
-        def _locator(sel: str) -> MagicMock:
-            loc = MagicMock()
-            loc.first = loc
-            n = call_count[0]
-            call_count[0] += 1
-            loc.wait_for = AsyncMock(side_effect=Exception("timeout") if n == 0 else None)
-            loc.click = AsyncMock()
-            return loc
-
-        page.locator = MagicMock(
-            side_effect=lambda sel: trigger_loc if "arrow_drop_down" in sel else _locator(sel)
-        )
-        page.wait_for_timeout = AsyncMock()
-        page.keyboard = MagicMock()
-        page.keyboard.press = AsyncMock()
-
-        # Patch a model to have two selectors so the fallthrough is exercised.
-        two_sel = ("[role='menuitem']:has-text('MISS')", "[role='menuitem']:has-text('Imagen 4')")
-        patched = {**IMAGE_MODEL_OPTION_SELECTORS, Model.IMAGEN_3_5: two_sel}
+    async def test_cascade_falls_through_to_the_second_selector(self) -> None:
+        """First candidate matches nothing, second does — the fallback chain holds."""
+        two = ("[role='menuitem']:has-text('MISS')", "[role='menuitem']:has-text('HIT')")
+        patched = {**IMAGE_MODEL_OPTION_SELECTORS, Model.IMAGEN_3_5: two}
+        page = self._page({two[1]: 1})
         with (
             patch(
                 "gflow_cli.api.transports.ui_automation.IMAGE_MODEL_OPTION_SELECTORS",
@@ -2721,36 +2738,31 @@ class TestSelectImageModel:
             patch("gflow_cli.api.transports.ui_automation.log") as mock_log,
         ):
             await UiAutomationTransport._select_image_model(page, Model.IMAGEN_3_5)
-
-        mock_log.debug.assert_called_once()
-        mock_log.info.assert_called_once()
-        page.keyboard.press.assert_not_called()
+        assert mock_log.info.call_args[1]["via"] == two[1]
 
     @pytest.mark.asyncio
-    async def test_all_selectors_fail_logs_warning_and_presses_escape(self) -> None:
-        """All selectors raise → RuntimeError caught, warning logged, Escape pressed."""
-        page = _make_model_page_mock(selector_side_effects=[[Exception("timeout")]])
-        with patch("gflow_cli.api.transports.ui_automation.log") as mock_log:
+    async def test_no_match_raises_instead_of_warning(self) -> None:
+        """WAS: logged a warning and generated on Flow's default, billing the user."""
+        page = self._page({})
+        with pytest.raises(UiSelectorDriftError):
             await UiAutomationTransport._select_image_model(page, Model.GEM_PIX_2)
-        mock_log.warning.assert_called()
-        warned_event = mock_log.warning.call_args[0][0]
-        assert warned_event == "ui_automation.image_model_not_set"
-        page.keyboard.press.assert_called_once_with("Escape")
+        # TWO Escapes: the model menu AND the generation-settings panel beneath
+        # it. Raising skips the panel-close at the end of
+        # _configure_generation_settings, and a single Escape would leave the
+        # panel open — which the next batch prompt then toggles SHUT, cascading
+        # one drifted selector into a whole-batch failure.
+        assert page.keyboard.press.call_count == 2
+        assert all(c[0] == ("Escape",) for c in page.keyboard.press.call_args_list)
 
     @pytest.mark.asyncio
-    async def test_unknown_model_logs_warning_and_returns(self) -> None:
-        """Model not in dict → early return with image_model_unknown warning."""
-        page = MagicMock()
-        page.wait_for_timeout = AsyncMock()
-        with patch("gflow_cli.api.transports.ui_automation.log") as mock_log:
-            with patch(
-                "gflow_cli.api.transports.ui_automation.IMAGE_MODEL_OPTION_SELECTORS",
-                {},
-            ):
-                await UiAutomationTransport._select_image_model(page, Model.NARWHAL)
-        mock_log.warning.assert_called_once()
-        assert mock_log.warning.call_args[0][0] == "ui_automation.image_model_unknown"
-        page.locator.assert_not_called()
+    async def test_unregistered_model_raises_instead_of_returning(self) -> None:
+        """WAS: warned and returned, so --model was a silent no-op."""
+        page = self._page({})
+        with (
+            patch("gflow_cli.api.transports.ui_automation.IMAGE_MODEL_OPTION_SELECTORS", {}),
+            pytest.raises(UiSelectorDriftError),
+        ):
+            await UiAutomationTransport._select_image_model(page, Model.NARWHAL)
 
 
 def _exit_agent_page(initial: dict) -> tuple[MagicMock, dict]:

--- a/tests/fixtures/flow_model_inventory.json
+++ b/tests/fixtures/flow_model_inventory.json
@@ -1,0 +1,16 @@
+{
+  "_provenance": {
+    "captured_utc": "2026-08-26T11:45:00Z",
+    "profile": "denon82",
+    "account_locale": "pt",
+    "method": "scripts/dev/spike_model_inventory.py — menu read WHILE OPEN",
+    "note": "An EMPTY read is instrument failure, never data. #539 recorded a previous capture taken after the menu closed and treated the emptiness as absence; that conclusion was wrong. Never write this file from an empty read."
+  },
+  "image": [
+    "🍌 Nano Banana Pro",
+    "🍌 Nano Banana 2",
+    "🍌 Nano Banana 2 Lite"
+  ],
+  "video": null,
+  "_video_note": "Not yet captured — the video picker uses a different trigger than the image one. null means UNKNOWN, which the governance test treats as 'cannot assert', NOT as 'empty'. #539 depends on this being captured."
+}

--- a/tests/fixtures/flow_project_listing_media.json
+++ b/tests/fixtures/flow_project_listing_media.json
@@ -1,0 +1,54 @@
+{
+  "result": {
+    "data": {
+      "json": {
+        "projectContents": {
+          "media": [
+            {
+              "name": "67d7bf3a-79b3-4125-9ac7-a19cd1d0a598",
+              "projectId": "58ec10b9-87f6-4c72-9243-8581bdfc93e5",
+              "workflowId": "16c323b5-d0eb-40ed-85bd-ff26c3c78492",
+              "workflowStepId": "CAE",
+              "mediaMetadata": {
+                "createTime": "2026-07-27T10:05:17.670598Z",
+                "requestData": {
+                  "promptInputs": [
+                    {
+                      "textInput": "PR 389 E2E verification: a simple blue ceramic cup centered on a plain white table in a 1:1 aspect ratio.",
+                      "structuredPrompt": {
+                        "parts": [
+                          {
+                            "text": "PR 389 E2E verification: a simple blue ceramic cup centered on a plain white table in a 1:1 aspect ratio."
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "imageGenerationRequestData": {},
+                  "clientPlatform": "CLIENT_PLATFORM_WEB"
+                },
+                "visibility": "PRIVATE",
+                "mediaBlobSize": "443650"
+              },
+              "image": {
+                "generatedImage": {
+                  "seed": 308519,
+                  "mediaGenerationId": "CAMSJDU4ZWMxMGI5LTg3ZjYtNGM3Mi05MjQzLTg1ODFiZGZjOTNlNRokZGI2MTEwMTMtYTFhYy00MjVmLThkMWItM2RjOTBmYjc1OGI2IgNDQUUqJDY3ZDdiZjNhLTc5YjMtNDEyNS05YWM3LWExOWNkMWQwYTU5OA",
+                  "prompt": "PR 389 E2E verification: a simple blue ceramic cup centered on a plain white table in a 1:1 aspect ratio.",
+                  "modelNameType": "NARWHAL",
+                  "previousMediaGenerationId": "",
+                  "workflowId": "16c323b5-d0eb-40ed-85bd-ff26c3c78492",
+                  "aspectRatio": "IMAGE_ASPECT_RATIO_SQUARE"
+                },
+                "dimensions": {
+                  "width": 1024,
+                  "height": 1024
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/flow_selectors/test_model_governance.py
+++ b/tests/flow_selectors/test_model_governance.py
@@ -1,0 +1,193 @@
+"""Governance: our model selectors must still resolve against what Flow offers.
+
+Model drift is invisible by construction. Flow removes an entry or adds a
+near-duplicate on their schedule, with no signal on ours — no failing test, no
+error, no changed line of our code. On 2026-08-26 a manual spike found three
+distinct drifts that had been live for an unknown period:
+
+    Flow offers: Nano Banana Pro / Nano Banana 2 / Nano Banana 2 Lite
+
+    GEM_PIX_2   has-text('Nano Banana Pro')  -> HIT
+    NARWHAL     has-text('Nano Banana 2')    -> AMBIGUOUS (also matches "2 Lite")
+    IMAGEN_3_5  has-text('Imagen 4')         -> MISS (entry no longer exists)
+    (unmodelled)                             -> "Nano Banana 2 Lite" is a tier we
+                                                do not expose at all
+
+This test is the guard. It runs offline in CI on every commit, grading our
+selectors against a recorded inventory that the live probe refreshes. When the
+probe records a new entry that makes a selector ambiguous, CI fails HERE rather
+than a user being billed for the wrong model.
+
+The recorded inventory is evidence, not configuration: it is what Flow actually
+rendered, with provenance. Editing it to make this test pass, without a probe
+run behind it, defeats the entire mechanism.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.api.image import Model
+from gflow_cli.api.transports.ui_automation import IMAGE_MODEL_OPTION_SELECTORS
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "flow_model_inventory.json"
+
+#: Entries Flow offers that we knowingly do not model. Each needs a reason and,
+#: ideally, an issue. An empty waiver list is the goal, not the default.
+#: Models Flow has REMOVED from its picker. Kept in the registry so the removal
+#: stays visible and `--model` fails with a named reason rather than the model
+#: silently vanishing. Each entry is a decision that needs closing out, not a
+#: place to park failures.
+_NO_LONGER_OFFERED: dict[Model, str] = {
+    Model.IMAGEN_3_5: (
+        "Flow removed 'Imagen 4' from the image picker — confirmed live 2026-08-26 "
+        "(offered: Nano Banana Pro / 2 / 2 Lite). Until this model is retired or "
+        "remapped, requesting it raises UiSelectorDriftError (exit 23) naming what "
+        "Flow does offer, instead of silently generating on the default and billing "
+        "for it. Follow-up: decide retire-vs-remap."
+    ),
+}
+
+_UNMODELLED_WAIVERS: dict[str, str] = {
+    "🍌 Nano Banana 2 Lite": (
+        "Discovered 2026-08-26. A lower-tier image model we do not expose. "
+        "Waived pending a capability spike (cost/quality) before we ship it."
+    ),
+}
+
+
+def _inventory() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _matches(selector: str, offered: list[str]) -> list[str]:
+    """Model Playwright's text-matching faithfully, or this guard lies.
+
+    Supported forms, because the real selectors use all three:
+      :has-text('X')        substring, case-insensitive
+      :text-is('X')         exact match on normalised whitespace
+      :not(:has-text('Y'))  excludes entries containing Y
+
+    Modelling this precisely is the whole point — 'Nano Banana 2' looks unique
+    until you notice it is a SUBSTRING of 'Nano Banana 2 Lite'. A matcher that
+    treated has-text as equality would have reported the pre-fix selectors clean
+    and the guard would have been decorative.
+    """
+    excludes = [
+        m.split("has-text('", 1)[1].split("')", 1)[0]
+        for m in re.findall(r":not\(:has-text\('[^']+'\)\)", selector)
+    ]
+    positives = re.sub(r":not\(:has-text\('[^']+'\)\)", "", selector)
+
+    exacts = re.findall(r":text-is\('([^']+)'\)", positives)
+    subs = re.findall(r":has-text\('([^']+)'\)", positives)
+    if not exacts and not subs:
+        return []
+
+    def _norm(v: str) -> str:
+        return " ".join(v.split()).lower()
+
+    out = []
+    for item in offered:
+        n = _norm(item)
+        if exacts and not any(_norm(e) == n for e in exacts):
+            continue
+        if subs and not all(_norm(x) in n for x in subs):
+            continue
+        if any(_norm(x) in n for x in excludes):
+            continue
+        out.append(item)
+    return out
+
+
+def test_fixture_has_provenance() -> None:
+    """A recorded inventory without provenance is indistinguishable from a guess."""
+    prov = _inventory().get("_provenance", {})
+    assert prov.get("captured_utc"), "inventory must record WHEN it was captured"
+    assert prov.get("method"), "inventory must record HOW it was captured"
+
+
+def test_every_model_has_a_picker_selector() -> None:
+    """A model cannot be added without a way to select it.
+
+    Without this, `gflow models` can advertise something the transport silently
+    cannot choose.
+    """
+    missing = [m.value for m in Model if m not in IMAGE_MODEL_OPTION_SELECTORS]
+    assert not missing, f"models with no picker selector: {missing}"
+
+
+@pytest.mark.parametrize("model", list(Model))
+def test_selector_matches_exactly_one_offered_entry(model: Model) -> None:
+    """The core guard: exactly one, never zero, never more.
+
+    - zero  => MISS. The old code silently generated on Flow's default and billed
+               for it (the Imagen 4 case).
+    - many  => AMBIGUOUS. `.first` picks by DOM order, so behaviour changes when
+               Flow reorders, with no code change on our side (the
+               'Nano Banana 2' / '2 Lite' case).
+    """
+    if model in _NO_LONGER_OFFERED:
+        pytest.skip(f"{model.value}: {_NO_LONGER_OFFERED[model]}")
+
+    offered = _inventory()["image"]
+    selectors = IMAGE_MODEL_OPTION_SELECTORS.get(model, ())
+
+    # A cascade is a FALLBACK CHAIN: the transport tries each in order and uses
+    # the first that matches (ui_automation.py `for sel in option_sels`). Summing
+    # across all of them would report a model with two equivalent selectors as
+    # AMBIGUOUS, which is a false alarm — the second is never reached.
+    total: list[str] = []
+    for sel in selectors:
+        total = _matches(sel, offered)
+        if total:
+            break
+
+    assert total, (
+        f"{model.value}: MISS — no offered entry matches {list(selectors)}.\n"
+        f"Flow offered: {offered}\n"
+        f"gflow would previously have generated on Flow's default model and billed for it."
+    )
+    assert len(total) == 1, (
+        f"{model.value}: AMBIGUOUS — {len(total)} entries match: {total}\n"
+        f"Selecting .first picks by DOM order and can bill a different model."
+    )
+
+
+def test_every_offered_entry_is_modelled_or_waived() -> None:
+    """Flow offering something we do not model is drift too — the quiet kind.
+
+    A new tier we never expose is a missed capability rather than a bug, but it
+    should be a decision on the record, not something nobody noticed.
+    """
+    offered = _inventory()["image"]
+    claimed = {
+        m
+        for model in Model
+        for sel in IMAGE_MODEL_OPTION_SELECTORS.get(model, ())
+        for m in _matches(sel, offered)
+    }
+    unexplained = [o for o in offered if o not in claimed and o not in _UNMODELLED_WAIVERS]
+    assert not unexplained, (
+        f"Flow offers entries we neither model nor waive: {unexplained}\n"
+        f"Either add a Model for it, or record a waiver with a reason."
+    )
+
+
+def test_video_inventory_is_unknown_not_empty() -> None:
+    """`null` must mean UNKNOWN, never 'Flow offers nothing'.
+
+    #539's earlier capture read an empty menu (taken after it closed) and the
+    emptiness was mistaken for absence. Encoding UNKNOWN distinctly is what stops
+    that error being repeated — and this test fails once the video inventory IS
+    captured, which is the prompt to assert on it properly.
+    """
+    inv = _inventory()
+    assert inv["video"] is None, (
+        "video inventory is now captured — replace this test with the same "
+        "exactly-one-match assertions used for image models (see #539)."
+    )

--- a/tests/services/test_media_attribution.py
+++ b/tests/services/test_media_attribution.py
@@ -1,0 +1,91 @@
+"""Server-side attribution: what model ACTUALLY generated a media (issue #586).
+
+gflow records which model produced an image from two different sources:
+
+* classic — the `batchGenerateImages` RESPONSE (`dto.py:183`) — observed truth
+* agentic — the REQUEST we sent (`agentic.py:914`) — our own intent
+
+Both land in the same catalog column (`recorder.py:503`), indistinguishably.
+
+Observed live on 2026-08-26: an agentic run requested `GEM_PIX_2`
+(Nano Banana Pro) and Flow generated with `NARWHAL`. The CLI exited 0, printed
+`GEM_PIX_2`, and the catalog recorded `GEM_PIX_2` with `seed=0`/`0x0` sentinels.
+The server, asked directly, said `NARWHAL` with `seed=93862`.
+
+The agentic driver documents these fields as unobservable because they live in a
+Web-Worker SSE stream Playwright cannot see. That is true of the DOM and of
+page-level network events — and it does not follow that they are unknowable.
+`flow.projectInitialData` returns every one of them, keyed by the media UUID the
+scraper already extracts, through a fetcher gflow already has
+(`client.fetch_project_listing`, ~0.5s, cookie auth, free).
+
+The fixture is a real captured payload from an agentic run (PR #389 live
+verification, 2026-07-27), trimmed to the media array.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.services.catalog_sync import parse_media_attribution
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "flow_project_listing_media.json"
+_MEDIA = "67d7bf3a-79b3-4125-9ac7-a19cd1d0a598"
+
+
+def _payload() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_extracts_observed_attribution_keyed_by_media_uuid() -> None:
+    attrs = parse_media_attribution(_payload())
+
+    assert _MEDIA in attrs, f"expected {_MEDIA} in {list(attrs)}"
+    a = attrs[_MEDIA]
+    assert a.model_name_type == "NARWHAL"
+    assert a.seed == 308519
+    assert a.aspect_ratio == "IMAGE_ASPECT_RATIO_SQUARE"
+
+
+def test_seed_is_int_not_the_wire_string() -> None:
+    """The wire sends seed as a STRING ('308519'); the catalog column is an int.
+
+    Leaving it as a string would compare unequal to a recorded int forever, so a
+    drift check built on it would fire on every row.
+    """
+    assert isinstance(parse_media_attribution(_payload())[_MEDIA].seed, int)
+
+
+def test_missing_generated_image_is_omitted_not_faked() -> None:
+    """A media row without generatedImage yields NO entry.
+
+    Absence must stay absent. Emitting a placeholder here would recreate exactly
+    the bug this exists to detect — a synthesised value indistinguishable from an
+    observed one.
+    """
+    payload = {
+        "result": {"data": {"json": {"projectContents": {"media": [{"name": "no-image-row"}]}}}}
+    }
+    assert parse_media_attribution(payload) == {}
+
+
+def test_unparseable_envelope_raises_rather_than_returning_empty() -> None:
+    """Same contract as parse_project_listing: an unrecognised envelope fails loudly.
+
+    Returning {} would read as "the server attributes nothing", which a caller
+    would take as agreement.
+    """
+    with pytest.raises(ValueError, match="projectContents"):
+        parse_media_attribution({"result": {"data": {"json": {}}}})
+
+
+def test_non_media_rows_do_not_break_the_parse() -> None:
+    payload = _payload()
+    payload["result"]["data"]["json"]["projectContents"]["media"].append(
+        {"name": "junk", "image": "not-a-dict"}
+    )
+    attrs = parse_media_attribution(payload)
+    assert _MEDIA in attrs


### PR DESCRIPTION
Closes #586. Council-reviewed across four dimensions; several findings were against my own first implementation and are folded in.

## The defect, observed

`--model imagen4` produced an image on `NARWHAL` and **exited 0**. Confirmed three independent ways:

| layer | evidence |
|---|---|
| log | `image_model_not_set model=IMAGEN_3_5` |
| catalog | `{"prompt": "old behaviour check", "model": "NARWHAL"}` |
| **wire** | **HAR: `requests[0].imageModelName = 'NARWHAL'`** |

**There is no fallback logic.** Nothing maps `IMAGEN_3_5` to `NARWHAL`. The code failed to *change* the picker, pressed Escape, and the submit inherited whatever that project's panel held. The catalog timeline names the source — a `--model nano2` run **two hours earlier in the same project**:

```
11:55:16  model=NARWHAL  proj=2ddc3a33  'a harbour at dawn'      <- --model nano2
14:08:07  model=NARWHAL  proj=2ddc3a33  'old behaviour check'    <- --model imagen4
```

So the effective model is residual browser state: no code path to review, no default to point at, and different results for the same command depending on what ran before.

Flow's picker today offers **Nano Banana Pro / Nano Banana 2 / Nano Banana 2 Lite**. `Imagen 4` is gone, and `has-text('Nano Banana 2')` matches the Lite tier too — `.first` was resolving by DOM order.

## What ships

- Missing **or ambiguous** selector → `UiSelectorDriftError` (exit 23) naming what Flow offered, before submitting. Ambiguity is a failure, not a `.first` guess.
- NARWHAL disambiguated against the Lite tier. The `text-is` candidate was tried and **removed** — it matched the fixture but never matched live (fixture stores normalised labels; `text-is` matches raw `innerText`).
- **`parse_media_attribution`** reads `modelNameType`/`seed`/`aspectRatio` from the `flow.projectInitialData` listing we already fetch. Rows without `generatedImage` are **omitted, never defaulted** — a placeholder would be indistinguishable from an observation, which is the defect being detected.
- Restored the visibility gate lost when ambiguity detection was added (`count()` counts mounted-but-hidden Radix nodes).
- `_close_model_menu` presses Escape **twice** — menu and the settings panel beneath it.

## Why the server read matters more than the guard

**The guard is inert on the agentic arm**, which never calls `_configure_generation_settings`. Observed live during this work — the cohort flapped mid-session:

```
ui_driver.bound  mode=agentic          <- every earlier run bound classic
requested        GEM_PIX_2             <- CLI printed this; catalog records this
server truth     NARWHAL, seed=93862   <- catalog holds seed=0, dimensions 0x0
exit             0
```

The agentic driver documents those fields as unobservable because they live in a Web-Worker SSE stream Playwright cannot see. True of the DOM and of page-level network events — and **it does not follow that they are unknowable**. `flow.projectInitialData` returns every one of them, keyed by the UUID the scraper already extracts, via a fetcher gflow already has (~0.5s, cookie auth, free).

## Deliberately NOT shipped, with reasons

- **Panel-miss WARNS, does not raise.** An earlier version raised; the existing batch tests showed it turning one transient miss on prompt 0 into a whole-batch abort — the transport cannot distinguish "user passed `--model X`" from "X is the default", since `request.model` is populated either way.
- **No wire-vs-intent refusal.** `image.py` documents `GEM_PIX_2` and `IMAGEN_3_5` as *"inferred from Flow's UI labels"* — only `NARWHAL` has ever been observed on the wire. Refusing on a comparison against a guessed constant would false-positive **after** the quota is spent.

## Correction to an earlier claim

I stated a wrong-model generation "billed" the user. **Retracted.** Images cost **0 credits** and are metered by a **per-model daily quota** (`test_classic_count_setter_e2e.py:7`; live cost line read `0`). The harm is consuming another model's daily allowance and getting different output. Video is the credit-metered arm.

## Language agnosticism — verified, not assumed

Editor entry, image-mode switch, and model selection all succeed in **pt / de / ja / fr / ru** driving the real transport code. The brand-name selectors matched in Japanese and Russian: Flow does not localise them. One account tests every locale because Flow routes locale by URL segment — the earlier "unverifiable without accounts in those locales" claim was wrong.

## Verification — every behaviour change exercised against real Flow

Re-run on the FINAL code after the council corrections, because several changes landed after the first e2e pass and an earlier verification does not transfer.

| behaviour | live result |
|---|---|
| Missing model refused | `EXIT=23`, **0 jpgs**, error names what Flow offered |
| **Ambiguous** model refused | `EXIT=23`, **0 jpgs**, `AMBIGUOUS - 2 entries match` (ambiguous selector temporarily restored to reach the branch) |
| Disambiguated NARWHAL selects | `image_model_selected via=...:not(:has-text('Lite'))`, real jpg |
| Visibility gate (S4) | classic run selected + generated on the post-change click path |
| No batch cascade (S3) | prompt 0 refused, **prompt 1 still OK** - `1/2 succeeded, 1 failure`, `EXIT=0` |
| Panel-miss warns, continues | `image_model_not_applied model=GEM_PIX_2 reason="...panel could not be opened"`, `EXIT=0`, 1 jpg |
| Server attribution detects mismatch | `EXIT=1` on the real agentic mis-attribution |
| Language agnosticism | editor entry + mode switch + model selection OK in **pt/de/ja/fr/ru** |

Each mutation used to reach a branch was reverted immediately; `git status` is clean and `git diff HEAD` is empty, so no mutation leaked into the commit.

- [x] **3427 passed**, 6 skipped, 0 failed
- [x] `ruff` clean, `pyright` 0 errors, repo hygiene (814 files), doc links
- [x] Live A/B with the old implementation restored on a scratch copy, then reverted
- [x] S2/S3/S4 mutation-verified offline AND exercised live

### Observed while verifying: the cohort race is real

Two identical `--ui-mode classic` runs, seconds apart: one bound classic and refused correctly (exit 23); the other failed at `mode_control.ensure_media_incomplete` with `FlowAppError` (**exit 31**) before reaching model selection at all - and wrote no image. The arm is decided by a DOM race, so "does my model guard engage" has no stable answer between two identical commands. Not introduced here, but it bounds what any pre-submit guard can promise.

## Known gaps, filed not hidden

Video model selection still has the pre-fix silent fallback — and video is the arm that costs credits (up to 100 vs 10). The governance test grades zero video selectors. That is the next piece, not this one.


