### PR TITLE
fix(api): refuse an unselectable video model instead of charging for another

### DIFF
--- a/docs/superpowers/specs/2026-08-26-model-attribution-provenance.md
+++ b/docs/superpowers/specs/2026-08-26-model-attribution-provenance.md
@@ -122,9 +122,19 @@ did not apply is this same bug class.
 - Numeric daily limits for any image model. Observable only on exhaustion.
 - Whether the daily quota is per-model or per-account.
 - Cost/quota of `Nano Banana 2 Lite`.
-- Whether `veo_3_1_lite_lower_priority` exists in the live picker (#539) — the
-  video picker uses a different trigger; two prior captures read an empty menu
-  **after it closed**, which is instrument failure, not absence.
+- ~~Whether `veo_3_1_lite_lower_priority` exists in the live picker (#539)~~ —
+  **answered 2026-08-26.** The picker rendered exactly `Omni Flash` /
+  `Veo 3.1 - Lite` / `Veo 3.1 - Fast` / `Veo 3.1 - Quality` for profile denon82.
+  The `[Lower Priority]` tier was **not offered to that account at that moment**,
+  which is not proof it does not exist — it may be cohort- or region-gated.
+  Recorded as a dated observation in `tests/fixtures/flow_model_inventory.json`.
+
+  The earlier "the video picker uses a different trigger" note is **FALSIFIED**:
+  `MODEL_PICKER_TRIGGER` and `IMAGE_MODEL_PICKER_TRIGGER` are byte-identical
+  strings. The empty captures were caused by the CAPTURE, not the product —
+  `_switch_to_video_mode` leaves the settings menu open by contract, and calling
+  `_open_gen_settings_panel` after it re-clicks the SAME button and toggles the
+  panel shut. Two prior captures blamed Flow for an instrument error.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md
+++ b/docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md
@@ -57,7 +57,9 @@ Governance is worthless if it records guesses as facts. Split explicitly:
 - Whether that limit is per-model or shared across models on an account.
 - Whether `Nano Banana 2 Lite` carries a different quota (it is a newly
   discovered tier we do not model).
-- Whether `veo_3_1_lite_lower_priority` is cheaper, free, or absent (#539).
+- Whether `veo_3_1_lite_lower_priority` is cheaper or free (#539). Its ABSENCE
+  from denon82's picker on 2026-08-26 is now recorded; its cost is still unknown
+  because it was never offered to select.
 
 ## Observability — and its hard limit
 
@@ -109,7 +111,10 @@ Scenario: a requested model is not offered by Flow
 ```
 
 **E2E.** The credit-line read per video model is credit-free and repeatable —
-that is the gate for the video half. The image half is asserted through the
+that is the gate for the video half. The video model *selection* guard is
+verified the same way, credit-free: selection happens in the settings panel
+entirely before submit, so `scripts/dev/live_verify_video_model_select.py` drives
+the real production function against the real DOM and never sends a prompt. The image half is asserted through the
 already-passing loud-failure path; deliberately exhausting a daily quota to
 observe a 429 is **not** a routine test, and the catalogue records the value
 opportunistically when a real 429 occurs.

--- a/scripts/dev/live_verify_video_model_select.py
+++ b/scripts/dev/live_verify_video_model_select.py
@@ -1,0 +1,108 @@
+"""Does `_select_video_model` really select — and really refuse? Zero credits.
+
+Video is the credit-bearing arm (veo-quality 100 against veo-lite's 10), so the
+guard added on 2026-08-26 must be verified without generating. It can be: model
+selection happens in the settings panel, entirely BEFORE submit. This drives the
+real production function against the real Flow DOM and never sends a prompt.
+
+Three questions, all answered live:
+
+1. Does every model Flow offers still select? (the guard must not break the
+   working path — a false refusal is as bad as a silent fallback)
+2. Does a model Flow does NOT offer refuse? `VEO_3_1_LITE_LOWER_PRIORITY` was
+   not offered to denon82 on 2026-08-26, which makes it a real MISS to test
+   rather than a synthetic one.
+3. Does an AMBIGUOUS selector refuse rather than resolving `.first`? Injected by
+   monkeypatching the registry with a deliberately-ambiguous selector — `Veo 3.1`
+   matches Lite, Fast and Quality.
+
+    uv run python scripts/dev/live_verify_video_model_select.py \
+        --profile denon82 --project <pid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from gflow_cli.api.transports import ui_automation_video as mod  # noqa: E402
+from gflow_cli.api.video import VideoModel  # noqa: E402
+from gflow_cli.errors import VideoModelSelectionError  # noqa: E402
+
+
+async def _try_select(page: Any, transport: Any, model: VideoModel) -> tuple[str, str]:
+    """Re-enter video mode, attempt a selection, report the outcome."""
+    # A fresh editor entry each time: `_switch_to_video_mode` leaves the settings
+    # menu OPEN by contract, and its trigger is the SAME button as the panel's,
+    # so re-clicking without a reset toggles it shut. That exact sequencing error
+    # is what made #539's video capture read empty for months.
+    await transport._enter_editor(page, None, project_id=_PROJECT)
+    await transport._switch_to_video_mode(page, out_dir=None)
+    try:
+        await mod.VideoGenerationMixin._select_video_model(page, model, out_dir=None)
+    except VideoModelSelectionError as exc:
+        return "REFUSED", str(exc)[:160]
+    except Exception as exc:  # noqa: BLE001
+        return f"OTHER({type(exc).__name__})", str(exc)[:160]
+    finally:
+        await page.keyboard.press("Escape")
+        await page.wait_for_timeout(300)
+    return "SELECTED", ""
+
+
+_PROJECT = ""
+
+
+async def main() -> int:
+    global _PROJECT
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    _PROJECT = args.project
+
+    rows: list[tuple[str, str, str, str]] = []
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        t = client.transport
+        page = client._page
+
+        # --- 1 & 2: every registered model, as-shipped ---
+        for model in VideoModel:
+            outcome, detail = await _try_select(page, t, model)
+            expected = (
+                "REFUSED" if model is VideoModel.VEO_3_1_LITE_LOWER_PRIORITY else "SELECTED"
+            )
+            rows.append((model.value, expected, outcome, detail))
+
+        # --- 3: injected ambiguity ---
+        original = mod.VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_FAST]
+        mod.VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_FAST] = (
+            "[role='menuitem']:has-text('Veo 3.1')"  # matches Lite + Fast + Quality
+        )
+        try:
+            outcome, detail = await _try_select(page, t, VideoModel.VEO_3_1_FAST)
+            rows.append(("veo_3_1_fast (AMBIGUOUS selector)", "REFUSED", outcome, detail))
+        finally:
+            mod.VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_FAST] = original
+
+    print(f"\n{'case':<40}{'expected':<11}{'actual':<11}detail")
+    print("-" * 120)
+    failures = 0
+    for case, expected, actual, detail in rows:
+        ok = actual == expected
+        failures += 0 if ok else 1
+        print(f"{'OK ' if ok else 'FAIL'} {case:<36}{expected:<11}{actual:<11}{detail}")
+
+    print(f"\n{len(rows) - failures}/{len(rows)} as expected. Zero credits spent (no submit).")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/dev/spike_model_inventory.py
+++ b/scripts/dev/spike_model_inventory.py
@@ -53,12 +53,24 @@ _READ_MENU = """
 """
 
 
-async def open_and_read(page: Any, label: str) -> dict[str, Any]:
-    """Click the model picker and read the menu WHILE IT IS OPEN."""
+async def open_and_read(page: Any, label: str, *, trigger_idx: int = 0) -> dict[str, Any]:
+    """Click the model picker and read the menu WHILE IT IS OPEN.
+
+    ``trigger_idx`` exists because the trigger selector is an `arrow_drop_down`
+    button, and the VIDEO settings panel renders several of them (model,
+    duration, aspect...). `.first` is therefore not necessarily the model picker
+    — the recorded "video picker uses a different trigger" note was a guess; the
+    two module constants are byte-identical strings.
+    """
+    n = await page.locator(IMAGE_MODEL_PICKER_TRIGGER).count()
     try:
-        await page.locator(IMAGE_MODEL_PICKER_TRIGGER).first.click(timeout=6000)
+        await page.locator(IMAGE_MODEL_PICKER_TRIGGER).nth(trigger_idx).click(timeout=6000)
     except Exception as exc:  # noqa: BLE001
-        return {"stage": label, "instrument_error": f"trigger: {type(exc).__name__}"}
+        return {
+            "stage": label,
+            "trigger_count": n,
+            "instrument_error": f"trigger: {type(exc).__name__}",
+        }
     await page.wait_for_timeout(1200)
     snap = await page.evaluate(_READ_MENU)
     snap["stage"] = label
@@ -66,6 +78,8 @@ async def open_and_read(page: Any, label: str) -> dict[str, Any]:
         # Never report this as "no models" — #539's earlier capture made exactly
         # that mistake and the conclusion was wrong.
         snap["instrument_error"] = "menu read empty — menu was not open; INCONCLUSIVE"
+    snap["trigger_count"] = n
+    snap["trigger_idx"] = trigger_idx
     return snap
 
 
@@ -95,9 +109,22 @@ async def main() -> int:
         await page.wait_for_timeout(400)
 
         # --- VIDEO ---
+        # `_switch_to_video_mode` leaves the settings menu OPEN by contract (its
+        # docstring: "The menu stays open afterward so the caller can also set
+        # aspect + count"), unlike `_switch_to_image_mode`, which closes it with
+        # Escape. So do NOT call `_open_gen_settings_panel` here: the panel and
+        # the mode dropdown are the SAME crop_* trigger button, and clicking it
+        # again TOGGLES the panel shut. The video tab probe then misses on all
+        # five selectors and the capture reads empty.
+        #
+        # That is the instrument failure #539 recorded as "the video picker uses
+        # a different trigger". Falsified 2026-08-26: MODEL_PICKER_TRIGGER and
+        # IMAGE_MODEL_PICKER_TRIGGER are byte-identical strings, and a DOM dump
+        # (spike_video_tab_dom.py) showed `-trigger-VIDEO` present and visible
+        # throughout. Re-entering the editor gives a known-closed starting state.
+        await t._enter_editor(page, None, project_id=args.project)
         try:
             await t._switch_to_video_mode(page, out_dir=None)
-            await t._open_gen_settings_panel(page)
             out["video"] = await open_and_read(page, "video")
             await page.keyboard.press("Escape")
         except Exception as exc:  # noqa: BLE001

--- a/scripts/dev/spike_video_tab_dom.py
+++ b/scripts/dev/spike_video_tab_dom.py
@@ -1,0 +1,102 @@
+"""What does Flow's mode dropdown ACTUALLY render? (#539, video-tab drift)
+
+`spike_model_inventory.py` could not reach video mode on 2026-08-26: all five
+`VIDEO_TAB_IN_MENU_SELECTORS` missed on an `html_lang=en` account, while the
+image tab matched via `aria-controls*='IMAGE'`. Note the asymmetry — image uses
+a CONTAINS match, video an ENDS-WITH (`$='-content-VIDEO'`). This dumps every
+`[role='tab']` with its id / aria-controls / text so the miss is diagnosed from
+evidence rather than from a guess about which trigger is which.
+
+Navigation and menu clicks only. Never submits. Zero credits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
+    MODE_SWITCH_TRIGGER_SELECTORS,
+)
+
+_DUMP_TABS = """
+() => ({
+  tabs: Array.from(document.querySelectorAll("[role='tab']")).map(e => ({
+    id: e.id || null,
+    ariaControls: e.getAttribute('aria-controls'),
+    ariaSelected: e.getAttribute('aria-selected'),
+    text: (e.innerText || '').replace(/\s+/g, ' ').trim(),
+    visible: !!(e.offsetParent || e.getClientRects().length),
+  })),
+  menus: document.querySelectorAll("[role='menu']").length,
+  menuitems: Array.from(document.querySelectorAll("[role='menuitem']"))
+      .map(e => (e.innerText || '').replace(/\s+/g, ' ').trim()).filter(Boolean),
+  dropdowns: Array.from(document.querySelectorAll("button[aria-haspopup='menu']")).map(e => ({
+    text: (e.innerText || '').replace(/\s+/g, ' ').trim(),
+    expanded: e.getAttribute('aria-expanded'),
+    icons: Array.from(e.querySelectorAll('i')).map(i => (i.textContent || '').trim()),
+    visible: !!(e.offsetParent || e.getClientRects().length),
+  })),
+})
+"""
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+
+    out: dict[str, Any] = {}
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        t = client.transport
+        page = client._page
+        await t._enter_editor(page, None, project_id=args.project)
+        out["html_lang"] = await page.evaluate("document.documentElement.lang")
+
+        out["before_open"] = await page.evaluate(_DUMP_TABS)
+
+        opened = None
+        for sel in MODE_SWITCH_TRIGGER_SELECTORS:
+            if await page.locator(sel).count() > 0:
+                await page.locator(sel).first.click(timeout=6000)
+                opened = sel
+                break
+        out["mode_trigger_used"] = opened
+        await page.wait_for_timeout(1200)
+        out["after_open"] = await page.evaluate(_DUMP_TABS)
+
+        # Now go to VIDEO mode and dump the settings panel's dropdowns, so the
+        # model picker is identified by what it renders, not by an index guess.
+        await t._switch_to_video_mode(page, out_dir=None)
+        await t._open_gen_settings_panel(page)
+        await page.wait_for_timeout(800)
+        out["video_panel"] = await page.evaluate(_DUMP_TABS)
+
+    print(f"html_lang={out['html_lang']}  trigger={out['mode_trigger_used']}")
+    for stage in ("before_open", "after_open"):
+        blk = out[stage]
+        print(f"\n=== {stage} === menus={blk['menus']} dropdowns={blk['dropdowns']}")
+        for tb in blk["tabs"]:
+            print(
+                f"  id={tb['id']!r} aria-controls={tb['ariaControls']!r} "
+                f"selected={tb['ariaSelected']} visible={tb['visible']} text={tb['text']!r}"
+            )
+
+    dest = Path("scripts/dev/_spike_out/spike_video_tab_dom.json")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nevidence: {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -258,3 +258,70 @@ def _redacted_snippet(text: str) -> str:
     success path pays nothing.
     """
     return redact_error_detail(text)[:200]
+
+
+# ---------------------------------------------------------------------------
+# Model-picker primitives, shared by the image and video transports.
+#
+# Both arms drive a Radix `[role='menu']` of `[role='menuitem']` entries through
+# the SAME trigger selector, and both were bitten by the same two hazards:
+# `has-text` is a SUBSTRING match (so one label can be a prefix of another), and
+# a raw `count()` includes mounted-but-hidden nodes. Keeping one copy means a
+# fix on one arm cannot silently skip the other.
+# ---------------------------------------------------------------------------
+
+READ_MENU_ITEM_LABELS = r"""
+() => Array.from(document.querySelectorAll("[role='menuitem']"))
+    .map(e => (e.innerText || '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+"""
+
+
+async def offered_menu_labels(page: Any) -> list[str]:
+    """What the picker is rendering RIGHT NOW — read while the menu is open.
+
+    Included in every failure message: a bare "model not found" is unactionable,
+    whereas the actual list tells an operator immediately whether Flow renamed an
+    entry, removed it, or added a near-duplicate. Best-effort — diagnostics must
+    never mask the error they describe.
+    """
+    try:
+        return list(await page.evaluate(READ_MENU_ITEM_LABELS))
+    except Exception:  # noqa: BLE001
+        return []
+
+
+async def close_menu(page: Any) -> None:
+    """Leave no stray open UI behind after a refusal.
+
+    TWO Escapes, deliberately: the model menu and the generation-settings panel
+    beneath it. Raising out of a model select skips the caller's own panel-close,
+    so a single Escape leaves the panel open. In a batch that then toggles the
+    panel SHUT on the next prompt's open attempt, turning one drifted selector
+    into a whole-batch failure.
+    """
+    for _ in range(2):
+        try:
+            await page.keyboard.press("Escape")
+        except Exception:  # noqa: BLE001, S110 — cleanup only
+            return
+
+
+async def count_visible(page: Any, selector: str) -> tuple[int, Any]:
+    """Number of VISIBLE matches for *selector*, plus the first of them.
+
+    `count()` alone counts mounted-but-hidden nodes. Radix keeps menus mounted,
+    so a stale or offscreen menu inflates the count and either forces a false
+    AMBIGUOUS or resolves to a node that cannot be clicked.
+    """
+    loc = page.locator(selector)
+    total = await loc.count()
+    matches = 0
+    first: Any = None
+    for i in range(total):
+        nth = loc.nth(i)
+        if await nth.is_visible():
+            matches += 1
+            if first is None:
+                first = nth
+    return matches, first

--- a/src/gflow_cli/api/transports/drivers/classic.py
+++ b/src/gflow_cli/api/transports/drivers/classic.py
@@ -141,11 +141,15 @@ class ClassicFlowUiDriver:
             effective_model = I2V_DEFAULT_MODEL
 
         if effective_model is not None:
+            # No `required` flag: EVERY miss is fatal now. We only get here when
+            # a model was explicitly requested (`--model` defaults to None on all
+            # video commands), so there is no case where falling back to Flow's
+            # current selection is what the caller asked for — and video spends
+            # credits, up to 100 for veo-quality against veo-lite's 10.
             await VideoGenerationMixin._select_video_model(  # type: ignore[reportPrivateUsage]
                 page,
                 effective_model,
                 out_dir=out_dir,
-                required=is_i2v_with_frames,
             )
         if request.mode is Mode.I2V:
             await VideoGenerationMixin._switch_video_sub_mode(  # type: ignore[reportPrivateUsage]

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -31,8 +31,11 @@ from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports._common import (
     await_url_settled,
+    close_menu,
+    count_visible,
     extract_project_id,
     generation_error,
+    offered_menu_labels,
 )
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
@@ -98,43 +101,6 @@ _PROJECT_URL_FRAGMENT = "/project/"
 IMAGE_MODEL_PICKER_TRIGGER = (
     "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))"
 )
-_READ_OFFERED_MODELS = r"""
-() => Array.from(document.querySelectorAll("[role='menuitem']"))
-    .map(e => (e.innerText || '').replace(/\s+/g, ' ').trim())
-    .filter(Boolean)
-"""
-
-
-async def _offered_model_labels(page: Any) -> list[str]:
-    """What the picker is rendering RIGHT NOW — read while the menu is open.
-
-    Included in every failure message: a bare "model not found" is unactionable,
-    whereas the actual list tells an operator immediately whether Flow renamed an
-    entry, removed it, or added a near-duplicate. Best-effort — diagnostics must
-    never mask the error they describe.
-    """
-    try:
-        return list(await page.evaluate(_READ_OFFERED_MODELS))
-    except Exception:  # noqa: BLE001
-        return []
-
-
-async def _close_model_menu(page: Any) -> None:
-    """Leave no stray open UI behind after a refusal.
-
-    TWO Escapes, deliberately: the model menu and the generation-settings panel
-    beneath it. Raising out of `_select_image_model` skips the panel-close at the
-    end of `_configure_generation_settings`, so a single Escape leaves the panel
-    open. In a batch that then toggles the panel SHUT on the next prompt's open
-    attempt, turning one drifted selector into a whole-batch failure.
-    """
-    for _ in range(2):
-        try:
-            await page.keyboard.press("Escape")
-        except Exception:  # noqa: BLE001, S110 — cleanup only
-            return
-
-
 # Verified live 2026-08-26 (menu read WHILE OPEN, profile denon82):
 #   ['Nano Banana Pro', 'Nano Banana 2', 'Nano Banana 2 Lite']
 # `has-text` is a SUBSTRING match, so 'Nano Banana 2' also matches
@@ -1829,32 +1795,17 @@ class UiAutomationTransport(VideoGenerationMixin):
         await trigger.click()
         await page.wait_for_timeout(500)
 
-        offered = await _offered_model_labels(page)
+        offered = await offered_menu_labels(page)
         for sel in option_sels:
-            loc = page.locator(sel)
             try:
-                # Count VISIBLE matches only. `count()` alone counts mounted-but-
-                # hidden nodes — Radix keeps menus mounted, so a stale or offscreen
-                # menu inflates the count and either forces a false AMBIGUOUS or
-                # resolves to a node that cannot be clicked. The visibility gate
-                # was in the pre-2026-08-26 code and was dropped when ambiguity
-                # detection was added; this restores it.
-                total = await loc.count()
-                matches = 0
-                first_visible = None
-                for i in range(total):
-                    nth = loc.nth(i)
-                    if await nth.is_visible():
-                        matches += 1
-                        if first_visible is None:
-                            first_visible = nth
+                matches, first_visible = await count_visible(page, sel)
             except Exception as exc:  # noqa: BLE001
                 log.debug("ui_automation.image_model_selector_miss", sel=sel, error=str(exc)[:120])
                 continue
             if matches == 0:
                 continue
             if matches > 1:
-                await _close_model_menu(page)
+                await close_menu(page)
                 raise UiSelectorDriftError(
                     selector_drift_detail(
                         "image_model",
@@ -1873,7 +1824,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             log.info("ui_automation.image_model_selected", model=model.value, via=sel)
             return
 
-        await _close_model_menu(page)
+        await close_menu(page)
         raise UiSelectorDriftError(
             selector_drift_detail(
                 "image_model",

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -27,7 +27,13 @@ import structlog
 
 from gflow_cli.api import routes
 from gflow_cli.api._retry import parse_retry_after
-from gflow_cli.api.transports._common import extract_project_id, generation_error
+from gflow_cli.api.transports._common import (
+    close_menu,
+    count_visible,
+    extract_project_id,
+    generation_error,
+    offered_menu_labels,
+)
 from gflow_cli.api.transports.drivers.factory import AGENTIC_INDICATOR_SELECTORS
 from gflow_cli.api.video import (
     I2V_DEFAULT_MODEL,
@@ -1513,67 +1519,82 @@ class VideoGenerationMixin:
         model: VideoModel,
         *,
         out_dir: Path | None,
-        required: bool = False,
     ) -> None:
-        """Open the model picker and select `model`.
+        """Open the model picker and select *model*, or FAIL before spending.
 
-        On miss the default behaviour is non-fatal (Flow's default model
-        applies) but logged at WARNING — picking the wrong model changes credit
-        cost. When ``required=True`` (i2v: see issue #125), a miss is FATAL and
-        raises ``VideoModelSelectionError`` BEFORE any frame attach or submit:
-        an i2v run on an unverified model breaks the request contract (cost
-        tier, duration cap, end-frame capability — first+last is Veo-3.1-only).
-        Failing here spends nothing.
+        Every miss is FATAL (changed 2026-08-26). This previously refused only
+        when ``required=True`` (i2v with frames, issue #125); a plain t2v miss
+        logged "Flow default model applies" and returned, so the run generated on
+        whatever model Flow last had selected and CHARGED FOR THAT TIER. Video is
+        the credit-bearing arm — veo-quality costs 100 against veo-lite's 10.
+
+        Refusing is unambiguously correct here, unlike the image panel-miss,
+        which stayed a warning. ``configure_video_settings`` calls this **only**
+        when ``effective_model is not None``, and ``--model`` defaults to
+        ``None`` on every video command, so reaching this function means a model
+        was EXPLICITLY requested. There is no "default or asked-for?" ambiguity.
+
+        AMBIGUOUS is a failure, not a ``.first`` guess: ``.first`` resolves by
+        DOM order, so an ambiguous selector silently picks whichever Flow renders
+        first and changes behaviour with no code change on our side.
+        ``has-text`` is a SUBSTRING match and ``Veo 3.1 - Lite`` is a prefix of
+        ``Veo 3.1 - Lite [Lower Priority]``, so this is a live hazard, not a
+        theoretical one.
 
         Reliability (issue #125): the trigger click occasionally does not open
-        the menu (the option probe then times out and Flow keeps its default).
-        We click the trigger and probe the option up to two times, pressing
+        the menu. We click the trigger and probe up to two times, pressing
         Escape between attempts to reset the dropdown state.
+
+        Runs before frame attach and submit, so a refusal spends nothing.
         """
         option_sel = VIDEO_MODEL_OPTION_SELECTORS.get(model)
         if option_sel is None:
-            log.warning("ui_automation_video.model_unknown", model=model.value)
-            if required:
-                # Consistent with the other required-misses below: a typed
-                # exit-18 error, not a bare RuntimeError (exit 1). Unreachable
-                # for the 5 registered models, but keeps the i2v contract intact.
-                msg = f"no model-picker selector registered for {model.value!r}"
-                raise VideoModelSelectionError(detail=msg, route="model_option")
-            return
+            # Unreachable for the registered models — the governance test pins
+            # that every VideoModel has a selector — but keeps the contract if
+            # one is added without one.
+            raise VideoModelSelectionError(
+                detail=f"no model-picker selector registered for {model.value!r}",
+                route="model_option",
+            )
         trigger = await VideoGenerationMixin._probe_selector_cascade(
             page,
             "model_picker_trigger",
             (MODEL_PICKER_TRIGGER,),
         )
         if trigger is None:
-            log.warning(
-                "ui_automation_video.model_picker_not_found",
-                model=model.value,
-                note="Flow default model applies",
-            )
-            if required:
-                shot = await _capture_debug_screenshot(page, out_dir, "debug_no_model_picker.png")
-                msg = (
-                    f"model picker trigger not found; cannot select {model.value!r} "
-                    f"for i2v. Refusing to proceed — an i2v run on an unverified "
-                    f"model breaks the request contract (refs #125)."
+            shot = await _capture_debug_screenshot(page, out_dir, "debug_no_model_picker.png")
+            raise VideoModelSelectionError(
+                detail=(
+                    f"model picker trigger not found; cannot select {model.value!r}. "
+                    f"Refusing to proceed — generating on whatever model Flow last "
+                    f"had selected would spend credits on a tier that was not "
+                    f"requested (refs #125). No credits were spent."
                     f"{screenshot_clause(shot)}"
-                )
-                raise VideoModelSelectionError(detail=msg, route="model_picker_trigger")
-            return
+                ),
+                route="model_picker_trigger",
+            )
 
+        offered: list[str] = []
         for attempt in (1, 2):
             await trigger.click()
             await page.wait_for_timeout(600)
-            option = await VideoGenerationMixin._probe_selector_cascade(
-                page,
-                "model_option",
-                (option_sel,),
-            )
-            if option is not None:
-                await option.click()
+            offered = await offered_menu_labels(page)
+            matches, first_visible = await count_visible(page, option_sel)
+            if matches > 1:
+                await close_menu(page)
+                raise VideoModelSelectionError(
+                    detail=(
+                        f"selector for {model.value!r} is AMBIGUOUS — {matches} entries "
+                        f"match {option_sel!r}. Selecting .first would pick by DOM order "
+                        f"and could charge a different credit tier than requested. "
+                        f"Flow offered: {offered}. No credits were spent."
+                    ),
+                    route="model_option",
+                )
+            if matches == 1:
+                await first_visible.click()
                 await page.wait_for_timeout(800)
-                log.info("ui_automation_video.model_selected", model=model.value)
+                log.info("ui_automation_video.model_selected", model=model.value, via=option_sel)
                 return
             # The menu may not have opened (trigger click raced) or rendered the
             # option late. Escape closes only the dropdown (the settings popover
@@ -1582,27 +1603,29 @@ class VideoGenerationMixin:
                 "ui_automation_video.model_option_retry",
                 model=model.value,
                 attempt=attempt,
+                offered=offered,
             )
             await page.keyboard.press("Escape")
             await page.wait_for_timeout(200)
 
         log.warning(
-            "ui_automation_video.model_option_not_found",
-            model=model.value,
-            note="Flow default model applies" if not required else "i2v — refusing T2V fallback",
+            "ui_automation_video.model_option_not_found", model=model.value, offered=offered
         )
-        if required:
-            shot = await _capture_debug_screenshot(
-                page, out_dir, "debug_model_option_not_found.png"
-            )
-            msg = (
-                f"could not select video model {model.value!r} for i2v after 2 "
-                f"attempts. Refusing to proceed — an i2v run on whatever model "
-                f"Flow last had selected breaks the request contract (cost "
-                f"tier, duration cap, end-frame capability — refs #125)."
+        # Screenshot BEFORE closing: the whole point of this capture is what the
+        # menu was rendering, and `close_menu` dismisses it.
+        shot = await _capture_debug_screenshot(page, out_dir, "debug_model_option_not_found.png")
+        await close_menu(page)
+        raise VideoModelSelectionError(
+            detail=(
+                f"video model {model.value!r} is not selectable — no picker entry "
+                f"matched after 2 attempts. Flow offered: {offered}. Refusing to "
+                f"generate on a different model than requested: the wrong tier "
+                f"costs different credits, caps duration differently, and only "
+                f"Veo 3.1 supports an end frame (refs #125). No credits were spent."
                 f"{screenshot_clause(shot)}"
-            )
-            raise VideoModelSelectionError(detail=msg, route="model_option")
+            ),
+            route="model_option",
+        )
 
     @staticmethod
     async def _select_video_duration(page: Page, seconds: int, *, out_dir: Path | None) -> None:

--- a/tests/api/transports/test_ui_automation_video.py
+++ b/tests/api/transports/test_ui_automation_video.py
@@ -227,12 +227,19 @@ def _cascade_page(visible: set[str]) -> MagicMock:
         else:
             loc.wait_for = AsyncMock(side_effect=Exception("not visible"))
         loc.click = AsyncMock()
+        # `_select_video_model` counts VISIBLE matches rather than resolving
+        # `.first`, so the fake has to model presence as well as visibility.
+        hit = sel in visible
+        loc.count = AsyncMock(return_value=1 if hit else 0)
+        loc.nth = MagicMock(return_value=loc)
+        loc.is_visible = AsyncMock(return_value=hit)
         return loc
 
     page.locator = MagicMock(side_effect=_locator)
     page.wait_for_timeout = AsyncMock()
     page.screenshot = AsyncMock()
     page.keyboard.press = AsyncMock()
+    page.evaluate = AsyncMock(return_value=[])
     return page
 
 
@@ -360,21 +367,35 @@ class TestSelectVideoModel:
         page.locator.assert_any_call(opt)
 
     @pytest.mark.asyncio
-    async def test_missing_trigger_is_non_fatal(self) -> None:
+    async def test_missing_trigger_is_now_fatal(self) -> None:
+        """Was `test_missing_trigger_is_non_fatal` — it encoded the bug.
+
+        A missing picker meant the run proceeded on Flow's current selection and
+        CHARGED CREDITS for that tier. We only reach here when a model was
+        explicitly requested, so there is nothing to legitimately fall back to.
+        """
         from gflow_cli.api.video import VideoModel
+        from gflow_cli.errors import VideoModelSelectionError
 
         page = _cascade_page(set())
-        # must not raise
-        await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+        with pytest.raises(VideoModelSelectionError):
+            await VideoGenerationMixin._select_video_model(
+                page, VideoModel.OMNI_FLASH, out_dir=None
+            )
 
     @pytest.mark.asyncio
-    async def test_missing_option_escapes_to_recover(self) -> None:
+    async def test_missing_option_escapes_to_recover_then_refuses(self) -> None:
         from gflow_cli.api.transports import ui_automation_video as mod
         from gflow_cli.api.video import VideoModel
+        from gflow_cli.errors import VideoModelSelectionError
 
-        # trigger visible but the option is not -> Escape closes the stray menu
+        # trigger visible but the option is not -> Escape closes the stray menu,
+        # and the run is refused rather than generating on the wrong tier.
         page = _cascade_page({mod.MODEL_PICKER_TRIGGER})
-        await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+        with pytest.raises(VideoModelSelectionError):
+            await VideoGenerationMixin._select_video_model(
+                page, VideoModel.OMNI_FLASH, out_dir=None
+            )
         page.keyboard.press.assert_any_call("Escape")
 
 
@@ -733,7 +754,8 @@ class TestGenerateVideoGuards:
 
         select_call = cast("Any", VideoGenerationMixin._select_video_model)
         select_call.assert_awaited()
-        assert select_call.await_args.kwargs.get("required") is True
+        # `required` is gone: every miss is fatal now, on i2v and t2v alike.
+        assert "required" not in select_call.await_args.kwargs
         assert select_call.await_args.args[1] is I2V_DEFAULT_MODEL
 
     @pytest.mark.asyncio
@@ -1100,47 +1122,70 @@ def _select_model_page(*, option_visible_on_attempt: int | None) -> MagicMock:
             if sel == trigger_sel:
                 state["clicks"] += 1
 
+        async def _count() -> int:
+            if sel == trigger_sel:
+                return 1
+            if sel == option_sel and option_visible_on_attempt is not None:
+                return 1 if state["clicks"] >= option_visible_on_attempt else 0
+            return 0
+
+        async def _is_visible(*_a: object, **_k: object) -> bool:
+            return await _count() > 0
+
         loc.wait_for = _wait_for
         loc.click = _click
+        loc.count = _count
+        loc.nth = MagicMock(return_value=loc)
+        loc.is_visible = _is_visible
         return loc
 
     page.locator = MagicMock(side_effect=_locator)
     page.wait_for_timeout = AsyncMock()
     page.keyboard.press = AsyncMock()
     page.screenshot = AsyncMock()
+    page.evaluate = AsyncMock(return_value=[])
     return page
 
 
 class TestSelectVideoModelRequired:
+    """Named for the old ``required=`` flag, which no longer exists: as of
+    2026-08-26 EVERY model miss is fatal, on i2v and t2v alike."""
+
     @pytest.mark.asyncio
     async def test_required_raises_when_option_never_found(self) -> None:
-        """Issue #125 Layer 1: with required=True (i2v), a model-option miss is
-        FATAL — raise rather than let Flow fall back to omni-flash -> T2V."""
+        """Issue #125 Layer 1: a model-option miss is FATAL — raise rather than
+        let Flow fall back to omni-flash -> T2V."""
         from gflow_cli.errors import VideoModelSelectionError
 
         page = _select_model_page(option_visible_on_attempt=None)
         with pytest.raises(VideoModelSelectionError, match="#125"):
             await VideoGenerationMixin._select_video_model(
-                page, VideoModel.VEO_3_1_LITE, out_dir=None, required=True
+                page, VideoModel.VEO_3_1_LITE, out_dir=None
             )
 
     @pytest.mark.asyncio
-    async def test_not_required_warns_and_returns_on_miss(self) -> None:
-        """required=False (t2v/r2v): a miss is non-fatal (Flow default applies)."""
+    async def test_t2v_miss_is_fatal_too(self) -> None:
+        """Was `test_not_required_warns_and_returns_on_miss`.
+
+        The old contract let t2v/r2v proceed on Flow's current model. Video is
+        the credit-bearing arm (veo-quality 100 against veo-lite's 10), and this
+        function is only reached when a model was explicitly requested, so a miss
+        has no defensible fallback. The `required` flag is gone entirely.
+        """
+        from gflow_cli.errors import VideoModelSelectionError
+
         page = _select_model_page(option_visible_on_attempt=None)
-        # Must NOT raise.
-        await VideoGenerationMixin._select_video_model(
-            page, VideoModel.VEO_3_1_LITE, out_dir=None, required=False
-        )
+        with pytest.raises(VideoModelSelectionError):
+            await VideoGenerationMixin._select_video_model(
+                page, VideoModel.VEO_3_1_LITE, out_dir=None
+            )
 
     @pytest.mark.asyncio
     async def test_retries_trigger_click_and_succeeds_second_attempt(self) -> None:
         """Reliability: the first trigger click may not open the menu; the
         second attempt finds the option and selects it (no raise)."""
         page = _select_model_page(option_visible_on_attempt=2)
-        await VideoGenerationMixin._select_video_model(
-            page, VideoModel.VEO_3_1_LITE, out_dir=None, required=True
-        )
+        await VideoGenerationMixin._select_video_model(page, VideoModel.VEO_3_1_LITE, out_dir=None)
 
 
 class TestI2vT2vRoutingBackstop:

--- a/tests/api/transports/test_video_model_selection_loud.py
+++ b/tests/api/transports/test_video_model_selection_loud.py
@@ -1,0 +1,179 @@
+"""A video model that cannot be selected must fail BEFORE spending credits.
+
+The image arm was made loud on 2026-08-26; the video arm was left as it was, and
+video is the arm that actually costs Flow **credits** — veo-quality is 100
+against veo-lite's 10, a 10x spread. `_select_video_model` refused only when
+``required=True`` (i2v with frames, issue #125). For plain t2v it logged
+``model_option_not_found`` with the note "Flow default model applies" and
+returned, so the run generated on whatever model Flow last had selected and
+charged for that tier.
+
+Why refusing is unambiguously right here, unlike the image panel-miss:
+``configure_video_settings`` calls this **only** when ``effective_model is not
+None`` (drivers/classic.py), and ``--model`` defaults to ``None`` on every video
+command. So reaching this function means a model was EXPLICITLY requested. There
+is no "is it the default or did the user ask?" ambiguity that forced the image
+panel-miss to stay a warning.
+
+Live evidence, profile denon82, 2026-08-26 — the picker rendered exactly:
+
+    Omni Flash / Veo 3.1 - Lite / Veo 3.1 - Fast / Veo 3.1 - Quality
+
+`VideoModel.VEO_3_1_LITE_LOWER_PRIORITY`'s ``has-text('[Lower Priority]')``
+matches none of them. So `gflow video t2v --model veo-lite-lp` was a live,
+reachable, credit-spending wrong-model path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gflow_cli.api.transports.ui_automation_video import (
+    VIDEO_MODEL_OPTION_SELECTORS,
+    VideoGenerationMixin,
+)
+from gflow_cli.api.video import VideoModel
+from gflow_cli.errors import VideoModelSelectionError
+
+
+class _Loc:
+    def __init__(self, count: int, *, visible: list[bool] | None = None) -> None:
+        self._count = count
+        self._visible = visible if visible is not None else [True] * count
+        self.click = AsyncMock()
+
+    async def wait_for(self, **_: Any) -> None:
+        """Absence must actually fail, or a MISS test passes for the wrong reason.
+
+        `_probe_selector_cascade` resolves `.first` and awaits `wait_for`; an
+        unconditional AsyncMock here would make every probe "succeed" on an empty
+        locator and the miss branches would never be reached.
+        """
+        if self._count == 0 or not any(self._visible):
+            raise TimeoutError("no such element")
+
+    def nth(self, i: int) -> _Loc:
+        return _Loc(1, visible=[self._visible[i] if i < len(self._visible) else True])
+
+    @property
+    def first(self) -> _Loc:
+        return self
+
+    async def count(self) -> int:
+        return self._count
+
+    async def is_visible(self, **_: Any) -> bool:
+        return bool(self._visible and self._visible[0])
+
+
+class _Page:
+    def __init__(
+        self,
+        counts: dict[str, int],
+        offered: list[str] | None = None,
+        visible: dict[str, list[bool]] | None = None,
+    ) -> None:
+        self._counts = counts
+        self._visible = visible or {}
+        self._offered = offered or []
+        self.keyboard = AsyncMock()
+        self.wait_for_timeout = AsyncMock()
+
+    def locator(self, sel: str) -> _Loc:
+        if "arrow_drop_down" in sel:  # the model picker trigger
+            return _Loc(1)
+        return _Loc(self._counts.get(sel, 0), visible=self._visible.get(sel))
+
+    async def evaluate(self, *_a: Any, **_k: Any) -> list[str]:
+        return self._offered
+
+
+_LIVE_MENU = [
+    "volume_up Omni Flash",
+    "volume_up Veo 3.1 - Lite",
+    "volume_up Veo 3.1 - Fast",
+    "volume_up Veo 3.1 - Quality",
+]
+
+
+@pytest.mark.asyncio
+async def test_t2v_miss_refuses_instead_of_charging_for_flows_default() -> None:
+    """The regression this file exists for: required=False must still refuse.
+
+    This is `--model veo-lite-lp` against the live 2026-08-26 picker.
+    """
+    page = _Page(counts={}, offered=_LIVE_MENU)
+
+    with pytest.raises(VideoModelSelectionError) as exc:
+        await VideoGenerationMixin._select_video_model(
+            page, VideoModel.VEO_3_1_LITE_LOWER_PRIORITY, out_dir=None
+        )
+
+    msg = str(exc.value)
+    # The message must name what Flow DID offer, or the operator cannot act.
+    assert "Veo 3.1 - Quality" in msg, msg
+    # ...and must say nothing was spent, because nothing was.
+    assert "credit" in msg.lower(), msg
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_video_model_refuses_rather_than_guessing_with_first() -> None:
+    """`.first` picks by DOM order — across tiers that differ 10x in credits.
+
+    `has-text('Veo 3.1 - Lite')` is a PREFIX of `Veo 3.1 - Lite [Lower Priority]`.
+    If Flow ships the LP tier to this account, an unguarded selector would match
+    both and silently resolve to whichever renders first.
+    """
+    sel = VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_FAST]
+    page = _Page(counts={sel: 2}, offered=_LIVE_MENU)
+
+    with pytest.raises(VideoModelSelectionError) as exc:
+        await VideoGenerationMixin._select_video_model(page, VideoModel.VEO_3_1_FAST, out_dir=None)
+
+    assert "ambiguous" in str(exc.value).lower(), str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_unique_match_still_selects_normally() -> None:
+    """The guard must not break the working path."""
+    sel = VIDEO_MODEL_OPTION_SELECTORS[VideoModel.OMNI_FLASH]
+    page = _Page(counts={sel: 1}, offered=_LIVE_MENU)
+
+    await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+
+
+@pytest.mark.asyncio
+async def test_hidden_duplicate_does_not_force_a_false_ambiguous() -> None:
+    """Radix keeps menus mounted, so a stale menu inflates a raw count()."""
+    sel = VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_QUALITY]
+    page = _Page(counts={sel: 2}, visible={sel: [True, False]}, offered=_LIVE_MENU)
+
+    await VideoGenerationMixin._select_video_model(page, VideoModel.VEO_3_1_QUALITY, out_dir=None)
+
+
+@pytest.mark.asyncio
+async def test_missing_picker_trigger_refuses_on_t2v_too() -> None:
+    """The trigger-miss branch had the same required-only gate."""
+
+    class _NoTrigger(_Page):
+        def locator(self, sel: str) -> _Loc:
+            return _Loc(0)
+
+    page = _NoTrigger(counts={}, offered=[])
+    with pytest.raises(VideoModelSelectionError):
+        await VideoGenerationMixin._select_video_model(page, VideoModel.OMNI_FLASH, out_dir=None)
+
+
+def test_every_video_model_selector_excludes_the_lower_priority_sibling() -> None:
+    """Substring hazard, pinned. `has-text` is a SUBSTRING match.
+
+    Any selector whose text is a prefix of another offered label must carry a
+    `:not(...)` guard, or it goes AMBIGUOUS the moment Flow ships that sibling.
+    """
+    lp = VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_LITE_LOWER_PRIORITY]
+    lite = VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_LITE]
+    assert "[Lower Priority]" in lp
+    assert ":not(" in lite, "veo-lite must exclude the [Lower Priority] sibling"

--- a/tests/fixtures/flow_model_inventory.json
+++ b/tests/fixtures/flow_model_inventory.json
@@ -1,6 +1,6 @@
 {
   "_provenance": {
-    "captured_utc": "2026-08-26T11:45:00Z",
+    "captured_utc": "2026-08-26T23:05:00Z",
     "profile": "denon82",
     "account_locale": "pt",
     "method": "scripts/dev/spike_model_inventory.py — menu read WHILE OPEN",
@@ -11,6 +11,13 @@
     "🍌 Nano Banana 2",
     "🍌 Nano Banana 2 Lite"
   ],
-  "video": null,
-  "_video_note": "Not yet captured — the video picker uses a different trigger than the image one. null means UNKNOWN, which the governance test treats as 'cannot assert', NOT as 'empty'. #539 depends on this being captured."
+  "video": [
+    "volume_up Omni Flash",
+    "volume_up Veo 3.1 - Lite",
+    "volume_up Veo 3.1 - Fast",
+    "volume_up Veo 3.1 - Quality"
+  ],
+  "_video_note": "Captured 2026-08-26 after fixing the CAPTURE, not the product. The earlier empty read was caused by calling _open_gen_settings_panel after _switch_to_video_mode: both click the SAME crop_* trigger, so the second click toggled the panel shut and the video-tab probe missed on all five selectors. #539's note that 'the video picker uses a different trigger' is FALSIFIED — MODEL_PICKER_TRIGGER and IMAGE_MODEL_PICKER_TRIGGER are byte-identical strings.",
+  "_video_credit_line": "10 (the live cost line with Veo 3.1 - Lite selected; matches the documented veo-lite cost). Per-model cost was NOT swept in this capture.",
+  "_lower_priority_finding": "'Veo 3.1 - Lite [Lower Priority]' was NOT offered to profile denon82 on 2026-08-26 (picker rendered exactly: Omni Flash / Veo 3.1 - Lite / Fast / Quality). That is one account at one moment, NOT proof the tier does not exist — it may be cohort-gated or region-gated, which is what #539 is open to establish. Recorded as an observation with a date, per docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md."
 }

--- a/tests/flow_selectors/test_model_governance.py
+++ b/tests/flow_selectors/test_model_governance.py
@@ -33,6 +33,8 @@ import pytest
 
 from gflow_cli.api.image import Model
 from gflow_cli.api.transports.ui_automation import IMAGE_MODEL_OPTION_SELECTORS
+from gflow_cli.api.transports.ui_automation_video import VIDEO_MODEL_OPTION_SELECTORS
+from gflow_cli.api.video import VideoModel
 
 _FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "flow_model_inventory.json"
 
@@ -49,6 +51,20 @@ _NO_LONGER_OFFERED: dict[Model, str] = {
         "remapped, requesting it raises UiSelectorDriftError (exit 23) naming what "
         "Flow does offer, instead of silently generating on the default and billing "
         "for it. Follow-up: decide retire-vs-remap."
+    ),
+}
+
+#: Video models Flow does not offer. Same contract as `_NO_LONGER_OFFERED`:
+#: a named, dated decision — not a place to park failures.
+_VIDEO_NOT_OFFERED: dict[VideoModel, str] = {
+    VideoModel.VEO_3_1_LITE_LOWER_PRIORITY: (
+        "'Veo 3.1 - Lite [Lower Priority]' was NOT offered to profile denon82 on "
+        "2026-08-26 (picker rendered exactly: Omni Flash / Veo 3.1 - Lite / Fast / "
+        "Quality). That is one account at one moment, NOT proof the tier does not "
+        "exist — it may be cohort- or region-gated, which is precisely what #539 is "
+        "open to establish. Requesting it now raises VideoModelSelectionError "
+        "(exit 18) naming what Flow does offer, instead of silently generating on "
+        "whatever model Flow had selected and CHARGING CREDITS for it."
     ),
 }
 
@@ -178,16 +194,57 @@ def test_every_offered_entry_is_modelled_or_waived() -> None:
     )
 
 
-def test_video_inventory_is_unknown_not_empty() -> None:
-    """`null` must mean UNKNOWN, never 'Flow offers nothing'.
+def test_every_video_model_has_a_picker_selector() -> None:
+    missing = [m.value for m in VideoModel if m not in VIDEO_MODEL_OPTION_SELECTORS]
+    assert not missing, f"video models with no picker selector: {missing}"
 
-    #539's earlier capture read an empty menu (taken after it closed) and the
-    emptiness was mistaken for absence. Encoding UNKNOWN distinctly is what stops
-    that error being repeated — and this test fails once the video inventory IS
-    captured, which is the prompt to assert on it properly.
+
+@pytest.mark.parametrize("model", list(VideoModel))
+def test_video_selector_matches_exactly_one_offered_entry(model: VideoModel) -> None:
+    """Same guard as the image arm — and this one is the CREDIT-BEARING arm.
+
+    An image miss burns a daily quota; a video miss burns credits (up to 100 for
+    veo-quality against 10 for veo-lite). The video registry also carries the
+    identical substring hazard the image arm was fixed for: `has-text('Veo 3.1 -
+    Lite')` is a prefix of `Veo 3.1 - Lite [Lower Priority]`, which is why that
+    selector needs its `:not(...)` guard to stay correct if the LP tier appears.
     """
-    inv = _inventory()
-    assert inv["video"] is None, (
-        "video inventory is now captured — replace this test with the same "
-        "exactly-one-match assertions used for image models (see #539)."
+    if model in _VIDEO_NOT_OFFERED:
+        pytest.skip(f"{model.value}: {_VIDEO_NOT_OFFERED[model]}")
+
+    offered = _inventory()["video"]
+    assert offered is not None, "video inventory not captured — cannot grade"
+    sel = VIDEO_MODEL_OPTION_SELECTORS[model]
+    hits = _matches(sel, offered)
+
+    assert hits, (
+        f"{model.value}: MISS — no offered entry matches {sel!r}.\n"
+        f"Flow offered: {offered}\n"
+        f"gflow would generate on Flow's current model and SPEND CREDITS on it."
     )
+    assert len(hits) == 1, (
+        f"{model.value}: AMBIGUOUS — {len(hits)} entries match: {hits}\n"
+        f"Resolving .first picks by DOM order and can charge a different tier."
+    )
+
+
+def test_every_offered_video_entry_is_modelled() -> None:
+    """A video tier Flow offers that we cannot select is a missed capability."""
+    offered = _inventory()["video"]
+    claimed = {
+        m for model in VideoModel for m in _matches(VIDEO_MODEL_OPTION_SELECTORS[model], offered)
+    }
+    unexplained = [o for o in offered if o not in claimed]
+    assert not unexplained, f"Flow offers video entries we do not model: {unexplained}"
+
+
+def test_lower_priority_absence_is_recorded_as_an_observation() -> None:
+    """#539's trap, encoded: absence-on-one-account is not absence.
+
+    The earlier capture read an empty menu and the emptiness was mistaken for
+    proof the tier was gone. This asserts the fixture states WHERE and WHEN the
+    tier was not offered, so the claim can never harden into "it does not exist".
+    """
+    note = _inventory()["_lower_priority_finding"]
+    assert "NOT proof" in note, "the LP finding must not be recorded as proof of absence"
+    assert "denon82" in note and "2026-08-26" in note, "must name the account and the date"


### PR DESCRIPTION
## Summary

Video model selection silently fell back to whatever model Flow already had selected — on the arm that spends **credits**. `_select_video_model` refused only when `required=True` (i2v with frames, #125). For plain `t2v`/`r2v` a miss logged `"Flow default model applies"` and returned, so the run generated on the wrong tier and charged for it. veo-quality costs **100** credits against veo-lite's **10**.

This was not theoretical. Flow's video picker, read live on 2026-08-26, offers exactly:

```
Omni Flash / Veo 3.1 - Lite / Veo 3.1 - Fast / Veo 3.1 - Quality
```

`VideoModel.VEO_3_1_LITE_LOWER_PRIORITY`'s `has-text('[Lower Priority]')` matches **none** of them. `gflow video t2v --model veo-lite-lp` was a live, reachable, credit-spending wrong-model path.

## Why refusing is right here, when the image panel-miss stayed a warning

The image arm had to keep warning because the transport cannot tell "user passed `--model X`" from "X is the default" — `request.model` is populated either way.

Video has no such ambiguity. `configure_video_settings` calls `_select_video_model` **only** when `effective_model is not None`, and `--model` defaults to `None` on every video command. Reaching this function means a model was **explicitly requested**. So the `required` flag is deleted outright rather than defaulted — every miss is fatal, on i2v and t2v alike.

## Also fixed

- **AMBIGUOUS is refused, not guessed.** `_probe_selector_cascade` resolved `.first`, which picks by DOM order across tiers that differ 10x in credits. Now counts **visible** matches and refuses on >1.
- **Errors name what Flow offered**, so a drift is actionable rather than "model not found".
- **Screenshot before `close_menu`**, not after — the capture exists to show what the menu was rendering.
- **Deduped**, not copy-pasted: `offered_menu_labels` / `close_menu` / `count_visible` moved to `_common.py` and the image arm now uses them. Net **-49 lines** in `ui_automation.py`.

## #539 answered — and an old note falsified

The video inventory is captured (governance previously graded **zero** video selectors; it now grades all five).

The recorded claim *"the video picker uses a different trigger"* is **wrong**: `MODEL_PICKER_TRIGGER` and `IMAGE_MODEL_PICKER_TRIGGER` are **byte-identical strings**. The empty captures were caused by the **capture**, not the product — `_switch_to_video_mode` leaves the settings menu open by contract, and the previous capture called `_open_gen_settings_panel` after it, re-clicking the same button and toggling the panel shut.

`Veo 3.1 - Lite [Lower Priority]` was **not offered to denon82 on 2026-08-26**. That is one account at one moment, recorded as a dated observation — **not proof the tier does not exist**, which is the exact error this issue already made once.

## Verification — all live against real Flow

**Zero-credit A/B** (selection happens before submit, so a refusal spends nothing):

| case | old code | new code |
|---|---|---|
| `omni_flash` | SELECTED | **SELECTED** |
| `veo_3_1_lite` | SELECTED | **SELECTED** |
| `veo_3_1_fast` | SELECTED | **SELECTED** |
| `veo_3_1_quality` | SELECTED | **SELECTED** |
| `veo-lite-lp` (not offered) | **SELECTED** — returned success, run would submit and charge | **REFUSED** |
| ambiguous selector (3 match) | **SELECTED** — `.first` guess | **REFUSED** |

The old-code column is a real run of the pre-fix code against live Flow, not a reading of the diff.

**CLI, end to end:**

- `gflow video t2v --model veo-lite-lp` → **EXIT 18**, no submit, message lists all four models Flow offers and states no credits were spent.
- `gflow video t2v --model omni-flash` → **EXIT 0**, `model_selected model=omni_flash`, real 2.2 MB mp4, catalog recorded `omni_flash`. The guard does not break the working path.

## Not verified, and not claimed

- The **cost** of the `[Lower Priority]` tier. It was never offered, so the credit-line oracle had nothing to read.
- Whether that tier is cohort- or region-gated. One account, one timestamp.
- The agentic arm — `configure_video_settings` raises `FlowAgentUiError` there; agentic video is unsupported and untouched.

Closes #539
