### PR TITLE
fix(data): a NULL model/aspect/project_id no longer reads back as "None"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A NULL `model` / `aspect` / `project_id` no longer reads back as the string
+  `"None"` in `gflow data list images|videos`.** All three columns are nullable in
+  the schema (`assets.model`, `assets.aspect_ratio`, `assets.flow_project_id`), but
+  both listing constructors wrapped them in a bare `str(...)`, so a NULL became the
+  four-character string `"None"` — emitted verbatim into `--json` and
+  indistinguishable from a real value. `_row_to_operation_error` in the same module
+  already guarded `model` correctly; the two listing paths never got the same
+  treatment. `ImageRow` / `VideoRow` now type these fields `str | None` and the JSON
+  output carries `null`.
+
 ## [0.61.0] — 2026-08-27
 
 ### Fixed

--- a/src/gflow_cli/data/queries.py
+++ b/src/gflow_cli/data/queries.py
@@ -121,10 +121,10 @@ def list_projects(
 class ImageRow:
     media_id: str
     profile: str
-    project_id: str
+    project_id: str | None
     prompt: str | None
-    aspect: str
-    model: str
+    aspect: str | None
+    model: str | None
     created_at: datetime
     local_path: str | None
     copy_count: int = 1
@@ -258,10 +258,10 @@ def list_images(
         ImageRow(
             media_id=str(r["media_id"]),
             profile=str(r["profile"]),
-            project_id=str(r["project_id"]),
+            project_id=str(r["project_id"]) if r["project_id"] is not None else None,
             prompt=str(r["prompt"]) if r["prompt"] is not None else None,
-            aspect=str(r["aspect"]),
-            model=str(r["model"]),
+            aspect=str(r["aspect"]) if r["aspect"] is not None else None,
+            model=str(r["model"]) if r["model"] is not None else None,
             created_at=datetime.fromisoformat(str(r["created_at"])),
             local_path=str(r["local_path"]) if r["local_path"] is not None else None,
             copy_count=int(r["copy_count"]),
@@ -277,10 +277,10 @@ def list_images(
 class VideoRow:
     media_id: str
     profile: str
-    project_id: str
+    project_id: str | None
     prompt: str | None
-    aspect: str
-    model: str
+    aspect: str | None
+    model: str | None
     duration: float | None
     created_at: datetime
     local_path: str | None
@@ -379,10 +379,10 @@ def list_videos(
         VideoRow(
             media_id=str(r["media_id"]),
             profile=str(r["profile"]),
-            project_id=str(r["project_id"]),
+            project_id=str(r["project_id"]) if r["project_id"] is not None else None,
             prompt=str(r["prompt"]) if r["prompt"] is not None else None,
-            aspect=str(r["aspect"]),
-            model=str(r["model"]),
+            aspect=str(r["aspect"]) if r["aspect"] is not None else None,
+            model=str(r["model"]) if r["model"] is not None else None,
             duration=float(r["duration"]) if r["duration"] is not None else None,
             created_at=datetime.fromisoformat(str(r["created_at"])),
             local_path=str(r["local_path"]) if r["local_path"] is not None else None,

--- a/tests/data/test_null_columns_stay_null.py
+++ b/tests/data/test_null_columns_stay_null.py
@@ -1,0 +1,126 @@
+"""A NULL column must read back as ``None``, never as the string ``"None"``.
+
+``assets`` declares three columns that gflow reads into every listing row and
+that the schema leaves **nullable** (``migrations/0001_initial.sql``):
+
+    flow_project_id TEXT      -- ImageRow.project_id / VideoRow.project_id
+    model           TEXT      -- .model
+    aspect_ratio    TEXT      -- .aspect
+
+``list_images`` / ``list_videos`` wrapped all three in a bare ``str(...)``. On a
+NULL that produces the four-character string ``"None"``, which is indistinguishable
+from a model genuinely called "None" and is emitted verbatim into
+``gflow data list images --json``. Downstream that is worse than a crash: a
+consumer filtering ``model == "None"`` silently matches real rows, and the
+governance work in v0.61.0 exists precisely to stop synthesised values passing
+as observed ones.
+
+``_row_to_operation_error`` (same module) already guards ``model`` correctly —
+the two listing paths simply never got the same treatment.
+
+These rows are reachable today: the agentic arm records assets before the model
+is known, and a project id is absent for media that arrives without one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.data.models import AssetKind, AssetRecord, ProjectRecord
+from gflow_cli.data.queries import list_images, list_videos
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+_PROFILE = "nulltest"
+_ISO = datetime.now(UTC).isoformat()
+
+
+def _seed(db: Path, kind: AssetKind) -> None:
+    """One asset with model / aspect_ratio / flow_project_id all NULL."""
+    store = DataStore.open(db)
+    repo = DataRepository(store)
+    repo.upsert_profile(name=_PROFILE, profile_dir=Path(f"/home/{_PROFILE}/.config/gflow"))
+    # A project row must exist for the listing join, but the ASSET deliberately
+    # carries no flow_project_id — that is the nullable case under test.
+    repo.upsert_project(
+        ProjectRecord(
+            id=str(uuid.uuid4()),
+            profile_name=_PROFILE,
+            flow_project_id=f"proj-{uuid.uuid4()}",
+            title="null-column project",
+            source="cli",
+            created_at=_ISO,
+        )
+    )
+    repo.upsert_asset(
+        AssetRecord(
+            id=str(uuid.uuid4()),
+            profile_name=_PROFILE,
+            flow_project_id=None,
+            flow_media_id=f"media-{uuid.uuid4()}",
+            flow_workflow_id=None,
+            flow_media_generation_id=None,
+            kind=kind,
+            status="ready",
+            model=None,
+            aspect_ratio=None,
+            width=None,
+            height=None,
+            duration_seconds=None,
+            seed=None,
+            created_at=_ISO,
+            metadata_json=None,
+        )
+    )
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("kind", "lister"),
+    [(AssetKind.IMAGE, list_images), (AssetKind.VIDEO, list_videos)],
+    ids=["images", "videos"],
+)
+def test_null_columns_read_back_as_none(tmp_path: Path, kind: AssetKind, lister: object) -> None:
+    db = tmp_path / "null.db"
+    _seed(db, kind)
+
+    rows = lister(db_path=db, profile=_PROFILE, limit=10, offset=0)  # type: ignore[operator]
+
+    assert len(rows) == 1, rows
+    row = rows[0]
+    for field in ("model", "aspect", "project_id"):
+        value = getattr(row, field)
+        assert value is None, f"{field} came back as {value!r} — a NULL was stringified"
+        assert value != "None"
+
+
+@pytest.mark.parametrize(
+    ("kind", "lister"),
+    [(AssetKind.IMAGE, list_images), (AssetKind.VIDEO, list_videos)],
+    ids=["images", "videos"],
+)
+def test_all_copies_path_guards_the_same_columns(
+    tmp_path: Path, kind: AssetKind, lister: object
+) -> None:
+    """``--all-copies`` is a SEPARATE SQL + constructor; it must not diverge.
+
+    The two listing paths are built from different statements, so a guard added
+    to one is not a guard added to the other.
+    """
+    db = tmp_path / "null_copies.db"
+    _seed(db, kind)
+
+    rows = lister(  # type: ignore[operator]
+        db_path=db, profile=_PROFILE, limit=10, offset=0, all_copies=True
+    )
+
+    # No local_files rows were seeded, so the flat path may legitimately return
+    # nothing; when it returns a row, that row must obey the same contract.
+    for row in rows:
+        assert row.model is None
+        assert row.aspect is None
+        assert row.project_id is None


### PR DESCRIPTION
## Summary

`assets.model`, `assets.aspect_ratio` and `assets.flow_project_id` are all **nullable** (`migrations/0001_initial.sql`), but `list_images` and `list_videos` wrapped each in a bare `str(...)`. On a NULL that produces the four-character string `"None"`.

That is worse than a crash: it goes straight into `gflow data list images --json` as `"model": "None"`, indistinguishable from a real value, and a consumer filtering `model == "None"` silently matches genuine rows. It is the same class of defect as the synthesised attribution sentinels v0.61.0 was cut to stop.

`_row_to_operation_error`, a few lines further down **in the same module**, already guarded `model` correctly — the two listing paths simply never got the same treatment.

## Root-cause pass, not just the reported line

The report named `model`. Two sibling columns in the same constructors had the identical defect, and both listers shared it — 3 columns x 2 listers, not 1 line.

I then checked **every** remaining bare `str(r[...])` in the module against the schema:

| site | column | verdict |
|---|---|---|
| `list_projects:106` | `projects.flow_project_id` | **NOT NULL** — safe |
| `_row_to_operation_error:430` | `operations.mode` | **NOT NULL** — safe |
| `list_profiles:594` | `last_used_at` | `MAX(created_at)` over NOT NULL columns, in a CTE that only emits profiles having rows — **safe** |

No other guard is needed. `ImageRow` / `VideoRow` now type the three fields `str | None`.

## Verification

- New test seeds a real asset with all three columns NULL and asserts they read back as `None`, for images **and** videos, on both the default and `--all-copies` paths (separate SQL, same constructor).
- It **failed for the right reason first**: `project_id=(quote)None(quote)`, `model=(quote)None(quote)`.
- Real CLI, real catalog: `{"project_id": null, "aspect": null, "model": null}`.
- Rich table renders empty cells, no crash on a None row.
- `pyright src` 0 errors — no downstream fallout from the type change.
- Full suite **3443 passed, 0 failed**.