### PR TITLE
perf(client): probe the account locale once per profile, not once per command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`gflow project list` / `project show` and the MCP `gflow_list_projects` tool now
+  emit an account-correct editor URL
+  ([#587](https://github.com/ffroliva/gflow-cli/issues/587)).** They previously
+  emitted no URL at all: they are network-free catalog reads, so they had no way to
+  resolve a locale and correctly declined to guess one. With the locale now cached
+  per profile the link is readable offline. An unknown locale still yields the bare
+  URL — never a guessed `/fx/en/...`, which is the shape that started this thread by
+  being handed to a pt-BR account owner. In the terminal the project id renders as a
+  hyperlink, costing no column width.
+
+### Changed
+
+- **The account-locale probe no longer costs 4 s on every command
+  ([#587](https://github.com/ffroliva/gflow-cli/issues/587)).** The probe added in
+  v0.61.0 settles the bootstrap navigation to learn where Flow lands. On an account
+  Flow does *not* redirect there is nothing to settle, so `wait_for_url` ran to the
+  full timeout every single invocation. Measured live on 2026-08-27: **7.22 s ->
+  2.80 s** setup on the non-redirecting account. The outcome is now cached in the
+  profile dir (`.gflow_locale`, a sibling of the existing `.gflow_account`) in three
+  states, not two: never probed, redirected-to-`X`, and **not redirected** — that
+  last one is the account paying the cost, and recording it as "nothing" would
+  re-probe forever.
+
+  The cache decides only *whether to wait*, never *where to navigate*. Sending the
+  browser to a cached `/fx/{seg}/...` was measured and rejected: Flow serves
+  whatever segment it is asked for, so a pt-BR account handed `/fx/de/` stayed
+  there and rendered `html lang=de` with no redirect — no correction signal, and a
+  wrong-language UI for as long as the stale value lived. That is #580's defect in
+  a new hat. The navigation therefore stays bare, which is what lets Flow state the
+  account's own answer: a redirecting account still settles (fast, and self-heals a
+  stale segment on the next run — verified live against a deliberately poisoned
+  cache), and only the "not redirected" state skips the wait.
+
 ### Fixed
 
 - **A NULL `model` / `aspect` / `project_id` no longer reads back as the string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,26 +21,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The account-locale probe no longer costs 4 s on every command
+- **The account-locale probe no longer costs ~4 s on every command
   ([#587](https://github.com/ffroliva/gflow-cli/issues/587)).** The probe added in
   v0.61.0 settles the bootstrap navigation to learn where Flow lands. On an account
   Flow does *not* redirect there is nothing to settle, so `wait_for_url` ran to the
-  full timeout every single invocation. Measured live on 2026-08-27: **7.22 s ->
-  2.80 s** setup on the non-redirecting account. The outcome is now cached in the
-  profile dir (`.gflow_locale`, a sibling of the existing `.gflow_account`) in three
-  states, not two: never probed, redirected-to-`X`, and **not redirected** — that
-  last one is the account paying the cost, and recording it as "nothing" would
-  re-probe forever.
+  full `URL_SETTLE_TIMEOUT_MS` every single invocation. Measured live 2026-08-27,
+  best of 3 rounds per arm: **5.94 s -> 2.00 s** setup on the non-redirecting
+  account, against an unchanged 2.82 s -> 2.90 s on a redirecting one (the control).
+  The outcome is cached in the profile dir (`.gflow_locale`, a sibling of the
+  existing `.gflow_account`) in three states, not two: never probed,
+  redirected-to-`X`, and **not redirected** — that last one is the account paying
+  the cost, and recording it as "nothing" would re-probe forever. The same guard
+  now covers all four `await_url_settled` call sites; guarding only the editor
+  entry left three navigations still paying the timeout.
 
   The cache decides only *whether to wait*, never *where to navigate*. Sending the
-  browser to a cached `/fx/{seg}/...` was measured and rejected: Flow serves
-  whatever segment it is asked for, so a pt-BR account handed `/fx/de/` stayed
-  there and rendered `html lang=de` with no redirect — no correction signal, and a
-  wrong-language UI for as long as the stale value lived. That is #580's defect in
-  a new hat. The navigation therefore stays bare, which is what lets Flow state the
-  account's own answer: a redirecting account still settles (fast, and self-heals a
-  stale segment on the next run — verified live against a deliberately poisoned
-  cache), and only the "not redirected" state skips the wait.
+  browser to a cached `/fx/{seg}/...` was built, measured, and rejected: Flow
+  serves whatever segment it is asked for, so a pt-BR account handed `/fx/de/`
+  stayed there and rendered `html lang=de` with no redirect — no correction signal,
+  and a wrong-language UI for as long as the stale value lived. That is #580's
+  defect in a new hat. The navigation therefore stays bare, which is what lets Flow
+  state the account's own answer: a redirecting account still settles (and rewrites
+  the locale every run, so a changed locale needs no special handling), while a
+  cache that wrongly says "not redirected" — reachable by one transient probe
+  timeout — is healed from the landing URL at teardown. Reproducer:
+  `scripts/dev/spike_locale_poison.py`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   v0.61.0 settles the bootstrap navigation to learn where Flow lands. On an account
   Flow does *not* redirect there is nothing to settle, so `wait_for_url` ran to the
   full `URL_SETTLE_TIMEOUT_MS` every single invocation. Measured live 2026-08-27,
-  best of 3 rounds per arm: **5.94 s -> 2.00 s** setup on the non-redirecting
-  account, against an unchanged 2.82 s -> 2.90 s on a redirecting one (the control).
+  best-of-N per arm: **~6.2 s -> ~2.0 s** setup on the non-redirecting account,
+  against an unchanged ~2.8 s -> ~2.9 s on a redirecting one (the control, which
+  shows the cold-then-warm ordering is worth nothing on its own). Run-to-run
+  variance is over a second, so read the delta as "the 4 s settle timeout", not to
+  two decimals.
   The outcome is cached in the profile dir (`.gflow_locale`, a sibling of the
-  existing `.gflow_account`) in three states, not two: never probed,
-  redirected-to-`X`, and **not redirected** — that last one is the account paying
-  the cost, and recording it as "nothing" would re-probe forever. The same guard
-  now covers all four `await_url_settled` call sites **in the UI transport**;
-  guarding only the editor entry left three navigations still paying the timeout.
-  (The three sites in the experimental REST transports have no resolved locale to
-  gate on and are unchanged.)
+  existing `.gflow_account`). The same guard covers all four `await_url_settled`
+  call sites **in the UI transport**; guarding only the editor entry left three
+  navigations still paying the timeout. (The three sites in the experimental REST
+  transports have no resolved locale to gate on and are unchanged.)
 
   The cache decides only *whether to wait*, never *where to navigate*. Sending the
   browser to a cached `/fx/{seg}/...` was built, measured, and rejected: Flow
@@ -43,11 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stayed there and rendered `html lang=de` with no redirect — no correction signal,
   and a wrong-language UI for as long as the stale value lived. That is #580's
   defect in a new hat. The navigation therefore stays bare, which is what lets Flow
-  state the account's own answer: a redirecting account still settles (and rewrites
-  the locale every run, so a changed locale needs no special handling), while a
-  cache that wrongly says "not redirected" — reachable by one transient probe
-  timeout — is healed from the landing URL at teardown. Reproducer:
-  `scripts/dev/spike_locale_poison.py`.
+  state the account's own answer. Reproducer: `scripts/dev/spike_locale_poison.py`.
+
+  The cache holds **four** states, and the fourth is what keeps it honest.
+  `await_url_settled` returns `None` for both "Flow does not redirect this account"
+  and "the settle timed out this once", so one slow network could otherwise commit
+  to "not redirected" permanently and silently restore #580's post-`goto` race. A
+  no-redirect observation is therefore **provisional** until a second run agrees;
+  a transient timeout costs one extra probe instead of a lasting defect.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing `.gflow_account`) in three states, not two: never probed,
   redirected-to-`X`, and **not redirected** — that last one is the account paying
   the cost, and recording it as "nothing" would re-probe forever. The same guard
-  now covers all four `await_url_settled` call sites; guarding only the editor
-  entry left three navigations still paying the timeout.
+  now covers all four `await_url_settled` call sites **in the UI transport**;
+  guarding only the editor entry left three navigations still paying the timeout.
+  (The three sites in the experimental REST transports have no resolved locale to
+  gate on and are unchanged.)
 
   The cache decides only *whether to wait*, never *where to navigate*. Sending the
   browser to a cached `/fx/{seg}/...` was built, measured, and rejected: Flow

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -106,8 +106,9 @@ established, not merely plausible.**
 > `project_editor_url()` still served `/fx/pt/` in Portuguese"* — is the **inverse** of
 > what `scripts/dev/spike_locale_poison.py` measures: Flow serves whatever segment it
 > is asked for and never corrects a wrong-but-valid one. The original observation was
-> almost certainly the ineffective `locale="en-US"` noted in the corollary below never
-> reaching the URL at all. §2.4's *conclusion* (account-driven) stands on the
+> almost certainly the ineffective launch-context `locale="en-US"` noted in the
+> corollary below — a Chrome kwarg, never a URL segment — rather than the URL
+> builder, which does reduce `en-US` to `/fx/en/`. §2.4's *conclusion* (account-driven) stands on the
 > authed/unauthed contrast; the mechanism sentence does not. Do not use it to argue
 > that navigating to a cached segment is safe — that design was built and rejected.
 

--- a/docs/superpowers/specs/2026-08-21-selector-registry-design.md
+++ b/docs/superpowers/specs/2026-08-21-selector-registry-design.md
@@ -102,6 +102,15 @@ established, not merely plausible.**
 
 ### 2.4 Locale is account-driven
 
+> **Superseded 2026-08-27 (#587).** The sentence below — *"Passing `locale="en"` to
+> `project_editor_url()` still served `/fx/pt/` in Portuguese"* — is the **inverse** of
+> what `scripts/dev/spike_locale_poison.py` measures: Flow serves whatever segment it
+> is asked for and never corrects a wrong-but-valid one. The original observation was
+> almost certainly the ineffective `locale="en-US"` noted in the corollary below never
+> reaching the URL at all. §2.4's *conclusion* (account-driven) stands on the
+> authed/unauthed contrast; the mechanism sentence does not. Do not use it to argue
+> that navigating to a cached segment is safe — that design was built and rejected.
+
 Passing `locale="en"` to `project_editor_url()` still served `/fx/pt/` in Portuguese.
 The *evidence* for account-attribution is the authed/unauthed contrast at identical
 `Accept-Language` and IP: **authed → `pt`, unauthed → `en`, cookie the only variable**

--- a/scripts/dev/measure_locale_probe.py
+++ b/scripts/dev/measure_locale_probe.py
@@ -11,6 +11,10 @@ arm differs from the cold one in exactly one way: when the cached answer is
 profile) warm and cold are expected to be identical, and that row is the control:
 it shows what the cold-then-warm ordering is worth on its own.
 
+**Why the warm arm primes first.** A no-redirect observation is PROVISIONAL until
+a second run agrees, so the run right after a cold one still probes. The warm arm
+therefore primes to a terminal cache state before timing anything.
+
 **Why it repeats.** A single cold/warm pair measures the fix plus whatever
 browser/OS warm-up the first run paid. The first version of this script reported
 a 4.42 s delta against a 4.0 s mechanism ceiling — an excess that can only be
@@ -36,6 +40,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 from gflow_cli.api.client import FlowApiClient  # noqa: E402
 from gflow_cli.profile_store import (  # noqa: E402
     LOCALE_FILE,
+    PROVISIONAL,
     read_account_locale,
 )
 
@@ -51,6 +56,19 @@ async def _setup_once(profile_dir: Path, *, cold: bool) -> tuple[float, str | No
         return elapsed, client._account_locale  # noqa: SLF001 — dev instrument
 
 
+async def _prime(profile_dir: Path) -> None:
+    """Run until the cache reaches a terminal state, so "warm" really is warm.
+
+    A no-redirect observation is only PROVISIONAL until a second run agrees
+    (#587), so on such an account the second run still probes. Measuring it as
+    the warm arm would report no improvement at all — the instrument, not the fix.
+    """
+    for _ in range(3):
+        if read_account_locale(profile_dir) not in (None, PROVISIONAL):
+            return
+        await _setup_once(profile_dir, cold=False)
+
+
 async def _main(profiles: list[str], rounds: int) -> int:
     # Resolve every profile BEFORE launching anything: a typo must not create and
     # ACL-harden a junk profile dir halfway through a run.
@@ -63,6 +81,8 @@ async def _main(profiles: list[str], rounds: int) -> int:
         best: dict[str, float] = {}
         locales: dict[str, str | None] = {}
         for arm, cold in (("cold", True), ("warm", False)):
+            if arm == "warm":
+                await _prime(pdir)
             samples: list[float] = []
             for _ in range(rounds):
                 elapsed, locale = await _setup_once(pdir, cold=cold)

--- a/scripts/dev/measure_locale_probe.py
+++ b/scripts/dev/measure_locale_probe.py
@@ -1,0 +1,61 @@
+"""Measure the account-locale probe, cold vs cached (#587). Zero credits.
+
+The claim in #587 is a *timing* claim, so no unit test can close it: the probe
+costs the full ``URL_SETTLE_TIMEOUT_MS`` only on an account Flow does not
+redirect, and only against live Flow. This harness runs the real client setup
+on a real profile, twice per profile:
+
+    cold  — cache file removed; the probe runs and its outcome is persisted
+    warm  — cache present; the bootstrap goes straight to the localised URL
+
+and prints the setup wall-clock for each. Nothing is generated and no project is
+created, so the run is credit-free.
+
+Run both arms of the issue's table:
+
+    uv run python scripts/dev/measure_locale_probe.py denon82 ffroliva
+
+The only side effect is the ``.gflow_locale`` file this feature exists to write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from time import perf_counter
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.auth import profile_dir
+from gflow_cli.profile_store import LOCALE_FILE, read_account_locale
+
+
+async def _setup_once(profile: str, *, cold: bool) -> tuple[float, str | None]:
+    pdir = profile_dir(profile)
+    if cold:
+        (pdir / LOCALE_FILE).unlink(missing_ok=True)
+    started = perf_counter()
+    async with FlowApiClient(profile_dir=pdir) as client:
+        elapsed = perf_counter() - started
+        return elapsed, client._account_locale
+
+
+async def _main(profiles: list[str]) -> int:
+    print(f"{'profile':<12} {'arm':<6} {'setup':>8}  locale   cached")
+    print("-" * 52)
+    for profile in profiles:
+        for cold in (True, False):
+            elapsed, locale = await _setup_once(profile, cold=cold)
+            cached = read_account_locale(profile_dir(profile))
+            print(
+                f"{profile:<12} {'cold' if cold else 'warm':<6} "
+                f"{elapsed:>7.2f}s  {locale or '-':<8} {cached!r}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    names = sys.argv[1:]
+    if not names:
+        print(__doc__)
+        raise SystemExit(2)
+    raise SystemExit(asyncio.run(_main(names)))

--- a/scripts/dev/measure_locale_probe.py
+++ b/scripts/dev/measure_locale_probe.py
@@ -2,60 +2,88 @@
 
 The claim in #587 is a *timing* claim, so no unit test can close it: the probe
 costs the full ``URL_SETTLE_TIMEOUT_MS`` only on an account Flow does not
-redirect, and only against live Flow. This harness runs the real client setup
-on a real profile, twice per profile:
+redirect, and only against live Flow.
 
-    cold  — cache file removed; the probe runs and its outcome is persisted
-    warm  — cache present; the bootstrap goes straight to the localised URL
+**What "warm" means here.** The navigation is bare on BOTH arms — the cache never
+supplies the URL, only the answer to "does this account redirect?". So the warm
+arm differs from the cold one in exactly one way: when the cached answer is
+``NOT_REDIRECTED`` the settle is skipped. On a *redirecting* account (e.g. a pt
+profile) warm and cold are expected to be identical, and that row is the control:
+it shows what the cold-then-warm ordering is worth on its own.
 
-and prints the setup wall-clock for each. Nothing is generated and no project is
-created, so the run is credit-free.
-
-Run both arms of the issue's table:
+**Why it repeats.** A single cold/warm pair measures the fix plus whatever
+browser/OS warm-up the first run paid. The first version of this script reported
+a 4.42 s delta against a 4.0 s mechanism ceiling — an excess that can only be
+noise. Each arm is therefore run ``--rounds`` times and the **minimum** is
+reported, the standard way to read a timing sample whose noise is one-sided.
 
     uv run python scripts/dev/measure_locale_probe.py denon82 ffroliva
+    uv run python scripts/dev/measure_locale_probe.py --rounds 5 ffroliva
 
 The only side effect is the ``.gflow_locale`` file this feature exists to write.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import sys
+from pathlib import Path
 from time import perf_counter
 
-from gflow_cli.api.client import FlowApiClient
-from gflow_cli.auth import profile_dir
-from gflow_cli.profile_store import LOCALE_FILE, read_account_locale
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.profile_store import (  # noqa: E402
+    LOCALE_FILE,
+    read_account_locale,
+)
+
+from _spike_common import resolve_profile_dir  # noqa: E402, isort: skip
 
 
-async def _setup_once(profile: str, *, cold: bool) -> tuple[float, str | None]:
-    pdir = profile_dir(profile)
+async def _setup_once(profile_dir: Path, *, cold: bool) -> tuple[float, str | None]:
     if cold:
-        (pdir / LOCALE_FILE).unlink(missing_ok=True)
+        (profile_dir / LOCALE_FILE).unlink(missing_ok=True)
     started = perf_counter()
-    async with FlowApiClient(profile_dir=pdir) as client:
+    async with FlowApiClient(profile_dir=profile_dir) as client:
         elapsed = perf_counter() - started
-        return elapsed, client._account_locale
+        return elapsed, client._account_locale  # noqa: SLF001 — dev instrument
 
 
-async def _main(profiles: list[str]) -> int:
-    print(f"{'profile':<12} {'arm':<6} {'setup':>8}  locale   cached")
-    print("-" * 52)
-    for profile in profiles:
-        for cold in (True, False):
-            elapsed, locale = await _setup_once(profile, cold=cold)
-            cached = read_account_locale(profile_dir(profile))
+async def _main(profiles: list[str], rounds: int) -> int:
+    # Resolve every profile BEFORE launching anything: a typo must not create and
+    # ACL-harden a junk profile dir halfway through a run.
+    dirs = {name: resolve_profile_dir(name) for name in profiles}
+
+    print(f"{'profile':<12} {'arm':<6} {'best':>8} {'of':>3}  locale   cached")
+    print("-" * 56)
+    regressed = False
+    for name, pdir in dirs.items():
+        best: dict[str, float] = {}
+        locales: dict[str, str | None] = {}
+        for arm, cold in (("cold", True), ("warm", False)):
+            samples: list[float] = []
+            for _ in range(rounds):
+                elapsed, locale = await _setup_once(pdir, cold=cold)
+                samples.append(elapsed)
+                locales[arm] = locale
+            best[arm] = min(samples)
             print(
-                f"{profile:<12} {'cold' if cold else 'warm':<6} "
-                f"{elapsed:>7.2f}s  {locale or '-':<8} {cached!r}"
+                f"{name:<12} {arm:<6} {best[arm]:>7.2f}s {rounds:>3}  "
+                f"{locales[arm] or '-':<8} {read_account_locale(pdir)!r}"
             )
-    return 0
+        # A redirecting account is the CONTROL: warm == cold is the expected,
+        # correct result there, so only a slower warm arm is a real regression.
+        if best["warm"] > best["cold"] + 0.5:
+            print(f"  !! {name}: warm arm slower than cold — investigate")
+            regressed = True
+    return 1 if regressed else 0
 
 
 if __name__ == "__main__":
-    names = sys.argv[1:]
-    if not names:
-        print(__doc__)
-        raise SystemExit(2)
-    raise SystemExit(asyncio.run(_main(names)))
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profiles", nargs="+", help="profile names to measure")
+    ap.add_argument("--rounds", type=int, default=3, help="samples per arm (default: 3)")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profiles, max(1, args.rounds))))

--- a/scripts/dev/spike_changelog_modal.py
+++ b/scripts/dev/spike_changelog_modal.py
@@ -1,0 +1,163 @@
+"""Does Flow's changelog modal block the app behind it? (#587 follow-up). Zero credits.
+
+Flow began showing a full announcement dialog ("360p option for Gemini Omni Flash",
+observed 2026-08-27 on a pt account) over the project editor. A run that hit it
+timed out AFTER `url_stable_after_goto` — i.e. the navigation was fine and
+something later could not be clicked.
+
+Two things need measuring, not assuming:
+
+1. **Does the modal actually make the background unactionable?** A dialog can be
+   purely visual, or it can trap pointer events / mark the rest `inert` or
+   `aria-hidden`. Only the second kind explains a timeout on a background
+   control. This reports which, per element.
+2. **Do gflow's EXISTING detectors already see it?** `TOP_BANNER_SELECTORS` and
+   `WELCOME_SCREEN_SELECTORS` anchor on `a[href*='changelog']`, and the modal
+   carries a "Ver todos os registros de alterações" link — so it may already be
+   matched and simply not dismissible by the close-button list.
+
+    uv run python scripts/dev/spike_changelog_modal.py denon82 --project <id>
+
+Read-only: it never clicks, so the account's dismissal state is unchanged and the
+modal is still there for the next run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.api.transports.ui_automation import (  # noqa: E402
+    MODE_SWITCH_TRIGGER_SELECTORS,
+    OVERLAY_CLOSE_BUTTON_SELECTORS,
+    TOP_BANNER_SELECTORS,
+    WELCOME_SCREEN_SELECTORS,
+)
+
+from _spike_common import resolve_profile_dir  # noqa: E402, isort: skip
+
+# Reports, for every dialog on the page: its accessible shape, whether it traps
+# pointer events, and whether the app behind it was marked unactionable.
+_PROBE = """
+() => {
+  const out = {dialogs: [], blockers: [], body: {}};
+  const bs = getComputedStyle(document.body);
+  out.body = {
+    overflow: bs.overflow,
+    pointerEvents: bs.pointerEvents,
+    ariaHidden: document.body.getAttribute('aria-hidden'),
+    inert: document.body.hasAttribute('inert'),
+  };
+  for (const d of document.querySelectorAll("[role='dialog'],[role='alertdialog'],dialog")) {
+    const cs = getComputedStyle(d);
+    out.dialogs.push({
+      role: d.getAttribute('role') || d.tagName.toLowerCase(),
+      modal: d.getAttribute('aria-modal'),
+      label: (d.getAttribute('aria-label') || '').slice(0, 60),
+      changelogLink: !!d.querySelector("a[href*='changelog']"),
+      buttons: Array.from(d.querySelectorAll('button')).map(b => ({
+        text: (b.innerText || '').replace(/\\s+/g, ' ').trim().slice(0, 30),
+        icons: Array.from(b.querySelectorAll('i')).map(i => (i.innerText || '').trim()),
+        aria: b.getAttribute('aria-label'),
+      })).slice(0, 8),
+      z: cs.zIndex,
+      pointerEvents: cs.pointerEvents,
+    });
+  }
+  // Anything that covers the viewport centre and is NOT the dialog itself.
+  const cx = innerWidth / 2, cy = innerHeight / 2;
+  const top = document.elementFromPoint(cx, cy);
+  out.topAtCentre = top ? {
+    tag: top.tagName.toLowerCase(),
+    cls: (top.className || '').toString().slice(0, 80),
+    inDialog: !!top.closest("[role='dialog'],[role='alertdialog'],dialog"),
+  } : null;
+  for (const el of document.querySelectorAll('body > *')) {
+    const cs = getComputedStyle(el);
+    if (cs.pointerEvents === 'none') continue;
+    if (el.hasAttribute('inert') || el.getAttribute('aria-hidden') === 'true') {
+      out.blockers.push({
+        tag: el.tagName.toLowerCase(),
+        inert: el.hasAttribute('inert'),
+        ariaHidden: el.getAttribute('aria-hidden'),
+      });
+    }
+  }
+  return out;
+}
+"""
+
+
+async def _run(profile: str, project_id: str | None) -> int:
+    pdir = resolve_profile_dir(profile)
+    async with FlowApiClient(profile_dir=pdir) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        if project_id:
+            url = routes.project_editor_url(client._account_locale, project_id)  # noqa: SLF001
+            await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+        await page.wait_for_timeout(6000)
+
+        print("\n=== page URL ===")
+        print(page.url)
+
+        probe = await page.evaluate(_PROBE)
+        print("\n=== dialogs on the page ===")
+        print(json.dumps(probe["dialogs"], indent=2)[:3000])
+        print("\n=== what is on top at the viewport centre ===")
+        print(json.dumps(probe["topAtCentre"], indent=2))
+        print("\n=== body / inert-or-aria-hidden siblings ===")
+        print(json.dumps({"body": probe["body"], "blockers": probe["blockers"]}, indent=2))
+
+        print("\n=== do gflow's EXISTING detectors see it? ===")
+        for name, sels in (
+            ("TOP_BANNER", TOP_BANNER_SELECTORS),
+            ("WELCOME_SCREEN", WELCOME_SCREEN_SELECTORS),
+            ("CLOSE_BUTTONS", OVERLAY_CLOSE_BUTTON_SELECTORS),
+        ):
+            for sel in sels:
+                try:
+                    n = await page.locator(sel).count()
+                    vis = await page.locator(sel).first.is_visible() if n else False
+                except Exception as exc:  # noqa: BLE001
+                    n, vis = -1, f"ERR {type(exc).__name__}"
+                print(f"  {name:<15} count={n!s:<4} visible={vis!s:<6} {sel}")
+
+        print("\n=== is the app behind it ACTIONABLE? ===")
+        # The mode-switch trigger is a real control gflow clicks on every run.
+        for sel in MODE_SWITCH_TRIGGER_SELECTORS[:3]:
+            loc = page.locator(sel).first
+            try:
+                count = await page.locator(sel).count()
+                visible = await loc.is_visible() if count else False
+                enabled = await loc.is_enabled() if count else False
+            except Exception as exc:  # noqa: BLE001
+                count, visible, enabled = -1, "ERR", type(exc).__name__
+            blocked = "n/a"
+            if count and visible:
+                # Actionability is what Playwright waits on: a covered element is
+                # visible and enabled yet never receives the click.
+                blocked = await loc.evaluate(
+                    "el => { const r = el.getBoundingClientRect();"
+                    " const t = document.elementFromPoint(r.x + r.width/2, r.y + r.height/2);"
+                    " return t === el || el.contains(t) ? 'reachable' : 'COVERED by <' +"
+                    " (t ? t.tagName.toLowerCase() : 'null') + '>'; }"
+                )
+            print(f"  count={count!s:<4} visible={visible!s:<6} enabled={enabled!s:<6} {blocked}")
+            print(f"    {sel}")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profile")
+    ap.add_argument("--project", default=None, help="project id to open (else the gallery)")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_run(args.profile, args.project)))

--- a/scripts/dev/spike_locale_poison.py
+++ b/scripts/dev/spike_locale_poison.py
@@ -27,11 +27,9 @@ signal ever arrives, and the UI renders in a language the account never chose â€
 for as long as the stale value lives. Hence the shipped design: the cache decides
 whether to WAIT, never where to GO, and only a bare navigation is evidence.
 
-The second half asserts the two shipped recoveries: a cache poisoned with a
-SEGMENT heals via the bootstrap settle, and one wrongly reading NOT_REDIRECTED --
-the state a single transient timeout produces -- heals from the landing URL at
-teardown. The latter is best-effort: it needs the session to outlive Flow's
-redirect, which any real command does.
+The second half asserts the shipped recovery: a cache poisoned with a SEGMENT
+heals on the very next ordinary run, because that run navigates bare and rewrites
+the locale from what Flow answers.
 
 Restores the profile's original cache value on the way out.
 """
@@ -49,7 +47,6 @@ from gflow_cli.api import routes  # noqa: E402
 from gflow_cli.api.client import FlowApiClient  # noqa: E402
 from gflow_cli.profile_store import (  # noqa: E402
     LOCALE_FILE,
-    NOT_REDIRECTED,
     read_account_locale,
     write_account_locale,
 )
@@ -85,6 +82,13 @@ async def _run(profile: str, segment: str, settle_ms: int) -> bool:
         landed_bad, lang_bad = await _land_on(pdir, poisoned, settle_ms)
         print(_ROW.format("poison", poisoned, landed_bad, lang_bad))
 
+        if routes.locale_segment_from_url(landed_bare) == segment:
+            print(
+                f"\n!! --segment {segment!r} IS this account's real locale; the poison"
+                " arm would prove nothing. Re-run with a different --segment."
+            )
+            return False
+
         corrected = routes.locale_segment_from_url(landed_bad) != segment
         print(
             f"\nFlow corrected the wrong segment: {corrected}"
@@ -99,27 +103,7 @@ async def _run(profile: str, segment: str, settle_ms: int) -> bool:
         healed_a = read_account_locale(pdir)
         print(f"cache={segment!r} (segment) -> run used {used!r} -> cache now {healed_a!r}")
 
-        # Recovery B -- a cache wrongly reading NOT_REDIRECTED, the state ONE
-        # transient settle timeout produces. Nothing upstream repairs it: the
-        # settle is skipped, so only `_persist_locale_correction` can, and this is
-        # the only arm that reaches its write branch. Recovery A does NOT exercise
-        # it (a cached segment makes the correction stand down by design).
-        write_account_locale(pdir, None)
-        async with FlowApiClient(profile_dir=pdir) as client:
-            used_b = client._account_locale  # noqa: SLF001
-            # The bare bootstrap redirect lands AFTER goto returns, and this arm
-            # skips the settle by design (that is the 4 s it saves). A real command
-            # then does seconds of work, so the redirect has long landed by the
-            # time teardown reads page.url. An open-and-close has not -- without
-            # this wait the arm measures the harness, not the fix.
-            await client._page.wait_for_timeout(settle_ms)  # noqa: SLF001
-        healed_b = read_account_locale(pdir)
-        print(
-            f"cache={NOT_REDIRECTED!r} (transient-timeout state) -> run used {used_b!r} "
-            f"-> cache now {healed_b!r}"
-        )
-
-        return not corrected and healed_a != segment and healed_b != NOT_REDIRECTED
+        return not corrected and healed_a != segment
     finally:
         # `write_account_locale(pdir, original or None)` would turn a NEVER-PROBED
         # cache (None) into NOT_REDIRECTED (""), leaving a real profile marked
@@ -132,6 +116,10 @@ async def _run(profile: str, segment: str, settle_ms: int) -> bool:
 
 
 async def _main(profiles: list[str], segment: str, settle_ms: int) -> int:
+    # Resolve every profile up front: `resolve_profile_dir` exits(2) on a typo, and
+    # resolving inside the loop would run profile 1 and then die with no RESULT.
+    for name in profiles:
+        resolve_profile_dir(name)
     results = [await _run(p, segment, settle_ms) for p in profiles]
     ok = all(results)
     print("\nRESULT:", "as expected" if ok else "UNEXPECTED â€” re-read the rows above")

--- a/scripts/dev/spike_locale_poison.py
+++ b/scripts/dev/spike_locale_poison.py
@@ -1,0 +1,107 @@
+"""Does Flow correct a wrong-but-valid locale segment? (#587). Zero credits.
+
+This is the load-bearing experiment behind #587's design. The issue assumed a
+stale cached locale is self-correcting — *"a stale value produces one redirect,
+which the #584 settle already tolerates"*. If that were true, the fast design
+(navigate straight to the cached ``/fx/{seg}/...`` and skip the settle) would be
+safe, and it saves ~3 s on every account rather than only the non-redirecting
+ones.
+
+It is not true. Run this and read the CONTROL row against the POISON row.
+
+    uv run python scripts/dev/spike_locale_poison.py denon82
+    uv run python scripts/dev/spike_locale_poison.py --segment ja denon82 ffroliva
+
+Measured 2026-08-27 on a pt-BR account, poisoned with ``de``:
+
+    arm      requested                              landed                                 lang
+    control  https://labs.google/fx/tools/flow      https://labs.google/fx/pt/tools/flow   en
+    poison   https://labs.google/fx/de/tools/flow   https://labs.google/fx/de/tools/flow   de
+
+Flow serves whatever segment it is asked for. No redirect, so no correction
+signal ever arrives, and the UI renders in a language the account never chose —
+for as long as the stale value lives. Hence the shipped design: the cache decides
+whether to WAIT, never where to GO, and only a bare navigation is evidence.
+
+The second half asserts the shipped recovery: a poisoned cache heals on the very
+next ordinary run, because that run navigates bare.
+
+Restores the profile's original cache value on the way out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.profile_store import read_account_locale, write_account_locale  # noqa: E402
+
+from _spike_common import resolve_profile_dir  # noqa: E402, isort: skip
+
+_ROW = "{:<8} {:<40} {:<40} {}"
+
+
+async def _land_on(profile_dir: Path, url: str, settle_ms: int) -> tuple[str, str]:
+    """Navigate to *url*, wait past any redirect, and report where we ended up."""
+    async with FlowApiClient(profile_dir=profile_dir) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+        # Well past URL_SETTLE_TIMEOUT_MS: if a redirect were coming, it has come.
+        await page.wait_for_timeout(settle_ms)
+        lang = await page.evaluate("document.documentElement.lang")
+        return str(page.url), str(lang)
+
+
+async def _run(profile: str, segment: str, settle_ms: int) -> bool:
+    pdir = resolve_profile_dir(profile)
+    original = read_account_locale(pdir)
+    print(f"\n=== {profile} (cache before: {original!r}) ===")
+    print(_ROW.format("arm", "requested", "landed", "lang"))
+    try:
+        bare = routes.EDITOR_BOOTSTRAP_URL
+        landed_bare, lang_bare = await _land_on(pdir, bare, settle_ms)
+        print(_ROW.format("control", bare, landed_bare, lang_bare))
+
+        poisoned = f"https://labs.google/fx/{segment}/tools/flow?hl=en"
+        landed_bad, lang_bad = await _land_on(pdir, poisoned, settle_ms)
+        print(_ROW.format("poison", poisoned, landed_bad, lang_bad))
+
+        corrected = routes.locale_segment_from_url(landed_bad) != segment
+        print(
+            f"\nFlow corrected the wrong segment: {corrected}"
+            f"   (expected False — this is why the navigation stays bare)"
+        )
+
+        # Shipped recovery: a poisoned CACHE heals on the next ordinary run.
+        write_account_locale(pdir, segment)
+        async with FlowApiClient(profile_dir=pdir) as client:
+            used = client._account_locale  # noqa: SLF001
+        healed = read_account_locale(pdir)
+        print(f"cache poisoned with {segment!r} -> run used {used!r} -> cache now {healed!r}")
+        return not corrected and healed != segment
+    finally:
+        write_account_locale(pdir, original or None)
+        print(f"restored cache to {read_account_locale(pdir)!r}")
+
+
+async def _main(profiles: list[str], segment: str, settle_ms: int) -> int:
+    results = [await _run(p, segment, settle_ms) for p in profiles]
+    ok = all(results)
+    print("\nRESULT:", "as expected" if ok else "UNEXPECTED — re-read the rows above")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profiles", nargs="+")
+    ap.add_argument("--segment", default="de", help="wrong-but-valid segment (default: de)")
+    ap.add_argument("--settle-ms", type=int, default=6000)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profiles, args.segment, args.settle_ms)))

--- a/scripts/dev/spike_locale_poison.py
+++ b/scripts/dev/spike_locale_poison.py
@@ -14,17 +14,24 @@ It is not true. Run this and read the CONTROL row against the POISON row.
 
 Measured 2026-08-27 on a pt-BR account, poisoned with ``de``:
 
-    arm      requested                              landed                                 lang
-    control  https://labs.google/fx/tools/flow      https://labs.google/fx/pt/tools/flow   en
-    poison   https://labs.google/fx/de/tools/flow   https://labs.google/fx/de/tools/flow   de
+    arm      requested              landed                 lang
+    control  /fx/tools/flow?hl=en   /fx/pt/tools/flow      pt     <- Flow chose pt
+    poison   /fx/de/tools/flow      /fx/de/tools/flow      de     <- served as asked
+
+The conclusion rests on the LANDED column, not on ``lang``: both arms carry
+``?hl=en``, which the path segment overrides, so ``lang`` has been observed both
+``en`` and ``pt`` on the control across runs.
 
 Flow serves whatever segment it is asked for. No redirect, so no correction
 signal ever arrives, and the UI renders in a language the account never chose —
 for as long as the stale value lives. Hence the shipped design: the cache decides
 whether to WAIT, never where to GO, and only a bare navigation is evidence.
 
-The second half asserts the shipped recovery: a poisoned cache heals on the very
-next ordinary run, because that run navigates bare.
+The second half asserts the two shipped recoveries: a cache poisoned with a
+SEGMENT heals via the bootstrap settle, and one wrongly reading NOT_REDIRECTED --
+the state a single transient timeout produces -- heals from the landing URL at
+teardown. The latter is best-effort: it needs the session to outlive Flow's
+redirect, which any real command does.
 
 Restores the profile's original cache value on the way out.
 """
@@ -40,11 +47,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
 from gflow_cli.api import routes  # noqa: E402
 from gflow_cli.api.client import FlowApiClient  # noqa: E402
-from gflow_cli.profile_store import read_account_locale, write_account_locale  # noqa: E402
+from gflow_cli.profile_store import (  # noqa: E402
+    LOCALE_FILE,
+    NOT_REDIRECTED,
+    read_account_locale,
+    write_account_locale,
+)
 
 from _spike_common import resolve_profile_dir  # noqa: E402, isort: skip
 
-_ROW = "{:<8} {:<40} {:<40} {}"
+_ROW = "{:<8} {:<44} {:<44} {}"
 
 
 async def _land_on(profile_dir: Path, url: str, settle_ms: int) -> tuple[str, str]:
@@ -79,15 +91,43 @@ async def _run(profile: str, segment: str, settle_ms: int) -> bool:
             f"   (expected False — this is why the navigation stays bare)"
         )
 
-        # Shipped recovery: a poisoned CACHE heals on the next ordinary run.
+        # Recovery A -- a cache poisoned with a SEGMENT heals via the bootstrap
+        # settle, which rewrites the account locale on every such run.
         write_account_locale(pdir, segment)
         async with FlowApiClient(profile_dir=pdir) as client:
             used = client._account_locale  # noqa: SLF001
-        healed = read_account_locale(pdir)
-        print(f"cache poisoned with {segment!r} -> run used {used!r} -> cache now {healed!r}")
-        return not corrected and healed != segment
+        healed_a = read_account_locale(pdir)
+        print(f"cache={segment!r} (segment) -> run used {used!r} -> cache now {healed_a!r}")
+
+        # Recovery B -- a cache wrongly reading NOT_REDIRECTED, the state ONE
+        # transient settle timeout produces. Nothing upstream repairs it: the
+        # settle is skipped, so only `_persist_locale_correction` can, and this is
+        # the only arm that reaches its write branch. Recovery A does NOT exercise
+        # it (a cached segment makes the correction stand down by design).
+        write_account_locale(pdir, None)
+        async with FlowApiClient(profile_dir=pdir) as client:
+            used_b = client._account_locale  # noqa: SLF001
+            # The bare bootstrap redirect lands AFTER goto returns, and this arm
+            # skips the settle by design (that is the 4 s it saves). A real command
+            # then does seconds of work, so the redirect has long landed by the
+            # time teardown reads page.url. An open-and-close has not -- without
+            # this wait the arm measures the harness, not the fix.
+            await client._page.wait_for_timeout(settle_ms)  # noqa: SLF001
+        healed_b = read_account_locale(pdir)
+        print(
+            f"cache={NOT_REDIRECTED!r} (transient-timeout state) -> run used {used_b!r} "
+            f"-> cache now {healed_b!r}"
+        )
+
+        return not corrected and healed_a != segment and healed_b != NOT_REDIRECTED
     finally:
-        write_account_locale(pdir, original or None)
+        # `write_account_locale(pdir, original or None)` would turn a NEVER-PROBED
+        # cache (None) into NOT_REDIRECTED (""), leaving a real profile marked
+        # "skip the settle" -- this instrument re-creating the very bug it studies.
+        if original is None:
+            (pdir / LOCALE_FILE).unlink(missing_ok=True)
+        else:
+            write_account_locale(pdir, original or None)
         print(f"restored cache to {read_account_locale(pdir)!r}")
 
 

--- a/scripts/dev/verify_language_agnostic.py
+++ b/scripts/dev/verify_language_agnostic.py
@@ -14,9 +14,12 @@ dropdown that must be opened first). Calling the real methods cannot be wrong
 about its own preconditions.
 
 Flow routes locale by URL PATH SEGMENT, so ONE account can be served every
-locale — this does not need 14 Google accounts. Note `/fx/en/` is Flow's
-"default", which redirects to the account locale; en is therefore only testable
-on an en account.
+locale — this does not need 14 Google accounts.
+
+Note only the BARE URL redirects to the account locale — Flow serves whatever
+segment it is asked for and never corrects a wrong-but-valid one
+(scripts/dev/spike_locale_poison.py, #587). So `/fx/en/` is served as asked on
+any account, and en is only meaningfully testable on an en account.
 
 Navigation and menu interaction only. Never submits a prompt, never generates,
 spends no credits.

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -90,7 +90,7 @@ from gflow_cli.errors import (
 )
 from gflow_cli.paths import adjust_key_extension, character_output_path, looks_like_video
 from gflow_cli.profile_lease import ProfileLease
-from gflow_cli.profile_store import read_account_locale, write_account_locale
+from gflow_cli.profile_store import NOT_REDIRECTED, read_account_locale, write_account_locale
 from gflow_cli.redaction import redact_sensitive_text
 from gflow_cli.storage import AnyPath, storage_path, write_asset_async
 from gflow_cli.winsec import ensure_profile_hardened
@@ -334,8 +334,13 @@ class FlowApiClient:
         self._access_token_exp: float = 0.0  # epoch seconds; 0 = unknown/expired
         self._pw: Playwright | None = None
         self._context: BrowserContext | None = None
-        # Account locale segment, resolved once from the bootstrap navigation (#580).
+        # Account locale segment, resolved once from the bootstrap navigation (#580),
+        # then cached per profile (#587).
         self._account_locale: str | None = None
+        # Set when a CALLER-supplied locale drives a navigation on the shared page.
+        # From that moment the page URL reflects our choice, not Flow's answer, so
+        # it can no longer be used as evidence — see _persist_locale_correction.
+        self._caller_locale_navigated: bool = False
         # Cross-process profile lease (D3). Acquired in _enter_setup immediately
         # BEFORE the persistent context launches (so contention fails fast with
         # ProfileLockedError instead of racing two Chromes onto one profile dir)
@@ -731,10 +736,9 @@ class FlowApiClient:
 
         The probe (#580) costs the full ``URL_SETTLE_TIMEOUT_MS`` on any account
         Flow does **not** redirect: ``wait_for_url`` never matches, so it runs to
-        timeout. Measured 7.0 s setup on the ``en`` account vs a 3.5 s floor —
-        4 s of pure dead time, on every command, forever. That single case is
-        the entire cost, and the cache exists to answer exactly one question:
-        *does this account redirect?*
+        timeout, on every command, forever. That single case is the entire cost
+        (figures in the CHANGELOG), and the cache exists to answer exactly one
+        question: *does this account redirect?*
 
         The navigation itself stays **bare, always**. Sending the browser to a
         cached ``/fx/{seg}/...`` was measured on 2026-08-27 to be unsafe: Flow
@@ -757,7 +761,7 @@ class FlowApiClient:
             wait_until="domcontentloaded",
             timeout=60_000,
         )
-        if cached == "":
+        if cached == NOT_REDIRECTED:
             self._account_locale = None
             logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
             return
@@ -768,31 +772,49 @@ class FlowApiClient:
         self._account_locale = await self._resolve_account_locale(self._page)
         write_account_locale(self.profile_dir, self._account_locale)
 
-    def _persist_locale_correction(self) -> None:
-        """Re-cache the locale if the browser demonstrably landed somewhere else (#587).
+    def _locale_for_navigation(self, caller_locale: str | None) -> str | None:
+        """Resolve the locale for a navigation, recording whether the CALLER chose it.
 
-        Covers the one case the bootstrap settle cannot: an account cached as
-        "not redirected" skips the settle, so if it ever *starts* redirecting
-        nothing upstream would notice. Because the bootstrap navigation is bare,
-        Flow gets to state its own answer, and by teardown the redirect has long
-        since landed — so this costs no waiting at all.
-
-        Only a positively-observed *different* segment overwrites. A URL with no
-        segment is left alone — it can be an auth page, an error page, or a route
-        Flow does not localise, and reading it as "this account stopped
-        redirecting" would discard a good value and bring the probe back.
+        A caller-supplied locale makes the resulting page URL our own choice rather
+        than Flow's answer, which disqualifies it as cache evidence (#587).
         """
+        if caller_locale is not None:
+            self._caller_locale_navigated = True
+            return caller_locale
+        return self._account_locale
+
+    def _persist_locale_correction(self) -> None:
+        """Heal a cache that wrongly says "this account is not redirected" (#587).
+
+        That is the one state nothing else can repair, and a **transient** probe
+        failure is the likely way to reach it: one slow network or Flow hiccup
+        makes the settle time out on an account that really does redirect,
+        ``NOT_REDIRECTED`` is written, and from then on the settle is skipped
+        forever — silently restoring #580's post-``goto`` redirect race with
+        nothing left to notice it. Reading the landing URL at teardown costs no
+        waiting and heals it on the next run.
+
+        Deliberately does nothing when a segment is already cached: the bootstrap
+        settle re-derives and rewrites the account locale on every such run, so a
+        changed locale is already handled there. Staying out of that case is also
+        what makes this safe — with no segment cached, every URL gflow builds is
+        bare, so a localised landing can only be Flow's own doing. Flow serves
+        whatever segment it is asked for (measured 2026-08-27), so a URL we chose
+        is never evidence; ``_caller_locale_navigated`` covers the remaining way a
+        caller can steer this page (``gflow character create --locale de``).
+
+        A URL with no segment is likewise not evidence of "stopped redirecting":
+        it can be an auth page, an error page, or a route Flow does not localise.
+        """
+        if self._page is None or self._account_locale is not None or self._caller_locale_navigated:
+            return
         try:
-            landed = routes.locale_segment_from_url(str(self._page.url))  # type: ignore[union-attr]
+            landed = routes.locale_segment_from_url(str(self._page.url))
         except Exception:  # noqa: BLE001 — teardown observation, never fatal
             return
-        if landed is None or landed == self._account_locale:
+        if landed is None:
             return
-        logger.info(
-            "client.account_locale_changed",
-            was=self._account_locale,
-            now=landed,
-        )
+        logger.info("client.account_locale_changed", was=self._account_locale, now=landed)
         write_account_locale(self.profile_dir, landed)
 
     async def _resolve_account_locale(self, page: Any) -> str | None:
@@ -2734,7 +2756,7 @@ class FlowApiClient:
             # #580: caller override wins; otherwise the ACCOUNT's own locale.
             # Never "en-US" — a wrong segment bounces the character route, which
             # is how #395 presented.
-            locale=locale if locale is not None else self._account_locale,
+            locale=self._locale_for_navigation(locale),
             format_prompt=format_prompt,
         )
         _images, workflows = cast(

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -90,6 +90,7 @@ from gflow_cli.errors import (
 )
 from gflow_cli.paths import adjust_key_extension, character_output_path, looks_like_video
 from gflow_cli.profile_lease import ProfileLease
+from gflow_cli.profile_store import read_account_locale, write_account_locale
 from gflow_cli.redaction import redact_sensitive_text
 from gflow_cli.storage import AnyPath, storage_path, write_asset_async
 from gflow_cli.winsec import ensure_profile_hardened
@@ -719,21 +720,80 @@ class FlowApiClient:
         # (Phase 3 deferred ``_new_session_id`` flake is addressed in T3 by
         # re-minting reCAPTCHA inside each retry loop on the worker's own
         # Page; no session-id work happens in T2.)
+        await self._bootstrap_and_resolve_locale()
+
+        # --- Step 2: Resolve and set up transport, passing the live Page so
+        # S1 can share this context rather than opening its own.
+        await self._setup_transport()
+
+    async def _bootstrap_and_resolve_locale(self) -> None:
+        """Navigate the bootstrap page and settle the account locale (#580, #587).
+
+        The probe (#580) costs the full ``URL_SETTLE_TIMEOUT_MS`` on any account
+        Flow does **not** redirect: ``wait_for_url`` never matches, so it runs to
+        timeout. Measured 7.0 s setup on the ``en`` account vs a 3.5 s floor —
+        4 s of pure dead time, on every command, forever. That single case is
+        the entire cost, and the cache exists to answer exactly one question:
+        *does this account redirect?*
+
+        The navigation itself stays **bare, always**. Sending the browser to a
+        cached ``/fx/{seg}/...`` was measured on 2026-08-27 to be unsafe: Flow
+        serves whatever segment it is asked for. A ``pt`` account handed
+        ``/fx/de/`` stayed on ``/fx/de/`` and rendered ``html lang=de`` — no
+        redirect, no correction signal, wrong-language UI for as long as the
+        stale value lived. That is #580's defect wearing a new hat: a locale we
+        invented, which Flow silently honours. A bare navigation is the only
+        thing that makes Flow state the account's own answer.
+
+        So a cached **segment** still settles — the redirect lands fast and is
+        the live truth, which also re-heals a stale value for free. Only the
+        "not redirected" state (``""``) skips the wait, and skipping it there is
+        safe because there is provably nothing to wait for.
+        """
+        assert self._page is not None
+        cached = read_account_locale(self.profile_dir)
         await self._page.goto(
             routes.EDITOR_BOOTSTRAP_URL,
             wait_until="domcontentloaded",
             timeout=60_000,
         )
-        # #580: the bootstrap navigation ITSELF races — measured 797 ms to return
-        # with the locale redirect landing afterwards. Settling it here fixes that
-        # race AND yields the account's locale segment for free, with no extra
-        # request. Best-effort: an unresolved locale degrades to bare URLs, which
-        # is never worse than the hardcoded "en-US" it replaces.
+        if cached == "":
+            self._account_locale = None
+            logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
+            return
+        # The probe ran, so persist its outcome unconditionally — including when
+        # it merely confirms what was cached. A conditional write here silently
+        # dropped the first-run "never probed -> not redirected" transition,
+        # which is the one outcome the whole cache exists to record.
         self._account_locale = await self._resolve_account_locale(self._page)
+        write_account_locale(self.profile_dir, self._account_locale)
 
-        # --- Step 2: Resolve and set up transport, passing the live Page so
-        # S1 can share this context rather than opening its own.
-        await self._setup_transport()
+    def _persist_locale_correction(self) -> None:
+        """Re-cache the locale if the browser demonstrably landed somewhere else (#587).
+
+        Covers the one case the bootstrap settle cannot: an account cached as
+        "not redirected" skips the settle, so if it ever *starts* redirecting
+        nothing upstream would notice. Because the bootstrap navigation is bare,
+        Flow gets to state its own answer, and by teardown the redirect has long
+        since landed — so this costs no waiting at all.
+
+        Only a positively-observed *different* segment overwrites. A URL with no
+        segment is left alone — it can be an auth page, an error page, or a route
+        Flow does not localise, and reading it as "this account stopped
+        redirecting" would discard a good value and bring the probe back.
+        """
+        try:
+            landed = routes.locale_segment_from_url(str(self._page.url))  # type: ignore[union-attr]
+        except Exception:  # noqa: BLE001 — teardown observation, never fatal
+            return
+        if landed is None or landed == self._account_locale:
+            return
+        logger.info(
+            "client.account_locale_changed",
+            was=self._account_locale,
+            now=landed,
+        )
+        write_account_locale(self.profile_dir, landed)
 
     async def _resolve_account_locale(self, page: Any) -> str | None:
         """Settle the bootstrap navigation and read the account's locale (#580).
@@ -904,6 +964,10 @@ class FlowApiClient:
         Teardown order: (4) close context/browser -> stop driver;
         (6) release the profile lease.
         """
+        # #587: read where the browser actually landed BEFORE the context closes.
+        # Free (no wait) and the only honest evidence that a cached locale went
+        # stale — the bootstrap URL is our own guess and proves nothing.
+        self._persist_locale_correction()
         # Stop accepting incident events and detach listeners BEFORE the
         # context closes — late callbacks become no-ops (design §6.2 step 7).
         self._detach_recorder()

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -90,7 +90,12 @@ from gflow_cli.errors import (
 )
 from gflow_cli.paths import adjust_key_extension, character_output_path, looks_like_video
 from gflow_cli.profile_lease import ProfileLease
-from gflow_cli.profile_store import NOT_REDIRECTED, read_account_locale, write_account_locale
+from gflow_cli.profile_store import (
+    NOT_REDIRECTED,
+    next_locale_state,
+    read_account_locale,
+    write_account_locale,
+)
 from gflow_cli.redaction import redact_sensitive_text
 from gflow_cli.storage import AnyPath, storage_path, write_asset_async
 from gflow_cli.winsec import ensure_profile_hardened
@@ -337,15 +342,6 @@ class FlowApiClient:
         # Account locale segment, resolved once from the bootstrap navigation (#580),
         # then cached per profile (#587).
         self._account_locale: str | None = None
-        # Set once the bootstrap navigation has actually landed. Until then the
-        # page still holds whatever URL Chrome's PWA restored from a previous run
-        # (ui_automation.py documents that restore), which may carry a locale a
-        # PAST `--locale` run chose — not Flow's answer.
-        self._bootstrap_landed: bool = False
-        # Set when a CALLER-supplied locale drives a navigation on the shared page.
-        # From that moment the page URL reflects our choice, not Flow's answer, so
-        # it can no longer be used as evidence — see _persist_locale_correction.
-        self._caller_locale_navigated: bool = False
         # Cross-process profile lease (D3). Acquired in _enter_setup immediately
         # BEFORE the persistent context launches (so contention fails fast with
         # ProfileLockedError instead of racing two Chromes onto one profile dir)
@@ -747,9 +743,11 @@ class FlowApiClient:
         The navigation stays **bare, always** — never to a cached segment. Flow
         serves whatever segment it is asked for, so only a bare navigation makes
         it state the account's own answer; see the CHANGELOG entry for #587 and
-        ``scripts/dev/spike_locale_poison.py``. A cached segment therefore still
-        settles (fast, and rewrites the locale every run); only the
-        "not redirected" state skips the wait, where nothing can be waited for.
+        ``scripts/dev/spike_locale_poison.py``.
+
+        The settle is skipped only on :data:`NOT_REDIRECTED`, which
+        :func:`next_locale_state` reaches only after two runs agree — so a single
+        transient timeout cannot disable it.
         """
         assert self._page is not None
         cached = read_account_locale(self.profile_dir)
@@ -758,56 +756,15 @@ class FlowApiClient:
             wait_until="domcontentloaded",
             timeout=60_000,
         )
-        self._bootstrap_landed = True
         if cached == NOT_REDIRECTED:
             self._account_locale = None
             logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
             return
-        # The probe ran, so persist its outcome unconditionally — including when
-        # it merely confirms what was cached. A conditional write here silently
-        # dropped the first-run "never probed -> not redirected" transition,
-        # which is the one outcome the whole cache exists to record.
         self._account_locale = await self._resolve_account_locale(self._page)
-        write_account_locale(self.profile_dir, self._account_locale)
-
-    def _persist_locale_correction(self) -> None:
-        """Heal a cache that wrongly says "this account is not redirected" (#587).
-
-        One transient settle timeout writes ``NOT_REDIRECTED`` on an account that
-        really does redirect, and the settle is then skipped forever — silently
-        restoring #580's post-``goto`` race with nothing left to notice it. This is
-        the only repair for that state, and it costs no waiting.
-
-        Every guard below exists so the URL is one **Flow** chose, never one we
-        did; see the CHANGELOG entry for #587 for why that distinction is the
-        whole design.
-        """
-        if (
-            self._page is None
-            # bootstrap never landed => the URL is Chrome's PWA restore, possibly
-            # carrying a locale a PAST `--locale` run chose
-            or not self._bootstrap_landed
-            # a segment is cached => the bootstrap settle already rewrote it, and
-            # gflow's own URLs then carry that segment
-            or self._account_locale is not None
-            # a caller chose the locale for this page
-            or self._caller_locale_navigated
-        ):
-            logger.debug("client.locale_correction_skipped", landed=self._bootstrap_landed)
-            return
-        try:
-            url = str(self._page.url)
-        except Exception:  # noqa: BLE001 — teardown observation, never fatal
-            return
-        landed = routes.locale_segment_from_url(url)
-        if landed is None:
-            # Not evidence of "stopped redirecting": an auth page, an error page,
-            # or a route Flow does not localise all look like this.
-            logger.debug("client.locale_correction_no_segment", url=url)
-            return
-        # `was` is the ON-DISK value; self._account_locale is None by the guard above.
-        logger.info("client.account_locale_changed", was=NOT_REDIRECTED, now=landed)
-        write_account_locale(self.profile_dir, landed)
+        state = next_locale_state(cached, self._account_locale)
+        if state != cached:
+            logger.info("client.account_locale_state", was=cached, now=state)
+        write_account_locale(self.profile_dir, state)
 
     async def _resolve_account_locale(self, page: Any) -> str | None:
         """Settle the bootstrap navigation and read the account's locale (#580).
@@ -978,10 +935,6 @@ class FlowApiClient:
         Teardown order: (4) close context/browser -> stop driver;
         (6) release the profile lease.
         """
-        # #587: read where the browser actually landed BEFORE the context closes.
-        # Free (no wait) and the only honest evidence that a cached locale went
-        # stale — the bootstrap URL is our own guess and proves nothing.
-        self._persist_locale_correction()
         # Stop accepting incident events and detach listeners BEFORE the
         # context closes — late callbacks become no-ops (design §6.2 step 7).
         self._detach_recorder()
@@ -2740,11 +2693,6 @@ class FlowApiClient:
             )
             raise RuntimeError(msg)
 
-        if locale is not None:
-            # #587: a caller-chosen locale steers this shared page, so its URL
-            # stops being evidence of the ACCOUNT's locale. Latches for the rest
-            # of the session — see _persist_locale_correction.
-            self._caller_locale_navigated = True
         _raw = await self.transport.generate_character_images(  # type: ignore[attr-defined]
             project_id=project_id,
             entity_id=entity_id,

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -337,6 +337,11 @@ class FlowApiClient:
         # Account locale segment, resolved once from the bootstrap navigation (#580),
         # then cached per profile (#587).
         self._account_locale: str | None = None
+        # Set once the bootstrap navigation has actually landed. Until then the
+        # page still holds whatever URL Chrome's PWA restored from a previous run
+        # (ui_automation.py documents that restore), which may carry a locale a
+        # PAST `--locale` run chose — not Flow's answer.
+        self._bootstrap_landed: bool = False
         # Set when a CALLER-supplied locale drives a navigation on the shared page.
         # From that moment the page URL reflects our choice, not Flow's answer, so
         # it can no longer be used as evidence — see _persist_locale_correction.
@@ -736,23 +741,15 @@ class FlowApiClient:
 
         The probe (#580) costs the full ``URL_SETTLE_TIMEOUT_MS`` on any account
         Flow does **not** redirect: ``wait_for_url`` never matches, so it runs to
-        timeout, on every command, forever. That single case is the entire cost
-        (figures in the CHANGELOG), and the cache exists to answer exactly one
-        question: *does this account redirect?*
+        timeout on every command. That single case is the entire cost, and the
+        cache answers exactly one question: *does this account redirect?*
 
-        The navigation itself stays **bare, always**. Sending the browser to a
-        cached ``/fx/{seg}/...`` was measured on 2026-08-27 to be unsafe: Flow
-        serves whatever segment it is asked for. A ``pt`` account handed
-        ``/fx/de/`` stayed on ``/fx/de/`` and rendered ``html lang=de`` — no
-        redirect, no correction signal, wrong-language UI for as long as the
-        stale value lived. That is #580's defect wearing a new hat: a locale we
-        invented, which Flow silently honours. A bare navigation is the only
-        thing that makes Flow state the account's own answer.
-
-        So a cached **segment** still settles — the redirect lands fast and is
-        the live truth, which also re-heals a stale value for free. Only the
-        "not redirected" state (``""``) skips the wait, and skipping it there is
-        safe because there is provably nothing to wait for.
+        The navigation stays **bare, always** — never to a cached segment. Flow
+        serves whatever segment it is asked for, so only a bare navigation makes
+        it state the account's own answer; see the CHANGELOG entry for #587 and
+        ``scripts/dev/spike_locale_poison.py``. A cached segment therefore still
+        settles (fast, and rewrites the locale every run); only the
+        "not redirected" state skips the wait, where nothing can be waited for.
         """
         assert self._page is not None
         cached = read_account_locale(self.profile_dir)
@@ -761,6 +758,7 @@ class FlowApiClient:
             wait_until="domcontentloaded",
             timeout=60_000,
         )
+        self._bootstrap_landed = True
         if cached == NOT_REDIRECTED:
             self._account_locale = None
             logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
@@ -772,49 +770,43 @@ class FlowApiClient:
         self._account_locale = await self._resolve_account_locale(self._page)
         write_account_locale(self.profile_dir, self._account_locale)
 
-    def _locale_for_navigation(self, caller_locale: str | None) -> str | None:
-        """Resolve the locale for a navigation, recording whether the CALLER chose it.
-
-        A caller-supplied locale makes the resulting page URL our own choice rather
-        than Flow's answer, which disqualifies it as cache evidence (#587).
-        """
-        if caller_locale is not None:
-            self._caller_locale_navigated = True
-            return caller_locale
-        return self._account_locale
-
     def _persist_locale_correction(self) -> None:
         """Heal a cache that wrongly says "this account is not redirected" (#587).
 
-        That is the one state nothing else can repair, and a **transient** probe
-        failure is the likely way to reach it: one slow network or Flow hiccup
-        makes the settle time out on an account that really does redirect,
-        ``NOT_REDIRECTED`` is written, and from then on the settle is skipped
-        forever — silently restoring #580's post-``goto`` redirect race with
-        nothing left to notice it. Reading the landing URL at teardown costs no
-        waiting and heals it on the next run.
+        One transient settle timeout writes ``NOT_REDIRECTED`` on an account that
+        really does redirect, and the settle is then skipped forever — silently
+        restoring #580's post-``goto`` race with nothing left to notice it. This is
+        the only repair for that state, and it costs no waiting.
 
-        Deliberately does nothing when a segment is already cached: the bootstrap
-        settle re-derives and rewrites the account locale on every such run, so a
-        changed locale is already handled there. Staying out of that case is also
-        what makes this safe — with no segment cached, every URL gflow builds is
-        bare, so a localised landing can only be Flow's own doing. Flow serves
-        whatever segment it is asked for (measured 2026-08-27), so a URL we chose
-        is never evidence; ``_caller_locale_navigated`` covers the remaining way a
-        caller can steer this page (``gflow character create --locale de``).
-
-        A URL with no segment is likewise not evidence of "stopped redirecting":
-        it can be an auth page, an error page, or a route Flow does not localise.
+        Every guard below exists so the URL is one **Flow** chose, never one we
+        did; see the CHANGELOG entry for #587 for why that distinction is the
+        whole design.
         """
-        if self._page is None or self._account_locale is not None or self._caller_locale_navigated:
+        if (
+            self._page is None
+            # bootstrap never landed => the URL is Chrome's PWA restore, possibly
+            # carrying a locale a PAST `--locale` run chose
+            or not self._bootstrap_landed
+            # a segment is cached => the bootstrap settle already rewrote it, and
+            # gflow's own URLs then carry that segment
+            or self._account_locale is not None
+            # a caller chose the locale for this page
+            or self._caller_locale_navigated
+        ):
+            logger.debug("client.locale_correction_skipped", landed=self._bootstrap_landed)
             return
         try:
-            landed = routes.locale_segment_from_url(str(self._page.url))
+            url = str(self._page.url)
         except Exception:  # noqa: BLE001 — teardown observation, never fatal
             return
+        landed = routes.locale_segment_from_url(url)
         if landed is None:
+            # Not evidence of "stopped redirecting": an auth page, an error page,
+            # or a route Flow does not localise all look like this.
+            logger.debug("client.locale_correction_no_segment", url=url)
             return
-        logger.info("client.account_locale_changed", was=self._account_locale, now=landed)
+        # `was` is the ON-DISK value; self._account_locale is None by the guard above.
+        logger.info("client.account_locale_changed", was=NOT_REDIRECTED, now=landed)
         write_account_locale(self.profile_dir, landed)
 
     async def _resolve_account_locale(self, page: Any) -> str | None:
@@ -2748,6 +2740,11 @@ class FlowApiClient:
             )
             raise RuntimeError(msg)
 
+        if locale is not None:
+            # #587: a caller-chosen locale steers this shared page, so its URL
+            # stops being evidence of the ACCOUNT's locale. Latches for the rest
+            # of the session — see _persist_locale_correction.
+            self._caller_locale_navigated = True
         _raw = await self.transport.generate_character_images(  # type: ignore[attr-defined]
             project_id=project_id,
             entity_id=entity_id,
@@ -2756,7 +2753,7 @@ class FlowApiClient:
             # #580: caller override wins; otherwise the ACCOUNT's own locale.
             # Never "en-US" — a wrong segment bounces the character route, which
             # is how #395 presented.
-            locale=self._locale_for_navigation(locale),
+            locale=locale if locale is not None else self._account_locale,
             format_prompt=format_prompt,
         )
         _images, workflows = cast(

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -168,9 +168,12 @@ LOCALE_SEGMENT_RE = re.compile(r"^https://labs\.google/fx/([a-z]{2,3})(?:-[A-Za-
 def locale_segment_from_url(url: str) -> str | None:
     """Extract the account's locale segment from a **settled** Flow URL (#580).
 
-    Flow serves the editor under ``/fx/{locale}/tools/flow`` and redirects any
-    other form to the account's own locale. That redirect is the ONLY trustworthy
-    source of the account locale:
+    Flow serves the editor under ``/fx/{locale}/tools/flow`` and redirects the
+    **bare** form to the account's own locale. It does NOT correct a wrong-but-
+    valid segment: measured 2026-08-27 (#587), a pt-BR account sent to
+    ``/fx/de/tools/flow`` stayed there and rendered ``html lang=de``. So only a
+    BARE navigation reveals the account locale — never navigate to a segment we
+    chose and read it back as an observation:
 
     * ``GET /fx/api/auth/session`` carries no locale field.
     * ``navigator.language`` reports the value **gflow itself sets** when it

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -210,10 +210,29 @@ def project_editor_url(locale: str | None, project_id: str) -> str:
     ``None`` omits the segment and lets Flow normalise, which still redirects but
     never sends the caller somewhere it has to be bounced back from.
     """
+    # Same allowlist as the sibling builders (batch_generate_images_url, scenes_url):
+    # this URL is now rendered into terminal OSC-8 sequences and JSON, so an id
+    # carrying control characters or spaces must not reach them (#587).
+    if not _PROJECT_ID_RE.fullmatch(project_id):
+        msg = f"Invalid project_id: {project_id!r}"
+        raise ValueError(msg)
     segment = _segment_or_none(locale)
     if segment is None:
         return f"{LABS_FX_BASE}/tools/flow/project/{project_id}"
     return f"{LABS_FX_BASE}/{segment}/tools/flow/project/{project_id}"
+
+
+def project_editor_url_or_none(locale: str | None, project_id: str) -> str | None:
+    """Display-safe :func:`project_editor_url`: ``None`` instead of raising (#587).
+
+    Navigation must refuse a malformed id; a LISTING must not. A catalog row with
+    an odd id should still print — dropping its link is the right degradation,
+    crashing `project list` over one row is not.
+    """
+    try:
+        return project_editor_url(locale, project_id)
+    except ValueError:
+        return None
 
 
 def _segment_or_none(locale: str | None) -> str | None:

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1211,6 +1211,19 @@ class UiAutomationTransport(VideoGenerationMixin):
             )
             return False
 
+    async def _settle_if_redirecting(self, page: Any) -> str | None:
+        """Settle a navigation only on an account Flow actually redirects (#587).
+
+        No resolved locale means the bootstrap probe saw Flow serve the bare URL
+        without redirecting, so there is nothing to wait for and
+        :func:`await_url_settled` would burn its full timeout on EVERY navigation.
+        Four call sites need this; guarding only the editor entry left the others
+        paying 4 s each.
+        """
+        if self._account_locale is None:
+            return None
+        return await await_url_settled(page)
+
     async def _enter_editor(
         self,
         page: Page,
@@ -1248,7 +1261,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             # served the bare URL without redirecting, so there is nothing to wait
             # for and the wait would be pure dead time on EVERY navigation.
             before = page.url
-            settled = await await_url_settled(page) if self._account_locale else None
+            settled = await self._settle_if_redirecting(page)
             if settled and settled != before:
                 log.warning(
                     "ui_automation.url_redirected_after_goto",
@@ -1281,7 +1294,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             # real buttons — running it mid-redirect clicks a page that is
             # leaving. The wait_for_timeout below would absorb it, but it comes
             # after this call, not before.
-            await await_url_settled(page)
+            await self._settle_if_redirecting(page)
             await self._bypass_onboarding(page)
 
         await page.wait_for_timeout(3000)
@@ -3292,7 +3305,7 @@ class UiAutomationTransport(VideoGenerationMixin):
                 break
             await page.wait_for_timeout(self._CHARACTER_ROUTE_BACKOFF_MS)
             await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
-            await await_url_settled(page)
+            await self._settle_if_redirecting(page)
             await self._dismiss_blocking_overlays(page, self._out_dir)
 
         shot = await _capture_debug_screenshot(
@@ -3339,7 +3352,7 @@ class UiAutomationTransport(VideoGenerationMixin):
         # this exact race. `_settle_on_character_route` below only checks that
         # `entity_id` is still in the URL, which a locale-only redirect PRESERVES,
         # so it returns instantly and cannot substitute for this wait.
-        await await_url_settled(page)
+        await self._settle_if_redirecting(page)
         await self._dismiss_blocking_overlays(page, self._out_dir)
         await self._settle_on_character_route(page, entity_id=entity_id, url=url)
 

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -18,6 +18,7 @@ from rich.table import Table
 
 from gflow_cli import json_output, profile_store
 from gflow_cli._cli_helpers import run_with_handlers, safe_path_text
+from gflow_cli.api import routes
 from gflow_cli.config import get_settings
 from gflow_cli.data.models import AssetLookup
 from gflow_cli.data.queries import (
@@ -104,8 +105,13 @@ def _emit_projects_table(rows: list[ProjectRow]) -> None:
     for col in ("PROJECT_ID", "TITLE", "PROFILE", "CREATED", "IMG", "VID"):
         tbl.add_column(col)
     for r in rows:
+        # #587: the id is rendered as a Rich hyperlink to the account-correct
+        # editor URL. Costs no column width and degrades to plain text on
+        # terminals that do not support OSC-8, so the table stays as it was for
+        # anyone piping or grepping it.
+        url = routes.project_editor_url(profile_store.account_locale_for(r.profile), r.project_id)
         tbl.add_row(
-            r.project_id,
+            f"[link={url}]{r.project_id}[/link]",
             _truncate(r.title),
             r.profile,
             r.created_at.strftime("%Y-%m-%d %H:%M"),

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -15,6 +15,7 @@ import click
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
+from rich.text import Text
 
 from gflow_cli import json_output, profile_store
 from gflow_cli._cli_helpers import run_with_handlers, safe_path_text
@@ -105,13 +106,15 @@ def _emit_projects_table(rows: list[ProjectRow]) -> None:
     for col in ("PROJECT_ID", "TITLE", "PROFILE", "CREATED", "IMG", "VID"):
         tbl.add_column(col)
     for r in rows:
-        # #587: the id is rendered as a Rich hyperlink to the account-correct
-        # editor URL. Costs no column width and degrades to plain text on
-        # terminals that do not support OSC-8, so the table stays as it was for
-        # anyone piping or grepping it.
+        # #587: the id links to the account-correct editor URL. Costs no column
+        # width and degrades to plain text without OSC-8.
+        # Built as a Text with a link STYLE, never as "[link=...]" markup: a "]"
+        # anywhere in the URL closes the tag early, and escaping does not apply
+        # inside a tag attribute — so markup here raises MarkupError on ids the
+        # plain add_row it replaced rendered without complaint.
         url = routes.project_editor_url(profile_store.account_locale_for(r.profile), r.project_id)
         tbl.add_row(
-            f"[link={url}]{r.project_id}[/link]",
+            Text(r.project_id, style=f"link {url}"),
             _truncate(r.title),
             r.profile,
             r.created_at.strftime("%Y-%m-%d %H:%M"),

--- a/src/gflow_cli/cli_data.py
+++ b/src/gflow_cli/cli_data.py
@@ -14,6 +14,7 @@ from typing import Any
 import click
 from rich.console import Console
 from rich.markup import escape
+from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 
@@ -108,13 +109,16 @@ def _emit_projects_table(rows: list[ProjectRow]) -> None:
     for r in rows:
         # #587: the id links to the account-correct editor URL. Costs no column
         # width and degrades to plain text without OSC-8.
-        # Built as a Text with a link STYLE, never as "[link=...]" markup: a "]"
-        # anywhere in the URL closes the tag early, and escaping does not apply
-        # inside a tag attribute — so markup here raises MarkupError on ids the
-        # plain add_row it replaced rendered without complaint.
-        url = routes.project_editor_url(profile_store.account_locale_for(r.profile), r.project_id)
+        # `Style(link=url)`, never markup and never a style STRING. Both are
+        # parsed: "[link=...]" ends at the first "]" in the URL (MarkupError), and
+        # "link {url}" ends at the first space, letting the rest of an id become
+        # style tokens — an id like "x https://evil" then renders this project's
+        # name pointing somewhere else entirely. A Style object parses nothing.
+        url = routes.project_editor_url_or_none(
+            profile_store.account_locale_for(r.profile), r.project_id
+        )
         tbl.add_row(
-            Text(r.project_id, style=f"link {url}"),
+            Text(r.project_id, style=Style(link=url) if url else ""),
             _truncate(r.title),
             r.profile,
             r.created_at.strftime("%Y-%m-%d %H:%M"),

--- a/src/gflow_cli/cli_project.py
+++ b/src/gflow_cli/cli_project.py
@@ -68,7 +68,7 @@ def list_subcommand(profile: str | None, limit: int, as_json: bool) -> None:
                         # #587: account-correct, from the locale cached per
                         # profile. Unknown locale => bare URL, never a guessed
                         # `en` — that guess was the original defect (#580).
-                        "url": routes.project_editor_url(
+                        "url": routes.project_editor_url_or_none(
                             account_locale_for(r.profile), r.project_id
                         ),
                     }
@@ -107,7 +107,9 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
         console.print(f"[yellow]Project not found:[/yellow] {project_id}")
         raise SystemExit(1)
 
-    url = routes.project_editor_url(account_locale_for(record.profile_name), record.flow_project_id)
+    url = routes.project_editor_url_or_none(
+        account_locale_for(record.profile_name), record.flow_project_id
+    )
     if as_json:
         json_output.emit(
             {
@@ -130,7 +132,8 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
         console.print(f"[bold]Source:[/bold] {record.source}")
         if record.created_at:
             console.print(f"[bold]Created:[/bold] {record.created_at}")
-        console.print(f"[bold]URL:[/bold] {url}")
+        if url:
+            console.print(f"[bold]URL:[/bold] {url}")
 
 
 async def _run_create_project(

--- a/src/gflow_cli/cli_project.py
+++ b/src/gflow_cli/cli_project.py
@@ -133,7 +133,10 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
         if record.created_at:
             console.print(f"[bold]Created:[/bold] {record.created_at}")
         if url:
-            console.print(f"[bold]URL:[/bold] {url}")
+            # soft_wrap: without it Rich folds the URL at the terminal width,
+            # leaving a dangling "URL:" label and a link broken for copy-paste
+            # and for `| grep URL`.
+            console.print(f"[bold]URL:[/bold] {url}", soft_wrap=True)
 
 
 async def _run_create_project(

--- a/src/gflow_cli/cli_project.py
+++ b/src/gflow_cli/cli_project.py
@@ -16,12 +16,14 @@ from gflow_cli._cli_helpers import (
     _validate_project_id,
     run_with_handlers,
 )
+from gflow_cli.api import routes
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.cli_data import _db_path, _emit_projects_table
 from gflow_cli.data.models import ProjectRecord
 from gflow_cli.data.queries import list_projects
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
+from gflow_cli.profile_store import account_locale_for
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -63,6 +65,12 @@ def list_subcommand(profile: str | None, limit: int, as_json: bool) -> None:
                         "created_at": r.created_at.isoformat(),
                         "image_count": r.image_count,
                         "video_count": r.video_count,
+                        # #587: account-correct, from the locale cached per
+                        # profile. Unknown locale => bare URL, never a guessed
+                        # `en` — that guess was the original defect (#580).
+                        "url": routes.project_editor_url(
+                            account_locale_for(r.profile), r.project_id
+                        ),
                     }
                     for r in rows
                 ],
@@ -99,6 +107,7 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
         console.print(f"[yellow]Project not found:[/yellow] {project_id}")
         raise SystemExit(1)
 
+    url = routes.project_editor_url(account_locale_for(record.profile_name), record.flow_project_id)
     if as_json:
         json_output.emit(
             {
@@ -110,6 +119,7 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
                     "profile": record.profile_name,
                     "source": record.source,
                     "created_at": record.created_at,
+                    "url": url,
                 },
             }
         )
@@ -120,6 +130,7 @@ def show_subcommand(project_id: str, profile: str | None, as_json: bool) -> None
         console.print(f"[bold]Source:[/bold] {record.source}")
         if record.created_at:
             console.print(f"[bold]Created:[/bold] {record.created_at}")
+        console.print(f"[bold]URL:[/bold] {url}")
 
 
 async def _run_create_project(

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -1207,7 +1207,9 @@ async def gflow_list_projects(
                 "video_count": r.video_count,
                 # #587: account-correct editor link from the locale cached per
                 # profile. Bare URL when unknown — never a guessed `en`.
-                "url": routes.project_editor_url(account_locale_for(r.profile), r.project_id),
+                "url": routes.project_editor_url_or_none(
+                    account_locale_for(r.profile), r.project_id
+                ),
             }
             for r in rows
         ],

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -32,6 +32,7 @@ import structlog
 
 from gflow_cli import auth as auth_mod
 from gflow_cli._cli_helpers import _FLOW_ID_RE
+from gflow_cli.api import routes
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.image import AgentInstruction
 from gflow_cli.api.video import is_media_uuid
@@ -44,7 +45,12 @@ from gflow_cli.data.repository import DataRepository, verified_local_path
 from gflow_cli.data.store import DataStore
 from gflow_cli.errors import GFlowError, is_retryable
 from gflow_cli.mcp.server import server
-from gflow_cli.profile_store import NoDefaultProfileError, NoProfilesError, resolve_profile
+from gflow_cli.profile_store import (
+    NoDefaultProfileError,
+    NoProfilesError,
+    account_locale_for,
+    resolve_profile,
+)
 from gflow_cli.worker import codec
 from gflow_cli.worker.daemon import FlowWorker
 from gflow_cli.worker.queue import QueueRepository
@@ -1199,6 +1205,9 @@ async def gflow_list_projects(
                 "created_at": r.created_at.isoformat(),
                 "image_count": r.image_count,
                 "video_count": r.video_count,
+                # #587: account-correct editor link from the locale cached per
+                # profile. Bare URL when unknown — never a guessed `en`.
+                "url": routes.project_editor_url(account_locale_for(r.profile), r.project_id),
             }
             for r in rows
         ],

--- a/src/gflow_cli/profile_store.py
+++ b/src/gflow_cli/profile_store.py
@@ -33,6 +33,13 @@ if TYPE_CHECKING:
 CONFIG_FILENAME = "config.toml"
 PROFILE_DIR_PREFIX = "profile_"
 ACCOUNT_FILE = ".gflow_account"
+LOCALE_FILE = ".gflow_locale"
+
+# A locale SEGMENT as Flow serves it under /fx/{segment}/tools/flow — bare
+# lowercase ISO-639, never a full BCP-47 tag. Enforced on READ because this value
+# is interpolated into a URL path: a hand-edited or corrupted file must degrade
+# to "probe again", not build https://labs.google/fx/../../etc/passwd/tools/flow.
+_LOCALE_SEGMENT_RE = re.compile(r"^[a-z]{2,3}$")
 
 # Mirrors gflow_cli.paths._SAFE_ID_RE — alphanumerics, hyphens, underscores, ≤128 chars.
 _SAFE_PROFILE_NAME_RE = re.compile(r"^[\w\-]{1,128}$")
@@ -264,6 +271,56 @@ def _dump_config(data: dict[str, object]) -> str:
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
         lines.append(f'{key} = "{escaped}"')
     return "\n".join(lines) + "\n"
+
+
+def read_account_locale(profile_path: Path) -> str | None:
+    """Cached account-locale segment for a profile dir (#587). THREE states.
+
+    ``None``  — never probed. The caller must run the live probe.
+    ``""``    — probed; Flow does not redirect this account. Skip the probe.
+    ``"pt"``  — probed; this is the account's locale segment.
+
+    The empty-string state is the point of the cache, not an edge case: an
+    account Flow does not redirect resolves to "no locale", and that is exactly
+    the account burning the full ``URL_SETTLE_TIMEOUT_MS`` on every command.
+    Storing it as "nothing written" would be indistinguishable from "never
+    asked" and would re-probe forever.
+
+    Anything that is not a bare segment reads as ``None`` so a corrupted file
+    self-heals on the next run.
+    """
+    try:
+        raw = (profile_path / LOCALE_FILE).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not raw:
+        return ""
+    return raw if _LOCALE_SEGMENT_RE.match(raw) else None
+
+
+def write_account_locale(profile_path: Path, locale: str | None) -> None:
+    """Persist a probe outcome; ``None`` records "this account is not redirected".
+
+    Best-effort by construction — a cache write that fails must never take down
+    a run that has already done its real work. The cost of not persisting is one
+    wasted probe on the next command.
+    """
+    try:
+        (profile_path / LOCALE_FILE).write_text(locale or "", encoding="utf-8")
+    except OSError:
+        return
+
+
+def account_locale_for(profile_name: str) -> str | None:
+    """Cached locale segment for a NAMED profile, or ``None`` when unknown (#587).
+
+    The offline entry point: catalog listings know a profile name, not a dir, and
+    have no browser to ask. Collapses the cache's ``""`` (probed, not redirected)
+    and ``None`` (never probed) into a single ``None``, because a URL builder has
+    nothing to do differently with the two. A catalog row can outlive its profile
+    dir, so a missing dir is a normal ``None``, not an error.
+    """
+    return read_account_locale(profile_dir(profile_name)) or None
 
 
 def _read_account_file(profile_path: Path) -> str | None:

--- a/src/gflow_cli/profile_store.py
+++ b/src/gflow_cli/profile_store.py
@@ -23,7 +23,7 @@ import shutil
 import tomllib
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from gflow_cli.auth import default_profile_root, profile_dir, status
 
@@ -34,6 +34,11 @@ CONFIG_FILENAME = "config.toml"
 PROFILE_DIR_PREFIX = "profile_"
 ACCOUNT_FILE = ".gflow_account"
 LOCALE_FILE = ".gflow_locale"
+
+# The cache's third state: "probed, and Flow does NOT redirect this account".
+# Distinct from None ("never probed") — folding the two together re-probes
+# forever on exactly the account the cache exists for.
+NOT_REDIRECTED: Final = ""
 
 # A locale SEGMENT as Flow serves it under /fx/{segment}/tools/flow — bare
 # lowercase ISO-639, never a full BCP-47 tag. Enforced on READ because this value
@@ -276,37 +281,30 @@ def _dump_config(data: dict[str, object]) -> str:
 def read_account_locale(profile_path: Path) -> str | None:
     """Cached account-locale segment for a profile dir (#587). THREE states.
 
-    ``None``  — never probed. The caller must run the live probe.
-    ``""``    — probed; Flow does not redirect this account. Skip the probe.
-    ``"pt"``  — probed; this is the account's locale segment.
+    ``None``               — never probed; the caller must run the live probe.
+    :data:`NOT_REDIRECTED` — probed; Flow does not redirect this account.
+    ``"pt"``               — probed; this is the account's locale segment.
 
-    The empty-string state is the point of the cache, not an edge case: an
-    account Flow does not redirect resolves to "no locale", and that is exactly
-    the account burning the full ``URL_SETTLE_TIMEOUT_MS`` on every command.
-    Storing it as "nothing written" would be indistinguishable from "never
-    asked" and would re-probe forever.
-
-    Anything that is not a bare segment reads as ``None`` so a corrupted file
-    self-heals on the next run.
+    Anything else reads as ``None`` so a corrupt file self-heals: the value is
+    interpolated into a URL path, and ``ValueError`` covers the undecodable-bytes
+    case that would otherwise crash every listing command.
     """
     try:
         raw = (profile_path / LOCALE_FILE).read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, ValueError):
         return None
     if not raw:
-        return ""
+        return NOT_REDIRECTED
     return raw if _LOCALE_SEGMENT_RE.match(raw) else None
 
 
 def write_account_locale(profile_path: Path, locale: str | None) -> None:
     """Persist a probe outcome; ``None`` records "this account is not redirected".
 
-    Best-effort by construction — a cache write that fails must never take down
-    a run that has already done its real work. The cost of not persisting is one
-    wasted probe on the next command.
+    Best-effort: a failed cache write costs one extra probe, never a run.
     """
     try:
-        (profile_path / LOCALE_FILE).write_text(locale or "", encoding="utf-8")
+        (profile_path / LOCALE_FILE).write_text(locale or NOT_REDIRECTED, encoding="utf-8")
     except OSError:
         return
 
@@ -315,10 +313,9 @@ def account_locale_for(profile_name: str) -> str | None:
     """Cached locale segment for a NAMED profile, or ``None`` when unknown (#587).
 
     The offline entry point: catalog listings know a profile name, not a dir, and
-    have no browser to ask. Collapses the cache's ``""`` (probed, not redirected)
-    and ``None`` (never probed) into a single ``None``, because a URL builder has
-    nothing to do differently with the two. A catalog row can outlive its profile
-    dir, so a missing dir is a normal ``None``, not an error.
+    have no browser to ask. Collapses :data:`NOT_REDIRECTED` into ``None`` — a URL
+    builder does nothing different with the two. A catalog row can outlive its
+    profile dir, so a missing dir is a normal ``None``.
     """
     return read_account_locale(profile_dir(profile_name)) or None
 

--- a/src/gflow_cli/profile_store.py
+++ b/src/gflow_cli/profile_store.py
@@ -35,9 +35,14 @@ PROFILE_DIR_PREFIX = "profile_"
 ACCOUNT_FILE = ".gflow_account"
 LOCALE_FILE = ".gflow_locale"
 
-# The cache's third state: "probed, and Flow does NOT redirect this account".
-# Distinct from None ("never probed") — folding the two together re-probes
-# forever on exactly the account the cache exists for.
+# The probe cannot tell "Flow does not redirect this account" from "the settle
+# timed out this once" — `await_url_settled` returns None for both. Committing
+# straight to NOT_REDIRECTED on the first no-redirect observation therefore lets a
+# single slow network permanently disable the settle, silently restoring #580's
+# post-goto race. So a no-redirect observation is PROVISIONAL until a second run
+# agrees; the poisoned state cannot arise, and the cost of a false timeout is one
+# extra probe rather than a permanent defect.
+PROVISIONAL: Final = "?"
 NOT_REDIRECTED: Final = ""
 
 # A locale SEGMENT as Flow serves it under /fx/{segment}/tools/flow — bare
@@ -279,11 +284,12 @@ def _dump_config(data: dict[str, object]) -> str:
 
 
 def read_account_locale(profile_path: Path) -> str | None:
-    """Cached account-locale segment for a profile dir (#587). THREE states.
+    """Cached account-locale probe outcome for a profile dir (#587). FOUR states.
 
-    ``None``               — never probed; the caller must run the live probe.
-    :data:`NOT_REDIRECTED` — probed; Flow does not redirect this account.
-    ``"pt"``               — probed; this is the account's locale segment.
+    ``None``               — never probed; probe, then record the outcome.
+    :data:`PROVISIONAL`    — ONE no-redirect observation; probe again to confirm.
+    :data:`NOT_REDIRECTED` — two agreed; skip the settle, there is nothing to wait for.
+    ``"pt"``               — the account's locale segment.
 
     Anything else reads as ``None`` so a corrupt file self-heals: the value is
     interpolated into a URL path, and ``ValueError`` covers the undecodable-bytes
@@ -295,29 +301,51 @@ def read_account_locale(profile_path: Path) -> str | None:
         return None
     if not raw:
         return NOT_REDIRECTED
+    if raw == PROVISIONAL:
+        return PROVISIONAL
     return raw if _LOCALE_SEGMENT_RE.match(raw) else None
 
 
-def write_account_locale(profile_path: Path, locale: str | None) -> None:
-    """Persist a probe outcome; ``None`` records "this account is not redirected".
+def write_account_locale(profile_path: Path, value: str | None) -> None:
+    """Persist a probe outcome verbatim; ``None`` means :data:`NOT_REDIRECTED`.
 
     Best-effort: a failed cache write costs one extra probe, never a run.
     """
     try:
-        (profile_path / LOCALE_FILE).write_text(locale or NOT_REDIRECTED, encoding="utf-8")
+        (profile_path / LOCALE_FILE).write_text(value or NOT_REDIRECTED, encoding="utf-8")
     except OSError:
         return
 
 
+def next_locale_state(cached: str | None, observed: str | None) -> str:
+    """Fold a fresh probe outcome into the cached one (#587).
+
+    A no-redirect observation only reaches :data:`NOT_REDIRECTED` by agreeing with
+    a previous one, which is what makes a single transient settle timeout cost an
+    extra probe instead of permanently disabling the settle. A segment is always
+    taken at face value — Flow stating a locale is not ambiguous the way silence is.
+    """
+    if observed is not None:
+        return observed
+    # Silence corroborates an earlier silence; it never demotes a committed state
+    # (unreachable from the client, which returns early on NOT_REDIRECTED, but the
+    # function must be right on its own terms).
+    return NOT_REDIRECTED if cached in (PROVISIONAL, NOT_REDIRECTED) else PROVISIONAL
+
+
 def account_locale_for(profile_name: str) -> str | None:
-    """Cached locale segment for a NAMED profile, or ``None`` when unknown (#587).
+    """Cached locale SEGMENT for a named profile, or ``None`` when unknown (#587).
 
     The offline entry point: catalog listings know a profile name, not a dir, and
-    have no browser to ask. Collapses :data:`NOT_REDIRECTED` into ``None`` — a URL
-    builder does nothing different with the two. A catalog row can outlive its
-    profile dir, so a missing dir is a normal ``None``.
+    have no browser to ask. Only a real segment is a locale — the bookkeeping
+    states must never leak into a URL, and :data:`PROVISIONAL` is truthy, so this
+    checks the shape rather than truthiness. A catalog row can outlive its profile
+    dir, so a missing dir is a normal ``None``.
     """
-    return read_account_locale(profile_dir(profile_name)) or None
+    cached = read_account_locale(profile_dir(profile_name))
+    if cached is None or not _LOCALE_SEGMENT_RE.match(cached):
+        return None
+    return cached
 
 
 def _read_account_file(profile_path: Path) -> str | None:

--- a/tests/api/test_client_generate_character.py
+++ b/tests/api/test_client_generate_character.py
@@ -175,6 +175,25 @@ class TestGenerateCharacterImage:
         )
 
         assert transport.calls[0]["locale"] == "fr-FR"
+        # #587: a caller-chosen locale steers the shared page, so its URL stops
+        # being evidence of the ACCOUNT's locale. Without this latch the teardown
+        # correction cached "fr" as the account locale — reproduced by the
+        # council against real code.
+        assert client._caller_locale_navigated is True
+
+    async def test_omitted_locale_does_not_latch_the_caller_flag(self, tmp_path: Path) -> None:
+        """No caller locale => the page stays usable as evidence."""
+        transport = _FakeCharTransport()
+        client = _client_with_transport(tmp_path, transport)
+
+        await client.generate_character_image(
+            project_id=_PROJECT_ID,
+            entity_id=_ENTITY_ID,
+            req=CharacterImageRequest(prompt="test"),
+            image_reference_index=0,
+        )
+
+        assert client._caller_locale_navigated is False
 
     async def test_omitted_locale_uses_the_resolved_account_locale(self, tmp_path: Path) -> None:
         """Omitting locale must use the ACCOUNT's locale, not 'en-US' (#580).

--- a/tests/api/test_client_generate_character.py
+++ b/tests/api/test_client_generate_character.py
@@ -175,25 +175,6 @@ class TestGenerateCharacterImage:
         )
 
         assert transport.calls[0]["locale"] == "fr-FR"
-        # #587: a caller-chosen locale steers the shared page, so its URL stops
-        # being evidence of the ACCOUNT's locale. Without this latch the teardown
-        # correction cached "fr" as the account locale — reproduced by the
-        # council against real code.
-        assert client._caller_locale_navigated is True
-
-    async def test_omitted_locale_does_not_latch_the_caller_flag(self, tmp_path: Path) -> None:
-        """No caller locale => the page stays usable as evidence."""
-        transport = _FakeCharTransport()
-        client = _client_with_transport(tmp_path, transport)
-
-        await client.generate_character_image(
-            project_id=_PROJECT_ID,
-            entity_id=_ENTITY_ID,
-            req=CharacterImageRequest(prompt="test"),
-            image_reference_index=0,
-        )
-
-        assert client._caller_locale_navigated is False
 
     async def test_omitted_locale_uses_the_resolved_account_locale(self, tmp_path: Path) -> None:
         """Omitting locale must use the ACCOUNT's locale, not 'en-US' (#580).

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -1,0 +1,208 @@
+"""The locale probe runs once per profile, not once per command (#587).
+
+``_resolve_account_locale`` (#580) settles the bootstrap navigation to learn the
+account's locale. On an account Flow does **not** redirect there is nothing to
+settle, so ``wait_for_url`` runs to the full 4 s timeout
+(``_common.py:153``) — every command, forever. Measured live 2026-08-27: 7.0 s
+setup on the ``en`` account against a 3.5 s floor once cached.
+
+The fix caches the probe's outcome in the profile dir. Two properties matter and
+both are pinned here:
+
+1. **A cache hit must not probe.** Including the "no redirect" outcome — that is
+   the account paying the cost.
+2. **The cache decides whether to WAIT, never where to GO.** Measured live on
+   2026-08-27: Flow serves whatever locale segment it is asked for. A pt-BR
+   account sent to ``/fx/de/tools/flow`` stayed there and rendered
+   ``html lang=de`` — no redirect, so no correction signal, and a wrong-language
+   UI for as long as the stale value lived. That is #580's defect in a new hat.
+   The bootstrap navigation is therefore always bare, and only the
+   "not redirected" state skips the settle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.profile_store import read_account_locale, write_account_locale
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakePage:
+    """Bootstrap page. ``wait_for_url`` NEVER resolves — a probe here is a failure.
+
+    A probe that runs is the bug under test, so the fake makes it loud rather
+    than slow: any call raises instead of burning the real 4 s.
+    """
+
+    def __init__(self, url: str = "https://labs.google/fx/tools/flow?hl=en") -> None:
+        self.url = url
+        self.goto = AsyncMock()
+        self.probed = False
+
+    async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+        self.probed = True
+        raise AssertionError("the locale probe ran on a cache hit")
+
+
+def _client(tmp_path: Path) -> FlowApiClient:
+    return FlowApiClient(tmp_path)
+
+
+async def test_first_run_probes_and_persists_the_segment(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
+    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    assert client._account_locale == "pt"
+    assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_first_run_persists_the_no_redirect_outcome(tmp_path: Path) -> None:
+    """The account that pays the 4 s must record *that* answer, not nothing."""
+    client = _client(tmp_path)
+    page = _FakePage(url="https://labs.google/fx/tools/flow?hl=en")
+
+    async def _timeout(*_a: Any, **_k: Any) -> None:
+        raise TimeoutError("no localised URL ever appeared")
+
+    page.wait_for_url = _timeout  # type: ignore[method-assign]
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == ""
+
+
+async def test_a_cached_segment_still_settles(tmp_path: Path) -> None:
+    """A redirecting account keeps asking Flow — the redirect is fast AND true.
+
+    Skipping it here would buy ~3 s at the price of never being able to notice a
+    changed locale, because a bare navigation is the only thing that makes Flow
+    state the account's own answer.
+    """
+    write_account_locale(tmp_path, "pt")
+    client = _client(tmp_path)
+    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
+    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    assert client._account_locale == "pt"
+
+
+async def test_a_stale_segment_self_heals_on_the_next_run(tmp_path: Path) -> None:
+    """The poisoned-cache case, which the live run proved a localised bootstrap could not fix."""
+    write_account_locale(tmp_path, "de")
+    client = _client(tmp_path)
+    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
+    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    assert client._account_locale == "pt"
+    assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_cached_no_redirect_skips_the_probe_entirely(tmp_path: Path) -> None:
+    """This is the 4 s the issue is about. It must not be spent twice."""
+    write_account_locale(tmp_path, None)
+    client = _client(tmp_path)
+    page = _FakePage()
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    assert client._account_locale is None
+    assert page.probed is False
+
+
+@pytest.mark.parametrize("cached", ["pt", "", None], ids=["segment", "no-redirect", "unprobed"])
+async def test_the_bootstrap_navigation_is_always_bare(tmp_path: Path, cached: str | None) -> None:
+    """Never send the browser to a locale we chose. Flow would simply obey.
+
+    Live on 2026-08-27, a pt-BR account handed ``/fx/de/`` served German and never
+    redirected — the cached value becomes both unverifiable and actively wrong.
+    """
+    if cached is not None:
+        write_account_locale(tmp_path, cached or None)
+    client = _client(tmp_path)
+    page = _FakePage()
+    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    client._page = page  # type: ignore[assignment]
+
+    await client._bootstrap_and_resolve_locale()
+
+    (url,), _ = page.goto.call_args
+    assert url == "https://labs.google/fx/tools/flow?hl=en"
+
+
+# --- staleness: correct only on positive evidence ---------------------------
+
+
+async def test_a_changed_locale_is_re_cached_at_teardown(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, "pt")
+    client = _client(tmp_path)
+    client._account_locale = "pt"
+    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
+
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "de"
+
+
+async def test_the_same_locale_is_not_rewritten(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, "pt")
+    client = _client(tmp_path)
+    client._account_locale = "pt"
+    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
+
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_a_bare_url_does_not_erase_a_known_locale(tmp_path: Path) -> None:
+    """Absence of evidence is not evidence of absence.
+
+    A last URL without a locale segment can be an auth page, an error page, or a
+    route Flow simply does not localise. Treating it as "this account stopped
+    redirecting" would throw away a good value and reintroduce the probe.
+    """
+    write_account_locale(tmp_path, "pt")
+    client = _client(tmp_path)
+    client._account_locale = "pt"
+    client._page = _FakePage(url="https://labs.google/fx/tools/flow")  # type: ignore[assignment]
+
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_correction_never_raises_on_a_dead_page(tmp_path: Path) -> None:
+    """Teardown runs while the browser is closing; `.url` can throw."""
+
+    class _Dead:
+        @property
+        def url(self) -> str:
+            raise RuntimeError("target closed")
+
+    client = _client(tmp_path)
+    client._account_locale = "pt"
+    client._page = _Dead()  # type: ignore[assignment]
+
+    client._persist_locale_correction()  # must not raise

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gflow_cli.api.client import FlowApiClient
-from gflow_cli.profile_store import read_account_locale, write_account_locale
+from gflow_cli.profile_store import (
+    NOT_REDIRECTED,
+    PROVISIONAL,
+    read_account_locale,
+    write_account_locale,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -54,82 +59,68 @@ class _FakePage:
         self.url = self._redirects_to
 
 
-def _client(tmp_path: Path) -> FlowApiClient:
-    return FlowApiClient(tmp_path)
+async def _bootstrap(tmp_path: Path, page: _FakePage) -> FlowApiClient:
+    client = FlowApiClient(tmp_path)
+    client._page = page  # type: ignore[assignment]
+    await client._bootstrap_and_resolve_locale()
+    return client
+
+
+# --- the probe outcome is cached ---------------------------------------------
 
 
 async def test_first_run_probes_and_persists_the_segment(tmp_path: Path) -> None:
-    client = _client(tmp_path)
     page = _FakePage("https://labs.google/fx/pt/tools/flow")
-    client._page = page  # type: ignore[assignment]
 
-    await client._bootstrap_and_resolve_locale()
+    client = await _bootstrap(tmp_path, page)
 
     assert page.probed is True
     assert client._account_locale == "pt"
     assert read_account_locale(tmp_path) == "pt"
 
 
-async def test_first_run_persists_the_no_redirect_outcome(tmp_path: Path) -> None:
-    """The account that pays the 4 s must record *that* answer, not nothing."""
-    client = _client(tmp_path)
-    page = _FakePage(None)  # Flow never redirects this account
-    client._page = page  # type: ignore[assignment]
-
-    await client._bootstrap_and_resolve_locale()
-
-    assert client._account_locale is None
-    assert read_account_locale(tmp_path) == ""
-
-
 async def test_a_cached_segment_still_settles(tmp_path: Path) -> None:
     """A redirecting account keeps asking Flow — the redirect is fast AND true.
 
-    Skipping it here would buy ~3 s at the price of never being able to notice a
-    changed locale, because a bare navigation is the only thing that makes Flow
-    state the account's own answer.
+    Asserting the OUTCOME alone is vacuous: mutation testing showed it passed
+    against a build where every cache hit skipped the settle.
     """
     write_account_locale(tmp_path, "pt")
-    client = _client(tmp_path)
     page = _FakePage("https://labs.google/fx/pt/tools/flow")
-    client._page = page  # type: ignore[assignment]
 
-    await client._bootstrap_and_resolve_locale()
+    client = await _bootstrap(tmp_path, page)
 
-    # Asserting the OUTCOME alone is vacuous — mutation testing showed it passed
-    # against a build where every cache hit skipped the settle. That the settle
-    # RAN is the behaviour under test.
     assert page.probed is True
     assert client._account_locale == "pt"
 
 
 async def test_a_stale_segment_self_heals_on_the_next_run(tmp_path: Path) -> None:
-    """The poisoned-cache case, which the live run proved a localised bootstrap could not fix."""
+    """The poisoned-cache case, which a localised bootstrap could not fix."""
     write_account_locale(tmp_path, "de")
-    client = _client(tmp_path)
     page = _FakePage("https://labs.google/fx/pt/tools/flow")
-    client._page = page  # type: ignore[assignment]
 
-    await client._bootstrap_and_resolve_locale()
+    client = await _bootstrap(tmp_path, page)
 
     assert client._account_locale == "pt"
     assert read_account_locale(tmp_path) == "pt"
 
 
 async def test_cached_no_redirect_skips_the_probe_entirely(tmp_path: Path) -> None:
-    """This is the 4 s the issue is about. It must not be spent twice."""
-    write_account_locale(tmp_path, None)
-    client = _client(tmp_path)
+    """This is the timeout the issue is about. It must not be spent twice."""
+    write_account_locale(tmp_path, NOT_REDIRECTED)
     page = _FakePage()
-    client._page = page  # type: ignore[assignment]
 
-    await client._bootstrap_and_resolve_locale()
+    client = await _bootstrap(tmp_path, page)
 
-    assert client._account_locale is None
     assert page.probed is False
+    assert client._account_locale is None
 
 
-@pytest.mark.parametrize("cached", ["pt", "", None], ids=["segment", "no-redirect", "unprobed"])
+@pytest.mark.parametrize(
+    "cached",
+    ["pt", NOT_REDIRECTED, PROVISIONAL, None],
+    ids=["segment", "no-redirect", "provisional", "unprobed"],
+)
 async def test_the_bootstrap_navigation_is_always_bare(tmp_path: Path, cached: str | None) -> None:
     """Never send the browser to a locale we chose. Flow would simply obey.
 
@@ -137,128 +128,77 @@ async def test_the_bootstrap_navigation_is_always_bare(tmp_path: Path, cached: s
     redirected — the cached value becomes both unverifiable and actively wrong.
     """
     if cached is not None:
-        write_account_locale(tmp_path, cached or None)
-    client = _client(tmp_path)
+        write_account_locale(tmp_path, cached)
     page = _FakePage("https://labs.google/fx/pt/tools/flow")
-    client._page = page  # type: ignore[assignment]
 
-    await client._bootstrap_and_resolve_locale()
+    await _bootstrap(tmp_path, page)
 
     (url,), _ = page.goto.call_args
     assert url == "https://labs.google/fx/tools/flow?hl=en"
 
 
-# --- staleness: correct only on positive evidence ---------------------------
+# --- one transient timeout must not disable the settle forever ---------------
 
 
-async def test_a_cached_segment_is_left_to_the_bootstrap_settle(tmp_path: Path) -> None:
-    """With a segment cached, the correction must stand down.
+async def test_a_first_no_redirect_is_only_provisional(tmp_path: Path) -> None:
+    """``await_url_settled`` returns None for BOTH "no redirect" and "timed out".
 
-    That run probes anyway and rewrites the account locale unconditionally, so the
-    correction adds nothing — and reading a URL that gflow itself may have chosen
-    adds risk. The committed poison spike caught exactly that: a direct `page.goto`
-    to `/fx/de/` made teardown log `account_locale_changed now=de was=pt`.
+    Committing to NOT_REDIRECTED on the first observation is what let one slow
+    network permanently restore #580's race. Every guard the old teardown
+    self-heal carried existed to repair that after the fact; two agreeing
+    observations make the bad state unreachable instead.
     """
-    write_account_locale(tmp_path, "pt")
-    client = _client(tmp_path)
-    client._account_locale = "pt"
-    client._bootstrap_landed = True
-    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
+    page = _FakePage(None)  # the settle finds nothing
 
-    client._persist_locale_correction()
+    client = await _bootstrap(tmp_path, page)
 
-    assert read_account_locale(tmp_path) == "pt"
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == PROVISIONAL
 
 
-async def test_a_bare_url_is_not_read_as_stopped_redirecting(tmp_path: Path) -> None:
-    """Absence of evidence is not evidence of absence.
+async def test_a_provisional_cache_still_probes(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, PROVISIONAL)
+    page = _FakePage(None)
 
-    A segment-less last URL can be an auth page, an error page, or a route Flow
-    does not localise.
-    """
-    write_account_locale(tmp_path, None)
-    client = _client(tmp_path)
-    client._account_locale = None
-    client._bootstrap_landed = True
-    client._page = _FakePage(url="https://labs.google/fx/tools/flow")  # type: ignore[assignment]
+    await _bootstrap(tmp_path, page)
 
-    client._persist_locale_correction()
-
-    assert read_account_locale(tmp_path) == ""
+    assert page.probed is True
 
 
-async def test_correction_never_raises_on_a_dead_page(tmp_path: Path) -> None:
-    """Teardown runs while the browser is closing; `.url` can throw."""
+async def test_two_agreeing_no_redirects_commit(tmp_path: Path) -> None:
+    """Only the SECOND agreeing observation earns the skip."""
+    write_account_locale(tmp_path, PROVISIONAL)
+    page = _FakePage(None)
 
-    class _Dead:
-        @property
-        def url(self) -> str:
-            raise RuntimeError("target closed")
+    client = await _bootstrap(tmp_path, page)
 
-    client = _client(tmp_path)
-    # MUST be None with the bootstrap landed, or the guards return before `.url`
-    # is ever read and the try/except under test is unreachable — mutation showed
-    # deleting it left the suite green.
-    client._account_locale = None
-    client._bootstrap_landed = True
-    client._page = _Dead()  # type: ignore[assignment]
-
-    client._persist_locale_correction()  # must not raise
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
 
 
-# --- regressions the council reproduced ------------------------------------
-
-
-async def test_a_caller_supplied_locale_never_becomes_the_account_locale(
+async def test_a_transient_timeout_on_a_redirecting_account_does_not_commit(
     tmp_path: Path,
 ) -> None:
-    """`gflow character create --locale de` must not cache `de` as the account locale.
+    """THE regression this design exists for.
 
-    Reproduced by the council against real code: the character editor navigates
-    the SHARED client page to a caller-chosen `/fx/de/...`, and teardown then read
-    that URL as if Flow had chosen it. `project list` afterwards emitted
-    `/fx/de/...` — exactly the guessed segment this PR exists to remove.
+    A cached segment plus one failed settle must not become "not redirected":
+    that state skips the settle forever, and nothing downstream can tell it from
+    a genuine answer. It falls back to PROVISIONAL, so the next run re-probes.
     """
-    write_account_locale(tmp_path, None)  # account is NOT redirected
-    client = _client(tmp_path)
-    client._account_locale = None
+    write_account_locale(tmp_path, "pt")
+    page = _FakePage(None)  # slow network, Flow hiccup — the settle times out
 
-    # what `generate_character_image` does when the caller passes --locale
-    client._caller_locale_navigated = True
-    client._bootstrap_landed = True
-    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
-    client._persist_locale_correction()
+    await _bootstrap(tmp_path, page)
 
-    assert read_account_locale(tmp_path) == "", "a caller's locale was cached as the account's"
+    assert read_account_locale(tmp_path) == PROVISIONAL
+    assert read_account_locale(tmp_path) != NOT_REDIRECTED
 
 
-async def test_correction_is_wired_into_teardown(tmp_path: Path) -> None:
-    """Cover the CALL, not just the method — deleting the call site broke no test."""
-    client = _client(tmp_path)
-    client._account_locale = None
-    client._bootstrap_landed = True
-    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
+async def test_a_segment_after_a_provisional_is_taken_at_face_value(tmp_path: Path) -> None:
+    """Flow stating a locale is not ambiguous the way silence is."""
+    write_account_locale(tmp_path, PROVISIONAL)
+    page = _FakePage("https://labs.google/fx/pt/tools/flow")
 
-    await client._close_browser_resources()
+    await _bootstrap(tmp_path, page)
 
     assert read_account_locale(tmp_path) == "pt"
-
-
-async def test_a_pwa_restored_url_is_not_read_as_the_account_locale(tmp_path: Path) -> None:
-    """A failed bootstrap leaves Chrome's RESTORED url on the page — not evidence.
-
-    `_page` is assigned before `_bootstrap_and_resolve_locale` runs, and
-    `__aenter__`'s failure guard tears down through `_close_browser_resources`.
-    Chrome's PWA restores the last-visited project URL, so a PREVIOUS
-    `gflow character create --locale de` run leaves `/fx/de/...` sitting there for
-    a fresh process to mistake for Flow's answer.
-    """
-    write_account_locale(tmp_path, None)
-    client = _client(tmp_path)
-    client._account_locale = None
-    client._bootstrap_landed = False  # the goto never completed
-    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
-
-    client._persist_locale_correction()
-
-    assert read_account_locale(tmp_path) == "", "a restored URL was cached as the account locale"

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -1,11 +1,8 @@
 """The locale probe runs once per profile, not once per command (#587).
 
-Two properties, both load-bearing:
-
-1. A cache hit must not probe — including the "not redirected" outcome, which is
-   the account that pays the 4 s ``URL_SETTLE_TIMEOUT_MS``.
-2. The cache decides whether to WAIT, never where to GO. Flow serves whatever
-   segment it is asked for, so only a BARE navigation is evidence. See CHANGELOG.
+Two properties: a cache hit must not probe (including the "not redirected"
+outcome, which is the account that pays the timeout), and the cache decides
+whether to WAIT, never where to GO. See the CHANGELOG entry for #587.
 """
 
 from __future__ import annotations
@@ -165,6 +162,7 @@ async def test_a_cached_segment_is_left_to_the_bootstrap_settle(tmp_path: Path) 
     write_account_locale(tmp_path, "pt")
     client = _client(tmp_path)
     client._account_locale = "pt"
+    client._bootstrap_landed = True
     client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
 
     client._persist_locale_correction()
@@ -181,6 +179,7 @@ async def test_a_bare_url_is_not_read_as_stopped_redirecting(tmp_path: Path) -> 
     write_account_locale(tmp_path, None)
     client = _client(tmp_path)
     client._account_locale = None
+    client._bootstrap_landed = True
     client._page = _FakePage(url="https://labs.google/fx/tools/flow")  # type: ignore[assignment]
 
     client._persist_locale_correction()
@@ -197,7 +196,11 @@ async def test_correction_never_raises_on_a_dead_page(tmp_path: Path) -> None:
             raise RuntimeError("target closed")
 
     client = _client(tmp_path)
-    client._account_locale = "pt"
+    # MUST be None with the bootstrap landed, or the guards return before `.url`
+    # is ever read and the try/except under test is unreachable — mutation showed
+    # deleting it left the suite green.
+    client._account_locale = None
+    client._bootstrap_landed = True
     client._page = _Dead()  # type: ignore[assignment]
 
     client._persist_locale_correction()  # must not raise
@@ -220,31 +223,42 @@ async def test_a_caller_supplied_locale_never_becomes_the_account_locale(
     client = _client(tmp_path)
     client._account_locale = None
 
-    assert client._locale_for_navigation("de") == "de"  # caller override wins
+    # what `generate_character_image` does when the caller passes --locale
+    client._caller_locale_navigated = True
+    client._bootstrap_landed = True
     client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
     client._persist_locale_correction()
 
     assert read_account_locale(tmp_path) == "", "a caller's locale was cached as the account's"
 
 
-async def test_correction_still_heals_when_no_caller_locale_was_used(tmp_path: Path) -> None:
-    """The suppression must not disable the transient-timeout self-heal."""
-    write_account_locale(tmp_path, None)
-    client = _client(tmp_path)
-    client._account_locale = None
-    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
-
-    client._persist_locale_correction()
-
-    assert read_account_locale(tmp_path) == "pt"
-
-
 async def test_correction_is_wired_into_teardown(tmp_path: Path) -> None:
     """Cover the CALL, not just the method — deleting the call site broke no test."""
     client = _client(tmp_path)
     client._account_locale = None
+    client._bootstrap_landed = True
     client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
 
     await client._close_browser_resources()
 
     assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_a_pwa_restored_url_is_not_read_as_the_account_locale(tmp_path: Path) -> None:
+    """A failed bootstrap leaves Chrome's RESTORED url on the page — not evidence.
+
+    `_page` is assigned before `_bootstrap_and_resolve_locale` runs, and
+    `__aenter__`'s failure guard tears down through `_close_browser_resources`.
+    Chrome's PWA restores the last-visited project URL, so a PREVIOUS
+    `gflow character create --locale de` run leaves `/fx/de/...` sitting there for
+    a fresh process to mistake for Flow's answer.
+    """
+    write_account_locale(tmp_path, None)
+    client = _client(tmp_path)
+    client._account_locale = None
+    client._bootstrap_landed = False  # the goto never completed
+    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
+
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "", "a restored URL was cached as the account locale"

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -1,23 +1,11 @@
 """The locale probe runs once per profile, not once per command (#587).
 
-``_resolve_account_locale`` (#580) settles the bootstrap navigation to learn the
-account's locale. On an account Flow does **not** redirect there is nothing to
-settle, so ``wait_for_url`` runs to the full 4 s timeout
-(``_common.py:153``) — every command, forever. Measured live 2026-08-27: 7.0 s
-setup on the ``en`` account against a 3.5 s floor once cached.
+Two properties, both load-bearing:
 
-The fix caches the probe's outcome in the profile dir. Two properties matter and
-both are pinned here:
-
-1. **A cache hit must not probe.** Including the "no redirect" outcome — that is
-   the account paying the cost.
-2. **The cache decides whether to WAIT, never where to GO.** Measured live on
-   2026-08-27: Flow serves whatever locale segment it is asked for. A pt-BR
-   account sent to ``/fx/de/tools/flow`` stayed there and rendered
-   ``html lang=de`` — no redirect, so no correction signal, and a wrong-language
-   UI for as long as the stale value lived. That is #580's defect in a new hat.
-   The bootstrap navigation is therefore always bare, and only the
-   "not redirected" state skips the settle.
+1. A cache hit must not probe — including the "not redirected" outcome, which is
+   the account that pays the 4 s ``URL_SETTLE_TIMEOUT_MS``.
+2. The cache decides whether to WAIT, never where to GO. Flow serves whatever
+   segment it is asked for, so only a BARE navigation is evidence. See CHANGELOG.
 """
 
 from __future__ import annotations
@@ -37,20 +25,36 @@ pytestmark = pytest.mark.asyncio
 
 
 class _FakePage:
-    """Bootstrap page. ``wait_for_url`` NEVER resolves — a probe here is a failure.
+    """Bootstrap page modelling Flow's real sequence: land BARE, then redirect.
 
-    A probe that runs is the bug under test, so the fake makes it loud rather
-    than slow: any call raises instead of burning the real 4 s.
+    Seeding ``url`` with the localised form (the first version of this fake) made
+    ``await_url_settled`` short-circuit on line one, so "the settle ran" could not
+    be asserted at all. ``goto`` therefore lands on the requested (bare) URL and
+    only ``wait_for_url`` — the settle — moves it to ``redirects_to``.
+
+    ``probed`` records whether the settle ran; when ``redirects_to`` is None the
+    wait raises, matching an account Flow never redirects.
     """
 
-    def __init__(self, url: str = "https://labs.google/fx/tools/flow?hl=en") -> None:
+    def __init__(
+        self,
+        redirects_to: str | None = None,
+        *,
+        url: str = "https://labs.google/fx/tools/flow?hl=en",
+    ) -> None:
         self.url = url
-        self.goto = AsyncMock()
+        self._redirects_to = redirects_to
         self.probed = False
+        self.goto = AsyncMock(side_effect=self._goto)
+
+    async def _goto(self, url: str, **_k: Any) -> None:
+        self.url = url
 
     async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
         self.probed = True
-        raise AssertionError("the locale probe ran on a cache hit")
+        if self._redirects_to is None:
+            raise TimeoutError("no localised URL ever appeared")
+        self.url = self._redirects_to
 
 
 def _client(tmp_path: Path) -> FlowApiClient:
@@ -59,12 +63,12 @@ def _client(tmp_path: Path) -> FlowApiClient:
 
 async def test_first_run_probes_and_persists_the_segment(tmp_path: Path) -> None:
     client = _client(tmp_path)
-    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
-    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    page = _FakePage("https://labs.google/fx/pt/tools/flow")
     client._page = page  # type: ignore[assignment]
 
     await client._bootstrap_and_resolve_locale()
 
+    assert page.probed is True
     assert client._account_locale == "pt"
     assert read_account_locale(tmp_path) == "pt"
 
@@ -72,12 +76,7 @@ async def test_first_run_probes_and_persists_the_segment(tmp_path: Path) -> None
 async def test_first_run_persists_the_no_redirect_outcome(tmp_path: Path) -> None:
     """The account that pays the 4 s must record *that* answer, not nothing."""
     client = _client(tmp_path)
-    page = _FakePage(url="https://labs.google/fx/tools/flow?hl=en")
-
-    async def _timeout(*_a: Any, **_k: Any) -> None:
-        raise TimeoutError("no localised URL ever appeared")
-
-    page.wait_for_url = _timeout  # type: ignore[method-assign]
+    page = _FakePage(None)  # Flow never redirects this account
     client._page = page  # type: ignore[assignment]
 
     await client._bootstrap_and_resolve_locale()
@@ -95,12 +94,15 @@ async def test_a_cached_segment_still_settles(tmp_path: Path) -> None:
     """
     write_account_locale(tmp_path, "pt")
     client = _client(tmp_path)
-    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
-    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    page = _FakePage("https://labs.google/fx/pt/tools/flow")
     client._page = page  # type: ignore[assignment]
 
     await client._bootstrap_and_resolve_locale()
 
+    # Asserting the OUTCOME alone is vacuous — mutation testing showed it passed
+    # against a build where every cache hit skipped the settle. That the settle
+    # RAN is the behaviour under test.
+    assert page.probed is True
     assert client._account_locale == "pt"
 
 
@@ -108,8 +110,7 @@ async def test_a_stale_segment_self_heals_on_the_next_run(tmp_path: Path) -> Non
     """The poisoned-cache case, which the live run proved a localised bootstrap could not fix."""
     write_account_locale(tmp_path, "de")
     client = _client(tmp_path)
-    page = _FakePage(url="https://labs.google/fx/pt/tools/flow")
-    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    page = _FakePage("https://labs.google/fx/pt/tools/flow")
     client._page = page  # type: ignore[assignment]
 
     await client._bootstrap_and_resolve_locale()
@@ -141,8 +142,7 @@ async def test_the_bootstrap_navigation_is_always_bare(tmp_path: Path, cached: s
     if cached is not None:
         write_account_locale(tmp_path, cached or None)
     client = _client(tmp_path)
-    page = _FakePage()
-    page.wait_for_url = AsyncMock()  # type: ignore[method-assign]
+    page = _FakePage("https://labs.google/fx/pt/tools/flow")
     client._page = page  # type: ignore[assignment]
 
     await client._bootstrap_and_resolve_locale()
@@ -154,7 +154,14 @@ async def test_the_bootstrap_navigation_is_always_bare(tmp_path: Path, cached: s
 # --- staleness: correct only on positive evidence ---------------------------
 
 
-async def test_a_changed_locale_is_re_cached_at_teardown(tmp_path: Path) -> None:
+async def test_a_cached_segment_is_left_to_the_bootstrap_settle(tmp_path: Path) -> None:
+    """With a segment cached, the correction must stand down.
+
+    That run probes anyway and rewrites the account locale unconditionally, so the
+    correction adds nothing — and reading a URL that gflow itself may have chosen
+    adds risk. The committed poison spike caught exactly that: a direct `page.goto`
+    to `/fx/de/` made teardown log `account_locale_changed now=de was=pt`.
+    """
     write_account_locale(tmp_path, "pt")
     client = _client(tmp_path)
     client._account_locale = "pt"
@@ -162,35 +169,23 @@ async def test_a_changed_locale_is_re_cached_at_teardown(tmp_path: Path) -> None
 
     client._persist_locale_correction()
 
-    assert read_account_locale(tmp_path) == "de"
-
-
-async def test_the_same_locale_is_not_rewritten(tmp_path: Path) -> None:
-    write_account_locale(tmp_path, "pt")
-    client = _client(tmp_path)
-    client._account_locale = "pt"
-    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
-
-    client._persist_locale_correction()
-
     assert read_account_locale(tmp_path) == "pt"
 
 
-async def test_a_bare_url_does_not_erase_a_known_locale(tmp_path: Path) -> None:
+async def test_a_bare_url_is_not_read_as_stopped_redirecting(tmp_path: Path) -> None:
     """Absence of evidence is not evidence of absence.
 
-    A last URL without a locale segment can be an auth page, an error page, or a
-    route Flow simply does not localise. Treating it as "this account stopped
-    redirecting" would throw away a good value and reintroduce the probe.
+    A segment-less last URL can be an auth page, an error page, or a route Flow
+    does not localise.
     """
-    write_account_locale(tmp_path, "pt")
+    write_account_locale(tmp_path, None)
     client = _client(tmp_path)
-    client._account_locale = "pt"
+    client._account_locale = None
     client._page = _FakePage(url="https://labs.google/fx/tools/flow")  # type: ignore[assignment]
 
     client._persist_locale_correction()
 
-    assert read_account_locale(tmp_path) == "pt"
+    assert read_account_locale(tmp_path) == ""
 
 
 async def test_correction_never_raises_on_a_dead_page(tmp_path: Path) -> None:
@@ -206,3 +201,50 @@ async def test_correction_never_raises_on_a_dead_page(tmp_path: Path) -> None:
     client._page = _Dead()  # type: ignore[assignment]
 
     client._persist_locale_correction()  # must not raise
+
+
+# --- regressions the council reproduced ------------------------------------
+
+
+async def test_a_caller_supplied_locale_never_becomes_the_account_locale(
+    tmp_path: Path,
+) -> None:
+    """`gflow character create --locale de` must not cache `de` as the account locale.
+
+    Reproduced by the council against real code: the character editor navigates
+    the SHARED client page to a caller-chosen `/fx/de/...`, and teardown then read
+    that URL as if Flow had chosen it. `project list` afterwards emitted
+    `/fx/de/...` — exactly the guessed segment this PR exists to remove.
+    """
+    write_account_locale(tmp_path, None)  # account is NOT redirected
+    client = _client(tmp_path)
+    client._account_locale = None
+
+    assert client._locale_for_navigation("de") == "de"  # caller override wins
+    client._page = _FakePage(url="https://labs.google/fx/de/tools/flow/project/x")  # type: ignore[assignment]
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "", "a caller's locale was cached as the account's"
+
+
+async def test_correction_still_heals_when_no_caller_locale_was_used(tmp_path: Path) -> None:
+    """The suppression must not disable the transient-timeout self-heal."""
+    write_account_locale(tmp_path, None)
+    client = _client(tmp_path)
+    client._account_locale = None
+    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
+
+    client._persist_locale_correction()
+
+    assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_correction_is_wired_into_teardown(tmp_path: Path) -> None:
+    """Cover the CALL, not just the method — deleting the call site broke no test."""
+    client = _client(tmp_path)
+    client._account_locale = None
+    client._page = _FakePage(url="https://labs.google/fx/pt/tools/flow/project/x")  # type: ignore[assignment]
+
+    await client._close_browser_resources()
+
+    assert read_account_locale(tmp_path) == "pt"

--- a/tests/api/transports/test_locale_navigation.py
+++ b/tests/api/transports/test_locale_navigation.py
@@ -146,3 +146,49 @@ async def test_settle_wait_returns_the_settled_url() -> None:
             return None
 
     assert await await_url_settled(_Settling()) == "https://labs.google/fx/pt/tools/flow/project/x"
+
+
+# --- #587: the settle must be skipped on accounts Flow does not redirect ----
+
+
+class _CountingPage:
+    """Counts settle waits so "was it skipped?" is observable.
+
+    Deliberately NOT a `_FakePage` subclass: that fake assigns `wait_for_url` as
+    an *instance* attribute, which shadows any subclass method — the counter
+    stayed 0 forever and the skip assertion passed vacuously.
+    """
+
+    def __init__(self) -> None:
+        self.url = "https://labs.google/fx/tools/flow"
+        self.goto = AsyncMock()
+        self.waits = 0
+
+    async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+        self.waits += 1
+        raise TimeoutError("a bare URL never becomes localised")
+
+
+@pytest.mark.asyncio
+async def test_settle_is_skipped_when_the_account_is_not_redirected() -> None:
+    """No resolved locale => nothing to wait for => no 4 s timeout.
+
+    Guarding only `_enter_editor` left three other `await_url_settled` calls
+    burning the full `URL_SETTLE_TIMEOUT_MS` on every navigation — the very cost
+    #587 exists to remove.
+    """
+    t = _transport(None)
+    page = _CountingPage()
+
+    assert await t._settle_if_redirecting(page) is None
+    assert page.waits == 0
+
+
+@pytest.mark.asyncio
+async def test_settle_still_runs_when_the_account_is_redirected() -> None:
+    t = _transport("pt")
+    page = _CountingPage()
+
+    await t._settle_if_redirecting(page)
+
+    assert page.waits == 1

--- a/tests/api/transports/test_navigation_settled.py
+++ b/tests/api/transports/test_navigation_settled.py
@@ -50,15 +50,24 @@ def _goto_calls(path: Path) -> list[tuple[int, str]]:
     return out
 
 
+_SETTLE_CALLS = frozenset({"await_url_settled", "_settle_if_redirecting"})
+
+
 def _settle_lines(path: Path) -> set[int]:
     """Line numbers of every `await_url_settled(...)` call."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     return {
         n.lineno
         for n in ast.walk(tree)
+        # `await_url_settled(page)` directly, or the `_settle_if_redirecting`
+        # wrapper that gates it on "does this account actually redirect?" (#587).
+        # The ratchet must know BOTH names: renaming the call site is exactly how
+        # a settle silently disappears from under this test.
         if isinstance(n, ast.Call)
-        and isinstance(n.func, ast.Name)
-        and n.func.id == "await_url_settled"
+        and (
+            (isinstance(n.func, ast.Name) and n.func.id in _SETTLE_CALLS)
+            or (isinstance(n.func, ast.Attribute) and n.func.attr in _SETTLE_CALLS)
+        )
     }
 
 

--- a/tests/test_profile_store_locale.py
+++ b/tests/test_profile_store_locale.py
@@ -1,13 +1,14 @@
-"""The account locale is cached per profile — with THREE states, not two (#587).
+"""The account locale is cached per profile — FOUR states, not two (#587).
 
-    None                 -> never probed; the caller must run the live probe
-    NOT_REDIRECTED ("")  -> probed; Flow does not redirect this account
-    "pt"                 -> probed; this is the account's locale segment
+    None                 -> never probed
+    PROVISIONAL ("?")    -> ONE no-redirect observation; probe again
+    NOT_REDIRECTED ("")  -> two agreed; skip the settle
+    "pt"                 -> the account's locale segment
 
-The empty state is the point, not an edge case: an account Flow does not redirect
-resolves to "no locale", and that is exactly the account burning the settle
-timeout on every command. Storing it as "nothing written" is indistinguishable
-from "never asked". Storage mirrors the existing `.gflow_account` dotfile.
+`await_url_settled` returns None for both "Flow does not redirect this account"
+and "the settle timed out this once", so a single observation cannot be trusted
+to disable the settle permanently. Storage mirrors the existing `.gflow_account`
+dotfile.
 """
 
 from __future__ import annotations
@@ -16,7 +17,14 @@ from pathlib import Path
 
 import pytest
 
-from gflow_cli.profile_store import LOCALE_FILE, read_account_locale, write_account_locale
+from gflow_cli.profile_store import (
+    LOCALE_FILE,
+    NOT_REDIRECTED,
+    PROVISIONAL,
+    next_locale_state,
+    read_account_locale,
+    write_account_locale,
+)
 
 
 def test_never_probed_reads_as_none(tmp_path: Path) -> None:
@@ -91,3 +99,54 @@ def test_undecodable_bytes_read_as_never_probed(tmp_path: Path) -> None:
     (tmp_path / LOCALE_FILE).write_bytes(b"\xff\xfe\x00pt")
 
     assert read_account_locale(tmp_path) is None
+
+
+# --- the state machine that makes the poisoned state unreachable ------------
+
+
+@pytest.mark.parametrize(
+    ("cached", "observed", "expected"),
+    [
+        (None, None, PROVISIONAL),
+        (PROVISIONAL, None, NOT_REDIRECTED),
+        (NOT_REDIRECTED, None, NOT_REDIRECTED),
+        ("pt", None, PROVISIONAL),
+        (None, "pt", "pt"),
+        (PROVISIONAL, "pt", "pt"),
+        (NOT_REDIRECTED, "pt", "pt"),
+        ("de", "pt", "pt"),
+    ],
+    ids=[
+        "first-silence-is-provisional",
+        "second-silence-commits",
+        "committed-stays",
+        "segment-then-silence-falls-back",
+        "first-segment",
+        "segment-clears-provisional",
+        "segment-overrides-committed",
+        "segment-replaces-segment",
+    ],
+)
+def test_next_locale_state(cached: str | None, observed: str | None, expected: str) -> None:
+    """Silence needs corroboration; a stated segment never does.
+
+    The `("pt", None) -> PROVISIONAL` row is the whole point: one transient
+    timeout on a redirecting account must not reach NOT_REDIRECTED, because that
+    state skips the settle forever and looks identical to a real answer.
+    """
+    assert next_locale_state(cached, observed) == expected
+
+
+def test_provisional_round_trips(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, PROVISIONAL)
+    assert read_account_locale(tmp_path) == PROVISIONAL
+
+
+def test_provisional_is_never_offered_as_a_locale(tmp_path: Path, monkeypatch) -> None:
+    """PROVISIONAL is truthy — a `or None` collapse would leak "?" into a URL."""
+    import gflow_cli.profile_store as ps
+
+    monkeypatch.setattr(ps, "profile_dir", lambda _name: tmp_path)
+    write_account_locale(tmp_path, PROVISIONAL)
+
+    assert ps.account_locale_for("whoever") is None

--- a/tests/test_profile_store_locale.py
+++ b/tests/test_profile_store_locale.py
@@ -1,22 +1,13 @@
 """The account locale is cached per profile — with THREE states, not two (#587).
 
-#580 resolves the account locale by settling the bootstrap navigation. That probe
-costs the full ``URL_SETTLE_TIMEOUT_MS`` (4 s, ``_common.py:153``) on any account
-Flow does **not** redirect, because ``wait_for_url`` never matches and the wait
-runs to timeout. Measured: 6.1 s setup on an ``en`` account vs 3.4 s on a
-redirecting ``pt`` one.
+    None                 -> never probed; the caller must run the live probe
+    NOT_REDIRECTED ("")  -> probed; Flow does not redirect this account
+    "pt"                 -> probed; this is the account's locale segment
 
-A two-state cache (value / no value) does not fix that account — "no locale" is
-exactly its answer, and storing it as "nothing" is indistinguishable from "never
-asked". So the cache encodes three states:
-
-    None  -> never probed; the caller MUST run the live probe
-    ""    -> probed; Flow does not redirect this account. Skip the probe.
-    "pt"  -> probed; this is the account's locale segment.
-
-Storage mirrors ``.gflow_account`` (``profile_store.py``, written at
-``internal_chromium.py:185``): a sibling dotfile in the profile dir. No schema
-migration, no config plumbing, and it is readable offline by ``project list``.
+The empty state is the point, not an edge case: an account Flow does not redirect
+resolves to "no locale", and that is exactly the account burning the settle
+timeout on every command. Storing it as "nothing written" is indistinguishable
+from "never asked". Storage mirrors the existing `.gflow_account` dotfile.
 """
 
 from __future__ import annotations
@@ -31,11 +22,6 @@ from gflow_cli.profile_store import LOCALE_FILE, read_account_locale, write_acco
 def test_never_probed_reads_as_none(tmp_path: Path) -> None:
     """No file at all means "ask Flow", not "no locale"."""
     assert read_account_locale(tmp_path) is None
-
-
-def test_a_resolved_segment_round_trips(tmp_path: Path) -> None:
-    write_account_locale(tmp_path, "pt")
-    assert read_account_locale(tmp_path) == "pt"
 
 
 def test_no_redirect_is_recorded_and_is_not_none(tmp_path: Path) -> None:
@@ -92,3 +78,16 @@ def test_write_never_raises_on_an_unwritable_dir(tmp_path: Path) -> None:
     missing = tmp_path / "does" / "not" / "exist"
     write_account_locale(missing, "pt")  # must not raise
     assert read_account_locale(missing) is None
+
+
+def test_undecodable_bytes_read_as_never_probed(tmp_path: Path) -> None:
+    """A corrupt file must self-heal, not crash every listing command.
+
+    Reproduced by the council: catching only `OSError` let `UnicodeDecodeError`
+    escape `read_account_locale`, killing `project list`, `project show`, the MCP
+    listing tool and every browser run — while the docstring promised the file
+    "self-heals".
+    """
+    (tmp_path / LOCALE_FILE).write_bytes(b"\xff\xfe\x00pt")
+
+    assert read_account_locale(tmp_path) is None

--- a/tests/test_profile_store_locale.py
+++ b/tests/test_profile_store_locale.py
@@ -1,0 +1,94 @@
+"""The account locale is cached per profile — with THREE states, not two (#587).
+
+#580 resolves the account locale by settling the bootstrap navigation. That probe
+costs the full ``URL_SETTLE_TIMEOUT_MS`` (4 s, ``_common.py:153``) on any account
+Flow does **not** redirect, because ``wait_for_url`` never matches and the wait
+runs to timeout. Measured: 6.1 s setup on an ``en`` account vs 3.4 s on a
+redirecting ``pt`` one.
+
+A two-state cache (value / no value) does not fix that account — "no locale" is
+exactly its answer, and storing it as "nothing" is indistinguishable from "never
+asked". So the cache encodes three states:
+
+    None  -> never probed; the caller MUST run the live probe
+    ""    -> probed; Flow does not redirect this account. Skip the probe.
+    "pt"  -> probed; this is the account's locale segment.
+
+Storage mirrors ``.gflow_account`` (``profile_store.py``, written at
+``internal_chromium.py:185``): a sibling dotfile in the profile dir. No schema
+migration, no config plumbing, and it is readable offline by ``project list``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gflow_cli.profile_store import LOCALE_FILE, read_account_locale, write_account_locale
+
+
+def test_never_probed_reads_as_none(tmp_path: Path) -> None:
+    """No file at all means "ask Flow", not "no locale"."""
+    assert read_account_locale(tmp_path) is None
+
+
+def test_a_resolved_segment_round_trips(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, "pt")
+    assert read_account_locale(tmp_path) == "pt"
+
+
+def test_no_redirect_is_recorded_and_is_not_none(tmp_path: Path) -> None:
+    """The whole point of the issue.
+
+    An account Flow does not redirect resolves to ``None``. Persisting that as
+    "nothing written" would make it re-probe forever — and it is precisely the
+    account paying the 4 s. It must come back as ``""``: falsy for the caller
+    that wants a locale, distinct from ``None`` for the caller asking whether we
+    have ever looked.
+    """
+    write_account_locale(tmp_path, None)
+
+    cached = read_account_locale(tmp_path)
+    assert cached == ""
+    assert cached is not None
+
+
+def test_a_later_probe_overwrites_an_earlier_one(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, "pt")
+    write_account_locale(tmp_path, "de")
+    assert read_account_locale(tmp_path) == "de"
+
+
+@pytest.mark.parametrize(
+    "junk",
+    ["../../etc/passwd", "pt-BR", "PT", "en_US", "toolong", "x", "https://evil", "1"],
+    ids=["traversal", "full-tag", "upper", "underscore", "too-long", "too-short", "url", "digit"],
+)
+def test_garbage_reads_as_never_probed(tmp_path: Path, junk: str) -> None:
+    """A malformed file must degrade to "probe again", never be used as a URL segment.
+
+    This value is interpolated into a URL path. Anything that is not a bare
+    lowercase 2-3 letter segment is rejected on READ, so a hand-edited or
+    corrupted file self-heals on the next run instead of building
+    ``https://labs.google/fx/../../etc/passwd/tools/flow``.
+    """
+    (tmp_path / LOCALE_FILE).write_text(junk, encoding="utf-8")
+    assert read_account_locale(tmp_path) is None
+
+
+def test_whitespace_only_is_the_no_redirect_state(tmp_path: Path) -> None:
+    """A trailing newline must not turn "no redirect" back into "never probed"."""
+    (tmp_path / LOCALE_FILE).write_text("\n", encoding="utf-8")
+    assert read_account_locale(tmp_path) == ""
+
+
+def test_write_never_raises_on_an_unwritable_dir(tmp_path: Path) -> None:
+    """Best-effort by construction.
+
+    A cache write failing must never take down a generation run that has already
+    done its real work. The cost of failing to persist is one wasted probe.
+    """
+    missing = tmp_path / "does" / "not" / "exist"
+    write_account_locale(missing, "pt")  # must not raise
+    assert read_account_locale(missing) is None

--- a/tests/test_project_list_urls.py
+++ b/tests/test_project_list_urls.py
@@ -1,0 +1,118 @@
+"""Offline listings render account-correct editor URLs (#587).
+
+`gflow project list` emitted no URLs at all. It is a local, network-free catalog
+read by contract, so it cannot resolve a locale itself — which is why it emitted
+nothing rather than something wrong.
+
+Once the locale is persisted per profile (the cache #587 adds for the probe),
+the value is readable offline and the listing can render the real link. The gap
+that started this thread was an `/fx/en/...` link handed to a pt-BR account
+owner: Flow redirects it, so it resolves, but it is the wrong shape and reads
+as broken.
+
+Unknown locale still yields the BARE url, never a guessed `en` — the same rule
+`project_editor_url` already enforces for navigation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gflow_cli import profile_store
+from gflow_cli.cli import main
+from gflow_cli.data.models import ProjectRecord
+from gflow_cli.data.repository import DataRepository
+from gflow_cli.data.store import DataStore
+
+PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from gflow_cli.config import reset_settings
+
+    monkeypatch.setenv("GFLOW_CLI_HOME", str(tmp_path))
+    monkeypatch.delenv("GFLOW_CLI_PROFILE", raising=False)
+    reset_settings()
+    db = tmp_path / "gflow.db"
+    monkeypatch.setenv("GFLOW_CLI_DB_PATH", str(db))
+    reset_settings()
+    with DataStore.open(db) as store:
+        repo = DataRepository(store)
+        repo.upsert_profile("denon82", tmp_path / "profile_denon82")
+        repo.upsert_project(
+            ProjectRecord(
+                id="rec-1",
+                profile_name="denon82",
+                flow_project_id=PID,
+                title="A project",
+                source="gflow-cli",
+            )
+        )
+    yield tmp_path
+    reset_settings()
+
+
+def _pdir(home: Path) -> Path:
+    d = home / "profile_denon82"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _list_json(runner: CliRunner) -> dict:
+    res = runner.invoke(main, ["project", "list", "--json"])
+    assert res.exit_code == 0, res.output
+    return json.loads(res.output)
+
+
+def test_cached_locale_produces_an_account_correct_url(home: Path) -> None:
+    profile_store.write_account_locale(_pdir(home), "pt")
+
+    payload = _list_json(CliRunner())
+
+    assert payload["projects"][0]["url"] == (f"https://labs.google/fx/pt/tools/flow/project/{PID}")
+
+
+def test_unknown_locale_yields_a_bare_url_not_a_guessed_en(home: Path) -> None:
+    """No cache entry => no segment. A guessed `en` is the original defect."""
+    _pdir(home)
+
+    payload = _list_json(CliRunner())
+
+    url = payload["projects"][0]["url"]
+    assert url == f"https://labs.google/fx/tools/flow/project/{PID}"
+    assert "/fx/en/" not in url
+
+
+def test_no_redirect_account_also_yields_a_bare_url(home: Path) -> None:
+    """`""` means "probed, Flow does not redirect" — still no segment to add."""
+    profile_store.write_account_locale(_pdir(home), None)
+
+    payload = _list_json(CliRunner())
+
+    assert payload["projects"][0]["url"] == (f"https://labs.google/fx/tools/flow/project/{PID}")
+
+
+def test_project_show_reports_the_same_url(home: Path) -> None:
+    profile_store.write_account_locale(_pdir(home), "pt")
+
+    res = CliRunner().invoke(main, ["project", "show", PID, "--json"])
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.output)["project"]["url"] == (
+        f"https://labs.google/fx/pt/tools/flow/project/{PID}"
+    )
+
+
+def test_account_locale_for_reads_the_named_profile(home: Path) -> None:
+    profile_store.write_account_locale(_pdir(home), "de")
+    assert profile_store.account_locale_for("denon82") == "de"
+
+
+def test_account_locale_for_is_none_when_the_profile_dir_is_absent(home: Path) -> None:
+    """A catalog row can outlive its profile dir; that must not raise."""
+    assert profile_store.account_locale_for("deleted-profile") is None

--- a/tests/test_project_list_urls.py
+++ b/tests/test_project_list_urls.py
@@ -20,6 +20,7 @@ from gflow_cli.data.models import ProjectRecord
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 
+TAB, LF, ESC, BEL = chr(9), chr(10), chr(27), chr(7)
 PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
 
 
@@ -130,3 +131,104 @@ def test_mcp_list_projects_emits_the_url(
     assert url.endswith(PID)
     assert expected_segment in url
     assert "/fx/en/" not in url
+
+
+# --- the table render must survive a hostile project id ---------------------
+
+
+@pytest.mark.parametrize(
+    "pid",
+    [
+        "550e8400-e29b-41d4-a716-446655440000",
+        "ab]cd",
+        "ab[bold red]cd",
+        "ab[/link]XX",
+        "ab link https://evil.example",
+        "ab conceal",
+        "",
+    ],
+    ids=["uuid", "bracket", "markup", "close-tag", "link-hijack", "style-token", "empty"],
+)
+def test_projects_table_survives_a_hostile_id(pid: str) -> None:
+    """Rendering must never raise, and never link somewhere we did not choose.
+
+    Two parsers were tried and both were wrong: `[link=...]` markup ends at the
+    first `]` in the URL (MarkupError), and a `f"link {url}"` style STRING ends at
+    the first space, letting the rest of an id become style tokens -- an id like
+    `x https://evil` rendered this project's name pointing elsewhere.
+    """
+    import io
+    import re
+    from datetime import UTC, datetime
+
+    from rich.console import Console
+
+    from gflow_cli import cli_data
+    from gflow_cli.data.queries import ProjectRow
+
+    buf = io.StringIO()
+    fake = Console(file=buf, force_terminal=True, width=250, legacy_windows=False)
+    original = cli_data.Console
+    cli_data.Console = lambda *a, **k: fake  # type: ignore[assignment,misc]
+    try:
+        cli_data._emit_projects_table(
+            [
+                ProjectRow(
+                    project_id=pid,
+                    profile="denon82",
+                    created_at=datetime.now(UTC),
+                    image_count=0,
+                    video_count=0,
+                    title="T",
+                )
+            ]
+        )
+    finally:
+        cli_data.Console = original  # type: ignore[assignment]
+
+    osc8 = re.compile(ESC + r"\]8;[^;]*;([^" + ESC + r"\x07]*)")
+    for target in osc8.findall(buf.getvalue()):
+        assert target == "" or target.startswith("https://labs.google/fx/"), target
+
+
+# --- the id allowlist is a security control; pin it directly ----------------
+
+
+@pytest.mark.parametrize(
+    "pid",
+    [
+        "ab link https://evil.example",
+        "../../etc/passwd",
+        "a b",
+        "x" + TAB + "y",
+        "x" + LF + "y",
+        ESC + "]0;pwned" + BEL,
+        "",
+        "a" * 200,
+    ],
+    ids=["space-hijack", "traversal", "space", "tab", "newline", "ansi", "empty", "too-long"],
+)
+def test_editor_url_refuses_a_malformed_project_id(pid: str) -> None:
+    """`Style(link=...)` neutralises the hijack; this is the layer beneath it.
+
+    Mutation testing found the allowlist could be deleted with the whole suite
+    still green -- defence in depth that nothing pinned. The strict builder feeds
+    navigation, so it refuses; the tolerant one feeds listings, so it degrades.
+    """
+    from gflow_cli.api import routes
+
+    with pytest.raises(ValueError, match="Invalid project_id"):
+        routes.project_editor_url("pt", pid)
+
+    assert routes.project_editor_url_or_none("pt", pid) is None
+
+
+def test_editor_url_accepts_a_real_flow_id() -> None:
+    from gflow_cli.api import routes
+
+    assert routes.project_editor_url("pt", PID) == (
+        f"https://labs.google/fx/pt/tools/flow/project/{PID}"
+    )
+    assert routes.project_editor_url_or_none(None, PID) == (
+        f"https://labs.google/fx/tools/flow/project/{PID}"
+    )

--- a/tests/test_project_list_urls.py
+++ b/tests/test_project_list_urls.py
@@ -1,17 +1,9 @@
 """Offline listings render account-correct editor URLs (#587).
 
-`gflow project list` emitted no URLs at all. It is a local, network-free catalog
-read by contract, so it cannot resolve a locale itself — which is why it emitted
-nothing rather than something wrong.
-
-Once the locale is persisted per profile (the cache #587 adds for the probe),
-the value is readable offline and the listing can render the real link. The gap
-that started this thread was an `/fx/en/...` link handed to a pt-BR account
-owner: Flow redirects it, so it resolves, but it is the wrong shape and reads
-as broken.
-
-Unknown locale still yields the BARE url, never a guessed `en` — the same rule
-`project_editor_url` already enforces for navigation.
+`project list` / `project show` / MCP emitted no URL at all: they are
+network-free catalog reads, so they could not resolve a locale and correctly
+declined to guess one. With the locale cached per profile the value is readable
+offline. Unknown locale still yields the BARE url, never a guessed `en`.
 """
 
 from __future__ import annotations
@@ -108,11 +100,33 @@ def test_project_show_reports_the_same_url(home: Path) -> None:
     )
 
 
-def test_account_locale_for_reads_the_named_profile(home: Path) -> None:
-    profile_store.write_account_locale(_pdir(home), "de")
-    assert profile_store.account_locale_for("denon82") == "de"
-
-
 def test_account_locale_for_is_none_when_the_profile_dir_is_absent(home: Path) -> None:
     """A catalog row can outlive its profile dir; that must not raise."""
     assert profile_store.account_locale_for("deleted-profile") is None
+
+
+# --- MCP `gflow_list_projects` carries the same URL (had zero coverage) ------
+
+
+@pytest.mark.parametrize(
+    ("cached", "expected_segment"),
+    [("pt", "/fx/pt/"), (None, "/fx/tools/")],
+    ids=["segment", "no-redirect"],
+)
+def test_mcp_list_projects_emits_the_url(
+    home: Path, cached: str | None, expected_segment: str
+) -> None:
+    """The MCP listing inherits whatever `project list` does — pin it directly."""
+    import asyncio
+
+    from gflow_cli.mcp.tools import gflow_list_projects
+
+    profile_store.write_account_locale(_pdir(home), cached)
+
+    payload = asyncio.run(gflow_list_projects(profile="denon82", limit=10))
+
+    assert payload["status"] == "ok"
+    url = payload["projects"][0]["url"]
+    assert url.endswith(PID)
+    assert expected_segment in url
+    assert "/fx/en/" not in url

--- a/tests/test_project_list_urls.py
+++ b/tests/test_project_list_urls.py
@@ -20,7 +20,6 @@ from gflow_cli.data.models import ProjectRecord
 from gflow_cli.data.repository import DataRepository
 from gflow_cli.data.store import DataStore
 
-TAB, LF, ESC, BEL = chr(9), chr(10), chr(27), chr(7)
 PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
 
 
@@ -138,24 +137,19 @@ def test_mcp_list_projects_emits_the_url(
 
 @pytest.mark.parametrize(
     "pid",
-    [
-        "550e8400-e29b-41d4-a716-446655440000",
-        "ab]cd",
-        "ab[bold red]cd",
-        "ab[/link]XX",
-        "ab link https://evil.example",
-        "ab conceal",
-        "",
-    ],
-    ids=["uuid", "bracket", "markup", "close-tag", "link-hijack", "style-token", "empty"],
+    ["550e8400-e29b-41d4-a716-446655440000", "ab link https://evil.example"],
+    ids=["links", "rejected"],
 )
-def test_projects_table_survives_a_hostile_id(pid: str) -> None:
-    """Rendering must never raise, and never link somewhere we did not choose.
+def test_projects_table_survives_a_hostile_id(home: Path, pid: str) -> None:
+    """Rendering must never raise, and any link emitted must be a Flow URL.
 
     Two parsers were tried and both were wrong: `[link=...]` markup ends at the
-    first `]` in the URL (MarkupError), and a `f"link {url}"` style STRING ends at
-    the first space, letting the rest of an id become style tokens -- an id like
-    `x https://evil` rendered this project's name pointing elsewhere.
+    first `]` in the URL (MarkupError), and a `f"link {url}"` style STRING ends
+    at the first space, letting the rest of an id become style tokens.
+
+    The "rejected" case pins the choice: with the allowlist refusing that id the
+    URL is None, and a style STRING renders `link None` as a literal link target
+    "None" — mutation-verified. The allowlist itself is pinned separately below.
     """
     import io
     import re
@@ -186,7 +180,7 @@ def test_projects_table_survives_a_hostile_id(pid: str) -> None:
     finally:
         cli_data.Console = original  # type: ignore[assignment]
 
-    osc8 = re.compile(ESC + r"\]8;[^;]*;([^" + ESC + r"\x07]*)")
+    osc8 = re.compile(r"\x1b\]8;[^;]*;([^\x1b\a]*)")
     for target in osc8.findall(buf.getvalue()):
         assert target == "" or target.startswith("https://labs.google/fx/"), target
 
@@ -200,9 +194,9 @@ def test_projects_table_survives_a_hostile_id(pid: str) -> None:
         "ab link https://evil.example",
         "../../etc/passwd",
         "a b",
-        "x" + TAB + "y",
-        "x" + LF + "y",
-        ESC + "]0;pwned" + BEL,
+        "x\ty",
+        "x\ny",
+        "\x1b]0;pwned\a",
         "",
         "a" * 200,
     ],


### PR DESCRIPTION
## Summary

The account-locale probe added in v0.61.0 (#580) settles the bootstrap navigation to learn where Flow lands. On an account Flow does **not** redirect there is nothing to settle, so `wait_for_url` runs to the full `URL_SETTLE_TIMEOUT_MS` — every command, forever.

The outcome is now cached per profile in `.gflow_locale`, a sibling of the existing `.gflow_account`. No schema migration, no config plumbing, readable offline.

**Measured live 2026-08-27** (`scripts/dev/measure_locale_probe.py`, credit-free, best-of-N per arm):

| profile | cold | warm | |
|---|---|---|---|
| `ffroliva` (en, non-redirecting) | ~6.2 s | **~2.0 s** | the 4 s settle timeout |
| `denon82` (pt, redirecting) | ~2.8 s | ~2.9 s | control — unchanged by design |

Run-to-run variance is over a second, so read the delta as "the 4 s timeout", not to two decimals. The redirecting account is the control: it shows cold-then-warm ordering is worth nothing on its own.

## Two design findings, both from measurement

**1. Flow serves whatever locale segment it is asked for.** The issue assumed a stale cached locale self-corrects — *"a stale value produces one redirect, which the #584 settle already tolerates."* It does not. A pt-BR account sent to `/fx/de/tools/flow` stayed there and rendered `html lang=de`: no redirect, no correction signal, and a wrong-language UI for as long as the stale value lived. The fast design (navigate straight to the cached segment, skip the settle) was built, measured, and **rejected** — it is #580's defect in a new hat.

So the cache decides only **whether to wait**, never **where to navigate**. The bootstrap stays bare, which is the only thing that makes Flow state the account's own answer. Reproducer: `scripts/dev/spike_locale_poison.py`.

**2. `await_url_settled` returns `None` for two different things** — "Flow does not redirect this account" and "the settle timed out this once". Committing to "not redirected" on the first silence let one slow network permanently disable the settle, silently restoring #580's race.

The cache therefore holds **four** states: a no-redirect observation is `PROVISIONAL` until a second run agrees. The bad state is unreachable rather than repaired, which deleted an entire self-heal subsystem (`_persist_locale_correction`, two provenance flags, a caller latch, 6 tests) that existed only to read `page.url` at teardown and try to prove whose URL it was. Verified live on the `en` account:

```
run 1: probe -> timeout -> cache '?'   (provisional)
run 2: probe -> timeout -> cache ''    (committed)
run 3: settle_skipped=True, no probe
```

Cost: one extra probe on a first-run false timeout.

## Second benefit: offline consumers get correct links

`gflow project list`, `project show` and MCP `gflow_list_projects` previously emitted **no** URL at all — network-free catalog reads with no way to resolve a locale, correctly declining to guess. They now render the real link; unknown locale still yields the **bare** URL, never `/fx/en/...`. Ids are validated against the same allowlist the sibling URL builders use, and the terminal link is built with `Style(link=url)` — never markup or a style string, both of which are parsed and were each exploitable.

## Review

Four rounds of `/gflow:pr-council-review` (9 dimensions each). Round 1 was RED with 3 reproduced defects; rounds 2 and 3 each found defects introduced by the previous round's fixes; round 4 replaced the mechanism those defects lived in. Correctness, quality, security and tests were all GREEN at round 3, before this simplification.

## Verification status

- [x] `ruff check` + `ruff format --check` + doc-links + repo-hygiene clean
- [x] `pyright` 0 errors on every changed file
- [x] `tests/api` + MCP + CLI **1486 passed** · rest of suite (excl. e2e) **2277 passed**
- [x] **Mutation battery: 11 mutations, 11 caught** (baseline 80). One initially reported as caught-by-nothing: the guard text appears 4× in `routes.py` and the mutation had been rewriting the wrong builder.
- [x] **Live**: timing, both profiles, repeated rounds
- [x] **Live**: Flow does not correct a wrong segment (control + poison arms)
- [x] **Live**: a cache poisoned with a segment heals on the next ordinary run
- [x] **Live**: the full provisional lifecycle on a non-redirecting account
- [x] **Live: the editor-entry settle site** (`ui_automation.py:1264`) — exercised by a real `gflow image t2i` run on `denon82`, `url_stable_after_goto settle_skipped=false` against the correct `/fx/pt/` URL, image produced (`49c79a0e-…_1.jpg`, NARWHAL). Images cost 0 credits (per-model daily quota), so this was free.
- [ ] **The other three settle sites are not exercised live.** `:1297` (PWA gallery re-nav), `:3308`/`:3355` (character editor). Covered by unit tests and the AST ratchet that pins every `goto` to a following settle.

**Credits spent: zero.**

## Found while verifying: #593

The first live run failed with an unexplained `TimeoutError`. Cause: Flow now shows a full announcement modal over the editor, which sets `body { pointer-events: none }` while leaving the app **not** `aria-hidden` and **not** `inert` — so every control reads visible and enabled yet never receives a click. Our existing detector and dismissal handle it correctly and content-independently once reached, and dismissal persists server-side. Filed as **#593** with the measurements, including that it can turn the nightly canary RED. `scripts/dev/spike_changelog_modal.py` (read-only) is the reproducer; it is the only out-of-scope file here.

## Known follow-ups (deliberately not in this PR)

- `docs/CHARACTER.md:304` and its `website/` mirror still say Flow renders in the Chrome profile language — #580-era drift in an unrelated feature doc.
- `gflow data list projects --json` (JSONL) still lacks the `url` key that `project list --json` and MCP now carry.
- `docs/MCP.md` does not document the new per-row `url`.

Closes #587

