### PR TITLE
fix(ui-mode): auto requires the classic arm for image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`--ui-mode auto` (the default) now requires the *classic* Flow arm for image
+  generation ([#595](https://github.com/ffroliva/gflow-cli/issues/595)).** `auto`
+  used to bind whatever the composer rendered, so an account that Flow moved into
+  its **agentic** cohort — observed live on two accounts on 2026-08-27 — took a
+  path that cannot satisfy an image request and failed with either
+  `image_mode_tab` selector drift (exit 23) or a `WireFormatError` about video
+  bytes. Neither error named the cause, and the workaround
+  (`GFLOW_CLI_PREFER_CLASSIC=1`) had to be discovered from an error message.
+  `auto` now means "no arm was asked for" and resolves to `classic`, matching the
+  rule video has followed since [#299](https://github.com/ffroliva/gflow-cli/issues/299).
+  The bind still attempts classic recovery first and the cohort flaps per page
+  load, so a run only aborts (`UiModeUnavailableError`, **exit 28**, pre-submit,
+  zero credits) when the arm is genuinely pinned — and that abort is retryable.
+  The agentic arm stays reachable, but only when asked for by name
+  (`--ui-mode agentic` / `GFLOW_CLI_UI_MODE=agentic`) or by need (`-i` agent
+  instructions, which are agentic-only and still force it). The image **batch**
+  path carried its own inline mode resolution and so kept binding `auto`; it now
+  routes through the same policy as the single-prompt path.
+
 ### Fixed
 
 - **A Flow announcement modal no longer wedges a run with an unexplained timeout

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -345,7 +345,7 @@ GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
 
 **What:** Which Flow UI arm to use for generation. Flow serves a **classic** composer (hard crop/aspect controls) or an **agentic** chat cohort, server-assigned and flapping per page load ([#299](https://github.com/ffroliva/gflow-cli/issues/299)).
 **Values:**
-- `auto` (default) — bind whatever the composer renders.
+- `auto` (default) — no arm was asked for, so gflow **requires `classic`** ([#595](https://github.com/ffroliva/gflow-cli/issues/595)): classic is the arm that can satisfy a generation request, and it is recovered first, so this only aborts when the arm is genuinely pinned. Before v0.62.0 `auto` bound whatever rendered, which put an account in Flow's agentic cohort on a driver that cannot produce an image — failing mid-run as `image_mode_tab` selector drift or a `WireFormatError` about video bytes. Agentic is still reachable, but only by name (`--ui-mode agentic`) or by need (`-i`).
 - `classic` — require the classic composer (hard aspect controls). gflow switches to it, re-probes to verify, and if the arm is still agentic **aborts before submitting** with `UiModeUnavailableError` (**exit 28**) — no credits spent.
 - `agentic` — require the agentic chat surface (needed for `-i` agent instructions). gflow switches to it, verifies, and aborts (exit 28) if it can't be reached.
 **Default:** `auto`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -196,7 +196,9 @@ Options:
   --ui-mode [auto|classic|agentic]
                             Require a Flow UI arm: classic (hard aspect
                             controls) / agentic (chat surface; forced by -i) /
-                            auto (default). Aborts exit 28 if unreachable.
+                            auto (default) — auto resolves to classic, the only
+                            arm that can satisfy an image request (#595).
+                            Aborts exit 28 if unreachable.
                             Single-prompt only; batch uses GFLOW_CLI_UI_MODE.
   --profile NAME            Profile name (overrides default).
 ```

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -1707,8 +1707,10 @@ class FlowApiClient:
                 detail=(
                     "image download returned video content (ISO-BMFF/WebM magic "
                     "bytes) — the agentic conversational agent likely produced a "
-                    "video instead of an image. Use a Classic UI profile "
-                    "(GFLOW_CLI_PREFER_CLASSIC=1) or rephrase the prompt."
+                    "video instead of an image. The agentic arm is only bound "
+                    "when asked for by name or by -i instructions, so drop "
+                    "--ui-mode agentic / GFLOW_CLI_UI_MODE=agentic / -i "
+                    "(auto resolves to classic), or rephrase the prompt."
                 ),
                 route=route,
             )

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -3242,15 +3242,18 @@ class UiAutomationTransport(VideoGenerationMixin):
         # cohort flaps per page load; bind once per batch (the editor stays
         # mounted so the cohort is stable for this batch's lifetime).
         # Classic driver requires a transport reference for send_prompt.
-        # No instruction inference here: the image-batch manifest carries no
-        # per-item -i instructions (single-prompt only), so the required arm is
-        # just the resolved --ui-mode / env. Route through infer_required_ui_mode
-        # if batch ever gains instruction support.
-        from gflow_cli.config import resolve_ui_mode
+        # The image-batch manifest carries no per-item -i instructions
+        # (single-prompt only), so ``has_instructions`` is fixed False — but the
+        # call still routes through infer_required_ui_mode so batch inherits the
+        # same policy as the single path (#595: auto ≡ classic). It had its own
+        # inline resolve_ui_mode and so kept binding AUTO after the single path
+        # stopped. Pass instructions through here if batch ever gains them.
+        from gflow_cli.config import infer_required_ui_mode, resolve_ui_mode
 
+        required_mode = infer_required_ui_mode(resolve_ui_mode(None), has_instructions=False)
         # Inject ``self`` into the classic driver at construction (via the
         # factory) — never mutate ``_transport`` onto the driver after the fact.
-        ui_driver = await get_ui_driver(page, ui_mode=resolve_ui_mode(None), transport=self)
+        ui_driver = await get_ui_driver(page, ui_mode=required_mode, transport=self)
 
         try:
             await ui_driver.switch_to_image_mode(page, out_dir=out_dir)

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -785,9 +785,10 @@ _ui_mode_option = click.option(
     default=None,
     help=(
         "Which Flow UI arm to require: 'classic' (hard aspect controls), "
-        "'agentic' (chat surface; needed for -i), or 'auto' (bind whatever "
-        "renders). gflow switches to it and aborts (exit 28, retryable) if it "
-        "can't be reached. Overrides GFLOW_CLI_UI_MODE. Single-prompt only."
+        "'agentic' (chat surface; needed for -i), or 'auto' (default) — which "
+        "resolves to classic, the only arm that can satisfy an image request. "
+        "gflow switches to it and aborts (exit 28, retryable) if it can't be "
+        "reached. Overrides GFLOW_CLI_UI_MODE. Single-prompt only."
     ),
 )
 

--- a/src/gflow_cli/config.py
+++ b/src/gflow_cli/config.py
@@ -267,10 +267,21 @@ def infer_required_ui_mode(base: UiMode, *, has_instructions: bool) -> UiMode:
     agentic when the caller didn't already ask for a specific arm. Explicitly
     demanding ``classic`` *and* passing instructions is contradictory (classic
     cannot apply cards) — a hard :class:`ConfigurationError` instead of a silent
-    drop. Without instructions, ``base`` passes through unchanged.
+    drop.
+
+    Without instructions, ``auto`` resolves to ``classic`` (#595): ``auto``
+    means "no arm was asked for", and classic is the arm that can satisfy a
+    media request. Binding whatever rendered put an account in Flow's agentic
+    cohort on a driver that cannot — failing mid-run as ``image_mode_tab``
+    selector drift or a ``WireFormatError`` about video bytes, neither of which
+    names the cause. The bind's classic recovery still runs first, and the
+    cohort flaps per load, so this only aborts (exit 28, pre-submit, $0) when
+    the arm is genuinely pinned. Agentic stays reachable by name
+    (``--ui-mode agentic``) or by needing it (``-i``). An explicit ``classic``
+    or ``agentic`` passes through unchanged.
     """
     if not has_instructions:
-        return base
+        return UiMode.CLASSIC if base is UiMode.AUTO else base
     if base is UiMode.CLASSIC:
         from gflow_cli.errors import ConfigurationError
 

--- a/tests/api/transports/drivers/test_ui_mode.py
+++ b/tests/api/transports/drivers/test_ui_mode.py
@@ -101,9 +101,15 @@ def test_explicit_ui_mode_beats_deprecated(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_infer_passthrough_without_instructions() -> None:
-    assert infer_required_ui_mode(UiMode.AUTO, has_instructions=False) is UiMode.AUTO
     assert infer_required_ui_mode(UiMode.CLASSIC, has_instructions=False) is UiMode.CLASSIC
     assert infer_required_ui_mode(UiMode.AGENTIC, has_instructions=False) is UiMode.AGENTIC
+
+
+def test_infer_auto_requires_classic() -> None:
+    """#595: ``auto`` means "no arm was asked for", and classic is the arm that
+    can satisfy an image request. An account in Flow's agentic cohort otherwise
+    binds a driver that cannot produce an image and fails mid-run."""
+    assert infer_required_ui_mode(UiMode.AUTO, has_instructions=False) is UiMode.CLASSIC
 
 
 def test_infer_instructions_force_agentic_from_auto() -> None:

--- a/tests/api/transports/test_ui_automation.py
+++ b/tests/api/transports/test_ui_automation.py
@@ -3182,11 +3182,12 @@ async def test_instructions_infer_agentic_required_mode(
 
 
 @pytest.mark.asyncio
-async def test_no_instructions_defaults_to_auto_ui_mode(
+async def test_no_instructions_requires_classic_ui_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No instructions and no explicit mode → the transport requires nothing
-    (ui_mode=AUTO): bind whatever renders."""
+    """#595: no instructions and no explicit mode → the transport REQUIRES
+    classic. Binding "whatever renders" put an agentic-cohort account on a
+    driver that cannot satisfy an image request."""
     from gflow_cli.api.transports.drivers import factory as _factory
     from gflow_cli.config import UiMode, reset_settings
 
@@ -3211,7 +3212,43 @@ async def test_no_instructions_defaults_to_auto_ui_mode(
     with pytest.raises(_StopFlowError):
         await t._generate_images_locked(req)  # noqa: SLF001
 
-    assert get_driver.await_args.kwargs["ui_mode"] is UiMode.AUTO
+    assert get_driver.await_args.kwargs["ui_mode"] is UiMode.CLASSIC
+
+
+@pytest.mark.asyncio
+async def test_batch_requires_classic_ui_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#595: the batch path binds through the same policy as the single path.
+    It had its own inline ``resolve_ui_mode(None)`` and so kept binding AUTO."""
+    from gflow_cli.api.transports.drivers import factory as _factory
+    from gflow_cli.config import UiMode, reset_settings
+
+    for var in ("GFLOW_CLI_UI_MODE", "GFLOW_CLI_PREFER_CLASSIC", "GFLOW_CLI_FORCE_AGENT_UI"):
+        monkeypatch.delenv(var, raising=False)
+    reset_settings()
+
+    t = UiAutomationTransport()
+    t._page = MagicMock()  # noqa: SLF001
+    t._page.url = "https://labs.google/fx/tools/flow/project/11111111-2222-3333-4444-555555555555"
+    t._out_dir = None  # noqa: SLF001
+    monkeypatch.setattr(t, "_enter_editor", AsyncMock())
+    monkeypatch.setattr(t, "_dismiss_blocking_overlays", AsyncMock())
+
+    classic_driver = MagicMock()
+    classic_driver.name = "classic"
+    classic_driver.switch_to_image_mode = AsyncMock(side_effect=_StopFlowError)
+    get_driver = AsyncMock(return_value=classic_driver)
+    monkeypatch.setattr(_factory, "get_ui_driver", get_driver)
+
+    with pytest.raises(_StopFlowError):
+        await t._generate_images_batch_locked(  # noqa: SLF001
+            prompts=[GenerateImageRequest(prompt="a red apple")],
+            jitter_range=(0.0, 0.0),
+            continue_on_error=False,
+        )
+
+    assert get_driver.await_args.kwargs["ui_mode"] is UiMode.CLASSIC
 
 
 class TestReferenceEntitiesInterception:

--- a/website/docs/CONFIGURATION.md
+++ b/website/docs/CONFIGURATION.md
@@ -345,7 +345,7 @@ GFLOW_CLI_HISTORY_PROMPTS=redacted gflow image t2i "confidential brief"
 
 **What:** Which Flow UI arm to use for generation. Flow serves a **classic** composer (hard crop/aspect controls) or an **agentic** chat cohort, server-assigned and flapping per page load ([#299](https://github.com/ffroliva/gflow-cli/issues/299)).
 **Values:**
-- `auto` (default) — bind whatever the composer renders.
+- `auto` (default) — no arm was asked for, so gflow **requires `classic`** ([#595](https://github.com/ffroliva/gflow-cli/issues/595)): classic is the arm that can satisfy a generation request, and it is recovered first, so this only aborts when the arm is genuinely pinned. Before v0.62.0 `auto` bound whatever rendered, which put an account in Flow's agentic cohort on a driver that cannot produce an image — failing mid-run as `image_mode_tab` selector drift or a `WireFormatError` about video bytes. Agentic is still reachable, but only by name (`--ui-mode agentic`) or by need (`-i`).
 - `classic` — require the classic composer (hard aspect controls). gflow switches to it, re-probes to verify, and if the arm is still agentic **aborts before submitting** with `UiModeUnavailableError` (**exit 28**) — no credits spent.
 - `agentic` — require the agentic chat surface (needed for `-i` agent instructions). gflow switches to it, verifies, and aborts (exit 28) if it can't be reached.
 **Default:** `auto`

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -196,7 +196,9 @@ Options:
   --ui-mode [auto|classic|agentic]
                             Require a Flow UI arm: classic (hard aspect
                             controls) / agentic (chat surface; forced by -i) /
-                            auto (default). Aborts exit 28 if unreachable.
+                            auto (default) — auto resolves to classic, the only
+                            arm that can satisfy an image request (#595).
+                            Aborts exit 28 if unreachable.
                             Single-prompt only; batch uses GFLOW_CLI_UI_MODE.
   --profile NAME            Profile name (overrides default).
 ```


### PR DESCRIPTION
Closes #595

## The failure

Flow moved both test accounts into its **agentic** cohort on 2026-08-27 (observed while live-verifying #593), and plain `gflow image t2i` failed on both — in two different ways:

- **A** — no classic mode dropdown → `image_mode_tab` selector drift (exit 23)
- **B** — the conversational agent returned **video** bytes for an image request → `WireFormatError`

Neither error names the cause, and neither points at the working remediation. The default a new user gets (`GFLOW_CLI_UI_MODE=auto`) is exactly the one that breaks.

## The change

`auto` used to mean "bind whatever the composer renders". It now means **"no arm was asked for"**, and resolves to **`classic`** — the arm that can satisfy an image request. This is the rule video has followed since #299.

The clamp lives in `config.infer_required_ui_mode`, the one place both image call sites route through, so it cannot be added to one path and forgotten on the other. That is not hypothetical: the **image batch** path carried its own inline `resolve_ui_mode(None)` and would have kept binding `AUTO` — its own comment already asked for the routing ("Route through `infer_required_ui_mode` if batch ever gains instruction support"). It now does.

What does **not** change:

- The bind still runs classic recovery first (`get_ui_driver`'s `_exit_agent_mode`), and the common case — the media panel is already mounted — returns early, so a classic account pays nothing.
- The cohort flaps per page load, so an abort only happens when the arm is genuinely pinned: `UiModeUnavailableError`, **exit 28**, pre-submit, **$0**, and retryable.
- **Agentic stays reachable**, but only when asked for by name (`--ui-mode agentic` / `GFLOW_CLI_UI_MODE=agentic`) or by need (`-i` instructions, still agentic-only and still forcing it — `--ui-mode classic` + `-i` remains a hard conflict).
- Video is untouched: it already hardcodes `UiMode.CLASSIC` at its own bind site.

## Maintainer decision this implements

> Classic mode should be the default if no other format is known to be selected.

Recorded on #595 (2026-08-27). No `/gflow:predict` council was run: the decision the council would deliberate was already made by the maintainer on the issue.

## Tests

- `test_infer_auto_requires_classic` — the policy itself: `AUTO` + no instructions → `CLASSIC`.
- `test_no_instructions_requires_classic_ui_mode` — the single-prompt transport binds `ui_mode=CLASSIC` (was `AUTO`).
- `test_batch_requires_classic_ui_mode` — **new**: the batch transport binds `CLASSIC` too. This is the test that would have caught the half-fix.
- Untouched and still green: `-i` still forces `AGENTIC`, explicit `classic`/`agentic` still pass through, `classic` + `-i` still raises, and `get_ui_driver(ui_mode=AUTO)` still binds by detection (the factory's semantics are deliberately unchanged — the policy layer decides, the factory obeys).

## Verification status

- [x] 3518 offline tests pass, 7 skipped
- [x] ruff check + ruff format --check clean (repo-wide), pyright strict 0 errors
- [x] repo hygiene, doc links, website-docs PII, website mirror in sync
- [x] pylint duplication proxy — only pre-existing findings in untouched files
- [ ] **Live run on an agentic-cohort account — needs a human.** The cohort is server-assigned; it cannot be provoked from here. The equivalent behaviour *was* verified live on 2026-08-27: `GFLOW_CLI_PREFER_CLASSIC=1 gflow image t2i` succeeded on the same account, in the same session, immediately after the unflagged run failed — and that flag resolves to exactly the `classic` requirement this PR now applies by default. What is **not** proven here is that this build takes that path; that needs one `gflow image t2i` on an agentic-cohort account.

## Docs

`CONFIGURATION.md` (the `auto` bullet), `USAGE.md` + the `--ui-mode` help text, and the `WireFormatError` remediation hint, which still advertised the deprecated `GFLOW_CLI_PREFER_CLASSIC=1` as the fix for symptom B — that path is now only reachable when agentic was explicitly requested, so the hint says so instead.
