### PR TITLE
fix(transport): guard the one overlay epoch the #593 audit found unguarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An announcement modal that mounts *during* a batch generation no longer
+  silently changes the next prompt's settings**
+  ([#593](https://github.com/ffroliva/gflow-cli/issues/593) follow-up). #593 left a
+  stated gap: call sites that neither route through `_probe_selector_cascade` nor
+  sit behind a navigation gate were still unguarded, and the set had not been
+  enumerated. Auditing all 73 click/fill/press sites in the UI transports found
+  exactly one that survives the "can a modal actually land here?" test — the image
+  **batch** loop's per-prompt boundary. A batch dismisses overlays once, during
+  setup; from prompt 2 on, the settings clicks are the first act after a
+  multi-second generation wait on a page that never navigates. This one is worse
+  than a timeout: `_open_gen_settings_panel` returns `False` when no selector
+  matches and the caller falls back to Flow's current defaults, so a modal that
+  mounted during prompt 1 did not fail prompt 2 — it generated it at the wrong
+  aspect/count. The boundary now runs the same `_require_unblocked` check the
+  navigation epochs use (one probe on the happy path), so the run aborts with
+  exit 23 and a screenshot instead of producing a quietly wrong image.
+
 - **A Flow announcement modal no longer wedges a run with an unexplained timeout
   ([#593](https://github.com/ffroliva/gflow-cli/issues/593)).** When Google ships a
   feature, Flow puts a full changelog dialog over the editor and sets

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -3063,7 +3063,18 @@ class UiAutomationTransport(VideoGenerationMixin):
             )
 
         # Step 1 — configure settings (aspect + count) for this prompt.
+        #
+        # #593 gap audit: this is an overlay epoch, and it was the last unguarded
+        # one. A batch dismisses overlays ONCE during setup; from prompt 2 on,
+        # these settings clicks are the first act after `_await_captured` — a
+        # multi-second generation wait on a page that never navigates, so neither
+        # the navigation gate nor `_probe_selector_cascade` covers them. And the
+        # failure here is silent, not loud: `_open_gen_settings_panel` returns
+        # False when nothing matches and the caller falls back to Flow's current
+        # defaults, so a modal that mounted during prompt 1 does not fail prompt 2
+        # — it generates it at the wrong aspect/count. One probe on the happy path.
         try:
+            await self._require_unblocked(page, out_dir, epoch=f"batch prompt {idx}")
             await ui_driver.configure_image_settings(
                 page,
                 req,

--- a/tests/api/transports/test_overlay_precondition.py
+++ b/tests/api/transports/test_overlay_precondition.py
@@ -405,3 +405,67 @@ class TestDismissalIsVerified:
         result = await t._dismiss_blocking_overlays(page)  # type: ignore[attr-defined]
 
         assert result is False
+
+
+@pytest.mark.asyncio
+class TestBatchInterPromptBoundary:
+    """#593 gap audit: the batch loop's per-prompt boundary is an overlay epoch.
+
+    A batch dismisses overlays ONCE, during setup. Prompts 2..N then open the
+    settings panel as their first act after ``_await_captured`` — a real
+    multi-second generation wait, on a page that never navigates. Neither
+    existing guard applies: not behind a navigation gate, and the image settings
+    clicks do not route through ``_probe_selector_cascade``.
+
+    What makes it worth guarding rather than leaving self-reporting:
+    ``_open_gen_settings_panel`` returns **False** when no selector matches, and
+    its caller falls back to Flow's current defaults. A modal that mounts during
+    prompt 1's generation therefore does not fail prompt 2 — it silently
+    generates it at the wrong aspect/count. A quiet wrong result, not a timeout.
+    """
+
+    async def test_blocked_page_aborts_before_configuring(self, tmp_path: Path) -> None:
+        from gflow_cli.api.image import GenerateImageRequest
+        from gflow_cli.errors import UiSelectorDriftError
+
+        page = _page_with_pointer_events("none")
+        ui_driver = MagicMock()
+        ui_driver.configure_image_settings = AsyncMock()
+
+        t = UiAutomationTransport()
+        result, fatal = await t._run_one_prompt_in_batch(  # type: ignore[attr-defined]
+            page=page,
+            idx=1,
+            req=GenerateImageRequest(prompt="a red apple"),
+            project_id="11111111-2222-3333-4444-555555555555",
+            out_dir=tmp_path,
+            ui_driver=ui_driver,
+        )
+
+        # The point of the guard: never click into a page that cannot receive
+        # clicks, so the settings silently kept from the previous prompt can
+        # never reach the wire.
+        ui_driver.configure_image_settings.assert_not_awaited()
+        assert result.status == "fail"
+        assert isinstance(fatal, UiSelectorDriftError)
+
+    async def test_clear_page_configures_as_before(self, tmp_path: Path) -> None:
+        """No overlay → the guard is one probe and the cycle proceeds."""
+        from gflow_cli.api.image import GenerateImageRequest
+
+        page = _page_with_pointer_events("auto")
+        ui_driver = MagicMock()
+        ui_driver.configure_image_settings = AsyncMock(side_effect=RuntimeError("stop here"))
+
+        t = UiAutomationTransport()
+        result, _fatal = await t._run_one_prompt_in_batch(  # type: ignore[attr-defined]
+            page=page,
+            idx=1,
+            req=GenerateImageRequest(prompt="a red apple"),
+            project_id="11111111-2222-3333-4444-555555555555",
+            out_dir=tmp_path,
+            ui_driver=ui_driver,
+        )
+
+        ui_driver.configure_image_settings.assert_awaited_once()
+        assert result.status == "fail"  # the sentinel, not the guard


### PR DESCRIPTION
Refs #593 — closes the gap that issue's fix deliberately left open and stated.

## The audit

#593 shipped with a known, written-down gap: *call sites that neither route through `_probe_selector_cascade` nor sit behind a navigation gate are still unguarded; the set has NOT been enumerated.* The agreed follow-up was to enumerate it and guard only what survives — **not** to pre-guard on a hunch about where a modal might land, since speculative guards are untestable exit-23 hazards.

All **73** `click` / `fill` / `press` / `set_input_files` sites in `ui_automation.py` (30) and `ui_automation_video.py` (43), classified:

| Class | Sites | Why it's covered |
|---|---|---|
| Routed through `_probe_selector_cascade` | `_switch_to_image_mode`, `_switch_to_video_mode`, `_switch_video_sub_mode`, `_select_video_model`, `_select_video_duration`, `_select_video_aspect`, `_set_output_count` | The #593 guard lives in the cascade |
| Behind a navigation gate | everything downstream of `_enter_editor` / `_enter_character_editor` / `_settle_on_character_route` | Each dismisses + `_require_unblocked` right after its `goto` |
| Is the dismissal machinery | `_bypass_onboarding`, `_try_page_close_button`, `_try_iframe_close_button`, `_dismiss_blocking_overlays` | n/a |
| Mid-panel, no navigation and no long wait | the picker/attach family (`_attach_*`, `_pick_option_and_include`, `_search_picker_for_tile`, `_ensure_picker_project`, …) | A modal cannot mount between two clicks in the same open panel |
| **Neither — and reachable** | **the image batch per-prompt boundary** | **This PR** |

## The one survivor

A batch dismisses overlays **once**, in setup. Then `_run_one_prompt_in_batch` runs configure → attach → submit → **await** → detach → parse, per prompt, serially. So from prompt 2 on, the settings clicks are the first act after `_await_captured` — a real multi-second generation wait — on a page that never navigates. Neither guard applies: no navigation gate, and the image settings clicks don't route through the cascade (only `_switch_to_image_mode` does, once per batch).

**It fails silently, which is why it's worth fixing rather than leaving self-reporting.** `_open_gen_settings_panel` returns `False` when no selector matches, and its caller "falls back to Flow's current defaults". A modal that mounts during prompt 1's generation therefore does **not** fail prompt 2 — it generates it at the wrong aspect/count, billed and wrong, with nothing in the log saying so. That is the exact failure class #593 was about, on the one path #593 didn't reach.

Every other unguarded site fails *loudly* if it is ever hit (exit 23 with a probe name and a screenshot, or an `overlay_postmortem` warning), which is the agreed reason not to pre-guard them.

## The fix

One call, the existing mechanism, at the newly-named epoch — not a second mechanism:

```python
await self._require_unblocked(page, out_dir, epoch=f"batch prompt {idx}")
```

Inside step 1's `try`, so batch error semantics (`continue_on_error`, the `_fail` envelope) are unchanged. On the happy path it is a single `body{pointer-events}` probe.

## Tests

- `test_blocked_page_aborts_before_configuring` — a persistently blocked page fails the prompt with `UiSelectorDriftError` **and never awaits `configure_image_settings`**. That second assertion is the real content: it proves the wrong-settings write can't reach the wire.
- `test_clear_page_configures_as_before` — no overlay, one probe, the cycle proceeds untouched.

## Verification status

- [x] 3520 offline tests pass (+2 new), 7 skipped
- [x] ruff check + ruff format --check clean repo-wide, pyright strict 0 errors
- [x] repo hygiene, doc links, website mirror in sync
- [ ] **Not reproduced live, and it cannot be here.** All three accounts have acknowledged Flow's current announcement, so no modal can be provoked until Google ships the next one — and provoking one *mid-batch-generation* needs that timing on top. The guard is exercised offline against the captured markup and mocks; the live path it protects is the same `_require_unblocked` already proven on 2026-08-27 at the navigation epochs.

## Not in scope

The audit's classification is recorded above rather than in a doc, deliberately — it is a statement about today's call graph, and the thing that keeps it true is the cascade, not a list that would drift. If a new unguarded epoch appears, the signal is unchanged: a bare `TimeoutError` with no `overlay_detected`, or a settings step that silently no-ops.
