### PR TITLE
fix(autopilot): pin git to repo_dir so a stray run can't check out develop in the real clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Windows-only, intermittent). Two independent guards now close it:
   `scripts/autopilot/pr_triage_autopilot.py` pins every git call with
   `--git-dir`/`--work-tree`, so a `repo_dir` that is not a repository fails loudly
-  with exit 128 instead of retargeting whatever clone encloses it (this also
+  — git's exit 128 when the path exists but is not a repo — instead of
+  retargeting whatever clone encloses it (this also
   hardens the VPS triage path against a mistyped `--repo-dir`), and
   `tests/conftest.py` sets `GIT_CEILING_DIRECTORIES` to pytest's basetemp so no
   test can walk out of its temp dir into this repo. What removed the temp `.git`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The offline test suite could `git checkout develop` in the developer's own
+  clone ([#605](https://github.com/ffroliva/gflow-cli/issues/605)).** git's
+  repository discovery walks *up* from `cwd`, and `--basetemp=tmp/pytest` puts
+  every `tmp_path` inside this repository, so an autopilot test whose temp `.git`
+  went missing had its `git checkout develop` silently resolved against the real
+  working tree — moving the developer off their branch mid-run (reflog-confirmed,
+  Windows-only, intermittent). Two independent guards now close it:
+  `scripts/autopilot/pr_triage_autopilot.py` pins every git call with
+  `--git-dir`/`--work-tree`, so a `repo_dir` that is not a repository fails loudly
+  with exit 128 instead of retargeting whatever clone encloses it (this also
+  hardens the VPS triage path against a mistyped `--repo-dir`), and
+  `tests/conftest.py` sets `GIT_CEILING_DIRECTORIES` to pytest's basetemp so no
+  test can walk out of its temp dir into this repo. What removed the temp `.git`
+  is still unexplained — it now surfaces as a plain "not a git repository" rather
+  than a silent branch switch.
+
 ## [0.62.1] — 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   working tree — moving the developer off their branch mid-run (reflog-confirmed,
   Windows-only, intermittent). Two independent guards now close it:
   `scripts/autopilot/pr_triage_autopilot.py` pins every git call with
-  `--git-dir`/`--work-tree`, so a `repo_dir` that is not a repository fails loudly
-  — git's exit 128 when the path exists but is not a repo — instead of
+  `--git-dir`/`--work-tree`, so a `repo_dir` that is not a repository fails loudly,
+  raising with git's own `fatal: not a git repository` text rather than
   retargeting whatever clone encloses it (this also
   hardens the VPS triage path against a mistyped `--repo-dir`), and
   `tests/conftest.py` sets `GIT_CEILING_DIRECTORIES` to pytest's basetemp so no

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -272,15 +272,30 @@ def _git(repo_dir: Path, *args: str, check: bool = True) -> subprocess.Completed
     whatever clone happens to enclose it, so ``git checkout develop`` silently
     rewrites someone else's working tree. That is issue #605: a local test run
     under ``--basetemp=tmp/pytest`` moved the developer's own clone off its
-    branch. Pinned, the same call fails loudly with git's exit 128.
+    branch. Pinned, the same call fails loudly instead.
+
+    Raises the module's ``RuntimeError`` idiom rather than letting ``check=True``
+    produce a ``CalledProcessError``: that renders only "returned non-zero exit
+    status 128" and keeps git's own "fatal: not a git repository: ..." in an
+    unread ``.stderr``. Callers log ``str(exc)``, so the diagnostic this pinning
+    exists to produce would never reach the operator. Matches ``_gh_json`` and
+    ``post_gh_comment``.
+
+    ``repo_dir`` is resolved first because ``--git-dir``/``--work-tree`` are
+    interpreted relative to ``cwd`` -- which is ``repo_dir`` -- so a relative path
+    would double-nest into ``<repo_dir>/<repo_dir>/.git``.
     """
-    return subprocess.run(
+    repo_dir = repo_dir.resolve()
+    proc = subprocess.run(
         ["git", f"--git-dir={repo_dir / '.git'}", f"--work-tree={repo_dir}", *args],
         cwd=repo_dir,
         capture_output=True,
         text=True,
-        check=check,
+        check=False,
     )
+    if check and proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed in {repo_dir}: {proc.stderr.strip()}")
+    return proc
 
 
 def fetch_and_checkout_pr(pr_num: int, repo_dir: Path) -> str:

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -263,30 +263,39 @@ def check_daily_review_count(entries: list[dict]) -> int:
     return count
 
 
+def _git(repo_dir: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a git command pinned to ``repo_dir``.
+
+    ``--git-dir``/``--work-tree`` bypass git's *upward* repository discovery.
+    Without them a ``repo_dir`` that is not a repository -- a mistyped
+    ``--repo-dir``, or a checkout whose ``.git`` has gone missing -- resolves to
+    whatever clone happens to enclose it, so ``git checkout develop`` silently
+    rewrites someone else's working tree. That is issue #605: a local test run
+    under ``--basetemp=tmp/pytest`` moved the developer's own clone off its
+    branch. Pinned, the same call fails loudly with git's exit 128.
+    """
+    return subprocess.run(
+        ["git", f"--git-dir={repo_dir / '.git'}", f"--work-tree={repo_dir}", *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
 def fetch_and_checkout_pr(pr_num: int, repo_dir: Path) -> str:
     """Fetch the PR branch, checkout, and return the head SHA."""
     # Fetch
     ref = f"pull/{pr_num}/head:pr-{pr_num}-review"
     logger.info("Fetching PR branch", pr=pr_num, ref=ref)
-    subprocess.run(
-        ["git", "fetch", "-f", "origin", ref], cwd=repo_dir, capture_output=True, check=True
-    )
+    _git(repo_dir, "fetch", "-f", "origin", ref)
 
     # Get head SHA
-    sha_proc = subprocess.run(
-        ["git", "rev-parse", f"pr-{pr_num}-review"],
-        cwd=repo_dir,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    head_sha = sha_proc.stdout.strip()
+    head_sha = _git(repo_dir, "rev-parse", f"pr-{pr_num}-review").stdout.strip()
 
     # Checkout
     logger.info("Checking out PR branch", sha=head_sha)
-    subprocess.run(
-        ["git", "checkout", f"pr-{pr_num}-review"], cwd=repo_dir, capture_output=True, check=True
-    )
+    _git(repo_dir, "checkout", f"pr-{pr_num}-review")
     return head_sha
 
 
@@ -300,12 +309,10 @@ def restore_repo_branch(repo_dir: Path, pr_num: int | None = None) -> None:
     branch to drop, and cleanup must never mask the original error.
     """
     logger.info("Restoring repository to develop branch")
-    subprocess.run(["git", "checkout", "develop"], cwd=repo_dir, capture_output=True, check=True)
+    _git(repo_dir, "checkout", "develop")
     if pr_num is not None:
         branch = f"pr-{pr_num}-review"
-        proc = subprocess.run(
-            ["git", "branch", "-D", branch], cwd=repo_dir, capture_output=True, check=False
-        )
+        proc = _git(repo_dir, "branch", "-D", branch, check=False)
         if proc.returncode == 0:
             logger.info("Deleted PR review branch", branch=branch)
 

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -454,7 +454,7 @@ def test_post_gh_comment_passes_the_write_token_explicitly():
     assert m_run.call_args.kwargs["env"]["GH_TOKEN"] == "write-token"
 
 
-def _git(repo, *args):
+def _raw_git(repo, *args):
     subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
 
 
@@ -462,14 +462,14 @@ def _make_repo(tmp_path):
     """A real repo on develop with a pr-999-review branch checked out."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _git(repo, "init", "-q", "-b", "develop")
-    _git(repo, "config", "user.email", "t@t")
-    _git(repo, "config", "user.name", "t")
+    _raw_git(repo, "init", "-q", "-b", "develop")
+    _raw_git(repo, "config", "user.email", "t@t")
+    _raw_git(repo, "config", "user.name", "t")
     (repo / "f.txt").write_text("x")
-    _git(repo, "add", ".")
-    _git(repo, "commit", "-qm", "init")
-    _git(repo, "branch", "pr-999-review")
-    _git(repo, "checkout", "-q", "pr-999-review")
+    _raw_git(repo, "add", ".")
+    _raw_git(repo, "commit", "-qm", "init")
+    _raw_git(repo, "branch", "pr-999-review")
+    _raw_git(repo, "checkout", "-q", "pr-999-review")
     return repo
 
 
@@ -494,8 +494,8 @@ def test_restore_repo_branch_deletes_the_pr_branch(tmp_path):
 def test_restore_repo_branch_tolerates_absent_pr_branch(tmp_path):
     """A run that failed before fetching leaves no branch; cleanup must not raise."""
     repo = _make_repo(tmp_path)
-    _git(repo, "checkout", "-q", "develop")
-    _git(repo, "branch", "-D", "pr-999-review")
+    _raw_git(repo, "checkout", "-q", "develop")
+    _raw_git(repo, "branch", "-D", "pr-999-review")
 
     pr_triage_autopilot.restore_repo_branch(repo, pr_num=999)
 
@@ -533,7 +533,7 @@ def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path)
     inner = outer / "inner"  # nested, deliberately not a repository
     inner.mkdir()
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(RuntimeError, match="not a git repository"):
         pr_triage_autopilot.restore_repo_branch(inner, pr_num=999)
 
     assert _head(outer) == "pr-999-review", "escaped and checked out develop in the parent repo"

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import re
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -453,8 +454,6 @@ def test_post_gh_comment_passes_the_write_token_explicitly():
 
 
 def _git(repo, *args):
-    import subprocess
-
     subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
 
 
@@ -474,8 +473,6 @@ def _make_repo(tmp_path):
 
 
 def _branches(repo):
-    import subprocess
-
     out = subprocess.run(
         ["git", "branch", "--format=%(refname:short)"], cwd=repo, capture_output=True, text=True
     )
@@ -508,6 +505,49 @@ def test_restore_repo_branch_without_pr_num_still_restores_develop(tmp_path):
     repo = _make_repo(tmp_path)
     pr_triage_autopilot.restore_repo_branch(repo)
     assert "pr-999-review" in _branches(repo)
+
+
+def _head(repo):
+    out = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo, capture_output=True, text=True
+    )
+    return out.stdout.strip()
+
+
+def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path, monkeypatch):
+    """#605: a missing .git must fail loudly, never retarget the enclosing clone.
+
+    git's repository discovery walks *up* from ``cwd``. When ``repo_dir`` is not a
+    repository -- a mistyped ``--repo-dir`` on the VPS, or a temp repo whose
+    ``.git`` vanished mid-run -- the bare ``git checkout develop`` resolved against
+    whatever clone enclosed it and silently rewrote that working tree.
+
+    The ceiling guard in ``tests/conftest.py`` would mask the escape, so this test
+    drops it deliberately: it asserts the *production* pinning, not the guard.
+    """
+    monkeypatch.delenv("GIT_CEILING_DIRECTORIES", raising=False)
+    outer = _make_repo(tmp_path)  # a real repo, checked out on pr-999-review
+    inner = outer / "inner"  # nested, deliberately not a repository
+    inner.mkdir()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pr_triage_autopilot.restore_repo_branch(inner, pr_num=999)
+
+    assert _head(outer) == "pr-999-review", "escaped and checked out develop in the parent repo"
+    assert "pr-999-review" in _branches(outer), "escaped and deleted a branch in the parent repo"
+
+
+def test_git_cannot_escape_the_pytest_basetemp(tmp_path):
+    """#605: ``--basetemp=tmp/pytest`` puts every tmp dir *inside* this clone.
+
+    Any test that shells out to git in a tmp dir with no ``.git`` would otherwise
+    resolve against the real repository. ``tests/conftest.py`` pins
+    ``GIT_CEILING_DIRECTORIES`` to stop the upward search at the basetemp.
+    """
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert proc.returncode != 0, f"git escaped the temp dir and found {proc.stdout.strip()!r}"
 
 
 def test_memory_dir_cli_arg_wins_over_env(monkeypatch, tmp_path):

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import re
 import subprocess
 import sys
@@ -514,7 +515,7 @@ def _head(repo):
     return out.stdout.strip()
 
 
-def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path, monkeypatch):
+def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path):
     """#605: a missing .git must fail loudly, never retarget the enclosing clone.
 
     git's repository discovery walks *up* from ``cwd``. When ``repo_dir`` is not a
@@ -522,10 +523,12 @@ def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path,
     ``.git`` vanished mid-run -- the bare ``git checkout develop`` resolved against
     whatever clone enclosed it and silently rewrote that working tree.
 
-    The ceiling guard in ``tests/conftest.py`` would mask the escape, so this test
-    drops it deliberately: it asserts the *production* pinning, not the guard.
+    This isolates the *production* pinning even with the suite-wide ceiling guard
+    left on: ``outer`` is a real repository *below* the ceiling, so unpinned
+    discovery finds it one level up and never walks far enough to be stopped.
+    Disabling the guard here would not sharpen the test -- it would only strip the
+    net from ``_make_repo``'s own unpinned, mutating git calls.
     """
-    monkeypatch.delenv("GIT_CEILING_DIRECTORIES", raising=False)
     outer = _make_repo(tmp_path)  # a real repo, checked out on pr-999-review
     inner = outer / "inner"  # nested, deliberately not a repository
     inner.mkdir()
@@ -537,13 +540,22 @@ def test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo(tmp_path,
     assert "pr-999-review" in _branches(outer), "escaped and deleted a branch in the parent repo"
 
 
-def test_git_cannot_escape_the_pytest_basetemp(tmp_path):
+def test_git_cannot_escape_the_pytest_basetemp(tmp_path, tmp_path_factory):
     """#605: ``--basetemp=tmp/pytest`` puts every tmp dir *inside* this clone.
 
     Any test that shells out to git in a tmp dir with no ``.git`` would otherwise
     resolve against the real repository. ``tests/conftest.py`` pins
-    ``GIT_CEILING_DIRECTORIES`` to stop the upward search at the basetemp.
+    ``GIT_CEILING_DIRECTORIES`` to stop the upward search above the basetemp.
+
+    Asserts the mechanism *and* the symptom: pointing ``--basetemp`` outside the
+    tree would make the behavioral half pass for free, so the env check is what
+    keeps this test honest if ``pytest_configure`` ever resolves the wrong dir.
     """
+    expected = str(tmp_path_factory.getbasetemp().resolve().parent)
+    assert os.environ.get("GIT_CEILING_DIRECTORIES", "").split(os.pathsep)[0] == expected, (
+        "conftest ceiling guard not installed; git would resolve tmp dirs against the real repo"
+    )
+
     proc = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=tmp_path, capture_output=True, text=True
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ before and after every test. Without this, any test that calls
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -28,6 +29,22 @@ import structlog
 # tests/fixtures/doctor_env.py; re-exported here so pytest registers it for
 # both tests/services/test_doctor.py and tests/cli/test_cli_doctor.py.
 from tests.fixtures.doctor_env import healthy_doctor_env  # noqa: F401
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Stop git from escaping pytest's basetemp into the real clone (#605).
+
+    ``addopts`` pins ``--basetemp=tmp/pytest`` *inside* the working tree (so msys2's
+    ``TMPDIR=$PWD`` cannot scatter ``pytest-of-*/`` dirs around). The cost is that
+    every ``tmp_path`` is a directory nested in a git repository: a test that shells
+    out to git in a tmp dir without a ``.git`` has its command resolved against the
+    enclosing gflow-cli clone. That is how a full offline run checked out ``develop``
+    over the developer's own branch. ``GIT_CEILING_DIRECTORIES`` stops git's upward
+    search at the basetemp, turning the escape into a plain "not a git repository".
+    """
+    basetemp = config.getoption("basetemp", None)
+    if basetemp:
+        os.environ["GIT_CEILING_DIRECTORIES"] = str(Path(basetemp).resolve())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,11 +40,18 @@ def pytest_configure(config: pytest.Config) -> None:
     out to git in a tmp dir without a ``.git`` has its command resolved against the
     enclosing gflow-cli clone. That is how a full offline run checked out ``develop``
     over the developer's own branch. ``GIT_CEILING_DIRECTORIES`` stops git's upward
-    search at the basetemp, turning the escape into a plain "not a git repository".
+    search above the basetemp, turning the escape into a plain "not a git repository".
+
+    The ceiling is the basetemp's *parent*, not the basetemp: git stops when it
+    reaches a ceiling directory but still searches the one it started in, so
+    pinning the basetemp itself would leave a test whose cwd IS the basetemp
+    (``tmp_path_factory.getbasetemp()``) free to walk out. Any ceiling the
+    developer already set is preserved after ours.
     """
     basetemp = config.getoption("basetemp", None)
     if basetemp:
-        os.environ["GIT_CEILING_DIRECTORIES"] = str(Path(basetemp).resolve())
+        ceilings = [str(Path(basetemp).resolve().parent), os.environ.get("GIT_CEILING_DIRECTORIES")]
+        os.environ["GIT_CEILING_DIRECTORIES"] = os.pathsep.join(c for c in ceilings if c)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Fixes the foot-gun in #605: running the offline test suite on Windows could silently `git checkout develop` in the developer's own clone, discarding the branch they were on mid-run.

**Root cause is git's repository discovery, not the flaky test.** git walks *up* from `cwd` looking for a repo. Every git call in `scripts/autopilot/pr_triage_autopilot.py` passed a bare `cwd=repo_dir`, so a `repo_dir` that is *not* a repository resolved against whatever clone enclosed it. `pyproject.toml` pins `--basetemp=tmp/pytest` **inside the working tree**, so every `tmp_path` is nested in this repo — when an autopilot test's temp `.git` went missing, `restore_repo_branch()` ran its `git checkout develop` against the real tree. Reflog-confirmed in the issue.

Two guards, each at the single choke point for its surface:

| Surface | Guard |
|---|---|
| Production (`pr_triage_autopilot`, incl. the VPS) | New `_git()` helper pins every call with `--git-dir`/`--work-tree`, bypassing discovery entirely. All five call sites route through it. |
| The whole test suite | `tests/conftest.py` sets `GIT_CEILING_DIRECTORIES` to pytest's basetemp, so no test can walk out of its temp dir into this repo. |

The production guard also hardens the VPS triage path, where a mistyped `--repo-dir` currently checks out `develop` in whatever repo encloses it. A non-repo `repo_dir` now fails loudly with git's exit 128.

## Test plan

Both regression tests were confirmed **RED before the fix**, for the right reasons:

- `test_git_cannot_escape_the_pytest_basetemp` reproduced the escape live, reporting the branch of this very clone: `AssertionError: git escaped the temp dir and found 'bugfix/605-git-repo-escape'`.
- `test_restore_repo_branch_refuses_to_escape_into_the_enclosing_repo` builds a real repo inside `tmp_path` with a non-repo subdir, and asserts `restore_repo_branch()` raises rather than moving the *outer* repo's HEAD. It drops `GIT_CEILING_DIRECTORIES` deliberately so it tests the production pinning, not the suite guard.

Empirically verified before writing either fix: bare discovery escapes and returns the parent's branch; `--git-dir`/`--work-tree` fails with exit 128; `--git-dir` also resolves a worktree gitfile correctly; `GIT_CEILING_DIRECTORIES` stops the upward walk.

## Verification status

- [x] `tests/autopilot/` — 46 passed (44 pre-existing + 2 new)
- [x] **Full Windows offline suite (`pytest -q`, unscoped) — 3526 passed, 7 skipped, 93 deselected.** Re-run on the final commit `23993e2`; branch checked before and after: both `bugfix/605-git-repo-escape`, tree clean. This is the only condition that ever reproduced #605.
- [x] `ruff check` + `ruff format --check src tests` clean (the exact CI gate)
- [x] `pyright src` — 0 errors, 0 warnings
- [x] Repo hygiene, doc links, website-docs PII, website mirror — all clean
- [x] **CI green — all 15 checks pass**, including `test` on 3.11 / 3.12 / 3.13 and the SonarCloud quality gate
- [x] Seven-dimension council review — all GREEN (see below)
- [x] A/B controls re-run after every change: neutering either guard fails its own test

**On the strength of that clean full run:** the original failure was intermittent (3 failures on one run, 1 on the next, 0 on the two after), so one green run is *not* by itself proof of absence. The deterministic proof is `test_git_cannot_escape_the_pytest_basetemp`, which fails the moment the guard is removed — it asserts the escape vector is closed rather than hoping the trigger does not fire.

## Notes

- Blast radius of the conftest guard is limited: `tests/autopilot` is the only place in the suite that shells out to real git, and `src/` never shells out to git at all. The full-suite run above confirms zero collateral impact.
- **What removed the temp `.git` is still unexplained** — the issue's "not yet root-caused" section stands. This PR does not claim to explain it; it makes the consequence safe and loud. If it recurs, the failure is now a plain "not a git repository" naming the git call that found nothing, instead of a silent branch switch.

## Council review

Seven-dimension council run (`/gflow:pr-council-review`), all dimensions **GREEN** after fixes:

| Dim | Verdict | Outcome |
|---|---|---|
| D1 Correctness | GREEN | Root-cause fix confirmed; all 5 call sites route through `_git()` |
| D2 Code quality | GREEN | Found the stderr-swallowing issue below; caught its own fork fabricating 2 findings and refused to relay them |
| D3 Security | GREEN | Reproduced both A/B arms; no injection (`pr_num` is a JSON int, `repo_dir` is `.resolve()`d), fails closed |
| D4 Tests | YELLOW → resolved | Must-fix applied (see below) |
| D5 Memory hygiene | GREEN | Superseded memory correctly retired; index in sync |
| D13 Dev scripts | GREEN | Worktree gitfile, `branch -D`, `fetch`, Windows backslash paths all empirically verified |
| **D14 Over-engineering** | GREEN | Two guards justified — different processes, neither redundant; 5 alternatives evaluated and rejected on merit |

**Three findings acted on:**

1. **D4 Must-fix — the regression test disabled the guard it was testing.** `monkeypatch.delenv("GIT_CEILING_DIRECTORIES")` was both unnecessary (`outer` is a real repo *below* the ceiling, so discovery finds it one level up and never walks far enough to be stopped) and harmful (it stripped the net from `_make_repo`'s seven unpinned, mutating git calls). Removed; A/B re-confirms the test still isolates the production pin.
2. **D2 — the loud failure was unreadable.** `CalledProcessError` renders only "returned non-zero exit status 128"; git's `fatal: not a git repository` sat in an unread `.stderr` while every caller logs `str(exc)`. `_git()` now uses the module's own `RuntimeError`-with-stderr idiom.
3. **D2 — relative `repo_dir` double-nested** into `<repo_dir>/<repo_dir>/.git`, since `--git-dir` resolves against `cwd`. Latent only (`main()` resolves), now closed.

**Declined, with reasons:** pinning `scripts/canary/run_canary.py` (its `REPO_ROOT` is always a real repo root — no upward escape exists to prevent; that would be the shape of the fix without its purpose); pinning the test helpers (the restored ceiling covers them); wrapping the `finally:` cleanup (D2 and D13 disagreed — D13 is right, the alert fires *before* `finally`, and aborting the cycle on a wedged clone is correct).

Refs #605



