### PR TITLE
docs(issue-resolve): make the council review explicitly non-optional

### DIFF
--- a/skills/issue-resolve/SKILL.md
+++ b/skills/issue-resolve/SKILL.md
@@ -39,6 +39,12 @@ Allowed autonomously:
 - ✅ Post one issue comment (status / reply to reporter).
 - ✅ Open a **draft** PR (push a `bugfix/`-prefixed branch off `develop`).
 - ✅ Run **browser-free / credit-free** verification (unit, lint, type, recording-verif, Gemini tool-path).
+- ✅ Run the council review (`/gflow:pr-council-review` / `/gflow:branch-review`), `/gflow:check`,
+  `/gflow:sonar`, `/gflow:doc-review` — **without asking.** These are mandated steps, not
+  offers. A general "don't spawn subagents unless the user requested it" rule does **not**
+  gate them: the user requested them by invoking this workflow. Stopping to ask makes the
+  maintainer re-authorize the same step every issue, and it stalls the pipeline at exactly
+  the point review is worth most.
 
 Never (these require a human, regardless of pressure):
 - ❌ Spend Veo credits (no live video generation to "verify").
@@ -84,8 +90,10 @@ locally (full `pytest --cov` OOMs — memory `full-test-suite-ooms`); trust CI.
 `gh pr create --draft --base develop`. Body is a **plain string** (never a
 heredoc — CLAUDE.md MCP rule). Include a **Verification status** section with
 checked/unchecked boxes; use `Refs #N` when a human must still verify,
-`Closes #N` only when fully verified here. Then `/gflow:pr-council-review`
-(or `/gflow:branch-review` pre-push). **STOP** — a human promotes and merges.
+`Closes #N` only when fully verified here. Then run `/gflow:pr-council-review`
+(or `/gflow:branch-review` pre-push) — baseline D1–D5 **plus D14 over-engineering /
+YAGNI**, which is the lens correctness and quality reviews do not apply. Apply the
+findings (or record why you declined each), then **STOP** — a human promotes and merges.
 
 ---
 
@@ -107,6 +115,9 @@ checked/unchecked boxes; use `Refs #N` when a human must still verify,
 ## Common mistakes
 
 - Working on `develop` instead of a `bugfix/` branch off it (memory: `develop-divergence-recovery`).
+- Treating step 6's council as optional, or asking permission to run it. It is neither
+  (memory: `council-review-is-standing-authorized`). Ask before merging, marking a PR
+  ready, or spending credits — never before reviewing.
 ### Pipeline Continuation (Next Step Handoff)
 
 Upon completing Issue Resolution:


### PR DESCRIPTION
## Summary

Docs-only change to `skills/issue-resolve/SKILL.md`. No code.

While resolving #605 I finished the implementation, opened the draft PR, then **stopped and asked** whether to run `/gflow:pr-council-review` — a global "don't spawn subagents unless the user requested it" rule read as a gate on it. It isn't: the user requested the council by invoking this workflow, and step 6 already mandated it.

The dimension coverage was never missing — `pr-council-review` already runs **D1/D2 via the `code-review` skill** and **D14 over-engineering via `ponytail:ponytail-review`**, both baseline/always. Only the *enforcement* was implicit, and it was implicit at exactly the point where the wrong call gets made.

That stop was expensive, not merely slow: the council went on to find three real issues in #607, including one that undercut the fix's core value (`CalledProcessError` swallowed git's own error text, so the "loud failure" the PR existed to create never reached the operator).

## Changes

- **Autonomy envelope** now lists council review, `/gflow:check`, `/gflow:sonar` and `/gflow:doc-review` as explicitly allowed without asking, with the reason.
- **Step 6** names D14 so an agent skimming the protocol sees the over-engineering lens exists, and requires findings to be applied or declined on the record.
- **Common mistakes** gains the failure itself: ask before merging, marking ready, or spending credits — never before reviewing.

## Test plan

- [x] `check_doc_links.py` — all links resolved across 29 files
- [x] `check_repo_hygiene.py` — 840 tracked files, no violations
- [ ] CI green

No runtime surface touched; `src/` and `tests/` are unchanged.

Refs #605
