### PR TITLE
docs(readme): sponsor button, coverage badge, and star-history chart

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: ffroliva

--- a/README.md
+++ b/README.md
@@ -158,12 +158,9 @@ Full milestone history lives in [CHANGELOG.md](CHANGELOG.md). Where the project 
 
 ### Star history
 
-<a href="https://www.star-history.com/?repos=ffroliva%2Fgflow-cli&type=date&legend=top-left">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&theme=dark&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
-    <img alt="Star history chart for ffroliva/gflow-cli" src="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
-  </picture>
-</a>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&theme=dark&legend=top-left" />
+  <img alt="Star history chart for ffroliva/gflow-cli" src="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left" />
+</picture>
 
 If `gflow-cli` saves you time, please ⭐ the repo. It is the cheapest way to support the project.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Type checked: pyright](https://img.shields.io/badge/type%20checked-pyright-blue.svg)](https://github.com/microsoft/pyright)
 [![Tests: TDD](https://img.shields.io/badge/tests-TDD-brightgreen.svg)](CONTRIBUTING.md)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ffroliva_gflow-cli)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ffroliva_gflow-cli&metric=coverage)](https://sonarcloud.io/component_measures?id=ffroliva_gflow-cli&metric=coverage)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ffroliva/gflow-cli/badge)](https://scorecard.dev/viewer/?uri=github.com/ffroliva/gflow-cli)
 
 > ⚠️ **Read this before you install.** gflow-cli is **unofficial, alpha, and reverse-engineered — not affiliated with Google**. It drives a headed browser on *your own* Google Flow session, so treat it as your own account risk: automation is subject to Google's ToS, and endpoints or UI can change without notice. It works with **any Google account** that has Flow access, and every generation bills against your account's Flow credit allowance. Read the full [DISCLAIMER](DISCLAIMER.md).
@@ -154,5 +155,15 @@ Full milestone history lives in [CHANGELOG.md](CHANGELOG.md). Where the project 
 [![GitHub last commit](https://img.shields.io/github/last-commit/ffroliva/gflow-cli?cacheSeconds=3600)](https://github.com/ffroliva/gflow-cli/commits/main)
 [![GitHub repo size](https://img.shields.io/github/repo-size/ffroliva/gflow-cli?cacheSeconds=3600)](https://github.com/ffroliva/gflow-cli)
 [![PyPI downloads](https://static.pepy.tech/badge/gflow-cli/month)](https://pepy.tech/project/gflow-cli)
+
+### Star history
+
+<a href="https://www.star-history.com/?repos=ffroliva%2Fgflow-cli&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&theme=dark&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
+    <img alt="Star history chart for ffroliva/gflow-cli" src="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
+  </picture>
+</a>
 
 If `gflow-cli` saves you time, please ⭐ the repo. It is the cheapest way to support the project.


### PR DESCRIPTION
## Summary

Completes the three README-polish items. All three are visible from the **default branch (`develop`)**, so merging here is sufficient — no `main` merge required.

- **`.github/FUNDING.yml`** — `github: ffroliva`. Enables the native GitHub Sponsors button. Verified the account has a public sponsors listing (`hasSponsorsListing: true`), so the button will actually render rather than silently no-op.
- **SonarCloud coverage badge** — zero new infrastructure; CI already uploads `coverage.xml` to the same project. Live at 92.4%. Project key cross-checked against `sonar-project.properties`.
- **Star-history chart** — `<picture>` with a dark `<source>` and a light `<img>` fallback.

Closes the sponsorship wiring that has been marked *deferred* since v0.9.0 (`CHANGELOG.md:2539`, `docs/LIVE_VERIFICATION_v0.9.0.md:96`).

## Note on the star-history embed

GitHub restricted the public `/stargazers` endpoint in July 2026. star-history's documented workaround is a `sealed_token` embed — a PAT they encrypt into the image URL and decrypt server-side on every README view.

**The first commit used that form; the second commit removes it.** A/B against the live endpoint:

| request | result |
|---|---|
| owner's sealed token | 200, 65013 bytes |
| no token | 200, 65013 bytes |
| deliberately garbage token | 200, 65013 bytes |

Byte-identical with a *garbage* token, so the parameter is inert for this repo — star-history appears to serve cached star data once a repo has been fetched once. It bought nothing while publishing a sealed credential into a file `pyproject.toml` bakes into every immutable PyPI release. Removed.

Known trade-off: if star-history's cache expires, the chart may revert to their "restricted access" notice. That degrades to a cosmetic broken image at the bottom of the README, not a functional failure.

## Council review

Six dimensions (D1–D5 + D14). Consensus 🟡 YELLOW, all code findings fixed in `339c9af`:

- **D2 / D14** — `sealed_token` inert (removed); light `<source>` was byte-identical to the `<img>` fallback, md5-confirmed (removed); `<a>` click-through pointed at a page that renders the restriction notice for any non-collaborator (removed).
- **D1 / D4** — GREEN. Default branch confirmed `develop`; all four doc gates pass.
- **D3** — the remaining findings are GitHub-side, not in this diff: the `STAR_HISTORY_PAT` Actions secret has zero consumers across all 11 workflows, and the PAT itself is non-expiring. Tracked separately.
- **D5** — three memory writes owed on merge (supersede the handoff entry, update its index hook, add the star-history constraint entry).

## Test plan

- [x] `check_repo_hygiene.py` — 841 tracked files, no violations
- [x] `check_doc_links.py` — all links resolved across 29 files
- [x] `check_website_docs_pii.py` — no private identifiers
- [x] `generate_website_docs.py --check` — mirror in sync, nav complete
- [x] Both chart URLs re-verified live after the edit: light 200/65013, dark 200/65019, neither showing the restriction notice
- [x] Coverage badge SVG curled directly (not browser — camo caches): 200, `<text>` = `coverage` / `92.4%`
- [x] No Python source touched — `git diff --name-only` is exactly `.github/FUNDING.yml` + `README.md`
- [ ] Post-merge: confirm the Sponsor button appears on the repo page and both chart variants load in light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011STLkmAhaaGczzsw2FuWzL