### PR TITLE
docs: make AGENTS.md load, instead of asking to be read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,41 @@
 
 Supported tools that auto-discover this file: Cursor, Codex, Aider, Antigravity (`agy`), Jules, Devin, Windsurf, Zed, Warp, opencode, RooCode, Amp, Junie, Phoenix, GitHub Copilot, VS Code, Factory, Augment, Semgrep, Kilo Code, UiPath. Claude Code reads [CLAUDE.md](CLAUDE.md), which cross-references this file.
 
+## Skill Routing — the default workflow, not a menu
+
+**The `/gflow:` skills ARE this project's development lifecycle.** They are not
+optional tooling you may reach for; they are how work is done here. If a row below
+matches your situation, load that skill **before acting** — before exploring the
+codebase, before answering, before editing. A skill loaded after the work is a skill
+that did not run.
+
+| If you are about to… | Load first | Non-negotiable because |
+|---|---|---|
+| Touch a GitHub issue | `/gflow:issue-assessment <N>` | Read-only triage precedes any fix; classification changes what "fixing" means |
+| Propose a transport, auth, selector, or schema change | `/gflow:predict <proposal>` | Five adversarial personas return GO / CAUTION / STOP before code exists |
+| Start a feature | `/gflow:scenario` → `/gflow:plan` | Edge cases before tasks; tasks before code |
+| Resume work / ask "where are we?" | `/gflow:status` | The current plan's next unchecked task is the answer, not your guess |
+| Commit **anything** | `/gflow:check` | It is the exact CI gate; skipping it is how a format failure shipped past an 8-agent council (PR #269) |
+| Open or review a PR | `/gflow:pr-council-review <N>` (or `/gflow:branch-review`) | Standing-authorized. Run it — do not ask permission first |
+| Claim a generation feature works | `/gflow:live-verify` | Offline-green is never done-done on a generation path |
+| Cut a release | `/gflow:release` | It hard-gates on changelog → check → live-verify → doc-review; each is a STOP |
+| Audit docs before shipping | `/gflow:doc-review` | Catches same-release errors a read-through cannot |
+| See a red SonarCloud check | `/gflow:sonar <N>` | The gate measures *new* code; the fix is rarely where you would look |
+| Touch auth or reCAPTCHA | `/gflow:known-issues` | Known-broken surfaces have documented workarounds; rediscovering them costs days |
+
+**Canonical bodies live in `skills/<name>/SKILL.md`** — plain Markdown, agent-agnostic
+by construction, so Codex / Cursor / Aider / `agy` read exactly what Claude Code reads.
+`.claude/commands/gflow/*.md` are thin Claude-Code wrappers that point at them.
+
+> **This table exists because routing by memory failed.** On 2026-09-01 an agent worked
+> a full session — recovering two interrupted sessions, merging five PRs — without ever
+> loading this file, because `CLAUDE.md` only *asked* it to. It reached step 10 of a
+> release before meeting the pipeline's own doc-review gate, and the required
+> `LIVE_VERIFICATION_v0.63.0.md` had not been written despite the feature having been
+> live-verified. `CLAUDE.md` now `@`-imports this file, so it is always in context. The
+> table is the other half: being loaded is useless if the mapping from situation to skill
+> is left to recall.
+
 ## Project at a glance
 
 - Unofficial Python CLI for [Google Flow](https://labs.google/fx/tools/flow) — drives Veo (image-to-video, text-to-video) and Imagen (text-to-image) generations from the terminal by reverse-engineering Flow's private REST API at `aisandbox-pa.googleapis.com`.
@@ -97,7 +132,7 @@ All AI agents and harnesses working on `gflow-cli` follow this standard 10-phase
 | 7. Pre-Commit Quality | `/gflow:check` | The Impeccable Routine (hygiene, ruff, pyright, pytest) | All green local checks |
 | 8. Live Verification | `/gflow:live-verify` | 5-layer proof against real Flow transport | `docs/LIVE_VERIFICATION_vX.Y.Z.md` |
 | 9. PR & Issue Close | `/gflow:issue-resolve <N>` | PR, SonarCloud 0-issue gate, merge to develop | Closed GitHub issue |
-| 10. Release Pipeline | `/gflow:release` | Version bump, signed tag (`git tag -s`), PyPI publish | Shipped release & back-merge |
+| 10. Release Pipeline | `/gflow:release` | Version bump, signed tag (`git tag -s`), PyPI publish. **Internally gates on `/gflow:changelog` → `/gflow:check` → `/gflow:live-verify` → `/gflow:doc-review`; a failure at any of them is a STOP, not a warning.** | Shipped release & back-merge |
 
 ### Pipeline Continuation Mandate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,30 @@
 
 `gflow-cli` is an unofficial Python CLI that drives [Google Flow](https://labs.google/fx/tools/flow) (Veo image-to-video, Imagen text-to-image) from the terminal by reverse-engineering Flow's private REST API. See [README.md](README.md) for the user-facing overview.
 
+## System rules — loaded, not requested
+
+**[AGENTS.md](AGENTS.md) is imported below and is therefore already in context before
+you read this line.** It is the system rule for this project: the `/gflow:` skills are
+the default development lifecycle, and its Skill Routing table says which one to load
+for the situation in front of you. Follow it — it is not advisory, and "I hadn't read
+it yet" is not a reachable state.
+
+> **Why an import and not a bullet that says "read AGENTS.md".** That bullet is what
+> used to be here, and it failed exactly as written: an agent that skips it is not
+> corrected by anything, and no gate notices. A session on 2026-09-01 went straight
+> into work without it and reached step 10 of a release before discovering the
+> pipeline's own doc-review and live-verification gates. `@AGENTS.md` removes the
+> choice — the harness resolves the import and injects the file, with no agent
+> cooperation required. Never downgrade this back to prose.
+
+@AGENTS.md
+
 ## On every session start
 
-1. Read **[AGENTS.md](AGENTS.md)** — universal rules every agent must follow.
-2. Read **[docs/INDEX.md](docs/INDEX.md)** — routing layer for all project docs and commands.
-3. Pull deeper context on demand:
+1. Read **[docs/INDEX.md](docs/INDEX.md)** — routing layer for all project docs and
+   commands. Deliberately *not* imported: at 36 KB it is a lookup table, not a rule set,
+   and AGENTS.md points into it. Read it when you need to find a doc.
+2. Pull deeper context on demand:
    - Current task / where we left off → `/gflow:status`
    - Starting a new feature → `/gflow:predict` → `/gflow:scenario` → `/gflow:plan <feature>`
    - Touching auth or reCAPTCHA → `/gflow:known-issues`
@@ -20,8 +39,15 @@
 
 ## Claude-Code-specific
 
-- Slash commands live under `.claude/commands/gflow/` (all prefixed `/gflow:`).
-- Skills under `skills/` are auto-discoverable; `gflow-cli` ships its own at [`skills/gflow-cli/SKILL.md`](skills/gflow-cli/SKILL.md).
+- Slash commands live under `.claude/commands/gflow/` (all prefixed `/gflow:`). **These
+  are the invocable surface** — they appear in the session's skill list and may be called
+  with the `Skill` tool as `gflow:<name>`.
+- **`skills/<name>/SKILL.md` are the canonical bodies, and are NOT `Skill`-tool-invocable.**
+  They are plain Markdown, agent-agnostic on purpose so Codex/Cursor/Aider can read the
+  same file. `Skill(skill="release")` fails with `Unknown skill: release`; each wrapper in
+  `.claude/commands/gflow/` says to read its `skills/<name>/SKILL.md` directly, and that is
+  the supported path. (This bullet previously claimed they were "auto-discoverable", which
+  is false and sends agents into a failing tool call.)
 - Auto-memory at `~/.claude/projects/C--development-github-gflow-cli/memory/MEMORY.md` carries cross-session feedback and project state.
 - **Worktrees:** the native `EnterWorktree` tool branches from `origin/main` (the default branch). Feature work integrates via `develop` — after entering a fresh worktree, immediately `git switch -c <type>/<name> origin/develop` and delete the auto-created `worktree-*` branch. On Windows, worktree removal can fail on a file lock (the worktree's `.venv`); `git worktree prune` + manual delete later is fine.
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` said *"On every session start: 1. Read AGENTS.md"*. That is prose, and prose only runs if the agent chooses to run it.

On 2026-09-01 a session worked end to end — recovering two credit-interrupted sessions, merging five PRs, reaching step 10 of a release — and never loaded `AGENTS.md`, because nothing made it. It discovered the release pipeline's own doc-review and live-verification gates only when the release skill named them, and `docs/LIVE_VERIFICATION_v0.63.0.md` was missing despite the feature having been live-verified days earlier.

## The fix is mechanical, not advisory

**1. `CLAUDE.md` now `@AGENTS.md`.** The harness resolves imports and injects the file before the agent acts, with no agent cooperation required — the same mechanism the maintainer's global `CLAUDE.md` already relies on for `RTK.md`, which is demonstrably injected every session. "I had not read it yet" stops being a reachable state.

`docs/INDEX.md` stays on-demand deliberately: at 36 KB it is a lookup table, not a rule set, and `AGENTS.md` points into it.

**2. `AGENTS.md` opens with a Skill Routing table.** Being in context is useless if the mapping from situation to skill is left to recall. The table maps: issue → `issue-assessment`, proposal → `predict`, feature → `scenario`/`plan`, commit → `check`, PR → `pr-council-review`, generation claim → `live-verify`, release → `release`, red Sonar → `sonar`, auth work → `known-issues` — and states that the `/gflow:` skills ARE the lifecycle, not optional tooling, and that a skill loaded after the work did not run.

## Two things corrected that actively misled

- `CLAUDE.md` claimed skills under `skills/` are "auto-discoverable". They are **not** `Skill`-tool-invocable — `Skill(skill="release")` fails with `Unknown skill: release`. The wrappers in `.claude/commands/gflow/` are the invocable surface; each points at its `skills/<name>/SKILL.md`.
- The Standard Workflow Sequence's Phase 10 row described release as bump + tag + publish, hiding that `/gflow:release` hard-gates on changelog → check → live-verify → doc-review. **That row is the proximate cause of the missed live-verification doc** — an agent reading the pipeline table could not see the gate existed.

## Verification

- Every `/gflow:` reference in the new routing table resolves to a real wrapper in `.claude/commands/gflow/` (checked programmatically; `branch-review` correctly has no separate `skills/` body — it is a documented mode of `pr-council-review`).
- `check_repo_hygiene.py` 858 files clean · `check_doc_links.py` all links resolved across 29 files · `check_website_docs_pii.py` clean · website mirror in sync, nav complete · `ruff check` + `ruff format --check` clean repo-wide.

Docs-only; no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiMwnA3S8SFoBL6YiYKN1B