### PR TITLE
chore(release): gate PROJECT_STATUS currency; fix rotted i2v e2e tests

### DIFF
--- a/scripts/ci/check_release_artifacts.py
+++ b/scripts/ci/check_release_artifacts.py
@@ -6,7 +6,9 @@ Enforces (for the version in pyproject.toml):
   3. CHANGELOG footer links: ``[<version>]: …compare/…v<version>`` and
      ``[Unreleased]: …compare/v<version>...HEAD``,
   4. ``docs/LIVE_VERIFICATION_v<version>.md`` exists (the step-4b gate),
-  5. ``docs/INDEX.md`` references that live-verification doc.
+  5. ``docs/INDEX.md`` references that live-verification doc,
+  6. ``docs/PROJECT_STATUS.md``'s "## Current release" section names this
+     version (added 2026-09-02 — see ``_project_status_violations``).
 
 Run by the main-base guard workflow on PRs targeting ``main`` (release PRs).
 Born 2026-07-17: v0.38.1 was initially cut WITHOUT /gflow:release — the missing
@@ -59,7 +61,41 @@ def find_violations(root: Path) -> list[str]:
     ):
         violations.append(f"docs/INDEX.md: no reference to LIVE_VERIFICATION_v{version}.md")
 
+    violations.extend(_project_status_violations(root, version))
     return violations
+
+
+def _project_status_violations(root: Path, version: str) -> list[str]:
+    """``docs/PROJECT_STATUS.md``'s "Current release" must name this version.
+
+    That file's own header promises it is "Updated on every signed tag", and
+    nothing enforced it: v0.64.0 was cut with the section still announcing
+    v0.63.0 as current, caught only because a human doc-review council read the
+    file. Shipping a release that announces the wrong version as current is a
+    documentation defect users see, so it belongs in the mechanical gate.
+
+    Scoped to the "## Current release" section deliberately. Every past release
+    is still named further down the file, so a whole-file substring search
+    would pass on a completely stale header — the exact drift being caught.
+    """
+    status = root / "docs" / "PROJECT_STATUS.md"
+    if not status.exists():
+        return ["docs/PROJECT_STATUS.md missing (step 9 of /gflow:release)"]
+
+    text = status.read_text(encoding="utf-8")
+    m = re.search(r"^## Current release\s*$", text, re.M)
+    if not m:
+        return ['docs/PROJECT_STATUS.md: no "## Current release" section found']
+
+    rest = text[m.end() :]
+    next_heading = re.search(r"^(?:## |<details>)", rest, re.M)
+    section = rest[: next_heading.start()] if next_heading else rest
+    if f"v{version}" not in section:
+        return [
+            f'docs/PROJECT_STATUS.md: "## Current release" does not mention v{version} '
+            "— update it to describe the release being cut (step 9 of /gflow:release)"
+        ]
+    return []
 
 
 def main() -> int:

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -135,6 +135,27 @@ rg -n "__version__|<OLD_VERSION>|version assertion" tests src pyproject.toml .co
   [<NEW_VERSION>]: https://github.com/ffroliva/gflow-cli/compare/v<PREV_VERSION>...v<NEW_VERSION>
   ```
 
+**9b. Update `docs/PROJECT_STATUS.md` — this is an ACTION, not a review finding.**
+
+Rewrite the `## Current release` section to describe the release being cut, and add a
+milestone-history row for its headline change. Demote the previous release into a
+`<details><summary>vPREV — …</summary>` block rather than deleting it.
+
+The file's own header says "Updated on every signed tag" — a promise that went unkept for
+five consecutive releases, and again in v0.64.0, where the section still announced v0.63.0 as
+current at tag time. It was caught only because a human council happened to read the file.
+`scripts/ci/check_release_artifacts.py` now enforces it (violation 6): the version being cut
+must appear in that section specifically, not merely somewhere in the file — every past
+release is still named further down, so a whole-file search would pass on a fully stale
+header. Run it before committing:
+
+```bash
+uv run python scripts/ci/check_release_artifacts.py
+```
+
+Doing this at step 9b rather than discovering it at step 10 is the point: doc-review is a
+*detector*, and a gate that only detects still costs a round trip every release.
+
 **10. Run the documentation review gate.**
 
 Run `/gflow:doc-review` — audit all version refs, INDEX completeness, evidence files, **the published `website/docs/` mirror (PII gate + content-drift check, §4b)**, **code↔docs parity via git log (§4c)**, skill files, CHANGELOG footer, and memory files. Fix every **FAIL** before continuing. Fold all discovered fixes into the release prep commit — **including any `website/docs/` re-sync** (the mirror is anonymized and hand-synced; a canonical doc change this release must be mirrored, and `CHANGELOG.md` must never appear under `website/docs/`).
@@ -149,6 +170,7 @@ will fail the gate.
 
 ```bash
 git add pyproject.toml .codex-plugin/plugin.json src/gflow_cli/__init__.py uv.lock CHANGELOG.md
+git add docs/PROJECT_STATUS.md                 # step 9b — enforced by check_release_artifacts
 git add docs/ website/docs/ skills/ .claude/commands/gflow/   # include any doc-review + mirror fixes
 # doc-review version-currency fixes often also touch ROOT docs — stage them too:
 git add README.md PLAN.md KNOWN_ISSUES.md AGENTS.md llms.txt 2>/dev/null || true

--- a/tests/e2e/test_i2v_flags_e2e.py
+++ b/tests/e2e/test_i2v_flags_e2e.py
@@ -19,6 +19,18 @@ Criteria covered:
                was bound through the editor's media dialog (not silently dropped).
   I2V-FLAG-2 — Positional back-compat form (``gflow video i2v <img> "<prompt>"``)
                still produces a successful VideoResult — no regression.
+  I2V-FLAG-3 — ``--initial-frame`` + ``--end-frame`` together bind both slots.
+  I2V-FLAG-4 — omni-flash + end frame + ``--duration 10``: the largest-payload
+               combination, asserting the captured route is
+               ``StartAndEndImage`` rather than a silently degraded
+               ``StartImage`` (#626).
+
+Every test here passes ``--model omni-flash`` wherever it passes ``--duration``.
+That is not stylistic: since #451/#288 the Veo 3.1 models render no duration
+control at all, so ``--duration`` without that flag now fails before any browser
+work. These tests carried a bare ``--duration 4`` for months after that shipped
+and would all have failed — they never run in CI (opt-in, credit-bearing), so
+nothing noticed. If you add a case here, run it at least once.
 
 Note: ``--end-frame`` / ``--end-image`` interpolation is covered at the
 transport level by ``test_e2e_i2v_start_end_frame_attach`` in
@@ -134,6 +146,8 @@ def test_e2e_i2v_initial_frame_flag(
             "9:16",
             "--out-dir",
             str(out_dir),
+            "--model",
+            "omni-flash",
             "--duration",
             "4",
             "--count",
@@ -186,6 +200,8 @@ def test_e2e_i2v_positional_back_compat(
             "9:16",
             "--out-dir",
             str(out_dir),
+            "--model",
+            "omni-flash",
             "--duration",
             "4",
             "--count",
@@ -233,6 +249,8 @@ def test_e2e_i2v_start_end_frame_flags(
             "16:9",
             "--out-dir",
             str(out_dir),
+            "--model",
+            "omni-flash",
             "--duration",
             "4",
             "--profile",
@@ -253,4 +271,80 @@ def test_e2e_i2v_start_end_frame_flags(
     # One for start, one for end.
     assert len(frame_attached_events) >= 2, (
         f"expected at least 2 frame_attached events, got {len(frame_attached_events)}"
+    )
+
+
+def test_e2e_i2v_omni_flash_end_frame_max_duration(
+    e2e_profile_dir: Path,
+    unisolated_home: Path,
+    tmp_path: Path,
+    install_log_capture: structlog.testing.LogCapture,
+) -> None:
+    """I2V-FLAG-4: omni-flash + end frame + ``--duration 10`` (#626).
+
+    The largest-payload i2v combination, and the one v0.64.0 shipped
+    **submit-verified only**: its live run reached
+    ``batchAsyncGenerateVideoStartAndEndImage`` with both images bound, then the
+    status poll returned HTTP 401 (#561) before the render finished. This test
+    is the executable form of that missing check, so the gap closes the next
+    time anyone runs the credit-bearing suite instead of waiting for another
+    hand-typed live session.
+
+    omni-flash is also the ONLY model that renders a duration control, so this
+    is the sole path that exercises duration and end-frame interpolation
+    together. Asserting the captured route (not just exit 0) is what would fail
+    if Flow silently degraded ``StartAndEndImage`` back to ``StartImage`` — the
+    mis-billing shape ``_assert_i2v_route`` exists to refuse.
+    """
+    start = _make_png(tmp_path / "start.png")
+    end = _make_png(tmp_path / "end.png")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(exist_ok=True)
+
+    profile_name = os.environ["GFLOW_CLI_E2E_PROFILE"]
+    runner = CliRunner()
+    result = runner.invoke(
+        video,
+        [
+            "i2v",
+            "--initial-frame",
+            str(start),
+            "--end-frame",
+            str(end),
+            _PROMPT,
+            "--aspect",
+            "9:16",
+            "--out-dir",
+            str(out_dir),
+            "--model",
+            "omni-flash",
+            "--duration",
+            "10",
+            "--profile",
+            profile_name,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert list(out_dir.glob("*.mp4")), "expected a downloaded mp4 for omni-flash first+last"
+
+    captured = [
+        e
+        for e in install_log_capture.entries
+        if e.get("event") == "ui_automation_video.generate_captured"
+    ]
+    assert captured, "no generate_captured event — cannot prove which route Flow used"
+    url = str(captured[-1].get("url", ""))
+    assert "batchAsyncGenerateVideoStartAndEndImage" in url, (
+        f"omni-flash carried an end frame but Flow routed to {url!r}; the end frame "
+        "was dropped at submit (refs #626)"
+    )
+
+    duration_events = [
+        e
+        for e in install_log_capture.entries
+        if e.get("event") == "ui_automation_video.duration_set"
+    ]
+    assert any(e.get("seconds") == 10 for e in duration_events), (
+        f"expected duration_set seconds=10, got {[e.get('seconds') for e in duration_events]}"
     )

--- a/tests/scripts/test_check_release_artifacts.py
+++ b/tests/scripts/test_check_release_artifacts.py
@@ -35,8 +35,16 @@ def _repo(tmp_path: Path, version: str = "1.2.3", *, complete: bool = True) -> P
         (tmp_path / "docs" / "INDEX.md").write_text(
             f"[LIVE_VERIFICATION_v{version}](LIVE_VERIFICATION_v{version}.md)", encoding="utf-8"
         )
+        (tmp_path / "docs" / "PROJECT_STATUS.md").write_text(
+            f"# Project Status\n\n## Current release\n\n**v{version} — alpha.** shipped.\n",
+            encoding="utf-8",
+        )
     else:
         (tmp_path / "docs" / "INDEX.md").write_text("nothing", encoding="utf-8")
+        (tmp_path / "docs" / "PROJECT_STATUS.md").write_text(
+            "# Project Status\n\n## Current release\n\n**v0.0.1 — alpha.** stale.\n",
+            encoding="utf-8",
+        )
     return tmp_path
 
 
@@ -50,6 +58,51 @@ def test_missing_live_verification_fails(tmp_path: Path) -> None:
     root = _repo(tmp_path, complete=False)
     violations = find_violations(root)
     assert any("LIVE_VERIFICATION_v1.2.3.md missing" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_stale_project_status_current_release_fails(tmp_path: Path) -> None:
+    """PROJECT_STATUS.md's "Current release" must name the version being cut.
+
+    That file claims in its own header to be "Updated on every signed tag", and
+    nothing enforced it: v0.64.0 was cut with the section still announcing
+    v0.63.0 as current, caught only by a human doc-review council. A release
+    that ships announcing the wrong version as current is a release-blocking
+    documentation defect, so it belongs in the mechanical gate.
+    """
+    root = _repo(tmp_path)
+    (root / "docs" / "PROJECT_STATUS.md").write_text(
+        "# Project Status\n\n## Current release\n\n**v1.2.2 — alpha.** the PREVIOUS release.\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(root)
+    assert any("PROJECT_STATUS.md" in v for v in violations), violations
+
+
+@pytest.mark.unit
+def test_missing_project_status_fails(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    (root / "docs" / "PROJECT_STATUS.md").unlink()
+    violations = find_violations(root)
+    assert any("PROJECT_STATUS.md" in v for v in violations), violations
+
+
+@pytest.mark.unit
+def test_project_status_version_elsewhere_does_not_satisfy_the_gate(tmp_path: Path) -> None:
+    """The version must appear in the "Current release" section specifically.
+
+    Every past release is still named further down the file, so a plain
+    whole-file substring search would pass on a completely stale header — the
+    exact failure this check exists to catch.
+    """
+    root = _repo(tmp_path)
+    (root / "docs" / "PROJECT_STATUS.md").write_text(
+        "# Project Status\n\n## Current release\n\n**v1.2.2 — alpha.** stale header.\n\n"
+        "<details><summary>older</summary>\n\n**v1.2.3 — alpha.** buried mention.\n\n</details>\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(root)
+    assert any("PROJECT_STATUS.md" in v for v in violations), violations
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Answers two questions raised after the v0.64.0 cut, and fixes what they exposed.

## 1. When should `docs/PROJECT_STATUS.md` be updated? — During the release, and now enforced

It was a **detected** problem, not an **enforced** one. The file's own header promises it is "Updated on every signed tag"; nothing checked. It drifted for five consecutive releases, and again in v0.64.0 — the "Current release" section still announced v0.63.0 at tag time, caught only because a human doc-review council read it. A gate that only detects costs a round trip every release.

- `check_release_artifacts.py` enforces it as **violation 6**, scoped to the `## Current release` section. That scoping matters: every past release is still named further down the file, so a whole-file substring search would pass on a fully stale header.
- **A/B-verified against the real file:** passes on `0.64.0`, fires on the stale-`0.63.0` case *even though that string appears elsewhere in the file*.
- `skills/release` gains **step 9b**, making the update an action taken before step 10's review rather than a finding produced by it.

## 2. Should the `--duration 10` gap have an e2e test? — Yes, and the suite was already broken

All three credit-bearing tests in `tests/e2e/test_i2v_flags_e2e.py` passed a bare `--duration 4` with **no `--model`**. Since #451/#288 only omni-flash renders a duration control, so every one of them would have failed on its next run. They never execute in CI (opt-in, credit-bearing), so nothing noticed — same class as #620.

Adds `test_e2e_i2v_omni_flash_end_frame_max_duration`: the executable form of the one thing v0.64.0 shipped **submit-verified only**. It asserts the *captured route* is `StartAndEndImage`, not merely exit 0 — that assertion is what fails if Flow degrades to `StartImage` and bills a clip that was never interpolated.

## Found along the way, deliberately NOT fixed here

**#630** — `--duration` without `--model` on i2v dies as "Unexpected error" (exit 1) instead of the usage error whose text already exists. `_reject_duration_without_control` returns early on `model is None`, but i2v's default (veo-lite) has no duration control, so the guard is bypassed in exactly the default case. Filed with two candidate fixes rather than bundled, because the root-cause option changes an exception type on a shared DTO path.

## Test plan

- [x] TDD: 3 new gate tests written and watched fail ("no violation reported") before the checker changed
- [x] `tests/scripts/test_check_release_artifacts.py`: 8 passed
- [x] Affected suites: 314 passed
- [x] `check_release_artifacts.py` against the live repo: protocol satisfied
- [x] ruff check + format, doc links, repo hygiene, website mirror: green
- [x] New e2e test collects and is correctly deselected without opt-in (4 deselected)
- [ ] The new e2e test itself is credit-bearing and unrun — it is the gap-closer for the *next* live pass, not something to burn credits on now

Refs #451, #288, #626, #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjLK6uiPRNbk4QeeDojDK5