### PR TITLE
docs(readme): restore the sealed_token the star-history chart needs, and watch for it silently dying

### DIFF
--- a/.github/workflows/star-history-watch.yml
+++ b/.github/workflows/star-history-watch.yml
@@ -1,0 +1,89 @@
+name: Star history watch
+
+# ── Why this exists ──────────────────────────────────────────────────────────
+# The star-history chart in README.md is the project's front door — it renders on
+# GitHub and on the PyPI project page. When it breaks it does so SILENTLY: the
+# endpoint answers HTTP 200 with `image/svg+xml`, and the body is a "GitHub
+# restricted access to star data" placard instead of a chart. Every status-code
+# check passes. That is how it stayed broken from 2026-08-30 to 2026-09-02 with
+# no signal — a human noticed it in a browser.
+#
+# The chart depends on the `sealed_token` param surviving in the README URL
+# (GitHub restricted the public /stargazers endpoint on 2026-06-30; star-history's
+# per-repo cache expires in under 3 days without a token-bearing request). So this
+# probes for the two ways it dies: the token gets stripped, or the underlying PAT
+# expires or is revoked.
+#
+# The URL is read out of README.md rather than hardcoded here, so the probe can
+# never drift from what is actually shipped.
+
+on:
+  schedule:
+    # Daily 06:00 UTC — an hour after the selector probe, well clear of it.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe the README star-history chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository == 'ffroliva/gflow-cli'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Fetch each star-history URL in README.md and inspect the SVG body
+        run: |
+          set -uo pipefail
+          urls=$(grep -o 'https://api\.star-history\.com/chart?[^"]*' README.md | sort -u)
+          if [ -z "$urls" ]; then
+            echo "::error::No star-history URL found in README.md. If the chart was removed on"
+            echo "::error::purpose, delete this workflow too."
+            exit 1
+          fi
+
+          failed=0
+          while IFS= read -r url; do
+            # Redact the sealed token before anything reaches the public log.
+            safe=$(printf '%s' "$url" | sed 's/sealed_token=.\{8\}.*/sealed_token=<redacted>/')
+            echo "── $safe"
+
+            case "$url" in
+              *sealed_token=*) ;;
+              *)
+                echo "::error::sealed_token is missing from this URL. A tokenless chart reverts to"
+                echo "::error::the restriction placard within ~3 days. See the comment in README.md."
+                failed=1
+                ;;
+            esac
+
+            # Cache-bust so we measure the live endpoint, not star-history's warm cache.
+            code=$(curl -sS --max-time 30 -o body.svg -w '%{http_code}' "$url&cb=$GITHUB_RUN_ID") || {
+              echo "::warning::curl failed — treating as a transient star-history outage, not a token problem."
+              continue
+            }
+            bytes=$(wc -c < body.svg)
+            echo "   http=$code bytes=$bytes"
+
+            if [ "$code" != "200" ]; then
+              echo "::warning::HTTP $code from star-history — likely their outage, not our token."
+              continue
+            fi
+            # The whole point: a 200 is not proof. Read the SVG text.
+            if grep -qi 'restricted access to star data' body.svg; then
+              echo "::error::Chart is serving the GitHub restriction placard. The sealed token is"
+              echo "::error::present but not working — the underlying PAT has most likely expired or"
+              echo "::error::been revoked. Mint a fine-grained PAT (metadata:read on this repo), seal"
+              echo "::error::it at star-history.com, and replace the sealed_token param in README.md."
+              failed=1
+            else
+              echo "   ✅ real chart"
+            fi
+          done <<< "$urls"
+
+          exit "$failed"

--- a/README.md
+++ b/README.md
@@ -158,9 +158,16 @@ Full milestone history lives in [CHANGELOG.md](CHANGELOG.md). Where the project 
 
 ### Star history
 
+<!-- DO NOT strip `sealed_token` from the URLs below. GitHub restricted the public
+     /stargazers endpoint (2026-06-30), so star-history can only build this chart from a
+     token-authenticated request. Its per-repo cache expires in <3 days, so a tokenless
+     URL renders a "GitHub restricted access to star data" placard — served as HTTP 200,
+     which is why nothing catches it. `.github/workflows/star-history-watch.yml` probes
+     for exactly that. The token is sealed with star-history's key and grants metadata
+     read on a public repo; it is safe in a public README, and they recommend it. -->
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&theme=dark&legend=top-left" />
-  <img alt="Star history chart for ffroliva/gflow-cli" src="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&theme=dark&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
+  <img alt="Star history chart for ffroliva/gflow-cli" src="https://api.star-history.com/chart?repos=ffroliva/gflow-cli&type=date&legend=top-left&sealed_token=7kTiE_HExjjY2aT7O-_hMxY_Mf6n-ET17mi_RXcRjCSS5rHSBDMd7xFYCzT_yaXhAXrgF8AGTQc6mny_qfuJc7473KGqb-5U41Dpu-tpZIS1IYl-xVQR9ziGJtL0KWQVyWZU1IoUmLWwo43PhgVTo4MJfmWOvluFJq2zlGxE_iLl9wMRgpwQaiC4ufOK" />
 </picture>
 
 If `gflow-cli` saves you time, please ⭐ the repo. It is the cheapest way to support the project.


### PR DESCRIPTION
## Summary

The star-history chart in the README has been rendering a **\"GitHub restricted access to star data\"** placard instead of a chart since **2026-08-30** — on GitHub *and* on the PyPI project page. Nobody noticed for three days because the failure is invisible to every automated check: the endpoint answers **HTTP 200** with `image/svg+xml`, and the placard is the body.

### Root cause

GitHub restricted the public `/stargazers` endpoint on 2026-06-30 to a repo's own admins and collaborators. star-history's servers aren't a collaborator here, so they can only build the curve from a token-authenticated request.

PR #610 bootstrapped the chart *with* a sealed token, then removed it again in `339c9af` — "drop inert sealed_token" — on the finding that the param made no difference once star-history had cached the repo. That finding came from an A/B run in a confounding order:

| # | request | cache | result |
|---|---|---|---|
| 1 | real sealed token | cold | real chart (65367 B) |
| 2 | no token | warm (filled by #1) | real chart |
| 3 | garbage token | warm | real chart |

Three identical byte counts read as "the endpoint isn't validating the param." It was reading its own cache fill. Re-run cold-first, the control separates cleanly:

| # | request | cache | result |
|---|---|---|---|
| 1 | no token | **cold** | **restriction placard** (60125 B) |
| 2 | real sealed token | **cold** | **real chart** (65367 B) |

star-history's per-repo cache expires in under 3 days — exactly the gap between the #610 merge and the chart going dark.

### The fix

`sealed_token` is restored to both URLs. This is self-healing rather than a recurring chore: every reader's page load carries the token, so a cold-cache visitor refills the cache and gets a real chart back on that same request. Nothing to re-bootstrap.

The token is sealed with star-history's key and grants metadata read on a public repo. Publishing it is [their documented guidance](https://www.star-history.com/blog/github-stargazer-api-restriction) — and it is already in this repo's public history at `83f26e2`.

## Hardening

The bug wasn't the stripped token; it was that stripping it produced **no signal for three days**. Two guards:

1. **A comment at the call site** in `README.md` saying not to strip it, and why a tokenless URL looks healthy for 72 hours. This is where the mistake was made, so it's where the warning goes.
2. **`.github/workflows/star-history-watch.yml`** — daily probe that reads the URLs *out of `README.md`* (so it can't drift from what ships), cache-busts, and greps the SVG body rather than trusting the status code. It fails on either death mode: token stripped, or the underlying PAT expired/revoked. Transient star-history outages (non-200, curl failure) warn instead of failing, so it doesn't page anyone over someone else's downtime. The token is redacted from the job log.

## Test plan

- [x] Cold-cache A/B confirms the token is causal, not inert (tables above), probed live with cache-busting and `<text>`-grep
- [x] Both README URLs verified live → real charts (65367 / 65373 bytes)
- [x] Probe logic A/B'd locally: real README → exit 0; token-stripped control → exit 1. The control still returned a *real chart* from the warm cache, and the missing-token check caught it anyway — which is the point of having both checks
- [x] YAML parses; action pinned to the same SHA as the other workflows
- [x] `check_repo_hygiene` (860 files), `check_doc_links` (29 files), `check_website_docs_pii`, `generate_website_docs --check` — all green
- [ ] Confirm the chart renders on this PR's rendered README

`ruff` / `pyright` / `pytest` not run: the diff is one Markdown file and one workflow, with no Python touched. No CLI or MCP surface change, so MCP parity is not in scope.

## Residual risk

If the PAT expires or is revoked, the chart breaks silently again — same 200, same placard. That is precisely what the new workflow exists to catch, and its error message says how to re-seal.
