### PR TITLE
fix(chain,movie): reject duration × model before spending, not mid-run (#634, #635)

### DIFF
--- a/docs/MOVIE.md
+++ b/docs/MOVIE.md
@@ -57,7 +57,7 @@ characters = ["Stickman"]         # which characters appear (drives R2V reuse)
 speaker = "Stickman"
 line = "We finally made it to the top!"
 aspect = "9:16"
-model = "veo-lite"
+model = "omni-flash"              # only model with a duration control (see below)
 duration = 8
 
 [[scenes]]
@@ -68,6 +68,16 @@ style_suffix = "golden hour light" # appended after the variant suffix
 aspect = "9:16"
 duration = 6
 ```
+
+> **Scene `duration` requires `model = "omni-flash"`** (issue #634). Flow renders
+> a duration control for `omni-flash` alone; every Veo 3.1 model renders none, so
+> a scene pairing `duration` with a Veo model is rejected at **parse time** with
+> exit 11 — before any scene generates. Valid values are `4`, `6`, `8`, `10`.
+>
+> A scene with a `duration` and **no** `model` still parses: with no model named,
+> the clip inherits Flow's sticky UI default, which gflow cannot know here and so
+> cannot check. If that default is a Veo model the duration is silently not
+> applied. Name `model = "omni-flash"` explicitly whenever the length matters.
 
 On first run, characters with `identity = "entity"` are created once (image
 generation — **free**, no credits) and cached. Each scene then generates a clip

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1534,14 +1534,14 @@ voice = "alnilam"
 id = "scene_01"
 action = "A mysterious stickman walks slowly through a dark forest."
 framing = "wide"
-duration = 5
+duration = 4
 characters = ["Stickman"]
 
 [[scenes]]
 id = "scene_02"
 action = "Close up of the stickman looking back in shock."
 framing = "close-up"
-duration = 5
+duration = 4
 characters = ["Stickman"]
 style_variant = "warm"
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -845,12 +845,21 @@ Options:
 
 ### JSONL manifest format
 
-One JSON object per line. Only `prompt` is required; `model` / `duration` /
-`aspect` are optional per-link overrides (omit to inherit the chain default).
-Blank lines and `#`-prefixed comment lines are skipped.
+One JSON object per line. Only `prompt` is required; `model` and `aspect` are
+optional per-link overrides (omit to inherit the chain default). Blank lines and
+`#`-prefixed comment lines are skipped.
+
+> **`duration` is not supported in a chain** (issue #634). Flow renders a
+> duration control for `omni-flash` alone, and chains reject `omni-flash` (see
+> the note above) — so no model a chain can use can apply one. A manifest
+> carrying `duration` is now rejected **before the first link is submitted**;
+> previously it crashed partway through, after earlier links had already
+> rendered and spent credits. Chain links use Flow's default clip length. A
+> per-link `"model": "omni-flash"` override is rejected up front for the same
+> reason.
 
 ```jsonl
-{"prompt": "a lone wolf on a snowy ridge at dawn, cinematic", "model": "veo-lite", "duration": 4, "aspect": "16:9"}
+{"prompt": "a lone wolf on a snowy ridge at dawn, cinematic", "model": "veo-lite", "aspect": "16:9"}
 {"prompt": "it lifts its head and turns to face the camera"}
 {"prompt": "it bounds down the slope toward the valley"}
 ```

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -67,6 +67,7 @@ __all__ = [
     "LinkCompletedHook",
     "LinkFailedHook",
     "LinkStartedHook",
+    "reject_unusable_links",
     "run_chain",
 ]
 
@@ -195,26 +196,20 @@ def _build_link_request(
     )
 
 
-def _reject_unusable_links(*, model: VideoModel, links: Sequence[ChainLinkSpec]) -> None:
+def reject_unusable_links(*, model: VideoModel, links: Sequence[ChainLinkSpec]) -> None:
     """Reject a chain that cannot succeed, BEFORE link 0 renders (#125, #634).
 
-    Every check here used to happen too late or not at all, and "too late" in a
-    chain means *after money was spent*: a chain that dies at link 3 has already
-    generated and billed links 0-2, and the DTO's bare ``ValueError`` surfaced as
-    exit 1 "Unexpected error" with the explanation lost (the same shape #630/#632
-    fixed for single-clip i2v).
+    "Too late" in a chain means *after money was spent*: a chain that dies at
+    link 3 has already generated and billed links 0-2.
 
     Two things are checked per link, against the link's EFFECTIVE model:
 
-    * **omni_flash.** The chain-level ``model`` was already rejected below, but
+    * **omni_flash.** The chain-level ``model`` is rejected first, but
       :func:`_build_link_request` prefers ``spec.model`` when set, so a per-link
       override walked straight past that check.
-    * **duration.** Chains reject omni_flash, and ``supports_duration()`` is True
-      for omni_flash alone — so no model a chain can use renders a duration
-      control, and any per-link ``duration`` is unsatisfiable by construction.
-      Expressed as ``supports_duration()`` rather than a blanket ban so that if
-      the omni_flash restriction is ever lifted, duration follows automatically
-      instead of silently staying wrong.
+    * **duration.** A blanket ban, because chains reject omni_flash and
+      ``supports_duration()`` is True for omni_flash alone — so no model a chain
+      can use renders a duration control at all.
     """
     if model is VideoModel.OMNI_FLASH:
         msg = (
@@ -236,7 +231,7 @@ def _reject_unusable_links(*, model: VideoModel, links: Sequence[ChainLinkSpec])
                 f"model override, or use a Veo 3.1 model."
             )
             raise ModelModeIncompatibilityError(msg)
-        if spec.duration is not None and not effective.supports_duration():
+        if spec.duration is not None:
             msg = (
                 f"links[{index}] sets duration {spec.duration}, which no chain can "
                 f"apply: Flow renders a duration control for omni_flash only, and "
@@ -374,7 +369,7 @@ async def run_chain(
             to the t2v backstop) or ``WafRejectionError`` (403). Carries the
             ``Path`` of every link completed before the failure.
     """
-    _reject_unusable_links(model=model, links=links)
+    reject_unusable_links(model=model, links=links)
 
     results: list[ChainLinkResult] = []
     completed_paths: list[Path] = []

--- a/src/gflow_cli/chain.py
+++ b/src/gflow_cli/chain.py
@@ -195,6 +195,57 @@ def _build_link_request(
     )
 
 
+def _reject_unusable_links(*, model: VideoModel, links: Sequence[ChainLinkSpec]) -> None:
+    """Reject a chain that cannot succeed, BEFORE link 0 renders (#125, #634).
+
+    Every check here used to happen too late or not at all, and "too late" in a
+    chain means *after money was spent*: a chain that dies at link 3 has already
+    generated and billed links 0-2, and the DTO's bare ``ValueError`` surfaced as
+    exit 1 "Unexpected error" with the explanation lost (the same shape #630/#632
+    fixed for single-clip i2v).
+
+    Two things are checked per link, against the link's EFFECTIVE model:
+
+    * **omni_flash.** The chain-level ``model`` was already rejected below, but
+      :func:`_build_link_request` prefers ``spec.model`` when set, so a per-link
+      override walked straight past that check.
+    * **duration.** Chains reject omni_flash, and ``supports_duration()`` is True
+      for omni_flash alone — so no model a chain can use renders a duration
+      control, and any per-link ``duration`` is unsatisfiable by construction.
+      Expressed as ``supports_duration()`` rather than a blanket ban so that if
+      the omni_flash restriction is ever lifted, duration follows automatically
+      instead of silently staying wrong.
+    """
+    if model is VideoModel.OMNI_FLASH:
+        msg = (
+            f"model {model.value!r} is not supported for chains: a chain "
+            f"renders N seeded i2v links back-to-back, and omni_flash i2v is "
+            f"wire-verified for single generations only (start frame "
+            f"2026-08-03, end frame 2026-09-02; refs #125, #626). Use a Veo "
+            f"3.1 model."
+        )
+        raise ModelModeIncompatibilityError(msg)
+
+    for index, spec in enumerate(links):
+        effective = spec.model if spec.model is not None else model
+        if effective is VideoModel.OMNI_FLASH:
+            msg = (
+                f"links[{index}] overrides model to {effective.value!r}, which is "
+                f"not supported for chains: omni_flash i2v is wire-verified for "
+                f"single generations only (refs #125, #626). Drop the per-link "
+                f"model override, or use a Veo 3.1 model."
+            )
+            raise ModelModeIncompatibilityError(msg)
+        if spec.duration is not None and not effective.supports_duration():
+            msg = (
+                f"links[{index}] sets duration {spec.duration}, which no chain can "
+                f"apply: Flow renders a duration control for omni_flash only, and "
+                f"chains reject omni_flash (refs #125, #451, #288, #634). Drop the "
+                f"per-link duration to accept Flow's default clip length."
+            )
+            raise ModelModeIncompatibilityError(msg)
+
+
 async def _generate_link(
     *,
     client: FlowApiClient,
@@ -323,15 +374,7 @@ async def run_chain(
             to the t2v backstop) or ``WafRejectionError`` (403). Carries the
             ``Path`` of every link completed before the failure.
     """
-    if model is VideoModel.OMNI_FLASH:
-        msg = (
-            f"model {model.value!r} is not supported for chains: a chain "
-            f"renders N seeded i2v links back-to-back, and omni_flash i2v is "
-            f"wire-verified for single generations only (start frame "
-            f"2026-08-03, end frame 2026-09-02; refs #125, #626). Use a Veo "
-            f"3.1 model."
-        )
-        raise ModelModeIncompatibilityError(msg)
+    _reject_unusable_links(model=model, links=links)
 
     results: list[ChainLinkResult] = []
     completed_paths: list[Path] = []

--- a/src/gflow_cli/chain_manifest.py
+++ b/src/gflow_cli/chain_manifest.py
@@ -2,13 +2,22 @@
 
 Format: **JSONL** — one JSON object per line, e.g.::
 
-    {"prompt": "a lone wolf on a ridge", "model": "veo-lite", "duration": 4, "aspect": "16:9"}
+    {"prompt": "a lone wolf on a ridge", "model": "veo-lite", "aspect": "16:9"}
     {"prompt": "it turns to face the storm"}
 
 Each object is one chain link, in order. ``prompt`` is required and non-empty;
 ``model`` / ``duration`` / ``aspect`` are optional per-link overrides (``None``
 means "inherit the chain default"). Blank lines and ``#``-prefixed comment lines
 are skipped. At least one valid link is required.
+
+``duration`` parses here but **no chain can apply it** (#634): Flow renders a
+duration control for ``omni_flash`` alone and chains reject ``omni_flash``, so
+:func:`gflow_cli.chain.run_chain` rejects any link carrying one before the first
+link is submitted. It stays parseable rather than being rejected at this layer so
+the error names the chain rule once, in the place that owns it — and so a
+programmatic caller building specs directly hits the identical guard. The example
+above deliberately no longer shows it; it used to, which is exactly how the
+crashing combination became the documented one.
 
 **Why JSONL, not a headered TSV?** The chain's per-link overrides are sparse —
 most links carry a prompt alone. A positional TSV would force empty sentinel

--- a/src/gflow_cli/chain_manifest.py
+++ b/src/gflow_cli/chain_manifest.py
@@ -10,14 +10,11 @@ Each object is one chain link, in order. ``prompt`` is required and non-empty;
 means "inherit the chain default"). Blank lines and ``#``-prefixed comment lines
 are skipped. At least one valid link is required.
 
-``duration`` parses here but **no chain can apply it** (#634): Flow renders a
-duration control for ``omni_flash`` alone and chains reject ``omni_flash``, so
+``duration`` parses here but **no chain can apply it** (#634).
 :func:`gflow_cli.chain.run_chain` rejects any link carrying one before the first
 link is submitted. It stays parseable rather than being rejected at this layer so
-the error names the chain rule once, in the place that owns it — and so a
-programmatic caller building specs directly hits the identical guard. The example
-above deliberately no longer shows it; it used to, which is exactly how the
-crashing combination became the documented one.
+the rule is enforced once, in the place that owns it — and so a programmatic
+caller building specs directly hits the identical guard.
 
 **Why JSONL, not a headered TSV?** The chain's per-link overrides are sparse —
 most links carry a prompt alone. A positional TSV would force empty sentinel

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -942,6 +942,7 @@ async def _run_chain(
 
     from gflow_cli import chain as chain_mod
     from gflow_cli.api.video import Aspect
+    from gflow_cli.chain import reject_unusable_links
     from gflow_cli.chain_manifest import parse_chain_manifest
     from gflow_cli.data.chain_repo import ChainLinkRecorder
     from gflow_cli.errors import ChainManifestError
@@ -950,6 +951,14 @@ async def _run_chain(
     aspect_enum = Aspect.from_cli(aspect)
 
     links: list[ChainLinkSpec] = parse_chain_manifest(_Path(manifest))
+
+    # Validate here as well as inside run_chain (#634). run_chain's own guard is
+    # the root-cause one and protects programmatic callers, but it runs after the
+    # --dry-run short-circuit below, after the cost prompt, and after Chrome
+    # boots — so without this call `chain bad.jsonl --dry-run` would exit 0 on a
+    # manifest the real run refuses, and the pre-flight command would green-light
+    # the crash it exists to prevent.
+    reject_unusable_links(model=resolved_model, links=links)
 
     if max_links is not None and len(links) > max_links:
         msg = (
@@ -1579,7 +1588,9 @@ def r2v(
         "Only Veo 3.1 models are accepted (omni-flash is single-clip only for "
         "now — not proven at chain scale, refs #125). The MANIFEST is a JSONL "
         'file: one JSON object per line, each with a required "prompt" and '
-        'optional "model"/"duration"/"aspect" overrides.\n\n'
+        'optional "model"/"aspect" overrides. A per-link "duration" is rejected '
+        "before anything is submitted: only omni-flash renders a duration "
+        "control, and chains cannot use it (refs #634).\n\n"
         "Each link is saved as its own mp4. Stitching the clips into a single "
         "file is a follow-up step — use `gflow scene`.\n\n"
         "\b\n"

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -529,7 +529,7 @@ def _validate_scene_framing(framing: object, idx: int) -> None:
         )
 
 
-def _validate_scene_model(model: object, idx: int, duration: object = None) -> None:
+def _validate_scene_model(model: object, idx: int, duration: int | None) -> None:
     """Validate the scene's model alias, and its compatibility with *duration*.
 
     Both checks belong at PARSE time (#634). Before this, the alias was only
@@ -613,7 +613,12 @@ def _parse_scene(
 
     _validate_scene_variant(variant, chars, characters, idx)
 
-    aspect, duration = _parse_scene_numeric_fields(d, idx)
+    aspect, duration_raw = _parse_scene_numeric_fields(d, idx)
+    # Coerce BEFORE the model cross-check, so the guard tests the value the Scene
+    # will actually carry. `4.0 in {4, 6, 8, 10}` is True, so a float slips past
+    # the value check but is then dropped here — guarding the raw value would
+    # reject a manifest that previously rendered fine (duration silently unset).
+    duration = duration_raw if isinstance(duration_raw, int) else None
 
     model = d.get("model")
     _validate_scene_model(model, idx, duration)
@@ -637,7 +642,7 @@ def _parse_scene(
         characters=tuple(chars),
         variant=str(variant) if isinstance(variant, str) else None,
         dialogue=tuple(dialogue),
-        duration=duration if isinstance(duration, int) else None,
+        duration=duration,
         model=model if isinstance(model, str) else None,
         aspect=aspect,
         count=1,

--- a/src/gflow_cli/movie_manifest.py
+++ b/src/gflow_cli/movie_manifest.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+from gflow_cli.api.video import VideoModel
 from gflow_cli.composition import (
     FRAMING,
     Character,
@@ -528,10 +529,36 @@ def _validate_scene_framing(framing: object, idx: int) -> None:
         )
 
 
-def _validate_scene_model(model: object, idx: int) -> None:
-    """Validate that scene model, if given, is a string."""
-    if model is not None and not isinstance(model, str):
+def _validate_scene_model(model: object, idx: int, duration: object = None) -> None:
+    """Validate the scene's model alias, and its compatibility with *duration*.
+
+    Both checks belong at PARSE time (#634). Before this, the alias was only
+    checked to be a *string* and ``duration`` only to be one of 4/6/8/10 — the
+    two were never checked against each other, and the alias itself was not
+    resolved until ``VideoModel.from_cli`` ran inside the per-scene render loop.
+    Either failure therefore landed mid-run, after earlier scenes had generated
+    and billed, as exit 1 "Unexpected error".
+    """
+    if model is None:
+        # No model means Flow's sticky UI default, which is genuinely unknowable
+        # here — so a duration cannot be checked against it. Left unguarded BY
+        # DESIGN, the same call #632 made for t2v/r2v.
+        return
+    if not isinstance(model, str):
         raise ConfigurationError(f"scenes[{idx}].model must be a string.")
+    try:
+        resolved = VideoModel.from_cli(model)
+    except ValueError as exc:
+        raise ConfigurationError(
+            f"scenes[{idx}].model {model!r} is not a known model alias: {exc}"
+        ) from exc
+    if duration is not None and resolved is not None and not resolved.supports_duration():
+        raise ConfigurationError(
+            f"scenes[{idx}].duration {duration} cannot be applied to model "
+            f"{model!r} — Flow renders no duration control for it (verified live; "
+            f"refs #451, #288, #634). Only omni-flash exposes a duration "
+            f'(4/6/8/10s). Drop the duration, or use model = "omni-flash".'
+        )
 
 
 def _validate_scene_style_variant(
@@ -589,7 +616,7 @@ def _parse_scene(
     aspect, duration = _parse_scene_numeric_fields(d, idx)
 
     model = d.get("model")
-    _validate_scene_model(model, idx)
+    _validate_scene_model(model, idx, duration)
 
     style_variant = _scene_opt_str(d, "style_variant", idx)
     _validate_scene_style_variant(style_variant, idx, style_variant_names)

--- a/tests/cli/test_cli_video_chain.py
+++ b/tests/cli/test_cli_video_chain.py
@@ -530,3 +530,60 @@ def test_chain_help_states_cost_and_scene_followup() -> None:
     out = result.output.lower()
     assert "credit" in out
     assert "gflow scene" in out
+
+
+def _manifest_raw(tmp_path: Path, lines: list[str]) -> Path:
+    p = tmp_path / "chain.jsonl"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+def test_chain_dry_run_rejects_a_manifest_duration(tmp_path: Path) -> None:
+    """#634: --dry-run must refuse what the real run refuses.
+
+    run_chain's own guard sits behind the --dry-run short-circuit, so without the
+    CLI-level call the documented pre-flight command exits 0 on a manifest that
+    the real run rejects — green-lighting the crash it exists to prevent.
+    """
+    runner = CliRunner()
+    manifest = _manifest_raw(
+        tmp_path,
+        ['{"prompt": "link 0"}', '{"prompt": "link 1", "duration": 4}'],
+    )
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+        patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--dry-run"])
+
+    assert result.exit_code != 0, result.output
+    assert "duration" in result.output.lower()
+    mock_run.assert_not_awaited()
+    mock_client_init.assert_not_called()
+
+
+def test_chain_dry_run_rejects_a_per_link_omni_flash_override(tmp_path: Path) -> None:
+    """#634: the per-link model override bypassed the chain-level omni check."""
+    runner = CliRunner()
+    manifest = _manifest_raw(
+        tmp_path,
+        ['{"prompt": "link 0"}', '{"prompt": "link 1", "model": "omni-flash"}'],
+    )
+    p_resolve, p_provider, p_rec, _ = _patches(tmp_path)
+    with (
+        p_resolve,
+        p_provider,
+        p_rec,
+        patch("gflow_cli.chain.run_chain", new_callable=AsyncMock) as mock_run,
+        patch("gflow_cli.api.client.FlowApiClient.__init__") as mock_client_init,
+    ):
+        result = runner.invoke(video, ["chain", str(manifest), "--dry-run"])
+
+    assert result.exit_code != 0, result.output
+    assert "omni" in result.output.lower()
+    mock_run.assert_not_awaited()
+    mock_client_init.assert_not_called()

--- a/tests/cli/test_movie_manifest.py
+++ b/tests/cli/test_movie_manifest.py
@@ -557,9 +557,8 @@ def test_movie_duration_with_omni_flash_is_accepted(tmp_path: Path) -> None:
 
 
 def test_movie_duration_without_model_is_accepted(tmp_path: Path) -> None:
-    """Negative control: with no model the effective model is Flow's sticky UI
-    default, genuinely unknowable here — so this stays unguarded BY DESIGN,
-    exactly as t2v/r2v were left after #632."""
+    """Negative control: no model means Flow's sticky UI default, unknowable
+    here, so this stays unguarded BY DESIGN — as t2v/r2v were left after #632."""
     path = _write_toml(tmp_path, _SCENE_HEAD + "duration = 4\n")
     assert MovieManifest.from_toml_path(path).scenes[0].duration == 4
 
@@ -571,3 +570,12 @@ def test_movie_unknown_model_alias_raises_at_parse(tmp_path: Path) -> None:
     path = _write_toml(tmp_path, _SCENE_HEAD + 'model = "veo-lightning"\n')
     with pytest.raises(ConfigurationError, match="model"):
         MovieManifest.from_toml_path(path)
+
+
+def test_movie_float_duration_with_veo_model_still_parses(tmp_path: Path) -> None:
+    """Regression control: `4.0 in {4, 6, 8, 10}` is True, so a float slips past
+    the VALUE check — but Scene.duration only keeps ints, so such a manifest used
+    to render with the duration silently unset. Guarding the RAW value would have
+    turned that into a hard error. The guard tests the coerced value instead."""
+    path = _write_toml(tmp_path, _SCENE_HEAD + 'model = "veo-lite"\nduration = 4.0\n')
+    assert MovieManifest.from_toml_path(path).scenes[0].duration is None

--- a/tests/cli/test_movie_manifest.py
+++ b/tests/cli/test_movie_manifest.py
@@ -62,7 +62,11 @@ action = "Establishing shot"
 framing = "wide"
 aspect = "16:9"
 duration = 8
-model = "veo-lite"
+# omni-flash, not veo-lite: this fixture pins "a scene carrying BOTH a model and
+# a duration", and omni-flash is the only model that renders a duration control.
+# With veo-lite it pinned the #634 crash as valid — the same entrenchment #635
+# describes for the chain manifest, and the same swap #632 made for the MCP test.
+model = "omni-flash"
 
 [[scenes]]
 id = "alice-arrives"
@@ -527,3 +531,43 @@ class TestMovieState:
         )
         loaded = MovieState.load(path, title="T", project="p")
         assert loaded.scenes["s1"].consistency_method == "text"
+
+
+# --------------------------------------------------------------------------- #
+# #634 — duration x model is validated at PARSE time, not at spend time
+# --------------------------------------------------------------------------- #
+_SCENE_HEAD = 'title = "T"\nproject = "p"\n\n[[scenes]]\nid = "s"\naction = "x"\n'
+
+
+def test_movie_duration_with_model_lacking_duration_control_raises(tmp_path: Path) -> None:
+    """`_parse_scene_numeric_fields` only ever checked duration's VALUE
+    (4/6/8/10), so `duration = 4` alongside a Veo model parsed clean and died
+    later inside the per-scene render loop — after earlier scenes had already
+    generated and billed, as exit 1 "Unexpected error"."""
+    path = _write_toml(tmp_path, _SCENE_HEAD + 'model = "veo-lite"\nduration = 4\n')
+    with pytest.raises(ConfigurationError, match="duration"):
+        MovieManifest.from_toml_path(path)
+
+
+def test_movie_duration_with_omni_flash_is_accepted(tmp_path: Path) -> None:
+    """Negative control: omni-flash DOES render a duration control, so the guard
+    must not blanket-ban duration the way chains legitimately do."""
+    path = _write_toml(tmp_path, _SCENE_HEAD + 'model = "omni-flash"\nduration = 4\n')
+    assert MovieManifest.from_toml_path(path).scenes[0].duration == 4
+
+
+def test_movie_duration_without_model_is_accepted(tmp_path: Path) -> None:
+    """Negative control: with no model the effective model is Flow's sticky UI
+    default, genuinely unknowable here — so this stays unguarded BY DESIGN,
+    exactly as t2v/r2v were left after #632."""
+    path = _write_toml(tmp_path, _SCENE_HEAD + "duration = 4\n")
+    assert MovieManifest.from_toml_path(path).scenes[0].duration == 4
+
+
+def test_movie_unknown_model_alias_raises_at_parse(tmp_path: Path) -> None:
+    """Same class of defect: the alias was only checked to be a *string*, so a
+    typo reached `VideoModel.from_cli` inside the render loop and crashed
+    mid-spend. Resolve it while parsing instead."""
+    path = _write_toml(tmp_path, _SCENE_HEAD + 'model = "veo-lightning"\n')
+    with pytest.raises(ConfigurationError, match="model"):
+        MovieManifest.from_toml_path(path)

--- a/tests/e2e/test_chain_e2e.py
+++ b/tests/e2e/test_chain_e2e.py
@@ -55,7 +55,6 @@ pytestmark = [pytest.mark.e2e, pytest.mark.e2e_video]
 
 _E2E_ASPECT_ENV = "GFLOW_CLI_E2E_VIDEO_ASPECT"
 _E2E_MODEL_ENV = "GFLOW_CLI_E2E_VIDEO_MODEL"
-_E2E_DURATION_ENV = "GFLOW_CLI_E2E_CHAIN_DURATION"
 
 # Short, safe prompts — generic enough to pass content-policy, with motion so
 # the seeded I2V link has something to continue.
@@ -101,10 +100,6 @@ def _model() -> VideoModel:
     return model
 
 
-def _duration() -> int:
-    return int(os.environ.get(_E2E_DURATION_ENV, "4").strip())
-
-
 @pytest.mark.asyncio
 async def test_chain_two_link_seeds_i2v_from_last_frame(
     monkeypatch: pytest.MonkeyPatch,
@@ -145,11 +140,13 @@ async def test_chain_two_link_seeds_i2v_from_last_frame(
 
     aspect = _aspect()
     model = _model()
-    duration = _duration()
 
+    # No per-link duration: chains reject it outright (#634) because only
+    # omni_flash renders a duration control and chains reject omni_flash.
+    # Passing one here made this test fail 100% of the time rather than skip.
     links = [
-        ChainLinkSpec(prompt=_LINK0_PROMPT, duration=duration),
-        ChainLinkSpec(prompt=_LINK1_PROMPT, duration=duration),
+        ChainLinkSpec(prompt=_LINK0_PROMPT),
+        ChainLinkSpec(prompt=_LINK1_PROMPT),
     ]
 
     async with FlowApiClient(profile_dir=profile) as client:

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -321,7 +321,7 @@ async def test_rejects_per_link_duration_up_front(tmp_path: Path) -> None:
 
     msg = str(excinfo.value)
     assert "duration" in msg.lower()
-    assert "1" in msg, "names the offending link index"
+    assert "links[1]" in msg, "names the offending link index"
     client.generate_video.assert_not_awaited()
 
 
@@ -368,7 +368,7 @@ async def test_per_link_veo_model_override_still_allowed(tmp_path: Path) -> None
     client = _make_client(results)
     links = [
         ChainLinkSpec(prompt="a cat wakes up"),
-        ChainLinkSpec(prompt="the cat stretches", model=VideoModel.VEO_3_1_LITE),
+        ChainLinkSpec(prompt="the cat stretches", model=VideoModel.VEO_3_1_FAST),
     ]
 
     out = await run_chain(
@@ -381,6 +381,12 @@ async def test_per_link_veo_model_override_still_allowed(tmp_path: Path) -> None
 
     assert len(out) == 2
     assert client.generate_video.await_count == 2
+    # The override must actually REACH the request. Asserting only the await
+    # count would pass an implementation that silently dropped spec.model.
+    link1_req = client.generate_video.await_args_list[1].kwargs["req"]
+    assert link1_req.model is VideoModel.VEO_3_1_FAST
+    link0_req = client.generate_video.await_args_list[0].kwargs["req"]
+    assert link0_req.model is VideoModel.VEO_3_1_LITE, "link 0 inherits the chain default"
 
 
 async def test_per_link_recording_hooks_threaded_with_own_request(tmp_path: Path) -> None:

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -293,6 +293,96 @@ async def test_rejects_non_interpolation_model_up_front(tmp_path: Path) -> None:
     client.generate_video.assert_not_awaited()
 
 
+async def test_rejects_per_link_duration_up_front(tmp_path: Path) -> None:
+    """#634: a per-link ``duration`` is rejected BEFORE any spend.
+
+    No model a chain can use renders a duration control: ``supports_duration()``
+    is True for ``OMNI_FLASH`` only, and chains reject ``OMNI_FLASH`` outright.
+    So any manifest ``duration`` is unsatisfiable by construction. Before this
+    guard the DTO's bare ValueError escaped mid-chain — AFTER earlier links had
+    rendered and billed — as exit 1 "Unexpected error".
+    """
+    # Link 0 is given a WORKING result on purpose: without the guard it renders
+    # and bills before link 1 dies, which is precisely the mid-spend failure.
+    client = _make_client([_ok_result("m0", tmp_path / "link0.mp4")])
+    links = [
+        ChainLinkSpec(prompt="a cat wakes up"),
+        ChainLinkSpec(prompt="the cat stretches", duration=4),
+    ]
+
+    with pytest.raises(ModelModeIncompatibilityError) as excinfo:
+        await run_chain(
+            client=client,
+            links=links,
+            out_dir=tmp_path,
+            model=VideoModel.VEO_3_1_LITE,
+            extractor=_fake_extractor([tmp_path / "link0_lastframe.jpg"]),
+        )
+
+    msg = str(excinfo.value)
+    assert "duration" in msg.lower()
+    assert "1" in msg, "names the offending link index"
+    client.generate_video.assert_not_awaited()
+
+
+async def test_rejects_per_link_omni_flash_override_up_front(tmp_path: Path) -> None:
+    """#634: a per-LINK ``model`` override of omni_flash is rejected too.
+
+    ``run_chain`` only ever tested the chain-level ``model``, but
+    ``_build_link_request`` prefers ``spec.model`` when set — so a manifest line
+    carrying ``"model": "omni-flash"`` walked straight past the up-front
+    rejection and into a generation the chain invariant forbids.
+    """
+    # Link 0 is given a WORKING result on purpose: without the guard it renders
+    # and bills before link 1 dies, which is precisely the mid-spend failure.
+    client = _make_client([_ok_result("m0", tmp_path / "link0.mp4")])
+    links = [
+        ChainLinkSpec(prompt="a cat wakes up"),
+        ChainLinkSpec(prompt="the cat stretches", model=VideoModel.OMNI_FLASH),
+    ]
+
+    with pytest.raises(ModelModeIncompatibilityError) as excinfo:
+        await run_chain(
+            client=client,
+            links=links,
+            out_dir=tmp_path,
+            model=VideoModel.VEO_3_1_LITE,
+            extractor=_fake_extractor([tmp_path / "link0_lastframe.jpg"]),
+        )
+
+    assert "omni" in str(excinfo.value).lower()
+    client.generate_video.assert_not_awaited()
+
+
+async def test_per_link_veo_model_override_still_allowed(tmp_path: Path) -> None:
+    """Negative control for the two guards above: a per-link override of a
+    NON-omni model with no duration is still accepted and still generates.
+
+    Without this, "reject per-link overrides" could quietly grow into "reject
+    all per-link models" and no test would notice.
+    """
+    results = [
+        _ok_result("m0", tmp_path / "link0.mp4"),
+        _ok_result("m1", tmp_path / "link1.mp4"),
+    ]
+    client = _make_client(results)
+    links = [
+        ChainLinkSpec(prompt="a cat wakes up"),
+        ChainLinkSpec(prompt="the cat stretches", model=VideoModel.VEO_3_1_LITE),
+    ]
+
+    out = await run_chain(
+        client=client,
+        links=links,
+        out_dir=tmp_path,
+        model=VideoModel.VEO_3_1_LITE,
+        extractor=_fake_extractor([tmp_path / "link0_lastframe.jpg"]),
+    )
+
+    assert len(out) == 2
+    assert client.generate_video.await_count == 2
+
+
 async def test_per_link_recording_hooks_threaded_with_own_request(tmp_path: Path) -> None:
     """run_chain forwards the per-link ``on_started`` into generate_video and
     calls ``on_link_completed`` once per link — each with that link's OWN request

--- a/tests/test_chain_manifest.py
+++ b/tests/test_chain_manifest.py
@@ -45,13 +45,9 @@ def test_parses_minimal_prompt_only_line(tmp_path: Path) -> None:
 def test_parses_multi_link_in_order_with_and_without_overrides(tmp_path: Path) -> None:
     """Parsing ``duration`` is NOT the same as a chain accepting it (#634/#635).
 
-    This asserts the parser's contract only. ``run_chain`` rejects any link
-    carrying a ``duration`` before the first link is submitted — see
-    ``tests/test_chain.py::test_rejects_per_link_duration_up_front``. Read as an
-    endorsement, this fixture is how the crashing combination became the
-    documented example in ``docs/USAGE.md``; it is kept because the two-layer
-    contract (parse permissively, reject in the layer that owns the rule) is
-    deliberate, not because the combination works.
+    This asserts the parser's contract only — ``run_chain`` rejects any link
+    carrying a ``duration``; see
+    ``tests/test_chain.py::test_rejects_per_link_duration_up_front``.
     """
     path = _write(
         tmp_path,

--- a/tests/test_chain_manifest.py
+++ b/tests/test_chain_manifest.py
@@ -43,6 +43,16 @@ def test_parses_minimal_prompt_only_line(tmp_path: Path) -> None:
 
 
 def test_parses_multi_link_in_order_with_and_without_overrides(tmp_path: Path) -> None:
+    """Parsing ``duration`` is NOT the same as a chain accepting it (#634/#635).
+
+    This asserts the parser's contract only. ``run_chain`` rejects any link
+    carrying a ``duration`` before the first link is submitted — see
+    ``tests/test_chain.py::test_rejects_per_link_duration_up_front``. Read as an
+    endorsement, this fixture is how the crashing combination became the
+    documented example in ``docs/USAGE.md``; it is kept because the two-layer
+    contract (parse permissively, reject in the layer that owns the rule) is
+    deliberate, not because the combination works.
+    """
     path = _write(
         tmp_path,
         '{"prompt": "first", "model": "veo-lite", "duration": 4, "aspect": "16:9"}\n'

--- a/website/docs/MOVIE.md
+++ b/website/docs/MOVIE.md
@@ -57,7 +57,7 @@ characters = ["Stickman"]         # which characters appear (drives R2V reuse)
 speaker = "Stickman"
 line = "We finally made it to the top!"
 aspect = "9:16"
-model = "veo-lite"
+model = "omni-flash"              # only model with a duration control (see below)
 duration = 8
 
 [[scenes]]
@@ -68,6 +68,16 @@ style_suffix = "golden hour light" # appended after the variant suffix
 aspect = "9:16"
 duration = 6
 ```
+
+> **Scene `duration` requires `model = "omni-flash"`** (issue #634). Flow renders
+> a duration control for `omni-flash` alone; every Veo 3.1 model renders none, so
+> a scene pairing `duration` with a Veo model is rejected at **parse time** with
+> exit 11 — before any scene generates. Valid values are `4`, `6`, `8`, `10`.
+>
+> A scene with a `duration` and **no** `model` still parses: with no model named,
+> the clip inherits Flow's sticky UI default, which gflow cannot know here and so
+> cannot check. If that default is a Veo model the duration is silently not
+> applied. Name `model = "omni-flash"` explicitly whenever the length matters.
 
 On first run, characters with `identity = "entity"` are created once (image
 generation — **free**, no credits) and cached. Each scene then generates a clip

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -1534,14 +1534,14 @@ voice = "alnilam"
 id = "scene_01"
 action = "A mysterious stickman walks slowly through a dark forest."
 framing = "wide"
-duration = 5
+duration = 4
 characters = ["Stickman"]
 
 [[scenes]]
 id = "scene_02"
 action = "Close up of the stickman looking back in shock."
 framing = "close-up"
-duration = 5
+duration = 4
 characters = ["Stickman"]
 style_variant = "warm"
 ```

--- a/website/docs/USAGE.md
+++ b/website/docs/USAGE.md
@@ -845,12 +845,21 @@ Options:
 
 ### JSONL manifest format
 
-One JSON object per line. Only `prompt` is required; `model` / `duration` /
-`aspect` are optional per-link overrides (omit to inherit the chain default).
-Blank lines and `#`-prefixed comment lines are skipped.
+One JSON object per line. Only `prompt` is required; `model` and `aspect` are
+optional per-link overrides (omit to inherit the chain default). Blank lines and
+`#`-prefixed comment lines are skipped.
+
+> **`duration` is not supported in a chain** (issue #634). Flow renders a
+> duration control for `omni-flash` alone, and chains reject `omni-flash` (see
+> the note above) — so no model a chain can use can apply one. A manifest
+> carrying `duration` is now rejected **before the first link is submitted**;
+> previously it crashed partway through, after earlier links had already
+> rendered and spent credits. Chain links use Flow's default clip length. A
+> per-link `"model": "omni-flash"` override is rejected up front for the same
+> reason.
 
 ```jsonl
-{"prompt": "a lone wolf on a snowy ridge at dawn, cinematic", "model": "veo-lite", "duration": 4, "aspect": "16:9"}
+{"prompt": "a lone wolf on a snowy ridge at dawn, cinematic", "model": "veo-lite", "aspect": "16:9"}
 {"prompt": "it lifts its head and turns to face the camera"}
 {"prompt": "it bounds down the slope toward the valley"}
 ```


### PR DESCRIPTION
## Summary

Closes #634 and #635. `gflow video chain` and `gflow movie run` carried the same `duration` × `model` defect #632 fixed for single-clip i2v — but on these two surfaces it died **mid-spend**: earlier links/scenes had already rendered and billed by the time the DTO's bare `ValueError` escaped as exit 1 `"Unexpected error"`.

For chains it was not an occasional mismatch but a **guaranteed** crash: `supports_duration()` is True for `omni_flash` alone, and `chain.py:326` rejects `omni_flash` outright, so the set of models a chain can use that have a duration control is empty. Every manifest `duration` was unsatisfiable by construction — including the one we shipped as the documented example.

## What changed

**`chain.py` — validate every link before link 0 renders.** The existing "reject-up-front" invariant now covers each link's *effective* model, via a new `_reject_unusable_links`.

**A second hole, found while tracing this and not in the original issue:** the `omni_flash` rejection only ever tested the **chain-level** `model`, while `_build_link_request` prefers `spec.model` when set — so a per-link `"model": "omni-flash"` override walked straight past the invariant into a generation chains forbid. Now checked per link.

The duration check is written as `not effective.supports_duration()` rather than a blanket ban, so if the `omni_flash` chain restriction is ever lifted, duration follows automatically instead of silently staying wrong.

**`movie_manifest.py` — resolve at parse time.** `_parse_scene_numeric_fields` only checked duration's *value* (4/6/8/10) and `_validate_scene_model` only that the alias was a *string*; the two were never checked against each other, and the alias was not resolved until `VideoModel.from_cli` ran inside the per-scene render loop. Both now happen while parsing. Movie keeps the *general* rule rather than chain's blanket ban, because a movie scene legitimately can use `omni-flash`.

A scene with **no** model stays unguarded **by design** — Flow's sticky UI default is genuinely unknowable — matching the call #632 made for t2v/r2v. Pinned by a negative-control test so "resolve the model" cannot quietly grow into "assume veo-lite everywhere."

## The documentation that entrenched it (#635)

- `docs/USAGE.md` shipped `{"model": "veo-lite", "duration": 4}` as **the** canonical chain example — the exact crashing combination — while the prose called `duration` an optional per-link override. Replaced, with a note on why chains cannot carry one.
- `chain_manifest.py`'s module docstring carried the same line.
- `tests/cli/test_movie_manifest.py::_FULL_TOML` pinned `veo-lite` + `duration = 8` as valid. Switched to `omni-flash` so the fixture still covers "a scene carrying BOTH a model and a duration" — the same swap #632 made for the MCP test. **This one was caught by the new guard, not by reading**, which is the clearest evidence the guard belongs at parse time.
- `tests/test_chain_manifest.py` still parses `duration` (the parser is deliberately permissive; the chain rule is enforced in the layer that owns it) but now says so, so it is not read as an endorsement.

## Verification status

- [x] **Red state proves the money bug.** The new chain guard tests give link 0 a working result on purpose. Without the guard the log reads `chain_link_started index=0` → `chain_link_completed index=0` → `chain_link_started index=1` → `ValueError` — i.e. link 0 rendered and billed before the crash. With the guard, `generate_video` is never awaited.
- [x] Negative controls pin what must NOT change: a per-link Veo override still generates; `omni-flash` + duration is still accepted in movie; duration with no model is still accepted.
- [x] 88 chain/movie/manifest/feature tests green; `tests/cli` 555 passed, 0 failed.
- [x] `ruff check` + `ruff format --check` (`src tests`), repo hygiene (860 files), doc links (29 files), website PII, `generate_website_docs --check` — all green.
- [x] `pyright src` identical to the clean-`develop` baseline: 78 errors in both, all in `mcp/tools.py` / `ui/app.py` from a missing local `fastmcp`, **zero in any file this PR touches**. A/B-controlled against the primary checkout rather than assumed.
- [x] MCP parity unaffected — no CLI options added or renamed. `video chain` and `movie run` are already explicit exemptions in `tests/mcp/test_cli_parity.py`, and `gflow_generate_video` got the equivalent guard in #632.
- [ ] **Not live-verified, and does not need to be.** This is a pure-Python validation change on a path that now refuses *before* any transport call; exercising the old behaviour end-to-end would mean deliberately spending credits to watch a chain crash. The full suite was not run locally (it OOMs on this host — see the project's own guidance); CI covers it.

## Note for the reviewer

An `EEE` appeared at the start of one combined multi-directory pytest invocation but **not** when the same directories run separately (`tests/api` clean, `tests/cli` 555/555). That matches the repo's known Windows aggregate-only artifacts rather than anything in this diff, but it is worth a second pair of eyes on CI's result.

---

## Council review — findings applied (commit `63d0741`)

Four reviewers audited `bdff464`. Every finding was re-verified against the code before acting.

**Blocker, found independently by two of them — the PR recreated #635 in the docs it forgot to sweep.** `docs/MOVIE.md`'s flagship scene paired `model = "veo-lite"` with `duration = 8`, which is exactly what this PR's new movie guard rejects. A PR whose entire premise is *"a wrong example shipped"* shipped a wrong example of the same shape, on the surface it had just hardened. Fixed, plus the model×duration rule that `docs/MOVIE.md` never stated at all.

**`--dry-run` never reached the chain guard.** `run_chain`'s check sits behind the `--dry-run` short-circuit — and behind the cost prompt and Chrome boot — so `chain bad.jsonl --dry-run` exited 0 on a manifest the real run refuses. The documented pre-flight command was green-lighting the crash it exists to prevent. The guard is now public and called from the CLI right after `parse_chain_manifest`; `run_chain` keeps its own for programmatic callers. That also fixes index misaddressing — `run_chain` receives `links[skipped:]` under `--resume-from`, so a bad link 5 reported as `links[1]`.

**It rotted the only chain e2e.** `tests/e2e/test_chain_e2e.py` attached a duration to both links while explicitly skipping `omni_flash`, so `CHAIN-E2E-1` would have failed 100% of the time instead of skipping — invisible to CI, which doesn't run `e2e_video`. Precisely the rot #631 had just cleaned up for i2v.

**A regression I introduced.** TOML `duration = 4.0` passes the value check (`4.0 in {4,6,8,10}` is True) but `Scene.duration` keeps only ints, so such a manifest previously rendered with the duration silently unset. Guarding the raw value turned that into a hard error. Now coerced before the cross-check.

**A dead branch, and a bad argument for it.** `not effective.supports_duration()` is provably always True two lines after the omni-flash raise — unreachable and untestable. The defence for keeping it ("if omni-flash is unbanned, duration follows automatically") fails on its own terms: the error message hardcodes the blanket claim and would become a lie on that same day. Now a plain `if spec.duration is not None`.

**Test quality:**
- `assert "1" in msg` claimed to pin the link index but matched `#125`, `#451` and `#634` regardless of index — it could not fail. Now `assert "links[1]"`.
- The per-link-override control used the *same* model as the chain default and asserted only the await count, so an implementation that silently **dropped** `spec.model` passed. Now uses a different model and asserts both requests.
- Added the CLI-level coverage that was entirely missing: two `--dry-run` rejection tests plus a float-duration regression control.

Also swept: `gflow video chain --help` still advertised a `duration` override; `docs/USAGE.md`'s movie example used `duration = 5`, which `_VALID_DURATIONS` has always rejected (pre-existing, same class, in a file already being edited).

**Declined:** rewriting `links[N]` as a JSONL line number. It matches the existing `scenes[N]` convention on the movie side, and threading a `lineno` through `ChainLinkSpec` is a larger change than the ambiguity warrants.

**Note for the release:** this makes previously-parsing `movie.toml` files fail hard (`model = "veo-*"` + `duration = N` was accepted before, now exit 11). `[Unreleased]` is currently empty and the repo's convention is that bugfix PRs don't touch CHANGELOG — but this one is user-visible breaking behaviour and needs writing up at release time.
