### PR TITLE
fix(locale): recover the account locale from <html lang> on flow.google.com (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Locale resolution was blind on `flow.google.com`, and silently discarded a locale it had
+  already learned ([#643](https://github.com/ffroliva/gflow-cli/issues/643)).** The migrated
+  origin serves `/project/<id>` with no `/fx/<locale>/tools/flow` segment, so
+  `locale_segment_from_url` could never match there. The locale had not disappeared — it moved
+  into `<html lang>`, which stays correct on the migrated host. Two measured consequences:
+  `next_locale_state("pt", None)` returned PROVISIONAL, **demoting** an already-learned locale
+  on every migrated load (so a fully-migrated account could never learn it again, undoing
+  [#587](https://github.com/ffroliva/gflow-cli/issues/587)); and `await_url_settled` burned the
+  full 4 s timeout per navigation waiting for a shape that can no longer exist. gflow now falls
+  back to `<html lang>` when the URL carries no segment, and skips the settle wait entirely on
+  the migrated origin.
+
+  The fallback is evidence-backed, not assumed: measured on two accounts (`en` and `pt-BR`),
+  `<html lang>` **agreed with the URL segment wherever both existed**. Unlike
+  `navigator.language` — which reports the value gflow itself sets — it is server-rendered by
+  Flow. Where Flow does state the locale in the URL, that stays authoritative.
+
 ## [0.66.0] — 2026-09-03
 
 ### Fixed

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -792,8 +792,23 @@ class FlowApiClient:
         segment = routes.locale_segment_from_url(settled or "")
         if segment is not None:
             logger.info("client.account_locale_resolved", locale=segment, url=settled)
-        else:
-            logger.info("client.account_locale_unresolved", last_url=settled)
+            return segment
+        # #643: the migrated flow.google.com origin serves /project/<id> with no
+        # locale segment, so the URL can never answer there — but Flow still
+        # renders the account locale into <html lang>. Without this the resolver
+        # returns None and `next_locale_state` DEMOTES an already-learned locale
+        # to PROVISIONAL (measured: a pt account lost its "pt" on every migrated
+        # load). Best-effort: a probe failure must never break navigation.
+        try:
+            lang = await page.evaluate("() => document.documentElement.lang || ''")
+        except Exception as exc:  # noqa: BLE001 - observation only
+            logger.info("client.account_locale_lang_probe_failed", error=type(exc).__name__)
+            lang = None
+        segment = routes.locale_segment_from_lang_attr(lang)
+        if segment is not None:
+            logger.info("client.account_locale_resolved", locale=segment, source="html_lang")
+            return segment
+        logger.info("client.account_locale_unresolved", last_url=settled)
         return segment
 
     async def _launch_persistent_context(self, kwargs: JsonObject) -> BrowserContext:

--- a/src/gflow_cli/api/routes.py
+++ b/src/gflow_cli/api/routes.py
@@ -212,6 +212,38 @@ def locale_segment_from_url(url: str) -> str | None:
     return match.group(1).lower()
 
 
+_LANG_ATTR_RE = re.compile(r"^([a-z]{2,3})(?:-[a-z]{2,4})?$")
+
+
+def locale_segment_from_lang_attr(lang: str | None) -> str | None:
+    """Derive Flow's locale SEGMENT from a page's ``<html lang>`` attribute (#643).
+
+    Needed because the migrated ``flow.google.com`` origin serves ``/project/<id>``
+    with **no locale segment at all** — :func:`locale_segment_from_url` is
+    structurally blind there. The locale did not disappear with the URL shape; it
+    is still served in the document.
+
+    Measured 2026-09-03 on two profiles, old host vs migrated:
+
+    * ``ffroliva``  old ``/fx/tools/flow`` (bare), ``lang=en``  -> migrated ``lang=en-GB``
+    * ``denon82``   old ``/fx/pt/tools/flow``,     ``lang=pt``  -> migrated ``lang=pt``
+
+    ``html lang`` **agreed with the URL segment wherever both existed**, which is
+    what licenses it as a fallback. Unlike ``navigator.language`` — which reports
+    the value gflow itself sets when it launches the context, and so answers
+    confidently but wrongly — this attribute is server-rendered by Flow.
+
+    The region suffix is dropped (``en-GB`` -> ``en``) because Flow's URL segments
+    carry no region, and the two derivations must stay comparable. Anything that
+    is not a plausible tag returns ``None`` — "build the bare URL" is always safe,
+    and guessing is the defect this exists to avoid.
+    """
+    if not lang:
+        return None
+    match = _LANG_ATTR_RE.match(lang.strip().lower())
+    return match.group(1) if match else None
+
+
 def project_editor_url(locale: str | None, project_id: str) -> str:
     """Build the user-facing Flow editor URL for an existing project.
 

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -224,6 +224,12 @@ async def await_url_settled(page: Any) -> str | None:
         current = ""
     if current and FLOW_LOCALISED_URL_RE.match(current):
         return current
+    # #643: on the migrated origin the localised shape can NEVER appear — the path
+    # is /project/<id>, with no /fx/<locale>/tools/flow segment. Waiting for it
+    # burned the full timeout (measured 4018 ms on every migrated navigation) to
+    # return the None we can return now.
+    if flow_host_kind(current) == "migrated":
+        return None
 
     try:
         await page.wait_for_url(FLOW_LOCALISED_URL_RE, timeout=URL_SETTLE_TIMEOUT_MS)

--- a/tests/api/test_routes_locale.py
+++ b/tests/api/test_routes_locale.py
@@ -10,9 +10,11 @@ sets at launch). This parses that landing URL.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
-from gflow_cli.api.routes import locale_segment_from_url
+from gflow_cli.api.routes import locale_segment_from_lang_attr, locale_segment_from_url
 
 PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
 
@@ -66,3 +68,118 @@ def test_returns_none_when_no_trustworthy_segment(url: str) -> None:
 def test_bcp47_tail_is_dropped() -> None:
     """`pt-BR` in the path reduces to the primary tag Flow actually serves."""
     assert locale_segment_from_url("https://labs.google/fx/pt-BR/tools/flow") == "pt"
+
+
+# ---------------------------------------------------------------------------
+# #643: on flow.google.com the locale left the URL but NOT the document
+# ---------------------------------------------------------------------------
+
+
+class TestLocaleSegmentFromLangAttr:
+    """The migrated origin serves `/project/<id>` with no locale segment, so
+    `locale_segment_from_url` is structurally blind there — but the locale is
+    still being served, in `<html lang>`.
+
+    Measured on two profiles, old host vs migrated:
+
+        ffroliva  old: /fx/tools/flow (bare)    lang=en     migrated: lang=en-GB
+        denon82   old: /fx/**pt**/tools/flow    lang=pt     migrated: lang=pt
+
+    `html lang` AGREED with the URL segment wherever both existed, which is what
+    makes it a trustworthy fallback. Unlike `navigator.language` — which reports
+    the value gflow itself sets when it launches the context — this attribute is
+    server-rendered by Flow.
+    """
+
+    def test_plain_segment(self) -> None:
+        assert locale_segment_from_lang_attr("pt") == "pt"
+
+    def test_region_suffix_is_reduced_to_the_segment(self) -> None:
+        """Measured: the migrated English account renders `en-GB`; Flow's URL
+        segment form is `en`, so the region must be dropped to stay comparable."""
+        assert locale_segment_from_lang_attr("en-GB") == "en"
+        assert locale_segment_from_lang_attr("pt-BR") == "pt"
+
+    def test_case_is_normalised(self) -> None:
+        assert locale_segment_from_lang_attr("PT-br") == "pt"
+
+    def test_three_letter_segment_allowed(self) -> None:
+        assert locale_segment_from_lang_attr("fil") == "fil"
+
+    def test_junk_is_none_not_a_guess(self) -> None:
+        for bad in ("", "   ", "x", "english", "e n", "1234", "zz-ZZ-ZZ-ZZ"):
+            assert locale_segment_from_lang_attr(bad) is None, bad
+
+    def test_none_input(self) -> None:
+        assert locale_segment_from_lang_attr(None) is None
+
+    def test_agrees_with_url_derivation_where_both_exist(self) -> None:
+        """The property that licenses the fallback: on the OLD host, both
+        sources are present and they must not disagree."""
+        url = "https://labs.google/fx/pt/tools/flow"
+        assert locale_segment_from_url(url) == locale_segment_from_lang_attr("pt")
+
+
+# ---------------------------------------------------------------------------
+# #643: the resolver must USE the fallback, not just have one available
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAccountLocaleFallsBackToHtmlLang:
+    """`_resolve_account_locale` derived the locale from the settled URL only.
+
+    On the migrated origin that URL carries no segment, so it resolved `None` —
+    and `next_locale_state("pt", None)` then returned PROVISIONAL, DEMOTING a
+    correctly-learned locale (measured on `denon82`). The locale was sitting in
+    `<html lang>` the whole time.
+    """
+
+    @staticmethod
+    def _page(url: str, lang: str) -> MagicMock:
+        page = MagicMock()
+        page.url = url
+        page.wait_for_url = AsyncMock()
+        page.evaluate = AsyncMock(return_value=lang)
+        return page
+
+    @pytest.mark.asyncio
+    async def test_migrated_host_recovers_locale_from_html_lang(self) -> None:
+        from gflow_cli.api.client import FlowApiClient
+
+        page = self._page("https://flow.google.com/project/abc-123", "pt")
+        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        assert got == "pt"
+
+    @pytest.mark.asyncio
+    async def test_migrated_english_region_tag_reduces_to_segment(self) -> None:
+        from gflow_cli.api.client import FlowApiClient
+
+        page = self._page("https://flow.google.com/", "en-GB")
+        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        assert got == "en"
+
+    @pytest.mark.asyncio
+    async def test_url_segment_still_wins_on_the_old_host(self) -> None:
+        """No regression: where Flow states the locale in the URL, that stays
+        authoritative — the fallback must not override it."""
+        from gflow_cli.api.client import FlowApiClient
+
+        page = self._page("https://labs.google/fx/pt/tools/flow", "de")
+        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        assert got == "pt"
+        page.evaluate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_lang_stays_none_rather_than_guessing(self) -> None:
+        from gflow_cli.api.client import FlowApiClient
+
+        page = self._page("https://flow.google.com/", "")
+        assert await FlowApiClient._resolve_account_locale(object(), page) is None  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_failure_is_survivable(self) -> None:
+        from gflow_cli.api.client import FlowApiClient
+
+        page = self._page("https://flow.google.com/", "pt")
+        page.evaluate = AsyncMock(side_effect=RuntimeError("no execution context"))
+        assert await FlowApiClient._resolve_account_locale(object(), page) is None  # type: ignore[arg-type]

--- a/tests/api/transports/test_common.py
+++ b/tests/api/transports/test_common.py
@@ -6,7 +6,7 @@ RED phase: all tests fail with ModuleNotFoundError until _common.py is created.
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -15,6 +15,7 @@ from gflow_cli.api.transports._common import (
     FLOW_URL,
     PER_CALL_TIMEOUT_S,
     REFRESH_SAFETY_MARGIN_S,
+    await_url_settled,
     flow_host_kind,
     interpret_response,
     mint_batch_id,
@@ -294,3 +295,44 @@ class TestFlowHostKind:
     def test_malformed_url_is_none(self) -> None:
         assert flow_host_kind("https://[oops") is None
         assert flow_host_kind("") is None
+
+
+# ---------------------------------------------------------------------------
+# #643: await_url_settled must not wait for a shape the migrated origin cannot have
+# ---------------------------------------------------------------------------
+
+
+class TestAwaitUrlSettledOnMigratedHost:
+    """On `flow.google.com` the localised URL shape can never appear — the path is
+    `/project/<id>`, with no `/fx/<locale>/tools/flow` segment at all.
+
+    Measured on two profiles: `await_url_settled` burned the FULL 4 s
+    `URL_SETTLE_TIMEOUT_MS` on every migrated navigation (4018 ms / 4017 ms) to
+    return the `None` it could have returned immediately. That is spent on top of
+    the ~8 s mode-detect window and ~24 s crop cascade a migrated run already
+    wastes before failing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_none_immediately_on_migrated_host(self) -> None:
+        page = MagicMock()
+        page.url = "https://flow.google.com/project/abc-123"
+        page.wait_for_url = AsyncMock(side_effect=AssertionError("must not wait"))
+        assert await await_url_settled(page) is None
+        page.wait_for_url.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_still_waits_on_the_labs_host(self) -> None:
+        """No regression: the old host CAN still redirect, so the wait must stay."""
+        page = MagicMock()
+        page.url = "https://labs.google/fx/tools/flow"
+        page.wait_for_url = AsyncMock()
+        await await_url_settled(page)
+        page.wait_for_url.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_already_localised_url_still_short_circuits(self) -> None:
+        page = MagicMock()
+        page.url = "https://labs.google/fx/pt/tools/flow"
+        page.wait_for_url = AsyncMock(side_effect=AssertionError("must not wait"))
+        assert await await_url_settled(page) == "https://labs.google/fx/pt/tools/flow"


### PR DESCRIPTION
## Summary

Flow's migrated origin serves `/project/<id>` with **no** `/fx/<locale>/tools/flow` segment, so `LOCALE_SEGMENT_RE` can never match there. The locale did not disappear with the URL shape — it is still served, in `<html lang>`.

## The measurement this is built on

Two accounts, old host vs migrated, read-only, zero credits:

| | `ffroliva` (en) | `denon82` (pt-BR) |
|---|---|---|
| **old** URL | `labs.google/fx/tools/flow` | `labs.google/fx/**pt**/tools/flow` |
| `locale_segment_from_url` | `null` | **`"pt"`** |
| `html lang` | `en` | `pt` |
| **migrated** URL | `flow.google.com/` | `flow.google.com/?pli=1` |
| `locale_segment_from_url` | `null` | **`null`** |
| `html lang` | `en-GB` | **`pt`** — still correct |
| `await_url_settled` | `None` after **4018 ms** | `None` after **4017 ms** |

## Two consequences, both measured

1. **It demoted a locale already learned.** `next_locale_state("pt", None)` returns PROVISIONAL, so every migrated load discarded `denon82`'s `pt`. On a fully-migrated account it can then never be learned again, silently undoing #587. Not a correctness break — bare URLs are documented as "never worse" — but it throws away a correct answer we were holding.
2. **4 s wasted per navigation**, on top of the ~8 s mode-detect window and ~24 s crop cascade a migrated run already spends before failing.

## Why `<html lang>` is a legitimate source

It **agreed with the URL segment wherever both existed** (`pt`/`pt`, `en`/`en`). Unlike `navigator.language` — which `locale_segment_from_url`'s own docstring warns reports the value gflow itself sets, and so answers confidently but wrongly — this attribute is server-rendered by Flow. Where Flow states the locale in the URL, that stays authoritative and the probe is not even run.

## The one judgment call

Reducing a region tag (`en-GB` → `en`): Flow's URL segments carry no region, so the derivations must stay comparable. **Only two locales observed.** A locale whose region is semantically load-bearing (`zh-Hans` vs `zh-Hant`) would need this revisited — flagged in the docstring rather than left implicit.

## Test plan

- [x] 8 tests written **red first**, across 3 units
- [x] **A/B control**: with all three sites neutered, exactly **8 fail** — one per claimed behaviour. No test passes vacuously.
- [x] No-regression cases (URL segment still wins, junk input, probe failure, old-host wait preserved) pass in **both** directions — that is what makes them controls rather than decoration
- [x] `1625 passed, 3 skipped`; ruff clean; pyright **78 = exact `develop` baseline**
- [x] hygiene / doc-links / website-PII / mirror all green

## Not claimed

Live-verified against the real migrated frontend for the *measurement*; the fix itself is unit-verified. The migrated origin is not drivable regardless (#639), so an end-to-end generation on it is not available as a check.

Refs #643