### PR TITLE
perf(ui-mode): fail fast on the migrated origin instead of probing a doomed DOM (#639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A migrated-origin run spent ~36 s discovering a failure knowable in microseconds
+  ([#639](https://github.com/ffroliva/gflow-cli/issues/639)).** `flow.google.com` renders none
+  of the controls gflow drives, so every DOM probe is doomed before it starts — yet the run
+  still burned the full `detect_ui_mode` poll window (~8 s, both arms missing), the crop
+  selector cascade (~24 s) and the URL settle (4 s) before raising `FlowHostMigratedError`.
+  Because the rollout flaps per page load and callers retry on exit 36, that cost was paid on
+  **every attempt** of a retry loop. `get_ui_driver` now checks the host first and fails fast
+  with the same retryable exit 36. The old host is untouched and still gets full DOM detection;
+  a page whose URL cannot be read still probes rather than bailing, so a transient is never
+  mistaken for a migrated origin.
+
 - **Locale resolution was blind on `flow.google.com`, and silently discarded a locale it had
   already learned ([#643](https://github.com/ffroliva/gflow-cli/issues/643)).** The migrated
   origin serves `/project/<id>` with no `/fx/<locale>/tools/flow` segment, so

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -152,6 +152,27 @@ async def get_ui_driver(
     Call per generation — the cohort flaps per page load, so a cached driver
     goes stale on the next navigation / batch item.
     """
+    # #639: the migrated flow.google.com frontend renders none of the controls
+    # gflow drives, so every probe below is doomed before it starts. Finding that
+    # out the slow way costs ~32 s per attempt (the ~8 s detect_ui_mode poll
+    # window, both arms missing, plus the ~24 s crop cascade) -- and because the
+    # rollout flaps and callers retry on exit 36, that is paid on every attempt of
+    # a retry loop. The host is knowable from page.url in microseconds.
+    from gflow_cli.api.transports._common import flow_host_kind
+
+    if flow_host_kind(getattr(page, "url", None)) == "migrated":
+        from gflow_cli.errors import FlowHostMigratedError
+
+        log.info("ui_driver.migrated_host_bail")
+        raise FlowHostMigratedError(
+            detail=(
+                "Flow served this project from flow.google.com — the origin Google is "
+                "migrating the app onto — whose frontend renders none of the controls "
+                "gflow drives. This is not selector drift. The migration flaps per page "
+                "load, so retrying often lands the old frontend."
+            )
+        )
+
     # Prerequisite switch: when a specific arm is required and the current one
     # differs, attempt the DOM toggle for that direction (best-effort — the
     # server can pin the arm). The re-probe below VERIFIES whether it took.

--- a/tests/api/transports/drivers/test_ui_mode.py
+++ b/tests/api/transports/drivers/test_ui_mode.py
@@ -11,7 +11,7 @@ arm (which today drops `-i` cards and mis-hints aspect ratios).
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -317,3 +317,98 @@ def test_worker_video_ui_mode_agentic_payload_rejected() -> None:
 
     with _pytest.raises(ValueError, match="agentic"):
         build_video_request({"prompt": "a", "ui_mode": "agentic"})
+
+
+# ---------------------------------------------------------------------------
+# #639 follow-up: fail fast on the migrated origin instead of probing a DOM
+# that cannot answer
+# ---------------------------------------------------------------------------
+
+
+_CROP = "i.google-symbols:text-is('crop_16_9')"
+
+
+def _page_with_present(present: set[str]):
+    page = MagicMock()
+
+    def locator(sel: str):
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if sel in present else 0)
+        return loc
+
+    page.locator = MagicMock(side_effect=locator)
+    return page
+
+
+class TestMigratedOriginFailsFast:
+    """`flow.google.com` renders none of the controls gflow drives, so every
+    probe below is doomed before it starts. Measured cost of finding that out
+    the slow way, per attempt:
+
+        detect_ui_mode poll window   ~8 s   (both arms miss, falls to deadline)
+        crop selector cascade       ~24 s
+                                    -----
+                                    ~32 s   before FlowHostMigratedError is raised
+
+    The migration flaps per load and callers retry on exit 36, so that cost is
+    paid on every attempt of a retry loop. The host is knowable in microseconds
+    from `page.url`, so none of it needs to be spent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_raises_before_probing_the_dom(self) -> None:
+        from gflow_cli.api.transports.drivers.factory import get_ui_driver
+        from gflow_cli.errors import FlowHostMigratedError
+
+        page = MagicMock()
+        page.url = "https://flow.google.com/project/abc-123"
+        page.locator = MagicMock(side_effect=AssertionError("must not probe the DOM"))
+
+        with pytest.raises(FlowHostMigratedError):
+            await get_ui_driver(page)
+        page.locator.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_error_is_retryable_with_exit_36(self) -> None:
+        from gflow_cli.api.transports.drivers.factory import get_ui_driver
+        from gflow_cli.errors import EXIT_CODE_MAP, FlowHostMigratedError, is_retryable
+
+        page = MagicMock()
+        page.url = "https://flow.google.com/"
+        page.locator = MagicMock(side_effect=AssertionError("must not probe the DOM"))
+
+        with pytest.raises(FlowHostMigratedError) as exc:
+            await get_ui_driver(page)
+        assert is_retryable(exc.value)
+        assert EXIT_CODE_MAP[FlowHostMigratedError] == 36
+
+    @pytest.mark.asyncio
+    async def test_bail_names_the_migration_not_selector_drift(self) -> None:
+        from gflow_cli.api.transports.drivers.factory import get_ui_driver
+        from gflow_cli.errors import FlowHostMigratedError
+
+        page = MagicMock()
+        page.url = "https://flow.google.com/"
+        page.locator = MagicMock(side_effect=AssertionError("must not probe the DOM"))
+        with pytest.raises(FlowHostMigratedError) as exc:
+            await get_ui_driver(page)
+        assert "flow.google.com" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_labs_host_is_untouched(self) -> None:
+        """No regression: the old host must still go through full DOM detection."""
+        from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+
+        page = _page_with_present({_CROP})
+        page.url = "https://labs.google/fx/tools/flow/project/abc"
+        assert await detect_ui_mode(page, timeout_s=0.1, poll_interval_s=0.01) == "classic"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_url_still_probes_rather_than_bailing(self) -> None:
+        """Defensive: a page whose .url is not a usable string must NOT be
+        mistaken for a migrated host — that would turn a transient into a
+        permanent-looking abort."""
+        from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+
+        page = _page_with_present({_CROP})  # MagicMock .url, never assigned
+        assert await detect_ui_mode(page, timeout_s=0.1, poll_interval_s=0.01) == "classic"


### PR DESCRIPTION
## Summary

`flow.google.com` renders none of the controls gflow drives, so every DOM probe in `get_ui_driver` is doomed before it starts. Finding that out the slow way cost, **per attempt**:

| step | cost |
|---|---|
| `detect_ui_mode` poll window (both arms miss, runs to the deadline) | ~8 s |
| crop selector cascade | ~24 s |
| `await_url_settled` (fixed separately in #645) | 4 s |
| **total before `FlowHostMigratedError`** | **~36 s** |

The rollout **flaps per page load** and callers retry on exit 36 — the #639 reporter's orchestrator maps `retryable` onto its transient class and re-navigates — so this was paid on *every attempt of a retry loop*, not once.

The host is knowable from `page.url` in microseconds. `get_ui_driver` now checks it first and raises the same retryable `FlowHostMigratedError` immediately.

## Two no-regression properties, both tested in *both* directions

1. **The labs host is untouched** and still gets full DOM detection — the bail is host-scoped, not a general short-circuit.
2. **A page whose `.url` is not a readable string still probes rather than bailing.** `flow_host_kind` is total and returns `None` there, so a closed context or a test double can never be mistaken for a migrated origin. That would turn a transient into a permanent-looking abort — precisely the failure class #639 was about.

## Test plan

- [x] 5 tests written **red first**
- [x] **A/B control**: with the guard neutered, exactly **3 fail**, one per claimed behaviour. The two no-regression tests pass either way — that is what makes them controls rather than decoration.
- [x] `1614 passed, 3 skipped`; ruff clean; pyright **78 = exact `develop` baseline`**
- [x] hygiene / doc-links / mirror green

## Not claimed

The timings are measured from live migrated loads; the guard itself is unit-verified. The migrated origin is not drivable regardless (#639), so there is no end-to-end success path on it to check against.

Refs #639