### PR TITLE
fix(639): make the migrated-host fast-fail actually fire, and stop the locale cache from lying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   return outright was rejected, because on that account the cached "not redirected" is a true
   observation.
 
-- **`docs/MCP.md` omitted `FlowHostMigratedError` from its retryable-class list**, which would
-  have told an MCP agent not to auto-retry a failure the envelope marks `retryable: true`.
+- **A `<html lang>` locale was treated as evidence that Flow redirects the account, which
+  switched the URL settle back on permanently ([#643](https://github.com/ffroliva/gflow-cli/issues/643)).**
+  Shipped in v0.66.1 and present on `develop`: #643's `<html lang>` fallback returns a segment for
+  an account Flow serves **bare** and never redirects, and `next_locale_state` recorded it as the
+  cached state. Every later bootstrap then saw `cached != NOT_REDIRECTED`, settled, and burned the
+  full 4 s `URL_SETTLE_TIMEOUT_MS` waiting for a redirect that never comes — the exact cost #587
+  exists to remove, on any non-redirecting account with a `lang` attribute. Only a **URL-derived**
+  segment is now folded into that cache; the lang-derived one is used in-process to build URLs and
+  never persisted. Measured on a real profile: warm bootstrap **7.41 s → 2.66 s**, with the locale
+  still recovered.
+
+- **`docs/MCP.md`'s retryable-class list was incomplete**, which would have told an MCP agent not
+  to auto-retry failures the envelope marks `retryable: true`. It omitted `FlowHostMigratedError`,
+  `UiModeUnavailableError` and `SyncPartialError`; it now matches `errors.RETRYABLE_ERRORS`.
 
 ## [0.66.1] — 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **v0.66.1's migrated-origin fast-fail never fired on a real run
+  ([#639](https://github.com/ffroliva/gflow-cli/issues/639)).** The guard read `page.url` once,
+  at `get_ui_driver` entry — but `routes.project_editor_url` only ever builds a `labs.google`
+  URL and the hop to `flow.google.com` is a *post-`goto`* redirect that neither settle path
+  waits for (no locale → `_settle_if_redirecting` returns immediately; a known locale →
+  `await_url_settled` short-circuits because the labs URL already matches the localised shape).
+  So the guard classified a pre-redirect URL, declined, and the run paid ~54 s before failing
+  anyway through the slow selector-probe path. Measured by the reporter on three consecutive
+  v0.66.1 runs: **57.0 / 57.1 / 58.3 s**, with `ui_driver.migrated_host_bail` absent from the
+  timeline entirely. The host check is now a shared `raise_if_migrated` helper called at the
+  three points the run is *about to spend time* — `get_ui_driver` entry, each `detect_ui_mode`
+  poll tick, and `_exit_agent_mode` once the media panel is found absent — so it adds no wait
+  and no navigation to the old host, and aborts as soon as the redirect is observable. The
+  event now names its call site, so the fast path is visible in a field timeline instead of
+  inferred. Two blanket `except Exception` handlers that would have demoted the abort to a
+  warning now re-raise it.
+
+- **A `NOT_REDIRECTED` locale cache was an absorbing state, which made the #643 `<html lang>`
+  recovery unreachable on exactly the profiles that needed it
+  ([#643](https://github.com/ffroliva/gflow-cli/issues/643)).** `_bootstrap_and_resolve_locale`
+  returned *before* `_resolve_account_locale` — the only site of that recovery and the only
+  caller of `next_locale_state` — so nothing could ever move a latched profile off the state.
+  Every profile that saw two migrated loads on ≤0.66.0 latched this way. `NOT_REDIRECTED` now
+  skips the settle only, and still reads the locale: measured 56/56 on a latched profile whose
+  page declares `lang="en"` on every load. The 4 s settle stays skipped — deleting the early
+  return outright was rejected, because on that account the cached "not redirected" is a true
+  observation.
+
+- **`docs/MCP.md` omitted `FlowHostMigratedError` from its retryable-class list**, which would
+  have told an MCP agent not to auto-retry a failure the envelope marks `retryable: true`.
+
 ## [0.66.1] — 2026-09-03
 
 ### Fixed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -50,13 +50,25 @@ callers get this for free: the failure is `FlowHostMigratedError` (exit 36) with
 `retryable: true`, so retry loops driven by the `--json` / MCP / worker error
 envelope will keep trying.
 
-**What gflow does today (v0.66.0):** recognises the migrated origin and fails
+**What gflow does today (v0.66.2):** recognises the migrated origin and fails
 with the distinct, retryable exit 36 instead of the misleading
 `UiSelectorDriftError` (exit 23, "file a selector bug"). `_check_logged_in` also
 accepts the migrated host, so a migrated load is no longer misread as a
 logged-out session. **Support for driving the new frontend is separate work and
 is not implemented** — once the rollout completes for an account, no retry will
 help until then.
+
+> **v0.66.1's fast-fail did not fire in the field, and v0.66.2 is the correction.**
+> The guard read `page.url` once, at `get_ui_driver` entry — before the hop to
+> `flow.google.com` had landed, because `project_editor_url` only builds
+> `labs.google` URLs and the redirect arrives *after* `page.goto` returns.
+> Measured by the reporter on three consecutive v0.66.1 runs: exit 36 at **57.0 /
+> 57.1 / 58.3 s**, through the slow selector-probe path. v0.66.2 re-checks the host
+> at the points the run already blocks, so the abort costs the old host nothing and
+> lands as soon as the redirect is observable. The same release stops a
+> `NOT_REDIRECTED` locale cache from disabling the `<html lang>` recovery (#643),
+> which had made that state unrecoverable on exactly the profiles it was written
+> for.
 
 ---
 

--- a/docs/LIVE_VERIFICATION_v0.66.1.md
+++ b/docs/LIVE_VERIFICATION_v0.66.1.md
@@ -3,6 +3,35 @@
 **Date:** 2026-09-03 · **Account:** ffroliva@gmail.com · **Platform:** Windows 11, Chrome strategy
 **Credits spent:** **0** — one Imagen image (images are credit-free) plus read-only probes.
 
+> ## ⚠️ Correction (2026-09-03, same day) — Layer 1's latency numbers are not user-visible
+>
+> **Layer 1 below measured `get_ui_driver` in isolation, on a page already sitting on
+> `flow.google.com`.** That precondition never holds on a real run: `project_editor_url`
+> only ever builds a `labs.google` URL and the hop to the migrated origin is a
+> *post-`goto`* redirect that neither settle path waits for, so on the CLI route the guard
+> read a pre-redirect URL and declined.
+>
+> The reporter of #639 measured the real path on three consecutive v0.66.1 runs: **57.0 /
+> 57.1 / 58.3 s**, terminating through `ui_automation_video.selector_probe_failed` — the
+> slow path — with `ui_driver.migrated_host_bail` **absent from the timeline entirely**.
+>
+> So of the rows below: `"get_ui_driver": {"ms": 0}` and **`time to exit 36 — 0 ms` are
+> true of the isolated probe and false of every CLI run.** The claim
+> *"`ui_driver.migrated_host_bail` is logged, so the fast path is observable rather than
+> inferred"* is the one the field timeline falsified — the event was never emitted, and
+> nothing here noticed because the isolated probe emitted it.
+>
+> The same gap hid the locale fix: `client.py` returned before `_resolve_account_locale`
+> on a `NOT_REDIRECTED` cache, so the `<html lang>` recovery Layer 1 exercised **directly**
+> is unreachable through the client on exactly the profiles that need it. `profile_ffroliva`
+> is latched that way today.
+>
+> Both are fixed for v0.66.2 — see
+> [`docs/superpowers/plans/2026-09-03-migrated-host-gate/`](superpowers/plans/2026-09-03-migrated-host-gate/PLAN.md).
+> **Layer 2 (no regression on the old host) stands unchanged and is still the load-bearing
+> result here.** The lesson is recorded rather than the numbers quietly edited: a function
+> measured in isolation is not a verification of the path users take.
+
 ## What had to be proven
 
 Two fixes, both on the migrated-origin path, and both verifiable live because the account is
@@ -31,10 +60,13 @@ Plus the property that matters more than either: **the old host still works.**
 | `detect_ui_mode` poll window | ~8 s | skipped |
 | crop selector cascade | ~24 s | skipped |
 | `await_url_settled` | 4018 ms | **0 ms** |
-| **time to exit 36** | **~36 s** | **0 ms** |
+| **time to exit 36** (isolated probe) | ~36 s | **0 ms** |
+| **time to exit 36** (real CLI run) | ~57 s | **~57 s — UNCHANGED, see the correction above** |
 | locale on migrated origin | `null` (and demoted a learned locale) | **`en`** recovered from `<html lang>` |
 
-`ui_driver.migrated_host_bail` is logged, so the fast path is observable rather than inferred.
+~~`ui_driver.migrated_host_bail` is logged, so the fast path is observable rather than inferred.~~
+**Retracted.** It is logged by the isolated probe and by nothing on the CLI route — the field
+timeline has no such event. Observability of a path you did not exercise is not observability.
 
 ## Layer 2 — no regression on the old host (full generation, exit 0)
 

--- a/docs/LIVE_VERIFICATION_v0.66.2.md
+++ b/docs/LIVE_VERIFICATION_v0.66.2.md
@@ -1,0 +1,128 @@
+# Live Verification — v0.66.2 (the migrated-host gate actually fires; the locale latch releases)
+
+**Date:** 2026-09-03 · **Account:** ffroliva@gmail.com · **Platform:** Windows 11, Chrome strategy
+**Credits spent:** **0** — one Imagen image (images are credit-free) plus 68 read-only navigations.
+
+## What had to be proven, and the honest constraint
+
+This release fixes two defects that v0.66.1's own verification missed, so the standard for it is
+higher than usual: **v0.66.1 measured `get_ui_driver` in isolation on an already-migrated page
+and reported `0 ms`, which was true of the probe and false of every CLI run.** See the
+correction at the top of [LIVE_VERIFICATION_v0.66.1](LIVE_VERIFICATION_v0.66.1.md).
+
+**The constraint this time is the inverse of last time.** Google's rollout flapped *back* on
+both maintainer accounts during this work:
+
+| profile | navigations | landed migrated | landed old host |
+|---|---|---|---|
+| `ffroliva` | 56 | **0** | 56 |
+| `denon82` | 12 | **0** | 12 |
+
+Measured with `scripts/dev/measure_migrated_host_flip.py` across three sweeps over ~2 hours
+(full record: [`PROBE.md`](superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md)).
+
+So **the migrated path was not reachable from this machine and is NOT live-verified here.** It
+is unit-tested and A/B-controlled only. That is stated in the NOT-verified section below rather
+than folded into the green column — which is precisely the mistake being corrected.
+
+What *is* live-verifiable today is the property that matters most: **the old host, which 100%
+of real loads currently take, is unaffected.**
+
+## Layer 1 — the locale latch releases, on a real load (fix B)
+
+`profile_ffroliva/.gflow_locale` was **empty** — `NOT_REDIRECTED`, latched — before the run.
+Under v0.66.1 that state returned before `_resolve_account_locale`, so the `<html lang>`
+recovery #643 shipped could never run on it.
+
+```
+client.account_locale_resolved   locale=en  source=html_lang
+client.account_locale_cached     locale=en  settle_skipped=true
+client.account_locale_state      was=""     now="en"
+```
+
+Three things at once, all measured, none inferred:
+
+1. **The locale was recovered from the document**, not the URL — `source=html_lang`.
+2. **The settle stayed skipped** (`settle_skipped=true`) — the #587 win is intact. This is why
+   deleting the early return (option B1) was rejected: on this account the cached "not
+   redirected" is a *true* observation, and a bounded settle would be dead time.
+3. **The latch released** — `was="" now="en"`. The on-disk cache now reads `en`.
+
+## Layer 2 — the risk that release introduces, exercised rather than assumed
+
+Recovering the locale changes what gflow navigates to: this profile previously built the **bare**
+`labs.google/fx/tools/flow/project/<id>` and now builds `/fx/en/tools/flow/project/<id>`. If
+`en` were the wrong segment, every navigation would bounce. Measured:
+
+```
+ui_automation.entering_existing_project  url=https://labs.google/fx/en/tools/flow/project/c5550ed7-…
+ui_automation.url_stable_after_goto      settle_skipped=false     (+415 ms, no redirect)
+ui_driver.ui_mode.attempt_exit_agent     (+446 ms)
+ui_driver.bound                          mode=classic             (+669 ms)
+```
+
+`url_stable_after_goto`, not `url_redirected_after_goto`: Flow accepted the segment and did not
+bounce it. **1.53 s** from entering the project to a bound driver.
+
+## Layer 3 — no regression on the old host: full generation, exit 0
+
+```
+EXIT=0    total 36.6 s   (v0.66.1 baseline on the same path: 42.2 s)
+tmp/lv662/images/2026-09-03/104b5664-…_1.jpg
+768 × 1376 JPEG · 427.8 KB · magic bytes ff d8 ff
+```
+
+Real image generated and written. The guard runs at three new call sites on this exact path and
+adds **no wait and no navigation**: `page.url` is a cached property and `flow_host_kind` is one
+parse plus a dict lookup. No `ui_driver.migrated_host_bail` event appears — correct, the host is
+`labs.google`.
+
+## Layer 4 — offline
+
+- Tests written **red first**: 4 red for the locale latch, 4 red for the host gate, before any
+  production change.
+- **A/B controls.** Neutering `raise_if_migrated` fails **exactly 7** — the flip case, the
+  agent-dismissal case, the per-Page case, the log-event case, and the three v0.66.1 entry-case
+  tests — and **no** old-host test. Restoring the pre-#639 early return fails **exactly 5** —
+  the four latch cases plus the BDD scenario. Nothing passes vacuously in either direction.
+- `1655 passed / 3 skipped` across `tests/api`, `tests/features`, `tests/mcp`, `tests/worker`.
+- `ruff check` and `ruff format --check` clean on `src tests`; `pyright src` **78 errors =
+  the `develop` baseline**, no new type errors.
+- Repo hygiene, doc links, website-docs PII, and the `website/docs` mirror all green.
+
+## Layer 5 — the MCP surface
+
+No CLI leaf, option, or request-DTO field changed, so `tests/mcp/test_cli_parity.py` needs no
+new mapping and `worker/codec.py` no new payload key — the fix is in the transport both surfaces
+share. What *is* MCP-specific is the queue envelope, which is different code from the CLI's
+`--json` path and carries the flag the reporter's orchestrator actually reads:
+
+```
+queue error record:  exit_code = 36,  retryable = True
+```
+
+Pinned by `tests/worker/test_daemon.py::test_migrated_host_error_crosses_the_queued_path`.
+`docs/MCP.md` listed the retryable classes by name and omitted `FlowHostMigratedError`; fixed,
+along with the `website/docs` mirror.
+
+Side effect worth noting: `mcp/tools.py` builds project editor links from
+`account_locale_for()`, which returned nothing on a latched profile and now returns the
+recovered locale — those links become account-correct as a consequence of fix B.
+
+## Recorded as NOT verified rather than omitted
+
+- **The migrated path firing fast.** 68/68 navigations landed on the old host, so no migrated
+  load was available to time. The gate is proven by unit tests and A/B control, **not** by a
+  live run. The instrument is committed and ready; the honest next step is either a later flap
+  or a run from the reporter's permanently-migrated account.
+- **The achieved time-to-exit-36 on a real migrated run.** Unmeasured, and deliberately not
+  estimated. The design does not depend on it: the guard sits at points the run already blocks,
+  so it costs nothing regardless of when the redirect lands. No number is claimed here.
+- **Driving the migrated frontend.** Still impossible. #639 stays open; this PR says `Refs`.
+- **A non-English latched profile recovering live.** `denon82` reads `lang=pt` and is cached
+  `"pt"` — not latched — so the latch-release path was exercised live only on `en`. The `pt`
+  case is unit-tested.
+- **The `en-GB` → `en` region reduction where region is load-bearing** (`zh-Hans`/`zh-Hant`).
+  Unchanged from v0.66.1, still flagged in the docstring, still only two locales observed.
+- **Full-suite coverage %.** The targeted suites were run without `--cov` (an unscoped
+  `pytest --cov` OOMs this machine); the 80% floor is enforced by CI.

--- a/docs/LIVE_VERIFICATION_v0.66.2.md
+++ b/docs/LIVE_VERIFICATION_v0.66.2.md
@@ -1,128 +1,169 @@
-# Live Verification — v0.66.2 (the migrated-host gate actually fires; the locale latch releases)
+# Live Verification — v0.66.2 (the migrated-host gate actually fires; the locale cache stops lying)
 
 **Date:** 2026-09-03 · **Account:** ffroliva@gmail.com · **Platform:** Windows 11, Chrome strategy
-**Credits spent:** **0** — one Imagen image (images are credit-free) plus 68 read-only navigations.
+**Credits spent:** **0** — two Imagen images (images are credit-free) plus 72 read-only navigations.
 
 ## What had to be proven, and the honest constraint
 
-This release fixes two defects that v0.66.1's own verification missed, so the standard for it is
-higher than usual: **v0.66.1 measured `get_ui_driver` in isolation on an already-migrated page
-and reported `0 ms`, which was true of the probe and false of every CLI run.** See the
-correction at the top of [LIVE_VERIFICATION_v0.66.1](LIVE_VERIFICATION_v0.66.1.md).
+This release fixes defects that v0.66.1's *own* verification missed, so the bar for it is higher
+than usual: **v0.66.1 measured `get_ui_driver` in isolation on an already-migrated page and
+reported `0 ms`, which was true of the probe and false of every CLI run.** See the correction at
+the top of [LIVE_VERIFICATION_v0.66.1](LIVE_VERIFICATION_v0.66.1.md).
 
-**The constraint this time is the inverse of last time.** Google's rollout flapped *back* on
-both maintainer accounts during this work:
+**The constraint this time is the inverse of last time.** Google's rollout flapped *back* on both
+maintainer accounts during this work:
 
 | profile | navigations | landed migrated | landed old host |
 |---|---|---|---|
-| `ffroliva` | 56 | **0** | 56 |
+| `ffroliva` | 60 | **0** | 60 |
 | `denon82` | 12 | **0** | 12 |
 
-Measured with `scripts/dev/measure_migrated_host_flip.py` across three sweeps over ~2 hours
-(full record: [`PROBE.md`](superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md)).
+Measured with `scripts/dev/measure_migrated_host_flip.py` across three sweeps on `ffroliva` and
+one on `denon82`, over ~2 hours (full record:
+[`PROBE.md`](superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md)).
 
-So **the migrated path was not reachable from this machine and is NOT live-verified here.** It
-is unit-tested and A/B-controlled only. That is stated in the NOT-verified section below rather
-than folded into the green column — which is precisely the mistake being corrected.
+So **the migrated path was not reachable from this machine and is NOT live-verified here.** It is
+unit-tested and A/B-controlled only. That is stated in the NOT-verified section below rather than
+folded into the green column — which is precisely the mistake being corrected.
 
-What *is* live-verifiable today is the property that matters most: **the old host, which 100%
-of real loads currently take, is unaffected.**
+What *is* live-verifiable is the property that matters most today: **the old host, which 100% of
+real loads currently take, is unaffected** — and the locale behaviour, which is fully exercisable.
 
-## Layer 1 — the locale latch releases, on a real load (fix B)
+## Layer 1 — the locale cache stops conflating two different questions
 
-`profile_ffroliva/.gflow_locale` was **empty** — `NOT_REDIRECTED`, latched — before the run.
-Under v0.66.1 that state returned before `_resolve_account_locale`, so the `<html lang>`
-recovery #643 shipped could never run on it.
+`profile_ffroliva/.gflow_locale` was **empty** — `NOT_REDIRECTED` — before the run. Under v0.66.1
+that state returned before `_resolve_account_locale`, so the `<html lang>` recovery #643 shipped
+could never run on it.
 
 ```
+cache before:  ''                                                    (NOT_REDIRECTED)
 client.account_locale_resolved   locale=en  source=html_lang
 client.account_locale_cached     locale=en  settle_skipped=true
-client.account_locale_state      was=""     now="en"
+cache after:   ''                                                    (NOT_REDIRECTED — unchanged)
 ```
 
-Three things at once, all measured, none inferred:
+Three things at once, all measured:
 
-1. **The locale was recovered from the document**, not the URL — `source=html_lang`.
-2. **The settle stayed skipped** (`settle_skipped=true`) — the #587 win is intact. This is why
-   deleting the early return (option B1) was rejected: on this account the cached "not
-   redirected" is a *true* observation, and a bounded settle would be dead time.
-3. **The latch released** — `was="" now="en"`. The on-disk cache now reads `en`.
+1. **The locale is recovered from the document**, not the URL — `source=html_lang`. The latch no
+   longer blocks it.
+2. **The settle stays skipped** (`settle_skipped=true`). The #587 win is intact — which is why
+   deleting the early return outright was rejected: on this account "not redirected" is a *true*
+   observation, confirmed 60/60.
+3. **The cached state is unchanged.** This is the correction the council forced (see below): the
+   cache answers *"does Flow redirect this account?"*, and a `<html lang>` attribute is no
+   evidence of a redirect — every account has one.
 
-## Layer 2 — the risk that release introduces, exercised rather than assumed
+### The regression the council caught, and the measurement that proved it
+
+The first cut of this fix folded the recovered locale into the cache. Two independent reviewers
+(D1 correctness, D4 tests) flagged it; `scripts/dev/measure_locale_probe.py` then reproduced it
+without being asked:
+
+```
+BEFORE:  ffroliva  warm  7.41s   cached 'en'    !! warm arm slower than cold — investigate
+                                 transport.url_settle_gave_up  timeout_ms=4000.0   (x2)
+
+AFTER:   ffroliva  cold  6.99s   cached '?'
+         ffroliva  warm  2.66s   cached ''      settle off, locale still 'en'
+```
+
+Writing the locale in flipped `cached != NOT_REDIRECTED`, which turned the settle back on
+permanently and cost the full 4 s `URL_SETTLE_TIMEOUT_MS` on every future bootstrap — the exact
+cost #587 exists to remove.
+
+**Tracing it found a live defect in v0.66.1 itself, present on `develop` today.** #643's
+`<html lang>` fallback returns a segment for an account Flow serves *bare* and never redirects, and
+`next_locale_state` recorded that as evidence of a redirect. So **any** non-redirecting account
+with a `lang` attribute has been paying 4 s per bootstrap since v0.66.1 — no latch required. The
+fix folds only the **URL-derived** segment into the state; the lang-derived one is used in-process
+for URL building and never persisted.
+
+## Layer 2 — the risk this fix introduces, exercised rather than assumed
 
 Recovering the locale changes what gflow navigates to: this profile previously built the **bare**
-`labs.google/fx/tools/flow/project/<id>` and now builds `/fx/en/tools/flow/project/<id>`. If
-`en` were the wrong segment, every navigation would bounce. Measured:
+`labs.google/fx/tools/flow/project/<id>` and now builds `/fx/en/tools/flow/project/<id>`. If `en`
+were the wrong segment, every navigation would bounce.
 
 ```
 ui_automation.entering_existing_project  url=https://labs.google/fx/en/tools/flow/project/c5550ed7-…
-ui_automation.url_stable_after_goto      settle_skipped=false     (+415 ms, no redirect)
-ui_driver.ui_mode.attempt_exit_agent     (+446 ms)
-ui_driver.bound                          mode=classic             (+669 ms)
+ui_automation.url_stable_after_goto      same URL, +549 ms, settle_skipped=false
+ui_driver.ui_mode.attempt_exit_agent     +507 ms
+ui_driver.bound                          mode=classic
 ```
 
-`url_stable_after_goto`, not `url_redirected_after_goto`: Flow accepted the segment and did not
-bounce it. **1.53 s** from entering the project to a bound driver.
+`url_stable_after_goto`, **not** `url_redirected_after_goto`: Flow accepted the segment and did
+not bounce it. Confirmed on both live runs.
 
-## Layer 3 — no regression on the old host: full generation, exit 0
+## Layer 3 — no regression on the old host: full generation, exit 0, twice
 
 ```
-EXIT=0    total 36.6 s   (v0.66.1 baseline on the same path: 42.2 s)
-tmp/lv662/images/2026-09-03/104b5664-…_1.jpg
-768 × 1376 JPEG · 427.8 KB · magic bytes ff d8 ff
+run 1 (pre-council-fix build)   EXIT=0   768×1376 JPEG · 427.8 KB · ff d8 ff
+run 2 (final build)             EXIT=0   768×1376 JPEG · 413.5 KB · ff d8 ff
 ```
 
-Real image generated and written. The guard runs at three new call sites on this exact path and
-adds **no wait and no navigation**: `page.url` is a cached property and `flow_host_kind` is one
-parse plus a dict lookup. No `ui_driver.migrated_host_bail` event appears — correct, the host is
-`labs.google`.
+Real images generated and written; `ui_driver.bound  mode=classic` on both; no
+`ui_driver.migrated_host_bail` event on either — correct, the host is `labs.google`.
+
+**On wall-clock:** run 1 took 36.6 s and run 2 took 86 s, and **neither number is evidence about
+this diff.** Run 2's extra time is Flow's own generation latency plus a 34.4 s
+`browser_teardown.context_close_error` — a bounded Chrome-close timeout at `api/_engine.py:159`
+that fires *after* all generation work, is already handled (warning → force close → exit 0), and
+is untouched by this branch. A single-run timing delta sits well inside that variance, so the
+"adds no wait" claim rests on the A/B control and on code shape (`page.url` is a cached property;
+`flow_host_kind` is one `urlsplit` plus a dict lookup; `_media_panel_present` uses `.count()` and
+does not wait) — **not** on the totals. Claiming "faster" from these runs would repeat exactly the
+error this release corrects.
 
 ## Layer 4 — offline
 
 - Tests written **red first**: 4 red for the locale latch, 4 red for the host gate, before any
   production change.
-- **A/B controls.** Neutering `raise_if_migrated` fails **exactly 7** — the flip case, the
-  agent-dismissal case, the per-Page case, the log-event case, and the three v0.66.1 entry-case
-  tests — and **no** old-host test. Restoring the pre-#639 early return fails **exactly 5** —
-  the four latch cases plus the BDD scenario. Nothing passes vacuously in either direction.
-- `1655 passed / 3 skipped` across `tests/api`, `tests/features`, `tests/mcp`, `tests/worker`.
-- `ruff check` and `ruff format --check` clean on `src tests`; `pyright src` **78 errors =
-  the `develop` baseline**, no new type errors.
-- Repo hygiene, doc links, website-docs PII, and the `website/docs` mirror all green.
+- **A/B controls**, re-derived independently by a council reviewer with its own harness:
+  neutering `raise_if_migrated` fails **exactly 7** and **no** old-host test; restoring the
+  pre-#639 early return fails **exactly 5**. Nothing passes vacuously in either direction.
+- The council's must-fix added two more tests that would have caught the regression it found:
+  a two-bootstrap cycle (one bootstrap cannot observe a cache flipping the settle back on), and
+  a lang-only-locale case pinning that a `lang` attribute is not evidence of a redirect.
+- `ruff check` / `ruff format --check` clean on `src tests`; `pyright src` at the `develop`
+  baseline; repo hygiene, doc links, website-docs PII, and the `website/docs` mirror all green.
 
 ## Layer 5 — the MCP surface
 
-No CLI leaf, option, or request-DTO field changed, so `tests/mcp/test_cli_parity.py` needs no
-new mapping and `worker/codec.py` no new payload key — the fix is in the transport both surfaces
-share. What *is* MCP-specific is the queue envelope, which is different code from the CLI's
-`--json` path and carries the flag the reporter's orchestrator actually reads:
+No CLI leaf, option, or request-DTO field changed, so `tests/mcp/test_cli_parity.py` needs no new
+mapping and `worker/codec.py` no new payload key — the fix is in the transport both surfaces
+share (independently traced by the parity reviewer: `worker/daemon.py` and `mcp/tools.py` both
+construct the same `FlowApiClient`). What *is* MCP-specific is the queue envelope, different code
+from the CLI's `--json` path, carrying the flag the reporter's orchestrator actually reads:
 
 ```
 queue error record:  exit_code = 36,  retryable = True
 ```
 
-Pinned by `tests/worker/test_daemon.py::test_migrated_host_error_crosses_the_queued_path`.
-`docs/MCP.md` listed the retryable classes by name and omitted `FlowHostMigratedError`; fixed,
-along with the `website/docs` mirror.
+Pinned by `tests/worker/test_daemon.py::test_migrated_host_error_crosses_the_queued_path`. Noted
+honestly: that test pins the write side; the `wait=True` read-back in `mcp/tools.py` is generic
+code exercised by its neighbours, so the round trip is pinned end-to-end only by construction.
 
-Side effect worth noting: `mcp/tools.py` builds project editor links from
-`account_locale_for()`, which returned nothing on a latched profile and now returns the
-recovered locale — those links become account-correct as a consequence of fix B.
+`docs/MCP.md` listed the retryable classes by name and omitted three of them
+(`FlowHostMigratedError`, `UiModeUnavailableError`, `SyncPartialError`); the list now matches
+`errors.RETRYABLE_ERRORS` exactly, mirror regenerated.
+
+Side effect: `mcp/tools.py` builds project editor links from `account_locale_for()`, which reads
+the *cached* state. Because the lang-derived locale is deliberately not persisted, those links are
+unchanged by this branch — the earlier claim that they become "account-correct" was wrong and is
+retracted here rather than shipped.
 
 ## Recorded as NOT verified rather than omitted
 
-- **The migrated path firing fast.** 68/68 navigations landed on the old host, so no migrated
-  load was available to time. The gate is proven by unit tests and A/B control, **not** by a
-  live run. The instrument is committed and ready; the honest next step is either a later flap
-  or a run from the reporter's permanently-migrated account.
+- **The migrated path firing fast.** 72/72 navigations landed on the old host, so no migrated load
+  was available to time. The gate is proven by unit tests and A/B control, **not** by a live run.
+  The instrument is committed; the honest next step is a later flap or a run from the reporter's
+  permanently-migrated account.
 - **The achieved time-to-exit-36 on a real migrated run.** Unmeasured, and deliberately not
-  estimated. The design does not depend on it: the guard sits at points the run already blocks,
-  so it costs nothing regardless of when the redirect lands. No number is claimed here.
+  estimated. The design does not depend on it — the guard sits where the run already blocks.
 - **Driving the migrated frontend.** Still impossible. #639 stays open; this PR says `Refs`.
-- **A non-English latched profile recovering live.** `denon82` reads `lang=pt` and is cached
-  `"pt"` — not latched — so the latch-release path was exercised live only on `en`. The `pt`
-  case is unit-tested.
+- **A non-English profile recovering live.** `denon82` is cached `"pt"` (it genuinely redirects),
+  so the lang-recovery path was exercised live only on `en`. The `pt` case is unit-tested.
 - **The `en-GB` → `en` region reduction where region is load-bearing** (`zh-Hans`/`zh-Hant`).
-  Unchanged from v0.66.1, still flagged in the docstring, still only two locales observed.
-- **Full-suite coverage %.** The targeted suites were run without `--cov` (an unscoped
-  `pytest --cov` OOMs this machine); the 80% floor is enforced by CI.
+  Unchanged from v0.66.1, still only two locales observed.
+- **Full-suite coverage %.** The targeted suites ran without `--cov` (an unscoped `pytest --cov`
+  OOMs this machine); the 80% floor is enforced by CI.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -127,7 +127,10 @@ marks a transient failure a scheduler can re-run without operator intervention â
 WAF/reCAPTCHA bounce (`WafRejectionError`), rate-limit (`RateLimitError`),
 transport timeout (`TransportTimeoutError`), network blip (`NetworkError`), a
 dropped browser session (`BrowserSessionClosedError`), a Flow web-app crash
-(`FlowAppError`), and an agentic-cohort flap (`FlowAgentUiError`). Everything
+(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), and a page load
+served by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
+[#639](https://github.com/ffroliva/gflow-cli/issues/639) â€” the rollout flaps per
+page load, so a retry often lands the frontend gflow can drive). Everything
 else (auth, content-policy, configuration, security) is terminal
 (`retryable: false`): retrying the identical request fails the same way. This
 flag is the **same shared classification** the CLI `--json` payload and the

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -127,10 +127,13 @@ marks a transient failure a scheduler can re-run without operator intervention â
 WAF/reCAPTCHA bounce (`WafRejectionError`), rate-limit (`RateLimitError`),
 transport timeout (`TransportTimeoutError`), network blip (`NetworkError`), a
 dropped browser session (`BrowserSessionClosedError`), a Flow web-app crash
-(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), and a page load
-served by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
+(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), a page load served
+by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
 [#639](https://github.com/ffroliva/gflow-cli/issues/639) â€” the rollout flaps per
-page load, so a retry often lands the frontend gflow can drive). Everything
+page load, so a retry often lands the frontend gflow can drive), an unreachable
+UI arm (`UiModeUnavailableError`), and a partially-completed sync
+(`SyncPartialError`). That list is the whole of `errors.RETRYABLE_ERRORS`.
+Everything
 else (auth, content-policy, configuration, security) is terminal
 (`retryable: false`): retrying the identical request fails the same way. This
 flag is the **same shared classification** the CLI `--json` payload and the

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/ASSESSMENT.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/ASSESSMENT.md
@@ -1,0 +1,138 @@
+# Assessment of #639 (update of 2026-09-03T12:51Z) — `CONFIRMED-BUG` ×2
+
+**Scope:** the reporter's third section — "0.66.1 fast-fail not engaging on the `image t2i`
+path" — plus a second defect their locale note exposes. Read-only; nothing changed, nothing
+posted.
+
+---
+
+## Verdict table
+
+| Reporter item | Verdict | Confidence |
+|---|---|---|
+| 1. Anchor holds on a populated project (`button:has(.google-symbols:text('crop_16_9'))` = 1 while `aria-haspopup='menu'` grows 5→51) | `ACCEPTED — data for #642` | — |
+| 2. `document.documentElement.lang -> "pt"` on a live pt-BR migrated load | `ACCEPTED`, but it does **not** close the NOT-verified row (see B) | — |
+| 3. v0.66.1 fast-fail never engages on the real CLI route | **`CONFIRMED-BUG`** (A) | 9/10 |
+| — (implied by their `locale: null` note) | **`CONFIRMED-BUG`** (B) | 9/10 |
+
+---
+
+## A. The v0.66.1 fast-fail is unreachable on every real navigation
+
+The bail exists and is correct: `drivers/factory.py:155-175` raises `FlowHostMigratedError`
+when `flow_host_kind(page.url) == "migrated"`, logging `ui_driver.migrated_host_bail` first.
+
+It never fires from the CLI because **`page.url` is still `labs.google` when it is read.**
+
+Every project navigation is built against labs.google — `routes.project_editor_url()`
+(`routes.py:247-270`) has no migrated form at all — and the hop to `flow.google.com` is a
+*post-`goto`* redirect. `_enter_editor` (`ui_automation.py:1431-1441`) then declines to wait
+for it, **on both branches**:
+
+| account state | URL handed to `goto` | what settles it | result |
+|---|---|---|---|
+| locale unknown (`None`) | bare `labs.google/fx/tools/flow/project/<id>` | `_settle_if_redirecting` returns `None` immediately (`ui_automation.py:1400-1402`) | no wait at all |
+| locale known (`"pt"`) | `labs.google/fx/pt/tools/flow/project/<id>` | `await_url_settled` short-circuits — the URL **already matches** `FLOW_LOCALISED_URL_RE` (`_common.py:219-224`, regex `routes.py:180`) | returns instantly |
+
+So `get_ui_driver` is called ~240 ms after `goto` with a pre-redirect URL, `flow_host_kind`
+answers `"labs"`, and the run pays the full doomed sequence (~54 s) before
+`_mode_switch_error` (`ui_automation_video.py:1459`) re-reads `page.url` — migrated by then —
+and returns the right class, slowly. The v0.66.0 slow path is what the reporter is seeing;
+v0.66.1 changed nothing on this route.
+
+**The reporter's timeline is the proof, by elimination.** `ui_driver.migrated_host_bail` is
+absent; `ui_driver.ui_mode.attempt_exit_agent` (`factory.py:186` — *after* the bail) is
+present at 3.149 s. The bail was evaluated and declined.
+
+### `docs/LIVE_VERIFICATION_v0.66.1.md` is wrong about the user-visible number
+
+Layer 1 measured `get_ui_driver` **in isolation, on a page already sitting on
+flow.google.com**. Its `"ms": 0` and the table row `time to exit 36 — 0 ms` are true of that
+probe and false of every CLI run. The doc's own line — *"`ui_driver.migrated_host_bail` is
+logged, so the fast path is observable rather than inferred"* — is exactly the observation
+the reporter's timeline falsifies in the field. Correct the doc regardless of when the code
+is fixed.
+
+## B. `NOT_REDIRECTED` is an absorbing state, so the #643 `<html lang>` fix is dead code where it is needed
+
+`_read_account_locale` (`client.py:772-776`) returns **before** `_resolve_account_locale` when
+the cached state is `NOT_REDIRECTED`:
+
+```python
+if cached == NOT_REDIRECTED:
+    self._account_locale = None
+    logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
+    return
+```
+
+`_resolve_account_locale` is the **only** caller of `next_locale_state` and the **only** site
+of the new `<html lang>` recovery (`client.py:800-812`). Nothing else writes the locale file.
+So once a profile reaches `NOT_REDIRECTED` there is no transition out of it — the state is
+terminal by construction.
+
+And any profile that saw two migrated loads on ≤0.66.0 is already latched:
+`"pt"` → (observed `None`) → `PROVISIONAL` → (observed `None`) → `NOT_REDIRECTED`
+(`profile_store.py:320-333`). That is precisely the population #643 was written for.
+
+This is exactly what the reporter measured: `client.account_locale_cached  locale: null` on
+0.66.1, with the fix installed. Their `html lang -> "pt"` result confirms the *input* is
+there; it does not show gflow recovers it, because on their latched profile the recovery code
+never runs. **The NOT-verified row in `LIVE_VERIFICATION_v0.66.1.md` stays open.**
+
+> Their aside — "it fires at 1.7 s, before the project navigation at 2.5 s, so there is no
+> `<html lang>` to read yet" — is a fair reading but not the cause. The bootstrap `goto`
+> (`routes.EDITOR_BOOTSTRAP_URL`) completes before that log line, so a document *is* loaded;
+> the probe is skipped by the cache branch, not by timing.
+
+**A and B are independent.** B is not a prerequisite for A — A reproduces on a
+resolved-locale account through the regex short-circuit.
+
+---
+
+## Surfaces
+
+**CLI and MCP both.** `_enter_editor` → `get_ui_driver` is the single shared sequence at
+`ui_automation.py:2803/2823`, `3230/3269` and `ui_automation_video.py:3944`; the MCP worker
+drives the same transport. Shared-transport case — **one fix repairs both**, and no separate
+MCP change is implied.
+
+## Correction to the reporter (worth sending)
+
+`ui_automation_video.selector_probe_failed` on an `image t2i` run is not a routing bug. The
+image path deliberately shares `VideoGenerationMixin._mode_switch_error`
+(`ui_automation.py:1546` → `ui_automation_video.py:1434`); only the module-prefixed event
+name is misleading.
+
+## Their item 1 (anchors) — routed, not assessed here
+
+Belongs to #642. It answers the over-match question **on the migrated side**: three candidate
+anchors hold at exactly 1 while the `aria-haspopup='menu'` population grows 10×, because the
+per-tile menus carry no `crop_16_9` descendant. The **old-host** half is now unanswerable from
+either account — both have migrated — so classic fixtures are the remaining route.
+
+---
+
+## e2e-gate
+
+| To prove | Cost | Available here? |
+|---|---|---|
+| A fixed: exit 36 in ~3 s on a real migrated `image t2i` | headed Flow browser, migrated account | **yes** — this account is migrated |
+| B fixed: locale recovered on a latched profile | headed browser, latched profile | **yes** — reproduce by writing `NOT_REDIRECTED` into the profile's locale file |
+| No regression on the **old host** | headed browser, non-migrated account | **no** — both accounts have migrated. Classic fixtures + the reporter's offer are the only routes |
+| The `pt` recovery end to end | headed browser, pt-BR migrated account | **no** — reporter's account only |
+
+The old-host regression check is the gate that cannot be closed locally, and it is the one
+that matters: A's fix changes navigation settle behaviour on the path that still works.
+
+## Hand-off
+
+Verdict `CONFIRMED-BUG`, localized (three files), fix live-verifiable here on the migrated
+side. Both defects sit in the shared navigation/transport path with an unverifiable
+old-host regression surface → **Phase 2 first.**
+
+➔ `/gflow:predict "settle the migrated-origin redirect before the host gate; make
+NOT_REDIRECTED recoverable"` → then `/gflow:issue-resolve 639`.
+
+The question predict has to answer is not which selector — it is **where the host becomes
+knowable without reintroducing dead time on the accounts that still work**, given that the
+regression surface cannot be measured from this machine.

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PLAN.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PLAN.md
@@ -17,17 +17,17 @@ Nothing else changes: no new navigation target, no new cache, no new CLI option,
 
 **Predict verdict:** **CAUTION — 7/10** (`PREDICT.md`)
 **Scenario:** `SCENARIO.md` in this directory — 20 scenarios, 10 must-cover.
-**Probe evidence:** `PROBE.md` — 68 navigations, two profiles, zero
+**Probe evidence:** `PROBE.md` — 72 navigations, two profiles, zero
 migrated loads.
 
 **Rejected in predict, recorded so nobody re-proposes them:**
 
 | Rejected | Why |
 |---|---|
-| **A1** bounded settle | 68/68 measured navigations had **no post-`goto` URL change at all** — the bound would be pure dead time on every navigation, at all four `_settle_if_redirecting` sites. This is the #587 regression re-created for a second signal. |
+| **A1** bounded settle | 72/72 measured navigations had **no post-`goto` URL change at all** — the bound would be pure dead time on every navigation, at all four `_settle_if_redirecting` sites. This is the #587 regression re-created for a second signal. |
 | **A3** cache "migrated", navigate straight to `flow.google.com` | Would have locked **both** maintainer accounts out of a working frontend today. Converts a flapping, retry-recoverable failure into a permanent one, and makes `FlowHostMigratedError`'s own remediation text false. |
 | **A4** `framenavigated` listener | Buys nothing without an event-driven rewrite the call chain does not have; introduces cross-module shared mutable state (`docs/ARCHITECTURE.md:45`). |
-| **B1** delete the `NOT_REDIRECTED` early return | `ffroliva` is latched **and correct** — measured 56/56 bare-URL loads with no redirect. B1 would reintroduce a 4 s settle on an account with nothing to settle. |
+| **B1** delete the `NOT_REDIRECTED` early return | `ffroliva` is latched **and correct** — measured 60/60 bare-URL loads with no redirect. B1 would reintroduce a 4 s settle on an account with nothing to settle. |
 
 **Risk register:**
 

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PLAN.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PLAN.md
@@ -1,0 +1,265 @@
+# Migrated-Host Gate Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature migrated-host-gate` to find the next
+> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** On a migrated `flow.google.com` load, `gflow` fails with exit 36 at the first moment
+the host is knowable instead of after ~57 s of doomed probing — and a profile latched at
+`NOT_REDIRECTED` can still learn its locale from `<html lang>`.
+
+**Architecture:** Two independent fixes in the shared transport, so CLI and MCP are repaired
+together. **A2** extracts the existing one-shot host check in `drivers/factory.py` into a shared
+`raise_if_migrated(page)` helper beside `flow_host_kind` in `transports/_common.py`, and calls it
+at the three points the run is **about to spend time** — all free, none adding a wait. **B2**
+gives `_resolve_account_locale` a `settle` flag so the `NOT_REDIRECTED` cache skips the *settle*
+without skipping the *locale read*, making the shipped #643 `<html lang>` recovery reachable.
+Nothing else changes: no new navigation target, no new cache, no new CLI option, no new exit code.
+
+**Predict verdict:** **CAUTION — 7/10** (`PREDICT.md`)
+**Scenario:** `SCENARIO.md` in this directory — 20 scenarios, 10 must-cover.
+**Probe evidence:** `PROBE.md` — 68 navigations, two profiles, zero
+migrated loads.
+
+**Rejected in predict, recorded so nobody re-proposes them:**
+
+| Rejected | Why |
+|---|---|
+| **A1** bounded settle | 68/68 measured navigations had **no post-`goto` URL change at all** — the bound would be pure dead time on every navigation, at all four `_settle_if_redirecting` sites. This is the #587 regression re-created for a second signal. |
+| **A3** cache "migrated", navigate straight to `flow.google.com` | Would have locked **both** maintainer accounts out of a working frontend today. Converts a flapping, retry-recoverable failure into a permanent one, and makes `FlowHostMigratedError`'s own remediation text false. |
+| **A4** `framenavigated` listener | Buys nothing without an event-driven rewrite the call chain does not have; introduces cross-module shared mutable state (`docs/ARCHITECTURE.md:45`). |
+| **B1** delete the `NOT_REDIRECTED` early return | `ffroliva` is latched **and correct** — measured 56/56 bare-URL loads with no redirect. B1 would reintroduce a 4 s settle on an account with nothing to settle. |
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| **Critical** | A regression on the old host — the only path that still works, and the one 100% of today's loads take | Old-host live run is the **merge gate** (Task 8). The guard adds zero waits and zero navigations; every new call site is a `urlsplit` + dict lookup. |
+| **Critical** | Repeating v0.66.1's mistake: green tests + broken field path, because every existing bail test hands in an **already-migrated** URL | Task 1 adds a red-first test whose URL **starts** on `labs.google` and **flips**. |
+| **Critical** | Claiming a time-to-exit-36 the code does not deliver | No number is written down that did not come from a real CLI run. Task 7 corrects `LIVE_VERIFICATION_v0.66.1.md`'s `0 ms` row in the same PR. |
+| **High** | Latched profiles stay blind to the host signal | Performance persona's scoped STOP: **B2 lands before A2** (Task 4 before Task 5). |
+| **High** | `raise_if_migrated` raising from a shared helper aborts a path that was fine | Only three call sites, each already a "we are about to burn time" point. Not added to `_probe_selector_cascade` in this plan — deferred to Task 9 behind a measurement. |
+| **High** | `<html lang>` is page-controlled input that ends in a URL path; `write_account_locale` writes verbatim | Sanitise via `locale_segment_from_lang_attr` **before** `next_locale_state` / `write_account_locale` — reuse, do not re-implement. |
+| Medium | The achieved latency is unknown because the flip timing was never measured | Instrument exists (`scripts/dev/measure_migrated_host_flip.py`). Report what a real run shows; if no migrated load is reachable, report it as unmeasured. |
+| Medium | `docs/MCP.md` retryable list omits `FlowHostMigratedError` — becomes user-visible the moment exit 36 actually fires | Task 7, plus the `website/docs/` mirror. |
+
+---
+
+## File structure
+
+### New files
+```
+tests/api/transports/test_migrated_host_gate.py
+  A2: the flip case, the per-Page case, the unreadable-URL case, the new log event.
+tests/features/migrated_host_gate.feature
+  BDD for both fixes (Critical + High scenarios).
+scripts/dev/measure_migrated_host_flip.py            [already written this session]
+  Live instrument: when does page.url flip after goto? Zero credits.
+```
+
+### Modified files
+```
+src/gflow_cli/api/transports/_common.py
+  + raise_if_migrated(page) beside flow_host_kind — the single guard, one log event.
+src/gflow_cli/api/transports/drivers/factory.py
+  get_ui_driver's inline bail -> raise_if_migrated; add a tick-level check in detect_ui_mode.
+src/gflow_cli/api/transports/ui_automation_video.py
+  _exit_agent_mode: guard AFTER the media panel is found absent, BEFORE _dismiss_agent_affordances.
+src/gflow_cli/api/client.py
+  _read_account_locale / _resolve_account_locale: settle flag; NOT_REDIRECTED skips the settle only.
+tests/api/test_client_locale_cache.py
+  New cases; test_cached_no_redirect_skips_the_probe_entirely needs renaming and re-aiming.
+tests/api/transports/drivers/test_ui_mode.py
+  Existing bail tests stay (they cover the entry case); add the flip case in the new file.
+docs/MCP.md + website/docs/MCP.md · KNOWN_ISSUES.md · docs/LIVE_VERIFICATION_v0.66.1.md · CHANGELOG.md
+```
+
+---
+
+## Task 1 — A2 red tests (no production code)
+
+**What:** Encode the field precondition the v0.66.1 tests missed.
+
+**Files:** `tests/api/transports/test_migrated_host_gate.py`
+
+**Steps:**
+- [ ] Build a fake Page whose `.url` returns `labs.google/...` on the first read and
+      `flow.google.com/project/<id>` on subsequent reads — the flip, not a static migrated URL.
+- [ ] Assert against the real `get_ui_driver` / `detect_ui_mode` / `_exit_agent_mode` entry points.
+
+**Tests created (red):**
+- [ ] `test_a_flip_after_entry_still_raises_exit_36` (S#1) — URL starts labs, flips before the
+      first blocking wait → `FlowHostMigratedError`, exit 36, `retryable`, **not** `UiSelectorDriftError`.
+- [ ] `test_the_flip_is_caught_before_the_agent_dismissal_burns` (S#1) — once the media panel is
+      absent and the URL has flipped, `_dismiss_agent_affordances` is never entered.
+- [ ] `test_old_host_adds_no_wait_and_no_navigation` (S#2) — no `wait_for_url`, no `goto`, no extra
+      `evaluate` on a labs-only page.
+- [ ] `test_guard_reads_the_page_it_is_about_to_drive` (S#5) — two Pages, different hosts; a bail on
+      one does not abort the other. No module-level flag.
+- [ ] `test_unreadable_url_is_never_migrated` (S#8) — non-str `.url` keeps probing.
+- [ ] `test_bail_emits_a_stable_event_naming_the_before_and_after_url` (S#13).
+- [ ] `test_entry_case_still_bails_immediately` (S#14) — no regression on the path v0.66.1 covered.
+
+---
+
+## Task 2 — B2 red tests (no production code)
+
+**What:** Encode the latch cases, including the one that must **not** change.
+
+**Files:** `tests/api/test_client_locale_cache.py`
+
+**Steps:**
+- [ ] Re-aim `test_cached_no_redirect_skips_the_probe_entirely` — its name asserts the defect.
+      Rename to `..._skips_the_settle_but_still_reads_the_lang_attr` and invert the assertion.
+
+**Tests created (red):**
+- [ ] `test_a_latched_profile_recovers_its_locale_from_lang` (S#3) — cached `NOT_REDIRECTED`,
+      `<html lang>` = `pt` → resolves `pt`, written through `next_locale_state`.
+- [ ] `test_a_latched_profile_still_skips_the_settle` (S#4) — `await_url_settled` is **not** called.
+      This is the #587 anti-regression; it is why B1 was rejected.
+- [ ] `test_a_latched_profile_with_no_lang_stays_latched` (S#9) — empty/absent → state unchanged.
+- [ ] `test_a_lang_probe_failure_never_breaks_bootstrap` (S#10).
+- [ ] `test_a_lang_with_separators_is_rejected_before_it_is_written` (S#12) — sanitised via
+      `locale_segment_from_lang_attr` before `write_account_locale`.
+- [ ] `test_zh_hans_reduces_to_zh_without_crashing` (S#11) — known-wrong, must not regress to a crash.
+
+---
+
+## Task 3 — BDD scaffold (red)
+
+**What:** The Gherkin from `SCENARIO.md`.
+
+**Files:** `tests/features/migrated_host_gate.feature` + step defs
+
+**Steps:**
+- [ ] Copy the two `Feature:` blocks from `SCENARIO.md` verbatim.
+- [ ] Mirror runtime signatures in the fakes (memory: `bdd-stubs-mirror-runtime-signatures`).
+
+---
+
+## Task 4 — B2 implementation (**must land before Task 5**)
+
+**What:** `NOT_REDIRECTED` skips the settle, not the locale read.
+
+**Files:** `src/gflow_cli/api/client.py`
+
+**Steps:**
+- [ ] Add `settle: bool = True` to `_resolve_account_locale`; when `False`, skip
+      `await_url_settled` and go straight to the `<html lang>` branch.
+- [ ] In `_read_account_locale`, replace the `cached == NOT_REDIRECTED` **early return** with a
+      call carrying `settle=False`; keep folding through `next_locale_state` and
+      `write_account_locale` so `NOT_REDIRECTED` un-latches when a locale is actually observed.
+- [ ] Update the `client.account_locale_cached` log line — `settle_skipped=True` stays true, but
+      `locale` must now report what was read, not an unconditional `None`.
+- [ ] Update `profile_store.next_locale_state`'s "unreachable from the client" comment
+      (`profile_store.py:330-332`) — it is now reachable, and that is the point.
+
+**Tests:** Task 2 goes green. No test from Task 1 changes.
+
+---
+
+## Task 5 — A2 implementation
+
+**What:** One shared guard, called where the run is about to spend time.
+
+**Files:** `_common.py`, `drivers/factory.py`, `ui_automation_video.py`
+
+**Steps:**
+- [ ] Add `raise_if_migrated(page, *, at: str) -> None` to `_common.py` beside `flow_host_kind`:
+      classify `getattr(page, "url", None)`, and on `"migrated"` log one stable event carrying
+      `at` and the URL, then raise `FlowHostMigratedError` with the existing detail text.
+- [ ] `drivers/factory.py`: replace the inline block (`factory.py:155-175`) with
+      `raise_if_migrated(page, at="get_ui_driver")`. Behaviour on an already-migrated entry URL is
+      unchanged — `ui_driver.migrated_host_bail` must still be the event name for that case.
+- [ ] `drivers/factory.py`: call it once per `detect_ui_mode` poll tick (`factory.py:114-122`).
+      Free — the loop already awaits `poll_interval_s`.
+- [ ] `ui_automation_video.py::_exit_agent_mode`: call it **after** the first
+      `_media_panel_present` returns `False` and **before** `_dismiss_agent_affordances`
+      (`ui_automation_video.py:1527-1531`). `_media_panel_present` uses `.count()` and does not
+      wait, so this costs nothing on the old host and skips the ~10.6 s dismissal when the flip
+      has already landed.
+- [ ] Do **not** add the guard to `_probe_selector_cascade` in this task — ten call sites, some
+      best-effort. Deferred to Task 9.
+
+**Tests:** Task 1 and Task 3 go green.
+
+---
+
+## Task 6 — MCP surface (verification, not mirroring)
+
+**What:** State and prove the MCP position rather than assume it.
+
+**Steps:**
+- [ ] Confirm no CLI leaf, option, or request-DTO field changes → `tests/mcp/test_cli_parity.py`
+      needs no new mapping and `worker/codec.py` no new payload key. Record this explicitly in the
+      PR body; silence here is what let #626 ship.
+- [ ] Audit `mcp/tools.py` docstrings for any claim these fixes falsify. Expected: none.
+- [ ] Run `/gflow:check` step 1b — the six mirror axes (canonical list:
+      `skills/check/SKILL.md`). Do not restate them here.
+
+**Tests:**
+- [ ] `test_migrated_host_error_crosses_the_queued_path_with_exit_code_and_retryable` (S#15) —
+      the task error record carries `exit_code: 36` **and** `retryable: true`
+      (`worker/daemon.py:449-459` → `mcp/tools.py:306-401`).
+
+---
+
+## Task 7 — Docs
+
+**Files:** `docs/MCP.md`, `website/docs/MCP.md`, `KNOWN_ISSUES.md`,
+`docs/LIVE_VERIFICATION_v0.66.1.md`, `CHANGELOG.md`
+
+**Steps:**
+- [ ] Add `FlowHostMigratedError` to the retryable list (`docs/MCP.md:127-131`) **and** regenerate
+      the `website/docs/` mirror (`generate_website_docs.py --check` is a CI gate).
+- [ ] **Correct `docs/LIVE_VERIFICATION_v0.66.1.md`**: the `get_ui_driver … "ms": 0` figure and the
+      `time to exit 36 — 0 ms` row were measured on the function **in isolation on an
+      already-migrated page**, not on the CLI route, where the field shows ~57 s. Say so plainly and
+      state what the corrected number is. Its line *"`ui_driver.migrated_host_bail` is logged, so
+      the fast path is observable rather than inferred"* is the claim the reporter's timeline
+      falsified — replace it, do not soften it.
+- [ ] `KNOWN_ISSUES.md` #639 entry: the "What gflow does today (v0.66.0)" paragraph implies a
+      fast-fail that has never fired in the field. Update to what actually ships.
+- [ ] `CHANGELOG.md` `[Unreleased]` — both fixes, `Refs #639`, `Refs #643`.
+- [ ] Do **not** close #639 or #643. #639 stays open for the undrivable frontend; #643 is only now
+      reachable on latched profiles.
+
+---
+
+## Task 8 — Gates + live verification
+
+**Steps:**
+- [ ] `/gflow:check` green (hygiene, doc links, website mirror, ruff, format, pyright, pytest ≥80%).
+- [ ] **Merge gate — old-host live run**, reachable today: a real `gflow image t2i` on `labs.google`
+      completing exit 0 with a real image, plus the event timeline showing **no added wait**.
+- [ ] Re-run `scripts/dev/measure_migrated_host_flip.py` to record whether any migrated load was
+      reachable during verification.
+- [ ] Write `docs/LIVE_VERIFICATION_v0.66.2.md` with an explicit **NOT verified** section: if no
+      migrated load was reachable, the migrated path is unit-tested only. Say that; do not fold it
+      into the green column.
+- [ ] A/B control (memory: `ab-control-before-shipping-a-fix`): neuter each fix independently and
+      confirm exactly the expected tests fail — no test passing vacuously.
+- [ ] PR uses `Refs #639`, not `Closes #639`.
+
+---
+
+## Task 9 — Deferred, do not start without a measurement
+
+**What:** Extend the guard to `_probe_selector_cascade`, and/or add a bounded wait gated on a
+learned per-profile flag.
+
+**Gate:** Only if a real migrated run shows the Task 5 sites still cost more than is acceptable,
+**and** the flip timing has actually been measured. Until then this is designing against a guess —
+which is what produced the `0 ms` claim being corrected in Task 7.
+
+---
+
+## Definition of done
+
+- [ ] All task steps checked off (Task 9 excluded by design)
+- [ ] `/gflow:check` green
+- [ ] `CHANGELOG.md` `[Unreleased]` updated
+- [ ] Docs updated: `docs/MCP.md` + mirror, `KNOWN_ISSUES.md`, `LIVE_VERIFICATION_v0.66.1.md` corrected
+- [ ] BDD covers all Critical + High scenarios from `SCENARIO.md`
+- [ ] Old-host no-regression proven by a **live run**, not by unit tests
+- [ ] Every latency figure in the PR and docs traces to a real CLI run, or is labelled unmeasured
+- [ ] No `# TODO` without a tracked issue link

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PREDICT.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PREDICT.md
@@ -1,0 +1,148 @@
+# Predict: settle the migrated-origin host gate (#639-A) + make `NOT_REDIRECTED` recoverable (#639-B)
+
+## Verdict: **CAUTION**
+**Confidence:** 7/10 (persona average 7.8; held down by an unmeasured number and an
+unverifiable-today surface, not by disagreement about the fix)
+
+## Summary
+
+Both defects are real and the fix shape is agreed: **A2 (re-check the host where the run
+already blocks) + B2 (split "skip the settle" from "skip the locale probe")**. The council
+splits hard on one thing — Performance ranks A3 (cache "migrated", navigate straight to
+`flow.google.com`) first at ~0 ms; CLI-UX and Devil's Advocate disqualify it. **A live
+measurement taken during this predict settles it against A3**: 28/28 navigations across both
+maintainer profiles landed on `labs.google` today, so a sticky migrated-cache would have locked
+both accounts out of a working frontend. A3-as-specified is rejected. The residual CAUTION is
+that the migrated path **cannot be live-verified from this machine today** — which is exactly
+how v0.66.1 shipped a "0 ms" claim that was false in the field.
+
+## Persona findings
+
+### Architect — A2 + B2 (8/10)
+Ranks **A2 first**: reuses existing wait points, zero latency, single module, no lifecycle
+obligations; `flow_host_kind` is already imported in `factory.py:161`. **A1** is the "textbook"
+relocation but has no cheap short-circuit, so it reintroduces #587-shaped dead time. **A3
+CAUTION** — caching a signal the code itself twice documents as *flapping* (`factory.py:159,172`)
+reproduces Defect B's own failure shape, and spans 4 modules. **A4 CAUTION** — the flag becomes
+shared mutable state across a module boundary, which `docs/ARCHITECTURE.md:45` forbids outright.
+**B2** stays entirely inside `client.py`, the only caller of `next_locale_state` and only writer
+of the locale file; it makes `NOT_REDIRECTED` mean what its own docstring says
+(`profile_store.py:291`). No STOP.
+
+### Security / reCAPTCHA — no hard STOP (8/10)
+No option touches auth headers, cookie extraction, token minting, or profile isolation
+(`auth/verification.py:91-99` intact). **A3 is the one to scrutinise**: it would pick a *scheme
+and host* from a value read off disk. Safe only if the cache is a tight enum selecting between
+two hardcoded origin literals, never interpolated, self-healing on anything unrecognised —
+mirroring `read_account_locale`'s `_LOCALE_SEGMENT_RE` validation and `routes.py:263-265`'s
+`_PROJECT_ID_RE` allowlist. Also: bootstrap always targets `labs.google`
+(`routes.py:94`), which bounds A3's blast radius. **B2 condition:** route `<html lang>` through
+`locale_segment_from_lang_attr` *before* `next_locale_state`/`write_account_locale` —
+`write_account_locale` (`profile_store.py:309-317`) writes its argument **verbatim**.
+
+### Performance / Playwright — A3 first, A2 last (7/10)
+The checks themselves are free (`urlsplit` + dict lookup; `page.url` is a cached sync property).
+**The cost is what you wait before running them.** Proves **A2's pre-`_exit_agent_mode`
+checkpoint fires at the same instant as the entry check** — a no-op by construction against the
+field trace — so A2's only real window is `detect_ui_mode`'s poll loop, which cannot start until
+`_exit_agent_mode`'s ~10.6 s completes. **A2 ceiling: ~14-22 s, not sub-second.** A1 is paid at
+all four `_settle_if_redirecting` sites (`ui_automation.py:1441,1475,3516,3563`) including up to
+4 character-route retries. A4 buys nothing without an event-driven rewrite the call chain does
+not have. `FlowHostMigratedError` has **zero internal retry consumers** — every retry is a fresh
+process paying full browser launch, so per-attempt cost multiplies.
+**Scoped STOP:** do not ship an A-fix without B landing first or alongside — latched profiles are
+blind to the host signal today.
+
+### CLI UX / MCP — no STOP (8/10)
+**MCP verdict: one fix in the shared transport repairs both surfaces. No `mcp/tools.py` change,
+no new payload key, no new option, no `test_cli_parity.py` mapping.** Verified the worker
+(`worker/daemon.py:324,355`) builds the same `FlowApiClient` the CLI does. `exit_code: 36` and
+`retryable: true` **do** cross the MCP boundary intact for the queued generation path
+(`daemon.py:449-459` stamps them; `mcp/tools.py:306-401` returns them verbatim) — the reporter's
+whole benefit survives on MCP.
+Two doc-truth items: `docs/MCP.md:127-131` (and its `website/docs/` mirror) enumerate the
+retryable classes and **omit `FlowHostMigratedError`** — latent only because exit 36 never fires
+today; and A3 would make `FlowHostMigratedError`'s own "retrying often lands the old frontend"
+remediation (`errors.py:694-702`) **false**. Pre-existing, out of scope: the `wait=False` MCP path
+has no documented way to retrieve a task's terminal error.
+
+### Devil's Advocate — proceed now (8/10)
+The defer case needs a **monotonic** rollout; today's measurement falsifies that — it flaps, so
+gflow must survive both hosts for an unknown non-monotonic window. A is a small orthogonal diff
+that does not compete with #642's transport bet. **A3 disqualified as specified** — salvageable
+only as "cache the *prediction*, never change the navigation target, spend it purely as
+permission to pay a bounded wait". **#644 is not a prerequisite** — its own text scopes it to the
+browserless httpx harvest, which gates #642, not this. **No ADR in `PLAN.md` defers or
+contradicts this** (grep clean); **no PR in flight** on 639/642/643/644. Refuses to let either
+fix be called live-verified on the migrated path from this machine.
+
+## Live measurement taken during this predict
+
+`scripts/dev/measure_migrated_host_flip.py`, 68 navigations, two authenticated profiles, 25 ms
+sampling, zero credits (full record: `PROBE.md`):
+
+| profile | cached locale | resolved | navs | landed migrated | post-`goto` URL change | `html lang` |
+|---|---|---|---|---|---|---|
+| `ffroliva` | `''` (latched `NOT_REDIRECTED`) | `None` | 20 | **0** | **none, ever** | `en` |
+| `denon82` | `'pt'` | `'pt'` | 12 | **0** | **none, ever** | `pt` |
+
+1. **Defect B reproduces live on the maintainer's own primary profile** — every bootstrap logged
+   `client.account_locale_cached locale=None settle_skipped=True`, so the #643 recovery never ran,
+   while `html lang` reads `en` on that very page.
+2. **A1 would be pure dead time** — 28/28 with no post-`goto` URL change at all.
+3. **A3-direct-navigate would have locked both accounts out of a working frontend today.**
+4. **`ffroliva`'s latch is correct *about redirects*** — the bare URL is served as-is, never
+   redirected. So B1 (delete the early return) is the wrong shape; only the locale *read* is
+   wrongly disabled. B2 confirmed as the right split.
+
+## High-confidence risks (2+ personas)
+
+1. **A3's sticky cache converts a recoverable failure into a permanent one** — Architect, CLI-UX,
+   Devil's Advocate; now demonstrated by the 28/28 old-host measurement. **Rejected.**
+2. **Latched profiles are blind to the host signal until B lands** — Performance (scoped STOP),
+   Architect, Devil's Advocate. **B ships with or before A.**
+3. **Neither fix's migrated path is live-verifiable here today** — Performance, Devil's Advocate.
+   v0.66.1 already shipped a false "0 ms" on exactly this gap.
+
+## Conflicts resolved
+
+- **Architect (A2 first) vs Performance (A2 last).** Performance wins on mechanism: the
+  pre-`_exit_agent_mode` checkpoint is provably a no-op. Independently confirmed here —
+  `_media_panel_present` (`ui_automation_video.py:1353-1364`) uses `.count()`, no wait, so it
+  returns at ~3.16 s and the first real blocking wait is inside `_dismiss_agent_affordances`.
+  Architect wins on placement and cost. **Net: A2 is the right shape, worth ~14-22 s, not
+  sub-second — and the plan must say so rather than repeat v0.66.1's overclaim.**
+- **Performance (A3 first) vs CLI-UX + Devil's Advocate (A3 disqualified).** Resolved against A3
+  by measurement, not preference. Only the wait-budget variant survives, and it is **deferred**
+  until the flip timing is measured.
+- Devil's Advocate did not surface a simpler path the others missed — it endorsed the minimum
+  already tabled — so no −2 modifier. Not all five agree on the A ranking, so no +1 either.
+
+## Required mitigations before EXECUTE
+
+1. **B2 lands with or before A** (Performance's scoped STOP).
+2. **Reject A3-direct-navigate.** Never change the navigation target from a cached value. If a
+   bounded wait is added later, gate it on a learned per-profile flag and keep `goto` on
+   `labs.google` so the flap remains reachable.
+3. **Fix the test precondition, not just the code.** All five existing bail tests
+   (`tests/api/transports/drivers/test_ui_mode.py:343-410`) hand `get_ui_driver` a page whose
+   `.url` is *already* migrated — which is why they are green while the field path is broken. Add
+   a red-first test whose URL **starts** on `labs.google` and **flips** after `goto`.
+4. **Claim only what is measured.** Time-to-exit-36 must be reported from a real CLI run, never
+   from a function measured in isolation. Correct
+   `docs/LIVE_VERIFICATION_v0.66.1.md`'s "`time to exit 36 — 0 ms`" row in the same PR.
+5. **Merge gate = old-host no-regression** (live-verifiable today). Migrated path ships
+   unit-tested with `Refs #639` and an explicit NEEDS-E2E flag; optionally hand a build to the
+   reporter, whose account is migrated.
+6. **B2 must sanitise via `locale_segment_from_lang_attr`** before `next_locale_state` /
+   `write_account_locale`.
+7. **Emit a new structlog event** at the point the host is detected mid-run, so the fast path is
+   observable in a field timeline rather than inferred.
+8. **Add `FlowHostMigratedError` to the retryable list** in `docs/MCP.md` and its
+   `website/docs/` mirror (`generate_website_docs.py --check` gates the mirror).
+
+## Recommended next step
+
+Proceed to **Phase 3 — `/gflow:scenario`** for A2 + B2, with the flip-timing measurement carried
+as an explicit open question (the instrument exists; it needs a migrated load). Do **not** design
+for 0 ms until that number exists.

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PREDICT.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PREDICT.md
@@ -10,7 +10,7 @@ Both defects are real and the fix shape is agreed: **A2 (re-check the host where
 already blocks) + B2 (split "skip the settle" from "skip the locale probe")**. The council
 splits hard on one thing — Performance ranks A3 (cache "migrated", navigate straight to
 `flow.google.com`) first at ~0 ms; CLI-UX and Devil's Advocate disqualify it. **A live
-measurement taken during this predict settles it against A3**: 28/28 navigations across both
+measurement taken during this predict settles it against A3**: 32/32 navigations across both
 maintainer profiles landed on `labs.google` today, so a sticky migrated-cache would have locked
 both accounts out of a working frontend. A3-as-specified is rejected. The residual CAUTION is
 that the migrated path **cannot be live-verified from this machine today** — which is exactly
@@ -78,7 +78,10 @@ fix be called live-verified on the migrated path from this machine.
 
 ## Live measurement taken during this predict
 
-`scripts/dev/measure_migrated_host_flip.py`, 68 navigations, two authenticated profiles, 25 ms
+> Point-in-time record: 32 navigations were available when this verdict was issued.
+> Sweeping continued afterwards and reached **72** with the same result — see `PROBE.md`.
+
+`scripts/dev/measure_migrated_host_flip.py`, 32 navigations, two authenticated profiles, 25 ms
 sampling, zero credits (full record: `PROBE.md`):
 
 | profile | cached locale | resolved | navs | landed migrated | post-`goto` URL change | `html lang` |
@@ -89,7 +92,7 @@ sampling, zero credits (full record: `PROBE.md`):
 1. **Defect B reproduces live on the maintainer's own primary profile** — every bootstrap logged
    `client.account_locale_cached locale=None settle_skipped=True`, so the #643 recovery never ran,
    while `html lang` reads `en` on that very page.
-2. **A1 would be pure dead time** — 28/28 with no post-`goto` URL change at all.
+2. **A1 would be pure dead time** — 32/32 with no post-`goto` URL change at all.
 3. **A3-direct-navigate would have locked both accounts out of a working frontend today.**
 4. **`ffroliva`'s latch is correct *about redirects*** — the bare URL is served as-is, never
    redirected. So B1 (delete the early return) is the wrong shape; only the locale *read* is
@@ -98,7 +101,7 @@ sampling, zero credits (full record: `PROBE.md`):
 ## High-confidence risks (2+ personas)
 
 1. **A3's sticky cache converts a recoverable failure into a permanent one** — Architect, CLI-UX,
-   Devil's Advocate; now demonstrated by the 28/28 old-host measurement. **Rejected.**
+   Devil's Advocate; now demonstrated by the 32/32 old-host measurement. **Rejected.**
 2. **Latched profiles are blind to the host signal until B lands** — Performance (scoped STOP),
    Architect, Devil's Advocate. **B ships with or before A.**
 3. **Neither fix's migrated path is live-verifiable here today** — Performance, Devil's Advocate.

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md
@@ -10,19 +10,19 @@ After each `page.goto(<labs.google project URL>, wait_until="domcontentloaded")`
 sampled every 25 ms for 10-20 s, recording every change and the offset at which
 `flow_host_kind` first answers `"migrated"`.
 
-## Result — 68 navigations, two profiles, zero migrated loads
+## Result — 72 navigations, two profiles, zero migrated loads
 
 | profile | cached locale state | resolved | URL built | navs | landed migrated | post-`goto` URL change | `html lang` |
 |---|---|---|---|---|---|---|---|
-| `ffroliva` | `''` (= `NOT_REDIRECTED`, latched) | `None` | `labs.google/fx/tools/flow/project/<id>` (bare) | 56 | **0** | **none, ever** | `en` |
+| `ffroliva` | `''` (= `NOT_REDIRECTED`, latched) | `None` | `labs.google/fx/tools/flow/project/<id>` (bare) | 60 | **0** | **none, ever** | `en` |
 | `denon82` | `'pt'` | `'pt'` | `labs.google/fx/pt/tools/flow/project/<id>` | 12 | **0** | **none, ever** | `pt` |
 
-`goto` returned in **449-1036 ms** across all 68. Three sweeps, spread over ~2 hours.
+`goto` returned in **449-1036 ms** across all 72. Three sweeps on `ffroliva` plus one on `denon82`, spread over ~2 hours.
 
 ## What this establishes
 
 1. **The rollout has flapped back on both maintainer accounts.** Yesterday `ffroliva` served the
-   migrated frontend (see `docs/LIVE_VERIFICATION_v0.66.0.md`); today it is 56/56 old host. The
+   migrated frontend (see `docs/LIVE_VERIFICATION_v0.66.0.md`); today it is 60/60 old host. The
    reporter's account went 6/6 migrated yesterday. The flap is real and per-account.
    → **Today the old-host no-regression path IS live-verifiable here and the migrated path is NOT.**
    That is the inverse of yesterday, and the inverse of what the #639 assessment assumed.
@@ -33,7 +33,7 @@ sampled every 25 ms for 10-20 s, recording every change and the offset at which
    — and with it the whole #643 `<html lang>` recovery — never ran.
    And `html lang` reads **`en`** on that very page: the value B2 would recover is right there.
 
-3. **A bounded settle (A1) would be pure dead time here.** Not one of the 68 navigations produced a
+3. **A bounded settle (A1) would be pure dead time here.** Not one of the 72 navigations produced a
    post-`goto` URL change, on either the bare or the localised URL shape. There is nothing to wait
    for on a non-migrated load, and no predicate can distinguish "no redirect coming" from "redirect
    not yet arrived" without paying the bound. This is the measured form of the #587 regression
@@ -43,7 +43,7 @@ sampled every 25 ms for 10-20 s, recording every change and the offset at which
    redirected — so `NOT_REDIRECTED` is a true observation for that account. The defect is not the
    observation; it is that the cached observation also switches off the locale *read*. That is
    precisely B2's thesis, and it is why B1 (delete the early return) is the wrong shape: it would
-   reintroduce a 4 s settle on an account measured 56/56 to have nothing to settle.
+   reintroduce a 4 s settle on an account measured 60/60 to have nothing to settle.
 
 ## What this does NOT establish
 

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/PROBE.md
@@ -1,0 +1,56 @@
+# Probe evidence — migrated-host flip timing (#639-A / #639-B)
+
+**Instrument:** `scripts/dev/measure_migrated_host_flip.py` (new, this session)
+**Date:** 2026-09-03 · **Machine:** Windows 11, Chrome strategy · **Credits:** 0 (navigation only)
+**Raw:** `scripts/dev/_spike_out/migrated_host_flip_20260903_16{5632,}*.json`, `..._170004.json`, `..._170005.json`
+
+## What was measured
+
+After each `page.goto(<labs.google project URL>, wait_until="domcontentloaded")`, `page.url` was
+sampled every 25 ms for 10-20 s, recording every change and the offset at which
+`flow_host_kind` first answers `"migrated"`.
+
+## Result — 68 navigations, two profiles, zero migrated loads
+
+| profile | cached locale state | resolved | URL built | navs | landed migrated | post-`goto` URL change | `html lang` |
+|---|---|---|---|---|---|---|---|
+| `ffroliva` | `''` (= `NOT_REDIRECTED`, latched) | `None` | `labs.google/fx/tools/flow/project/<id>` (bare) | 56 | **0** | **none, ever** | `en` |
+| `denon82` | `'pt'` | `'pt'` | `labs.google/fx/pt/tools/flow/project/<id>` | 12 | **0** | **none, ever** | `pt` |
+
+`goto` returned in **449-1036 ms** across all 68. Three sweeps, spread over ~2 hours.
+
+## What this establishes
+
+1. **The rollout has flapped back on both maintainer accounts.** Yesterday `ffroliva` served the
+   migrated frontend (see `docs/LIVE_VERIFICATION_v0.66.0.md`); today it is 56/56 old host. The
+   reporter's account went 6/6 migrated yesterday. The flap is real and per-account.
+   → **Today the old-host no-regression path IS live-verifiable here and the migrated path is NOT.**
+   That is the inverse of yesterday, and the inverse of what the #639 assessment assumed.
+
+2. **Defect B reproduces live on the maintainer's own primary profile.** `profile_ffroliva/.gflow_locale`
+   is empty = `NOT_REDIRECTED`; every client bootstrap logged
+   `client.account_locale_cached locale=None settle_skipped=True`, i.e. `_resolve_account_locale`
+   — and with it the whole #643 `<html lang>` recovery — never ran.
+   And `html lang` reads **`en`** on that very page: the value B2 would recover is right there.
+
+3. **A bounded settle (A1) would be pure dead time here.** Not one of the 68 navigations produced a
+   post-`goto` URL change, on either the bare or the localised URL shape. There is nothing to wait
+   for on a non-migrated load, and no predicate can distinguish "no redirect coming" from "redirect
+   not yet arrived" without paying the bound. This is the measured form of the #587 regression
+   (`_common.py:181-185`) that `URL_SETTLE_TIMEOUT_MS` and the `NOT_REDIRECTED` cache exist to avoid.
+
+4. **`ffroliva`'s latch is *correct about redirects*.** The bare URL is served as-is and never
+   redirected — so `NOT_REDIRECTED` is a true observation for that account. The defect is not the
+   observation; it is that the cached observation also switches off the locale *read*. That is
+   precisely B2's thesis, and it is why B1 (delete the early return) is the wrong shape: it would
+   reintroduce a 4 s settle on an account measured 56/56 to have nothing to settle.
+
+## What this does NOT establish
+
+- **When the flip actually lands on a migrated load.** Zero migrated loads were sampled, so the
+  central timing number is still unmeasured. Any design that depends on it (a bounded wait's
+  bound; whether `page.url` is already migrated when `goto` returns) remains **LIKELY, not
+  CONFIRMED**. The instrument is ready; it needs a migrated load to run against — either a later
+  flap on these accounts, or the reporter's permanently-migrated account.
+- Whether navigating directly to `flow.google.com/project/<id>` forces the migrated frontend
+  (the question that decides if A3 destroys the retry workaround).

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/SCENARIO.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/SCENARIO.md
@@ -41,9 +41,9 @@ read**. The state keeps meaning what its own docstring says (`profile_store.py:2
 | # | Dim | Scenario | Severity | Expected behaviour | Test category |
 |---|---|---|---|---|---|
 | 1 | D7 | `page.url` is `labs.google` at `get_ui_driver` entry and `flow.google.com` by the first blocking wait (**the field case**) | **Critical** | `FlowHostMigratedError`, exit 36, `retryable: true`, raised at the first blocking wait — **not** `UiSelectorDriftError` exit 23, and not after the full ~54 s | Integration (mocked Playwright, URL flips between calls) |
-| 2 | D3/D7 | Old host throughout — 68/68 of today's measured loads | **Critical** | Byte-identical behaviour to v0.66.1: no added latency, no added navigation, no extra `page.evaluate`, driver binds and generation proceeds | Integration + **E2E live (old host) — the merge gate** |
+| 2 | D3/D7 | Old host throughout — 72/72 of today's measured loads | **Critical** | Byte-identical behaviour to v0.66.1: no added latency, no added navigation, no extra `page.evaluate`, driver binds and generation proceeds | Integration + **E2E live (old host) — the merge gate** |
 | 3 | D1 | Profile latched at `NOT_REDIRECTED`; `<html lang>` = `pt` | **Critical** | Locale resolves `pt`, is written through `next_locale_state`, **and the settle stays skipped** | Unit |
-| 4 | D1 | Profile latched at `NOT_REDIRECTED` on an account that genuinely never redirects (`ffroliva`, measured 56/56 bare-URL, `<html lang>` = `en`) | **Critical** | Records `en`; **no `await_url_settled` call, no 4 s regression**. This is the case B1 would break — the latch is *correct about redirects* | Unit + E2E live (old host) |
+| 4 | D1 | Profile latched at `NOT_REDIRECTED` on an account that genuinely never redirects (`ffroliva`, measured 60/60 bare-URL, `<html lang>` = `en`) | **Critical** | Records `en`; **no `await_url_settled` call, no 4 s regression**. This is the case B1 would break — the latch is *correct about redirects* | Unit + E2E live (old host) |
 | 5 | D5 | Two pooled Pages in one run land different hosts | **High** | The guard reads the Page it is about to drive; a bail on Page A must not abort work on Page B, and no module-level flag may be introduced | Unit |
 | 6 | D4 | Batch/chain item 3 of 10 lands migrated, items 1-2 and 4-10 land old host | **High** | Item 3 fails exit 36 `retryable`; the run does not abort the remaining items; no double-billing on retry | Integration |
 | 7 | D7 | Flow's web app crashed **and** the URL is migrated | **Medium** | Ordering stays deliberate and documented — `_mode_switch_error` checks the crash first today (`ui_automation_video.py:1447-1456`); the new early guard must not silently invert that | Unit |
@@ -88,11 +88,11 @@ read**. The state keeps meaning what its own docstring says (`profile_store.py:2
 
 ## Open question carried from predict (do not design around a guess)
 
-**When does `page.url` actually flip after `goto` on a migrated load?** Unmeasured — 68/68 of
+**When does `page.url` actually flip after `goto` on a migrated load?** Unmeasured — 72/72 of
 today's navigations landed old host, so zero migrated loads were sampled. The instrument exists
 (`scripts/dev/measure_migrated_host_flip.py`). Until that number exists:
 
-- Do **not** introduce a bounded wait (its bound would be a guess, and 68/68 says it would be
+- Do **not** introduce a bounded wait (its bound would be a guess, and 72/72 says it would be
   pure dead time on a healthy account).
 - Do **not** promise a sub-second time-to-exit-36. A2's honest value is ~14-22 s, down from ~57 s.
 - Report the achieved number from a real run, or report that it is unmeasured.

--- a/docs/superpowers/plans/2026-09-03-migrated-host-gate/SCENARIO.md
+++ b/docs/superpowers/plans/2026-09-03-migrated-host-gate/SCENARIO.md
@@ -1,0 +1,152 @@
+# Scenario: migrated-host gate settles before it decides (#639-A) + `NOT_REDIRECTED` stops disabling the locale probe (#639-B)
+
+Feeds `PLAN.md` in this directory. Predict verdict: **CAUTION 7/10**
+(`PREDICT.md`). Live probe evidence:
+`PROBE.md`.
+
+## What is being built
+
+**A2** — `get_ui_driver`'s migrated-host bail (`drivers/factory.py:155-175`) currently reads
+`page.url` once, at entry, before the post-`goto` redirect to `flow.google.com` has landed, so it
+declines and the run pays ~54 s of doomed work. Fix: re-check the host at the points the run
+**already blocks**, so the bail costs nothing on a healthy account and fires at the first
+blocking wait after the flip. Explicitly **not** a bounded wait, and explicitly **not** a
+per-profile cache that changes the navigation target — both rejected in predict, the second by
+measurement.
+
+**B2** — `client.py:772-776` returns before `_resolve_account_locale`, which is the only site of
+the #643 `<html lang>` recovery. Fix: `NOT_REDIRECTED` skips the **settle**, not the **locale
+read**. The state keeps meaning what its own docstring says (`profile_store.py:291`).
+
+## Coverage map
+
+| Dim | Active? | Why |
+|---|---|---|
+| D1 auth & session | **Yes** | The latched profile is an auth-adjacent per-profile cache; `_check_logged_in` already spans both hosts and must stay that way. |
+| D2 WAF / reCAPTCHA | No | No new navigation, no new token mint, no header change. Security persona confirmed zero wire footprint. |
+| D3 selector drift & locale invariance | **Yes** | `<html lang>` is a server-rendered attribute read, not a text-label selector — the distinction must hold. Locale feeds URL shape. |
+| D4 batch & resume | **Yes** | The flap is **per page load**, so a batch can straddle both hosts mid-run. |
+| D5 concurrency & Page pool | **Yes** | Same reason: two pooled Pages can land different hosts in one run. Any global/cached flag would be wrong; the guard must read the Page it is about to drive. |
+| D6 data layer | Partial | No `DataStore` change. The `.gflow_locale` profile file is touched — carried under D8/D11 instead. |
+| D7 error propagation & exit codes | **Yes** | Exit 36 exists; the new guard must not displace a *more* specific error, and must not turn a transient into a permanent-looking abort. |
+| D8 cross-platform paths | **Yes** | Locale-file write on Windows; must reuse the existing best-effort idiom, not invent an atomic one. |
+| D9 transport edge cases | No | No HTTP route, response shape, or download URL is touched. |
+| D10 headless vs headed | No | Neither fix depends on display or browser channel. |
+| D11 input validation | **Yes** | `<html lang>` is page-controlled input that ends up in a URL path. |
+| D12 observability | **Yes** | The whole reason this defect survived a release is that the fast path was *inferred*, not observed. |
+| D13 MCP parity | **Yes** | Shared transport, but the queued error record is different code. |
+
+## Scenario table
+
+| # | Dim | Scenario | Severity | Expected behaviour | Test category |
+|---|---|---|---|---|---|
+| 1 | D7 | `page.url` is `labs.google` at `get_ui_driver` entry and `flow.google.com` by the first blocking wait (**the field case**) | **Critical** | `FlowHostMigratedError`, exit 36, `retryable: true`, raised at the first blocking wait — **not** `UiSelectorDriftError` exit 23, and not after the full ~54 s | Integration (mocked Playwright, URL flips between calls) |
+| 2 | D3/D7 | Old host throughout — 68/68 of today's measured loads | **Critical** | Byte-identical behaviour to v0.66.1: no added latency, no added navigation, no extra `page.evaluate`, driver binds and generation proceeds | Integration + **E2E live (old host) — the merge gate** |
+| 3 | D1 | Profile latched at `NOT_REDIRECTED`; `<html lang>` = `pt` | **Critical** | Locale resolves `pt`, is written through `next_locale_state`, **and the settle stays skipped** | Unit |
+| 4 | D1 | Profile latched at `NOT_REDIRECTED` on an account that genuinely never redirects (`ffroliva`, measured 56/56 bare-URL, `<html lang>` = `en`) | **Critical** | Records `en`; **no `await_url_settled` call, no 4 s regression**. This is the case B1 would break — the latch is *correct about redirects* | Unit + E2E live (old host) |
+| 5 | D5 | Two pooled Pages in one run land different hosts | **High** | The guard reads the Page it is about to drive; a bail on Page A must not abort work on Page B, and no module-level flag may be introduced | Unit |
+| 6 | D4 | Batch/chain item 3 of 10 lands migrated, items 1-2 and 4-10 land old host | **High** | Item 3 fails exit 36 `retryable`; the run does not abort the remaining items; no double-billing on retry | Integration |
+| 7 | D7 | Flow's web app crashed **and** the URL is migrated | **Medium** | Ordering stays deliberate and documented — `_mode_switch_error` checks the crash first today (`ui_automation_video.py:1447-1456`); the new early guard must not silently invert that | Unit |
+| 8 | D7 | `page.url` is unreadable (MagicMock/None/non-str) | **High** | Never classified as migrated — that would turn a transient into a permanent-looking abort. Existing test `test_unreadable_url_still_probes_rather_than_bailing` must stay green | Unit (exists) |
+| 9 | D11 | `<html lang>` is empty, absent, or garbage | **High** | `locale_segment_from_lang_attr` returns `None`; state unchanged; bootstrap does not fail | Unit |
+| 10 | D11 | `<html lang>` probe raises (page closed, evaluate blocked) | **High** | Best-effort — logged, swallowed, navigation unaffected (`client.py:802-806` pattern preserved) | Unit |
+| 11 | D11 | `<html lang>` = `zh-Hans` (region is load-bearing) | Medium | Reduces to `zh`; **known-wrong and already flagged** in the v0.66.1 docstring. Not fixed here; must not regress into a crash | Unit |
+| 12 | D11 | `<html lang>` carries path separators or control characters | **High** | Sanitised via `locale_segment_from_lang_attr` **before** `write_account_locale`, which writes verbatim (`profile_store.py:309-317`) | Unit |
+| 13 | D12 | A maintainer reads a field timeline and must be able to prove the fast path fired | **High** | A stable structlog event at the detection point, distinct from `ui_driver.migrated_host_bail`, carrying the URL before/after and the elapsed offset | Unit (event asserted) |
+| 14 | D12 | Entry URL is already migrated (the isolated case v0.66.1 tested) | Medium | `ui_driver.migrated_host_bail` still fires at entry — no regression on the path that already worked | Unit (exists) |
+| 15 | D13 | The same failure via the MCP queued generation path | **High** | Task error record carries `exit_code: 36` **and** `retryable: true` (`worker/daemon.py:449-459` → `mcp/tools.py:306-401`); no new payload key, no `mcp/tools.py` change | Unit |
+| 16 | D13 | An MCP agent consults `docs/MCP.md` to decide whether to auto-retry | Medium | `FlowHostMigratedError` appears in the retryable list in `docs/MCP.md` **and** the `website/docs/` mirror | Doc gate (`generate_website_docs.py --check`) |
+| 17 | D8 | Locale file write on Windows with a Unicode profile path | Medium | Reuses the existing best-effort `write_text(..., encoding="utf-8")` + `except OSError` idiom — no new atomic-write machinery the sibling cache does not have | Unit |
+| 18 | D1/D8 | Two runs on the same profile write `.gflow_locale` concurrently | Low | Best-effort by design; last writer wins, a lost write costs one extra probe. Explicitly out of scope | — (documented, not tested) |
+| 19 | D12 | **Process:** the fix is claimed with a number measured in isolation | **Critical** | Any time-to-exit-36 figure comes from a real CLI run. `docs/LIVE_VERIFICATION_v0.66.1.md`'s `time to exit 36 — 0 ms` row is corrected in the same PR | Doc review |
+| 20 | D12 | **Process:** the new tests reproduce v0.66.1's blind spot | **Critical** | All five existing bail tests (`tests/api/transports/drivers/test_ui_mode.py:343-410`) hand in an **already-migrated** URL — the precondition that never holds in the field. At least one new test must **start** on `labs.google` and **flip** | Unit (red first) |
+
+## Must-cover before merge (Critical + High)
+
+1. **#1** — a red-first test whose page URL starts on `labs.google` and flips to
+   `flow.google.com` between calls. This is the test that would have caught v0.66.1.
+2. **#2** — old-host no-regression, proven by a **live run on this machine today** (the migrated
+   path is not reachable here; the old host is). This is the merge gate.
+3. **#3 + #4** — both latch cases: locale recovered, settle still skipped. #4 is the
+   anti-regression for #587 and the reason B1 was rejected.
+4. **#8** — unreadable URL never reads as migrated.
+5. **#5** — per-Page guard; no module-level flag.
+6. **#6** — a mid-batch flip fails one item, not the run.
+7. **#9, #10, #12** — `<html lang>` is untrusted page input: empty, raising, and unsanitised.
+8. **#13** — a stable, distinct structlog event so the fast path is observable, not inferred.
+9. **#15** — exit 36 + `retryable` survive the MCP queued path.
+10. **#19 + #20** — the two process guards. These are why this scenario exists at all.
+
+## Deferred (Medium + Low — not blockers)
+
+1. **#11** `zh-Hans` region reduction — already flagged in the shipped docstring; needs an
+   account on such a locale. Keep as a known limitation, do not guess.
+2. **#7** crash-vs-migrated ordering — document the chosen order; no evidence either ordering is
+   wrong today.
+3. **#17, #18** — reuse the existing idiom; do not harden what the sibling cache does not harden.
+4. **#16** doc list — must-do in this PR, but a doc gate rather than a code risk.
+
+## Open question carried from predict (do not design around a guess)
+
+**When does `page.url` actually flip after `goto` on a migrated load?** Unmeasured — 68/68 of
+today's navigations landed old host, so zero migrated loads were sampled. The instrument exists
+(`scripts/dev/measure_migrated_host_flip.py`). Until that number exists:
+
+- Do **not** introduce a bounded wait (its bound would be a guess, and 68/68 says it would be
+  pure dead time on a healthy account).
+- Do **not** promise a sub-second time-to-exit-36. A2's honest value is ~14-22 s, down from ~57 s.
+- Report the achieved number from a real run, or report that it is unmeasured.
+
+## Suggested BDD scenarios (`tests/features/`)
+
+```gherkin
+Feature: Flow's migrated origin is detected before the run pays for it
+
+  Scenario: the host flips after goto returns
+    Given a project navigation that returns on labs.google
+    And Flow redirects the page to flow.google.com before the first blocking wait
+    When gflow drives a generation
+    Then it fails with FlowHostMigratedError and exit code 36
+    And the error is retryable
+    And it does not report selector drift
+
+  Scenario: the old host is untouched
+    Given a project navigation that lands on labs.google and never redirects
+    When gflow drives a generation
+    Then no additional wait is performed
+    And the driver binds and the generation proceeds
+
+  Scenario: an unreadable URL is not mistaken for the migrated origin
+    Given a page whose url cannot be read as a string
+    When gflow probes the UI cohort
+    Then it continues probing rather than aborting
+
+Feature: A latched profile can still learn its locale
+
+  Scenario: the cached state says the account is not redirected
+    Given a profile cached as NOT_REDIRECTED
+    And Flow renders the document with lang "pt"
+    When gflow bootstraps
+    Then the account locale resolves to "pt"
+    And no URL settle is awaited
+
+  Scenario: the document declares no usable locale
+    Given a profile cached as NOT_REDIRECTED
+    And Flow renders the document with an empty lang attribute
+    When gflow bootstraps
+    Then the account locale stays unresolved
+    And the bootstrap completes without error
+```
+
+## Known-issues cross-reference
+
+- **KNOWN_ISSUES.md → "Flow is migrating to `flow.google.com`; the migrated frontend is not
+  drivable"** (Open, #639). This work **mitigates** it — the failure becomes fast and honest —
+  and does **not** resolve it: gflow still cannot drive the new frontend. The entry's "What gflow
+  does today (v0.66.0)" paragraph needs the v0.66.1/v0.66.2 correction, since the fast-fail it
+  implies has never fired in the field.
+- **#643** (locale blind on `flow.google.com`) — B2 is what makes the shipped #643 fix reachable
+  on latched profiles. #643 should not be closed on the v0.66.1 change alone.
+- **#642** (batchexecute spike) — independent. Devil's Advocate confirmed no ordering dependency.
+- **#644** (auth check keyed on a labs.google cookie) — **not** a prerequisite; it gates #642's
+  httpx transport, not this Playwright path.

--- a/scripts/dev/measure_migrated_host_flip.py
+++ b/scripts/dev/measure_migrated_host_flip.py
@@ -1,0 +1,152 @@
+"""Measure WHEN ``page.url`` flips to ``flow.google.com`` after ``goto`` returns (#639).
+
+Zero credits — pure navigation, nothing is submitted.
+
+**The question this exists to answer.** v0.66.1 added a fast-fail: ``get_ui_driver``
+raises ``FlowHostMigratedError`` when ``flow_host_kind(page.url) == "migrated"``
+(``drivers/factory.py``). In the field it never fires — the reporter of #639
+measured exit 36 arriving at ~57 s on three consecutive v0.66.1 runs, through the
+slow selector-probe path, with ``ui_driver.migrated_host_bail`` absent from the
+timeline.
+
+The hypothesis is that the guard reads a **pre-redirect** URL: ``project_editor_url``
+only ever builds a ``labs.google`` URL, the hop to ``flow.google.com`` lands AFTER
+``page.goto(wait_until="domcontentloaded")`` returns, and neither settle path waits
+for it (``_settle_if_redirecting`` returns immediately with no locale;
+``await_url_settled`` short-circuits with one, because the labs URL already matches
+``FLOW_LOCALISED_URL_RE``).
+
+That hypothesis is a *timing* claim, so no unit test can close it. The number it
+turns on — **how long after ``goto`` the flip actually lands** — is also what
+decides the fix: a flip at ~50 ms means a cheap bounded wait is viable, a flip at
+several seconds means the guard has to be re-checked at a point the run already
+waits at, or the navigation has to target the migrated origin directly.
+
+**What it reports**, per navigation: the URL the moment ``goto`` returns, every
+subsequent URL change with its offset, the offset at which ``flow_host_kind``
+first answers ``"migrated"``, and ``document.documentElement.lang`` at the end.
+
+    uv run python scripts/dev/measure_migrated_host_flip.py ffroliva <project-id>
+    uv run python scripts/dev/measure_migrated_host_flip.py --rounds 3 ffroliva <project-id>
+
+On Windows prefer ``.venv/Scripts/python.exe`` (memory: `uv run pytest` is broken
+there; the same launcher quirk applies to long-running scripts).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.transports._common import flow_host_kind  # noqa: E402
+from gflow_cli.profile_store import read_account_locale  # noqa: E402
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir  # noqa: E402, isort: skip
+
+# Fine enough to distinguish "already flipped when goto returned" from "flipped a
+# few hundred ms later" — the distinction the fix turns on.
+POLL_MS = 25
+WATCH_S = 20.0
+
+
+async def _watch(page: Any, label: str, url: str, watch_s: float = WATCH_S) -> dict[str, Any]:
+    """Navigate, then sample ``page.url`` until it settles or *watch_s* elapses."""
+    started = perf_counter()
+    await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+    at_goto_return = perf_counter() - started
+    seen = page.url
+    changes: list[dict[str, Any]] = [{"ms": round(at_goto_return * 1000), "url": seen}]
+    flipped_ms: float | None = None
+    if flow_host_kind(seen) == "migrated":
+        flipped_ms = at_goto_return * 1000
+
+    while perf_counter() - started < watch_s:
+        await page.wait_for_timeout(POLL_MS)
+        current = page.url
+        if current == seen:
+            continue
+        seen = current
+        offset = (perf_counter() - started) * 1000
+        changes.append({"ms": round(offset), "url": current})
+        if flipped_ms is None and flow_host_kind(current) == "migrated":
+            flipped_ms = offset
+
+    try:
+        lang = await page.evaluate("() => document.documentElement.lang || ''")
+    except Exception as exc:  # noqa: BLE001 — observation only
+        lang = f"<probe failed: {type(exc).__name__}>"
+
+    return {
+        "label": label,
+        "requested": url,
+        "url_when_goto_returned": changes[0]["url"],
+        "goto_returned_ms": round(at_goto_return * 1000),
+        "host_kind_when_goto_returned": flow_host_kind(changes[0]["url"]),
+        "migrated_flip_ms": None if flipped_ms is None else round(flipped_ms),
+        "changes": changes,
+        "final_url": seen,
+        "final_host_kind": flow_host_kind(seen),
+        "html_lang": lang,
+    }
+
+
+async def _main(profile: str, project_id: str, rounds: int, watch_s: float) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    cached_locale = read_account_locale(profile_dir)
+    rows: list[dict[str, Any]] = []
+
+    async with build_client(profile_dir) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        # The locale the client actually resolved decides which URL shape the
+        # transport builds, so both are recorded rather than assumed.
+        locale = client._account_locale  # noqa: SLF001 — dev instrument
+        editor_url = routes.project_editor_url(locale, project_id)
+
+        for i in range(rounds):
+            rows.append(await _watch(page, f"bootstrap[{i}]", routes.EDITOR_BOOTSTRAP_URL, watch_s))
+            rows.append(await _watch(page, f"project[{i}]", editor_url, watch_s))
+
+    out = {
+        "profile": profile,
+        "cached_locale_state": repr(cached_locale),
+        "resolved_account_locale": locale,
+        "project_editor_url": editor_url,
+        "poll_ms": POLL_MS,
+        "watch_s": watch_s,
+        "navigations": rows,
+    }
+    path = default_out_path("migrated_host_flip")
+    path.write_text(json.dumps(out, indent=2), encoding="utf-8")
+
+    print(f"\ncached locale state: {cached_locale!r}   resolved: {locale!r}")
+    print(f"project URL built:   {editor_url}")
+    print(f"\n{'navigation':<14} {'goto ret':>9} {'host@goto':>10} {'flip':>8}  final host")
+    print("-" * 62)
+    for r in rows:
+        flip = "—" if r["migrated_flip_ms"] is None else f'{r["migrated_flip_ms"]} ms'
+        print(
+            f'{r["label"]:<14} {r["goto_returned_ms"]:>7} ms '
+            f'{str(r["host_kind_when_goto_returned"]):>10} {flip:>8}  {r["final_host_kind"]}'
+        )
+    print(f"\nhtml lang (last): {rows[-1]['html_lang']!r}")
+    print(f"written: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("profile")
+    ap.add_argument("project_id")
+    ap.add_argument("--rounds", type=int, default=2)
+    ap.add_argument("--watch", type=float, default=WATCH_S)
+    ns = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(ns.profile, ns.project_id, ns.rounds, ns.watch)))

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -770,25 +770,44 @@ class FlowApiClient:
             wait_until="domcontentloaded",
             timeout=60_000,
         )
-        if cached == NOT_REDIRECTED:
-            self._account_locale = None
-            logger.info("client.account_locale_cached", locale=None, settle_skipped=True)
-            return
-        self._account_locale = await self._resolve_account_locale(self._page)
+        # #639: NOT_REDIRECTED means "there is no redirect to wait for". It must not
+        # ALSO mean "do not read the locale" — which is what returning here made it
+        # mean, and that made the state ABSORBING: `_resolve_account_locale` is the
+        # only site of the <html lang> recovery (#643) AND the only caller of
+        # `next_locale_state`, so nothing could ever move a latched profile off it.
+        # Every profile that saw two migrated loads on <=0.66.0 latched this way,
+        # which is exactly the population #643 was written for. Measured 2026-09-03
+        # on `ffroliva`: latched, and the page declares lang="en" on every load.
+        settle = cached != NOT_REDIRECTED
+        self._account_locale = await self._resolve_account_locale(self._page, settle=settle)
+        if not settle:
+            # Kept (not merged into account_locale_state) because field reports key
+            # on this event to tell "the settle was skipped" from "it timed out".
+            logger.info(
+                "client.account_locale_cached",
+                locale=self._account_locale,
+                settle_skipped=True,
+            )
         state = next_locale_state(cached, self._account_locale)
         if state != cached:
             logger.info("client.account_locale_state", was=cached, now=state)
         write_account_locale(self.profile_dir, state)
 
-    async def _resolve_account_locale(self, page: Any) -> str | None:
+    async def _resolve_account_locale(self, page: Any, *, settle: bool = True) -> str | None:
         """Settle the bootstrap navigation and read the account's locale (#580).
 
         Flow redirects the editor to the ACCOUNT's locale, but that redirect
         lands after ``goto`` returns — settling is what makes it observable.
         ``None`` means "build bare URLs", which is never worse than the
         hardcoded ``en-US`` this replaces.
+
+        ``settle=False`` (#639) skips only the wait, not the read. A profile
+        cached :data:`NOT_REDIRECTED` has nothing to wait for — measured 56/56 on
+        `ffroliva` — but its page still declares a locale in ``<html lang>``, and
+        skipping the whole function to save the wait is what made that cache an
+        absorbing state.
         """
-        settled = await await_url_settled(page)
+        settled = await await_url_settled(page) if settle else None
         segment = routes.locale_segment_from_url(settled or "")
         if segment is not None:
             logger.info("client.account_locale_resolved", locale=segment, url=settled)

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -779,7 +779,9 @@ class FlowApiClient:
         # which is exactly the population #643 was written for. Measured 2026-09-03
         # on `ffroliva`: latched, and the page declares lang="en" on every load.
         settle = cached != NOT_REDIRECTED
-        self._account_locale = await self._resolve_account_locale(self._page, settle=settle)
+        self._account_locale, from_url = await self._resolve_account_locale(
+            self._page, settle=settle
+        )
         if not settle:
             # Kept (not merged into account_locale_state) because field reports key
             # on this event to tell "the settle was skipped" from "it timed out".
@@ -788,12 +790,34 @@ class FlowApiClient:
                 locale=self._account_locale,
                 settle_skipped=True,
             )
-        state = next_locale_state(cached, self._account_locale)
+            # Do NOT fold this observation into the cache. The cached state answers
+            # ONE question — "does Flow redirect this account?" — and NOT_REDIRECTED
+            # is a true answer here. Writing the <html lang> locale into it would
+            # make `cached != NOT_REDIRECTED` on the next run, turning the settle
+            # back on for good and reintroducing the 4 s URL_SETTLE_TIMEOUT_MS that
+            # #587 removed. Measured on `ffroliva` when this return was missing:
+            # two `transport.url_settle_gave_up` timeouts and a warm bootstrap of
+            # 7.41 s, which `scripts/dev/measure_locale_probe.py` flagged as "warm
+            # arm slower than cold". Re-deriving the locale costs one sub-ms
+            # `page.evaluate` per run, which is strictly cheaper than persisting it.
+            return
+        # #639: fold ONLY the URL-derived segment. The cached state answers "does
+        # Flow redirect this account?", and a locale read from `<html lang>` is no
+        # evidence of a redirect — every account declares one. Folding it in made
+        # `next_locale_state` record a segment for an account Flow serves bare,
+        # which switched the settle on permanently and cost the full 4 s
+        # URL_SETTLE_TIMEOUT_MS on every bootstrap thereafter. That shipped in
+        # v0.66.1 with #643's `<html lang>` fallback and is measurable on any
+        # non-redirecting account: `scripts/dev/measure_locale_probe.py` reports
+        # two `transport.url_settle_gave_up` timeouts per run.
+        state = next_locale_state(cached, from_url)
         if state != cached:
             logger.info("client.account_locale_state", was=cached, now=state)
         write_account_locale(self.profile_dir, state)
 
-    async def _resolve_account_locale(self, page: Any, *, settle: bool = True) -> str | None:
+    async def _resolve_account_locale(
+        self, page: Any, *, settle: bool = True
+    ) -> tuple[str | None, str | None]:
         """Settle the bootstrap navigation and read the account's locale (#580).
 
         Flow redirects the editor to the ACCOUNT's locale, but that redirect
@@ -801,8 +825,15 @@ class FlowApiClient:
         ``None`` means "build bare URLs", which is never worse than the
         hardcoded ``en-US`` this replaces.
 
+        Returns ``(locale, from_url)`` — the same segment twice when the URL
+        answered, and ``(lang_segment, None)`` when only ``<html lang>`` did.
+        **The two are not interchangeable** (#639): the caller uses ``locale`` to
+        build URLs, but folds only ``from_url`` into the cached state, because
+        that cache answers "does Flow redirect this account?" and a ``lang``
+        attribute is no evidence of a redirect — every account has one.
+
         ``settle=False`` (#639) skips only the wait, not the read. A profile
-        cached :data:`NOT_REDIRECTED` has nothing to wait for — measured 56/56 on
+        cached :data:`NOT_REDIRECTED` has nothing to wait for — measured 60/60 on
         `ffroliva` — but its page still declares a locale in ``<html lang>``, and
         skipping the whole function to save the wait is what made that cache an
         absorbing state.
@@ -811,7 +842,7 @@ class FlowApiClient:
         segment = routes.locale_segment_from_url(settled or "")
         if segment is not None:
             logger.info("client.account_locale_resolved", locale=segment, url=settled)
-            return segment
+            return segment, segment
         # #643: the migrated flow.google.com origin serves /project/<id> with no
         # locale segment, so the URL can never answer there — but Flow still
         # renders the account locale into <html lang>. Without this the resolver
@@ -826,9 +857,9 @@ class FlowApiClient:
         segment = routes.locale_segment_from_lang_attr(lang)
         if segment is not None:
             logger.info("client.account_locale_resolved", locale=segment, source="html_lang")
-            return segment
+            return segment, None
         logger.info("client.account_locale_unresolved", last_url=settled)
-        return segment
+        return None, None
 
     async def _launch_persistent_context(self, kwargs: JsonObject) -> BrowserContext:
         """Launch the persistent context; translate a launch-time crash into ProfileLockedError."""

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -25,6 +25,7 @@ from gflow_cli.errors import (
     AuthExpiredError,
     ContentPolicyError,
     FlowApiError,
+    FlowHostMigratedError,
     NetworkError,
     RateLimitError,
     WafRejectionError,
@@ -83,6 +84,43 @@ def flow_host_kind(url: object) -> str | None:
     except ValueError:
         return None
     return _FLOW_HOSTS.get(host)
+
+
+def raise_if_migrated(page: object, *, at: str) -> None:
+    """Abort now if this page is on the migrated ``flow.google.com`` origin (#639).
+
+    The migrated frontend renders none of the controls gflow drives, so every probe
+    after this point is doomed. Call it wherever the run is **about to spend time**,
+    and never behind a wait of its own: ``page.url`` is a cached property and
+    :func:`flow_host_kind` is one parse plus a dict lookup, so a call costs the host
+    that still works nothing at all.
+
+    **Once, at entry, is not enough** — that was v0.66.1's defect.
+    ``routes.project_editor_url`` only ever builds a ``labs.google`` URL, and the hop
+    to the migrated origin is a *post-``goto``* redirect that neither settle path
+    waits for (no locale → ``_settle_if_redirecting`` returns immediately; a known
+    locale → :func:`await_url_settled` short-circuits because the labs URL already
+    matches :data:`FLOW_LOCALISED_URL_RE`). An entry-only check therefore reads a
+    pre-redirect URL and declines. Measured in the field on three consecutive runs:
+    exit 36 arrived at ~57 s, through the slow selector-probe path, with the bail
+    event absent from the timeline entirely.
+
+    ``at`` names the call site in the log event, so a field timeline SHOWS where the
+    host became knowable instead of leaving it to be inferred — which is exactly how
+    a fast path that never fired survived a release.
+    """
+    url = getattr(page, "url", None)
+    if flow_host_kind(url) != "migrated":
+        return
+    log.info("ui_driver.migrated_host_bail", at=at, url=url)
+    raise FlowHostMigratedError(
+        detail=(
+            "Flow served this project from flow.google.com — the origin Google is "
+            "migrating the app onto — whose frontend renders none of the controls "
+            "gflow drives. This is not selector drift. The migration flaps per page "
+            "load, so retrying often lands the old frontend."
+        )
+    )
 
 
 PROJECT_URL_FRAGMENT = "/project/"

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from gflow_cli.api.transports._common import raise_if_migrated
 from gflow_cli.api.transports.drivers.agentic import AgenticFlowUiDriver
 from gflow_cli.api.transports.drivers.classic import ClassicFlowUiDriver
 from gflow_cli.api.transports.mode_control import CROP_SELECTORS
@@ -111,8 +112,6 @@ async def detect_ui_mode(
     """
     timeout_s = _DETECT_TIMEOUT_S if timeout_s is None else timeout_s
     poll_interval_s = _DETECT_POLL_INTERVAL_S if poll_interval_s is None else poll_interval_s
-    from gflow_cli.api.transports._common import raise_if_migrated
-
     deadline = asyncio.get_event_loop().time() + timeout_s
     while True:
         # #639: re-read the host every tick. The loop already awaits between ticks,
@@ -169,8 +168,6 @@ async def get_ui_driver(
     # post-goto redirect nobody waits for, so on a fresh project navigation this
     # reads a pre-redirect URL and declines. The re-checks in detect_ui_mode and
     # _exit_agent_mode are what actually catch the field case.
-    from gflow_cli.api.transports._common import raise_if_migrated
-
     raise_if_migrated(page, at="get_ui_driver")
 
     # Prerequisite switch: when a specific arm is required and the current one
@@ -207,6 +204,14 @@ async def get_ui_driver(
         # tune-ligature force-clicker. mode_control is a leaf — no cycle.
         from gflow_cli.api.transports.mode_control import ensure_agent_mode
 
+        # #639: symmetric with the CLASSIC arm above. `ensure_agent_mode` opens with
+        # an ~8 s composer-ready poll that `mode_control` cannot guard on its own (it
+        # is a leaf and knows nothing about hosts), so without this the AGENTIC arm
+        # reaches the same verdict ~8 s later than CLASSIC.
+        # OUTSIDE the try on purpose: the blanket handler below would demote the
+        # abort to a warning and carry on, which is the exact failure the CLASSIC arm
+        # needs an `except FlowHostMigratedError: raise` carve-out to avoid.
+        raise_if_migrated(page, at="ensure_agent_mode")
         try:
             log.info("ui_driver.ui_mode.attempt_force_agent")
             await ensure_agent_mode(page)

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -109,6 +109,10 @@ async def detect_ui_mode(
     ``timeout_s`` / ``poll_interval_s`` default to the module constants resolved
     at call time (``None`` sentinel) so tests can patch the constants to skip the
     poll window without touching production behaviour.
+
+    **Not total** (#639): raises :class:`FlowHostMigratedError` if the page is on
+    the migrated ``flow.google.com`` origin, re-checked every tick. The return
+    annotation covers only the paths that return.
     """
     timeout_s = _DETECT_TIMEOUT_S if timeout_s is None else timeout_s
     poll_interval_s = _DETECT_POLL_INTERVAL_S if poll_interval_s is None else poll_interval_s

--- a/src/gflow_cli/api/transports/drivers/factory.py
+++ b/src/gflow_cli/api/transports/drivers/factory.py
@@ -111,8 +111,15 @@ async def detect_ui_mode(
     """
     timeout_s = _DETECT_TIMEOUT_S if timeout_s is None else timeout_s
     poll_interval_s = _DETECT_POLL_INTERVAL_S if poll_interval_s is None else poll_interval_s
+    from gflow_cli.api.transports._common import raise_if_migrated
+
     deadline = asyncio.get_event_loop().time() + timeout_s
     while True:
+        # #639: re-read the host every tick. The loop already awaits between ticks,
+        # so this is free on the host that works — and it is the first point at
+        # which a post-goto redirect to flow.google.com can be seen at all, since
+        # the caller's entry check ran before the redirect landed.
+        raise_if_migrated(page, at="detect_ui_mode")
         if await _any_present(page, _CLASSIC_CROP_SELECTORS):
             return "classic"
         if await _any_present(page, AGENTIC_INDICATOR_SELECTORS):
@@ -154,24 +161,17 @@ async def get_ui_driver(
     """
     # #639: the migrated flow.google.com frontend renders none of the controls
     # gflow drives, so every probe below is doomed before it starts. Finding that
-    # out the slow way costs ~32 s per attempt (the ~8 s detect_ui_mode poll
-    # window, both arms missing, plus the ~24 s crop cascade) -- and because the
-    # rollout flaps and callers retry on exit 36, that is paid on every attempt of
-    # a retry loop. The host is knowable from page.url in microseconds.
-    from gflow_cli.api.transports._common import flow_host_kind
+    # out the slow way costs ~54 s per attempt -- and because the rollout flaps and
+    # callers retry on exit 36, that is paid on every attempt of a retry loop.
+    #
+    # This entry check catches the case where the page ALREADY sits on the migrated
+    # origin. It is deliberately not the only one: the hop to flow.google.com is a
+    # post-goto redirect nobody waits for, so on a fresh project navigation this
+    # reads a pre-redirect URL and declines. The re-checks in detect_ui_mode and
+    # _exit_agent_mode are what actually catch the field case.
+    from gflow_cli.api.transports._common import raise_if_migrated
 
-    if flow_host_kind(getattr(page, "url", None)) == "migrated":
-        from gflow_cli.errors import FlowHostMigratedError
-
-        log.info("ui_driver.migrated_host_bail")
-        raise FlowHostMigratedError(
-            detail=(
-                "Flow served this project from flow.google.com — the origin Google is "
-                "migrating the app onto — whose frontend renders none of the controls "
-                "gflow drives. This is not selector drift. The migration flaps per page "
-                "load, so retrying often lands the old frontend."
-            )
-        )
+    raise_if_migrated(page, at="get_ui_driver")
 
     # Prerequisite switch: when a specific arm is required and the current one
     # differs, attempt the DOM toggle for that direction (best-effort — the
@@ -180,7 +180,7 @@ async def get_ui_driver(
         from gflow_cli.api.transports.ui_automation_video import (
             VideoGenerationMixin,
         )
-        from gflow_cli.errors import FlowAgentUiError
+        from gflow_cli.errors import FlowAgentUiError, FlowHostMigratedError
 
         try:
             log.info("ui_driver.ui_mode.attempt_exit_agent")
@@ -194,6 +194,11 @@ async def get_ui_driver(
             # Expected: a server-pinned agentic cohort cannot be exited
             # client-side. The verify check below turns this into a clean abort.
             log.info("ui_driver.ui_mode.cohort_natively_agentic", detail=str(exc))
+        except FlowHostMigratedError:
+            # #639: not a failed switch — the host cannot be driven at all. The
+            # blanket handler below would demote it to a warning and carry on into
+            # exactly the probing the bail exists to skip.
+            raise
         except Exception as exc:
             log.warning("ui_driver.ui_mode.exit_agent_failed", error=str(exc))
     elif ui_mode is UiMode.AGENTIC:

--- a/src/gflow_cli/api/transports/mode_control.py
+++ b/src/gflow_cli/api/transports/mode_control.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING, Literal
 
 import structlog
 
+from gflow_cli.api.transports._common import raise_if_migrated
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -130,9 +132,18 @@ async def _wait_until(
 
     Uses ``page.wait_for_timeout`` for the pacing so test fakes stay
     deterministic (their no-op wait makes the loop spin through instantly).
+
+    #639: the host is re-read every tick. This is the longest wait on the doomed
+    migrated-origin path — three call sites poll ``_composer_present`` for 8 s,
+    and on ``flow.google.com`` it can never become true — so without this an
+    ``--ui-mode agentic`` run, or a redirect that lands *during*
+    ``ensure_media_mode``, pays the whole window before anything notices the
+    origin changed. The callers' own guards are point-in-time snapshots taken
+    before this loop starts; they cannot see a flip that happens inside it.
     """
     waited = 0
     while True:
+        raise_if_migrated(page, at="mode_control")
         if await probe(page):
             return True
         if waited >= timeout_ms:

--- a/src/gflow_cli/api/transports/ui_automation_video.py
+++ b/src/gflow_cli/api/transports/ui_automation_video.py
@@ -34,6 +34,7 @@ from gflow_cli.api.transports._common import (
     flow_host_kind,
     generation_error,
     offered_menu_labels,
+    raise_if_migrated,
 )
 from gflow_cli.api.transports.drivers.factory import AGENTIC_INDICATOR_SELECTORS
 from gflow_cli.api.video import (
@@ -1527,6 +1528,14 @@ class VideoGenerationMixin:
             if await VideoGenerationMixin._media_panel_present(page):
                 return False
 
+            # #639: the media panel is missing. Before concluding that means Agent
+            # mode and spending ~10.6 s dismissing affordances that are not there,
+            # ask whether this is a host we can drive at all. `_media_panel_present`
+            # uses `.count()` and does not wait, but it is still the first DOM work
+            # after navigation — by here a post-goto redirect to flow.google.com has
+            # usually landed, which the caller's entry check was too early to see.
+            raise_if_migrated(page, at="exit_agent_mode")
+
             acted = await VideoGenerationMixin._dismiss_agent_affordances(
                 page, allow_reload=allow_reload
             )
@@ -1549,7 +1558,10 @@ class VideoGenerationMixin:
                     note="dismissed Agent affordance(s) but the media panel did not re-mount",
                 )
             return False
-        except FlowAgentUiError:
+        except (FlowAgentUiError, FlowHostMigratedError):
+            # #639: the migrated-host abort is a real verdict, not a probe failure.
+            # Falling into the handler below would log it at debug and return False,
+            # which is how a fast-fail becomes invisible.
             raise
         except Exception as e:  # noqa: BLE001
             log.debug("ui_automation_video.agent_toggle_probe_failed", error=str(e)[:80])

--- a/src/gflow_cli/profile_store.py
+++ b/src/gflow_cli/profile_store.py
@@ -327,9 +327,11 @@ def next_locale_state(cached: str | None, observed: str | None) -> str:
     """
     if observed is not None:
         return observed
-    # Silence corroborates an earlier silence; it never demotes a committed state
-    # (unreachable from the client, which returns early on NOT_REDIRECTED, but the
-    # function must be right on its own terms).
+    # Silence corroborates an earlier silence; it never demotes a committed state.
+    # Since #639 the ``NOT_REDIRECTED`` case is REACHABLE from the client: it now
+    # skips only the settle and still reads ``<html lang>``, so a latched profile
+    # folds a fresh observation through here on every run. That is the point — the
+    # state was absorbing precisely because this was unreachable.
     return NOT_REDIRECTED if cached in (PROVISIONAL, NOT_REDIRECTED) else PROVISIONAL
 
 

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -43,10 +43,13 @@ class _FakePage:
         redirects_to: str | None = None,
         *,
         url: str = "https://labs.google/fx/tools/flow?hl=en",
+        lang: str | None = "",
     ) -> None:
         self.url = url
         self._redirects_to = redirects_to
+        self._lang = lang
         self.probed = False
+        self.lang_probed = False
         self.goto = AsyncMock(side_effect=self._goto)
 
     async def _goto(self, url: str, **_k: Any) -> None:
@@ -57,6 +60,16 @@ class _FakePage:
         if self._redirects_to is None:
             raise TimeoutError("no localised URL ever appeared")
         self.url = self._redirects_to
+
+    async def evaluate(self, *_a: Any, **_k: Any) -> str:
+        """`document.documentElement.lang` (#643). ``lang=None`` models a probe
+        that raises — a closed page, or evaluate blocked — which must never break
+        the bootstrap."""
+        self.lang_probed = True
+        if self._lang is None:
+            msg = "Execution context was destroyed"
+            raise RuntimeError(msg)
+        return self._lang
 
 
 async def _bootstrap(tmp_path: Path, page: _FakePage) -> FlowApiClient:
@@ -105,15 +118,105 @@ async def test_a_stale_segment_self_heals_on_the_next_run(tmp_path: Path) -> Non
     assert read_account_locale(tmp_path) == "pt"
 
 
-async def test_cached_no_redirect_skips_the_probe_entirely(tmp_path: Path) -> None:
-    """This is the timeout the issue is about. It must not be spent twice."""
+async def test_cached_no_redirect_skips_the_settle_but_still_reads_the_lang_attr(
+    tmp_path: Path,
+) -> None:
+    """The 4 s settle is the timeout #587 is about — it must not be spent twice.
+
+    But #639 showed the early return was skipping too much: it returned before
+    ``_resolve_account_locale``, which is the only site of the ``<html lang>``
+    recovery, so the state was ABSORBING — a latched profile could never learn a
+    locale again. ``NOT_REDIRECTED`` means "skip the settle", not "skip
+    everything", which is exactly what its own docstring says.
+    """
     write_account_locale(tmp_path, NOT_REDIRECTED)
     page = _FakePage()
 
     client = await _bootstrap(tmp_path, page)
 
-    assert page.probed is False
+    assert page.probed is False, "the settle must still be skipped (#587)"
+    assert page.lang_probed is True, "the lang attribute must still be read (#639/#643)"
     assert client._account_locale is None
+
+
+# --- #639: NOT_REDIRECTED must not be an absorbing state ----------------------
+
+
+async def test_a_latched_profile_recovers_its_locale_from_lang(tmp_path: Path) -> None:
+    """Measured on a real pt-BR migrated load: the URL carries no segment, but
+    Flow still renders ``lang="pt"``. Before this, the profile stayed None forever."""
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="pt")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale == "pt"
+    assert read_account_locale(tmp_path) == "pt", "the latch must be released, not just read past"
+
+
+async def test_a_latched_profile_still_skips_the_settle(tmp_path: Path) -> None:
+    """The #587 anti-regression, and the reason deleting the early return was rejected.
+
+    Measured 2026-09-03 on `ffroliva`: 56/56 bootstrap loads served the bare URL
+    and never redirected. The cached ``NOT_REDIRECTED`` is a TRUE observation for
+    that account — only the locale read was wrongly disabled with it.
+    """
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="en-GB")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert page.probed is False, "no settle may be awaited on a known non-redirecting account"
+    assert client._account_locale == "en"
+
+
+async def test_a_latched_profile_with_no_lang_stays_latched(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
+
+
+async def test_a_lang_probe_failure_never_breaks_bootstrap(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang=None)  # evaluate raises
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
+
+
+@pytest.mark.parametrize(
+    "lang",
+    ["../../etc/passwd", "pt/../en", "e n", "toolongtag", "1234"],
+    ids=["traversal", "separator", "space", "too-long", "digits"],
+)
+async def test_a_malformed_lang_is_rejected_before_it_is_written(tmp_path: Path, lang: str) -> None:
+    """``write_account_locale`` writes VERBATIM and the value is interpolated into
+    a URL path, so the sanitising must happen before the write, not after."""
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang=lang)
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale is None
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
+
+
+async def test_zh_hans_reduces_to_zh_without_crashing(tmp_path: Path) -> None:
+    """Known-wrong and already flagged in the shipped docstring: Flow's URL
+    segments carry no region, so ``zh-Hans``/``zh-Hant`` both reduce to ``zh``.
+    Not fixed here — pinned so it cannot silently regress into a crash."""
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="zh-Hans")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale == "zh"
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -144,20 +144,51 @@ async def test_cached_no_redirect_skips_the_settle_but_still_reads_the_lang_attr
 
 async def test_a_latched_profile_recovers_its_locale_from_lang(tmp_path: Path) -> None:
     """Measured on a real pt-BR migrated load: the URL carries no segment, but
-    Flow still renders ``lang="pt"``. Before this, the profile stayed None forever."""
+    Flow still renders ``lang="pt"``. Before this, the profile stayed None forever.
+
+    The locale is recovered IN PROCESS and deliberately NOT written back: see
+    :func:`test_recovering_the_locale_must_not_switch_the_settle_back_on`.
+    """
     write_account_locale(tmp_path, NOT_REDIRECTED)
     page = _FakePage(lang="pt")
 
     client = await _bootstrap(tmp_path, page)
 
     assert client._account_locale == "pt"
-    assert read_account_locale(tmp_path) == "pt", "the latch must be released, not just read past"
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
+
+
+async def test_recovering_the_locale_must_not_switch_the_settle_back_on(
+    tmp_path: Path,
+) -> None:
+    """The regression the first cut of #639's fix actually shipped.
+
+    Folding the ``<html lang>`` observation into the cache made it a locale
+    segment, so the NEXT run saw ``cached != NOT_REDIRECTED``, turned the settle
+    back on, and paid the full 4 s ``URL_SETTLE_TIMEOUT_MS`` on every bootstrap of
+    an account that never redirects — the exact cost #587 exists to remove.
+    Measured live on `ffroliva`: two `transport.url_settle_gave_up` timeouts and a
+    7.41 s warm bootstrap, which `scripts/dev/measure_locale_probe.py` flagged as
+    "warm arm slower than cold".
+
+    Asserting only the first bootstrap cannot catch this. Run two.
+    """
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+
+    for run in range(2):
+        page = _FakePage(lang="en-GB")
+        client = await _bootstrap(tmp_path, page)
+        assert page.probed is False, f"run {run}: the settle came back on"
+        assert client._account_locale == "en", f"run {run}: the locale was not recovered"
+        assert read_account_locale(tmp_path) == NOT_REDIRECTED, (
+            f"run {run}: the cached settle decision was overwritten by a locale"
+        )
 
 
 async def test_a_latched_profile_still_skips_the_settle(tmp_path: Path) -> None:
     """The #587 anti-regression, and the reason deleting the early return was rejected.
 
-    Measured 2026-09-03 on `ffroliva`: 56/56 bootstrap loads served the bare URL
+    Measured 2026-09-03 on `ffroliva`: 60/60 bootstrap loads served the bare URL
     and never redirected. The cached ``NOT_REDIRECTED`` is a TRUE observation for
     that account — only the locale read was wrongly disabled with it.
     """
@@ -305,3 +336,40 @@ async def test_a_segment_after_a_provisional_is_taken_at_face_value(tmp_path: Pa
     await _bootstrap(tmp_path, page)
 
     assert read_account_locale(tmp_path) == "pt"
+
+
+async def test_a_lang_only_locale_is_not_evidence_that_flow_redirects(tmp_path: Path) -> None:
+    """The v0.66.1 defect this branch also repairs — present on `develop`, not
+    introduced here.
+
+    #643's ``<html lang>`` fallback made `_resolve_account_locale` return a
+    segment for an account Flow serves BARE and never redirects. `next_locale_state`
+    then recorded that segment as the cached state, so every later run saw
+    `cached != NOT_REDIRECTED`, settled, and burned the full 4 s
+    ``URL_SETTLE_TIMEOUT_MS`` waiting for a redirect that never comes. Measured on
+    `ffroliva`: `transport.url_settle_gave_up` twice per run, on a fresh profile.
+
+    Only a locale read from the URL proves a redirect happened. A `lang` attribute
+    proves nothing — every account has one.
+    """
+    page = _FakePage(redirects_to=None, lang="en-GB")  # never redirects, declares en-GB
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale == "en", "the locale is still recovered for URL building"
+    assert read_account_locale(tmp_path) == PROVISIONAL, (
+        "a lang-only locale must not be recorded as evidence of a redirect"
+    )
+
+    # Second run: the no-redirect observation is corroborated and commits, which is
+    # what finally switches the settle off for good.
+    page2 = _FakePage(redirects_to=None, lang="en-GB")
+    client2 = await _bootstrap(tmp_path, page2)
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED
+    assert client2._account_locale == "en"
+
+    # Third run: settle skipped, locale still recovered.
+    page3 = _FakePage(redirects_to=None, lang="en-GB")
+    client3 = await _bootstrap(tmp_path, page3)
+    assert page3.probed is False, "the settle must be off once NOT_REDIRECTED commits"
+    assert client3._account_locale == "en"

--- a/tests/api/test_routes_locale.py
+++ b/tests/api/test_routes_locale.py
@@ -132,6 +132,11 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
     and `next_locale_state("pt", None)` then returned PROVISIONAL, DEMOTING a
     correctly-learned locale (measured on `denon82`). The locale was sitting in
     `<html lang>` the whole time.
+
+    Since #639 the method returns ``(locale, from_url)``. The second element is the
+    ONLY evidence that Flow redirects this account, and the caller folds just that
+    into the cached state — a ``lang`` attribute is not a redirect, and treating it
+    as one switched the URL settle back on permanently.
     """
 
     @staticmethod
@@ -147,16 +152,18 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/project/abc-123", "pt")
-        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
         assert got == "pt"
+        assert from_url is None, "a lang-derived locale is not evidence of a redirect"
 
     @pytest.mark.asyncio
     async def test_migrated_english_region_tag_reduces_to_segment(self) -> None:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/", "en-GB")
-        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
         assert got == "en"
+        assert from_url is None
 
     @pytest.mark.asyncio
     async def test_url_segment_still_wins_on_the_old_host(self) -> None:
@@ -165,8 +172,9 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://labs.google/fx/pt/tools/flow", "de")
-        got = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
         assert got == "pt"
+        assert from_url == "pt", "a URL segment IS evidence of a redirect"
         page.evaluate.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -174,7 +182,7 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/", "")
-        assert await FlowApiClient._resolve_account_locale(object(), page) is None  # type: ignore[arg-type]
+        assert await FlowApiClient._resolve_account_locale(object(), page) == (None, None)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_evaluate_failure_is_survivable(self) -> None:
@@ -182,4 +190,4 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
 
         page = self._page("https://flow.google.com/", "pt")
         page.evaluate = AsyncMock(side_effect=RuntimeError("no execution context"))
-        assert await FlowApiClient._resolve_account_locale(object(), page) is None  # type: ignore[arg-type]
+        assert await FlowApiClient._resolve_account_locale(object(), page) == (None, None)  # type: ignore[arg-type]

--- a/tests/api/transports/test_migrated_host_gate.py
+++ b/tests/api/transports/test_migrated_host_gate.py
@@ -1,0 +1,188 @@
+"""The migrated-host gate must fire on a URL that FLIPS, not one that starts migrated (#639).
+
+v0.66.1 added a fast-fail to ``get_ui_driver`` and shipped with five green tests —
+every one of which hands it a page whose ``.url`` is **already**
+``flow.google.com``. That precondition never holds on a real run:
+``routes.project_editor_url`` only ever builds a ``labs.google`` URL, and the hop
+to the migrated origin is a *post-`goto`* redirect that neither settle path waits
+for. So the guard read a pre-redirect URL, declined, and the run paid ~54 s before
+failing anyway through the slow selector-probe path.
+
+Reported with a field timeline on three consecutive v0.66.1 runs (57.0 / 57.1 /
+58.3 s), in which ``ui_driver.migrated_host_bail`` is absent and
+``ui_driver.ui_mode.attempt_exit_agent`` — logged *after* the declined bail — is
+present at 3.149 s.
+
+These tests therefore model the flip. The already-migrated case stays covered by
+``tests/api/transports/drivers/test_ui_mode.py::TestMigratedOriginFailsFast``; it
+is not duplicated here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from structlog.testing import capture_logs
+
+from gflow_cli.errors import EXIT_CODE_MAP, FlowHostMigratedError, is_retryable
+
+pytestmark = pytest.mark.asyncio
+
+_LABS = "https://labs.google/fx/tools/flow/project/abc-123"
+_MIGRATED = "https://flow.google.com/project/abc-123"
+_CROP = "i.google-symbols:text-is('crop_16_9')"
+
+
+class _FlippingPage:
+    """`labs.google` when the run starts; `flow.google.com` once it touches the DOM.
+
+    The redirect lands while gflow is already probing, which is the whole defect:
+    a guard that reads ``page.url`` once, at entry, is reading it too early.
+    ``flip=False`` models the old host, which — measured 68/68 on two profiles
+    2026-09-03 — never changes URL after ``goto`` at all.
+    """
+
+    def __init__(self, *, present: set[str] | None = None, flip: bool = True) -> None:
+        self.url = _LABS
+        self._present = present or set()
+        self._flip = flip
+        self.locator_calls: list[str] = []
+
+    def locator(self, selector: str) -> Any:
+        self.locator_calls.append(selector)
+        if self._flip:
+            self.url = _MIGRATED
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if selector in self._present else 0)
+        loc.first = loc
+        loc.wait_for = AsyncMock(side_effect=TimeoutError("not visible"))
+        return loc
+
+    # A run that reaches for either of these has added work to the old-host path.
+    async def goto(self, *_a: Any, **_k: Any) -> None:
+        msg = "the guard must not navigate"
+        raise AssertionError(msg)
+
+    async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+        msg = "the guard must not wait for a URL"
+        raise AssertionError(msg)
+
+    async def evaluate(self, *_a: Any, **_k: Any) -> None:
+        msg = "the guard must not evaluate script"
+        raise AssertionError(msg)
+
+
+# --- the field case ----------------------------------------------------------
+
+
+async def test_a_flip_after_entry_still_raises_exit_36() -> None:
+    """The URL is labs.google at entry and flow.google.com by the first probe.
+
+    Before the fix ``get_ui_driver`` RETURNED a classic driver here — the caller
+    then died ~54 s later with `UiSelectorDriftError`, telling the user to file a
+    selector bug for a host change.
+    """
+    from gflow_cli.api.transports.drivers.factory import get_ui_driver
+
+    page = _FlippingPage()
+
+    with pytest.raises(FlowHostMigratedError) as exc:
+        await get_ui_driver(page, timeout_s=1.0, poll_interval_s=0.01)  # type: ignore[arg-type]
+
+    assert EXIT_CODE_MAP[FlowHostMigratedError] == 36
+    assert is_retryable(exc.value)
+    assert "flow.google.com" in str(exc.value)
+
+
+async def test_the_flip_is_caught_before_the_agent_dismissal_burns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_exit_agent_mode` finds the media panel absent — the migrated shape — and
+    must ask *why* before spending ~10.6 s dismissing Agent affordances that are
+    not there. `_media_panel_present` uses `.count()` and does not wait, so this
+    check costs the old host nothing."""
+    from gflow_cli.api.transports.ui_automation_video import VideoGenerationMixin
+
+    dismissed = False
+
+    async def _never(*_a: Any, **_k: Any) -> bool:
+        nonlocal dismissed
+        dismissed = True
+        return False
+
+    monkeypatch.setattr(VideoGenerationMixin, "_dismiss_agent_affordances", _never)
+    page = _FlippingPage()  # media panel absent -> crop selectors all miss
+
+    with pytest.raises(FlowHostMigratedError):
+        await VideoGenerationMixin._exit_agent_mode(page)  # type: ignore[arg-type]
+
+    assert dismissed is False, "the doomed dismissal must be skipped once the host is known"
+
+
+# --- the path that still works ----------------------------------------------
+
+
+async def test_old_host_adds_no_wait_and_no_navigation() -> None:
+    """The merge gate in miniature: 100% of today's real loads take this path.
+
+    `goto`, `wait_for_url` and `evaluate` all raise on this fake, so any added
+    wait or navigation fails the test rather than merely slowing the suite.
+    """
+    from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+
+    page = _FlippingPage(present={_CROP}, flip=False)
+
+    assert await detect_ui_mode(page, timeout_s=0.5, poll_interval_s=0.01) == "classic"  # type: ignore[arg-type]
+
+
+async def test_guard_reads_the_page_it_is_about_to_drive() -> None:
+    """The flap is per page LOAD, so two pooled Pages can straddle both hosts in
+    one run. A bail on one must not abort the other — which rules out any
+    module-level 'this account is migrated' flag."""
+    from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+
+    migrating = _FlippingPage()
+    healthy = _FlippingPage(present={_CROP}, flip=False)
+
+    with pytest.raises(FlowHostMigratedError):
+        await detect_ui_mode(migrating, timeout_s=1.0, poll_interval_s=0.01)  # type: ignore[arg-type]
+
+    assert await detect_ui_mode(healthy, timeout_s=0.5, poll_interval_s=0.01) == "classic"  # type: ignore[arg-type]
+
+
+async def test_unreadable_url_is_never_migrated() -> None:
+    """A page whose `.url` is not a usable string must keep probing. Classifying
+    it as migrated would turn a transient into a permanent-looking abort."""
+    from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+
+    page = MagicMock()  # .url is a MagicMock, never assigned
+
+    def _locator(sel: str) -> Any:
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if sel == _CROP else 0)
+        return loc
+
+    page.locator = MagicMock(side_effect=_locator)
+
+    assert await detect_ui_mode(page, timeout_s=0.5, poll_interval_s=0.01) == "classic"
+
+
+# --- observability -----------------------------------------------------------
+
+
+async def test_bail_emits_a_stable_event_naming_the_host_and_the_site() -> None:
+    """This defect survived a release because the fast path was *inferred* from a
+    function measured in isolation. A field timeline has to be able to show it."""
+    from gflow_cli.api.transports.drivers.factory import get_ui_driver
+
+    page = _FlippingPage()
+
+    with capture_logs() as logs, pytest.raises(FlowHostMigratedError):
+        await get_ui_driver(page, timeout_s=1.0, poll_interval_s=0.01)  # type: ignore[arg-type]
+
+    bail = [entry for entry in logs if entry["event"] == "ui_driver.migrated_host_bail"]
+    assert bail, f"expected a migrated_host_bail event, got {[e['event'] for e in logs]}"
+    assert bail[0]["url"] == _MIGRATED
+    assert bail[0]["at"] == "detect_ui_mode", "the event must say WHERE the host became knowable"

--- a/tests/api/transports/test_migrated_host_gate.py
+++ b/tests/api/transports/test_migrated_host_gate.py
@@ -60,6 +60,11 @@ class _FlippingPage:
         loc.wait_for = AsyncMock(side_effect=TimeoutError("not visible"))
         return loc
 
+    async def wait_for_timeout(self, *_a: Any, **_k: Any) -> None:
+        """Pacing for `mode_control._wait_until`. Not "added work" — the loop it
+        paces is pre-existing; the old-host assertions below guard the three calls
+        that WOULD be added work."""
+
     # A run that reaches for either of these has added work to the old-host path.
     async def goto(self, *_a: Any, **_k: Any) -> None:
         msg = "the guard must not navigate"
@@ -186,3 +191,60 @@ async def test_bail_emits_a_stable_event_naming_the_host_and_the_site() -> None:
     assert bail, f"expected a migrated_host_bail event, got {[e['event'] for e in logs]}"
     assert bail[0]["url"] == _MIGRATED
     assert bail[0]["at"] == "detect_ui_mode", "the event must say WHERE the host became knowable"
+
+
+# --- the long waits nobody was guarding ------------------------------------
+
+
+async def test_agentic_arm_does_not_burn_the_composer_poll_on_a_migrated_host() -> None:
+    """`--ui-mode agentic` reached `mode_control.ensure_agent_mode`, whose first act
+    is an 8 s `_composer_present` poll that on `flow.google.com` can never succeed —
+    and which returns normally rather than raising, so `get_ui_driver`'s blanket
+    `except Exception` never fired either.
+
+    The AGENTIC arm's own guard cannot cover this: no `await` separates it from the
+    entry guard, so it is the same point-in-time snapshot. Only a per-tick re-check
+    inside the poll can see a flip that happens *during* it.
+    """
+    from gflow_cli.api.transports.drivers.factory import get_ui_driver
+    from gflow_cli.config import UiMode
+
+    page = _FlippingPage()
+
+    with pytest.raises(FlowHostMigratedError):
+        await get_ui_driver(
+            page,  # type: ignore[arg-type]
+            ui_mode=UiMode.AGENTIC,
+            timeout_s=1.0,
+            poll_interval_s=0.01,
+        )
+
+
+async def test_mode_control_poll_re_reads_the_host_every_tick() -> None:
+    """The same gap on the CLASSIC path: `_exit_agent_mode`'s guard is taken before
+    `ensure_media_mode` starts, so a redirect landing inside that poll was unseen
+    until the caller's failure classifier ran ~10 s later."""
+    from gflow_cli.api.transports.mode_control import _wait_until
+
+    page = _FlippingPage()
+
+    async def _probe(p: Any) -> bool:
+        # Mirrors `_composer_present`: it touches the DOM, which is when the
+        # pending redirect becomes visible on `page.url`.
+        await p.locator("whatever").count()
+        return False
+
+    with pytest.raises(FlowHostMigratedError):
+        await _wait_until(page, _probe, 8000)  # type: ignore[arg-type]
+
+
+async def test_mode_control_poll_is_untouched_on_the_old_host() -> None:
+    """No regression: the guard must not disturb a probe that simply times out."""
+    from gflow_cli.api.transports.mode_control import _wait_until
+
+    page = _FlippingPage(flip=False)
+
+    async def _never(_p: Any) -> bool:
+        return False
+
+    assert await _wait_until(page, _never, 50) is False  # type: ignore[arg-type]

--- a/tests/features/latched_locale_recovery.feature
+++ b/tests/features/latched_locale_recovery.feature
@@ -9,6 +9,7 @@ Feature: A latched profile can still learn its locale
     When gflow bootstraps
     Then the account locale resolves to "pt"
     And no URL settle is awaited
+    And the profile stays cached as NOT_REDIRECTED
 
   Scenario: the document declares no usable locale
     Given a profile cached as NOT_REDIRECTED

--- a/tests/features/latched_locale_recovery.feature
+++ b/tests/features/latched_locale_recovery.feature
@@ -1,0 +1,18 @@
+Feature: A latched profile can still learn its locale
+  As an operator whose profile cached NOT_REDIRECTED before the rollout
+  I want the account locale recovered from the document
+  So that a cache about redirects does not permanently disable locale resolution
+
+  Scenario: the cached state says the account is not redirected
+    Given a profile cached as NOT_REDIRECTED
+    And Flow renders the document with lang "pt"
+    When gflow bootstraps
+    Then the account locale resolves to "pt"
+    And no URL settle is awaited
+
+  Scenario: the document declares no usable locale
+    Given a profile cached as NOT_REDIRECTED
+    And Flow renders the document with no lang attribute
+    When gflow bootstraps
+    Then the account locale stays unresolved
+    And the profile stays cached as NOT_REDIRECTED

--- a/tests/features/migrated_host_gate.feature
+++ b/tests/features/migrated_host_gate.feature
@@ -1,0 +1,23 @@
+Feature: Flow's migrated origin is detected before the run pays for it
+  As an operator whose account is inside Google's flow.google.com rollout
+  I want gflow to name the migration as soon as the host is knowable
+  So that a retry loop is not billed a doomed minute per attempt
+
+  Scenario: the host flips after goto returns
+    Given a project navigation that returns on labs.google
+    And Flow redirects the page to flow.google.com before the first blocking wait
+    When gflow probes the UI cohort
+    Then it fails with FlowHostMigratedError and exit code 36
+    And the error is retryable
+    And the error names flow.google.com rather than selector drift
+
+  Scenario: the old host is untouched
+    Given a project navigation that lands on labs.google and never redirects
+    When gflow probes the UI cohort
+    Then the classic cohort is bound
+    And no additional navigation or wait was performed
+
+  Scenario: an unreadable URL is not mistaken for the migrated origin
+    Given a page whose url cannot be read as a string
+    When gflow probes the UI cohort
+    Then the classic cohort is bound

--- a/tests/features/test_migrated_host_gate_steps.py
+++ b/tests/features/test_migrated_host_gate_steps.py
@@ -1,0 +1,211 @@
+"""BDD for #639: the migrated-host gate, and the locale latch it exposed.
+
+Both features model the *field* preconditions rather than the convenient ones.
+The URL flips mid-run instead of starting migrated, and the locale cache starts
+latched instead of empty — those are the two shapes v0.66.1's green tests did not
+have, which is why it shipped a fast path that never fired.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.transports.drivers.factory import detect_ui_mode
+from gflow_cli.errors import EXIT_CODE_MAP, FlowHostMigratedError, is_retryable
+from gflow_cli.profile_store import NOT_REDIRECTED, read_account_locale, write_account_locale
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+scenarios("migrated_host_gate.feature")
+scenarios("latched_locale_recovery.feature")
+
+_LABS = "https://labs.google/fx/tools/flow/project/abc-123"
+_MIGRATED = "https://flow.google.com/project/abc-123"
+_CROP = "i.google-symbols:text-is('crop_16_9')"
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gate_state() -> dict[str, Any]:
+    return {"page": None, "error": None, "mode": None}
+
+
+@pytest.fixture
+def locale_state() -> dict[str, Any]:
+    return {"page": None, "client": None}
+
+
+class _GatePage:
+    """A Playwright-shaped page whose host may flip once the run touches the DOM."""
+
+    def __init__(self, *, present: set[str], flip: bool) -> None:
+        self.url = _LABS
+        self._present = present
+        self._flip = flip
+        self.extra_work = False
+
+    def locator(self, selector: str) -> Any:
+        if self._flip:
+            self.url = _MIGRATED
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if selector in self._present else 0)
+        return loc
+
+    async def goto(self, *_a: Any, **_k: Any) -> None:
+        self.extra_work = True
+
+    async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+        self.extra_work = True
+
+
+class _BootstrapPage:
+    """Bootstrap page for a profile Flow does not redirect: the settle would time
+    out, and the locale lives only in ``<html lang>``."""
+
+    def __init__(self, lang: str) -> None:
+        self.url = "https://labs.google/fx/tools/flow?hl=en"
+        self._lang = lang
+        self.settled = False
+        self.goto = AsyncMock(side_effect=self._goto)
+
+    async def _goto(self, url: str, **_k: Any) -> None:
+        self.url = url
+
+    async def wait_for_url(self, *_a: Any, **_k: Any) -> None:
+        self.settled = True
+        raise TimeoutError("no localised URL ever appeared")
+
+    async def evaluate(self, *_a: Any, **_k: Any) -> str:
+        return self._lang
+
+
+# ---------------------------------------------------------------------------
+# Feature: the migrated origin is detected before the run pays for it
+# ---------------------------------------------------------------------------
+
+
+@given("a project navigation that returns on labs.google")
+def _returns_on_labs(gate_state: dict[str, Any]) -> None:
+    gate_state["page"] = _GatePage(present=set(), flip=False)
+
+
+@given("Flow redirects the page to flow.google.com before the first blocking wait")
+def _redirects_mid_run(gate_state: dict[str, Any]) -> None:
+    gate_state["page"] = _GatePage(present=set(), flip=True)
+
+
+@given("a project navigation that lands on labs.google and never redirects")
+def _stays_on_labs(gate_state: dict[str, Any]) -> None:
+    gate_state["page"] = _GatePage(present={_CROP}, flip=False)
+
+
+@given("a page whose url cannot be read as a string")
+def _unreadable_url(gate_state: dict[str, Any]) -> None:
+    page = MagicMock()  # .url is a MagicMock, never assigned
+    page.locator = MagicMock(
+        side_effect=lambda sel: MagicMock(count=AsyncMock(return_value=1 if sel == _CROP else 0))
+    )
+    gate_state["page"] = page
+
+
+@when("gflow probes the UI cohort")
+def _probe_cohort(gate_state: dict[str, Any]) -> None:
+    # pytest-bdd calls step functions synchronously — an `async def` step is never
+    # awaited and the scenario passes vacuously. Drive the coroutine here instead.
+    async def _run() -> None:
+        try:
+            gate_state["mode"] = await detect_ui_mode(
+                gate_state["page"], timeout_s=1.0, poll_interval_s=0.01
+            )
+        except FlowHostMigratedError as exc:
+            gate_state["error"] = exc
+
+    asyncio.run(_run())
+
+
+@then("it fails with FlowHostMigratedError and exit code 36")
+def _fails_with_36(gate_state: dict[str, Any]) -> None:
+    assert isinstance(gate_state["error"], FlowHostMigratedError)
+    assert EXIT_CODE_MAP[FlowHostMigratedError] == 36
+
+
+@then("the error is retryable")
+def _is_retryable(gate_state: dict[str, Any]) -> None:
+    assert is_retryable(gate_state["error"])
+
+
+@then("the error names flow.google.com rather than selector drift")
+def _names_the_host(gate_state: dict[str, Any]) -> None:
+    detail = str(gate_state["error"])
+    assert "flow.google.com" in detail
+    assert "selector drift" not in detail.lower().replace("this is not selector drift", "")
+
+
+@then("the classic cohort is bound")
+def _classic_bound(gate_state: dict[str, Any]) -> None:
+    assert gate_state["error"] is None, f"unexpected abort: {gate_state['error']}"
+    assert gate_state["mode"] == "classic"
+
+
+@then("no additional navigation or wait was performed")
+def _no_extra_work(gate_state: dict[str, Any]) -> None:
+    assert gate_state["page"].extra_work is False
+
+
+# ---------------------------------------------------------------------------
+# Feature: a latched profile can still learn its locale
+# ---------------------------------------------------------------------------
+
+
+@given("a profile cached as NOT_REDIRECTED")
+def _latched(tmp_path: Path) -> None:
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+
+
+@given(parsers.parse('Flow renders the document with lang "{lang}"'))
+def _document_lang(locale_state: dict[str, Any], lang: str) -> None:
+    locale_state["page"] = _BootstrapPage(lang)
+
+
+@given("Flow renders the document with no lang attribute")
+def _document_no_lang(locale_state: dict[str, Any]) -> None:
+    locale_state["page"] = _BootstrapPage("")
+
+
+@when("gflow bootstraps")
+def _bootstrap(locale_state: dict[str, Any], tmp_path: Path) -> None:
+    client = FlowApiClient(tmp_path)
+    client._page = locale_state["page"]  # type: ignore[assignment]
+    asyncio.run(client._bootstrap_and_resolve_locale())
+    locale_state["client"] = client
+
+
+@then(parsers.parse('the account locale resolves to "{expected}"'))
+def _locale_is(locale_state: dict[str, Any], expected: str) -> None:
+    assert locale_state["client"]._account_locale == expected
+
+
+@then("no URL settle is awaited")
+def _no_settle(locale_state: dict[str, Any]) -> None:
+    assert locale_state["page"].settled is False
+
+
+@then("the account locale stays unresolved")
+def _locale_unresolved(locale_state: dict[str, Any]) -> None:
+    assert locale_state["client"]._account_locale is None
+
+
+@then("the profile stays cached as NOT_REDIRECTED")
+def _stays_latched(tmp_path: Path) -> None:
+    assert read_account_locale(tmp_path) == NOT_REDIRECTED

--- a/tests/features/test_migrated_host_gate_steps.py
+++ b/tests/features/test_migrated_host_gate_steps.py
@@ -23,6 +23,9 @@ from gflow_cli.profile_store import NOT_REDIRECTED, read_account_locale, write_a
 if TYPE_CHECKING:
     from pathlib import Path
 
+# Two features, one step module: pytest-bdd resolves step phrases per collecting
+# module, so these definitions do not leak into other feature files — but the two
+# features here DO share this namespace, so their phrases must stay distinct.
 scenarios("migrated_host_gate.feature")
 scenarios("latched_locale_recovery.feature")
 

--- a/tests/worker/test_daemon.py
+++ b/tests/worker/test_daemon.py
@@ -746,3 +746,42 @@ async def test_worker_error_json_retryable_matches_cli(temp_db: DataStore) -> No
     assert updated.error["retryable"] is is_retryable(exc)
     assert updated.error["exit_code"] == 31
     worker.close()
+
+
+@pytest.mark.asyncio
+async def test_migrated_host_error_crosses_the_queued_path(temp_db: DataStore) -> None:
+    """#639: the MCP surface is repaired by the same shared-transport fix as the CLI,
+    but only if the envelope survives the queue.
+
+    The reporter's whole benefit is an orchestrator that reads ``retryable`` and
+    re-runs — before v0.66.0 the flag was false, so their retry loop never fired at
+    all. That flag reaches an MCP client only through this persisted queue row, which
+    is different code from the CLI's ``--json`` path.
+    """
+    from gflow_cli.errors import FlowHostMigratedError, is_retryable
+
+    repo = QueueRepository(temp_db)
+    task = repo.enqueue_task(
+        task_id="task-t2i-migrated-host",
+        profile_name="default",
+        task_type="t2i",
+        payload={"prompt": "scenic landscape"},
+    )
+
+    worker = FlowWorker("default", str(temp_db.path))
+    fake_client = FakeFlowApiClient()
+    fake_client.create_project.return_value = MagicMock(project_id="project-abc", title="T")
+    exc = FlowHostMigratedError(detail="Flow served this project from flow.google.com")
+    fake_client.generate_image.side_effect = exc
+
+    with patch("gflow_cli.worker.daemon.FlowApiClient", return_value=fake_client):
+        await worker.process_task(task)
+
+    updated = repo.get_task("task-t2i-migrated-host")
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.error is not None
+    assert updated.error["exit_code"] == 36
+    assert updated.error["retryable"] is True
+    assert updated.error["retryable"] is is_retryable(exc)
+    worker.close()

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -50,13 +50,25 @@ callers get this for free: the failure is `FlowHostMigratedError` (exit 36) with
 `retryable: true`, so retry loops driven by the `--json` / MCP / worker error
 envelope will keep trying.
 
-**What gflow does today (v0.66.0):** recognises the migrated origin and fails
+**What gflow does today (v0.66.2):** recognises the migrated origin and fails
 with the distinct, retryable exit 36 instead of the misleading
 `UiSelectorDriftError` (exit 23, "file a selector bug"). `_check_logged_in` also
 accepts the migrated host, so a migrated load is no longer misread as a
 logged-out session. **Support for driving the new frontend is separate work and
 is not implemented** — once the rollout completes for an account, no retry will
 help until then.
+
+> **v0.66.1's fast-fail did not fire in the field, and v0.66.2 is the correction.**
+> The guard read `page.url` once, at `get_ui_driver` entry — before the hop to
+> `flow.google.com` had landed, because `project_editor_url` only builds
+> `labs.google` URLs and the redirect arrives *after* `page.goto` returns.
+> Measured by the reporter on three consecutive v0.66.1 runs: exit 36 at **57.0 /
+> 57.1 / 58.3 s**, through the slow selector-probe path. v0.66.2 re-checks the host
+> at the points the run already blocks, so the abort costs the old host nothing and
+> lands as soon as the redirect is observable. The same release stops a
+> `NOT_REDIRECTED` locale cache from disabling the `<html lang>` recovery (#643),
+> which had made that state unrecoverable on exactly the profiles it was written
+> for.
 
 ---
 

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -127,7 +127,10 @@ marks a transient failure a scheduler can re-run without operator intervention â
 WAF/reCAPTCHA bounce (`WafRejectionError`), rate-limit (`RateLimitError`),
 transport timeout (`TransportTimeoutError`), network blip (`NetworkError`), a
 dropped browser session (`BrowserSessionClosedError`), a Flow web-app crash
-(`FlowAppError`), and an agentic-cohort flap (`FlowAgentUiError`). Everything
+(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), and a page load
+served by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
+[#639](https://github.com/ffroliva/gflow-cli/issues/639) â€” the rollout flaps per
+page load, so a retry often lands the frontend gflow can drive). Everything
 else (auth, content-policy, configuration, security) is terminal
 (`retryable: false`): retrying the identical request fails the same way. This
 flag is the **same shared classification** the CLI `--json` payload and the

--- a/website/docs/MCP.md
+++ b/website/docs/MCP.md
@@ -127,10 +127,13 @@ marks a transient failure a scheduler can re-run without operator intervention â
 WAF/reCAPTCHA bounce (`WafRejectionError`), rate-limit (`RateLimitError`),
 transport timeout (`TransportTimeoutError`), network blip (`NetworkError`), a
 dropped browser session (`BrowserSessionClosedError`), a Flow web-app crash
-(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), and a page load
-served by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
+(`FlowAppError`), an agentic-cohort flap (`FlowAgentUiError`), a page load served
+by the migrated `flow.google.com` frontend (`FlowHostMigratedError`,
 [#639](https://github.com/ffroliva/gflow-cli/issues/639) â€” the rollout flaps per
-page load, so a retry often lands the frontend gflow can drive). Everything
+page load, so a retry often lands the frontend gflow can drive), an unreachable
+UI arm (`UiModeUnavailableError`), and a partially-completed sync
+(`SyncPartialError`). That list is the whole of `errors.RETRYABLE_ERRORS`.
+Everything
 else (auth, content-policy, configuration, security) is terminal
 (`retryable: false`): retrying the identical request fails the same way. This
 flag is the **same shared classification** the CLI `--json` payload and the


### PR DESCRIPTION
## Summary

v0.66.1 shipped a migrated-host fast-fail for #639 that **never fired in the field**, with five green tests. This fixes that, and two locale defects that tracing it exposed.

The reporter of #639 measured v0.66.1 on three consecutive runs: exit 36 arriving at **57.0 / 57.1 / 58.3 s**, through the slow selector-probe path, with `ui_driver.migrated_host_bail` absent from the timeline entirely.

**Why it never fired.** `get_ui_driver` read `page.url` once, at entry — but `routes.project_editor_url` only ever builds a `labs.google` URL, and the hop to `flow.google.com` is a *post-`goto`* redirect that neither settle path waits for (no locale → `_settle_if_redirecting` returns immediately; a known locale → `await_url_settled` short-circuits because the labs URL already matches the localised shape). So the guard classified a pre-redirect URL and declined.

**Why the tests didn't catch it.** All five hand `get_ui_driver` a page whose `.url` is *already* `flow.google.com` — a precondition that never holds on a real run.

## What changed

**A — the host check moved to where the run already blocks.** A shared `raise_if_migrated(page, *, at)` is called at four points, none of which adds a wait: `get_ui_driver` entry, every `detect_ui_mode` poll tick, `_exit_agent_mode` once the media panel is found absent (before the ~10.6 s dismissal), and the AGENTIC arm before its ~8 s composer poll. `page.url` is a cached property and `flow_host_kind` is one `urlsplit` plus a dict lookup. Three blanket `except Exception` handlers that would have demoted the abort to a warning now re-raise it. The log event names its call site, so the fast path is *visible* in a field timeline instead of inferred.

**B — `NOT_REDIRECTED` stopped being an absorbing state.** `_bootstrap_and_resolve_locale` returned before `_resolve_account_locale` — the only site of #643's `<html lang>` recovery *and* the only caller of `next_locale_state` — so nothing could ever move a latched profile off it. Every profile that saw two migrated loads on ≤0.66.0 latched this way, which is exactly the population #643 was written for.

**C — a `lang` attribute is not evidence that Flow redirects.** Found by the council, and **already live on `develop`**: #643's fallback returns a segment for an account Flow serves *bare* and never redirects, and `next_locale_state` recorded that as evidence of a redirect. Any non-redirecting account with a `lang` attribute has been paying the full 4 s `URL_SETTLE_TIMEOUT_MS` on every bootstrap since v0.66.1. `_resolve_account_locale` now returns `(locale, from_url)`; only `from_url` is folded into the cache.

## Deliberately not done

| Rejected | Why |
|---|---|
| A bounded settle for the redirect | **72/72** measured navigations across two profiles produced no post-`goto` URL change at all — it would be pure dead time at all four settle call sites. |
| Caching "this profile is migrated" and navigating straight to `flow.google.com` | It would have locked **both** maintainer accounts out of a working frontend today, converting a flapping retry-recoverable failure into a permanent one. |
| Deleting the `NOT_REDIRECTED` early return | On such an account the cached "not redirected" is a *true* observation — 60/60 bare-URL loads. |

## Evidence

Measured with the new `scripts/dev/measure_migrated_host_flip.py` (zero credits):

```
warm bootstrap   7.41 s  ->  2.66 s      locale still recovered, settle stays off
cached state     'en'    ->  ''          (NOT_REDIRECTED preserved)
```

Live old-host gate, run twice, **EXIT=0** with real 768×1376 JPEGs. Flow accepts the newly-built `/fx/en/tools/flow/...` segment without a bounce.

**A/B controls:** neutering `raise_if_migrated` fails exactly 7 and no old-host test; restoring the pre-#639 early return fails exactly 5. Re-derived independently by a council reviewer with its own harness.

`1657 passed / 3 skipped`; ruff + format clean; pyright 78 = `develop` baseline.

## NOT verified — stated, not folded into the green column

**The migrated path is not live-verified.** The rollout flapped *back* during this work: 72/72 navigations landed on `labs.google`, so no migrated load was available. The gate is proven by unit tests and A/B control only, and **no time-to-exit-36 is claimed**. This PR also corrects `LIVE_VERIFICATION_v0.66.1.md`, whose `0 ms` was measured on `get_ui_driver` in isolation and is false of every CLI run.

## Review

9-dimension branch council. D3/D5/D6/D14/D15 GREEN; D1/D4 RED-then-fixed (defect C above); D2/D9 YELLOW-then-fixed. Every must-fix is addressed in `3896d1c`.

MCP: no CLI leaf, option, or DTO field changed — the fix is in the transport both surfaces share (traced, not assumed). `exit_code: 36` + `retryable: true` cross the queued path, pinned by a new test. `docs/MCP.md`'s retryable list now matches `errors.RETRYABLE_ERRORS` exactly.

## Test plan

- [x] `/gflow:check` gates green
- [x] Old-host live generation, exit 0, twice
- [x] A/B controls both directions
- [ ] Migrated-path run — needs an account inside the rollout

Refs #639
Refs #643
