### PR TITLE
fix(651): read `<html lang>` after hydration, not before

### DIFF
--- a/scripts/dev/measure_html_lang_settle.py
+++ b/scripts/dev/measure_html_lang_settle.py
@@ -1,0 +1,81 @@
+"""Does `<html lang>` change between goto-return and hydration, and what signals it? (#651)
+
+The reporter measured `locale=en` on a pt-BR account whose pages serve
+`<html lang="pt">`, and offered the mechanism as an explicit guess: the probe reads
+the initial HTML shell before the app sets `lang`.
+
+Run 1 confirmed the race on the OLD host (no migrated account needed):
+`en` until ~1.9 s, `pt` from ~2.9 s.
+
+This run adds `readyState` and a DOM-node count alongside `lang`, to find a
+*hydration signal* the fix can key on instead of a guessed timing constant.
+
+Zero credits: navigation only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from time import perf_counter
+from typing import Any
+
+sys.path.insert(0, r"C:\development\github\gflow-cli\src")
+sys.path.insert(0, r"C:\development\github\gflow-cli\scripts\dev")
+
+from gflow_cli.api import routes  # noqa: E402
+from gflow_cli.api.routes import locale_segment_from_lang_attr  # noqa: E402
+
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402, isort: skip
+
+SAMPLES_MS = [0, 200, 400, 600, 900, 1200, 1600, 2000, 2400, 2800, 3200, 4000, 6000]
+
+_SNAP = """() => ({
+  lang: document.documentElement.lang || '',
+  ready: document.readyState,
+  nodes: document.querySelectorAll('*').length
+})"""
+
+
+async def _sample(page: Any, label: str, url: str) -> None:
+    t0 = perf_counter()
+    await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+    rows: list[tuple[int, str, str | None, str, int]] = []
+    prev = 0
+    for target in SAMPLES_MS:
+        if target - prev > 0:
+            await page.wait_for_timeout(target - prev)
+        prev = target
+        try:
+            snap = await page.evaluate(_SNAP)
+        except Exception as exc:  # noqa: BLE001
+            snap = {"lang": f"<{type(exc).__name__}>", "ready": "?", "nodes": -1}
+        rows.append(
+            (
+                round((perf_counter() - t0) * 1000),
+                snap["lang"],
+                locale_segment_from_lang_attr(snap["lang"]),
+                snap["ready"],
+                snap["nodes"],
+            )
+        )
+
+    print(f"\n--- {label}  {url}")
+    print(f"{'t_ms':>7}  {'lang':<8} {'seg':<8} {'readyState':<12} {'DOM nodes'}")
+    for ms, lang, seg, ready, nodes in rows:
+        print(f"{ms:>7}  {lang!r:<8} {seg!r:<8} {ready:<12} {nodes}")
+
+
+async def _main(profile: str) -> int:
+    pdir = resolve_profile_dir(profile)
+    async with build_client(pdir) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        print(f"profile={profile}  client-resolved locale={client._account_locale!r}")  # noqa: SLF001
+        await _sample(page, "bootstrap", routes.EDITOR_BOOTSTRAP_URL)
+        await _sample(page, "bootstrap (2nd load)", routes.EDITOR_BOOTSTRAP_URL)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main(sys.argv[1] if len(sys.argv) > 1 else "denon82")))

--- a/scripts/dev/verify_lang_settle_fix.py
+++ b/scripts/dev/verify_lang_settle_fix.py
@@ -1,0 +1,75 @@
+"""Live proof for #651 — `<html lang>` is read after hydration, not before.
+
+Two measurements, deliberately kept distinct, because conflating them is the error
+this whole line of work exists to correct (see the correction block atop
+``docs/LIVE_VERIFICATION_v0.66.1.md``):
+
+**A — the helper, exercised against a live page.** ``_settled_lang`` is called
+directly on a real bootstrap page of a **pt** account. This proves the flip is
+captured: the naive early read returns ``en``, the fixed read returns ``pt``. It is
+a component measurement and is labelled as one.
+
+**B — the real bootstrap, end to end.** ``FlowApiClient.__aenter__`` on a latched
+profile whose locale *equals* the shell default, which is the case that pays the
+settle timeout. This is the user-visible cost, on the path a user actually takes.
+
+Zero credits: navigation only.
+
+    uv run python scripts/dev/verify_lang_settle_fix.py denon82 ffroliva
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from gflow_cli.api import routes  # noqa: E402
+
+from _spike_common import build_client, resolve_profile_dir  # noqa: E402, isort: skip
+
+
+async def _component_check(profile: str) -> None:
+    """A — does the helper capture the post-hydration value on a live page?"""
+    async with build_client(resolve_profile_dir(profile)) as client:
+        page: Any = client._page  # noqa: SLF001 — dev instrument
+        await page.goto(routes.EDITOR_BOOTSTRAP_URL, wait_until="domcontentloaded", timeout=45_000)
+
+        naive = await page.evaluate("() => document.documentElement.lang || ''")
+        t0 = perf_counter()
+        settled = await client._settled_lang(page)  # type: ignore[attr-defined]  # noqa: SLF001
+        ms = round((perf_counter() - t0) * 1000)
+
+        print(f"\n[A · COMPONENT — helper on a live page]  profile={profile}")
+        print(f"    naive early read : {naive!r}")
+        print(f"    _settled_lang    : {settled!r}   (+{ms} ms)")
+        print(f"    verdict          : {'CAPTURED THE FLIP' if settled != naive else 'no flip seen'}")
+
+
+async def _end_to_end(profile: str) -> None:
+    """B — what a real bootstrap costs on the account that pays the timeout."""
+    t0 = perf_counter()
+    async with build_client(resolve_profile_dir(profile)) as client:
+        ms = round((perf_counter() - t0) * 1000)
+        print(f"\n[B · END-TO-END — real bootstrap]  profile={profile}")
+        print(f"    resolved locale  : {client._account_locale!r}")  # noqa: SLF001
+        print(f"    __aenter__ total : {ms} ms")
+
+
+async def _main(flip_profile: str, shell_profile: str) -> int:
+    await _component_check(flip_profile)
+    await _end_to_end(shell_profile)
+    print(
+        "\nA is a component measurement; B is the user path. Reporting A's number as"
+        "\nthe user-visible one is precisely the v0.66.1 mistake."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:] or ["denon82", "ffroliva"]
+    raise SystemExit(asyncio.run(_main(args[0], args[1])))

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -22,7 +22,7 @@ import time
 import uuid
 from dataclasses import replace as _dataclass_replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, NoReturn, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Self, TypeVar, cast
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import structlog
@@ -849,17 +849,73 @@ class FlowApiClient:
         # returns None and `next_locale_state` DEMOTES an already-learned locale
         # to PROVISIONAL (measured: a pt account lost its "pt" on every migrated
         # load). Best-effort: a probe failure must never break navigation.
-        try:
-            lang = await page.evaluate("() => document.documentElement.lang || ''")
-        except Exception as exc:  # noqa: BLE001 - observation only
-            logger.info("client.account_locale_lang_probe_failed", error=type(exc).__name__)
-            lang = None
+        lang = await self._settled_lang(page)
         segment = routes.locale_segment_from_lang_attr(lang)
         if segment is not None:
             logger.info("client.account_locale_resolved", locale=segment, source="html_lang")
             return segment, None
         logger.info("client.account_locale_unresolved", last_url=settled)
         return None, None
+
+    #: How long to wait for `<html lang>` to leave the server-default shell value
+    #: (#651). Measured on a pt account, two consecutive loads: the attribute reads
+    #: `en` until ~1.9 s and flips to `pt` at 2.26 / 2.49 s. 4 s leaves margin
+    #: without being open-ended; a slower network could still exceed it, which the
+    #: `lang_unchanged` event makes visible rather than silent.
+    _LANG_SETTLE_TIMEOUT_MS: ClassVar[float] = 4_000.0
+
+    async def _settled_lang(self, page: Any) -> str | None:
+        """Read ``<html lang>`` only after hydration has had a chance to set it (#651).
+
+        Flow serves an **`en` shell** and the app rewrites ``lang`` during
+        hydration, so a single early read returns ``en`` for every account. That is
+        not a migrated-origin quirk — it was measured on the OLD host:
+
+        ===========  ==========  ==============
+        t (ms)       ``lang``    ``readyState``
+        ===========  ==========  ==============
+        887          ``en``      interactive
+        1510         ``en``      **complete**
+        2092         ``en``      complete
+        **2488**     **``pt``**  complete
+        ===========  ==========  ==============
+
+        **``readyState`` is not a usable signal** — it reaches ``complete`` a full
+        second *before* the flip, so the obvious "wait for complete, then read" is
+        wrong. The DOM node count oscillates (136 → 300 → 249 → 251) and does not
+        discriminate either. Nothing cheap predicts the flip, so this observes it.
+
+        Cost: an account whose real locale IS the shell default never changes the
+        attribute and pays the full timeout once per process. That is the price of
+        not guessing, and it is bounded; the alternative shipped a wrong locale for
+        every account whose URL could not answer.
+        """
+        try:
+            first = await page.evaluate("() => document.documentElement.lang || ''")
+        except Exception as exc:  # noqa: BLE001 - observation only
+            logger.info("client.account_locale_lang_probe_failed", error=type(exc).__name__)
+            return None
+        try:
+            await page.wait_for_function(
+                "initial => (document.documentElement.lang || '') !== initial",
+                arg=first,
+                timeout=self._LANG_SETTLE_TIMEOUT_MS,
+            )
+            after = await page.evaluate("() => document.documentElement.lang || ''")
+        except Exception as exc:  # noqa: BLE001 - a timeout is an ANSWER, not a failure
+            # Either the account's locale genuinely equals the shell default, or the
+            # page never hydrated within the window. Both leave the first read as the
+            # best available answer — which is exactly the pre-#651 behaviour, so this
+            # branch can never be worse than what it replaces.
+            logger.info(
+                "client.account_locale_lang_unchanged",
+                lang=first,
+                waited_ms=self._LANG_SETTLE_TIMEOUT_MS,
+                reason=type(exc).__name__,
+            )
+            return first
+        logger.info("client.account_locale_lang_settled", was=first, now=after)
+        return after
 
     async def _launch_persistent_context(self, kwargs: JsonObject) -> BrowserContext:
         """Launch the persistent context; translate a launch-time crash into ProfileLockedError."""

--- a/tests/api/test_client_locale_cache.py
+++ b/tests/api/test_client_locale_cache.py
@@ -44,12 +44,19 @@ class _FakePage:
         *,
         url: str = "https://labs.google/fx/tools/flow?hl=en",
         lang: str | None = "",
+        lang_after_hydration: str | None = None,
     ) -> None:
         self.url = url
         self._redirects_to = redirects_to
         self._lang = lang
+        #: #651: Flow serves an `en` shell and rewrites `lang` at hydration. When
+        #: set, the FIRST read returns `lang` and every read after the settle-wait
+        #: returns this — the shape a single early read gets wrong.
+        self._lang_after = lang_after_hydration
+        self._hydrated = False
         self.probed = False
         self.lang_probed = False
+        self.lang_waited = False
         self.goto = AsyncMock(side_effect=self._goto)
 
     async def _goto(self, url: str, **_k: Any) -> None:
@@ -69,7 +76,19 @@ class _FakePage:
         if self._lang is None:
             msg = "Execution context was destroyed"
             raise RuntimeError(msg)
+        if self._hydrated and self._lang_after is not None:
+            return self._lang_after
         return self._lang
+
+    async def wait_for_function(self, *_a: Any, **_k: Any) -> None:
+        """The #651 settle-wait. Hydration flips `lang` only if this page models
+        an account whose locale differs from the `en` shell; otherwise it times
+        out, which is a legitimate ANSWER (the shell value was already right)."""
+        self.lang_waited = True
+        if self._lang_after is None:
+            msg = "Timeout waiting for function"
+            raise TimeoutError(msg)
+        self._hydrated = True
 
 
 async def _bootstrap(tmp_path: Path, page: _FakePage) -> FlowApiClient:
@@ -373,3 +392,50 @@ async def test_a_lang_only_locale_is_not_evidence_that_flow_redirects(tmp_path: 
     client3 = await _bootstrap(tmp_path, page3)
     assert page3.probed is False, "the settle must be off once NOT_REDIRECTED commits"
     assert client3._account_locale == "en"
+
+
+# --- #651: <html lang> starts as the `en` shell and flips at hydration ---------
+
+
+async def test_a_lang_read_before_hydration_must_not_win(tmp_path: Path) -> None:
+    """The defect, measured on a real pt account on the OLD host: `<html lang>`
+    reads `en` until ~1.9 s and `pt` from ~2.3 s, so a single early read returned
+    `en` for EVERY account whose URL could not answer.
+
+    `readyState` cannot rescue this — it reaches "complete" ~1 s before the flip
+    (see `scripts/dev/measure_html_lang_settle.py`), so the fix has to observe the
+    change itself.
+    """
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="en", lang_after_hydration="pt")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert page.lang_waited is True, "the settle-wait must run"
+    assert client._account_locale == "pt", "the post-hydration locale must win"
+
+
+async def test_a_locale_equal_to_the_shell_default_still_resolves(tmp_path: Path) -> None:
+    """An `en` account never changes the attribute, so the wait times out. That is
+    an ANSWER, not a failure: the first read was already right."""
+    write_account_locale(tmp_path, NOT_REDIRECTED)
+    page = _FakePage(lang="en")  # no hydration flip
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert page.lang_waited is True
+    assert client._account_locale == "en"
+
+
+async def test_the_settle_wait_is_skipped_when_the_url_already_answered(
+    tmp_path: Path,
+) -> None:
+    """No regression for redirecting accounts: the URL is authoritative and cheap,
+    so the `<html lang>` path — and its wait — must never be reached."""
+    page = _FakePage("https://labs.google/fx/pt/tools/flow", lang="en", lang_after_hydration="de")
+
+    client = await _bootstrap(tmp_path, page)
+
+    assert client._account_locale == "pt"
+    assert page.lang_probed is False, "the URL answered; do not touch <html lang>"
+    assert page.lang_waited is False, "the URL answered; do not pay the settle-wait"

--- a/tests/api/test_routes_locale.py
+++ b/tests/api/test_routes_locale.py
@@ -10,10 +10,12 @@ sets at launch). This parses that landing URL.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.routes import locale_segment_from_lang_attr, locale_segment_from_url
 
 PID = "2ddc3a33-97db-41a0-a0d3-7f9488b0d5a9"
@@ -125,6 +127,13 @@ class TestLocaleSegmentFromLangAttr:
 # ---------------------------------------------------------------------------
 
 
+def _bare_client() -> Any:
+    """An uninitialised `FlowApiClient` so unbound-method calls still reach real
+    instance helpers. `object()` worked only while the method touched no `self`;
+    #651 gave it a `_settled_lang` helper, and a bare object cannot answer that."""
+    return FlowApiClient.__new__(FlowApiClient)
+
+
 class TestResolveAccountLocaleFallsBackToHtmlLang:
     """`_resolve_account_locale` derived the locale from the settled URL only.
 
@@ -145,6 +154,9 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         page.url = url
         page.wait_for_url = AsyncMock()
         page.evaluate = AsyncMock(return_value=lang)
+        # #651: the settle-wait times out when `lang` never changes, which is the
+        # legitimate "the shell value was already right" answer.
+        page.wait_for_function = AsyncMock(side_effect=TimeoutError("unchanged"))
         return page
 
     @pytest.mark.asyncio
@@ -152,7 +164,7 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/project/abc-123", "pt")
-        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(_bare_client(), page)  # type: ignore[arg-type]
         assert got == "pt"
         assert from_url is None, "a lang-derived locale is not evidence of a redirect"
 
@@ -161,7 +173,7 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/", "en-GB")
-        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(_bare_client(), page)  # type: ignore[arg-type]
         assert got == "en"
         assert from_url is None
 
@@ -172,7 +184,7 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://labs.google/fx/pt/tools/flow", "de")
-        got, from_url = await FlowApiClient._resolve_account_locale(object(), page)  # type: ignore[arg-type]
+        got, from_url = await FlowApiClient._resolve_account_locale(_bare_client(), page)  # type: ignore[arg-type]
         assert got == "pt"
         assert from_url == "pt", "a URL segment IS evidence of a redirect"
         page.evaluate.assert_not_awaited()
@@ -182,7 +194,7 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
         from gflow_cli.api.client import FlowApiClient
 
         page = self._page("https://flow.google.com/", "")
-        assert await FlowApiClient._resolve_account_locale(object(), page) == (None, None)  # type: ignore[arg-type]
+        assert await FlowApiClient._resolve_account_locale(_bare_client(), page) == (None, None)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_evaluate_failure_is_survivable(self) -> None:
@@ -190,4 +202,4 @@ class TestResolveAccountLocaleFallsBackToHtmlLang:
 
         page = self._page("https://flow.google.com/", "pt")
         page.evaluate = AsyncMock(side_effect=RuntimeError("no execution context"))
-        assert await FlowApiClient._resolve_account_locale(object(), page) == (None, None)  # type: ignore[arg-type]
+        assert await FlowApiClient._resolve_account_locale(_bare_client(), page) == (None, None)  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes [#651](https://github.com/ffroliva/gflow-cli/issues/651). Reported by [@maipmacrothorax-75](https://github.com/maipmacrothorax-75) on a pt-BR account, with the mechanism offered explicitly as a guess. **The guess was right**, and it reproduces on the *old* host — so this is not a migration bug.

## The measurement that decides the design

Flow serves an `en` shell and the app rewrites `lang` during hydration. Sampling a pt account after `goto` returns, two consecutive loads:

| t (ms) | `lang` | `readyState` |
|---|---|---|
| 887 | `en` | interactive |
| **1510** | `en` | **complete** |
| 2092 | `en` | complete |
| **2488** | **`pt`** | complete |

**`readyState` is not a usable signal** — it reaches `complete` a full second *before* the flip, so the obvious "wait for complete, then read" is wrong. DOM-node count oscillates (136 → 300 → 249 → 251) and doesn't discriminate either. Nothing cheap predicts the flip, so `_settled_lang` observes it: read, bounded-wait for a change, re-read.

**A timeout is an answer, not a failure.** Either the account's locale genuinely equals the shell default, or the page never hydrated in the window. Both leave the first read as the best available answer — which is exactly the pre-#651 behaviour, so this branch can never be worse than what it replaces. It logs `client.account_locale_lang_unchanged` so the field can distinguish them.

## Cost, measured

An account whose locale **is** the shell default pays the 4 s bound once per process (`ffroliva` bootstrap ~2.7 s → ~6 s). That is the price of not guessing, and it is bounded; the alternative shipped a wrong locale for every account whose URL couldn't answer.

## Live proof — reported as two separate measurements, deliberately

Conflating these is the error [v0.66.1](https://github.com/ffroliva/gflow-cli/blob/develop/docs/LIVE_VERIFICATION_v0.66.1.md) made and v0.66.2 corrected:

- **A · component** (helper on a live page): naive `'en'` → `_settled_lang` **`'pt'`** in **638 ms**.
- **B · end-to-end** (real bootstrap, shell-default account): resolves `'en'` correctly, pays the 4 s bound.

Two zero-credit instruments ship with it, neither needing a migrated account: `scripts/dev/measure_html_lang_settle.py` and `scripts/dev/verify_lang_settle_fix.py`.

## Open questions — carried, not smoothed over

1. **A cold-load case I cannot explain.** On one session's *first* navigation, `lang` did not flip within 4 s — yet a fresh navigation 2 s later flipped in 638 ms. Either Flow genuinely served English on that load (its URL settle also timed out, so no redirect either), or 4 s is too short cold. The `lang_unchanged` event makes this visible in the field rather than silent.
2. **A demotion introduced in v0.66.2, not by this PR.** Folding only the URL-derived segment means a learned `pt` becomes `PROVISIONAL` whenever the URL settle times out. It self-heals on the next redirecting run and the locale is re-derived per run, so nothing is permanently lost — but it is the same *shape* of demotion #643 originally complained about, and worth a decision rather than a rediscovery.

## Test plan

- [x] Red-first tests; A/B control fails exactly 3 (the two new cases plus the probe-failure test, since the helper owns the error handling)
- [x] ruff / format / pyright (78 = `develop` baseline) / repo hygiene
- [x] Scoped suite on the changed area
- [ ] **Full local sweep inconclusive** — this machine was saturated and the run stalled; CI's three-version matrix is the gate
- [ ] Non-`en` account end-to-end on a *migrated* origin — needs the reporter's account

Refs #651
Refs #643