### PR TITLE
fix(autopilot): keep sandbox logging out of public PR comments

### DIFF
--- a/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
+++ b/deploy/PR-TRIAGE-AUTOPILOT-OPS.md
@@ -44,6 +44,31 @@ An **empty** directory is a valid deployment — D5 then reports that no memory 
 >
 > The orchestrator validates the resolved path on the host and refuses to start with an actionable error if it is missing, rather than failing later inside the container.
 
+> **The memory namespace is NOT synced to this host, and that is currently the
+> autopilot's biggest blind spot.** Claude Code keys memory by working-directory
+> path, not repo identity, so `/opt/gflow-cli` starts empty — see
+> `docs/superpowers/specs/2026-07-04-pr-triage-autopilot-design.md` (the one-way
+> local-to-VPS sync it describes was never implemented). The orchestrator now logs
+> a warning when the resolved directory holds no `*.md`, and D5 must report
+> `UNAVAILABLE` rather than GREEN. On PR #650 it reported "no memory entry
+> contradicts this PR" from an empty mount while the local store recorded that
+> exact PR as REJECTED. Until a sync exists, read every autonomous D5 verdict as
+> "not checked".
+
+## 2b. What lands in the public PR comment
+
+The container's stdout is **sliced** before posting: from the first `# PR #`
+heading to the line before `SUMMARY_VERDICT:`. Everything else — the wrapper's
+Docker/iptables progress, the agent's preamble, the machine marker — is dropped.
+The wrapper logs operationally to **stderr**, which the orchestrator keeps for
+`RuntimeError` context and the log file but never posts. Both halves exist
+because a triage comment on PR #650 published the build steps, a raw Docker
+network id, and the bridge subnet to an external contributor.
+
+Adding a new operational `echo` to `run_sandboxed_review.sh`? Send it to `>&2`.
+Anything on stdout outside the two markers is silently discarded from the
+comment; anything between them is published verbatim.
+
 ---
 
 ## 3. Ephemeral Sandbox Firewall Hardening

--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -86,6 +86,12 @@ def check_claude_auth() -> str | None:
 # set is treated as unparseable (None) rather than interpolated downstream.
 VALID_VERDICTS = ("GREEN", "YELLOW", "RED")
 
+# Markers the council report is sliced on before it is posted publicly.
+# The heading opens the report; the machine line closes it and is parsed for
+# the verdict, so everything outside the pair is preamble or wrapper logging.
+REPORT_HEADING_PREFIX = "# PR #"
+SUMMARY_VERDICT_MARKER = "SUMMARY_VERDICT:"
+
 # Imports for cross-platform file locking
 try:
     import fcntl
@@ -358,12 +364,35 @@ def run_docker_sandbox(pr_num: int, repo_dir: Path, memory_dir: Path, gh_token: 
     return proc.stdout
 
 
+def extract_report(container_output: str) -> str:
+    """Return just the council report from the container's stdout.
+
+    The container's stdout also carries the reviewing agent's own preamble, and
+    historically the sandbox wrapper's Docker/iptables progress lines. Posting
+    all of it put the build steps, a raw Docker network id, and the bridge
+    subnet into a public reply to an external contributor (PR #650). The
+    wrapper now logs to stderr; this is the second half of that fix, and it
+    also drops the agent preamble.
+
+    Slice to the report proper: the first ``# PR #`` heading through the line
+    before the ``SUMMARY_VERDICT:`` machine marker. Falls back to the whole
+    output when either marker is missing -- a malformed report is still worth
+    posting, and silently truncating one would be worse than a noisy comment.
+    """
+    lines = container_output.splitlines()
+    start = next((i for i, ln in enumerate(lines) if ln.startswith(REPORT_HEADING_PREFIX)), None)
+    end = next((i for i, ln in enumerate(lines) if SUMMARY_VERDICT_MARKER in ln), None)
+    if start is None or end is None or end <= start:
+        return container_output.strip()
+    return "\n".join(lines[start:end]).strip()
+
+
 def parse_summary_verdict(container_output: str) -> tuple[str | None, int]:
     """Parse SUMMARY_VERDICT and MUST_FIX_COUNT from stdout."""
     verdict = None
     must_fixes = 0
     for line in container_output.splitlines():
-        if "SUMMARY_VERDICT:" in line:
+        if SUMMARY_VERDICT_MARKER in line:
             # Parse line e.g.: SUMMARY_VERDICT: YELLOW | MUST_FIX_COUNT: 5 | PR_URL: ...
             parts = [p.strip() for p in line.split("|")]
             for p in parts:
@@ -410,6 +439,13 @@ def resolve_memory_dir(cli_value: str | None = None) -> Path:
             f"  Create it:            mkdir -p {memory_dir}\n"
             f"  Or point elsewhere:   --memory-dir <path>  |  export {MEMORY_DIR_ENV}=<path>\n"
             "An empty directory is valid — D5 then reports that no memory is available."
+        )
+    if not any(memory_dir.glob("*.md")):
+        logger.warning(
+            "Council memory directory is empty; D5 must report UNAVAILABLE, not GREEN. "
+            "Memory is keyed by working-directory path and is not synced to this host "
+            "by default — see docs/superpowers/specs/2026-07-04-pr-triage-autopilot-design.md.",
+            memory_dir=str(memory_dir),
         )
     return memory_dir
 
@@ -592,10 +628,7 @@ def run_triage_cycle(
             else:
                 comment_body += "🟢 All checks passed! No must-fix items identified.\n\n"
 
-            comment_body += (
-                "<details>\n<summary>View Sandboxed Review Output</summary>\n\n"
-                f"{output}\n</details>"
-            )
+            comment_body += extract_report(output)
 
             post_gh_comment(pr_num, comment_body, repo, token=gh_token)
 

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -62,10 +62,10 @@ HOST_MEMORY=$(cd "$HOST_MEMORY" && pwd)
 # `docker network rm` refuses a network with attached containers, so this can
 # never disturb a concurrent review.
 for stale_net in $(docker network ls --filter "name=triage-net-" --format '{{.Name}}' 2>/dev/null); do
-  docker network rm "$stale_net" &>/dev/null && echo "Swept stale network $stale_net" || true
+  docker network rm "$stale_net" &>/dev/null && echo "Swept stale network $stale_net" >&2 || true
 done
 
-echo "Building Docker sandbox image..."
+echo "Building Docker sandbox image..." >&2
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 docker build -t gflow-triage:latest -f "$SCRIPT_DIR/Dockerfile.triage" "$SCRIPT_DIR"
 
@@ -75,14 +75,14 @@ docker build -t gflow-triage:latest -f "$SCRIPT_DIR/Dockerfile.triage" "$SCRIPT_
 docker image prune -f --filter "label=app=gflow-triage" &>/dev/null || true
 
 NET_NAME="triage-net-$PR_NUM"
-echo "Creating network $NET_NAME..."
-docker network create "$NET_NAME" || true
+echo "Creating network $NET_NAME..." >&2
+docker network create "$NET_NAME" >/dev/null || true
 
 SUBNET=$(docker network inspect "$NET_NAME" -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)
 
 # Cleanup trap
 cleanup() {
-  echo "Cleaning up network rules and Docker network..."
+  echo "Cleaning up network rules and Docker network..." >&2
   if [ -n "$SUBNET" ] && command -v iptables &> /dev/null; then
     sudo iptables -D FORWARD -s "$SUBNET" -j DROP &>/dev/null || true
     for ip in $(getent ahostsv4 github.com | awk '{print $1}' | sort -u); do
@@ -100,7 +100,7 @@ trap cleanup EXIT
 
 # Apply host iptables firewall restrictions if run with sudo/iptables access
 if [ -n "$SUBNET" ] && command -v iptables &> /dev/null; then
-  echo "Hardening network isolation for subnet $SUBNET via iptables..."
+  echo "Hardening network isolation for subnet $SUBNET via iptables..." >&2
   # Allow DNS
   sudo iptables -I FORWARD -s "$SUBNET" -p udp --dport 53 -j ACCEPT
   sudo iptables -I FORWARD -s "$SUBNET" -p tcp --dport 53 -j ACCEPT
@@ -124,10 +124,10 @@ if [ -n "$SUBNET" ] && command -v iptables &> /dev/null; then
   # Drop everything else from this subnet
   sudo iptables -A FORWARD -s "$SUBNET" -j DROP
 else
-  echo "Warning: iptables or network subnet lookup not available. Firewall rules skipped."
+  echo "Warning: iptables or network subnet lookup not available. Firewall rules skipped." >&2
 fi
 
-echo "Launching sandboxed review for PR $PR_NUM..."
+echo "Launching sandboxed review for PR $PR_NUM..." >&2
 COUNCIL_TOOLS="Bash(gh auth status:*) Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checks:*) Bash(gh pr list:*) Bash(git show:*) Bash(git rev-parse:*) Bash(git diff:*) Bash(git log:*) Bash(git ls-remote:*) Bash(grep:*) Bash(sort:*) Bash(head:*) Bash(tail:*) Bash(wc:*) Bash(awk:*) Bash(jq:*) Bash(cat:*) Bash(ls:*) Bash(comm:*) Bash(cut:*) Bash(uniq:*) Bash(tr:*) Read Grep Glob Task TodoWrite"
 COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory"
 # The council memory mount target is not arbitrary: SKILL.md D5 tells the

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -82,6 +82,15 @@ Pull in parallel via `ctx_batch_execute`:
 - `PR_CHECKS` → `gh pr checks <N>`
 - `TOUCHED_PATHS` → `gh pr view <N> --json files --jq '.files[].path' | sort -u`
 - `RECENT_COMMITS` → `gh pr view <N> --json commits --jq '.commits[-5:] | .[] | "\(.oid[:7]) \(.messageHeadline)"'`
+- `PR_COMMENTS` → `gh pr view <N> --json comments --jq '.comments[] | "\(.createdAt) \(.author.login): \(.body)"'`
+
+> **Read the thread before you flag "no evidence".** `PR_COMMENTS` is not optional colour:
+> a prior council verdict, a maintainer's counter-capture, and the contributor's reply all
+> live there and none of them appear in the diff. On PR #650 the autonomous run posted
+> *"reverses a confirmed-live finding with no live evidence attached"* as its headline
+> must-fix — 50 minutes after the contributor had posted a machine-generated capability
+> matrix with a SHA-256 and a screenshot in that same thread. Truncate long bodies if you
+> must, but never review a contested PR without reading what has already been said on it.
 
 **Reference files** (read via `git show origin/$head_branch:<path>` — NOT local `Read`, because the working tree is on `develop`):
 - `CLAUDE.md`, `AGENTS.md`, `docs/INDEX.md`
@@ -241,6 +250,14 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 - **D5 Memory hygiene & consolidation (NEW v2, refined v2.1):**
   - Inspect `~/.claude/projects/C--development-github-gflow-cli/memory/` (file-based memory — primary source).
   - **Concrete MCP memory-server probe (v2.1):** in the current session, look at the tool list for any tool whose name matches `mcp__*memory*`, `mcp__*mempalace*`, `mcp__*mem0*`, `mcp__*context-mode*` (for indexed KB), or any tool the user explicitly mentioned. If found, invoke its "list" / "search" / "stats" tool to enumerate stored items. If no such tool is loaded in-session, state explicitly "no MCP memory server loaded; D5 scope = file-based memory only".
+  - **An empty or absent memory directory is `UNAVAILABLE`, never GREEN.** Verify you can
+    actually read it (`ls` the path, quote the file count) before any verdict. Memory is keyed
+    by *working-directory path*, not repo identity, so a fresh clone — every autonomous
+    sandbox run — starts with an empty namespace unless the store was synced to that host.
+    Reporting "no memory entry contradicts this PR" from a directory you could not read is a
+    false negative dressed as a pass: it is the assumed-not-verified failure this dimension
+    already forbids, and it happened on PR #650, where `video-model-capability-matrix.md`
+    recorded that exact PR as REJECTED while D5 reported GREEN from an empty mount.
   - For each memory entry potentially relevant to the PR's surface: does the PR's content CONTRADICT or SUPERSEDE it? If so, the PR must include a memory edit/delete in the same change. Flag missing edits.
   - Does the PR introduce a new durable pattern / failure mode / decision that should be captured as a NEW memory entry? Flag missing additions.
   - Is `MEMORY.md` index still in sync (entries listed correspond to existing files)? Flag drift.

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -35,6 +35,65 @@ def test_parse_summary_verdict_rejects_non_allowlisted():
     assert count == 0
 
 
+# The container's stdout used to be posted verbatim inside a <details> block, so
+# the sandbox wrapper's Docker/iptables progress lines and the agent's own
+# preamble landed in a public reply to an external contributor (PR #650).
+_NOISY_OUTPUT = """Building Docker sandbox image...
+Creating network triage-net-650...
+a8458414d885f96791b57d645ebd9051693fff736e787be9a01c85ee12a06cd6
+Hardening network isolation for subnet 172.20.0.0/16 via iptables...
+Launching sandboxed review for PR 650...
+All 11 dimension reports are in. Synthesizing the final verdict now.
+
+# PR #650 - Council Review Verdict
+
+## Consensus: RED
+
+## Must-fix (1)
+1. Something concrete.
+
+SUMMARY_VERDICT: RED | MUST_FIX_COUNT: 1 | PR_URL: https://example.invalid/pull/650
+Cleaning up network rules and Docker network...
+"""
+
+
+def test_extract_report_drops_wrapper_noise_and_preamble():
+    report = pr_triage_autopilot.extract_report(_NOISY_OUTPUT)
+
+    assert report.startswith("# PR #650")
+    assert report.endswith("1. Something concrete.")
+    for leaked in (
+        "Building Docker sandbox image",
+        "triage-net-650",
+        "a8458414d885",
+        "172.20.0.0/16",
+        "iptables",
+        "All 11 dimension reports are in",
+        "SUMMARY_VERDICT:",
+        "Cleaning up network rules",
+    ):
+        assert leaked not in report, leaked
+
+
+def test_extract_report_still_parses_the_verdict_from_the_raw_output():
+    # Slicing is for the comment only; the machine marker must stay parseable.
+    assert pr_triage_autopilot.parse_summary_verdict(_NOISY_OUTPUT) == ("RED", 1)
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "no markers at all, just prose",
+        "# PR #7 heading but no machine marker",
+        "SUMMARY_VERDICT: RED | MUST_FIX_COUNT: 0 | PR_URL: x",  # marker before heading
+    ],
+)
+def test_extract_report_falls_back_to_full_output_when_markers_are_missing(output):
+    # A malformed report is still worth posting; silently truncating one would
+    # be worse than a noisy comment.
+    assert pr_triage_autopilot.extract_report(output) == output.strip()
+
+
 def test_get_pr_failures_count():
     entries = [
         {"pr": 101, "head_sha": "sha1", "status": "FAILED"},


### PR DESCRIPTION
## Summary

The PR-Triage Autopilot's comment on #650 published Docker build steps, a raw network id, the bridge subnet (`172.20.0.0/16`) and the reviewing agent's own preamble into a public reply to an external contributor. Two causes, both fixed here — plus two council-protocol defects the same run exposed.

## Changes

**1. Operational logging moves to stderr.** `run_sandboxed_review.sh` wrote its progress lines (`Building Docker sandbox image...`, `Creating network ...`, `Hardening network isolation for subnet ...`, `Cleaning up ...`) to **stdout**, and `docker network create` printed its id there too. All eight now go to `>&2` / `/dev/null`. `proc.stderr` was already captured for `RuntimeError` context and the log file, so nothing is lost.

**2. The comment is sliced to the report.** `extract_report()` takes the container stdout from the first `# PR #` heading to the line before the `SUMMARY_VERDICT:` marker, dropping the agent preamble and the machine line. Falls back to the full output when either marker is missing — a malformed report is still worth posting, and truncating one silently would be worse than a noisy comment. The `<details>` wrapper is gone; the report is now the comment body, matching what the interactive council posts.

**3. D5 must not report GREEN from an empty mount.** On #650 it stated *"no Claude-memory entry contradicts this PR"* while the local store recorded that exact PR as REJECTED. Memory is keyed by working-directory path, so every sandbox run starts with an empty namespace — the one-way sync in `docs/superpowers/specs/2026-07-04-pr-triage-autopilot-design.md` was never implemented. The skill now requires `UNAVAILABLE` over GREEN and an explicit read of the directory; the orchestrator logs a warning when it holds no `*.md`.

**4. The council never read the PR conversation.** Its headline must-fix on #650 was *"reverses a confirmed-live finding with no live evidence attached"* — posted 50 minutes after the contributor put a machine-generated capability matrix (with SHA-256) and a screenshot in that same thread. `PR_COMMENTS` is now part of the § 2 gather step.

## Test plan

- [x] `pytest tests/autopilot` — 51 passed, incl. 3 new tests for `extract_report` (noise-stripping against the verbatim #650 output shape, verdict still parseable from raw stdout, fallback when markers are missing)
- [x] `ruff check src tests scripts/autopilot` — clean
- [x] `ruff format --check src tests` — clean
- [x] `check_repo_hygiene.py`, `check_doc_links.py`, `generate_website_docs.py --check` — all green
- [x] `bash -n scripts/autopilot/run_sandboxed_review.sh`
- [ ] Not exercised end-to-end against a live sandbox run — next hourly tick on the VPS is the real check

## Notes

Deploy is unchanged: `/opt/gflow-cli` pulls this after merge. Nothing is edited on the VPS.

The memory-sync gap is documented, not closed — until a sync exists, every autonomous D5 verdict should be read as "not checked". `deploy/PR-TRIAGE-AUTOPILOT-OPS.md` now says so, with a new §2b describing exactly what lands in a public comment and the rule for adding future operational `echo`s.

Refs #650