### PR TITLE
docs(known-issues): record duration control as cohort-dependent, not removed

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -270,49 +270,49 @@ has not landed yet stay nameless until the next sync sweep.
 ### Video duration control is absent on some account cohorts
 
 - **Status:** Mitigated — fail-fast shipped in
-  [#289](https://github.com/ffroliva/gflow-cli/pull/289);
+  [#289](https://github.com/ffroliva/gflow-cli/pull/289).
   [#288](https://github.com/ffroliva/gflow-cli/issues/288) and
-  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed. The
-  underlying Flow behaviour is **cohort-dependent and unresolved**, so the row
-  stays here.
+  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed; the
+  Flow-side behaviour is unresolved and untracked upstream. Relaxing gflow's own
+  gate is tracked in [#650](https://github.com/ffroliva/gflow-cli/pull/650).
 - **Severity:** Medium · **Affected:** `gflow video` with an explicit
-  `--duration` on the affected cohorts (3/3 miss on a live 2026-07-11 run;
-  re-confirmed 2026-09-03)
+  `--duration` (3/3 miss on a live 2026-07-11 run; re-confirmed by a $0
+  capability capture 2026-09-03)
 
-The `duration_tab` selector cascade (`[role='tab']:text-is('4s')` /
-`:has-text('4s')`) fails to match on Flow's current Frames-submode settings
-panel. Pre-fix this silently produced a clip of Flow's default length; since
-the #289 fix the run fails fast with `UiSelectorDriftError` (exit 23) and a
-`debug_no_duration_tab.png` screenshot — live-verified 2026-07-11 on the
-denon82 profile (aborted pre-submit, saving the 10-credit generation).
+**Workaround:** omit `--duration` and accept Flow's default clip length, or pass
+`--model omni-flash`, the only model gflow currently allows a duration on.
+
+**What actually happens today.** gflow refuses `--duration` on every *named* Veo
+3.1 model at the CLI edge — `click.UsageError`, exit 2, before any browser
+launch — from a static capability table that does not consult your account. Only
+`--model omni-flash`, or `t2v`/`r2v` with `--model` omitted (nothing resolves, so
+the guard passes), reach Flow's settings popover. On that path a missing duration
+row fails fast with `UiSelectorDriftError` (exit 23) and a
+`debug_no_duration_tab.png` screenshot, aborting pre-submit so no credits are
+spent — live-verified 2026-07-11 on the denon82 profile.
 
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
 renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
 (9:16/16:9), count (1x–x4; labels renamed to xN since — see #404), and the
-model dropdown (Veo 3.1 - Lite), and
-nothing else. The earlier locale hypothesis is refuted: the UI renders in
-Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
-no duration row to click.
+model dropdown (Veo 3.1 - Lite), and nothing else. The earlier locale hypothesis
+is refuted: the UI renders in Portuguese and the sibling count tabs (`1x`/`x2`)
+match fine; there is simply no duration row to click.
 
 **Updated 2026-09-04 — it is a cohort difference, not a removal.** A third
-profile on the *same* `labs.google` frontend renders `4s/6s/8s` on every Veo 3.1
-model, with different credit prices, in a credit-free capture that passes this
-project's own read-validity checks (count tabs present, composer chip carrying
-the duration segment). So all three readings are honest: some accounts have the
-control, some do not. The cohort key — region, account age, experiment bucket —
-is still unknown.
+profile on the *same* `labs.google` frontend renders `4s/6s/8s` on all three
+selectable Veo 3.1 models, at different credit prices, in a credit-free capture
+whose count tabs came back on every model. (`veo_3_1_lite_lower_priority` missed
+its picker, so it is unmeasured either way.) Some accounts have the control, some
+do not; the cohort key — region, account age, experiment bucket — is unknown.
+So on an unaffected cohort Flow offers the row and gflow still refuses it: the
+flag is unavailable on every cohort today, for two different reasons.
 
-**What that means in practice.** On an affected cohort `--duration` cannot be
-honored, and the fail-fast is correct behaviour rather than a selector bug to
-patch. On an unaffected cohort it works. Because a static per-model table cannot
-express a per-account capability, treat *both* "Veo has no duration control" and
-"Veo supports 4/6/8s" as wrong when stated unconditionally.
-
-**Workaround:** omit `--duration` to accept Flow's default length. If your Flow
-UI does show a duration row for the same account and model while `gflow` still
-fails, that *is* worth reporting — attach the probe name and the
-`debug_no_duration_tab.png` screenshot (no tokens or signed URLs).
+**Reporting.** If Flow's UI shows a duration row for a Veo model on your account,
+that is useful — it narrows the cohort key. Attach the exact `--model` /
+`--duration` invocation and the error text; a `--model omni-flash` run
+additionally yields the probe name and `debug_no_duration_tab.png`. No tokens or
+signed URLs.
 
 ### macOS: generation runs logged-out → HTTP 401, even with `--browser chrome`
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -267,11 +267,17 @@ listing endpoint (privacy-gated to `store` history mode), and `gflow doctor`
 (#542) surfaces the affected-row count. Freshly generated rows whose caption
 has not landed yet stay nameless until the next sync sweep.
 
-### Video duration tab probe misses on the current Frames-submode DOM
+### Video duration control is absent on some account cohorts
 
-- **Status:** Open ([#288](https://github.com/ffroliva/gflow-cli/issues/288))
-- **Severity:** Medium · **Affected:** `gflow video` with an explicit `--duration`
-  on at least some Classic-profile cohorts (3/3 miss on a live 2026-07-11 run)
+- **Status:** Mitigated — fail-fast shipped in
+  [#289](https://github.com/ffroliva/gflow-cli/pull/289);
+  [#288](https://github.com/ffroliva/gflow-cli/issues/288) and
+  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed. The
+  underlying Flow behaviour is **cohort-dependent and unresolved**, so the row
+  stays here.
+- **Severity:** Medium · **Affected:** `gflow video` with an explicit
+  `--duration` on the affected cohorts (3/3 miss on a live 2026-07-11 run;
+  re-confirmed 2026-09-03)
 
 The `duration_tab` selector cascade (`[role='tab']:text-is('4s')` /
 `:has-text('4s')`) fails to match on Flow's current Frames-submode settings
@@ -279,7 +285,6 @@ panel. Pre-fix this silently produced a clip of Flow's default length; since
 the #289 fix the run fails fast with `UiSelectorDriftError` (exit 23) and a
 `debug_no_duration_tab.png` screenshot — live-verified 2026-07-11 on the
 denon82 profile (aborted pre-submit, saving the 10-credit generation).
-**Workaround:** omit `--duration` to accept Flow's default.
 
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
@@ -288,10 +293,26 @@ renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
 model dropdown (Veo 3.1 - Lite), and
 nothing else. The earlier locale hypothesis is refuted: the UI renders in
 Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
-no duration row to click. Whether Flow removed clip-length selection for this
-cohort/model or moved it elsewhere is unknown — until that's answered,
-`--duration` cannot be honored on affected cohorts and the fail-fast is the
-correct behavior, not a selector bug to patch.
+no duration row to click.
+
+**Updated 2026-09-04 — it is a cohort difference, not a removal.** A third
+profile on the *same* `labs.google` frontend renders `4s/6s/8s` on every Veo 3.1
+model, with different credit prices, in a credit-free capture that passes this
+project's own read-validity checks (count tabs present, composer chip carrying
+the duration segment). So all three readings are honest: some accounts have the
+control, some do not. The cohort key — region, account age, experiment bucket —
+is still unknown.
+
+**What that means in practice.** On an affected cohort `--duration` cannot be
+honored, and the fail-fast is correct behaviour rather than a selector bug to
+patch. On an unaffected cohort it works. Because a static per-model table cannot
+express a per-account capability, treat *both* "Veo has no duration control" and
+"Veo supports 4/6/8s" as wrong when stated unconditionally.
+
+**Workaround:** omit `--duration` to accept Flow's default length. If your Flow
+UI does show a duration row for the same account and model while `gflow` still
+fails, that *is* worth reporting — attach the probe name and the
+`debug_no_duration_tab.png` screenshot (no tokens or signed URLs).
 
 ### macOS: generation runs logged-out → HTTP 401, even with `--browser chrome`
 

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -270,49 +270,49 @@ has not landed yet stay nameless until the next sync sweep.
 ### Video duration control is absent on some account cohorts
 
 - **Status:** Mitigated — fail-fast shipped in
-  [#289](https://github.com/ffroliva/gflow-cli/pull/289);
+  [#289](https://github.com/ffroliva/gflow-cli/pull/289).
   [#288](https://github.com/ffroliva/gflow-cli/issues/288) and
-  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed. The
-  underlying Flow behaviour is **cohort-dependent and unresolved**, so the row
-  stays here.
+  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed; the
+  Flow-side behaviour is unresolved and untracked upstream. Relaxing gflow's own
+  gate is tracked in [#650](https://github.com/ffroliva/gflow-cli/pull/650).
 - **Severity:** Medium · **Affected:** `gflow video` with an explicit
-  `--duration` on the affected cohorts (3/3 miss on a live 2026-07-11 run;
-  re-confirmed 2026-09-03)
+  `--duration` (3/3 miss on a live 2026-07-11 run; re-confirmed by a $0
+  capability capture 2026-09-03)
 
-The `duration_tab` selector cascade (`[role='tab']:text-is('4s')` /
-`:has-text('4s')`) fails to match on Flow's current Frames-submode settings
-panel. Pre-fix this silently produced a clip of Flow's default length; since
-the #289 fix the run fails fast with `UiSelectorDriftError` (exit 23) and a
-`debug_no_duration_tab.png` screenshot — live-verified 2026-07-11 on the
-my-profile profile (aborted pre-submit, saving the 10-credit generation).
+**Workaround:** omit `--duration` and accept Flow's default clip length, or pass
+`--model omni-flash`, the only model gflow currently allows a duration on.
+
+**What actually happens today.** gflow refuses `--duration` on every *named* Veo
+3.1 model at the CLI edge — `click.UsageError`, exit 2, before any browser
+launch — from a static capability table that does not consult your account. Only
+`--model omni-flash`, or `t2v`/`r2v` with `--model` omitted (nothing resolves, so
+the guard passes), reach Flow's settings popover. On that path a missing duration
+row fails fast with `UiSelectorDriftError` (exit 23) and a
+`debug_no_duration_tab.png` screenshot, aborting pre-submit so no credits are
+spent — live-verified 2026-07-11 on the my-profile profile.
 
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
 renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
 (9:16/16:9), count (1x–x4; labels renamed to xN since — see #404), and the
-model dropdown (Veo 3.1 - Lite), and
-nothing else. The earlier locale hypothesis is refuted: the UI renders in
-Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
-no duration row to click.
+model dropdown (Veo 3.1 - Lite), and nothing else. The earlier locale hypothesis
+is refuted: the UI renders in Portuguese and the sibling count tabs (`1x`/`x2`)
+match fine; there is simply no duration row to click.
 
 **Updated 2026-09-04 — it is a cohort difference, not a removal.** A third
-profile on the *same* `labs.google` frontend renders `4s/6s/8s` on every Veo 3.1
-model, with different credit prices, in a credit-free capture that passes this
-project's own read-validity checks (count tabs present, composer chip carrying
-the duration segment). So all three readings are honest: some accounts have the
-control, some do not. The cohort key — region, account age, experiment bucket —
-is still unknown.
+profile on the *same* `labs.google` frontend renders `4s/6s/8s` on all three
+selectable Veo 3.1 models, at different credit prices, in a credit-free capture
+whose count tabs came back on every model. (`veo_3_1_lite_lower_priority` missed
+its picker, so it is unmeasured either way.) Some accounts have the control, some
+do not; the cohort key — region, account age, experiment bucket — is unknown.
+So on an unaffected cohort Flow offers the row and gflow still refuses it: the
+flag is unavailable on every cohort today, for two different reasons.
 
-**What that means in practice.** On an affected cohort `--duration` cannot be
-honored, and the fail-fast is correct behaviour rather than a selector bug to
-patch. On an unaffected cohort it works. Because a static per-model table cannot
-express a per-account capability, treat *both* "Veo has no duration control" and
-"Veo supports 4/6/8s" as wrong when stated unconditionally.
-
-**Workaround:** omit `--duration` to accept Flow's default length. If your Flow
-UI does show a duration row for the same account and model while `gflow` still
-fails, that *is* worth reporting — attach the probe name and the
-`debug_no_duration_tab.png` screenshot (no tokens or signed URLs).
+**Reporting.** If Flow's UI shows a duration row for a Veo model on your account,
+that is useful — it narrows the cohort key. Attach the exact `--model` /
+`--duration` invocation and the error text; a `--model omni-flash` run
+additionally yields the probe name and `debug_no_duration_tab.png`. No tokens or
+signed URLs.
 
 ### macOS: generation runs logged-out → HTTP 401, even with `--browser chrome`
 

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -267,11 +267,17 @@ listing endpoint (privacy-gated to `store` history mode), and `gflow doctor`
 (#542) surfaces the affected-row count. Freshly generated rows whose caption
 has not landed yet stay nameless until the next sync sweep.
 
-### Video duration tab probe misses on the current Frames-submode DOM
+### Video duration control is absent on some account cohorts
 
-- **Status:** Open ([#288](https://github.com/ffroliva/gflow-cli/issues/288))
-- **Severity:** Medium · **Affected:** `gflow video` with an explicit `--duration`
-  on at least some Classic-profile cohorts (3/3 miss on a live 2026-07-11 run)
+- **Status:** Mitigated — fail-fast shipped in
+  [#289](https://github.com/ffroliva/gflow-cli/pull/289);
+  [#288](https://github.com/ffroliva/gflow-cli/issues/288) and
+  [#451](https://github.com/ffroliva/gflow-cli/issues/451) are closed. The
+  underlying Flow behaviour is **cohort-dependent and unresolved**, so the row
+  stays here.
+- **Severity:** Medium · **Affected:** `gflow video` with an explicit
+  `--duration` on the affected cohorts (3/3 miss on a live 2026-07-11 run;
+  re-confirmed 2026-09-03)
 
 The `duration_tab` selector cascade (`[role='tab']:text-is('4s')` /
 `:has-text('4s')`) fails to match on Flow's current Frames-submode settings
@@ -279,7 +285,6 @@ panel. Pre-fix this silently produced a clip of Flow's default length; since
 the #289 fix the run fails fast with `UiSelectorDriftError` (exit 23) and a
 `debug_no_duration_tab.png` screenshot — live-verified 2026-07-11 on the
 my-profile profile (aborted pre-submit, saving the 10-credit generation).
-**Workaround:** omit `--duration` to accept Flow's default.
 
 **Root cause (confirmed live 2026-07-11, screenshot evidence on #288): the
 duration control is ABSENT from this cohort's settings popover** — the panel
@@ -288,10 +293,26 @@ renders mode tabs (Imagem/Video), sub-mode (Frames/Elementos), aspect
 model dropdown (Veo 3.1 - Lite), and
 nothing else. The earlier locale hypothesis is refuted: the UI renders in
 Portuguese and the sibling count tabs (`1x`/`x2`) match fine; there is simply
-no duration row to click. Whether Flow removed clip-length selection for this
-cohort/model or moved it elsewhere is unknown — until that's answered,
-`--duration` cannot be honored on affected cohorts and the fail-fast is the
-correct behavior, not a selector bug to patch.
+no duration row to click.
+
+**Updated 2026-09-04 — it is a cohort difference, not a removal.** A third
+profile on the *same* `labs.google` frontend renders `4s/6s/8s` on every Veo 3.1
+model, with different credit prices, in a credit-free capture that passes this
+project's own read-validity checks (count tabs present, composer chip carrying
+the duration segment). So all three readings are honest: some accounts have the
+control, some do not. The cohort key — region, account age, experiment bucket —
+is still unknown.
+
+**What that means in practice.** On an affected cohort `--duration` cannot be
+honored, and the fail-fast is correct behaviour rather than a selector bug to
+patch. On an unaffected cohort it works. Because a static per-model table cannot
+express a per-account capability, treat *both* "Veo has no duration control" and
+"Veo supports 4/6/8s" as wrong when stated unconditionally.
+
+**Workaround:** omit `--duration` to accept Flow's default length. If your Flow
+UI does show a duration row for the same account and model while `gflow` still
+fails, that *is* worth reporting — attach the probe name and the
+`debug_no_duration_tab.png` screenshot (no tokens or signed URLs).
 
 ### macOS: generation runs logged-out → HTTP 401, even with `--browser chrome`
 


### PR DESCRIPTION
## Summary

The `#288` row in `KNOWN_ISSUES.md` was wrong in two ways at once.

**It claimed `Status: Open`** while #288, #451 and #634 are all CLOSED on GitHub (`gh issue view 288` → `CLOSED`).

**It asserted the duration control had been removed** — "until that's answered, `--duration` cannot be honored on affected cohorts" — a claim disproved on 2026-09-04 when a third profile on the *same* `labs.google` frontend rendered `4s/6s/8s` on every Veo 3.1 model, at different credit prices, in a credit-free capture that passes this project's own read-validity checks (count tabs present, composer chip carrying the duration segment).

Both the 2026-07-11 and 2026-09-03 captures remain valid for their cohort. So does the opposite one. The cohort key — region, account age, experiment bucket — is still unknown.

## Changes

- Heading renamed: "probe misses on the current Frames-submode DOM" → "control is absent on some account cohorts". The old title asserted a selector defect; it is a capability difference.
- Status → **Mitigated** (fail-fast shipped in #289), with the row kept because the Flow-side behaviour is unresolved.
- New paragraph recording the cohort finding, and stating explicitly that *both* "Veo has no duration control" and "Veo supports 4/6/8s" are wrong when stated unconditionally.
- The workaround now says when filing a bug **is** warranted and what to attach.
- `website/docs/` mirror regenerated.

## Why this is separate from #650

External PR #650 also edits this block. I told its author I would take the `KNOWN_ISSUES` record, so this PR claims the whole section and #650 should drop it from its diff rather than both of us editing the same lines. Flagged on that PR.

## Test plan

- [x] `check_doc_links.py` — all links resolved across 29 files
- [x] `check_repo_hygiene.py` — 873 files, no violations
- [x] `check_website_docs_pii.py` — no private identifiers across 25 published files
- [x] `generate_website_docs.py --check` — mirror in sync, nav complete
- [x] Issue states verified against GitHub, not assumed

Docs-only; no code paths touched.

Refs #288, #451, #650