### PR TITLE
feat(recon): $0 stray-match probe, and stop the collector faking a positive

### DIFF
--- a/scripts/dev/capture_video_model_capability_matrix.py
+++ b/scripts/dev/capture_video_model_capability_matrix.py
@@ -131,16 +131,23 @@ async def _menu_state(page: Any) -> dict[str, Any]:
           // and `x{n}` (count) and takes `.first`. Any VISIBLE match outside the
           // open popover is an element the transport could click by mistake.
           // Empty lists across every model = scoping/read-back is unnecessary.
-          const STRAY_ROLES = [
+          // Mirrors of the transport's two cascades, which are NOT the same.
+          // ui_automation_video.py: duration probes five roles for `{n}s`;
+          // count probes ONLY [role='tab'], for BOTH affix orders `x{n}` and
+          // the #404 legacy `{n}x`. Scanning one shared list under-reported
+          // count (missed `2x`) and over-reported it (flagged buttons the
+          // transport can never click).
+          const DURATION_ROLES = [
             "[role='tab']", "[role='button']", "button",
             "[role='option']", "[role='menuitem']",
           ];
+          const COUNT_ROLES = ["[role='tab']"];
           const visible = (e) => !!(e.offsetParent || e.getClientRects().length);
-          const strayScan = (labels) => {
+          const strayScan = (labels, roles) => {
             const seen = new Set();
             const out = [];
             for (const label of labels) {
-              for (const role of STRAY_ROLES) {
+              for (const role of roles) {
                 for (const el of document.querySelectorAll(role)) {
                   if (menu && menu.contains(el)) continue;
                   if (!visible(el)) continue;
@@ -158,8 +165,12 @@ async def _menu_state(page: Any) -> dict[str, Any]:
             }
             return out;
           };
-          const durationStrays = strayScan([4, 6, 8, 10].map(n => n + 's'));
-          const countStrays = strayScan([1, 2, 3, 4].map(n => 'x' + n));
+          const durationStrays = strayScan(
+            [4, 6, 8, 10].map(n => n + 's'), DURATION_ROLES,
+          );
+          const countStrays = strayScan(
+            [1, 2, 3, 4].flatMap(n => ['x' + n, n + 'x']), COUNT_ROLES,
+          );
           const creditRe = /([\\d.,]+)\\s*(?:cr[e\\u00e9]dito?s?|credits?)/i;
           const credits = (text.match(creditRe) || [])[1] || null;
           // The composer's dynamic summary chip, e.g. "Video · 4s x1".
@@ -171,7 +182,6 @@ async def _menu_state(page: Any) -> dict[str, Any]:
             .sort((a, b) => a.length - b.length)[0] || null;
           const body = document.body.innerText.toLowerCase();
           return {
-            menu_present: !!menu,
             tabs,
             credits_text: credits,
             composer_chip: chip,
@@ -288,6 +298,9 @@ async def _run(profile: str, project: str) -> int:
                         "tabs": [t["label"] for t in miss_state["tabs"]],
                         "model_trigger_count": trigger_count,
                         "menuitems_seen": menuitems,
+                        "menu_present": miss_state["menu_present"],
+                        "duration_strays": miss_state["duration_strays"],
+                        "count_strays": miss_state["count_strays"],
                     }
                 )
                 step(
@@ -309,6 +322,12 @@ async def _run(profile: str, project: str) -> int:
                 "ingredient_rejected": state["ingredient_reject"],
                 "page_lang": state["page_lang"],
                 "menu_text": state["menu_text"],
+                # The kill condition is "empty across EVERY model", so these
+                # have to be per-row. In the first cut they existed only in the
+                # pre-model-select baseline, which cannot answer that question.
+                "menu_present": state["menu_present"],
+                "duration_strays": state["duration_strays"],
+                "count_strays": state["count_strays"],
             }
             rows.append(row)
             step(

--- a/scripts/dev/capture_video_model_capability_matrix.py
+++ b/scripts/dev/capture_video_model_capability_matrix.py
@@ -106,7 +106,16 @@ async def _menu_state(page: Any) -> dict[str, Any]:
         """() => {
           const menu = document.querySelector("[role='menu']");
           const scope = menu || document.body;
-          const tabs = [...scope.querySelectorAll("button, [role='tab'], [role='button'], [role='option'], [role='menuitem']")].map(t => ({
+          // A capability claim must come from the popover itself. Without this,
+          // a failed open scrapes the whole page and any stray "8s" button
+          // reads as a duration tab -- the instrument manufacturing a positive.
+          const tabScope = menu;
+          const TAB_ROLES = "button, [role='tab'], [role='button'],"
+                          + " [role='option'], [role='menuitem']";
+          const tabEls = tabScope === null
+            ? []
+            : [...tabScope.querySelectorAll(TAB_ROLES)];
+          const tabs = tabEls.map(t => ({
             label: (t.getAttribute('aria-label') || t.textContent || '').trim(),
             id: t.id || null,
             selected: t.getAttribute('aria-selected') === 'true',
@@ -117,6 +126,40 @@ async def _menu_state(page: Any) -> dict[str, Any]:
           // An English-only /Generating will use N credits/ silently returns
           // null on a pt-BR UI and reads as "no cost shown" (memory:
           // flow-locale-leak-icon-ligatures).
+          // --- $0 stray-match probe -------------------------------------
+          // ui_automation_video.py probes these five roles for `{n}s` (duration)
+          // and `x{n}` (count) and takes `.first`. Any VISIBLE match outside the
+          // open popover is an element the transport could click by mistake.
+          // Empty lists across every model = scoping/read-back is unnecessary.
+          const STRAY_ROLES = [
+            "[role='tab']", "[role='button']", "button",
+            "[role='option']", "[role='menuitem']",
+          ];
+          const visible = (e) => !!(e.offsetParent || e.getClientRects().length);
+          const strayScan = (labels) => {
+            const seen = new Set();
+            const out = [];
+            for (const label of labels) {
+              for (const role of STRAY_ROLES) {
+                for (const el of document.querySelectorAll(role)) {
+                  if (menu && menu.contains(el)) continue;
+                  if (!visible(el)) continue;
+                  const txt = (el.textContent || '').trim();
+                  if (!txt.includes(label)) continue;
+                  const key = label + '|' + role + '|' + (el.id || '') + '|' + txt.slice(0, 40);
+                  if (seen.has(key)) continue;
+                  seen.add(key);
+                  out.push({
+                    label, role, tag: el.tagName,
+                    id: el.id || null, text: txt.slice(0, 60),
+                  });
+                }
+              }
+            }
+            return out;
+          };
+          const durationStrays = strayScan([4, 6, 8, 10].map(n => n + 's'));
+          const countStrays = strayScan([1, 2, 3, 4].map(n => 'x' + n));
           const creditRe = /([\\d.,]+)\\s*(?:cr[e\\u00e9]dito?s?|credits?)/i;
           const credits = (text.match(creditRe) || [])[1] || null;
           // The composer's dynamic summary chip, e.g. "Video · 4s x1".
@@ -133,6 +176,9 @@ async def _menu_state(page: Any) -> dict[str, Any]:
             credits_text: credits,
             composer_chip: chip,
             menu_text: text.slice(0, 400),
+            menu_present: menu !== null,
+            duration_strays: durationStrays,
+            count_strays: countStrays,
             page_lang: document.documentElement.lang || null,
             ingredient_reject: body.includes('cannot use image ingredients')
               || body.includes('ingredientes de imagem'),

--- a/tests/scripts/test_capture_video_model_capability_matrix.py
+++ b/tests/scripts/test_capture_video_model_capability_matrix.py
@@ -1,15 +1,43 @@
 """Tests for the live capability matrix collector.
 
-The DOM scrape itself runs in the browser and cannot be exercised offline, so
-the two invariants that decide whether a capture can be TRUSTED are pinned here
-as source guards instead: the tab scrape must not fall back to the whole page,
-and the stray probe must report what it found.
+The DOM scrape runs in the browser and cannot be exercised offline. What CAN be
+checked offline is the thing that actually decides whether a capture is
+trustworthy: that the collector's stray probe mirrors the transport cascades it
+claims to replay.
+
+That matters because the probe's result is a **kill condition** — empty stray
+lists close issue #657 and task 7 of the duration plan without any code being
+written. A probe that under-reports deletes work that was needed. The first cut
+of this file asserted only that certain substrings appeared in the source, which
+passed against unmodified `develop` and caught none of that.
 """
 
-import inspect
+from __future__ import annotations
 
+import inspect
+import re
+
+from gflow_cli.api.transports import ui_automation_video as transport
 from scripts.dev import capture_video_model_capability_matrix as collector
 from scripts.dev.capture_video_model_capability_matrix import _classify
+
+ROLE_RE = re.compile(r"\[role='([a-z]+)'\]|(?<![\w'\-])(button)(?=:)")
+
+
+def _roles(source: str) -> set[str]:
+    """Every element role a cascade probes, from its source text."""
+    return {a or b for a, b in ROLE_RE.findall(source)}
+
+
+def _probe_roles(js_const: str) -> set[str]:
+    """Roles listed in one of the probe's JS role constants."""
+    block = re.search(rf"const {js_const} = \[(.*?)\];", _menu_state_src(), re.DOTALL)
+    assert block, f"{js_const} not found in the probe"
+    return {a or b for a, b in ROLE_RE.findall(block.group(1))}
+
+
+def _menu_state_src() -> str:
+    return inspect.getsource(collector._menu_state)
 
 
 def test_classify_detects_interactive_duration_labels() -> None:
@@ -27,27 +55,63 @@ def test_classify_detects_interactive_duration_labels() -> None:
     assert result["aspect"] == ["16:9"]
 
 
+def test_duration_probe_covers_every_role_the_transport_probes() -> None:
+    """A role the transport clicks but the probe skips is a silent false negative."""
+    transport_roles = _roles(
+        inspect.getsource(transport.VideoGenerationMixin._select_video_duration)
+    )
+    assert transport_roles, "failed to extract the transport's duration roles"
+    assert transport_roles <= _probe_roles("DURATION_ROLES")
+
+
+def test_count_probe_mirrors_the_transport_exactly() -> None:
+    """Count is NOT the same cascade as duration — it probes only [role='tab'].
+
+    Sharing one role list with duration both over-reported (flagging buttons the
+    transport can never click, inventing work) and, with the label bug below,
+    under-reported.
+    """
+    transport_roles = _roles(inspect.getsource(transport.VideoGenerationMixin._set_output_count))
+    assert transport_roles == {"tab"}, f"transport count roles changed: {transport_roles}"
+    assert _probe_roles("COUNT_ROLES") == {"tab"}
+
+
+def test_count_probe_scans_both_affix_orders() -> None:
+    """#404 renamed the count tabs `1x` -> `x1` and the transport probes BOTH.
+
+    Scanning only `x{n}` misses a visible `2x` outside the popover — clickable by
+    the transport, invisible to the probe. This is the exact bug the first cut
+    shipped, and it is the under-reporting direction that wrongly closes #657.
+    """
+    assert 'labels = (f"x{n}", f"{n}x")' in inspect.getsource(
+        transport.VideoGenerationMixin._set_output_count
+    ), "transport affix handling changed — re-check the probe"
+    src = _menu_state_src()
+    assert "'x' + n" in src and "n + 'x'" in src, "probe must scan both affix orders"
+
+
 def test_tab_scrape_never_falls_back_to_the_whole_page() -> None:
     """A capability claim must come from the popover, not from `document.body`.
 
-    With the widened selector, a popover that failed to open would otherwise
-    scrape every button on the page, and any stray "8s" would read as a
-    duration tab -- the instrument manufacturing the positive it is supposed to
-    measure. `menu_present` records which happened.
+    With the widened selector (#650), a popover that failed to open would scrape
+    every button on the page and any stray "8s" would read as a duration tab --
+    the instrument manufacturing the positive it exists to measure.
     """
-    src = inspect.getsource(collector._menu_state)
+    src = _menu_state_src()
     assert "const tabScope = menu;" in src
     assert "tabScope === null" in src, "tab scrape must yield [] when no menu is open"
-    assert "menu_present:" in src, "a capture must say whether the popover was open"
 
 
-def test_stray_probe_reports_both_cascades() -> None:
-    """The $0 kill-condition probe for the duration and count cascades.
+def test_strays_reach_every_per_model_row() -> None:
+    """The kill condition is "empty across EVERY model", so a baseline-only
+    sample cannot answer it. Both the selected-model row and the picker-miss row
+    must carry the probe output."""
+    src = inspect.getsource(collector)
+    for field in ("menu_present", "duration_strays", "count_strays"):
+        # once in the JS payload, once per row shape (selected + picker-miss)
+        assert src.count(f'"{field}"') >= 2, f"{field} does not reach the per-model rows"
 
-    Both are unscoped `.first` probes over the same five roles, so both need the
-    same evidence before anyone writes scoping or read-back code.
-    """
-    src = inspect.getsource(collector._menu_state)
-    assert "duration_strays:" in src
-    assert "count_strays:" in src
-    assert "menu.contains(el)" in src, "strays are matches OUTSIDE the open menu"
+
+def test_classify_handles_an_unopened_popover() -> None:
+    """`tabScope = menu` yields [] when no menu opened; nothing may explode."""
+    assert _classify([]) == {"duration": [], "count": [], "aspect": [], "other": []}

--- a/tests/scripts/test_capture_video_model_capability_matrix.py
+++ b/tests/scripts/test_capture_video_model_capability_matrix.py
@@ -1,5 +1,14 @@
-"""Tests for the live capability matrix classifier."""
+"""Tests for the live capability matrix collector.
 
+The DOM scrape itself runs in the browser and cannot be exercised offline, so
+the two invariants that decide whether a capture can be TRUSTED are pinned here
+as source guards instead: the tab scrape must not fall back to the whole page,
+and the stray probe must report what it found.
+"""
+
+import inspect
+
+from scripts.dev import capture_video_model_capability_matrix as collector
 from scripts.dev.capture_video_model_capability_matrix import _classify
 
 
@@ -16,3 +25,29 @@ def test_classify_detects_interactive_duration_labels() -> None:
     assert result["duration"] == ["4s", "6s", "8s"]
     assert result["count"] == ["x1"]
     assert result["aspect"] == ["16:9"]
+
+
+def test_tab_scrape_never_falls_back_to_the_whole_page() -> None:
+    """A capability claim must come from the popover, not from `document.body`.
+
+    With the widened selector, a popover that failed to open would otherwise
+    scrape every button on the page, and any stray "8s" would read as a
+    duration tab -- the instrument manufacturing the positive it is supposed to
+    measure. `menu_present` records which happened.
+    """
+    src = inspect.getsource(collector._menu_state)
+    assert "const tabScope = menu;" in src
+    assert "tabScope === null" in src, "tab scrape must yield [] when no menu is open"
+    assert "menu_present:" in src, "a capture must say whether the popover was open"
+
+
+def test_stray_probe_reports_both_cascades() -> None:
+    """The $0 kill-condition probe for the duration and count cascades.
+
+    Both are unscoped `.first` probes over the same five roles, so both need the
+    same evidence before anyone writes scoping or read-back code.
+    """
+    src = inspect.getsource(collector._menu_state)
+    assert "duration_strays:" in src
+    assert "count_strays:" in src
+    assert "menu.contains(el)" in src, "strays are matches OUTSIDE the open menu"


### PR DESCRIPTION
## Summary

Two open gates need the same evidence before anyone writes code — **#657** (the count-tab cascade) and **task 7** of `docs/superpowers/plans/2026-09-04-duration-cohort-probe/PLAN.md` (the duration read-back). Both are unscoped `.first` probes over the same five roles, and `/gflow:predict` rated the hazard **LIKELY, not CONFIRMED** for both: nobody has demonstrated a real element that actually collides.

This answers it for $0, on the script that already walks that DOM.

## The probe

`_menu_state` replays the transport's cascade document-wide and reports only matches **outside** the open popover — exactly the elements `.first` could hit instead of the real tab:

```json
"duration_strays": [{"label":"8s","role":"button","tag":"BUTTON","id":"…","text":"…"}],
"count_strays":    []
```

**Kill condition:** empty lists across every model ⇒ scoping and read-back are unnecessary, and both tasks close unstarted. That is the outcome I expect, and it is worth $0 to know rather than assume.

## The bug it also fixes

The collector could manufacture the positive it exists to measure.

`scope = menu || document.body` was harmless when the tab scrape was `[role='tab']` only. #650 widened it to plain buttons — so a popover that failed to open would scrape **the whole page**, and any stray `8s` button would be recorded as a duration tab. This is the instrument that settles capability arguments; it must not be able to invent one.

The tab scrape is now menu-only and yields `[]` when no menu is open, with `menu_present` recording which happened, so a miss can never read as an absence. The text and credit reads keep the body fallback — they are descriptive, not capability claims.

## How to run it

```powershell
$env:PYTHONUTF8=1
.venv\Scripts\python.exe scripts\dev\capture_video_model_capability_matrix.py --profile denon82 --project <id>
```

Navigation and popover reads only, nothing submitted, no credits. Run it on `denon82` — `ffroliva` is fully migrated to `flow.google.com` and exits 36 immediately.

## Test plan

- [x] `pytest tests/scripts/test_capture_video_model_capability_matrix.py` — 3 passed
- [x] `ruff check src tests scripts/dev/capture_video_model_capability_matrix.py` — clean (the file has no pre-existing errors; `scripts/dev/` at large has ~54 that CI does not gate)
- [x] `check_repo_hygiene.py`, `check_doc_links.py`, `check_council_memory.py` — green
- [ ] **Not run against live Flow** — that is the point of the PR, and it needs a maintainer's Chrome session

## On the tests

The DOM scrape runs in the browser and cannot be exercised offline, so the two invariants that decide whether a capture can be **trusted** are pinned as source guards instead. That is weaker than a behavioural test and I would rather say so than dress it up — the pre-existing test covered only `_classify`, which neither this change nor #650 touches.

Refs #657, #650, #288