### PR TITLE
docs(memory): record the two lessons today cost something to learn

### DIFF
--- a/docs/superpowers/memory/memory-is-working-dir-keyed.md
+++ b/docs/superpowers/memory/memory-is-working-dir-keyed.md
@@ -1,0 +1,44 @@
+---
+name: memory-is-working-dir-keyed
+description: "Claude Code keys memory by working-directory path, so any agent on another machine — sandboxed triage, CI, a fresh clone — starts with an EMPTY namespace. Anything an off-machine agent must read has to live in the repo. The review-relevant subset is published at docs/superpowers/memory/."
+---
+
+**Claude Code memory is keyed by working-directory path, not by repo identity.**
+A fresh clone at a different path — the autopilot's `/opt/gflow-cli`, a CI
+runner, another machine — starts with an **empty** memory namespace. None of the
+~230 accumulated files are visible there unless they were synced.
+
+This was documented in
+`docs/superpowers/specs/2026-07-04-pr-triage-autopilot-design.md` from the start,
+including a one-way local→VPS sync. **The sync was never implemented.**
+
+**What that cost.** On 2026-09-04 the PR-triage autopilot reviewed external PR
+#650 and reported D5 as **GREEN — "no Claude-memory entry contradicts this PR"**
+— from a directory it could not read, while the local store recorded that exact
+PR as REJECTED. Structural blindness was published as a positive finding, under
+the maintainer's identity, on a public PR. That is the assumed-not-verified
+failure the council protocol forbids by name, arriving through a deployment gap
+rather than a reasoning error.
+
+**The fix, shipped 2026-09-04 (PR #656).** The review-relevant subset now lives
+in the repo at **`docs/superpowers/memory/<slug>.md`**, so `[[slug]]` in a skill
+resolves to a real file for any agent that can read the tree — no sync, no
+secret, no VPS change, because the repo is already bind-mounted read-only into
+every sandbox. `scripts/ci/check_council_memory.py` enforces it both ways: a
+citation with no file fails, and a file no dimension cites fails.
+
+**How to apply.**
+- **Published copy is canonical for review; the private store is upstream
+  drafting.** A fact in both is edited in the repo first.
+- To add one: write `<slug>.md`, cite it from the Dimension → Slugs table in
+  `skills/pr-council-review/SKILL.md`, run the gate. Step 2 is the one people
+  skip, and it is enforced because an uncited file is unroutable.
+- Only review-relevant, publishable facts go there. Session handoffs, tooling
+  notes, and anything naming an account, profile, project UUID or local path
+  stay private — the gate rejects those patterns.
+- **Never report a memory dimension as GREEN from a store you could not read.**
+  Empty or absent is `UNAVAILABLE`. Verify you can actually read it, and quote
+  the file count, before any verdict.
+- The general form: *wire the rule, don't document it* — a documented sync that
+  nobody built is worth exactly nothing, and worse than nothing if a reviewer
+  assumes it ran. See [[wire-the-rule-dont-document-it]].

--- a/docs/superpowers/memory/prose-conflicts-hide-in-disjoint-files.md
+++ b/docs/superpowers/memory/prose-conflicts-hide-in-disjoint-files.md
@@ -1,0 +1,48 @@
+---
+name: prose-conflicts-hide-in-disjoint-files
+description: "Two PRs that edit DIFFERENT files can still contradict each other in prose. Git merges them clean, no conflict marker, and no CI gate can see it. When a PR changes behaviour, grep the docs it does NOT touch for the old behaviour stated as present-tense fact."
+---
+
+**Git only detects conflicts in the same lines of the same file. Two PRs that
+edit different files can still ship a repo that contradicts itself, and nothing
+in the toolchain will notice.**
+
+On 2026-09-04, #655 rewrote the `KNOWN_ISSUES.md` row describing gflow's video
+duration gate, correctly, for the code as it stood that morning. #650 then
+changed exactly that behaviour while deliberately **not** touching
+`KNOWN_ISSUES.md` — the maintainer had asked the contributor to drop it to avoid
+a merge conflict. The two merged cleanly. Three sentences in `KNOWN_ISSUES.md`
+became false the moment #650 landed:
+
+- "`--model omni-flash`, the only model gflow currently allows a duration on"
+- "gflow refuses `--duration` on every named Veo 3.1 model at the CLI edge"
+- "the flag is unavailable on every cohort today"
+
+Three separate council dimensions (D1 correctness, D9 docs, D15 parity) found it
+independently. No mechanical gate did, and none could: `check_doc_links.py`
+validates link targets, `generate_website_docs.py --check` validates the mirror
+is byte-identical to canonical, and both were green. **A mirror can be
+identically wrong, and a link can point at a page that lies.**
+
+**Why the usual instinct fails.** Asking a contributor to drop a file to dodge a
+conflict is the right call for *merge mechanics* and the wrong one for
+*correctness* — it converts a visible conflict into an invisible one. If the
+file must come out of their PR, the correction becomes yours, and it has to land
+with or immediately after theirs, never before.
+
+**How to apply.**
+- When reviewing a PR that changes behaviour, grep the docs it does **not**
+  touch for the old behaviour stated as present-tense fact. `KNOWN_ISSUES.md`,
+  `PROJECT_STATUS.md` and `docs/MCP.md` are the usual offenders here, because
+  they describe current state rather than usage.
+- When two PRs are in flight on one behaviour, name which one owns the doc, and
+  say so on both.
+- A doc correction that describes a PR's post-merge state **must not merge
+  first**. Open it as a draft gated on the other, or land it immediately after.
+- Watch for the mirror image too: while fixing an old absolute, it is easy to
+  write a new one. On the same day, #650 fixed "Veo renders no duration control"
+  in `USAGE.md` and simultaneously introduced "4/6/8 for Veo 3.1" with no cohort
+  caveat in `docs/MCP.md` and `docs/MOVIE.md`.
+
+See [[flow-capabilities-are-cohort-dependent]],
+[[doc-examples-are-untested-fixtures]], [[project-status-md-drifts-across-releases]].

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -235,11 +235,11 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 | D2 | `[[ruff-format-scope-is-src-tests]]`, `[[git-add-all-sweeps-scratch-files]]` |
 | D3 | `[[real-browser-auth-mandatory]]`, `[[release-signing]]` |
 | D4 | `[[force-color-breaks-cli-tests]]`, `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]` |
-| D5 | `[[release-spec-plan-memory-consolidation]]`, `[[pr-council-review-stale-tree-reads]]` (this very bug, as the council should self-improve) |
+| D5 | `[[memory-is-working-dir-keyed]]`, `[[release-spec-plan-memory-consolidation]]`, `[[pr-council-review-stale-tree-reads]]` (this very bug, as the council should self-improve) |
 | D6 | `[[ui-selector-drift-error-exit-23]]`, `[[credit-free-route-abort-verification]]`, `[[flow-credits-videos-only]]`, `[[flow-recon-must-run-on-denon82-ffroliva-migrated]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]` |
 | D7 | `[[on-started-callback-recorder-safety]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]` |
 | D8 | (none mandatory) |
-| D9 | `[[doc-examples-are-untested-fixtures]]`, `[[readme-hybrid-router-pattern]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]` |
+| D9 | `[[prose-conflicts-hide-in-disjoint-files]]`, `[[doc-examples-are-untested-fixtures]]`, `[[readme-hybrid-router-pattern]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]` |
 | D10 | `[[real-browser-auth-mandatory]]` |
 | D11 | `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`, `[[pypi-rejected-filename-reusable]]`, `[[draft-pr-merge-trap]]` |
 | D12 | `[[bdd-stubs-mirror-runtime-signatures]]` |


### PR DESCRIPTION
## Summary

Two failures from today's five merges, both paid for in real rework, neither written down anywhere. Published into `docs/superpowers/memory/` and cited from the dimensions that would have caught each one.

### 1. Prose conflicts hide in disjoint files

`[[prose-conflicts-hide-in-disjoint-files]]` → cited from **D9** (docs drift).

#655 rewrote the `KNOWN_ISSUES` duration row correctly for the code as it stood that morning. #650 then changed exactly that behaviour while deliberately **not** touching the file — because I had asked the contributor to drop it to avoid a merge conflict. Git merged them clean. Three sentences became false on merge.

Three council dimensions found it independently. **No mechanical gate did, and none could:** `check_doc_links.py` validates link targets, `generate_website_docs.py --check` validates the mirror is byte-identical to canonical, and both were green. A mirror can be identically wrong, and a link can point at a page that lies.

The instinct that caused it is the part worth recording: dropping a file to dodge a conflict is right for *merge mechanics* and wrong for *correctness*, because it converts a visible conflict into an invisible one. If the file leaves their PR, the correction becomes yours — and it must land with or after theirs, never before.

### 2. Memory is working-directory-keyed

`[[memory-is-working-dir-keyed]]` → cited from **D5** (memory hygiene).

The autopilot reported D5 **GREEN** — *"no memory entry contradicts this PR"* — from a directory it could not read, while the local store recorded that exact PR as REJECTED. Structural blindness published as a positive finding, on a public PR, under the maintainer's identity.

The one-way sync that would have prevented it was designed in `2026-07-04-pr-triage-autopilot-design.md` and never built. #656 solved it a different way — publishing the review-relevant subset into the repo, which needs no sync at all.

## The gate caught me while I wrote this

Worth reporting rather than quietly fixing: my publish helper *filtered* the `metadata:` line instead of *breaking* at it, so the indented `originSessionId` underneath survived into both published files. `check_council_memory.py` flagged it:

```
PRIVATE  docs/superpowers/memory/prose-conflicts-hide-in-disjoint-files.md  contains a session id
PRIVATE  docs/superpowers/memory/memory-is-working-dir-keyed.md             contains a session id
```

That rule shipped in #656 this morning and has now fired on its own author, on the second day of its existence. Fixed before commit.

## Test plan

- [x] `check_council_memory.py` — 45 files, all cited, all resolving, no private identifiers
- [x] `pytest tests/scripts` — 211 passed
- [x] `check_repo_hygiene.py`, `check_doc_links.py`, `generate_website_docs.py --check` — green

Docs-only. Refs #650, #655, #656