### PR TITLE
fix(autopilot): a quota wait is not a review failure

### DIFF
--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -86,6 +86,45 @@ def check_claude_auth() -> str | None:
 # set is treated as unparseable (None) rather than interpolated downstream.
 VALID_VERDICTS = ("GREEN", "YELLOW", "RED")
 
+# The review payload (`claude -p`) shares one subscription with interactive use,
+# so it can exhaust the session quota. That is transient and self-healing: the
+# window resets on its own. It reached us as a generic non-zero exit, which the
+# cycle counted as a review failure -- and three hourly retries land inside the
+# SAME exhausted window, so PR #650 was marked FAILED_PERMANENT (manual ledger
+# surgery) by a condition that needed nothing but time. The Docker build had
+# succeeded on every attempt.
+_QUOTA_SIGNATURES: tuple[str, ...] = (
+    "hit your session limit",
+    "usage limit reached",
+    "rate limit exceeded",
+    "429 too many requests",
+)
+
+# Docker's build progress is front-loaded (`#1 DONE`, `#2 DONE`, ...) and the
+# payload error is the LAST line, so a head-truncated alert shows only noise.
+# Every alert for the 2026-09-04 incident cut off before the sentence that
+# explained it.
+ALERT_EXCERPT_CHARS = 900
+
+
+def is_transient_quota_error(message: str) -> bool:
+    """True when a failure is an LLM quota wait rather than a defect.
+
+    Deliberately narrow: a broken sandbox, a missing token or a full disk must
+    still burn a retry, or a genuinely stuck PR would be retried forever with
+    nobody told.
+    """
+    haystack = message.casefold()
+    return any(sig in haystack for sig in _QUOTA_SIGNATURES)
+
+
+def alert_excerpt(message: str) -> str:
+    """Excerpt an error for an alert, keeping the END where the reason lives."""
+    text = message.strip()
+    if len(text) <= ALERT_EXCERPT_CHARS:
+        return text
+    return "...(truncated)... " + text[-ALERT_EXCERPT_CHARS:]
+
 # Markers the council report is sliced on before it is posted publicly.
 # The heading opens the report; the machine line closes it and is parsed for
 # the verdict, so everything outside the pair is preamble or wrapper logging.
@@ -660,6 +699,33 @@ def run_triage_cycle(
             )
 
         except Exception as exc:
+            # A quota wait is not a review failure. Record it, leave the retry
+            # budget untouched, and let the next tick pick the PR up once the
+            # window has reset.
+            if is_transient_quota_error(str(exc)):
+                logger.warning(
+                    "PR triage deferred: LLM quota exhausted",
+                    pr=pr_num,
+                    sha=head_sha,
+                    detail=alert_excerpt(str(exc)),
+                )
+                append_ledger_entry(
+                    ledger_path,
+                    {
+                        "pr": pr_num,
+                        "head_sha": head_sha,
+                        "status": "DEFERRED",
+                        "fail_count": 0,
+                        "error": alert_excerpt(str(exc)),
+                        "engine": engine,
+                    },
+                )
+                send_telegram_alert(
+                    f"\u23f8 PR #{pr_num} review deferred - LLM quota exhausted, "
+                    "retrying next tick (no retry burned)"
+                )
+                continue
+
             failures = get_pr_failures_count(ledger_entries, pr_num, head_sha) + 1
             status = "FAILED_PERMANENT" if failures >= MAX_RETRIS else "FAILED"
 
@@ -693,7 +759,7 @@ def run_triage_cycle(
                     f'<p>Review of <a href="https://github.com/{repo}/pull/{pr_num}">'
                     f"PR #{pr_num}</a> failed {MAX_RETRIS} times and auto-retry has "
                     f"stopped. Manual ledger reset required.</p>"
-                    f"<p>Last error: {html_lib.escape(str(exc)[:500])}</p>",
+                    f"<p>Last error: {html_lib.escape(alert_excerpt(str(exc)))}</p>",
                 )
             else:
                 send_telegram_alert(f"⚠️ PR #{pr_num} review attempt {failures} failed: {exc}")

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -94,6 +94,178 @@ def test_extract_report_falls_back_to_full_output_when_markers_are_missing(outpu
     assert pr_triage_autopilot.extract_report(output) == output.strip()
 
 
+# --- Claude session-limit handling -------------------------------------------
+#
+# Root cause, 2026-09-04: the sandbox exits non-zero when `claude -p` hits the
+# subscription quota. `run_docker_sandbox` labels EVERY non-zero exit "Docker
+# sandbox failed", and the cycle's generic `except Exception` counts it as a
+# review failure. Three hourly retries land in the SAME exhausted window, so a
+# self-healing condition permanently disabled PR #650 and required manual ledger
+# surgery. The Docker build had succeeded every time (`#14 DONE 0.1s`).
+
+_SESSION_LIMIT_TAIL = (
+    "Docker sandbox failed (exit 1): Building Docker sandbox image...\n"
+    "#14 DONE 0.1s\nCreating network triage-net-650...\n"
+    "Launching sandboxed review for PR 650...\n"
+    "You've hit your session limit \u00b7 resets 9:10pm (UTC)\n"
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "You've hit your session limit \u00b7 resets 9:10pm (UTC)",
+        "you've hit your session limit",
+        "Claude AI usage limit reached|1234567890",
+        "rate limit exceeded, please try again later",
+    ],
+)
+def test_is_transient_quota_error_recognises_real_messages(message):
+    assert pr_triage_autopilot.is_transient_quota_error(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Docker sandbox failed (exit 1): failed to solve: no space left on device",
+        "run_sandboxed_review.sh: line 53: cd: /opt/nope: No such file or directory",
+        "CLAUDE_CODE_OAUTH_TOKEN is not set.",
+        "",
+    ],
+)
+def test_is_transient_quota_error_ignores_real_failures(message):
+    # A genuine defect must still burn a retry -- otherwise a broken sandbox
+    # retries forever and nobody is told.
+    assert pr_triage_autopilot.is_transient_quota_error(message) is False
+
+
+@patch("pr_triage_autopilot.send_email_alert")
+@patch("pr_triage_autopilot.send_telegram_alert")
+@patch("pr_triage_autopilot.post_gh_comment")
+@patch("pr_triage_autopilot.run_docker_sandbox")
+@patch("pr_triage_autopilot.fetch_and_checkout_pr")
+@patch("pr_triage_autopilot.restore_repo_branch")
+@patch("pr_triage_autopilot._gh_json")
+@patch("pr_triage_autopilot.get_ledger_entries")
+@patch("pr_triage_autopilot.append_ledger_entry")
+def test_quota_exhaustion_defers_instead_of_burning_a_retry(
+    mock_append_ledger,
+    mock_get_ledger,
+    mock_gh_json,
+    mock_restore,
+    mock_fetch,
+    mock_sandbox,
+    mock_post_comment,
+    mock_telegram,
+    mock_email,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("GH_SANDBOX_TOKEN", "ro-token")
+    mock_gh_json.return_value = [
+        {
+            "number": 650,
+            "author": {"login": "external-contributor", "is_bot": False},
+            "baseRefName": "develop",
+            "title": "feat: duration",
+            "body": "x",
+            "state": "OPEN",
+            "isDraft": False,
+            "additions": 10,
+            "deletions": 2,
+            "changedFiles": 1,
+            "comments": [],
+        }
+    ]
+    mock_get_ledger.return_value = []
+    mock_fetch.return_value = "cc220d5f"
+    mock_sandbox.side_effect = RuntimeError(_SESSION_LIMIT_TAIL)
+
+    pr_triage_autopilot.run_triage_cycle(
+        repo="owner/repo",
+        repo_dir=tmp_path / "repo",
+        memory_dir=tmp_path / "memory",
+        ledger_path=tmp_path / "ledger.jsonl",
+        gh_token="token-test",
+    )
+
+    entry = mock_append_ledger.call_args[0][1]
+    assert entry["status"] == "DEFERRED", "a self-healing quota error must not count as a failure"
+    assert entry.get("fail_count", 0) == 0, "a deferred run must not burn a retry"
+    mock_email.assert_not_called()  # no "FAILED permanently" mail for a quota wait
+    mock_post_comment.assert_not_called()  # never post a half-review to the PR
+
+
+@patch("pr_triage_autopilot.send_email_alert")
+@patch("pr_triage_autopilot.send_telegram_alert")
+@patch("pr_triage_autopilot.post_gh_comment")
+@patch("pr_triage_autopilot.run_docker_sandbox")
+@patch("pr_triage_autopilot.fetch_and_checkout_pr")
+@patch("pr_triage_autopilot.restore_repo_branch")
+@patch("pr_triage_autopilot._gh_json")
+@patch("pr_triage_autopilot.get_ledger_entries")
+@patch("pr_triage_autopilot.append_ledger_entry")
+def test_a_real_sandbox_failure_still_counts_as_a_failure(
+    mock_append_ledger,
+    mock_get_ledger,
+    mock_gh_json,
+    mock_restore,
+    mock_fetch,
+    mock_sandbox,
+    mock_post_comment,
+    mock_telegram,
+    mock_email,
+    tmp_path,
+    monkeypatch,
+):
+    # The regression guard for the fix above: deferring must be narrow.
+    monkeypatch.setenv("GH_SANDBOX_TOKEN", "ro-token")
+    mock_gh_json.return_value = [
+        {
+            "number": 651,
+            "author": {"login": "external-contributor", "is_bot": False},
+            "baseRefName": "develop",
+            "title": "fix: x",
+            "body": "x",
+            "state": "OPEN",
+            "isDraft": False,
+            "additions": 1,
+            "deletions": 1,
+            "changedFiles": 1,
+            "comments": [],
+        }
+    ]
+    mock_get_ledger.return_value = []
+    mock_fetch.return_value = "sha-real"
+    mock_sandbox.side_effect = RuntimeError(
+        "Docker sandbox failed (exit 1): failed to solve: no space left on device"
+    )
+
+    pr_triage_autopilot.run_triage_cycle(
+        repo="owner/repo",
+        repo_dir=tmp_path / "repo",
+        memory_dir=tmp_path / "memory",
+        ledger_path=tmp_path / "ledger.jsonl",
+        gh_token="token-test",
+    )
+
+    entry = mock_append_ledger.call_args[0][1]
+    assert entry["status"] == "FAILED"
+    assert entry["fail_count"] == 1
+
+
+def test_alert_excerpt_keeps_the_end_of_the_error():
+    """The alert truncated to str(exc)[:500] -- the HEAD of a ~2500-char blob.
+
+    Docker progress output is front-loaded, so the payload error is always the
+    LAST line. Every alert for this incident showed nine lines of `#N DONE` and
+    cut off before the sentence that explained it.
+    """
+    excerpt = pr_triage_autopilot.alert_excerpt(_SESSION_LIMIT_TAIL)
+    assert "session limit" in excerpt, "the reason must survive truncation"
+    assert len(excerpt) <= pr_triage_autopilot.ALERT_EXCERPT_CHARS + 32
+
+
 def test_get_pr_failures_count():
     entries = [
         {"pr": 101, "head_sha": "sha1", "status": "FAILED"},


### PR DESCRIPTION
## Root cause

PR #650's review was marked `FAILED_PERMANENT` three times today by a condition that needed nothing but time.

The Docker build **succeeded on every attempt** — `#14 DONE 0.1s`, image named, network created, iptables applied, review launched, cleanup ran. From the untruncated VPS log, the last line was the real error:

```
You've hit your session limit · resets 9:10pm (UTC)
```

`claude -p` shares one subscription with interactive use and had exhausted the window. That reached the cycle as a generic non-zero exit, so `pr_triage_autopilot.py:662-664` counted it as a review failure. **Retries are hourly; the window is multi-hour.** All three landed inside the same exhausted window, and the PR was permanently disabled — a state whose documented remedy is manual ledger surgery.

Nine session-limit hits in the log today, the first at `00:10:33`. This is recurring, not a one-off.

## Two things hid it for a full day

**The exception lies about what failed.** `run_docker_sandbox` raises `"Docker sandbox failed (exit 1)"` for *any* non-zero exit from the wrapper — including a perfectly healthy build whose payload failed. MemPalace has this same wrapper lying once before, in August, when it actually meant a failed `cd`.

**The alert showed the least useful 500 bytes.** `str(exc)[:500]` takes the **head** of a ~2,500-char blob. Docker progress output is front-loaded (`#1 DONE`, `#2 DONE`…), so the payload error is always the **last** line. Every alert for this incident cut off before the sentence that explained it — which is why three days of failures produced no actionable signal.

## The fix

- `is_transient_quota_error()` — narrow signature match on quota/rate-limit messages
- On a match: ledger `DEFERRED`, `fail_count` untouched, no "failed permanently" email, no PR comment, and the next tick picks it up once the window resets
- `alert_excerpt()` — alerts now keep the **end** of the error, where the reason lives

**Deliberately narrow.** A full disk, a missing token, or a broken script still burns a retry, because a genuinely stuck PR must stop and tell someone. `test_a_real_sandbox_failure_still_counts_as_a_failure` guards that line — and it **passed before this change**, so it exists purely to fail if the deferral ever widens.

## No ledger reset needed

The alert said "Manual ledger reset required". True in general, wrong here: all three `FAILED_PERMANENT` entries are moot — both #650 entries are for a now-merged PR, and #549 does not resolve to a PR. I checked before mutating production rather than after.

## Test plan

- [x] 10 tests written **failing first** (systematic-debugging Phase 4), 62 passing after
- [x] Regression guard for the narrowness of the classifier
- [x] `ruff check src tests scripts/autopilot`, `ruff format --check` — clean
- [x] hygiene, doc-links, council-memory — green
- [ ] **Not exercised against a live sandbox run.** The next quota window is the real check; I can't force one.

## Worth knowing separately

The VPS has **~81 GB of reclaimable Docker garbage** (59 GB images at 97% reclaimable, 23.7 GB build cache) against 34 GB free, and swap is fully exhausted (44 Mi of 2 Gi). Neither caused this, but both are worth a sweep.

Refs #650