### PR TITLE
fix(639): settings pane is the overlay with the option groups; #650 verified on the migrated host

### DIFF
--- a/docs/LIVE_VERIFICATION_v0.67.0.md
+++ b/docs/LIVE_VERIFICATION_v0.67.0.md
@@ -60,6 +60,34 @@ resolved (ligatures, roles, class, numeric tokens) — no text label was matched
 - `DETAILS[10]` is the poster JPEG, `MEDIA_INFO[0][8]` the mp4 → mapping swapped,
   magic verified.
 
+## #650 — `--duration` on the Veo 3.1 models (verified on the migrated host, $0)
+
+Both maintainer accounts are on `flow.google.com` as of 2026-09-05 (the second one
+moved overnight: 3/3 loads), so the labs-side duration guard is **cohort-external**.
+Per model on the new host, measured with `scripts/dev/spike_migrated_duration_by_model.py`
+(read-only):
+
+| Model | Duration row | Resolution row | Credits (8 s, x1) |
+|---|---|---|---|
+| Omni 1.1 Flash | `4s 6s 8s 10s` | `360p 720p` | 12 |
+| Veo 3.1 – Lite | — | — | 10 |
+| Veo 3.1 – Fast | — | — | 20 |
+| Veo 3.1 – Quality | — | — | 100 |
+
+Entrypoint run: `gflow video t2v "…" --model veo-fast --duration 6 --aspect 16:9 --project <id> --json`
+on the flagged profile → **exit 11** in 9.7 s, `ConfigurationError`:
+*"the migrated Flow host renders no 'duration' control offering '6s' on this account
+and model (4 option groups shown) — drop the option or pick a model that offers it"*,
+`retryable: false`, `migrated.dispatch → editor_ready` and nothing after — no submit, no
+credits, no file. That is the #650 contract ("control rendered?" decides, pre-submit,
+at zero cost). The **positive** Veo 4/6/8 path remains NOT verified here: no maintainer
+cohort renders it on either host.
+
+The first attempt of this run exposed a driver bug on the `--model` path (the settings
+pane resolved to a detached menu overlay after the model switch, reporting "no 'aspect'
+control … 0 option groups"); fixed in the same change and pinned by
+`test_axes_still_resolve_after_a_model_switch`.
+
 ## NOT verified (recorded, not omitted)
 
 - `gflow image t2i` and every other command on the migrated host — not ported;

--- a/docs/superpowers/memory/flow-recon-must-run-on-denon82-ffroliva-migrated.md
+++ b/docs/superpowers/memory/flow-recon-must-run-on-denon82-ffroliva-migrated.md
@@ -54,3 +54,5 @@ host is necessary but NOT sufficient; name the profile too
 **Reviewer heuristic that follows:** when a PR relaxes a Flow capability gate, the
 first question is *"which host were you on?"*, before any code discussion. See
 [[unreproducible-bug-hand-to-reporter]] and [[pr-must-verify-on-affected-surface]].
+
+**2026-09-05 08:14Z — denon82 is moved too (3/3 loads land on flow.google.com, still authenticated). Both maintainer accounts are on the new host; there is NO labs.google account left for labs-side recon or verification. Labs-only behaviour (the labs duration guard, labs selectors) is now cohort-external — verify via a contributor or record NOT verified. The migrated composer (#664) is the driven path for both accounts.

--- a/scripts/dev/spike_migrated_duration_by_model.py
+++ b/scripts/dev/spike_migrated_duration_by_model.py
@@ -1,0 +1,103 @@
+r"""Which duration / resolution / count options does the migrated flow.google.com
+editor render per video model? ($0)
+
+#650 unlocked --duration 4/6/8 on the Veo 3.1 models with the caveat that Flow's
+duration control is cohort-dependent (labs cohorts differ; the maintainer's labs
+cohort renders none for Veo). This spike selects each model in the migrated host's
+model menu and records the option groups that remain, plus the cost line — so
+the #650 semantics can be verified on the new host, where the driver now runs t2v.
+
+Read-only: opens the settings pane, switches models, reads the DOM, closes the
+pane. Nothing is typed or submitted.
+
+    python scripts/dev/spike_migrated_duration_by_model.py --profile <name> --project <id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+from gflow_cli.api.transports.migrated_composer import (  # noqa: E402
+    VIDEO_MODEL_MENU_LABELS,
+    MigratedComposer,
+)
+
+_GROUPS_JS = r"""() => {
+  const pane = [...document.querySelectorAll('.cdk-overlay-pane')].find(p => p.querySelector("[role='radiogroup']"));
+  if (!pane) return {groups: [], cost: null, model: null};
+  const groups = [...pane.querySelectorAll("[role='radiogroup']")].map(g =>
+    [...g.querySelectorAll("[role='radio']")].map(r => ({
+      text: (r.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 24),
+      checked: r.getAttribute('aria-checked'),
+    })));
+  const text = (pane.innerText || '').replace(/\s+/g, ' ');
+  const cost = (text.match(/(\d+)\s*credits?/i) || [null, null])[1];
+  const btn = [...pane.querySelectorAll('button')].find(b => (b.textContent || '').includes('arrow_drop_down'));
+  return {groups, cost: cost ? Number(cost) : null, model: btn ? (btn.textContent || '').replace('arrow_drop_down', '').trim() : null};
+}"""
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    out: dict[str, Any] = {"profile": profile, "project": project[:8] + "...", "models": {}}
+    composer = MigratedComposer()
+    async with build_client(profile_dir) as client:
+        context = client._context  # noqa: SLF001 - spike reads the live context
+        assert context is not None
+        page = await context.new_page()
+        try:
+            await composer.ensure_editor(page, project)
+            for model, label in VIDEO_MODEL_MENU_LABELS.items():
+                # Fresh editor per model: a re-opened pane after a menu switch did
+                # not render its option groups on the first run of this spike.
+                await page.reload(wait_until="domcontentloaded")
+                await composer.ensure_editor(page, project)
+                pane = await composer._open_pane(page)  # noqa: SLF001 - spike
+                try:
+                    await composer._select_model(page, pane, model)  # noqa: SLF001 - spike
+                    await asyncio.sleep(0.8)
+                    facts = await page.evaluate(_GROUPS_JS)
+                except Exception as e:  # noqa: BLE001 - record, never abort
+                    facts = {"error": str(e)[:200]}
+                finally:
+                    await composer._close_pane(page)  # noqa: SLF001 - spike
+                    await asyncio.sleep(0.4)
+                out["models"][model.value] = {"menu_label": label, **facts}
+                groups = facts.get("groups") or []
+                summary = [[r["text"] for r in g] for g in groups]
+                step(
+                    "model", f"{label}: cost={facts.get('cost')} groups={json.dumps(summary)[:170]}"
+                )
+            shot = default_out_path(f"migrated_duration_{profile}", ".png")
+            await page.screenshot(path=str(shot))
+            out["screenshot"] = shot.name
+        finally:
+            await page.close()
+            path = default_out_path(f"migrated_duration_by_model_{profile}")
+            path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("out", str(path))
+    # The pane may be left on the last model; the composer re-selects per request.
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    a = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(a.profile, a.project)))

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -169,7 +169,11 @@ class MigratedComposer:
                 detail=f"migrated host: settings trigger ({READY_ANCHOR}) missing (host=migrated)"
             )
         await trigger.click(timeout=5000)
-        pane = page.locator(OVERLAY).last
+        # THE overlay that holds the option groups — not `.last`: once the model
+        # menu (a second overlay) has opened and closed, a detached menu pane can
+        # still be the last one in the DOM, and every axis after `--model` then
+        # reads "0 option groups" (measured 2026-09-05, $0 run).
+        pane = page.locator(OVERLAY).filter(has=page.locator(RADIOGROUP)).last
         try:
             await pane.locator(RADIOGROUP).first.wait_for(state="visible", timeout=8000)
         except Exception as e:

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -53,6 +53,7 @@ class Dom:
     prompt: str = ""
     submit_clicked: int = 0
     escape_closes: bool = True
+    menu_lingers: bool = False  # Angular keeps a detached menu pane as the LAST overlay
     events: list[str] = field(default_factory=list)
 
 
@@ -97,7 +98,9 @@ class FakeLocator:
 
     def filter(self, *, has: FakeLocator | None = None, has_text: Any = None) -> FakeLocator:
         items = self.items
-        if has is not None:  # `has=page.locator("mat-icon").filter(has_text=re)` → ligature match
+        if has is not None and has.kind == "group":  # pane.filter(has=<radiogroup>)
+            items = [i for i in items if i == "pane" and self.page.dom.pane_open]
+        elif has is not None:  # `has=page.locator("mat-icon").filter(has_text=re)` → ligature match
             pat = has.page._pending_lig
             items = [
                 r for r in items if isinstance(r, Radio) and pat is not None and pat.search(r.lig)
@@ -229,12 +232,18 @@ class FakePage:
             return FakeLocator(self, "trigger", ["trigger"] if dom.trigger_present else [])
         if css == ".cdk-overlay-pane":
             panes = (["pane"] if dom.pane_open else []) + (["menu"] if dom.menu_open else [])
+            if dom.menu_lingers and dom.pane_open and not dom.menu_open:
+                panes.append("stale-menu")  # what `.last` sees after a model switch
             return FakeLocator(self, "pane", panes)
         if css == ".cdk-overlay-backdrop":
             return FakeLocator(self, "backdrop", ["backdrop"] if dom.pane_open else [])
         if css == "[role='radiogroup']":
+            if scope is not None and scope.items and scope.items[0] != "pane":
+                return FakeLocator(self, "group", [])  # a menu pane has no option groups
             return FakeLocator(self, "group", list(dom.groups) if dom.pane_open else [])
         if css == "[role='radio']":
+            if scope is not None and scope.items and scope.items[0] != "pane":
+                return FakeLocator(self, "radio", [])
             radios = [r for g in dom.groups.values() for r in g] if dom.pane_open else []
             return FakeLocator(self, "radio", radios)
         if css == "mat-icon":
@@ -399,6 +408,21 @@ async def test_model_selected_from_menu_by_product_name() -> None:
     await MigratedComposer().apply_video_settings(page, _t2v(model=VideoModel.VEO_3_1_LITE))
     assert page.dom.model_label == "Veo 3.1 - Lite"
     assert not page.dom.menu_open and not page.dom.pane_open
+
+
+async def test_axes_still_resolve_after_a_model_switch() -> None:
+    """$0 run 2026-09-05: with --model, every axis after the menu switch read
+    "0 option groups" because a detached menu pane was the last overlay."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.menu_lingers = True
+    await MigratedComposer().apply_video_settings(
+        page, _t2v(model=VideoModel.VEO_3_1_LITE, aspect=Aspect.PORTRAIT, duration=6)
+    )
+    assert page.dom.model_label == "Veo 3.1 - Lite"
+    assert page.dom.groups["aspect"][1].checked  # 9:16 selected AFTER the switch
+    assert page.dom.groups["duration"][1].checked
 
 
 async def test_model_not_offered_lists_the_menu() -> None:


### PR DESCRIPTION
## Summary

Two things from verifying #650 on the merged driver (#664), both at zero credits.

**1. Bug on the `--model` path, fixed.** `gflow video t2v --model veo-fast --duration 6` on the migrated host aborted pre-submit as designed, but for the wrong axis: after the model menu (a second `cdk-overlay`) had opened and closed, `.cdk-overlay-pane.last` pointed at the detached menu pane, so the next axis read *"no 'aspect' control … 0 option groups"*. The live runs in #664 passed no `--model`, so it never fired. The pane is now resolved as **the overlay that contains a `[role='radiogroup']`**; the composer's fake page keeps a stale menu pane as the last overlay (as Angular does) so the regression test cannot pass vacuously.

**2. #650 verified on the migrated host — with a cohort caveat that is now permanent for these accounts.** Both maintainer accounts are on `flow.google.com` (denon82 moved overnight, 3/3 loads), so the labs-side duration guard is cohort-external. Per model on the new host (`scripts/dev/spike_migrated_duration_by_model.py`, $0):

| Model | Duration row | Resolution row | Credits |
|---|---|---|---|
| Omni 1.1 Flash | `4s 6s 8s 10s` | `360p 720p` | 12 |
| Veo 3.1 – Lite | — | — | 10 |
| Veo 3.1 – Fast | — | — | 20 |
| Veo 3.1 – Quality | — | — | 100 |

So a Veo duration request has no control on this cohort and the composer aborts pre-submit with **exit 11 naming the duration axis, zero credits** — the #650 "control rendered?" semantics, live. The positive Veo 4/6/8 path stays **NOT verified** here (contributor cohorts). Recorded in `docs/LIVE_VERIFICATION_v0.67.0.md`.

## Test plan
- [x] `test_axes_still_resolve_after_a_model_switch` (red before the fix) + composer/BDD/dispatch suites green
- [x] ruff / format / pyright clean
- [x] Live $0: `--model veo-fast --duration 6` → exit 11, `ConfigurationError` naming `duration`, no submit, no mp4
- [x] Memory (published + private) updated: both accounts moved; per-model matrix on the new host

Refs #639 #650
