### PR TITLE
fix(639): wait for the migrated composer's submit button to enable after insert_text (#670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Migrated host: `video t2v` no longer fails on the submit-enable race (#670).**
+  The Angular composer on `flow.google.com` flips the `arrow_forward` button
+  from `disabled` roughly 100 ms after `insert_text` lands, and the composer
+  read it synchronously, so a fully migrated account got
+  `UiSelectorDriftError` ("missing or disabled after the prompt was typed",
+  exit 23) on every run before anything was submitted. The composer now waits
+  up to 5 s (100 ms polls) for the button to enable; a button that never
+  enables is still selector drift, now worded as "stayed disabled for 5s".
+  Measured on a moved account: `insert_text` → enabled at the 107 ms sample;
+  with the wait, veo-lite t2v completed in 62 s.
+
 ### Added
 
 - **`gflow update` — self-update in place.** Runs the package manager that

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -66,6 +66,10 @@ SUBMIT_RPC = "YhhmEf"
 STATUS_RPCS = ("jwpduf", "as29s")
 #: The submit reply arrived 4.0–4.6 s after the click in both measured runs.
 SUBMIT_REPLY_BUDGET_S = 60.0
+# Angular enables the arrow_forward button ~100 ms after `insert_text` lands in the
+# composer (measured 2026-09-05, #670); checking it synchronously reads the stale state.
+SUBMIT_ENABLE_BUDGET_S = 5.0
+SUBMIT_ENABLE_POLL_S = 0.1
 #: A ``jwpduf`` poll reports status 3 first; the record that carries the signed
 #: URLs (``as29s``) followed 2–5 s later in every measured run. Wait that long
 #: for it before settling for the URL-less record.
@@ -368,13 +372,24 @@ class MigratedComposer:
         page.on("response", on_response)
         try:
             submit = page.locator("button").filter(has=_ligature(page, "arrow_forward")).first
-            if not await submit.count() or not await submit.is_enabled():
+            if not await submit.count():
                 raise UiSelectorDriftError(
                     detail=(
-                        "migrated host: the submit button (arrow_forward) is missing or "
-                        "disabled after the prompt was typed (host=migrated)"
+                        "migrated host: the submit button (arrow_forward) is missing "
+                        "after the prompt was typed (host=migrated)"
                     ),
                 )
+            enable_deadline = time.monotonic() + SUBMIT_ENABLE_BUDGET_S
+            while not await submit.is_enabled():
+                if time.monotonic() >= enable_deadline:
+                    raise UiSelectorDriftError(
+                        detail=(
+                            "migrated host: the submit button (arrow_forward) stayed disabled "
+                            f"for {SUBMIT_ENABLE_BUDGET_S:.0f}s after the prompt was typed "
+                            "(host=migrated)"
+                        ),
+                    )
+                await asyncio.sleep(SUBMIT_ENABLE_POLL_S)
             deadline = time.monotonic() + poll_timeout_s
             await submit.click(timeout=5000)
             log.info("migrated.submit_clicked")

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -52,6 +52,7 @@ class Dom:
     menu_open: bool = False
     prompt: str = ""
     submit_clicked: int = 0
+    submit_enable_after_reads: int = 0  # Angular flips `disabled` a tick after insert_text (#670)
     menu_lingers: bool = False  # Angular keeps a detached menu pane as the LAST overlay
     events: list[str] = field(default_factory=list)
 
@@ -121,7 +122,11 @@ class FakeLocator:
 
     async def is_enabled(self) -> bool:
         if self.kind == "submit":
-            return bool(self.page.dom.prompt)
+            dom = self.page.dom
+            if dom.submit_enable_after_reads > 0:
+                dom.submit_enable_after_reads -= 1
+                return False
+            return bool(dom.prompt)
         return bool(self.items)
 
     async def get_attribute(self, name: str) -> str | None:
@@ -470,6 +475,41 @@ async def test_submit_observes_submit_then_poll_then_result() -> None:
     )
     assert started[0].project_id == PROJ
     assert page.dom.submit_clicked == 1
+
+
+async def test_submit_waits_for_the_button_to_enable_after_insert_text() -> None:
+    """#670: the button reads disabled for a tick after the prompt lands; wait, don't raise."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.prompt = "a crane"
+    page.dom.submit_enable_after_reads = 2
+    page.scripted_responses = [
+        (_batch_url("YhhmEf"), _frame("YhhmEf", [None, 881, [[MEDIA]], [[_record(6)]]])),
+        (_batch_url("as29s"), _frame("as29s", _record(3, VIDEO_URL))),
+    ]
+    rec = await MigratedComposer().submit_and_observe(
+        page, poll_timeout_s=2.0, on_started=None, project_id=PROJ
+    )
+    assert rec.is_done and page.dom.submit_clicked == 1
+    assert page.dom.submit_enable_after_reads == 0
+
+
+async def test_submit_still_disabled_after_the_budget_is_selector_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gflow_cli.api.transports import migrated_composer
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    monkeypatch.setattr(migrated_composer, "SUBMIT_ENABLE_BUDGET_S", 0.05)
+    monkeypatch.setattr(migrated_composer, "SUBMIT_ENABLE_POLL_S", 0.01)
+    page = FakePage()
+    page.dom.prompt = ""  # nothing in the composer: the button never enables
+    with pytest.raises(UiSelectorDriftError, match="stayed disabled"):
+        await MigratedComposer().submit_and_observe(
+            page, poll_timeout_s=2.0, on_started=None, project_id=PROJ
+        )
+    assert page.dom.submit_clicked == 0
 
 
 async def test_status_three_in_a_poll_is_terminal_even_without_as29s() -> None:


### PR DESCRIPTION
## Summary

Fixes #670. On a fully migrated account, `video t2v … --project <id>` on 0.67.0 fails with `UiSelectorDriftError` "the submit button (arrow_forward) is missing or disabled after the prompt was typed" (exit 23) before anything is submitted. The Angular composer on `flow.google.com` flips the button's `disabled` roughly 100 ms after `keyboard.insert_text` lands; `submit_and_observe` read `is_enabled()` synchronously and got the stale state.

Measured on the account in #670 ($0, no submit), sampling `is_enabled()` every 100 ms after entering the prompt:

| input | 0 ms | 107 ms | 211 ms → 1148 ms |
|---|---|---|---|
| `keyboard.insert_text` (what the composer does) | **False** | True | True |
| `keyboard.type` | True | True | True |

**Change.** `submit_and_observe` now polls `is_enabled()` for up to `SUBMIT_ENABLE_BUDGET_S` (5 s, 100 ms steps) before deciding the button is drift. A missing button is still drift ("missing after the prompt was typed"); a button that never enables is still drift, worded "stayed disabled for 5s". No selector changes; the button is still found by the `arrow_forward` ligature.

## Lifecycle

- [x] Issue triaged: #670 carries the measurement and reproduces on the CLI surface (the MCP twin runs the same composer, not separately exercised)
- ~~`predict` verdict~~ — no selector, auth, transport or schema change; the fix adds a bounded wait on an existing locator
- ~~`scenario` + `plan`~~ — single-site timing fix with a two-row edge-case table (enables late / never enables), both covered by tests below
- [x] `check`-equivalent gates run locally (see Validation); step 1b mirror sweep n/a, no CLI or MCP surface changed
- [x] MCP twin: n/a, no new capability
- [x] Live-verified, with one caveat stated plainly below
- ~~Council review~~ — not run; happy to address whatever it raises

## Validation

- [x] Focused tests: `test_submit_waits_for_the_button_to_enable_after_insert_text` (button reads disabled for two reads, then enables; submit proceeds) and `test_submit_still_disabled_after_the_budget_is_selector_drift` (never enables → `UiSelectorDriftError`, no click). The fake DOM gained `submit_enable_after_reads` to model the tick.
- [x] CHANGELOG entry under Unreleased / Fixed
- [x] `uv run python scripts/ci/check_repo_hygiene.py` · `check_doc_links.py` · `check_website_docs_pii.py` · `generate_website_docs.py --check` — all green
- [x] `uv run ruff check` + `ruff format --check` on the two touched files — clean
- [x] `uv run pyright src/gflow_cli/api/transports/migrated_composer.py` — 0 errors
- [x] `uv run pytest tests/api/transports -q -p no:cov` — 824 passed

**Live verification.** The same wait (a `wait_for_function` on the button's `disabled`, 5 s) was applied to the installed 0.67.0 wheel and `video t2v --model veo-lite --aspect 16:9 --project <id>` then completed on the migrated account: `submit_clicked → submit_observed → status ×9 → result → download`, 62 s wall, 8.0 s 1280×720 mp4, `MEDIA_GENERATION_STATUS_SUCCESSFUL`. Two stock 0.67.0 runs before it failed identically at 0.26 s after `prompt_typed`. **Not verified:** this exact branch build end to end (that is one more paid clip; I can run it if you want the row for `LIVE_VERIFICATION`), and an unmigrated account.

## Contribution Checklist

- [x] Targets `develop`
- [x] Real Git identity
- [x] `Signed-off-by` present
- [x] No secrets, cookies, tokens, signed URLs or captured data
- [x] AI-assisted; reviewed before submitting
