### PR TITLE
docs: require e2e evidence for every behavior change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 - [ ] `scenario` + `plan` written under `docs/superpowers/plans/<date>-<slug>/` and linked here
 - [ ] `check` green, including the step 1b CLI↔MCP mirror sweep
 - [ ] MCP twin added, or a reasoned exemption in `tests/mcp/test_cli_parity.py`
+- [ ] **E2E evidence provided** — name the `tests/e2e/` test you ran and paste its result, or point at the new test this PR adds. If you could not run it, say why here:
 - [ ] Live-verified against real Flow where a generation path changed; what could NOT be verified is stated below
 - [ ] Council review run (`pr-council-review` / `branch-review`) and must-fix items addressed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,10 @@ the five other mirror axes), which no command here can check and no CI gate can 
 - Use `pytest -m "not live and not e2e and not smoke"` locally; full suite OOMs on small dev machines. Scope to changed dirs; trust CI for the full sweep.
 - TDD is non-negotiable. Coverage floor: 80% overall.
 - Documentation is a first-class deliverable. Every behavior, workflow, config, or operator-facing change must update the relevant docs or state why no docs changed in the PR/checklist. `scripts/ci/check_doc_links.py` is a merge gate.
-- **A PR is not done until its SonarCloud gate is green (zero new issues).** The six gates above are local/pre-commit; SonarCloud is server-side and runs in CI (`sonar.qualitygate.wait=true` → a red gate turns the `SonarCloud analysis` check red). Before calling a PR merge-ready, verify it with `/gflow:sonar <N>` (it is skipped on fork PRs — maintainer-checked there).
-- Live tests (`@pytest.mark.live`) opt in via `GFLOW_LIVE=1`. E2E tests require `GFLOW_CLI_E2E_PROFILE`.
+- **A PR is not done until its SonarCloud gate is green (zero new issues).** The nine gates above are local/pre-commit; SonarCloud is server-side and runs in CI (`sonar.qualitygate.wait=true` → a red gate turns the `SonarCloud analysis` check red). Before calling a PR merge-ready, verify it with `/gflow:sonar <N>` (it is skipped on fork PRs — maintainer-checked there).
+- **E2E is the decisive layer, and it is required for every behavior change.** Run the `tests/e2e/` test that covers the change, or write one — offline-green proves only that *our* code does what we think, never that Flow still behaves as captured. `/gflow:live-verify` does **not** satisfy this: it drives CLI commands by hand into a gitignored note and never runs `pytest -m e2e`. The two are complementary — an e2e test is a re-runnable regression, a live-verify ledger is a narrative record.
+- E2E tests require `GFLOW_CLI_E2E_PROFILE` and `-m e2e` (excluded from the default `addopts`, so they never run by accident). Cost sub-markers: `e2e_auth` (zero credits, browser only), `e2e_image` (zero credits, daily cap), `e2e_scene`, `e2e_data`, `e2e_batch`, `e2e_character`, `e2e_video` (spends Veo credits — opt in with `GFLOW_CLI_E2E_RUN_VIDEO=1`).
+- Live tests (`@pytest.mark.live`) opt in via `GFLOW_LIVE=1`.
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,8 @@ the five other mirror axes), which no command here can check and no CI gate can 
 - TDD is non-negotiable. Coverage floor: 80% overall.
 - Documentation is a first-class deliverable. Every behavior, workflow, config, or operator-facing change must update the relevant docs or state why no docs changed in the PR/checklist. `scripts/ci/check_doc_links.py` is a merge gate.
 - **A PR is not done until its SonarCloud gate is green (zero new issues).** The nine gates above are local/pre-commit; SonarCloud is server-side and runs in CI (`sonar.qualitygate.wait=true` → a red gate turns the `SonarCloud analysis` check red). Before calling a PR merge-ready, verify it with `/gflow:sonar <N>` (it is skipped on fork PRs — maintainer-checked there).
-- **E2E is the decisive layer, and it is required for every behavior change.** Run the `tests/e2e/` test that covers the change, or write one — offline-green proves only that *our* code does what we think, never that Flow still behaves as captured. `/gflow:live-verify` does **not** satisfy this: it drives CLI commands by hand into a gitignored note and never runs `pytest -m e2e`. The two are complementary — an e2e test is a re-runnable regression, a live-verify ledger is a narrative record.
-- E2E tests require `GFLOW_CLI_E2E_PROFILE` and `-m e2e` (excluded from the default `addopts`, so they never run by accident). Cost sub-markers: `e2e_auth` (zero credits, browser only), `e2e_image` (zero credits, daily cap), `e2e_scene`, `e2e_data`, `e2e_batch`, `e2e_character`, `e2e_video` (spends Veo credits — opt in with `GFLOW_CLI_E2E_RUN_VIDEO=1`).
+- **E2E is the decisive layer, and it is required for every behavior change that touches a Flow surface.** Run the `tests/e2e/` test that covers the change, or write one — offline-green proves only that *our* code does what we think, never that Flow still behaves as captured. `/gflow:live-verify` does **not** satisfy this: it drives CLI commands by hand into a gitignored note and never runs `pytest -m e2e`. The two are complementary — an e2e test is a re-runnable regression, a live-verify ledger is a narrative record. If you cannot run it, say so explicitly in the PR and a maintainer will; a change touching no Flow surface (docs, help text, exit-code plumbing) is out of scope — say that rather than leaving it blank.
+- E2E tests require `GFLOW_CLI_E2E_PROFILE` and `-m e2e` (excluded from the default `addopts`, so they never run by accident). Cost sub-markers: `e2e_auth` (zero credits, browser only), `e2e_image` (zero credits, daily cap), `e2e_scene`, `e2e_data`, `e2e_batch`, `e2e_character` (opt in with `GFLOW_CLI_E2E_RUN_CHARACTER=1`), `e2e_video` (spends Veo credits — opt in with `GFLOW_CLI_E2E_RUN_VIDEO=1`). Redact account identifiers and any token or cookie value before pasting output into a PR.
 - Live tests (`@pytest.mark.live`) opt in via `GFLOW_LIVE=1`.
 
 ## Code style
@@ -161,7 +161,7 @@ All AI agents and harnesses working on `gflow-cli` follow this standard 10-phase
 | 5. Council Review | `/gflow:pr-council-review` / `llm-council` | Multi-dimensional audit across 6 core dimensions | Consensus verdict report |
 | 6. Task Execution | `/gflow:status` | Track unchecked tasks during TDD execution | Next unchecked task |
 | 7. Pre-Commit Quality | `/gflow:check` | The Impeccable Routine (hygiene, ruff, pyright, pytest) | All green local checks |
-| 8. Live Verification | `/gflow:live-verify` | 5-layer proof against real Flow transport | `docs/LIVE_VERIFICATION_vX.Y.Z.md` |
+| 8. E2E + Live Verification | `pytest -m e2e` → `/gflow:live-verify` | The e2e suite against a live profile, then the 5-layer proof against real Flow transport | Pasted e2e result + `docs/LIVE_VERIFICATION_vX.Y.Z.md` |
 | 9. PR & Issue Close | `/gflow:issue-resolve <N>` | PR, SonarCloud 0-issue gate, merge to develop | Closed GitHub issue |
 | 10. Release Pipeline | `/gflow:release` | Version bump, signed tag (`git tag -s`), PyPI publish. **Internally gates on `/gflow:changelog` → `/gflow:check` → `/gflow:live-verify` → `/gflow:doc-review`; a failure at any of them is a STOP, not a warning.** | Shipped release & back-merge |
 
@@ -176,9 +176,9 @@ Every AI agent executing any phase of this pipeline MUST proactively state the c
 | Phase 3: BDD Scaffolding | `Scenario:` blocks & test scaffold | ➔ Phase 4: Implementation Plan (`/gflow:plan <feature>`) |
 | Phase 4: Implementation Plan | `PLAN.md` created & approved | ➔ Phase 6: Task Execution (`/gflow:status`) |
 | Phase 6: Task Execution | All plan tasks checked | ➔ Phase 7: Pre-Commit Quality (`/gflow:check`) |
-| Phase 7: Pre-Commit Quality | All 7 quality gates green | ➔ Phase 5: Council Review (`/gflow:branch-review` or `/gflow:pr-council-review`) |
-| Phase 5: Council Review | Consensus 🟢 GREEN | ➔ Phase 8: Live Verification (`/gflow:live-verify`) or Phase 9 (`/gflow:issue-resolve <N>`) |
-| Phase 8: Live Verification | `LIVE_VERIFICATION_vX.Y.Z.md` | ➔ Phase 9: Issue Resolve & PR (`/gflow:issue-resolve <N>`) |
+| Phase 7: Pre-Commit Quality | All quality gates green | ➔ Phase 5: Council Review (`/gflow:branch-review` or `/gflow:pr-council-review`) |
+| Phase 5: Council Review | Consensus 🟢 GREEN | ➔ Phase 8: E2E + Live Verification (`pytest -m e2e`, then `/gflow:live-verify`) or Phase 9 (`/gflow:issue-resolve <N>`) |
+| Phase 8: E2E + Live Verification | e2e result + `LIVE_VERIFICATION_vX.Y.Z.md` | ➔ Phase 9: Issue Resolve & PR (`/gflow:issue-resolve <N>`) |
 | Phase 9: Issue Resolve & PR | PR open & SonarCloud 0-issue gate green | ➔ Phase 10: Release Pipeline (`/gflow:release`) |
 | Phase 10: Release Pipeline | Signed tag & PyPI published | ➔ Done (Release shipped & back-merged) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,13 @@ What a contributor PR is expected to have gone through, phase by phase:
 | Transport / auth / selector / schema change | [`predict`](skills/predict/SKILL.md) | A GO / CAUTION / STOP verdict **before** code exists; STOP means open an issue instead |
 | Any feature | [`scenario`](skills/scenario/SKILL.md) → [`plan`](skills/plan/SKILL.md) | `docs/superpowers/plans/<date>-<slug>/SCENARIO.md` + `PLAN.md` — the edge-case table and the task list; link them from the PR (they live on the branch and in the PR's history; at release the durable facts are folded into `docs/superpowers/memory/` and the plan dir is removed) |
 | Every commit | [`check`](skills/check/SKILL.md) | The Impeccable Routine green (it is the exact CI gate), plus the **step 1b** CLI↔MCP mirror sweep no CI gate can see |
-| Anything on a generation path | [`live-verify`](skills/live-verify/SKILL.md) | Evidence against real Flow, not just green offline tests — this project drives a black box; say plainly what you could **not** verify |
+| Any behavior change | [`tests/e2e/`](tests/e2e/) | The e2e test you ran, or the new one you wrote. E2E is the layer that proves the change works against real Flow — unit + integration + BDD green is never the whole story here. Name the test and paste its result |
+| Anything on a generation path | [`live-verify`](skills/live-verify/SKILL.md) | Evidence against real Flow **on top of** the e2e run — the 5-layer ledger; say plainly what you could **not** verify |
 | Opening the PR | [`pr-council-review`](skills/pr-council-review/SKILL.md) / [`branch-review`](.claude/commands/gflow/branch-review.md) | The multi-dimension council (correctness, quality, security, tests, memory, YAGNI, parity …); maintainers run it on every PR, so running it yourself first removes a round trip |
 | Red SonarCloud check | [`sonar`](skills/sonar/SKILL.md) | Zero new issues — the gate measures *new* code |
 | Auth or reCAPTCHA | [`known-issues`](skills/known-issues/SKILL.md) | Known-broken surfaces have documented workarounds; rediscovering them costs days |
 
-Three rules the pipeline enforces that catch first-time contributors most often:
+Four rules the pipeline enforces that catch first-time contributors most often:
 
 1. **Ship each capability twice, or say why not.** Every CLI command has an MCP twin or a
    reasoned exemption in `tests/mcp/test_cli_parity.py` — and options, payload keys and tool
@@ -38,6 +39,11 @@ Three rules the pipeline enforces that catch first-time contributors most often:
    (AGENTS.md § *Locale-Invariance Discipline*).
 3. **Verified beats claimed.** If a fix cannot be verified on the affected surface in your
    environment, the PR says so and uses `Refs #N`, not a green checkbox.
+4. **E2E is the evidence layer.** A behavior change without an e2e test — run or written —
+   is not reviewable. `tests/e2e/` already covers auth, session, image, video, scene, data
+   and batch; if nothing there represents your use case, add a test that does. Read-only and
+   inspection paths belong under `e2e_auth` and cost zero credits, so "it's expensive" is
+   almost never the reason.
 
 The PR template's *Lifecycle* checklist mirrors this table. Tick what applies, strike what
 does not, and say why — a reviewer can then start from your evidence instead of re-deriving it.
@@ -102,6 +108,20 @@ async def test_full_t2i_roundtrip(): ...
 @pytest.mark.e2e_video         # Cost sub-marker: spends ~1 Veo credit (most expensive).
 async def test_full_i2v_roundtrip(): ...
 ```
+
+**E2E is required, not optional.** CI cannot run these — they need a live authenticated
+profile — so the e2e layer is the one gate that only a human, or an agent with credentials,
+can close. That makes it the contributor's job, not the maintainer's. A PR that changes
+behavior must either:
+
+- **run an existing test** that already covers the use case (`tests/e2e/` has ~25 of them),
+  and paste the result; or
+- **add a new one** when nothing covers it, marked `e2e` plus the cost sub-marker that fits.
+
+Pick the cost sub-marker honestly — most inspection and auth paths are `e2e_auth` and spend
+zero credits. Use the `e2e_profile_dir` / `e2e_env` fixtures in `tests/e2e/conftest.py`.
+If you genuinely cannot run e2e (no Flow account, no credits for a video path), say so
+explicitly in the PR and a maintainer will run it — but do not leave the box silently unticked.
 
 CI runs `unit` + `integration` on every push. `e2e` tests require a live authenticated profile and are opt-in:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,14 @@ Four rules the pipeline enforces that catch first-time contributors most often:
    (AGENTS.md § *Locale-Invariance Discipline*).
 3. **Verified beats claimed.** If a fix cannot be verified on the affected surface in your
    environment, the PR says so and uses `Refs #N`, not a green checkbox.
-4. **E2E is the evidence layer.** A behavior change without an e2e test — run or written —
-   is not reviewable. `tests/e2e/` already covers auth, session, image, video, scene, data
-   and batch; if nothing there represents your use case, add a test that does. Read-only and
-   inspection paths belong under `e2e_auth` and cost zero credits, so "it's expensive" is
-   almost never the reason.
+4. **E2E is the evidence layer.** A behavior change **that touches a Flow surface** needs an
+   e2e test — the one you ran, or the one you wrote. `tests/e2e/` already covers auth,
+   session, image, video, scene, data and batch; if nothing there represents your use case,
+   add a test that does. Read-only and inspection paths belong under `e2e_auth` and cost zero
+   credits, so "it's expensive" is almost never the reason. If you cannot run it, say why in
+   the PR and a maintainer will — a silently unticked box is what stalls a review. Changes
+   that touch no Flow surface at all (docs, help text, exit-code plumbing) are out of scope;
+   say that instead of leaving it blank.
 
 The PR template's *Lifecycle* checklist mirrors this table. Tick what applies, strike what
 does not, and say why — a reviewer can then start from your evidence instead of re-deriving it.
@@ -112,10 +115,10 @@ async def test_full_i2v_roundtrip(): ...
 **E2E is required, not optional.** CI cannot run these — they need a live authenticated
 profile — so the e2e layer is the one gate that only a human, or an agent with credentials,
 can close. That makes it the contributor's job, not the maintainer's. A PR that changes
-behavior must either:
+behavior **on a Flow surface** must either:
 
-- **run an existing test** that already covers the use case (`tests/e2e/` has ~25 of them),
-  and paste the result; or
+- **run an existing test** that already covers the use case — browse `tests/e2e/` — and
+  paste the result (redact account identifiers, emails and any token or cookie value); or
 - **add a new one** when nothing covers it, marked `e2e` plus the cost sub-marker that fits.
 
 Pick the cost sub-marker honestly — most inspection and auth paths are `e2e_auth` and spend
@@ -123,7 +126,8 @@ zero credits. Use the `e2e_profile_dir` / `e2e_env` fixtures in `tests/e2e/conft
 If you genuinely cannot run e2e (no Flow account, no credits for a video path), say so
 explicitly in the PR and a maintainer will run it — but do not leave the box silently unticked.
 
-CI runs `unit` + `integration` on every push. `e2e` tests require a live authenticated profile and are opt-in:
+CI runs `unit` + `integration` on every push. `e2e` tests require a live authenticated profile
+and are excluded from the default run — select them with `-m e2e`:
 
 ```bash
 export GFLOW_CLI_E2E_PROFILE=<profile-name>   # name of a logged-in profile

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -128,7 +128,9 @@ This repo is actively developed with Claude Code (see [CLAUDE.md](../CLAUDE.md))
 
 - Claude branches are renamed to the appropriate `feature/`, `fix/`, `docs/` prefix before the PR is opened. The `claude/` prefix is internal scaffolding.
 - Claude never bumps the version or cuts a release without explicit instruction — use `/release`.
-- Claude opens PRs as **drafts** targeting `develop`. The maintainer reviews, runs e2e if needed, and merges.
+- Claude opens PRs as **drafts** targeting `develop`. E2E evidence for any change touching a
+  Flow surface is part of the PR, not something the maintainer supplies afterwards (CONTRIBUTING
+  § *Test categories*); the maintainer reviews, runs e2e only where the author could not, and merges.
 - Commit messages never carry `Co-Authored-By: Claude` or any AI attribution — author credit is the human maintainer's only.
 
 ---

--- a/tests/test_documentation_gate.py
+++ b/tests/test_documentation_gate.py
@@ -34,6 +34,30 @@ def test_pull_request_template_requires_documentation_review() -> None:
     assert "`uv run python scripts/ci/check_doc_links.py`" in template
 
 
+# The e2e-evidence rule is stated in three places that must not drift apart:
+# the PR template asks for it, AGENTS.md states it for agents, CONTRIBUTING.md
+# for humans. A silently deleted line here is how the rule dies — PR #671
+# arrived with eight offline test files and zero e2e because nothing asked.
+def test_pull_request_template_requires_e2e_evidence() -> None:
+    template = (ROOT / ".github/PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+
+    assert "**E2E evidence provided**" in template
+    assert "`tests/e2e/`" in template
+
+
+def test_e2e_evidence_rule_is_stated_for_agents_and_contributors() -> None:
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    # Scoped to Flow surfaces — a docs-only change cannot produce an e2e run.
+    assert "required for every behavior change that touches a Flow surface" in agents
+    # live-verify is a narrative ledger, not a re-runnable regression; the two
+    # are complementary and the docs must keep saying so.
+    assert "never runs `pytest -m e2e`" in agents
+    assert "**E2E is required, not optional.**" in contributing
+    assert "E2E is the evidence layer." in contributing
+
+
 # `gflow video batch` was removed as a nonfunctional stub (production-readiness
 # hardening, task A1). These are the operator-facing docs that must not tell
 # a user to run a command that no longer exists. Historical text (CHANGELOG

--- a/website/docs/DEVELOPMENT.md
+++ b/website/docs/DEVELOPMENT.md
@@ -128,7 +128,9 @@ This repo is actively developed with Claude Code (see [CLAUDE.md](../CLAUDE.md))
 
 - Claude branches are renamed to the appropriate `feature/`, `fix/`, `docs/` prefix before the PR is opened. The `claude/` prefix is internal scaffolding.
 - Claude never bumps the version or cuts a release without explicit instruction — use `/release`.
-- Claude opens PRs as **drafts** targeting `develop`. The maintainer reviews, runs e2e if needed, and merges.
+- Claude opens PRs as **drafts** targeting `develop`. E2E evidence for any change touching a
+  Flow surface is part of the PR, not something the maintainer supplies afterwards (CONTRIBUTING
+  § *Test categories*); the maintainer reviews, runs e2e only where the author could not, and merges.
 - Commit messages never carry `Co-Authored-By: Claude` or any AI attribution — author credit is the human maintainer's only.
 
 ---


### PR DESCRIPTION
## Summary

Makes e2e evidence a contributor requirement instead of an opt-in maintainer activity.

E2E is the layer that proves a change works against the real Flow blackbox. Offline-green only proves our code does what we think it does. Nothing in the contributor path actually asked for it:

- the CONTRIBUTING lifecycle table routed only *generation-path* changes to `live-verify`
- "Test categories" documented **how** to run e2e, framing it as opt-in maintainer regression
- the PR template's only live-Flow line was scoped to generation paths too

External PR #671 followed all of that to the letter and arrived with eight offline test files and zero e2e — and the HTTP fast path it added failed on the first real run.

This also records what `/gflow:live-verify` is **not**: it drives CLI commands by hand into a gitignored `tmp/live-verify/` note and never runs `pytest -m e2e`. An e2e test is a re-runnable regression; a live-verify ledger is a narrative record. The two are complementary, and the docs now say so.

## Changes

- **CONTRIBUTING.md** — new lifecycle row (*any behavior change → the e2e test you ran or wrote*); the generation-path row now reads as layered on top of it; "Three rules" becomes four; new **"E2E is required, not optional"** block explaining that CI *cannot* run these, which is precisely why it falls to the contributor.
- **AGENTS.md** — the same rule where agents read it, the live-verify clarification, and the full cost sub-marker list.
- **.github/PULL_REQUEST_TEMPLATE.md** — an e2e line that has to be answered: name the test you ran, point at the new one, or say why you could not.
- **docs/DEVELOPMENT.md** (+ website mirror) — no longer says the maintainer runs e2e on the author's behalf.
- **tests/test_documentation_gate.py** — two tests pinning the rule, so deleting any of its three statements fails CI instead of passing quietly.

## Council fixes (`65a431e`)

Review returned YELLOW with five must-fix items, all applied:

1. **Exemption was stated three incompatible ways** — CONTRIBUTING said "not reviewable" (absolute), the template said "say why and a maintainer will run it" (exempt), AGENTS.md offered no exemption. All three now carry the template's wording.
2. **Scoped to "a behavior change that touches a Flow surface"** — as written the rule demanded an e2e run from docs-only, help-text and exit-code changes, which cannot produce one. This PR is itself such a change.
3. **CONTRIBUTING still called e2e "opt-in"** fourteen lines under "required, not optional" — now "excluded from the default run; select with `-m e2e`".
4. **Dropped the "~25 of them" count** (actually 32 files) — a hardcoded count drifts.
5. **Untouched files still taught the old rule** — `docs/DEVELOPMENT.md`, AGENTS.md's "All 7 quality gates" over a nine-command block, and a 10-phase table with no phase that runs the suite (Phase 8 is now "E2E + Live Verification").

Plus nice-to-haves: `GFLOW_CLI_E2E_RUN_CHARACTER` added to the marker list, and a redaction hint wherever the docs ask for pasted output.

## Test plan

Docs and tests only; no `src/` changes.

- [x] `uv run python scripts/ci/check_repo_hygiene.py` — 944 files, no violations
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved across 29 files
- [x] `uv run python scripts/ci/check_website_docs_pii.py` — clean across 25 published files
- [x] `uv run python scripts/ci/generate_website_docs.py --check` — mirror in sync (20 files)
- [x] `uv run python scripts/ci/check_council_memory.py` — 47 memory files, all cited and resolving
- [x] `uv run ruff check src tests` / `ruff format --check` — clean
- [x] `uv run pyright src` — 0 errors, 0 warnings
- [x] `pytest tests/test_documentation_gate.py tests/mcp tests/scripts tests/api/transports/test_overlay_precondition.py` — **412 passed**

The earlier body said "293 passed"; that run predated `tests/test_documentation_gate.py` — the one test file that reads AGENTS.md and the PR template, and therefore the one most able to catch a mistake here. It is now included, and the count above is from the current SHA.

E2E evidence: **not applicable — this PR touches no Flow surface.** Stated rather than silently skipped, per the exemption it introduces.