### PR TITLE
docs(release): cut in a worktree, announce the cut, re-check develop before signing

### DIFF
--- a/docs/superpowers/memory/release-back-merge-gap-recovery.md
+++ b/docs/superpowers/memory/release-back-merge-gap-recovery.md
@@ -1,6 +1,6 @@
 ---
 name: release-back-merge-gap-recovery
-description: "Two release-time drifts: (1) a skipped main → develop back-merge makes the NEXT release branch conflict on bump + CHANGELOG (take ours, re-add the footer); (2) develop moving between cut and tag in a shared checkout — cut in a worktree, announce via ListAgents, check rev-list before signing"
+description: "Release-time drift in both directions: main ahead of develop (skipped back-merge → next release branch conflicts on bump + CHANGELOG; take ours, re-add the footer) and develop ahead of the release branch (moved between cut and tag; merge, re-home CHANGELOG, re-run 4b, re-sign while unpushed)"
 ---
 
 Rule: Always do the **main → develop back-merge** as the LAST step of every release. If you didn't, the next release branch will hit predictable conflicts because main has a version bump + CHANGELOG section that develop never received.

--- a/docs/superpowers/memory/release-back-merge-gap-recovery.md
+++ b/docs/superpowers/memory/release-back-merge-gap-recovery.md
@@ -1,6 +1,6 @@
 ---
 name: release-back-merge-gap-recovery
-description: "If a prior release skipped main → develop back-merge, the NEXT release branch (cut from develop) will conflict with main on version bump + CHANGELOG — resolve by taking 'ours' on the bump files and re-adding the missing [previous-version] CHANGELOG footer"
+description: "Two release-time drifts: (1) a skipped main → develop back-merge makes the NEXT release branch conflict on bump + CHANGELOG (take ours, re-add the footer); (2) develop moving between cut and tag in a shared checkout — cut in a worktree, announce via ListAgents, check rev-list before signing"
 ---
 
 Rule: Always do the **main → develop back-merge** as the LAST step of every release. If you didn't, the next release branch will hit predictable conflicts because main has a version bump + CHANGELOG section that develop never received.
@@ -43,3 +43,23 @@ The v0.7.0 release skipped this; the v0.8.0 release (PR #42) had to merge main i
 **Reference:** PR #42 commit `08c081e` is the canonical conflict-resolution commit. `phase-b-followups` memory item D documents the original v0.7.0 skip.
 
 **See also:** [[branch-workflow]], [[release-signing]].
+
+## Shared-checkout race at cut time (2026-09-05, v0.68.0)
+
+The mirror-image failure: `develop` moving *after* the release branch is cut but *before*
+the tag. Two things went wrong in one evening, both in a checkout shared by four sessions:
+
+- The release branch was checked out in the shared working tree and another session's
+  `git checkout` switched it away mid-prep. Recovery cost real time. **Cut the release
+  branch in a dedicated worktree** (`git worktree add -b chore/release-vX ../gflow-cli-release-vX origin/develop`)
+  and announce the cut to every session (`ListAgents` + message) before doing it.
+- PR #672 merged into `develop` between the cut and the tag. The local signed tag then
+  pointed one commit before the fix the release notes claimed. Because nothing had been
+  pushed, the fix was `git merge origin/develop` on the release branch, re-home the
+  newcomer's `[Unreleased]` CHANGELOG entry under the new version, `git tag -d` +
+  re-sign. **Step 12 of the release skill now runs `git rev-list --count HEAD..origin/develop`
+  before signing** — expect 0.
+
+Same root cause as the gap above (two branches that must agree drifting between two
+steps), opposite direction: there `main` ran ahead of `develop`; here `develop` ran
+ahead of the release branch.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -86,12 +86,26 @@ which is why it is now an explicit gate. If a feature genuinely cannot be verifi
 this cycle, record that and the reason in the doc; never silently omit it. Stage
 the doc into the release-prep commit (step 11).
 
-**5. Create a release branch off `develop`.**
+**5. Create a release branch off `develop` — in its own worktree, after telling every
+other session.**
 
 ```bash
-git checkout develop                          # ensure the base is develop, not main
-git checkout -b chore/release-v<NEW_VERSION>
+git worktree add -b chore/release-v<NEW_VERSION> ../gflow-cli-release-v<NEW_VERSION> origin/develop
+cd ../gflow-cli-release-v<NEW_VERSION>
 ```
+
+Before cutting, run `ListAgents` (or the equivalent in your harness) and message every
+other session working on this repo: *"Cutting v<NEW_VERSION> from develop@<sha>; do not
+push to develop until the back-merge lands."* Then cut in a **dedicated worktree**, never
+in the shared checkout.
+
+> **Why.** On 2026-09-05 the v0.68.0 release branch was cut in the shared checkout and
+> then switched out from under the release runner by another session's `git checkout`,
+> costing a recovery; separately, an unrelated PR landed on `develop` between the cut and
+> the tag, so the signed tag had to be deleted and re-signed on a merged head (nothing
+> had been pushed, so no public tag moved — step 12 now checks for this). A worktree
+> makes the branch immune to sibling checkouts; the announcement makes the `develop`
+> race visible instead of discovered at tag time.
 
 This branch now contains all of `develop` (⊇ `main`) plus your release prep. All
 release prep commits live here; the PR into `main` (step 14) carries the full
@@ -185,6 +199,21 @@ git commit -m "chore(release): v<NEW_VERSION>"
 - The release-prep commit must NOT carry a `Co-Authored-By` trailer (see reminders).
 
 **12. Tag the release commit.** Use `-s` for a signed annotated tag so GitHub shows **"Verified"** AND `.github/workflows/release.yml` passes the signed-tag gate (unsigned or lightweight tags are rejected by CI).
+
+First confirm `develop` has not moved since step 5 — anything merged there in the
+meantime is not in this branch and would ship in the *next* release while its
+CHANGELOG entry sits under a heading that no longer exists:
+
+```bash
+git fetch origin
+git rev-list --count HEAD..origin/develop   # expect 0
+```
+
+If it is non-zero: `git merge origin/develop`, move the newcomers' `[Unreleased]`
+entries under `## [<NEW_VERSION>]`, re-run steps 4 and 10, amend or add to the step 11
+commit, and only then tag. If a tag was already created locally, `git tag -d
+v<NEW_VERSION>` and re-sign it on the merged head — this is safe only while the tag is
+unpushed (see the **NEVER force-push a release tag** reminder below).
 
 ```bash
 git tag -s v<NEW_VERSION> -m "v<NEW_VERSION>"

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -98,8 +98,9 @@ Before cutting, run `ListAgents` (or the equivalent in your harness) and message
 other session working on this repo: *"Cutting v<NEW_VERSION> from develop@<sha>; do not
 push to develop until the back-merge lands."* Then cut in a **dedicated worktree** (the
 repo convention is `.claude/worktrees/<slug>`), never in the shared checkout. The cut is
-from `origin/develop`, which step 3 just verified local `develop` matches — a local
-`develop` that goes stale later no longer matters. Steps 6–13 run inside this worktree;
+from `origin/develop`, which step 3 just verified local `develop` is not behind — a local
+`develop` that goes stale later no longer matters (unpushed local commits on `develop`
+are deliberately NOT in the release; push them first if they should be). Steps 6–13 run inside this worktree;
 step 14 returns to the main checkout and removes it.
 
 > **Why.** On 2026-09-05 the v0.68.0 release branch was cut in the shared checkout and
@@ -284,12 +285,21 @@ git worktree remove --force .claude/worktrees/release-v<NEW_VERSION>
 git worktree prune
 ```
 
-On Windows the removal can fail on the worktree's `.venv` file lock; `git worktree prune`
-now and a manual delete later is fine (CLAUDE.md § Worktrees). Then merge with a
-**merge commit** — never squash:
+Then merge with a **merge commit** — never squash:
 
 ```bash
 gh pr merge <N> --merge --delete-branch
+```
+
+On Windows the removal can fail on the worktree's `.venv` file lock. `git worktree prune`
+does **not** help — it only forgets worktrees whose directory is already gone, so the
+branch stays held and `--delete-branch` still fails. In that case merge without it and
+delete the remote ref explicitly; remove the directory and the local branch later
+(CLAUDE.md § Worktrees):
+
+```bash
+gh pr merge <N> --merge
+git push origin --delete chore/release-v<NEW_VERSION>
 ```
 
 > **NEVER `--squash` this PR.** Because the branch was cut from `develop`, the PR

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -90,14 +90,17 @@ the doc into the release-prep commit (step 11).
 other session.**
 
 ```bash
-git worktree add -b chore/release-v<NEW_VERSION> ../gflow-cli-release-v<NEW_VERSION> origin/develop
-cd ../gflow-cli-release-v<NEW_VERSION>
+git worktree add -b chore/release-v<NEW_VERSION> .claude/worktrees/release-v<NEW_VERSION> origin/develop
+cd .claude/worktrees/release-v<NEW_VERSION>
 ```
 
 Before cutting, run `ListAgents` (or the equivalent in your harness) and message every
 other session working on this repo: *"Cutting v<NEW_VERSION> from develop@<sha>; do not
-push to develop until the back-merge lands."* Then cut in a **dedicated worktree**, never
-in the shared checkout.
+push to develop until the back-merge lands."* Then cut in a **dedicated worktree** (the
+repo convention is `.claude/worktrees/<slug>`), never in the shared checkout. The cut is
+from `origin/develop`, which step 3 just verified local `develop` matches — a local
+`develop` that goes stale later no longer matters. Steps 6–13 run inside this worktree;
+step 14 returns to the main checkout and removes it.
 
 > **Why.** On 2026-09-05 the v0.68.0 release branch was cut in the shared checkout and
 > then switched out from under the release runner by another session's `git checkout`,
@@ -210,10 +213,15 @@ git rev-list --count HEAD..origin/develop   # expect 0
 ```
 
 If it is non-zero: `git merge origin/develop`, move the newcomers' `[Unreleased]`
-entries under `## [<NEW_VERSION>]`, re-run steps 4 and 10, amend or add to the step 11
-commit, and only then tag. If a tag was already created locally, `git tag -d
-v<NEW_VERSION>` and re-sign it on the merged head — this is safe only while the tag is
-unpushed (see the **NEVER force-push a release tag** reminder below).
+entries under `## [<NEW_VERSION>]`, re-run steps 4, **4b** and 10 — 4b because the
+newcomers are user-facing features that just entered this release and each needs its
+`LIVE_VERIFICATION_v<NEW_VERSION>.md` row (v0.68.0 shipped #672 this way and the ledger
+had no row until a reviewer supplied one) — amend or add to the step 11 commit, and only
+then tag. If a tag was already created locally, `git tag -d v<NEW_VERSION>` and re-sign
+it on the merged head — this is safe only while the tag is unpushed (see the **NEVER
+force-push a release tag** reminder below). `develop` can still move between this check
+and the step 13 push; that cannot corrupt the tag, it only means a late commit ships in
+the next release — re-run the `rev-list` immediately before pushing if you care.
 
 ```bash
 git tag -s v<NEW_VERSION> -m "v<NEW_VERSION>"
@@ -263,8 +271,22 @@ gh pr create --base main --head chore/release-v<NEW_VERSION> \
 
 Wait for PR CI to go green (`gh pr checks <N> --watch`). **The `SonarCloud analysis`
 check must be green (gate passed) — not just the test matrix.** If it is red or you
-want the verdict, run `/gflow:sonar <N>` and drive it to zero before merging. Then
-merge with a **merge commit** — never squash:
+want the verdict, run `/gflow:sonar <N>` and drive it to zero before merging.
+
+Before merging, leave the release worktree and remove it — `--delete-branch` deletes the
+local branch too, and git refuses to delete a branch a worktree has checked out
+(`error: cannot delete branch … used by worktree`). The branch is pushed, so nothing is
+lost:
+
+```bash
+cd <main checkout>                                   # e.g. C:/development/github/gflow-cli
+git worktree remove --force .claude/worktrees/release-v<NEW_VERSION>
+git worktree prune
+```
+
+On Windows the removal can fail on the worktree's `.venv` file lock; `git worktree prune`
+now and a manual delete later is fine (CLAUDE.md § Worktrees). Then merge with a
+**merge commit** — never squash:
 
 ```bash
 gh pr merge <N> --merge --delete-branch
@@ -278,9 +300,13 @@ gh pr merge <N> --merge --delete-branch
 
 **15. Back-merge `main` into `develop`.**
 
-After the release PR is merged, bring the bump commit back to `develop` so branches stay aligned:
+After the release PR is merged, bring the bump commit back to `develop` so branches stay aligned.
+This runs in the **main checkout** (step 14 already returned you there) — `develop` is
+checked out there, and git refuses `git checkout develop` from any other worktree
+(`fatal: 'develop' is already used by worktree at …`):
 
 ```bash
+cd <main checkout>
 git checkout develop
 git pull origin develop
 git fetch origin main
@@ -298,6 +324,10 @@ Tell the user:
 - On success: PyPI publish + GitHub Release with auto-generated notes.
 - On failure (most common: PyPI Trusted Publishing not yet configured): point to <https://pypi.org/manage/account/publishing/>.
 - `develop` is now synced with `main` (back-merge done in step 15).
+- The release worktree is gone (step 14); if Windows held its `.venv`, name the directory
+  that still needs a manual delete.
+- Message the sessions you announced to in step 5: the back-merge has landed, `develop` is
+  open again.
 - Next development cycle starts on `develop` — open `## [Unreleased]` in CHANGELOG is ready.
 
 ### Pipeline Continuation (Next Step Handoff)


### PR DESCRIPTION
## Summary

Folds the two lessons from cutting v0.68.0 tonight into the release skill and its memory entry. Docs-only.

- **Step 5** — cut the release branch in a dedicated worktree, after announcing the cut to every other session on the machine (`ListAgents` + message). The v0.68.0 branch was cut in the shared checkout and switched away by a sibling session mid-prep.
- **Step 12** — `git fetch && git rev-list --count HEAD..origin/develop` before signing; if non-zero, merge, re-home the newcomers' `[Unreleased]` entries, re-run gates, re-sign. PR #672 landed on `develop` between the cut and the tag, and the local signed tag pointed one commit before the fix the release notes claimed. Safe only while the tag is unpushed; the existing never-force-push reminder still governs.
- **`docs/superpowers/memory/release-back-merge-gap-recovery.md`** — new section for the mirror-image drift (`develop` ahead of the release branch, rather than `main` ahead of `develop`), description widened. Already cited from the D11 row, so `check_council_memory.py` stays green without touching the council skill.

Reported by the session that ran the release; written up here so the next runner does not rediscover it.

## Lifecycle

- ~~issue / predict / scenario / plan~~ — docs-only process change, no code
- [x] `check`-equivalent doc gates green: hygiene (944), doc-links (29), council-memory (47), website mirror, PII
- [x] MCP twin: n/a
- [x] E2E evidence: n/a, no behavior change
- ~~Council review~~ — small docs PR; happy to run it if wanted

## Test plan

- [x] `uv run python scripts/ci/check_doc_links.py` / `check_repo_hygiene.py` / `check_council_memory.py` / `generate_website_docs.py --check` / `check_website_docs_pii.py` — all green in a detached worktree at this commit
- [x] tests referencing the release skill (if any) run green — see the commit
