### PR TITLE
docs(skills): teach the council and live-verify the e2e-evidence rule

### DIFF
--- a/docs/superpowers/memory/e2e-evidence-is-a-contributor-deliverable.md
+++ b/docs/superpowers/memory/e2e-evidence-is-a-contributor-deliverable.md
@@ -5,7 +5,11 @@ description: "E2E is the decisive test layer; a PR touching a Flow surface owes 
 
 **Rule (since PR #675, merged 2026-09-05):** a behavior change **that touches a Flow surface**
 owes e2e evidence — the `tests/e2e/` test the author ran, with its result, or a new one they
-wrote. Not a nice-to-have: a reviewer treats its absence as a must-fix, and D4 scores YELLOW.
+wrote. Not a nice-to-have: **absent with no reason given, D4 scores RED** and consensus is RED.
+It is deliberately not YELLOW — a YELLOW is dismissable with a one-line logged justification,
+and *"the live runs in the PR body are good enough"* is precisely the justification that would
+be written, reopening the substitution below through the escape valve. If the author states why
+they could not run it, that is the documented exemption: YELLOW, blocked on a maintainer run.
 A change touching no Flow surface (docs, help text, exit-code plumbing) is out of scope, and
 the PR says that rather than leaving the box blank.
 
@@ -31,10 +35,15 @@ objection: `e2e_auth` and `e2e_image` spend zero credits, and read-only or inspe
 belong under `e2e_auth`.
 
 **How to apply (reviewer):**
-- Ask which `tests/e2e/` test covers the change. No answer and no new test on a Flow surface
-  → D4 must-fix, not a nice-to-have.
+- Ask which `tests/e2e/` test covers the change. No answer, no new test, and no stated reason
+  on a Flow surface → D4 RED, not YELLOW (see above for why the colour matters).
 - A PR body full of live runs does not close it. Ask for the test.
-- Do not hold a PR opened before 2026-09-05 to this rule retroactively; flag it forward-looking.
+- When a test *is* named, verify it: cite its file:line, confirm it exists at `REVIEWED_SHA`,
+  and confirm it exercises the changed surface. A passing e2e test that never touches the
+  changed path is [[pr-must-verify-on-affected-surface]] wearing an e2e label.
+- Do not hold a PR opened before #675 merged (`e7a09d8`, 2026-09-05 19:15Z) to this rule
+  retroactively; flag it forward-looking. Anchor on the merge, not the day — #669 and #671
+  were both opened hours earlier that same date.
 - The rule lives in `CONTRIBUTING.md` (lifecycle table + § Test categories), `AGENTS.md`
   (§ Testing instructions), and `.github/PULL_REQUEST_TEMPLATE.md`. `tests/test_documentation_gate.py`
   pins all three, so deleting one fails CI rather than passing quietly.

--- a/docs/superpowers/memory/e2e-evidence-is-a-contributor-deliverable.md
+++ b/docs/superpowers/memory/e2e-evidence-is-a-contributor-deliverable.md
@@ -1,0 +1,40 @@
+---
+name: e2e-evidence-is-a-contributor-deliverable
+description: "E2E is the decisive test layer; a PR touching a Flow surface owes an e2e test it ran or wrote. Offline-green and a live-verify ledger are both insufficient substitutes"
+---
+
+**Rule (since PR #675, merged 2026-09-05):** a behavior change **that touches a Flow surface**
+owes e2e evidence — the `tests/e2e/` test the author ran, with its result, or a new one they
+wrote. Not a nice-to-have: a reviewer treats its absence as a must-fix, and D4 scores YELLOW.
+A change touching no Flow surface (docs, help text, exit-code plumbing) is out of scope, and
+the PR says that rather than leaving the box blank.
+
+**Why offline-green is never enough here.** This project reverse-engineers a blackbox. Unit,
+integration and BDD tests prove only that *our* code does what we think it does; they cannot
+prove Flow still behaves the way we captured it. External PR #671 (`gflow credits`) shipped
+eight offline test files, zero e2e, and a fully green pipeline — and the HTTP fast path it
+added failed with `AisandboxAuthError` on both maintainer profiles the first time anyone ran
+it, falling back to a full Chrome launch per profile. An `e2e_auth`-marked test would have
+caught that before the PR was opened. See [[pr-must-verify-on-affected-surface]].
+
+**A live-verify ledger is not an e2e test.** `/gflow:live-verify` drives CLI commands by hand
+and writes a 5-layer ledger to a gitignored `tmp/live-verify/` note; it never runs
+`pytest -m e2e`. The two are complementary and neither substitutes for the other: an e2e test
+is a **re-runnable regression** that fails when Flow drifts, a ledger is a **narrative record**
+of one run on one account. A PR body describing live runs satisfies
+[[verification-ledger-5-layer]], not this rule. Accepting one for the other is how the rule
+erodes — it was proposed within an hour of the rule landing, on PR #669.
+
+**Why it falls on the contributor.** CI cannot run these — they need a live authenticated
+profile — so e2e is the one gate only someone with credentials can close. Cost is rarely the
+objection: `e2e_auth` and `e2e_image` spend zero credits, and read-only or inspection paths
+belong under `e2e_auth`.
+
+**How to apply (reviewer):**
+- Ask which `tests/e2e/` test covers the change. No answer and no new test on a Flow surface
+  → D4 must-fix, not a nice-to-have.
+- A PR body full of live runs does not close it. Ask for the test.
+- Do not hold a PR opened before 2026-09-05 to this rule retroactively; flag it forward-looking.
+- The rule lives in `CONTRIBUTING.md` (lifecycle table + § Test categories), `AGENTS.md`
+  (§ Testing instructions), and `.github/PULL_REQUEST_TEMPLATE.md`. `tests/test_documentation_gate.py`
+  pins all three, so deleting one fails CI rather than passing quietly.

--- a/skills/live-verify/SKILL.md
+++ b/skills/live-verify/SKILL.md
@@ -153,7 +153,13 @@ Upon completing Live Verification:
 
 ## Notes
 
-- This gate does not replace `/gflow:check` (offline gates before commit) or
-  `/gflow:doc-review` (release-time doc council) — it fills the gap between them.
+- This gate does not replace `/gflow:check` (offline gates before commit), nor
+  `pytest -m e2e` (the e2e suite against a live profile), nor `/gflow:doc-review`
+  (release-time doc council) — it fills the gap between them.
+- **This skill is not the e2e suite, and does not satisfy the e2e-evidence rule.** It drives
+  commands by hand and writes a narrative ledger to a gitignored `tmp/live-verify/` note; it
+  never runs `pytest -m e2e`. A PR touching a Flow surface owes BOTH: the e2e test is the
+  re-runnable regression, this ledger is the record of what was observed once, live. See
+  `[[e2e-evidence-is-a-contributor-deliverable]]` and CONTRIBUTING § *Test categories*.
 - Testing this skill itself means dry-running it on the next real feature that touches a
   generation path — there is no synthetic self-test for a live-Flow gate.

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -234,7 +234,7 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 | D1 | `[[pr-must-verify-on-affected-surface]]`, `[[video-model-capability-matrix]]`, `[[flow-capabilities-are-cohort-dependent]]` |
 | D2 | `[[ruff-format-scope-is-src-tests]]`, `[[git-add-all-sweeps-scratch-files]]` |
 | D3 | `[[real-browser-auth-mandatory]]`, `[[release-signing]]` |
-| D4 | `[[force-color-breaks-cli-tests]]`, `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]`, `[[windows-running-launcher-blocks-uv-upgrade]]` |
+| D4 | `[[e2e-evidence-is-a-contributor-deliverable]]`, `[[force-color-breaks-cli-tests]]`, `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]`, `[[windows-running-launcher-blocks-uv-upgrade]]` |
 | D5 | `[[memory-is-working-dir-keyed]]`, `[[release-spec-plan-memory-consolidation]]`, `[[pr-council-review-stale-tree-reads]]` (this very bug, as the council should self-improve) |
 | D6 | `[[ui-selector-drift-error-exit-23]]`, `[[credit-free-route-abort-verification]]`, `[[flow-credits-videos-only]]`, `[[flow-recon-must-run-on-denon82-ffroliva-migrated]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]`, `[[migrated-host-driver-wire-lessons]]` |
 | D7 | `[[on-started-callback-recorder-safety]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]` |
@@ -254,6 +254,11 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 - **D3 Security:** injection vectors? Env-var trust boundary? Shell interpolation? Path traversal? Secret-shaped literals? `--no-verify` / signature-bypass?
 - **D4 Tests:**
   - **Mandatory affected-surface check:** identify the runtime surface (T2V / I2V / data / CLI / auth / etc.). If the suite doesn't exercise that exact surface → **automatically YELLOW**. Cite the test file:line proving coverage, or state explicitly no such test exists.
+  - **Mandatory e2e-evidence check (since PR #675).** If the PR touches a **Flow surface**, it owes an e2e test — one the author ran, with its result, or a new one under `tests/e2e/`. Absent → **must-fix**, not a nice-to-have; offline-green is structurally incapable of proving a blackbox still behaves as captured (`[[e2e-evidence-is-a-contributor-deliverable]]`). Three traps to avoid:
+    - **A live-verify ledger is not an e2e test.** A PR body describing live runs satisfies `[[verification-ledger-5-layer]]`, not this. It is a narrative record of one run; an e2e test is a re-runnable regression. Never record live evidence as satisfying the e2e rule — that substitution was attempted on #669 within an hour of the rule landing.
+    - **A BDD `.feature` file is not an e2e test.** It runs offline against fakes.
+    - **Scope it honestly.** Docs-only, help-text and exit-code changes touch no Flow surface and are exempt; say so rather than demanding an impossible run.
+    - PRs opened before 2026-09-05 predate the rule — flag it forward-looking, do not hold it against them.
   - Test pyramid placement? Behavior vs shape? Coverage delta meaningful vs dead?
 - **D5 Memory hygiene & consolidation (NEW v2, refined v2.1):**
   - Inspect `~/.claude/projects/C--development-github-gflow-cli/memory/` (file-based memory — primary source).
@@ -448,6 +453,7 @@ When invoked unattended by `hermes-ops`'s automated triage runner, the agent and
 | § 5 step 8, YELLOW-dismiss escape valve | Never auto-dismiss or override. Report the consensus verdict (`YELLOW`/`RED`) exactly as-is. |
 | § 6, final "How to proceed" User Question | Omit the interactive question. Print the compiled markdown report directly to stdout. |
 | SonarCloud required-gate (CI policy) | Fork PR + skipped/missing SonarCloud check -> treat as informational note, not a block. |
+| D4 e2e-evidence check (§ Per-dimension specifics) | **Report, never run.** The sandbox has no Flow auth and must not spend credits, so the agent judges only whether the PR *carries* e2e evidence — it never executes `pytest -m e2e`. Missing evidence on a Flow surface is still reported as a must-fix; a GREEN verdict here means "evidence present and plausible", never "e2e passed". |
 
 ### Live-validation ceiling
 

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -254,11 +254,16 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 - **D3 Security:** injection vectors? Env-var trust boundary? Shell interpolation? Path traversal? Secret-shaped literals? `--no-verify` / signature-bypass?
 - **D4 Tests:**
   - **Mandatory affected-surface check:** identify the runtime surface (T2V / I2V / data / CLI / auth / etc.). If the suite doesn't exercise that exact surface → **automatically YELLOW**. Cite the test file:line proving coverage, or state explicitly no such test exists.
-  - **Mandatory e2e-evidence check (since PR #675).** If the PR touches a **Flow surface**, it owes an e2e test — one the author ran, with its result, or a new one under `tests/e2e/`. Absent → **must-fix**, not a nice-to-have; offline-green is structurally incapable of proving a blackbox still behaves as captured (`[[e2e-evidence-is-a-contributor-deliverable]]`). Three traps to avoid:
+  - **Mandatory e2e-evidence check (since PR #675).** If the PR touches a **Flow surface**, it owes an e2e test — one the author ran, with its result, or a new one under `tests/e2e/`. Offline-green is structurally incapable of proving a blackbox still behaves as captured (`[[e2e-evidence-is-a-contributor-deliverable]]`). Score it:
+    - **Absent, with no reason given → D4 RED**, which forces consensus RED under § 5 step 3. **Deliberately not YELLOW:** a YELLOW is dismissable under § 5 step 8 with a one-line justification, and *"the live runs in the PR body are good enough"* is exactly the justification someone will write — which reopens the substitution this check exists to close, through the escape valve rather than through the wording.
+    - **Absent, but the author states why they could not run it** (no Flow account, no credits for a video path) → **YELLOW**, blocked on a maintainer run. That is the documented exemption, not an evasion; name it in the report so the maintainer knows what to run.
+    - **Present → verify it, do not take it on trust.** Cite the `tests/e2e/` **file:line**, confirm it exists at `REVIEWED_SHA` (`git show $REVIEWED_SHA:<path>`), and confirm it exercises the surface this PR changed. A named test that passes but never touches the changed code path is the `[[pr-must-verify-on-affected-surface]]` failure with an e2e label on it.
+
+    Three traps to avoid:
     - **A live-verify ledger is not an e2e test.** A PR body describing live runs satisfies `[[verification-ledger-5-layer]]`, not this. It is a narrative record of one run; an e2e test is a re-runnable regression. Never record live evidence as satisfying the e2e rule — that substitution was attempted on #669 within an hour of the rule landing.
     - **A BDD `.feature` file is not an e2e test.** It runs offline against fakes.
     - **Scope it honestly.** Docs-only, help-text and exit-code changes touch no Flow surface and are exempt; say so rather than demanding an impossible run.
-    - PRs opened before 2026-09-05 predate the rule — flag it forward-looking, do not hold it against them.
+    - **PRs opened before #675 merged** (`e7a09d8`, 2026-09-05 19:15Z) predate the rule — flag it forward-looking, do not hold it against them. Anchor on the merge, not the calendar day: #669 (11:28Z) and #671 (13:38Z) were both opened that same day, hours before the rule existed, and are exactly the PRs this clause protects.
   - Test pyramid placement? Behavior vs shape? Coverage delta meaningful vs dead?
 - **D5 Memory hygiene & consolidation (NEW v2, refined v2.1):**
   - Inspect `~/.claude/projects/C--development-github-gflow-cli/memory/` (file-based memory — primary source).


### PR DESCRIPTION
## Summary

Follow-up to #675. That PR put the e2e-evidence rule in the contributor-facing docs; this one teaches the **review** skills to apply it. A rule the reviewer does not apply is not a rule.

Before this change, `pr-council-review` D4 scored a missing surface test as "automatically YELLOW", and nothing anywhere told a reviewer that a PR body full of live runs does not close the e2e requirement. That substitution was proposed on #669 within an hour of #675 landing — which is why it is now written down rather than left to judgement.

## Changes

- **New published memory slug** `docs/superpowers/memory/e2e-evidence-is-a-contributor-deliverable.md`, cited from the D4 mandatory-memory row. `check_council_memory.py` enforces the round trip both ways, so neither the citation nor the file can be dropped silently.
- **`skills/pr-council-review/SKILL.md` § D4** — missing e2e evidence on a Flow surface is a **must-fix**, with the three substitutions a reviewer must refuse named explicitly:
  - a live-verify ledger (a narrative record of one run, not a re-runnable regression),
  - a BDD `.feature` file (runs offline against fakes),
  - and demanding an impossible run from a docs-only change — the rule is scoped to Flow surfaces.

  PRs opened before 2026-09-05 are flagged forward-looking rather than held to it retroactively.
- **`skills/pr-council-review/SKILL.md` § 9** — autonomous mode **reports** e2e evidence, never runs it. The sandbox has no Flow auth and must not spend credits, so GREEN there means "evidence present and plausible", never "e2e passed".
- **`skills/live-verify/SKILL.md` § Notes** — states that this skill is not the e2e suite and does not satisfy the rule; a Flow-surface PR owes both. The ledger records what was observed once, live; the e2e test is what fails when Flow drifts.

## Test plan

Skills and memory only; no `src/` changes.

- [x] `uv run python scripts/ci/check_council_memory.py` — **48 memory files, all cited and all resolving** (47 before; the new slug is cited from D4, so the round trip passes in both directions)
- [x] `uv run python scripts/ci/check_repo_hygiene.py` — 946 tracked files, no violations
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved across 29 files
- [x] `uv run python scripts/ci/check_website_docs_pii.py` — clean across 25 published files
- [x] `uv run python scripts/ci/generate_website_docs.py --check` — mirror in sync (`skills/` is not mirrored)
- [x] `uv run ruff check src tests` / `ruff format --check` — clean
- [x] `pytest tests/test_documentation_gate.py tests/scripts tests/mcp` — 394 passed

E2E evidence: **not applicable — this PR touches no Flow surface.** Stated rather than silently skipped, per the rule it enforces.

No overlap with #676, which touches `skills/release/SKILL.md` only.