### PR TITLE
docs(skills): video-production skill v2.0 — composition guide, gates, scored task set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ The `skills/` directory ships installable agent skill docs in plain Markdown wit
 | `check` | [`skills/check/SKILL.md`](skills/check/SKILL.md) | Quality gates (lint/format/types/tests) before every commit |
 | `changelog` | [`skills/changelog/SKILL.md`](skills/changelog/SKILL.md) | Unreleased changes + last tagged version |
 | `known-issues` | [`skills/known-issues/SKILL.md`](skills/known-issues/SKILL.md) | Open/mitigated known issues — before auth/reCAPTCHA work |
+| `video-production` | [`skills/video-production/SKILL.md`](skills/video-production/SKILL.md) | User wants a finished multi-shot or dialogue video (consistent actors, room, several angles, spoken lines), or clips came back with a film border, a drifting room, rushed dialogue, a person-policy refusal or exit 36 |
 | `sonar` | [`skills/sonar/SKILL.md`](skills/sonar/SKILL.md) | Drive the SonarCloud quality gate to zero for a PR/branch |
 | `live-verify` | [`skills/live-verify/SKILL.md`](skills/live-verify/SKILL.md) | Pre-flight state check at start of work; live-verification against real Flow before claiming done |
 | `doc-review` | [`skills/doc-review/SKILL.md`](skills/doc-review/SKILL.md) | Council-driven documentation audit before a release |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ select = ["E", "F", "W", "I", "B", "UP", "N", "T20"]
 "tests/**" = ["T20"]
 "scripts/**" = ["T20"]
 "eval/**" = ["T20"]
+# skills/ ships runnable helper tools alongside each SKILL.md; a CLI helper prints.
+"skills/**" = ["T20"]
 
 [tool.pyright]
 include = ["src", "tests"]

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,7 +18,7 @@ This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.m
 | sonar | [`sonar/SKILL.md`](sonar/SKILL.md) | 1.0 |
 | doc-review | [`doc-review/SKILL.md`](doc-review/SKILL.md) | 1.0 |
 | release | [`release/SKILL.md`](release/SKILL.md) | 1.0 |
-| video-production | [`video-production/SKILL.md`](video-production/SKILL.md) | 1.0 |
+| video-production | [`video-production/SKILL.md`](video-production/SKILL.md) + [`clip_qa.py`](video-production/clip_qa.py) | 1.0 |
 
 ## gflow-cli skill
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,6 +18,7 @@ This directory ships installable agent skill docs for `gflow-cli`. Each `SKILL.m
 | sonar | [`sonar/SKILL.md`](sonar/SKILL.md) | 1.0 |
 | doc-review | [`doc-review/SKILL.md`](doc-review/SKILL.md) | 1.0 |
 | release | [`release/SKILL.md`](release/SKILL.md) | 1.0 |
+| video-production | [`video-production/SKILL.md`](video-production/SKILL.md) | 1.0 |
 
 ## gflow-cli skill
 

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -8,6 +8,18 @@ description: Use when the user wants a finished multi-shot or dialogue video out
 
 **Core principle:** lock the beat sheet, the room, the cast and the words on paper first; spend video credits only on beats that already passed the free checks. Companion to the `gflow-cli` skill (command surface) and `known-issues`.
 
+## Prerequisites
+
+**Everything gflow** — Python 3.11+, `uv`, an installed `gflow`, Playwright Chromium, a signed-in profile, Flow access — is the [`gflow-cli` skill](../gflow-cli/SKILL.md)'s Prerequisites section. Run its checks; do not restate them. The Step 0 host probe below drives Chrome through Playwright against gflow's own profile directory, so it inherits all of them.
+
+This skill adds three of its own:
+
+1. **`ffmpeg` and `ffprobe` on PATH, 5.0 or newer** — `ffmpeg -version`. The assembler uses `-fps_mode cfr`, which does not exist before 5.0.
+2. **An ffmpeg built with `libass` and `libfreetype`** — the same version banner lists the enabled libraries. Burned subtitles (the `subtitles` filter) and title cards (`drawtext`) are simply absent from minimal or "essentials" builds, which is the usual Windows trip.
+3. **`faster-whisper`, only if you want the transcript gate** — `python -c "import faster_whisper"`. **Nothing in gflow installs it.** `pip install faster-whisper`, then the first run downloads `base.en` (~75 MB, needs network once, cached after). Without it you lose the word-hit check and keep every other gate.
+
+`clip_qa.py`, beside this file, needs **only ffmpeg, ffprobe and the Python standard library** — no numpy, no model, no network — so the fluidity, lip-sync and A/V-drift gates still run on a machine where the transcript gate cannot.
+
 ## Step 0 — check the host, or the whole plan is dead
 
 Open `https://labs.google/fx/tools/flow/project/<id>` in the profile's Chrome and read the final URL.
@@ -87,7 +99,15 @@ Fluidity for dialogue shots: the whole-frame `tblend` median (calibrated on movi
 - **Trust the peak only if it stands up.** Require peak r ≥ 0.3, peak-minus-zero-lag prominence ≥ 0.05, and reject a peak pinned to the window edge. A flat correlation surface still has an argmax: one clip reported a 0.208 s "lag" whose peak stood 0.04 above zero lag, and another peaked at the boundary because it aligned line one's mouth with line two's audio. Both are no-opinion, not drift.
 - **Sync is only measurable where one person talks and little else moves.** Singles give r = 0.6–0.9; a busy two-shot gives r ≈ 0.1. **A low r means the shot cannot be measured, never that it is in sync.**
 
-Pass window: −0.045 s (audio early) to +0.125 s (audio late), the ITU-R BT.1359 detectability limits — the ear tolerates late sound far better than early. **Prove the detector before believing it**: re-encode a known-good clip with `adelay=200:all=1` and confirm it reports +0.2 s. Without that check a silently broken correlation reports every clip as perfect. Reference implementation: `fluidity.py` in the audition project.
+Pass window: −0.045 s (audio early) to +0.125 s (audio late), the ITU-R BT.1359 detectability limits — the ear tolerates late sound far better than early. **Prove the detector before believing it**: re-encode a known-good clip with `adelay=200:all=1` and confirm it reports +0.2 s. Without that check a silently broken correlation reports every clip as perfect.
+
+All of the above is implemented in **[`clip_qa.py`](clip_qa.py)** beside this file — run it rather than rebuilding it:
+
+```bash
+python clip_qa.py <clips_dir>            # every <xx00>.mp4: fluidity, sync, A/V drift
+python clip_qa.py final.mp4              # the assembled cut (skips the per-shot gates)
+python clip_qa.py --selftest <clip.mp4>  # prove the detector on a known-good single
+```
 
 This is worth running: on an 18-clip set where every clip had already passed the transcript, loudness and frame checks, it found two with 0.167 s and 0.333 s of audible audio lag.
 

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: video-production
+version: "1.0"
+description: Use when the user wants a finished multi-shot or dialogue video out of gflow — a scripted scene, a talking-head piece, an audition or rehearsal reference, a short film — and asks for consistent actors, a consistent room, several camera angles, spoken lines, or joining clips. Also use when clips came back with a film-strip border, a room that changes between shots, rushed or cut-off dialogue, a person-policy refusal, or a RecaptchaError/exit 36 on a generation.
+---
+
+# video-production
+
+**Core principle:** lock the beat sheet, the room, the cast and the words on paper first; spend video credits only on beats that already passed the free checks. Companion to the `gflow-cli` skill (command surface) and `known-issues`.
+
+## Step 0 — check the host, or the whole plan is dead
+
+Open `https://labs.google/fx/tools/flow/project/<id>` in the profile's Chrome and read the final URL.
+
+| Lands on | Lane | Usable on gflow 0.67.0 |
+|---|---|---|
+| `labs.google/fx/…` | **A, full** | everything below |
+| `flow.google.com/project/…` | **B, text only** | `video t2v --project` only. `image`, `character create`, `i2v/r2v`, `extend`, `scene create`, `movie run` exit 36 — a free `image t2i` there dies as `RecaptchaError` (that IS the migration, gflow-cli#639) |
+
+Do not write a plan that starts with `character create` or `movie run` before this check. Create the project with `gflow project create --name <piece> --json > out.json` (redirecting; piping through `head` kills the process before the JSON prints).
+
+## Step 1 — beat sheet (one line per clip)
+
+Fields: `id`, `setup`, `action`, `lines` as `[speaker, delivery, text]`, `duration`, `model`.
+
+- **Durations**: omni-flash 4/6/8/10 s (the only model whose `--duration` is honoured on every cohort); Veo 3.1 models 4/6/8 where the account renders the control. 8 s is the safe default, 10 s (omni-flash) for a long speech.
+- **≤ 2.5 spoken words per second**: 8 s ≈ 18 words, 10 s ≈ 24. Over that, the actor rushes and the last sentence is cut.
+- **Never rewrite the script to fit.** Split a long speech across beats; keep the author's words verbatim (a rehearsal reference with paraphrased lines is useless).
+- Two speakers per beat is fine, up to ~4 short alternating lines, written in order with a delivery note each; never three speakers.
+- One moment per clip; a beat with ~1 s of action in an 8 s clip invents the rest.
+- Close-ups for reaction lines, medium shots for long speeches (lip sync is more forgiving).
+
+## Step 2 — room: fixed geometry + named setups
+
+Flow has no environment entity; the room is text plus images attached per shot.
+
+- **Fixed-geometry paragraph**, verbatim in every prompt: furniture, doors, windows left-to-right, who is screen-left (180° axis, camera never crosses).
+- **Named setups** (`A_WIDE`, `B_MED_HUNT`, `C_CU_BELLA`, `D_TWO`), each naming the camera position and what is behind each actor; every beat references one. Arc: wide → medium → close-up → two-shot at the climax.
+- Lane A plates: `image t2i` the anchor angle (geometry only, no people), then each other angle with `image i2i --ref <ANCHOR_UUID>`; one plate per shot, the angle whose geometry matches; a plate for every region on screen or `r2v` invents it. Filenames per piece (`s024_env_window.jpg`), never generic.
+- **Nothing in frame carries text**: no "door marked PRINCIPAL", no posters with writing, no band logos. Whatever carries text invents text.
+
+## Step 3 — cast
+
+- Lane A: `gflow character create --project P --name <Name> --face-prompt "<face, plain background>" --body-prompt "<wardrobe token>" --voice <preset>` (`gflow character voices` lists the presets with samples); reuse with `@Name` or `--reference-entity <id>`. Lane B: the same description verbatim in every prompt.
+- Face prompt = role noun + hair + face marks, **with no age words at all** — write "a lanky young man with messy dark hair and faint stubble", "a woman with a neat blonde ponytail", "his adult granddaughter". Any number or age band trips the person policy on image and character generation, and minors are refused outright; cast school roles as adults. (Copy the wording above, not the red-flag list.)
+- **Wardrobe token** repeated in every shot; entities lock FACE, not clothing. Pin garments **plain, no print**.
+- **ONE face-bearing reference per generation.** Two `--reference-entity`, or an entity plus a portrait/frame `--ref`, returns HTTP 400 (`WireFormatError` with a misleading "simplify the prompt" hint). `movie run` with `characters = ["A", "B"]` on one scene is the same mistake.
+- **Two actors in one scene**: give the entity to whoever carries the beat (the speaker of the long line, the face in the close-up); the other rides on the verbatim canon plus wardrobe token, in profile or turned away in that shot. Alternate across beats so each actor is entity-locked in their own close-ups, which is where the audience reads identity; keep the non-entity description byte-identical between beats.
+
+## Step 4 — prompt shape
+
+`style → setting → geometry → cast → setup → action → dialogue → avoid`.
+
+- Style: "full-frame 16:9 image edge to edge, natural soft light, shallow depth of field". **Never** "35mm film", "IMAX 70mm", "film grain", "Unreal Engine render" — format words draw a sprocket-hole border or change the medium.
+- Camera words the model knows: eye-level, low/high angle, close-up, medium, wide, over-the-shoulder; static, pan, tilt, dolly, truck, zoom, handheld, rack focus.
+- Dialogue: attribution and delivery **before** the words — `HUNT says, bored, drawling: Will you relax?` Delivery levers: volume, emotional state, pace, register, physical condition, accent.
+- Avoid list = artefacts only: film-strip border, letterbox, vignette, subtitles, captions, readable text, extra people. Negations naming an action do not hold.
+- 1,100–1,400 characters.
+
+## Step 5 — which command, per beat
+
+| Beat needs | Command |
+|---|---|
+| canonical, anchor plate, prop sheet (free) | `image t2i` |
+| another angle of the same room (free) | `image i2i --ref <anchor UUID>` |
+| the exact approved frame animated | `video i2v --initial-frame` (no identity; omni-flash unlocks `--duration 10`, `--end-frame`) |
+| this person, this place, in motion | `video r2v --reference-entity <ONE> --ref <env> [--ref <prop>] --model omni-flash --duration 10 --count 1 --project P --json` |
+| continue the same shot past 8 s | `video extend <media_id> "<next lines>" --project P` (audio carries; segment holds ~7 s, trim `0-7`) |
+| a cut with continuity | `video chain` (restarts from a still, no audio carry, no omni-flash) |
+| join clips (free) | `scene create wf1 wf2:0-7 … -o out.mp4 --project P` |
+| scripted piece with one entity per scene | `movie run movie.toml` (`--stitch` is a preview, not a deliverable) |
+| lane B | `video t2v "<prompt>" --model omni-flash --duration 8|10 --aspect 16:9 --count 1 --project P -o clip.mp4 --json` |
+
+Model → refs, never refs → model. **Paid calls in the foreground, two beats per call**; a detached/background run lost a clip mid-poll. Trial one beat, check it, fix the template, then the rest. Never loop a retry into a refusal.
+
+## Step 6 — gates
+
+Before spend: prompt length; no ages; one face ref; words/second; text-free frame; the beat has motion for its whole length.
+
+After each clip: `ffprobe` duration; 1 fps frames viewed by eye (faces match canon, wardrobe token, geometry matches the setup, no text, no third person, no border); local speech-to-text transcript (faster-whisper `base.en`) word-hit ≥ 70 %; mean volume > −40 dB; opening clip motion (ffmpeg `tblend` median > 1.0).
+
+Fail → delete the clip, change ONE thing, re-check. Second identical failure → restage or delete the beat.
+
+## Step 7 — assemble and review
+
+Lane A: `scene create` with trims. Lane B: ffmpeg with title cards (one `drawtext` per line; `\n` inside one renders as "nn") and burned `.srt` subtitles from the beat timings, joined with the **concat filter** (`-filter_complex … concat=n=N:v=1:a=1`), every segment at the clips' frame rate. The concat *demuxer* with a 25 fps card among 24 fps clips produced a 164 s video track under 171 s of audio — lips drift ahead by 4 %. **Sync gate**: `ffprobe -show_entries stream=codec_type,duration` on the cut; video and audio durations must match within 0.1 s. Ship a local `review.html` beside the cut: final video, every clip with prompt, lines, transcript, metrics, frames.
+
+## Red flags — stop and re-plan
+
+- The plan opens with `character create` / `movie run` and nobody has looked at the final URL.
+- "teenage", "schoolgirl", "in her 20s", "about thirty" anywhere in a prompt.
+- A door, sign, poster or T-shirt described with words on it.
+- "35mm", "IMAX", "film grain", "Unreal Engine", "8K" in the style block.
+- Two `--reference-entity` flags, or `characters = [A, B]` on one scene.
+- A beat over 2.5 words/second, or a script line you shortened "to fit".
+- "Launch all remaining clips in a background job."
+
+| Rationalization | Reality |
+|---|---|
+| "Both faces need to be consistent, so both entities go in" | The second entity is the 400. One entity plus a role noun holds better than a refused generation. |
+| "The room description is in every prompt, that is enough" | Without named setups and a left-to-right geometry line the model re-invents the door on the first new angle. |
+| "Trim the monologue so it fits 8 s" | Split it into two beats. The words are the deliverable. |
+| "Kick off the batch and check in the morning" | One template bug repeats twelve times at twelve credits. Trial, check, then pairs. |

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -2,7 +2,8 @@
 name: video-production
 version: "2.0"
 skillopt_epoch: 0
-description: Use when the user wants a finished video out of gflow rather than a single clip — a scripted scene, a talking-head or dialogue piece, an explainer, a product montage, a story sequence, an audition or rehearsal reference, a short film — or asks for consistent actors, a consistent location, a specific prop that must not change, several camera angles, captions or subtitles, or joining clips into one file. Also use when clips came back wrong: a film-strip border, a room that changes between shots, a prop that morphs, rushed or cut-off speech, audio out of sync, a person-policy refusal, or exit 36 / RecaptchaError on a generation.
+description: >
+  Use when the user wants a finished video out of gflow rather than a single clip — a scripted scene, a talking-head or dialogue piece, an explainer, a product montage, a story sequence, an audition or rehearsal reference, a short film — or asks for consistent actors, a consistent location, a specific prop that must not change, several camera angles, captions or subtitles, or joining clips into one file. Also use when clips came back wrong: a film-strip border, a room that changes between shots, a prop that morphs, rushed or cut-off speech, audio out of sync, a person-policy refusal, or exit 36 / RecaptchaError on a generation.
 optimization_notes: |
   Known weak spots, each observed in a scored rollout. Targets for epoch 1+:
   - `--duration` passed without `--model`: binds veo-lite, which renders no duration control, exit 2

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -81,6 +81,16 @@ After each clip: `ffprobe` duration; 1 fps frames viewed by eye (faces match can
 
 Fluidity for dialogue shots: the whole-frame `tblend` median (calibrated on moving scenes, > 1.0) is blind to a locked-off talking head and reads 0.3–0.9 on perfectly live clips. Gate instead on **speech onset ≤ 1.6 s** (`silencedetect`) and **face-region motion**: crop the centre-top 60 % × 75 %, `tblend` median, 10th percentile > 0.15 (a held frame sits near 0). Inspect the two lowest clips at 2 fps by eye before re-rolling anything.
 
+**Lip sync, per clip.** Cross-correlate the face-region motion against the audio envelope over ±0.6 s; the lag of the peak is the drift. Three things make the difference between a number and noise, each learned by measuring:
+
+- **Compare like with like.** The motion series is a per-frame difference (spiky); the audio must therefore be an envelope of the same shape. Smooth the motion with a ~5-frame moving average and take audio RMS as **linear amplitude, not dB** — silence in dB is a large negative outlier that dominates the correlation. Raw difference against dB level measured r ≈ 0.0 at every lag; the corrected pair measures r = 0.6–0.9 on a single.
+- **Trust the peak only if it stands up.** Require peak r ≥ 0.3, peak-minus-zero-lag prominence ≥ 0.05, and reject a peak pinned to the window edge. A flat correlation surface still has an argmax: one clip reported a 0.208 s "lag" whose peak stood 0.04 above zero lag, and another peaked at the boundary because it aligned line one's mouth with line two's audio. Both are no-opinion, not drift.
+- **Sync is only measurable where one person talks and little else moves.** Singles give r = 0.6–0.9; a busy two-shot gives r ≈ 0.1. **A low r means the shot cannot be measured, never that it is in sync.**
+
+Pass window: −0.045 s (audio early) to +0.125 s (audio late), the ITU-R BT.1359 detectability limits — the ear tolerates late sound far better than early. **Prove the detector before believing it**: re-encode a known-good clip with `adelay=200:all=1` and confirm it reports +0.2 s. Without that check a silently broken correlation reports every clip as perfect. Reference implementation: `fluidity.py` in the audition project.
+
+This is worth running: on an 18-clip set where every clip had already passed the transcript, loudness and frame checks, it found two with 0.167 s and 0.333 s of audible audio lag.
+
 Fail → delete the clip, change ONE thing, re-check. Second identical failure → restage or delete the beat.
 
 ## Step 7 — assemble and review

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -1,135 +1,219 @@
 ---
 name: video-production
-version: "1.0"
-description: Use when the user wants a finished multi-shot or dialogue video out of gflow — a scripted scene, a talking-head piece, an audition or rehearsal reference, a short film — and asks for consistent actors, a consistent room, several camera angles, spoken lines, or joining clips. Also use when clips came back with a film-strip border, a room that changes between shots, rushed or cut-off dialogue, a person-policy refusal, or a RecaptchaError/exit 36 on a generation.
+version: "2.0"
+skillopt_epoch: 0
+description: Use when the user wants a finished video out of gflow rather than a single clip — a scripted scene, a talking-head or dialogue piece, an explainer, a product montage, a story sequence, an audition or rehearsal reference, a short film — or asks for consistent actors, a consistent location, a specific prop that must not change, several camera angles, captions or subtitles, or joining clips into one file. Also use when clips came back wrong: a film-strip border, a room that changes between shots, a prop that morphs, rushed or cut-off speech, audio out of sync, a person-policy refusal, or exit 36 / RecaptchaError on a generation.
+optimization_notes: |
+  Known weak spots, each observed in a scored rollout. Targets for epoch 1+:
+  - `--duration` passed without `--model`: binds veo-lite, which renders no duration control, exit 2
+  - `--ref` passed with `--model veo-quality`: that model's reference cap is 0, not 3
+  - Multi-angle sets generated as N independent `t2i` calls, then drift accepted as unavoidable
+  - "There is no `gflow project create`" — agents mint a project by burning a placeholder generation
+  - `nano-pro` used for bulk image work; it is daily-capped, `nano2` is the batch model
+  - Silent-video assumption: Veo always generates audio, a "silent" clip carries invented room tone
+  - No acceptance gate after generation — clips judged by looking at frame 0 only
+  - Speech length never budgeted, so lines are rushed or truncated inside the clip
+  - Two face-bearing references in one generation (two entities, or entity + portrait)
 ---
 
 # video-production
 
-**Core principle:** lock the beat sheet, the room, the cast and the words on paper first; spend video credits only on beats that already passed the free checks. Companion to the `gflow-cli` skill (command surface) and `known-issues`.
+**Core principle: control is everything.** Every guard-rail you put in front of the engine is drift you do not pay for later. Lock the shape, the cast, the location and the words before spending, then gate every clip on evidence rather than impression.
+
+This skill covers **composing gflow into a finished video**. It does not restate the command surface — that is the [`gflow-cli` skill](../gflow-cli/SKILL.md), which owns per-command syntax, flags and single-shot recipes. Load that one for "how do I call `t2v`", this one for "how do I turn a script into a film that holds together".
+
+## How to read the claims in this skill
+
+Every non-obvious statement is tagged. **This is one calibrated approach, not the only one.** Other people drive this engine with techniques not tracked here; absence from this document means untested, never forbidden.
+
+| Tag | Meaning | You may |
+|---|---|---|
+| **[CONSTRAINT]** | the engine refuses, fails, or silently drops the request | not deviate |
+| **[CALIBRATED]** | measured here, sample size and conditions stated | deviate with evidence |
+| **[CONVENTION]** | one shape that works; alternatives exist | deviate freely |
+| **[UNEXPLORED]** | known to exist, not tested here | try it, then add a task |
+
+## When NOT to use this skill
+
+A single clip with no continuity requirement, one image, or a pure command-syntax question — use the `gflow-cli` skill. Editing or grading existing footage — this is generation, not post. Any engine that is not Flow.
 
 ## Prerequisites
 
-**Everything gflow** — Python 3.11+, `uv`, an installed `gflow`, Playwright Chromium, a signed-in profile, Flow access — is the [`gflow-cli` skill](../gflow-cli/SKILL.md)'s Prerequisites section. Run its checks; do not restate them. The Step 0 host probe below drives Chrome through Playwright against gflow's own profile directory, so it inherits all of them.
+**Everything gflow** — Python 3.11+, `uv`, an installed `gflow`, Playwright Chromium, a signed-in profile, Flow access — belongs to the [`gflow-cli` skill](../gflow-cli/SKILL.md)'s Prerequisites. Run its checks; do not restate them.
 
-This skill adds three of its own:
+This skill adds three:
 
-1. **`ffmpeg` and `ffprobe` on PATH, 5.0 or newer** — `ffmpeg -version`. The assembler uses `-fps_mode cfr`, which does not exist before 5.0.
-2. **An ffmpeg built with `libass` and `libfreetype`** — the same version banner lists the enabled libraries. Burned subtitles (the `subtitles` filter) and title cards (`drawtext`) are simply absent from minimal or "essentials" builds, which is the usual Windows trip.
-3. **`faster-whisper`, only if you want the transcript gate** — `python -c "import faster_whisper"`. **Nothing in gflow installs it.** `pip install faster-whisper`, then the first run downloads `base.en` (~75 MB, needs network once, cached after). Without it you lose the word-hit check and keep every other gate.
+1. **`ffmpeg` and `ffprobe` on PATH, 5.0 or newer** — `ffmpeg -version`. The assembly step uses `-fps_mode`, which does not exist before 5.0.
+2. **An ffmpeg carrying `libass` and `libfreetype`** — the same banner lists enabled libraries. Burned subtitles (`subtitles`) and title cards (`drawtext`) are absent from minimal or "essentials" builds. Usual Windows trip.
+3. **`faster-whisper`, only if you want the transcript gate** — `python -c "import faster_whisper"`. **Nothing in gflow installs it.** First run pulls `base.en`, ~75 MB, once. Without it you lose the word-hit check and keep every other gate.
 
-`clip_qa.py`, beside this file, needs **only ffmpeg, ffprobe and the Python standard library** — no numpy, no model, no network — so the fluidity, lip-sync and A/V-drift gates still run on a machine where the transcript gate cannot.
+`clip_qa.py`, beside this file, needs **only ffmpeg, ffprobe and the standard library** — so the fluidity, lip-sync and A/V-drift gates still run where the transcript gate cannot.
 
-## Step 0 — check the host, or the whole plan is dead
+## Step 1 — intake, before anything else
 
-Open `https://labs.google/fx/tools/flow/project/<id>` in the profile's Chrome and read the final URL.
+The plan changes completely with the answers. Ask, or read them from the brief; do not assume.
 
-| Lands on | Lane | Usable on gflow 0.67.0 |
+| Question | Why it changes the plan |
+|---|---|
+| What is the deliverable, and who watches it? | a rehearsal reference tolerates flaws a client cut does not |
+| Does anyone speak **on camera**? | decides dialogue budgeting, lip-sync gating, and i2v-vs-r2v |
+| Is audio generated, added later, or discarded? | Veo always generates audio **[CONSTRAINT]** — see below |
+| Captions: none, burned-in, or a sidecar file? | burned-in needs `libass` and a timing source |
+| One location or several? How many camera angles each? | drives the plate-chaining work in `consistency.md` |
+| Recurring people? How many in frame at once? | one face-bearing reference per generation **[CONSTRAINT]** |
+| A prop that must not change? | needs its own sheet with a scale anchor |
+| Aspect, total length, credit ceiling | 16:9 or 9:16; clips are 4/6/8, or 10 on omni-flash |
+| One-off, or a repeatable pipeline? | decides the production shape in `composition.md` |
+
+**Veo always generates audio [CONSTRAINT].** There is no silent mode and omitting sound from the prompt does not produce silence. A "silent" montage returns invented room tone under every shot. If the audio is unwanted, strip it at assembly (`-an`) rather than hoping for a quiet clip.
+
+## Step 2 — check the host, or the whole plan is dead
+
+Load `https://labs.google/fx/tools/flow/project/<id>` in the profile's Chrome and read the **final** URL.
+
+| Lands on | Lane | What runs there |
 |---|---|---|
-| `labs.google/fx/…` | **A, full** | everything below |
-| `flow.google.com/project/…` | **B, text only** | `video t2v --project` only. `image`, `character create`, `i2v/r2v`, `extend`, `scene create`, `movie run` exit 36 — a free `image t2i` there dies as `RecaptchaError` (that IS the migration, gflow-cli#639) |
+| `labs.google/fx/…` | **A, full** | everything |
+| `flow.google.com/project/…` | **B, partial** | `video t2v --project` and `video i2v --initial-frame <local file> --project`. Everything else — `image`, `character create`, `r2v`, `extend`, `scene create`, `movie run`, and i2v by media UUID / `@Name` or with `--end-frame` — exits 36 **[CONSTRAINT]** |
 
-Do not write a plan that starts with `character create` or `movie run` before this check. Create the project with `gflow project create --name <piece> --json > out.json` (redirecting; piping through `head` kills the process before the JSON prints).
+Lane B grows as forms are ported, so **confirm the row rather than trusting it**: the
+maintained list is [CONFIGURATION § `GFLOW_CLI_FLOW_HOST`](../../docs/CONFIGURATION.md#gflow_cli_flow_host)
+and the [#639 entry in KNOWN_ISSUES](../../KNOWN_ISSUES.md). Exit 36 on a form the table
+says is ported is a regression worth filing, not the environment.
 
-## Step 1 — beat sheet (one line per clip)
+An unported command on lane B exits **36**, non-retryable, with a message naming the
+migration. A `RecaptchaError` instead means one of two other things: on gflow ≤ 0.68.0 the
+migration guard ran *after* the reCAPTCHA mint on the image path, so image commands died
+as exit 1 there (gflow-cli#673, fixed); on any build, a `RecaptchaError` right after
+`gflow auth login` is the cookie harvest keyed on the old host (gflow-cli#644). Either
+way the first move is the same: **read the final host URL before anything else.** Do not
+plan entities or plates before this check.
 
-Fields: `id`, `setup`, `action`, `lines` as `[speaker, delivery, text]`, `duration`, `model`.
+**There is a `gflow project create` [CONSTRAINT].** `gflow project create --name <piece> --json > out.json`, redirected to a file, never piped through `head`, which truncates the process before the JSON prints. Do not mint a project by burning a placeholder generation, and do not scrape the id from a browser URL.
 
-- **Durations**: omni-flash 4/6/8/10 s (the only model whose `--duration` is honoured on every cohort); Veo 3.1 models 4/6/8 where the account renders the control. 8 s is the safe default, 10 s (omni-flash) for a long speech.
-- **≤ 2.5 spoken words per second**: 8 s ≈ 18 words, 10 s ≈ 24. Over that, the actor rushes and the last sentence is cut.
-- **Never rewrite the script to fit.** Split a long speech across beats; keep the author's words verbatim (a rehearsal reference with paraphrased lines is useless).
-- Two speakers per beat is fine, up to ~4 short alternating lines, written in order with a delivery note each; never three speakers.
-- One moment per clip; a beat with ~1 s of action in an 8 s clip invents the rest.
-- Close-ups for reaction lines, medium shots for long speeches (lip sync is more forgiving).
+## Step 3 — the production shape
 
-## Step 2 — room: fixed geometry + named setups
+Pick one; each has a worked command chain in **[`composition.md`](composition.md)**.
 
-Flow has no environment entity; the room is text plus images attached per shot.
+| Shape | When | Driver |
+|---|---|---|
+| One-off sequence | a scene, an audition, a montage | shell, clip per beat |
+| Manifest-driven | a script that will be re-run as it is edited | `movie run` with a stable scene id per slot |
+| Continuous shot | one camera move longer than 8 s | `video extend` |
+| Deliberate cut with continuity | a new angle that must match the last frame | `video chain` |
+| Assembly only | clips already exist | `scene create` (free) |
 
-- **Fixed-geometry paragraph**, verbatim in every prompt: furniture, doors, windows left-to-right, who is screen-left (180° axis, camera never crosses).
-- **Named setups** (`A_WIDE`, `B_MED_HUNT`, `C_CU_BELLA`, `D_TWO`), each naming the camera position and what is behind each actor; every beat references one. Arc: wide → medium → close-up → two-shot at the climax.
-- Lane A plates: `image t2i` the anchor angle (geometry only, no people), then each other angle with `image i2i --ref <ANCHOR_UUID>`; one plate per shot, the angle whose geometry matches; a plate for every region on screen or `r2v` invents it. Filenames per piece (`s024_env_window.jpg`), never generic.
-- **Nothing in frame carries text**: no "door marked PRINCIPAL", no posters with writing, no band logos. Whatever carries text invents text.
+## Step 4 — lock the assets before spending
 
-## Step 3 — cast
+Full method in **[`consistency.md`](consistency.md)**. The short form:
 
-- Lane A: `gflow character create --project P --name <Name> --face-prompt "<face, plain background>" --body-prompt "<wardrobe token>" --voice <preset>` (`gflow character voices` lists the presets with samples); reuse with `@Name` or `--reference-entity <id>`. Lane B: the same description verbatim in every prompt.
-- Face prompt = role noun + hair + face marks, **with no age words at all** — write "a lanky young man with messy dark hair and faint stubble", "a woman with a neat blonde ponytail", "his adult granddaughter". Any number or age band trips the person policy on image and character generation, and minors are refused outright; cast school roles as adults. (Copy the wording above, not the red-flag list.)
-- **Wardrobe token** repeated in every shot; entities lock FACE, not clothing. Pin garments **plain, no print**.
-- **ONE face-bearing reference per generation.** Two `--reference-entity`, or an entity plus a portrait/frame `--ref`, returns HTTP 400 (`WireFormatError` with a misleading "simplify the prompt" hint). `movie run` with `characters = ["A", "B"]` on one scene is the same mistake.
-- **Two actors in one scene**: give the entity to whoever carries the beat (the speaker of the long line, the face in the close-up); the other rides on the verbatim canon plus wardrobe token, in profile or turned away in that shot. Alternate across beats so each actor is entity-locked in their own close-ups, which is where the audience reads identity; keep the non-entity description byte-identical between beats.
+- **People** are Flow CHARACTER entities, attached with `--reference-entity` or `@Name`. Identity.
+- **Locations and props** have no entity type **[CONSTRAINT]** — they are images attached per shot with `--ref`. Look.
+- **One face-bearing reference per generation [CONSTRAINT].** A second entity, or an entity plus a portrait, returns HTTP 400 reported as a wire-format error. Carry other people as role nouns in prose.
+- **Multi-angle locations must be chained, not generated in parallel [CALIBRATED]** — anchor angle by `t2i`, every other angle by `i2i --ref <anchor>`. Independent calls from the same paragraph produce different rooms.
+- Attaching by media UUID buys asset identity, never scene coherence.
 
-## Step 4 — prompt shape
+## Step 5 — beat sheet
+
+One row per clip: id, camera setup, action, lines with delivery, duration, model, references.
+
+- **Durations are 4/6/8, plus 10 on omni-flash [CONSTRAINT].** `--duration` requires an explicit `--model`; omitted, it binds `veo-lite`, which renders no duration control, and exits 2.
+- **≤ 2.5 spoken words per second [CALIBRATED, 25 clips, one model]** — 8 s ≈ 18 words, 10 s ≈ 24. Above it, delivery rushes and the last sentence is cut.
+- **Never rewrite the script to fit.** Split a long speech across beats; the words are the deliverable.
+- Two speakers per beat is fine with the order explicit; three is where sync breaks **[CALIBRATED]**.
+- One moment per clip. A beat with a second of action inside eight seconds invents material to fill the rest **[CALIBRATED]**.
+- Named camera setups and a declared 180° axis: see `consistency.md`.
+
+## Step 6 — prompt shape
 
 `style → setting → geometry → cast → setup → action → dialogue → avoid`.
 
-- Style: "full-frame 16:9 image edge to edge, natural soft light, shallow depth of field". **Never** "35mm film", "IMAX 70mm", "film grain", "Unreal Engine render" — format words draw a sprocket-hole border or change the medium.
-- Camera words the model knows: eye-level, low/high angle, close-up, medium, wide, over-the-shoulder; static, pan, tilt, dolly, truck, zoom, handheld, rack focus.
-- Dialogue: attribution and delivery **before** the words — `HUNT says, bored, drawling: Will you relax?` Delivery levers: volume, emotional state, pace, register, physical condition, accent.
-- Avoid list = artefacts only: film-strip border, letterbox, vignette, subtitles, captions, readable text, extra people. Negations naming an action do not hold.
-- 1,100–1,400 characters.
+- **Never name a film format** — "35mm", "IMAX", "film grain" draw a sprocket-hole border or change the medium **[CALIBRATED]**. Say "full-frame 16:9 image edge to edge" and put border, letterbox and vignette in the avoid list.
+- **No age words near a person [CONSTRAINT].** One age phrasing failed eight generations running; a relational or role noun passed immediately with everything else held constant. Minors are refused outright.
+- Dialogue as prose with the delivery **before** the words: `NAME says, weary: …`. Levers, most to least reliable: volume, emotional state, pace, register, physical condition, accent.
+- The avoid list holds artefacts only. **Negations that name an action do not suppress it** — restate positively.
+- ~1,100–1,400 characters **[CALIBRATED]**; longer prompts have returned 400.
+- Nothing in frame carries text unless you have a glyph master. Whatever carries text invents text.
 
-## Step 5 — which command, per beat
+## Step 7 — trial one beat, then batch in pairs
 
-| Beat needs | Command |
-|---|---|
-| canonical, anchor plate, prop sheet (free) | `image t2i` |
-| another angle of the same room (free) | `image i2i --ref <anchor UUID>` |
-| the exact approved frame animated | `video i2v --initial-frame` (no identity; omni-flash unlocks `--duration 10`, `--end-frame`) |
-| this person, this place, in motion | `video r2v --reference-entity <ONE> --ref <env> [--ref <prop>] --model omni-flash --duration 10 --count 1 --project P --json` |
-| continue the same shot past 8 s | `video extend <media_id> "<next lines>" --project P` (audio carries; segment holds ~7 s, trim `0-7`) |
-| a cut with continuity | `video chain` (restarts from a still, no audio carry, no omni-flash) |
-| join clips (free) | `scene create wf1 wf2:0-7 … -o out.mp4 --project P` |
-| scripted piece with one entity per scene | `movie run movie.toml` (`--stitch` is a preview, not a deliverable) |
-| lane B | `video t2v "<prompt>" --model omni-flash --duration 8|10 --aspect 16:9 --count 1 --project P -o clip.mp4 --json` |
+Generate **one** clip, run the gates, fix the template, then continue **two beats per foreground call** **[CALIBRATED]**. A detached background run lost a clip mid-poll and a template bug repeats once per clip at full price. Never loop a retry into a refusal.
 
-Model → refs, never refs → model. **Paid calls in the foreground, two beats per call**; a detached/background run lost a clip mid-poll. Trial one beat, check it, fix the template, then the rest. Never loop a retry into a refusal.
+## Step 8 — gates
 
-## Step 6 — gates
-
-Before spend: prompt length; no ages; one face ref; words/second; text-free frame; the beat has motion for its whole length.
-
-After each clip: `ffprobe` duration; 1 fps frames viewed by eye (faces match canon, wardrobe token, geometry matches the setup, no text, no third person, no border); local speech-to-text transcript (faster-whisper `base.en`) word-hit ≥ 70 %; mean volume > −40 dB.
-
-Fluidity for dialogue shots: the whole-frame `tblend` median (calibrated on moving scenes, > 1.0) is blind to a locked-off talking head and reads 0.3–0.9 on perfectly live clips. Gate instead on **speech onset ≤ 1.6 s** (`silencedetect`) and **face-region motion**: crop the centre-top 60 % × 75 %, `tblend` median, 10th percentile > 0.15 (a held frame sits near 0). Inspect the two lowest clips at 2 fps by eye before re-rolling anything.
-
-**Lip sync, per clip.** Cross-correlate the face-region motion against the audio envelope over ±0.6 s; the lag of the peak is the drift. Three things make the difference between a number and noise, each learned by measuring:
-
-- **Compare like with like.** The motion series is a per-frame difference (spiky); the audio must therefore be an envelope of the same shape. Smooth the motion with a ~5-frame moving average and take audio RMS as **linear amplitude, not dB** — silence in dB is a large negative outlier that dominates the correlation. Raw difference against dB level measured r ≈ 0.0 at every lag; the corrected pair measures r = 0.6–0.9 on a single.
-- **Trust the peak only if it stands up.** Require peak r ≥ 0.3, peak-minus-zero-lag prominence ≥ 0.05, and reject a peak pinned to the window edge. A flat correlation surface still has an argmax: one clip reported a 0.208 s "lag" whose peak stood 0.04 above zero lag, and another peaked at the boundary because it aligned line one's mouth with line two's audio. Both are no-opinion, not drift.
-- **Sync is only measurable where one person talks and little else moves.** Singles give r = 0.6–0.9; a busy two-shot gives r ≈ 0.1. **A low r means the shot cannot be measured, never that it is in sync.**
-
-Pass window: −0.045 s (audio early) to +0.125 s (audio late), the ITU-R BT.1359 detectability limits — the ear tolerates late sound far better than early. **Prove the detector before believing it**: re-encode a known-good clip with `adelay=200:all=1` and confirm it reports +0.2 s. Without that check a silently broken correlation reports every clip as perfect.
-
-All of the above is implemented in **[`clip_qa.py`](clip_qa.py)** beside this file — run it rather than rebuilding it:
+Nothing is accepted on impression. Run `clip_qa.py`; add the transcript check when speech matters.
 
 ```bash
-python clip_qa.py <clips_dir>            # every <xx00>.mp4: fluidity, sync, A/V drift
-python clip_qa.py final.mp4              # the assembled cut (skips the per-shot gates)
-python clip_qa.py --selftest <clip.mp4>  # prove the detector on a known-good single
+python clip_qa.py <clips_dir>            # fluidity, lip sync, A/V drift, per clip
+python clip_qa.py final.mp4              # the assembled cut
+python clip_qa.py --selftest <clip.mp4>  # prove the detector before believing it
 ```
 
-This is worth running: on an 18-clip set where every clip had already passed the transcript, loudness and frame checks, it found two with 0.167 s and 0.333 s of audible audio lag.
+| Gate | Threshold | Tier |
+|---|---|---|
+| Stream lengths on the cut | video and audio within 0.1 s | CONSTRAINT (a mismatch *is* drift) |
+| Speech onset after the cut | ≤ 1.6 s | CALIBRATED |
+| Face-region motion floor | 10th percentile > 0.15 | CALIBRATED, 25 clips @ 24 fps 720p |
+| Lip-sync lag | −0.045 s to +0.125 s, when correlation ≥ 0.3 | ITU-R BT.1359 detectability |
+| Transcript word-hit | ≥ 70 % of scripted words | CALIBRATED |
+| Mean volume | > −40 dB | CALIBRATED |
+| Frames, by eye, 1 fps | identity, wardrobe, geometry, no text, no extra person, no border | judgment |
 
-Fail → delete the clip, change ONE thing, re-check. Second identical failure → restage or delete the beat.
+**The whole-frame motion median does not work for dialogue [CALIBRATED].** Calibrated on moving scenes it reads above 1.0, but a locked-off talking head sits at 0.3–0.9 while performing normally. Gating on it condemns good work.
 
-## Step 7 — assemble and review
+**No metric can tell good motion from bad.** A hallucinated object is motion, so it *raises* every score; the highest-scoring take of five was the broken one. The eye stays in the loop.
 
-Lane A: `scene create` with trims. Lane B: ffmpeg with title cards (one `drawtext` per line; `\n` inside one renders as "nn") and burned `.srt` subtitles from the beat timings, joined with the **concat filter** (`-filter_complex … concat=n=N:v=1:a=1`), every segment at the clips' frame rate. The concat *demuxer* with a 25 fps card among 24 fps clips produced a 164 s video track under 171 s of audio — lips drift ahead by 4 %. **Sync gate**: `ffprobe -show_entries stream=codec_type,duration` on the cut; video and audio durations must match within 0.1 s. Ship a local `review.html` beside the cut: final video, every clip with prompt, lines, transcript, metrics, frames.
+Failure → delete the clip, change **one** thing, re-check. A second identical failure means the diagnosis is wrong: restage or delete the beat rather than rewrite the prompt again.
+
+## Step 9 — assemble and hand over
+
+Lane A joins with `scene create` and per-clip trims, free and server-side. Otherwise ffmpeg, and **join with the concat filter, not the demuxer** — mixed frame rates through the demuxer produced 164 s of video under 171 s of audio, lips running 4 % ahead **[CALIBRATED]**. Title cards need one `drawtext` per line; a newline inside one renders literally as "nn". Captions come from the **script**, not the transcript, so the reader sees the correct line even where the engine fluffed it.
+
+Ship a review page beside the cut: the final video, and every clip with its prompt, lines, transcript, metrics and frames.
 
 ## Red flags — stop and re-plan
 
-- The plan opens with `character create` / `movie run` and nobody has looked at the final URL.
-- "teenage", "schoolgirl", "in her 20s", "about thirty" anywhere in a prompt.
-- A door, sign, poster or T-shirt described with words on it.
-- "35mm", "IMAX", "film grain", "Unreal Engine", "8K" in the style block.
-- Two `--reference-entity` flags, or `characters = [A, B]` on one scene.
-- A beat over 2.5 words/second, or a script line you shortened "to fit".
-- "Launch all remaining clips in a background job."
+- Planning entities or plates before anyone looked at the final host URL.
+- An age word anywhere near a person.
+- A sign, poster, door or garment described as carrying words.
+- A film format in the style block.
+- Two `--reference-entity` flags, or `characters = [A, B]` on one manifest scene.
+- `--duration` with no `--model`; `--ref` with `veo-quality`.
+- A beat over 2.5 words per second, or a line shortened "to fit".
+- Angles of one location generated as independent `t2i` calls.
+- "Launch the rest in the background and check later."
+- Accepting any clip without running a gate.
 
-| Rationalization | Reality |
+| Rationalisation | Reality |
 |---|---|
-| "Both faces need to be consistent, so both entities go in" | The second entity is the 400. One entity plus a role noun holds better than a refused generation. |
-| "The room description is in every prompt, that is enough" | Without named setups and a left-to-right geometry line the model re-invents the door on the first new angle. |
-| "Trim the monologue so it fits 8 s" | Split it into two beats. The words are the deliverable. |
-| "Kick off the batch and check in the morning" | One template bug repeats twelve times at twelve credits. Trial, check, then pairs. |
+| "Both faces must stay consistent, so both entities go in" | the second entity is the 400. One entity plus a role noun beats a refused generation. |
+| "The room is described in every prompt, that is enough" | without an anchored plate chain, the first new angle invents a different room. |
+| "Trim the speech so it fits 8 s" | split it across beats. The words are the deliverable. |
+| "Reverse-angle drift is unavoidable" | it is avoidable: chain the angle off the anchor plate with `i2i`. |
+| "Kick the batch off and review in the morning" | one template bug bills once per clip. Trial, gate, then pairs. |
+| "It looks fine" | run the gates. Two clips that looked fine carried audible lag. |
+
+## What this skill does not cover
+
+Untested here, not discouraged. If you try one and it works, add a scored task and say so in `optimization_notes`.
+
+**[UNEXPLORED]** seed locking across generations for consistency · a single-image storyboard sheet fed to a video model as a *generation* input rather than a review artefact · first-and-last-frame interpolation for transitions · custom voices and voice references · agent-mode brief cards · character archetype generation · manifest runs at large scale · reference-to-video at high reference counts · non-English delivery, which Google documents as unevaluated · and on the tooling side, a real face detector in place of `clip_qa.py`'s fixed crop, plus frame-rate normalisation in the motion metric.
+
+## Keeping this skill honest
+
+The repo ships a scored harness. Measure before and after any edit:
+
+```bash
+python scripts/dev/skillopt/harness.py --skill skills/video-production/SKILL.md \
+                                       --tasks skills/video-production/tasks.json --dry-run
+```
+
+`tasks.json` beside this file holds the scored scenarios; every entry exists because an agent got it wrong in a rollout. When you find a new failure, add a task **first**, confirm it fails, then edit the skill until it passes. A rule added without a failing task is a guess.
+
+## Reference
+
+- **[`consistency.md`](consistency.md)** — character sheets, environment sets, prop sheets, film grammar
+- **[`composition.md`](composition.md)** — reference budget and ordering, command chains per production shape
+- **[`failure-modes.md`](failure-modes.md)** — symptom to cause to fix
+- **[`clip_qa.py`](clip_qa.py)** — the gates
+- **[`tasks.json`](tasks.json)** — the scored set

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -77,7 +77,9 @@ Model → refs, never refs → model. **Paid calls in the foreground, two beats 
 
 Before spend: prompt length; no ages; one face ref; words/second; text-free frame; the beat has motion for its whole length.
 
-After each clip: `ffprobe` duration; 1 fps frames viewed by eye (faces match canon, wardrobe token, geometry matches the setup, no text, no third person, no border); local speech-to-text transcript (faster-whisper `base.en`) word-hit ≥ 70 %; mean volume > −40 dB; opening clip motion (ffmpeg `tblend` median > 1.0).
+After each clip: `ffprobe` duration; 1 fps frames viewed by eye (faces match canon, wardrobe token, geometry matches the setup, no text, no third person, no border); local speech-to-text transcript (faster-whisper `base.en`) word-hit ≥ 70 %; mean volume > −40 dB.
+
+Fluidity for dialogue shots: the whole-frame `tblend` median (calibrated on moving scenes, > 1.0) is blind to a locked-off talking head and reads 0.3–0.9 on perfectly live clips. Gate instead on **speech onset ≤ 1.6 s** (`silencedetect`) and **face-region motion**: crop the centre-top 60 % × 75 %, `tblend` median, 10th percentile > 0.15 (a held frame sits near 0). Inspect the two lowest clips at 2 fps by eye before re-rolling anything.
 
 Fail → delete the clip, change ONE thing, re-check. Second identical failure → restage or delete the beat.
 

--- a/skills/video-production/clip_qa.py
+++ b/skills/video-production/clip_qa.py
@@ -21,6 +21,7 @@ Sync is only measurable where one person is talking and little else moves. On a 
 two-shot sync_r collapses to ~0.1 and the lag is noise — that is why a low sync_r means
 "no opinion", never "in sync". Measured 2026-09-05: singles r=0.6-0.8, two-shot r=0.1.
 """
+
 import json
 import re
 import statistics
@@ -44,13 +45,28 @@ def run(args: list[str], cwd: Path) -> str:
 
 
 def probe_fps(clip: Path) -> float:
-    out = subprocess.run(["ffprobe", "-v", "error", "-select_streams", "v:0",
-                          "-show_entries", "stream=r_frame_rate", "-of", "csv=p=0", clip.name],
-                         capture_output=True, text=True, cwd=clip.parent).stdout.strip()
+    out = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=r_frame_rate",
+            "-of",
+            "csv=p=0",
+            clip.name,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=clip.parent,
+    ).stdout.strip()
     num, _, den = out.partition("/")
     if not num.strip().isdigit():
         raise RuntimeError(
-            f"{clip.name}: ffprobe found no video stream (got {out!r}) — corrupt or not a video")
+            f"{clip.name}: ffprobe found no video stream (got {out!r}) — corrupt or not a video"
+        )
     return float(num) / float(den or 1)
 
 
@@ -59,9 +75,23 @@ def yavg(clip: Path, vf: str) -> list[float]:
     d = clip.parent
     m = d / "_m.txt"
     m.unlink(missing_ok=True)  # never read a stale file if the next call misbehaves
-    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name, "-vf",
-         f"{vf},tblend=all_mode=difference,signalstats,"
-         f"metadata=print:key=lavfi.signalstats.YAVG:file={m.name}", "-f", "null", "-"], d)
+    run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            clip.name,
+            "-vf",
+            f"{vf},tblend=all_mode=difference,signalstats,"
+            f"metadata=print:key=lavfi.signalstats.YAVG:file={m.name}",
+            "-f",
+            "null",
+            "-",
+        ],
+        d,
+    )
     vals = [float(x) for x in re.findall(r"YAVG=([0-9.]+)", m.read_text())]
     m.unlink(missing_ok=True)
     if not vals:
@@ -76,11 +106,27 @@ def audio_envelope(clip: Path, fps: float) -> list[float]:
     d = clip.parent
     a = d / "_a.txt"
     a.unlink(missing_ok=True)
-    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name, "-af",
-         f"aresample=48000,asetnsamples={round(48000 / fps)}:p=0,astats=metadata=1:reset=1,"
-         f"ametadata=print:key=lavfi.astats.Overall.RMS_level:file={a.name}", "-f", "null", "-"], d)
-    db = [-91.0 if x.lstrip("-") == "inf" else float(x)
-          for x in re.findall(r"RMS_level=(-?inf|-?[0-9.]+)", a.read_text())]
+    run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            clip.name,
+            "-af",
+            f"aresample=48000,asetnsamples={round(48000 / fps)}:p=0,astats=metadata=1:reset=1,"
+            f"ametadata=print:key=lavfi.astats.Overall.RMS_level:file={a.name}",
+            "-f",
+            "null",
+            "-",
+        ],
+        d,
+    )
+    db = [
+        -91.0 if x.lstrip("-") == "inf" else float(x)
+        for x in re.findall(r"RMS_level=(-?inf|-?[0-9.]+)", a.read_text())
+    ]
     a.unlink(missing_ok=True)
     return [10 ** (x / 20) for x in db]
 
@@ -90,7 +136,7 @@ def smooth(v: list[float], k: int = 5) -> list[float]:
     envelope; correlating a spike train against a plateau returns ~0 (measured)."""
     out = []
     for i in range(len(v)):
-        w = v[max(0, i - k // 2): i + k // 2 + 1]
+        w = v[max(0, i - k // 2) : i + k // 2 + 1]
         out.append(sum(w) / len(w))
     return out
 
@@ -124,8 +170,8 @@ def sync(motion: list[float], envelope: list[float], fps: float, window_s: float
     span = int(window_s * fps)
     curve = {}
     for lag in range(-span, span + 1):
-        a = mo[-lag:] if lag < 0 else mo[:n - lag]
-        b = en[:n + lag] if lag < 0 else en[lag:]
+        a = mo[-lag:] if lag < 0 else mo[: n - lag]
+        b = en[: n + lag] if lag < 0 else en[lag:]
         k = min(len(a), len(b))
         curve[lag] = pearson(a[:k], b[:k])
     best_lag = max(curve, key=curve.get)
@@ -143,9 +189,20 @@ def av_duration_delta(clip: Path) -> float:
     """Video stream length minus audio stream length. The 25 fps title cards concatenated
     into 24 fps clips produced 164 s of video under 171 s of audio — this is that check."""
     out = subprocess.run(
-        ["ffprobe", "-v", "error", "-show_entries", "stream=codec_type,duration",
-         "-of", "csv=p=0", clip.name],
-        capture_output=True, text=True, cwd=clip.parent).stdout
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type,duration",
+            "-of",
+            "csv=p=0",
+            clip.name,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=clip.parent,
+    ).stdout
     rows = (line.partition(",") for line in out.splitlines() if "," in line)
     d = {k: float(v) for k, _, v in rows if v.replace(".", "").isdigit()}
     return round(d.get("video", 0.0) - d.get("audio", 0.0), 3)
@@ -156,18 +213,30 @@ def measure(clip: Path) -> tuple[dict, dict]:
     whole = yavg(clip, "scale=180:320")
     face = yavg(clip, FACE_CROP)
     lag, r, prom, edge = sync(face, audio_envelope(clip, fps), fps)
-    err = run(["ffmpeg", "-i", clip.name, "-af", "silencedetect=n=-35dB:d=0.3",
-               "-f", "null", "-"], clip.parent)
+    err = run(
+        ["ffmpeg", "-i", clip.name, "-af", "silencedetect=n=-35dB:d=0.3", "-f", "null", "-"],
+        clip.parent,
+    )
     starts = [float(x) for x in re.findall(r"silence_start: ([0-9.]+)", err)]
     ends = [float(x) for x in re.findall(r"silence_end: ([0-9.]+)", err)]
     onset = ends[0] if starts and starts[0] < 0.05 and ends else 0.0
-    return ({"median": round(statistics.median(whole), 2),
-             "cut_spikes": sum(v >= 3.0 for v in whole), "fps": round(fps, 2)},
-            {"speech_onset_s": round(onset, 2),
-             "face_motion_median": round(statistics.median(face), 2),
-             "face_motion_p10": round(sorted(face)[len(face) // 10], 2),
-             "sync_lag_s": lag, "sync_r": r, "sync_prominence": prom, "sync_edge": edge,
-             "av_duration_delta_s": av_duration_delta(clip)})
+    return (
+        {
+            "median": round(statistics.median(whole), 2),
+            "cut_spikes": sum(v >= 3.0 for v in whole),
+            "fps": round(fps, 2),
+        },
+        {
+            "speech_onset_s": round(onset, 2),
+            "face_motion_median": round(statistics.median(face), 2),
+            "face_motion_p10": round(sorted(face)[len(face) // 10], 2),
+            "sync_lag_s": lag,
+            "sync_r": r,
+            "sync_prominence": prom,
+            "sync_edge": edge,
+            "av_duration_delta_s": av_duration_delta(clip),
+        },
+    )
 
 
 def verdict(fa: dict, is_beat: bool = True) -> str:
@@ -189,19 +258,36 @@ def selftest(clip: Path, shift_s: float = 0.2) -> None:
     base = measure(clip)[1]
     assert base["sync_r"] >= SYNC_MIN_R, (
         f"{clip.name} correlates at r={base['sync_r']} — too weak to test against. "
-        "Pick a single with one person talking, not a busy two-shot.")
+        "Pick a single with one person talking, not a busy two-shot."
+    )
     shifted = clip.parent / "_selftest.mp4"
-    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name,
-         "-af", f"adelay={int(shift_s * 1000)}:all=1",
-         "-c:v", "copy", shifted.name], clip.parent)
+    run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-y",
+            "-i",
+            clip.name,
+            "-af",
+            f"adelay={int(shift_s * 1000)}:all=1",
+            "-c:v",
+            "copy",
+            shifted.name,
+        ],
+        clip.parent,
+    )
     moved = measure(shifted)[1]
     shifted.unlink(missing_ok=True)
     drift = moved["sync_lag_s"] - base["sync_lag_s"]
-    print(f"baseline {base['sync_lag_s']:+.3f}s (r={base['sync_r']}) -> "
-          f"delayed {moved['sync_lag_s']:+.3f}s "
-          f"(r={moved['sync_r']}); detected {drift:+.3f}s, injected +{shift_s:.3f}s")
+    print(
+        f"baseline {base['sync_lag_s']:+.3f}s (r={base['sync_r']}) -> "
+        f"delayed {moved['sync_lag_s']:+.3f}s "
+        f"(r={moved['sync_r']}); detected {drift:+.3f}s, injected +{shift_s:.3f}s"
+    )
     assert abs(drift - shift_s) <= 0.06, (
-        f"detector missed the injected {shift_s}s shift (saw {drift:+.3f}s)")
+        f"detector missed the injected {shift_s}s shift (saw {drift:+.3f}s)"
+    )
     assert verdict(moved) == "DRIFT", "a clip shifted by 200 ms must not pass the sync gate"
     print("selftest OK")
 
@@ -211,8 +297,11 @@ if __name__ == "__main__":
         selftest(Path(sys.argv[2]))
         raise SystemExit(0)
     target = Path(sys.argv[1])
-    clips = ([target] if target.is_file() else
-             sorted(p for p in target.glob("*.mp4") if re.fullmatch(r"[a-z]{2}\d{2}\.mp4", p.name)))
+    clips = (
+        [target]
+        if target.is_file()
+        else sorted(p for p in target.glob("*.mp4") if re.fullmatch(r"[a-z]{2}\d{2}\.mp4", p.name))
+    )
     if not clips:
         raise SystemExit(f"no clips matched in {target} (expected <xx00>.mp4)")
     out_dir = target if target.is_dir() else target.parent
@@ -221,10 +310,12 @@ if __name__ == "__main__":
         is_beat = bool(re.fullmatch(r"[a-z]{2}\d{2}", clip.stem))
         motion[clip.stem], face[clip.stem] = measure(clip)
         f, m = face[clip.stem], motion[clip.stem]
-        print(f"{verdict(f, is_beat):5} {clip.stem} onset={f['speech_onset_s']:.2f}s "
-              f"face={f['face_motion_median']}/{f['face_motion_p10']} frame={m['median']} "
-              f"sync={f['sync_lag_s']:+.3f}s r={f['sync_r']} prom={f['sync_prominence']:+.3f} "
-              f"a/v={f['av_duration_delta_s']:+.3f}s")
+        print(
+            f"{verdict(f, is_beat):5} {clip.stem} onset={f['speech_onset_s']:.2f}s "
+            f"face={f['face_motion_median']}/{f['face_motion_p10']} frame={m['median']} "
+            f"sync={f['sync_lag_s']:+.3f}s r={f['sync_r']} prom={f['sync_prominence']:+.3f} "
+            f"a/v={f['av_duration_delta_s']:+.3f}s"
+        )
     if target.is_dir():  # a single-file run is a spot check; do not clobber the batch results
         (out_dir / "motion.json").write_text(json.dumps(motion, indent=1))
         (out_dir / "motion_face.json").write_text(json.dumps(face, indent=1))

--- a/skills/video-production/clip_qa.py
+++ b/skills/video-production/clip_qa.py
@@ -1,0 +1,230 @@
+"""Quality gates for generated dialogue clips: fluidity, lip sync, A/V drift.
+ffmpeg and ffprobe only — no model, no numpy, no network. Companion to SKILL.md.
+
+  python clip_qa.py <clips_dir>         every <xx00>.mp4 in the directory
+  python clip_qa.py <clip.mp4>          one file — use this on the assembled cut
+  python clip_qa.py --selftest <clip>   shift a known clip and prove the sync detector sees it
+
+Writes motion.json (whole-frame median, cut spikes) and motion_face.json (speech onset,
+face-region median / p10, sync lag and correlation) beside the clips.
+
+Gates: speech_onset_s <= 1.6 · face_motion_p10 > 0.15 (a held frame sits near 0) ·
+sync_lag_s within -0.045 s (audio early) to +0.125 s (audio late), the ITU-R BT.1359
+detectability window, and only when sync_r >= 0.3.
+
+Known limits, read before trusting a number: the face crop is a fixed rectangle, not a
+detector, so on a two-shot it straddles both actors; a hallucinated object is motion and
+RAISES the score, so this measures presence of change, never correctness of change; the
+motion series is inter-frame, giving a systematic half-frame (~0.02 s) bias in the lag.
+
+Sync is only measurable where one person is talking and little else moves. On a busy
+two-shot sync_r collapses to ~0.1 and the lag is noise — that is why a low sync_r means
+"no opinion", never "in sync". Measured 2026-09-05: singles r=0.6-0.8, two-shot r=0.1.
+"""
+import json
+import re
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+FACE_CROP = "crop=iw*0.6:ih*0.75:iw*0.2:0,scale=320:240"
+SYNC_EARLY, SYNC_LATE, SYNC_MIN_R, MIN_PROMINENCE = -0.045, 0.125, 0.3, 0.05
+AV_DURATION_TOLERANCE = 0.1  # video vs audio stream length on an assembled cut
+
+
+def run(args: list[str], cwd: Path) -> str:
+    """ffmpeg, failing loudly. A silent failure here would leave the previous clip's
+    metadata file on disk and report ITS numbers as this clip's."""
+    r = subprocess.run(args, capture_output=True, text=True, cwd=cwd)
+    if r.returncode != 0:
+        target = args[args.index("-i") + 1]
+        raise RuntimeError(f"ffmpeg failed ({r.returncode}) on {target}:\n{r.stderr[-800:]}")
+    return r.stderr
+
+
+def probe_fps(clip: Path) -> float:
+    out = subprocess.run(["ffprobe", "-v", "error", "-select_streams", "v:0",
+                          "-show_entries", "stream=r_frame_rate", "-of", "csv=p=0", clip.name],
+                         capture_output=True, text=True, cwd=clip.parent).stdout.strip()
+    num, _, den = out.partition("/")
+    if not num.strip().isdigit():
+        raise RuntimeError(
+            f"{clip.name}: ffprobe found no video stream (got {out!r}) — corrupt or not a video")
+    return float(num) / float(den or 1)
+
+
+def yavg(clip: Path, vf: str) -> list[float]:
+    """Per-frame mean luma of the frame difference — how much moved between frames."""
+    d = clip.parent
+    m = d / "_m.txt"
+    m.unlink(missing_ok=True)  # never read a stale file if the next call misbehaves
+    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name, "-vf",
+         f"{vf},tblend=all_mode=difference,signalstats,"
+         f"metadata=print:key=lavfi.signalstats.YAVG:file={m.name}", "-f", "null", "-"], d)
+    vals = [float(x) for x in re.findall(r"YAVG=([0-9.]+)", m.read_text())]
+    m.unlink(missing_ok=True)
+    if not vals:
+        raise RuntimeError(f"no frame data from {clip.name} — check the filter: {vf}")
+    return vals
+
+
+def audio_envelope(clip: Path, fps: float) -> list[float]:
+    """Per-VIDEO-frame loudness as LINEAR amplitude, by cutting the audio into frame-sized
+    chunks. Linear, not dB: silence in dB is a large negative outlier that dominates a
+    correlation, while in amplitude it is simply zero."""
+    d = clip.parent
+    a = d / "_a.txt"
+    a.unlink(missing_ok=True)
+    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name, "-af",
+         f"aresample=48000,asetnsamples={round(48000 / fps)}:p=0,astats=metadata=1:reset=1,"
+         f"ametadata=print:key=lavfi.astats.Overall.RMS_level:file={a.name}", "-f", "null", "-"], d)
+    db = [-91.0 if x.lstrip("-") == "inf" else float(x)
+          for x in re.findall(r"RMS_level=(-?inf|-?[0-9.]+)", a.read_text())]
+    a.unlink(missing_ok=True)
+    return [10 ** (x / 20) for x in db]
+
+
+def smooth(v: list[float], k: int = 5) -> list[float]:
+    """Centred moving average. Turns the spiky per-frame difference into an activity
+    envelope; correlating a spike train against a plateau returns ~0 (measured)."""
+    out = []
+    for i in range(len(v)):
+        w = v[max(0, i - k // 2): i + k // 2 + 1]
+        out.append(sum(w) / len(w))
+    return out
+
+
+def pearson(xs: list[float], ys: list[float]) -> float:
+    n = len(xs)
+    if n < 8:
+        return 0.0
+    mx, my = sum(xs) / n, sum(ys) / n
+    vx = sum((x - mx) ** 2 for x in xs)
+    vy = sum((y - my) ** 2 for y in ys)
+    if vx <= 0 or vy <= 0:
+        return 0.0
+    return sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True)) / (vx * vy) ** 0.5
+
+
+def sync(motion: list[float], envelope: list[float], fps: float, window_s: float = 0.6):
+    """Cross-correlate face motion against loudness. Returns (lag_seconds, peak_r, prominence).
+
+    Positive lag = the sound arrives AFTER the picture moves, i.e. audio is late.
+
+    Prominence is peak_r minus the correlation at zero lag. A flat surface has an argmax
+    but no meaning: bt05 measured a 0.208 s "lag" whose peak stood only 0.04 above zero,
+    while a real alignment (bt04) fell from 0.86 to 0.04 across the same window. Below
+    MIN_PROMINENCE the lag is reported as zero, because the data cannot tell it from zero.
+    """
+    n = min(len(motion), len(envelope))
+    if n < 16:
+        return 0.0, 0.0, 0.0, False
+    mo, en = smooth(motion[:n]), smooth(envelope[:n])
+    span = int(window_s * fps)
+    curve = {}
+    for lag in range(-span, span + 1):
+        a = mo[-lag:] if lag < 0 else mo[:n - lag]
+        b = en[:n + lag] if lag < 0 else en[lag:]
+        k = min(len(a), len(b))
+        curve[lag] = pearson(a[:k], b[:k])
+    best_lag = max(curve, key=curve.get)
+    peak_r, prominence = curve[best_lag], curve[best_lag] - curve[0]
+    # A peak pinned to the boundary means the real maximum is outside any plausible lip-sync
+    # range, so the correlation is aligning something else — on a two-line clip it can match
+    # line 1's mouth against line 2's audio. hb02 peaked at +0.75 s that way. No opinion.
+    at_edge = abs(best_lag) >= span
+    if prominence < MIN_PROMINENCE or at_edge:
+        best_lag = 0
+    return round(best_lag / fps, 3), round(peak_r, 2), round(prominence, 3), at_edge
+
+
+def av_duration_delta(clip: Path) -> float:
+    """Video stream length minus audio stream length. The 25 fps title cards concatenated
+    into 24 fps clips produced 164 s of video under 171 s of audio — this is that check."""
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "stream=codec_type,duration",
+         "-of", "csv=p=0", clip.name],
+        capture_output=True, text=True, cwd=clip.parent).stdout
+    rows = (line.partition(",") for line in out.splitlines() if "," in line)
+    d = {k: float(v) for k, _, v in rows if v.replace(".", "").isdigit()}
+    return round(d.get("video", 0.0) - d.get("audio", 0.0), 3)
+
+
+def measure(clip: Path) -> tuple[dict, dict]:
+    fps = probe_fps(clip)
+    whole = yavg(clip, "scale=180:320")
+    face = yavg(clip, FACE_CROP)
+    lag, r, prom, edge = sync(face, audio_envelope(clip, fps), fps)
+    err = run(["ffmpeg", "-i", clip.name, "-af", "silencedetect=n=-35dB:d=0.3",
+               "-f", "null", "-"], clip.parent)
+    starts = [float(x) for x in re.findall(r"silence_start: ([0-9.]+)", err)]
+    ends = [float(x) for x in re.findall(r"silence_end: ([0-9.]+)", err)]
+    onset = ends[0] if starts and starts[0] < 0.05 and ends else 0.0
+    return ({"median": round(statistics.median(whole), 2),
+             "cut_spikes": sum(v >= 3.0 for v in whole), "fps": round(fps, 2)},
+            {"speech_onset_s": round(onset, 2),
+             "face_motion_median": round(statistics.median(face), 2),
+             "face_motion_p10": round(sorted(face)[len(face) // 10], 2),
+             "sync_lag_s": lag, "sync_r": r, "sync_prominence": prom, "sync_edge": edge,
+             "av_duration_delta_s": av_duration_delta(clip)})
+
+
+def verdict(fa: dict, is_beat: bool = True) -> str:
+    """is_beat=False for an assembled cut: it opens on a title card, so the speech-onset
+    and per-shot sync gates do not apply — the stream-length check does."""
+    if abs(fa["av_duration_delta_s"]) > AV_DURATION_TOLERANCE:
+        return "DRIFT"
+    if not is_beat:
+        return "ok"
+    live = fa["speech_onset_s"] <= 1.6 and fa["face_motion_p10"] > 0.15
+    # a weak correlation means the shot gives the detector nothing to align, not that it drifts
+    measurable = fa["sync_r"] >= SYNC_MIN_R and not fa.get("sync_edge")
+    in_sync = not measurable or SYNC_EARLY <= fa["sync_lag_s"] <= SYNC_LATE
+    return "fluid" if live and in_sync else ("DRIFT" if live else "CHECK")
+
+
+def selftest(clip: Path, shift_s: float = 0.2) -> None:
+    """Delay the audio by a known amount; the detector must report that delay."""
+    base = measure(clip)[1]
+    assert base["sync_r"] >= SYNC_MIN_R, (
+        f"{clip.name} correlates at r={base['sync_r']} — too weak to test against. "
+        "Pick a single with one person talking, not a busy two-shot.")
+    shifted = clip.parent / "_selftest.mp4"
+    run(["ffmpeg", "-v", "error", "-y", "-i", clip.name,
+         "-af", f"adelay={int(shift_s * 1000)}:all=1",
+         "-c:v", "copy", shifted.name], clip.parent)
+    moved = measure(shifted)[1]
+    shifted.unlink(missing_ok=True)
+    drift = moved["sync_lag_s"] - base["sync_lag_s"]
+    print(f"baseline {base['sync_lag_s']:+.3f}s (r={base['sync_r']}) -> "
+          f"delayed {moved['sync_lag_s']:+.3f}s "
+          f"(r={moved['sync_r']}); detected {drift:+.3f}s, injected +{shift_s:.3f}s")
+    assert abs(drift - shift_s) <= 0.06, (
+        f"detector missed the injected {shift_s}s shift (saw {drift:+.3f}s)")
+    assert verdict(moved) == "DRIFT", "a clip shifted by 200 ms must not pass the sync gate"
+    print("selftest OK")
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "--selftest":
+        selftest(Path(sys.argv[2]))
+        raise SystemExit(0)
+    target = Path(sys.argv[1])
+    clips = ([target] if target.is_file() else
+             sorted(p for p in target.glob("*.mp4") if re.fullmatch(r"[a-z]{2}\d{2}\.mp4", p.name)))
+    if not clips:
+        raise SystemExit(f"no clips matched in {target} (expected <xx00>.mp4)")
+    out_dir = target if target.is_dir() else target.parent
+    motion, face = {}, {}
+    for clip in clips:
+        is_beat = bool(re.fullmatch(r"[a-z]{2}\d{2}", clip.stem))
+        motion[clip.stem], face[clip.stem] = measure(clip)
+        f, m = face[clip.stem], motion[clip.stem]
+        print(f"{verdict(f, is_beat):5} {clip.stem} onset={f['speech_onset_s']:.2f}s "
+              f"face={f['face_motion_median']}/{f['face_motion_p10']} frame={m['median']} "
+              f"sync={f['sync_lag_s']:+.3f}s r={f['sync_r']} prom={f['sync_prominence']:+.3f} "
+              f"a/v={f['av_duration_delta_s']:+.3f}s")
+    if target.is_dir():  # a single-file run is a spot check; do not clobber the batch results
+        (out_dir / "motion.json").write_text(json.dumps(motion, indent=1))
+        (out_dir / "motion_face.json").write_text(json.dumps(face, indent=1))

--- a/skills/video-production/composition.md
+++ b/skills/video-production/composition.md
@@ -1,0 +1,138 @@
+# Composition — choosing and chaining commands into a finished video
+
+Companion to [`SKILL.md`](SKILL.md). Tags: **[CONSTRAINT]** engine refuses · **[CALIBRATED]** measured here · **[CONVENTION]** one workable shape · **[UNEXPLORED]** untested.
+
+Per-command syntax lives in the [`gflow-cli` skill](../gflow-cli/SKILL.md). This file is about which command a beat needs, and how the calls join up.
+
+## Free versus paid, because it sets your risk appetite
+
+**Images are free** — they draw on a daily cap, which is a rate limit, not a charge. `image t2i`, `image i2i`, the image slots of `character create`, `instructions`, and `scene create` all cost nothing. **Only video bills.**
+
+So: never accept a weak plate or a weak still to save budget — re-roll it. Conversely every clip is a real spend, which makes the gate *before* a clip the expensive one to skip.
+
+## Which command for this beat
+
+| The beat needs | Command | Notes |
+|---|---|---|
+| a character reference, a location plate, a prop sheet | `image t2i` | free; text only |
+| another angle of the same location, or a still inheriting a set | `image i2i --ref <anchor>` | free; the anchor chain |
+| the exact approved frame, animated | `video i2v --initial-frame` | **carries no identity [CONSTRAINT]**; omni-flash unlocks 10 s and `--end-frame` |
+| this person, in this place, in motion | `video r2v --reference-entity <one> --ref <plate>` | the only video path carrying identity; composes its own frame |
+| a shot continuing past 8 s | `video extend <media_id>` | seeded server-side, motion **and audio** carry |
+| a deliberate cut with visual continuity | `video chain` | restarts from an extracted still; audio does **not** carry |
+| clips that already exist, joined | `scene create` | free, server-side, per-clip trims |
+| a script re-run as it is edited | `movie run` | resumable, one entity per scene |
+| no anchor at all | `video t2v` | the only option on lane B |
+
+### The trade that decides i2v against r2v
+
+**`i2v` guarantees the exact frame a human approved.** It pays for that by carrying one image and no identity whatsoever.
+
+**`r2v` is the only video path that carries a character.** It pays by giving up the guaranteed first frame — it composes its own.
+
+Measured both ways on the same beat: reference-to-video lifted a frozen opening from a median motion of 0.50 to 3.94, roughly eight times the still baseline **[CALIBRATED]**. On a different beat, the same command **omitted the staged focal object entirely** and rebuilt the location despite a plate being attached, because it composes rather than inherits **[CALIBRATED]**.
+
+So the rule is conditional. **When the staged object is the mechanism of the shot, use `i2v`.** When the shot needs a specific person moving through a specific place, use `r2v`. Mixing them beat by beat is the intended use, not a compromise.
+
+### extend against chain
+
+`extend` continues **the same shot** — seeded server-side from the source clip, so motion and audio run across the join. `chain` **cuts to a new shot** — it extracts the previous clip's last frame locally and restarts from a still, which is why it needs a fade guard and why audio does not carry.
+
+Use `extend` where a cut would break the effect: a continuous camera move, an unbroken performance, footage timed to a narration beat. Use `chain` when a cut is what you want.
+
+**An extend segment carries about 7 s of real content though 8 s is billed [CONSTRAINT].** Concatenating several leaves a frozen, silent second before every internal seam. Render without `-o` and trim each segment to `0-7` in `scene create`.
+
+## Chain 1 — one-off sequence
+
+A scene, an audition, a montage. Clip per beat, assembled locally or server-side.
+
+```bash
+gflow project create --name "<piece>" --json > project.json     # redirect, never pipe to head
+
+# assets (free)
+gflow character create --project P --name Lead \
+  --face-prompt "<canon, plain background>" --body-prompt "<wardrobe, no print>" --voice <preset>
+gflow image t2i "<location, geometry only, no people>" --aspect 16:9 --project P -o plate_wide.png
+gflow image i2i "<same room, reverse angle>" --ref <ANCHOR_UUID> --aspect 16:9 --project P -o plate_rev.png
+
+# trial ONE beat, gate it, fix the template, then continue in pairs
+gflow video r2v "<style + geometry + cast + setup + action + dialogue + avoid>" \
+  --reference-entity <LEAD_ID> --ref <PLATE_UUID> \
+  --model omni-flash --duration 8 --aspect 16:9 --count 1 --project P --json
+
+python clip_qa.py clips/
+
+# assemble (free)
+gflow scene create <wf1> <wf2> <wf3> -o final.mp4 --project P
+```
+
+## Chain 2 — manifest-driven, re-run as the script is edited
+
+The shape for a pipeline: a stable id per slot, one entity, resumable.
+
+```bash
+gflow movie template movie.toml          # scaffold
+gflow movie run movie.toml --dry-run     # parses, prices, spends nothing
+gflow movie run movie.toml --continue-on-error --out-dir ./out
+```
+
+Manifest essentials: a fixed `project`; one `[[characters]]` block with `identity = "entity"` so the same character is created once and reused; one `[[scenes]]` block per slot with a **stable `id`**; and an explicit `model` on every scene so the duration is validated at parse time rather than mid-spend.
+
+**Resume is by content hash, not by position [CONSTRAINT].** A sibling state file records each completed scene against a hash of its fully composed prompt. On re-run, an unchanged scene is skipped and never re-billed; only edited ones regenerate.
+
+Three consequences worth planning around:
+
+- **Scene ids must be stable across runs.** Reordering or inserting rows renumbers slots and re-bills everything after the insertion point.
+- **Editing the shared style block re-hashes every scene [CONSTRAINT].** A one-word style tweak silently regenerates the whole manifest. Keep style edits off script-only runs.
+- **`--stitch` is a hard concat preview, not a deliverable.** Assemble properly afterwards.
+
+Two-speaker scenes use per-character entries rather than the single-speaker shorthand — and remember one face-bearing reference per generation, so `characters = [A, B]` on one scene is the same 400 as two `--reference-entity` flags.
+
+## Chain 3 — a shot longer than eight seconds
+
+```bash
+gflow video r2v "<opening beat>" --reference-entity <ID> --ref <PLATE> \
+  --model omni-flash --duration 8 --project P --json          # note the media_id
+
+gflow video extend <media_id> "<next beat>" "<beat after>" --project P --aspect 16:9
+
+gflow scene create <wf1> <wf2>:0-7 <wf3>:0-7 -o shot.mp4 --project P
+```
+
+Trim every extension to `0-7`; see the 7-second constraint above. `1:1` is refused — there is no square extend model.
+
+## Chain 4 — assembly only
+
+```bash
+gflow data list videos --json                  # workflow ids
+gflow scene create <wf1> <wf2>:2.0-6.5 <wf3> -o cut.mp4 --project P
+```
+
+Free, server-side, no re-encode, per-clip trim windows in seconds.
+
+## Local assembly, when lane or format rules out `scene create`
+
+Join with the **concat filter**, never the demuxer:
+
+```bash
+ffmpeg -i card.mp4 -i clip1.mp4 -i clip2.mp4 \
+  -filter_complex "[0:v][0:a][1:v][1:a][2:v][2:a]concat=n=3:v=1:a=1[v][a]" \
+  -map "[v]" -map "[a]" -r 24 -fps_mode cfr -c:v libx264 -c:a aac -ar 48000 final.mp4
+```
+
+**Mixed frame rates through the concat demuxer produced 164 s of video under 171 s of audio — lips 4 % ahead by the end [CALIBRATED].** Every segment, title cards included, must be built at the clips' frame rate. Verify with `clip_qa.py final.mp4`; the stream lengths must agree within 0.1 s.
+
+Title cards need one `drawtext` filter **per line** — a newline inside a single `drawtext` renders literally as "nn".
+
+Captions come from the **script**, not from the transcript, so the reader sees the correct line even where the engine fluffed the delivery. Where speech is added in post and does not exist yet, the caption timing has to come from the voiceover once recorded; a per-shot even split is a placeholder, not a deliverable **[CONVENTION]**.
+
+Strip generated audio with `-an` where the sound is unwanted — the engine always produces some **[CONSTRAINT]**.
+
+## Pacing, sessions and what wastes money quietly
+
+- **Paid calls in the foreground, roughly two beats per invocation [CALIBRATED].** A detached background run lost a clip mid-poll after the credit was spent.
+- **One profile, no parallel generations.** Concurrent runs on one profile collide on its lease.
+- **Never auto-retry into a refusal.** A refusal aborts and keeps what completed; re-running into a block only raises the profile's risk score.
+- **`--dry-run` before any manifest run.** It prices the plan and catches model-duration mismatches without opening a browser.
+- **A run interrupted after submit but before download may still have billed.** Reconcile by listing media rather than re-running blind.
+- Keep prompts near the calibrated length; over-long prompts have returned 400 as a wire-format error whose advice is misleading.

--- a/skills/video-production/composition.md
+++ b/skills/video-production/composition.md
@@ -101,7 +101,30 @@ gflow scene create <wf1> <wf2>:0-7 <wf3>:0-7 -o shot.mp4 --project P
 
 Trim every extension to `0-7`; see the 7-second constraint above. `1:1` is refused — there is no square extend model.
 
-## Chain 4 — assembly only
+## Chain 4 — the composited approved frame
+
+The pattern to reach for when a shot needs **both** a specific person and a specific staged object, and the object is the point of the shot. `r2v` cannot serve it: it carries identity but composes its own frame, and has dropped a staged focal object outright. `i2v` guarantees the frame but carries no identity. So build the frame first, with identity baked in, then animate it.
+
+```bash
+# 1. compose the still: entity for the face, plates for the place and the prop.
+#    image i2i takes REPEATED --ref up to the model's cap (nano2: 10), so a plate
+#    and a prop sheet in one call is the normal case, not an advanced one. Free.
+gflow image i2i "<close crop, the action's start state, stated exactly>" \
+  --reference-entity <CHARACTER_ID> --ref <PLATE_UUID> --ref <PROP_UUID> \
+  --model nano2 --aspect 16:9 --project P -o frame_approved.png
+
+# 2. a human looks at it. This is the gate the whole pattern exists for.
+#    Crop to the prop and confirm the beat's start state is literally true in the
+#    frame — a prop touching a surface it must leave will animate as attached to it.
+
+# 3. animate the approved frame. No identity flag: the identity is in the pixels.
+gflow video i2v --initial-frame frame_approved.png "<what happens next>" \
+  --model omni-flash --duration 8 --aspect 16:9 --count 1 --project P --json
+```
+
+Use it for a mechanism-critical prop, a precise start state, or a shot that must match the previous clip's last frame. The cost is one extra free image and one human look.
+
+## Chain 5 — assembly only
 
 ```bash
 gflow data list videos --json                  # workflow ids
@@ -131,6 +154,16 @@ Strip generated audio with `-an` where the sound is unwanted — the engine alwa
 ## Pacing, sessions and what wastes money quietly
 
 - **Paid calls in the foreground, roughly two beats per invocation [CALIBRATED].** A detached background run lost a clip mid-poll after the credit was spent.
+
+  **This is about interactive iteration, not a ban on automation.** A scheduled pipeline cannot have a human per call, and does not need one — what it needs is the same guarantee by other means:
+
+  - Gate on a **canary scene** each run: generate one, check it, and stop the rest if it fails.
+  - Prefer `--fail-fast` over `--continue-on-error` unattended, so a broken template bills once instead of once per scene.
+  - **Reconcile rather than retry.** After any interrupted run, list the project's media and compare against the state file; a run cut off between submit and download may already have billed.
+  - Run the job in the foreground **of its own scheduled process**, one profile, never two overlapping invocations.
+  - Keep a credit ceiling per run and fail the job rather than the budget.
+
+  The rule the incident actually supports is: never detach a paid call from the process that is waiting on it. A cron job that blocks on its own run satisfies that; a background job inside an interactive session does not.
 - **One profile, no parallel generations.** Concurrent runs on one profile collide on its lease.
 - **Never auto-retry into a refusal.** A refusal aborts and keeps what completed; re-running into a block only raises the profile's risk score.
 - **`--dry-run` before any manifest run.** It prices the plan and catches model-duration mismatches without opening a browser.

--- a/skills/video-production/consistency.md
+++ b/skills/video-production/consistency.md
@@ -26,7 +26,7 @@ The two reference mechanisms are not interchangeable. This is the distinction pe
 
 `@Name` and `--reference-entity` are the same mechanism; one resolves by display name, the other takes the id. They dedupe against each other.
 
-**They are designed to combine.** An entity plus a location plate reads as *this person, in this place*. That composition is the normal case, not an advanced one.
+**They are designed to combine.** An entity plus a location plate reads as *this person, in this place*. That composition is the normal case, not an advanced one, and `--ref` is **repeatable up to the model's cap** — a plate and a prop sheet in the same call is ordinary usage. To pin a person, a place and an object into one approved still before animating it, see the composited-approved-frame pattern in [`composition.md`](composition.md).
 
 **Entities are project- and account-scoped [CONSTRAINT].** An entity minted on one account will not resolve when generating on another. Moving a production between accounts means rebuilding the cast under identical names, or accepting portrait images instead — a decision to make deliberately, not to discover mid-run.
 

--- a/skills/video-production/consistency.md
+++ b/skills/video-production/consistency.md
@@ -1,0 +1,152 @@
+# Consistency — cast, location, props, and the grammar that holds them together
+
+Companion to [`SKILL.md`](SKILL.md). Claims are tagged **[CONSTRAINT]** (the engine refuses), **[CALIBRATED]** (measured, conditions stated), **[CONVENTION]** (one workable shape), **[UNEXPLORED]** (untested here).
+
+## The one fact everything else follows from
+
+**Flow has exactly one reusable entity type: CHARACTER [CONSTRAINT].** There is no environment entity, no object entity, no prop entity and no style entity.
+
+Two consequences, and they shape the whole method:
+
+1. **Only the cast is name-addressable.** A character is created once, lives in the project, and is referenced by id or by name from then on.
+2. **Locations and props can never be remembered.** They are re-attached, as images, on every single shot that needs them. There is no shortcut and no persistence.
+
+## Identity versus image
+
+The two reference mechanisms are not interchangeable. This is the distinction people get wrong.
+
+| | `--ref` | `--reference-entity` / `@Name` |
+|---|---|---|
+| Wire field | `referenceImages` | `referenceEntities` |
+| Means | "look like **this picture**" | "this is **this person**" |
+| Use for | a location plate, a prop sheet, a one-off look | a saved character |
+| Persists in the project | no | yes, project-scoped |
+| Carries | one angle | a multi-angle turnaround, plus voice and personality |
+| Available on | `image i2i`, `video r2v` | `image t2i`/`i2i`, `video t2v`/`r2v` — **not `i2v`** |
+
+`@Name` and `--reference-entity` are the same mechanism; one resolves by display name, the other takes the id. They dedupe against each other.
+
+**They are designed to combine.** An entity plus a location plate reads as *this person, in this place*. That composition is the normal case, not an advanced one.
+
+**Entities are project- and account-scoped [CONSTRAINT].** An entity minted on one account will not resolve when generating on another. Moving a production between accounts means rebuilding the cast under identical names, or accepting portrait images instead — a decision to make deliberately, not to discover mid-run.
+
+**`i2v` has no identity channel at all [CONSTRAINT].** Its request rejects reference entities by design. Whoever is in the initial frame is who you get. Identity reaches an `i2v` clip only by being baked into that frame.
+
+## Character sheet
+
+### Building one
+
+```bash
+gflow character create --project <id> --name <Name> \
+  --face-prompt "<unchangeable features, plain background>" \
+  --body-prompt "<wardrobe, plain, no print>" \
+  --voice <preset>            # gflow character voices — lists presets with samples
+```
+
+The face prompt generates the first reference image. The body prompt is wrapped into a front/side/back triptych seeded by that face, so one generation yields all three angles on-model.
+
+### The rules that make it hold
+
+- **Face prompt carries unchangeable features only** — build, hair, facial structure, eye colour, defining marks — on a plain or segmented background, which is also Flow's own documented guidance for references. No hats, glasses or props unless permanent.
+- **An entity locks the face, not the clothing [CALIBRATED].** On one production 9 of 11 frames had the right person and only 4 of 11 the right garment. Wardrobe continuity comes from repeating **one wardrobe token verbatim** in every prompt — "the grey hoodie", "the navy cardigan" — never from the entity.
+- **Pin garments as plain, no print [CALIBRATED].** "A band t-shirt" rendered a misspelled logo on every clip of a six-clip scene. Whatever carries text invents text.
+- **No age words [CONSTRAINT].** One age phrasing failed eight generations running; a relational noun passed immediately, same references, same scene. Minors are refused outright — cast young roles as adults.
+- **One face-bearing reference per generation [CONSTRAINT].** Two entities, or an entity plus a portrait image, returns HTTP 400 surfaced as a wire-format error whose remediation text ("simplify the prompt") is misleading. This matches the documented single-subject reference design.
+- **Voice rides on the entity**, not on prose. Voice consistency across clips comes from the character, and presets are listed by `gflow character voices`.
+
+### Two people in one scene
+
+Give the entity to whoever carries the beat — the speaker of the long line, the face in the close-up. The other rides on the **verbatim canon plus wardrobe token**, staged in profile or turned away in that shot. Alternate across beats so each actor is entity-locked in their own close-ups, which is where an audience reads identity. Keep the non-entity description byte-identical between beats.
+
+### Without entities
+
+Where the lane or the account rules entities out, copy the **entire, unchanged character description into every prompt**, altering only action and setting. This is Google's own documented advice for character consistency, and it works — the whole cast canon plus a fixed geometry paragraph carried a three-scene piece with no entities at all **[CALIBRATED]**.
+
+## Environment sets
+
+### The failure this exists to prevent
+
+**A multi-angle set is N independent generations that merely share a paragraph [CALIBRATED].** Nothing binds angle two to angle one. "The same room from four angles" is a fiction the description implies and the engine never enforces. A real production shipped with a window that changed between beats, and a scored rollout accepted reverse-angle drift as *unavoidable* rather than fixable.
+
+It is fixable.
+
+### The anchor chain
+
+```bash
+# 1. the anchor angle — geometry only, no people, from text
+gflow image t2i "<room, furniture left to right, light source, materials>" \
+  --aspect 16:9 --project <id> -o plate_wide.png            # free
+
+# 2. every other angle, chained off the anchor — never a second t2i
+gflow image i2i "<same room, reverse angle from the door>" \
+  --ref <ANCHOR_UUID> --aspect 16:9 --project <id> -o plate_reverse.png
+gflow image i2i "<same room, close angle on the bench>" \
+  --ref <ANCHOR_UUID> --aspect 16:9 --project <id> -o plate_bench.png
+```
+
+Serial, and free — image generation draws on a daily cap, not credits. The only cost is that the set must be built in order.
+
+**Attaching by media UUID buys asset identity, never scene coherence.** Same bytes, no duplicate upload, clean provenance — and nothing whatsoever about whether two plates depict the same place. Asset management is not continuity. Believing otherwise is the design gap this section exists to close.
+
+### Plate rules
+
+- **Geometry only, no people.** Light and grade belong in the shot prose, not baked into the plate.
+- **Minimum useful set: a wide plus its reverse.** The reverse is what sits behind each actor in a two-shot, and it is the highest-drift angle.
+- **One plate per shot** — the angle whose geometry matches. Not all plates on every shot.
+- **A plate for every region that will be on screen.** Reference-to-video invents whatever the references do not cover, and re-invents it as the camera moves: a shot looking into a display case needs a case-interior plate, not just a room plate **[CALIBRATED]**.
+- **Scope filenames to the production** — `<piece>_env_window.png`, never `window.png`. The picker deduplicates by exact filename inside a project, so a generic name silently selects the wrong asset.
+- **Retire a bad plate; do not fight it in prose [CALIBRATED].** One mis-generated plate relocated every one of the four scenes it was attached to.
+- A different lighting state is a different plate, chained off the same anchor.
+
+### The text half
+
+Plates do not carry geometry reliably on their own. Pair every plate with a **fixed geometry paragraph, repeated verbatim in every prompt**: furniture, doors and windows named left to right, the light source, and who stands screen-left. Adding named camera setups plus that paragraph stopped room drift across ten consecutive shots where the first two had already diverged **[CALIBRATED]**.
+
+## Prop and object sheets
+
+- **One sheet per prop** that carries text, is counted, or is ever the focal object.
+- **The prop fills most of the frame.** Upload re-encoding destroys small detail and lettering.
+- **Every sheet needs a scale anchor** — a hand, a bench edge. Unanchored objects come back giant **[CALIBRATED]**.
+- **State-keyed sheets**: a prop that changes state is two sheets, not one.
+- **One assembly plate** with the props in place pins their relative scale and spatial relationships.
+- **Text-bearing props need a straight-on, glyph-exact master** — and prefer to avoid them. A prop that changes **kind** communicates a mechanism with no words at all; a prop that changes **wording** invites invented text.
+- **Never stage a prop touching a surface it must leave [CALIBRATED].** A card shown flat against a pane animated as attached to it, and the engine grew a duplicate in the actor's hand across three separate attempts. Restaging it an arm's length away fixed what three prompt rewrites could not.
+- **End a beat by hiding a prop, not by making it vanish.** "Into the drawer, and the drawer closes" is safe; "disappears" is an instruction satisfied by duplication.
+
+## Film grammar as data, not vibes
+
+Carry these as fields in the beat sheet, so they can be checked rather than remembered.
+
+- **Named camera setups [CONVENTION].** `A_WIDE`, `B_MED_<name>`, `C_CU_<name>`, `D_TWO` — each naming the camera position and what sits behind each actor. Every beat references one. Recurrence is what makes cuts read as edits of a single scene instead of unrelated shots.
+- **A declared 180° axis.** Who owns frame-left; the camera never crosses. One overhead blocking sketch settles axis, eyeline and reverse geography for the whole piece more cheaply than any amount of prose.
+- **A closed shot vocabulary** — wide, medium, close-up, extreme close-up, over-the-shoulder — with a deliberate arc across the piece rather than a random walk.
+- **A declared role for every reference injected**: geometry, dressing, or grade. A plate attached without a role gets treated as all three.
+
+## Three artefacts people call "storyboard"
+
+Keep them apart; they do different jobs.
+
+| Artefact | What it is | When | Status |
+|---|---|---|---|
+| **Beat sheet** | the machine-checkable table: id, setup, action, lines, duration, model, references | before any generation | required |
+| **Visual storyboard** | a single image containing a grid of panels for the whole piece, generated before final stills | between assets and production | advisory |
+| **Frame board** | the real generated frames laid out per beat, with prompts and metrics | after each batch | the review artefact |
+
+The visual storyboard earns its place as a **director's gate**: it catches shot-size monotony, axis breaks and geography errors before any per-shot budget is spent, because all panels are drawn in one generation and therefore share a look for free. It is **not** a stills replacement — panel resolution cannot hold fine detail, and it bypasses the per-shot reference machinery entirely.
+
+**[UNEXPLORED]** Feeding that sheet to a video model as a *generation* input, rather than using it for review, is a technique other people report. It has not been tested here.
+
+## Composition order
+
+When a shot carries several references, order and budget matter.
+
+1. **Characters first**, one face-bearing reference maximum.
+2. **Environment next, and environment is never trimmed.** A naive tail-trim once dropped the location plate from exactly the multi-character shots, producing set drift nobody could trace back **[CALIBRATED]**. If the budget would trim a location, fail loudly and split the shot instead.
+3. **Props last**, as budget allows; demote the rest to prose.
+4. **Preserve the order you wrote.** Do not sort the reference list.
+
+Caps are per model, and the entity counts against the same pool as the images: omni-flash 7, veo-lite / veo-fast / veo-lite-lp 3, **veo-quality 0 — it accepts no references at all [CONSTRAINT]**. On the image side nano2 and nano-pro take 10, imagen4 3.
+
+**Select the model before attaching references [CONSTRAINT].** Switching model afterwards invalidates what was attached.
+
+**Use `nano2` for bulk image work.** `nano-pro` is daily-capped and is the wrong default for building a set of plates.

--- a/skills/video-production/failure-modes.md
+++ b/skills/video-production/failure-modes.md
@@ -1,0 +1,76 @@
+# Failure modes — symptom, cause, fix
+
+Companion to [`SKILL.md`](SKILL.md). Each entry was paid for. Tags: **[CONSTRAINT]** engine refuses · **[CALIBRATED]** measured here.
+
+Find your symptom in the left column first. Several of these present as something other than their cause, which is why the table is ordered by what you actually see.
+
+## The command fails or is refused
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| Exit 2 naming the model | `--duration` passed with no `--model`. An omitted model is not "no model": it binds `veo-lite`, which renders no duration control **[CONSTRAINT]** | name the model explicitly whenever length matters; `omni-flash` for 10 s |
+| A reference is rejected or ignored | `--model veo-quality` accepts **zero** references **[CONSTRAINT]** | use omni-flash (7) or a veo-lite/fast variant (3) |
+| A reference silently stops applying | model selected *after* attaching **[CONSTRAINT]** | choose model, then attach — never the reverse |
+| HTTP 400 as `WireFormatError`, advice says "simplify the prompt" | two face-bearing references in one generation, **or** an age word in the prose **[CONSTRAINT]** | keep one face reference and carry others as role nouns; strip every age phrase |
+| The same refusal repeats no matter how the prose is rewritten | the diagnosis is wrong, not the wording **[CALIBRATED]** | after two identical failures stop rewriting and look one step upstream — the references, the casting, the beat itself |
+| `RecaptchaError` on a free image command | on gflow ≤ 0.68.0, the migrated host — the guard ran *after* the reCAPTCHA mint on the image path (#673, fixed: it is exit 36 now). On any build, right after `auth login`, the cookie harvest keyed on the old host (#644) **[CALIBRATED]** | check the final host URL before anything else; if it followed a fresh login, see #644 |
+| Exit 36 | migrated host, command not ported | that lane runs `t2v` and `i2v --initial-frame <local file>`; everything else is unported. Do not retry, it is not transient |
+| A run 400s only after a plate was attached | the plate pushed a multi-person prompt over the person policy | lean the prose to role nouns before attaching |
+| Exit 11 or a parse error on a manifest | a model and duration pair that could never render | `--dry-run` catches it before spending |
+
+## The clip generates but is wrong
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| A dark strip with sprocket holes down one edge | a **film format** named in the style block — "35mm", "IMAX", "film grain" **[CALIBRATED]** | describe the optical effect, not the stock: "full-frame 16:9 image edge to edge, shallow depth of field", with border and letterbox in the avoid list |
+| The room changes between shots | angles generated as independent `t2i` calls from one paragraph **[CALIBRATED]** | anchor plate by `t2i`, every other angle by `i2i --ref <anchor>`; add a verbatim geometry paragraph and named setups |
+| Every shot handed one plate lands in the wrong place | the plate itself contradicts the brief **[CALIBRATED]** | retire the plate and regenerate it; do not fight it in prose |
+| A defect appears in some shots and not others | a shared reference, not the prompts **[CALIBRATED]** | diff the reference lists of failing against passing shots before touching any wording |
+| The right face, the wrong clothes | an entity locks the face, never the clothing — measured 9 of 11 faces right, 4 of 11 garments **[CALIBRATED]** | repeat one wardrobe token verbatim in every prompt |
+| Invented lettering on a sign, poster or garment | anything carrying text invents text **[CALIBRATED]** | pin props as blank; prefer a prop that changes *kind* over one that changes *wording* |
+| A region of the frame keeps re-inventing itself as the camera moves | reference-to-video authors whatever the references do not cover **[CALIBRATED]** | supply a plate for every region that will be on screen, not just the room |
+| The staged hero object is missing from the clip | `r2v` composes its own frame and cannot guarantee a staged element **[CALIBRATED]** | use `i2v --initial-frame` when the staged object is the mechanism |
+| A prop stays stuck to a surface, or duplicates | it was touching that surface in the initial frame **[CALIBRATED]** | never stage a prop against a surface it must leave; three prompt rewrites failed where restaging an arm's length away worked immediately |
+| A prop vanishes instead of being put away | "disappears" is an instruction satisfied by duplication | end the beat by hiding it — into a drawer, and the drawer closes |
+| An object comes back the wrong size | the prop sheet had no scale anchor **[CALIBRATED]** | put a hand or a bench edge in every sheet |
+| The clip invents action in the back half | roughly a second of written action stretched across eight **[CALIBRATED]** | give the beat enough real motion, shorten the duration, or delete the beat |
+| A negation is ignored, or the named thing happens | negations name the unwanted action and do not suppress it **[CALIBRATED]** | restate positively: describe what *does* happen |
+| The wrong asset is attached from the picker | the picker deduplicates by exact filename **[CALIBRATED]** | scope every filename to the production |
+
+## The audio is wrong
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| Delivery rushed, last sentence cut | more than about 2.5 spoken words per second **[CALIBRATED, 25 clips]** | split across beats; never shorten the script to fit |
+| Room tone under a montage that should be silent | Veo always generates audio; there is no silent mode **[CONSTRAINT]** | strip it at assembly with `-an` |
+| Lips ahead of the voice across a whole cut | segments joined at mixed frame rates through the concat demuxer — 164 s of video under 171 s of audio **[CALIBRATED]** | join with the concat filter at one frame rate; gate on the stream lengths agreeing within 0.1 s |
+| One clip audibly out of sync while others are fine | genuine per-clip lag; two clips in an 18-clip set measured 0.167 s and 0.333 s after passing every other check **[CALIBRATED]** | measure it, do not listen for it — cross-correlate face motion against the audio envelope |
+| Speech starts late after the cut | the beat opens on a held face | open on an action, not a still pose |
+
+## The measurement is wrong
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| A locked-off dialogue clip scores "frozen" | the whole-frame motion median is calibrated on moving scenes; a talking head sits at 0.3–0.9 while performing **[CALIBRATED]** | gate on speech onset and face-region motion instead |
+| The best-scoring take is the broken one | a hallucinated object is motion, so it **raises** every score — the highest of five takes had invented an object that then vanished **[CALIBRATED]** | no metric can tell good motion from bad; the eye stays in the loop |
+| A confident sync lag that is not real | a flat correlation surface still has a maximum | require the peak to exceed zero lag by a margin, reject peaks pinned to the search boundary, and treat correlation below 0.3 as *unmeasurable*, never as *in sync* |
+| Every clip reports perfect sync | the detector is broken and silently returning nothing | prove it first: re-encode a known clip with a 200 ms audio delay and confirm it reports 200 ms |
+| A clip's numbers look like the previous clip's | a tool read a stale metadata file after a failed subprocess | check exit codes and delete the file before each write |
+
+## The run wastes money
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| One template bug billed once per clip | the batch was launched before a trial clip was gated **[CALIBRATED]** | trial one, gate it, fix the template, then two beats per foreground call |
+| A clip billed but never downloaded | a detached background run died mid-poll **[CALIBRATED]** | run paid calls in the foreground |
+| A whole manifest regenerated after a one-word change | editing the shared style block re-hashes every scene **[CONSTRAINT]** | keep style edits off script-only runs |
+| Everything after an inserted row re-billed | scene ids shifted, so the content hashes moved | keep scene ids stable and slot-shaped |
+| Two runs collided | concurrent generations on one profile take a lease | one profile, one run |
+| A placeholder generation burned to obtain a project id | `gflow project create --name <x> --json` exists **[CONSTRAINT]** | redirect its output to a file; piping through `head` truncates the process before the JSON prints |
+| An image daily cap hit early | `nano-pro` used for bulk plate work | `nano2` for volume |
+
+## Two habits that prevent most of the above
+
+**Diff before you rewrite.** When a defect clusters, compare what the failing shots were *given* against the passing ones. Most repeat failures are one bad shared asset, not a prompt problem, and rewriting prose cannot fix an input.
+
+**Change one thing per re-roll, and cap it at two.** A re-roll that fixes one axis frequently breaks another; re-gate against the originals rather than assuming forward progress. If a beat fails twice for the same reason, the beat is the problem — restage it or cut it.

--- a/skills/video-production/tasks.json
+++ b/skills/video-production/tasks.json
@@ -1,0 +1,498 @@
+[
+  {
+    "id": "host-001",
+    "question": "A free `gflow image t2i` fails after about five seconds with RecaptchaError, exit 1, retryable false. The session was verified minutes ago. What is the cause and what do you check?",
+    "context": "gflow-cli 0.68.0 or earlier — on later builds the same cause surfaces as exit 36 FlowHostMigratedError (#673). Video generation on the same profile has been working.",
+    "expected": {
+      "must_include": [
+        "flow.google.com",
+        "host"
+      ],
+      "must_not_include": [
+        "re-authenticate",
+        "auth login",
+        "headless",
+        "retry the command"
+      ],
+      "partial_credit": [
+        "labs.google",
+        "final URL",
+        "639",
+        "exit 36",
+        "not ported"
+      ]
+    },
+    "tags": [
+      "host",
+      "error-recovery"
+    ],
+    "notes": "Through v0.68.0 the migrated-host guard ran after the reCAPTCHA mint on the image path, so the error named the wrong thing; #673 moved the guard to the mint and it is exit 36 now. The task is kept because the reasoning it scores is unchanged: the cause is the host, and agents reach for re-auth, which is the documented fix for a different symptom (#644)."
+  },
+  {
+    "id": "host-002",
+    "question": "You need a fresh Flow project id to hold every asset for a new production. How do you obtain it?",
+    "context": "Nothing exists yet. The id must be captured for use in later scripted commands.",
+    "expected": {
+      "must_include": [
+        "gflow project create"
+      ],
+      "must_not_include": [
+        "placeholder",
+        "copy the id from the URL",
+        "scrape"
+      ],
+      "partial_credit": [
+        "--json",
+        "redirect",
+        "> ",
+        "never pipe"
+      ]
+    },
+    "tags": [
+      "host",
+      "setup"
+    ],
+    "notes": "A rollout asserted no such command exists and burned an image generation on a placeholder to mint a project. Piping the JSON through head truncates the process before it prints."
+  },
+  {
+    "id": "model-001",
+    "question": "Write the command for an 8-second image-to-video clip from an approved still, portrait, one output.",
+    "context": "The exact length matters because the clip has to match a narration beat.",
+    "expected": {
+      "must_include": [
+        "--model",
+        "--duration"
+      ],
+      "must_not_include": [
+        "--duration 8 --aspect 9:16 --count 1 --project"
+      ],
+      "partial_credit": [
+        "omni-flash",
+        "veo-lite",
+        "exit 2",
+        "no duration control"
+      ]
+    },
+    "tags": [
+      "video",
+      "model"
+    ],
+    "notes": "Omitting --model binds veo-lite, which renders no duration control, and the run exits 2. A rollout wrote five i2v calls with --duration and no --model."
+  },
+  {
+    "id": "model-002",
+    "question": "A close-up needs two reference images attached and the highest available quality. Which model do you pick and why?",
+    "context": "The references are a prop sheet and a location plate.",
+    "expected": {
+      "must_include": [
+        "omni-flash"
+      ],
+      "must_not_include": [
+        "veo-quality"
+      ],
+      "partial_credit": [
+        "accepts no references",
+        "cap",
+        "zero"
+      ]
+    },
+    "tags": [
+      "video",
+      "references"
+    ],
+    "notes": "veo-quality's reference cap is 0, not 3. A rollout chose it for a two-reference shot and annotated it as being under the cap."
+  },
+  {
+    "id": "model-003",
+    "question": "You need to generate twelve location plates as reference images. Which image model, and why?",
+    "context": "Volume work; the plates feed later video generations.",
+    "expected": {
+      "must_include": [
+        "nano2"
+      ],
+      "must_not_include": [
+        "nano-pro for all",
+        "imagen4"
+      ],
+      "partial_credit": [
+        "daily cap",
+        "free",
+        "rate limit"
+      ]
+    },
+    "tags": [
+      "image",
+      "quota"
+    ],
+    "notes": "nano-pro is daily-capped and is the wrong default for bulk plate work."
+  },
+  {
+    "id": "refs-001",
+    "question": "Two recurring actors appear in the same shot and both faces must stay consistent. How do you attach them?",
+    "context": "Both already exist as Flow CHARACTER entities in the project.",
+    "expected": {
+      "must_include": [
+        "one"
+      ],
+      "must_not_include": [
+        "both entities",
+        "two --reference-entity",
+        "--reference-entity A --reference-entity B"
+      ],
+      "partial_credit": [
+        "400",
+        "role noun",
+        "profile",
+        "turned away",
+        "person policy"
+      ]
+    },
+    "tags": [
+      "references",
+      "consistency"
+    ],
+    "notes": "Two face-bearing references in one generation returns HTTP 400 surfaced as a wire-format error. Both baseline rounds proposed stacking two entities."
+  },
+  {
+    "id": "refs-002",
+    "question": "One room, four camera angles across six shots, and it must read as the same room from every angle including the reverse. How do you build the location references?",
+    "context": "No assets exist yet. Image generation is free.",
+    "expected": {
+      "must_include": [
+        "i2i",
+        "anchor"
+      ],
+      "must_not_include": [
+        "unavoidable",
+        "cannot be guaranteed",
+        "manual QC is the only"
+      ],
+      "partial_credit": [
+        "t2i",
+        "--ref",
+        "chain",
+        "geometry",
+        "verbatim"
+      ]
+    },
+    "tags": [
+      "consistency",
+      "environment"
+    ],
+    "notes": "The highest-value gap. A rollout generated angles as independent t2i calls and concluded reverse-angle drift was unavoidable. Chaining every angle off one anchor plate with i2i fixes it, for free."
+  },
+  {
+    "id": "refs-003",
+    "question": "A specific hand tool must look like the same object in three separate shots. How do you guarantee it, and what does the reference sheet need?",
+    "context": "The tool is described as having distinctive wear.",
+    "expected": {
+      "must_include": [
+        "same",
+        "scale"
+      ],
+      "must_not_include": [
+        "regenerate the prop for each shot",
+        "entity for the prop"
+      ],
+      "partial_credit": [
+        "--ref",
+        "anchor",
+        "fills the frame",
+        "no object entity"
+      ]
+    },
+    "tags": [
+      "consistency",
+      "props"
+    ],
+    "notes": "Flow has no object entity. A prop sheet without a scale anchor comes back the wrong size."
+  },
+  {
+    "id": "prompt-001",
+    "question": "Clips are coming back with a dark strip of sprocket holes down one edge. The style block reads 'cinematic, 35mm lens look, shallow depth of field'. What is wrong?",
+    "context": "Every clip in the batch shows it.",
+    "expected": {
+      "must_include": [
+        "35mm"
+      ],
+      "must_not_include": [
+        "crop",
+        "aspect ratio",
+        "resolution"
+      ],
+      "partial_credit": [
+        "full-frame",
+        "edge to edge",
+        "film strip",
+        "avoid",
+        "format"
+      ]
+    },
+    "tags": [
+      "prompt",
+      "artefact"
+    ],
+    "notes": "Naming a film format renders the stock. Cropping the border away leaves the cause in place for every future clip."
+  },
+  {
+    "id": "prompt-002",
+    "question": "A generation is refused with HTTP 400 every time. The prompt describes 'a young woman in her early 20s' waiting in a school corridor, with one character entity attached. What do you change?",
+    "context": "The same scene with the same references succeeded before the description was expanded.",
+    "expected": {
+      "must_include": [
+        "age"
+      ],
+      "must_not_include": [
+        "simplify the prompt and retry",
+        "shorten the prompt"
+      ],
+      "partial_credit": [
+        "role noun",
+        "person policy",
+        "relational",
+        "adult"
+      ]
+    },
+    "tags": [
+      "prompt",
+      "policy"
+    ],
+    "notes": "Age-explicit descriptors trip the person policy on their own. The CLI's own remediation text sends agents to shorten the prompt, which does not help."
+  },
+  {
+    "id": "dialogue-001",
+    "question": "A beat carries 34 words of dialogue and is set to 8 seconds. The actor rushes and the last sentence is cut. Fix it.",
+    "context": "The script is a client deliverable and the lines are fixed.",
+    "expected": {
+      "must_include": [
+        "split"
+      ],
+      "must_not_include": [
+        "shorten the line",
+        "trim the dialogue",
+        "cut the last sentence",
+        "paraphrase"
+      ],
+      "partial_credit": [
+        "2.5",
+        "words per second",
+        "18 words",
+        "two beats"
+      ]
+    },
+    "tags": [
+      "dialogue",
+      "timing"
+    ],
+    "notes": "The words are the deliverable. Roughly 2.5 spoken words per second is the measured ceiling."
+  },
+  {
+    "id": "audio-001",
+    "question": "A 40-second product montage with nobody speaking. A voiceover will be added later in an editor. What do you have to handle about the audio?",
+    "context": "The client wants the montage delivered ready for the voiceover.",
+    "expected": {
+      "must_include": [
+        "audio"
+      ],
+      "must_not_include": [
+        "the clips will be silent",
+        "no audio is generated",
+        "omit sound from the prompt"
+      ],
+      "partial_credit": [
+        "-an",
+        "strip",
+        "always generates",
+        "room tone"
+      ]
+    },
+    "tags": [
+      "audio",
+      "assembly"
+    ],
+    "notes": "Veo always generates audio and there is no silent mode. A rollout planned a silent montage and never accounted for invented room tone under the voiceover."
+  },
+  {
+    "id": "assembly-001",
+    "question": "You are joining three-second title cards and a set of 24 fps clips into one file with ffmpeg. What must you be careful about, and how do you verify the result?",
+    "context": "The cards are generated separately from the clips.",
+    "expected": {
+      "must_include": [
+        "frame rate"
+      ],
+      "must_not_include": [
+        "concat demuxer is fine",
+        "-f concat is the simplest"
+      ],
+      "partial_credit": [
+        "filter",
+        "concat=n=",
+        "ffprobe",
+        "duration",
+        "stream"
+      ]
+    },
+    "tags": [
+      "assembly",
+      "sync"
+    ],
+    "notes": "A 25 fps card among 24 fps clips through the concat demuxer produced 164 s of video under 171 s of audio. The stream lengths must agree within 0.1 s."
+  },
+  {
+    "id": "qa-001",
+    "question": "A clip has come back and looks right in its first frame. What do you check before accepting it?",
+    "context": "It is one of eighteen in a dialogue piece.",
+    "expected": {
+      "must_include": [
+        "transcript"
+      ],
+      "must_not_include": [
+        "it looks correct, accept it",
+        "frame 0 matches, accept"
+      ],
+      "partial_credit": [
+        "ffprobe",
+        "frames",
+        "volume",
+        "sync",
+        "clip_qa",
+        "gate"
+      ]
+    },
+    "tags": [
+      "qa",
+      "gates"
+    ],
+    "notes": "All three baseline rollouts accepted clips on visual impression alone. Two clips in one production carried audible audio lag while passing every other check."
+  },
+  {
+    "id": "qa-002",
+    "question": "You built a tool that reports lip-sync lag by correlating mouth motion against the audio. It says every clip is perfectly in sync. What do you do before trusting it?",
+    "context": "The numbers look plausible and no clip is flagged.",
+    "expected": {
+      "must_include": [
+        "delay"
+      ],
+      "must_not_include": [
+        "the clips are in sync",
+        "trust the numbers"
+      ],
+      "partial_credit": [
+        "adelay",
+        "known",
+        "self-test",
+        "inject",
+        "200"
+      ]
+    },
+    "tags": [
+      "qa",
+      "tooling"
+    ],
+    "notes": "A silently broken correlation reports every clip as perfect. The first implementation returned near-zero correlation at every lag and looked fine."
+  },
+  {
+    "id": "batch-001",
+    "question": "Three clips of fifteen are done and look acceptable. To save time you want to launch the remaining twelve in one detached background job. Is that a good idea?",
+    "context": "Each clip costs credits. The prompt template is shared across all fifteen.",
+    "expected": {
+      "must_include": [
+        "foreground"
+      ],
+      "must_not_include": [
+        "yes, launch them",
+        "that saves time",
+        "run them all in parallel"
+      ],
+      "partial_credit": [
+        "trial",
+        "gate",
+        "one profile",
+        "lost",
+        "template"
+      ]
+    },
+    "tags": [
+      "batch",
+      "cost"
+    ],
+    "notes": "A template bug bills once per clip. A detached run also lost a clip mid-poll after the credit was spent."
+  },
+  {
+    "id": "manifest-001",
+    "question": "A 24-scene manifest is re-run nightly as the script is edited. Tonight three lines changed and you also tweaked one word in the shared style block. What will it cost?",
+    "context": "Resume is by content hash on a sibling state file.",
+    "expected": {
+      "must_include": [
+        "all"
+      ],
+      "must_not_include": [
+        "only the three",
+        "just the changed lines",
+        "three scenes regenerate"
+      ],
+      "partial_credit": [
+        "style",
+        "hash",
+        "every scene",
+        "24"
+      ]
+    },
+    "tags": [
+      "manifest",
+      "cost"
+    ],
+    "notes": "The composed prompt includes the style block, so a style edit re-hashes every scene and silently regenerates the whole manifest."
+  },
+  {
+    "id": "shot-001",
+    "question": "A beat is built around a specific object staged deliberately in frame, and the shot also needs a recurring character. Which video command, and what is the trade?",
+    "context": "The object is the point of the shot.",
+    "expected": {
+      "must_include": [
+        "i2v"
+      ],
+      "must_not_include": [
+        "r2v guarantees the frame",
+        "r2v is always better"
+      ],
+      "partial_credit": [
+        "initial-frame",
+        "composes its own",
+        "no identity",
+        "omitted"
+      ]
+    },
+    "tags": [
+      "video",
+      "shot-choice"
+    ],
+    "notes": "Reference-to-video composes its own frame and has omitted a staged focal object entirely. Image-to-video guarantees the approved frame but carries no identity, so identity must be baked into the still."
+  },
+  {
+    "id": "shot-002",
+    "question": "One continuous camera move needs to run for about 20 seconds with unbroken sound. How do you produce it and what do you watch for when joining?",
+    "context": "A cut would break the effect.",
+    "expected": {
+      "must_include": [
+        "extend"
+      ],
+      "must_not_include": [
+        "chain",
+        "video chain"
+      ],
+      "partial_credit": [
+        "7",
+        "trim",
+        "0-7",
+        "scene create",
+        "audio carries"
+      ]
+    },
+    "tags": [
+      "video",
+      "shot-choice"
+    ],
+    "notes": "extend continues a shot with motion and audio carried across; chain restarts from a still and drops audio continuity. An extend segment holds about 7 s of real content in an 8 s slot."
+  }
+]


### PR DESCRIPTION
Adds a `video-production` skill: how to turn a script into a finished multi-shot or dialogue video with gflow, as opposed to how to call one command (that stays the `gflow-cli` skill, which this one routes to rather than restating).

## What is in it

- **`SKILL.md`** routes: production shape, host lane check, the beat/cast/location locks, and the acceptance gate. Every non-obvious claim is tagged **CONSTRAINT** (the engine refuses) / **CALIBRATED** (measured, conditions stated) / **CONVENTION** (one shape that works) / **UNEXPLORED** (exists, untested here), so a reader knows what may be deviated from. Absence from the doc means untested, never forbidden.
- **`consistency.md`** character sheets, environment sets, prop sheets, film grammar. **`composition.md`** reference budget and ordering, command chains per production shape. **`failure-modes.md`** symptom to cause to fix.
- **`clip_qa.py`** the gates — fluidity, lip sync, A/V drift — on ffmpeg, ffprobe and the standard library only, so they run where the transcript gate cannot. `--selftest` proves the detector before you believe it.
- **`tasks.json`** 19 scored scenarios for the SkillOpt harness (`scripts/dev/skillopt/harness.py --skill … --tasks …`). Every entry exists because an agent got it wrong in a rollout; the frontmatter's `optimization_notes` lists those weak spots.

## Corrected against develop before landing

The skill was drafted against v0.67.0 and two merges today falsified part of it. Fixed here rather than shipped stale:

- Lane B is no longer "text-only": it runs `video t2v --project` **and** `video i2v --initial-frame <local file>` since #679. A frame by media UUID / `@Name`, `--end-frame` and r2v are still unported.
- `image t2i` on the migrated host was documented as dying with `RecaptchaError` and tagged **[CONSTRAINT]**. Since #673 it is exit 36. The remaining `RecaptchaError` shape — right after `auth login` — is #644, and the doc now separates the two.
- The lane table pinned a release number. It now points at CONFIGURATION § `GFLOW_CLI_FLOW_HOST` and KNOWN_ISSUES as the maintained list, and says exit 36 on a ported form is a regression to file rather than the environment.
- `failure-modes.md` and the `host-001` benchmark task carry the same correction. The task is kept, with its context pinned to the versions it describes, because the reasoning it scores is unchanged: the cause is the host, and agents reach for re-auth instead.

## Test plan

- [x] `check_repo_hygiene`, `check_doc_links` (all relative links resolve, including the new `../../docs/CONFIGURATION.md` and `../../KNOWN_ISSUES.md`), `check_website_docs_pii`, `check_council_memory`, website mirror — all green
- [x] `tasks.json` parses, 19 tasks; `clip_qa.py` compiles
- [x] Routing rows present in `AGENTS.md` and `skills/README.md`
- [ ] **SkillOpt benchmark not yet run** — the harness needs an API key and this is the first task set for this skill. Landing on develop is not releasing it; the baseline run is the next step and belongs before the skill is advertised
- [ ] No code paths touched, so no e2e evidence applies (docs-only change per the #675 rule)