### PR TITLE
feat(644): spike + observability for the labs.google auth-BFF coupling

### DIFF
--- a/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
+++ b/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
@@ -1,0 +1,145 @@
+# Spike — is the `labs.google` Flow session token a credential for `flow.google.com`?
+
+**Date:** 2026-09-06 · **Issue:** #644 (Refs #639, #642) · **Cost:** $0, read-only, no credits
+**Profile:** `denon82` (migrated account) · **Verdict:** NO — and #644 stays LATENT
+
+This spike answers the question a future #644 fix must not re-derive, and records the
+one arm of the experiment the 2026-09-03 measurement could not reach.
+
+---
+
+## Q1. Is `__Secure-next-auth.session-token` usable on `flow.google.com`?
+
+**No, for two independent reasons.**
+
+### 1a. It is never transmitted (measured)
+
+Cookie jar of `profile_denon82` replayed through `http.cookiejar`'s RFC 6265
+`DefaultCookiePolicy` against each host:
+
+| Request host | Cookies sent | `__Secure-next-auth.session-token` | `SAPISID` / `__Secure-1PSID` |
+|---|---|---|---|
+| `labs.google/fx/tools/flow` | 3 | no (already expired, see Q2) | no |
+| `flow.google.com/` | 14 | **no** | **yes** |
+| `flow.google.com/project/x` | 14 | **no** | **yes** |
+
+The token is scoped to domain `labs.google`; `flow.google.com` is under `google.com`,
+a different registrable domain. Domain-matching never attaches it. **The two hosts
+receive disjoint credential sets** — this is the correct half of #644's premise.
+
+### 1b. It would not be honoured if forced (mechanism, NOT measured)
+
+It is an Auth.js/NextAuth session handle minted by and validated against the
+`labs.google` BFF's own signing secret. `flow.google.com` is a Google-internal
+Angular frontend authenticating on the standard Google SSO cookie set — different
+issuer, different validator.
+
+> **Unverified.** Testing acceptance requires forcing the token onto a
+> `flow.google.com` request *while a live session exists*. This profile's session is
+> dead (Q2), so the test would be vacuous — both arms return signed-out regardless.
+> Re-run 1b after a fresh `gflow auth login`.
+
+---
+
+## Q2. Did the divergence #644 predicts appear?
+
+**No.** The discriminating experiment requires **Google SSO alive + labs Flow session
+dead**. What was measured is **everything dead** — a plain expiry, not a divergence.
+
+```
+labs.google/fx/api/auth/session   -> 200, 2 bytes ({}), has_user=False
+flow.google.com/                  -> redirects to /about (marketing), avatar=0, signin_cta=1
+labs.google/fx/tools/flow         -> rendered, avatar=0, no editor
+myaccount.google.com/             -> redirects to www.google.com/account/about (signed out)
+```
+
+Remaining `labs.google` cookies: `__Host-next-auth.csrf-token`,
+`__Secure-next-auth.callback-url`, `email`. The session token itself is **gone** —
+Chrome dropped it on expiry.
+
+**New information vs 2026-09-03.** That measurement could only observe the
+`has_user=true` arm. This one reaches the `has_user=false` arm and finds the two hosts
+**agree**: when the Google SSO session dies, the migrated host reports signed-out too.
+That is evidence *against* the two hosts having independent session lifetimes — the
+mechanism #644's false-negative scenario depends on.
+
+**Still unobserved, still the only thing that makes #644 actionable:** an account where
+`labs.google/fx/api/auth/session` returns `{}`/no-user **while** `flow.google.com`
+renders authenticated (avatar present, editor rendered).
+
+---
+
+## Q3. Does gflow report anything wrong today?
+
+**No.** `gflow auth status` on this profile yields `GOOGLE_SESSION_ONLY`
+(stale `SAPISID` present, BFF says no-user) → *"Signed in to Google, but not to the
+Flow app"* → re-login. On the measured state that guidance is **correct**.
+
+#644's claimed defect sites are also mis-localized, and a future fix should not start
+there:
+
+- `api/client.py:209` `_FLOW_SESSION_COOKIE` is a **log field** (`preread_session=`,
+  `client.py:624`) and the #222 macOS seed — not the auth check.
+- The auth check is a **live probe** of a live BFF
+  (`auth/verification.py::verify_flow_profile` → `fetch_flow_session_httpx`), not a
+  cookie-name test. It cannot "inspect the wrong credential"; it asks the server.
+- `auth/cookies.py`'s `flow_only=True` filter is a deliberate origin boundary, correct
+  for its only consumer (an httpx client that talks solely to `labs.google`). Widening
+  it would send `.google.com` SSO cookies to `labs.google` — a regression, not a fix.
+
+**No code change is warranted.** The harvest becomes wrong only when a browserless path
+to the migrated host exists; that is #642's scope, and the fix belongs there.
+
+---
+
+## Re-running this probe
+
+Needs a profile under `GFLOW_CLI_HOME` and nothing else. Adjust `PROFILE`.
+
+```python
+import asyncio, json
+from pathlib import Path
+import browser_cookie3, httpx
+from gflow_cli.auth.cookies import get_chrome_cookie_snapshot
+from gflow_cli.paths import get_cookies_path
+
+PROFILE = Path.home() / "AppData/Local/gflow-cli/profile_<name>"
+
+async def main():
+    snap = await get_chrome_cookie_snapshot(PROFILE)
+    print("labs cookies:", len(snap.httpx_cookies),
+          "next-auth:", "__Secure-next-auth.session-token" in snap.httpx_cookies,
+          "SAPISID:", snap.google_session)
+
+    # A) what verify_flow_profile actually asks
+    async with httpx.AsyncClient(cookies=snap.httpx_cookies, timeout=20.0,
+                                 headers={"referer": "https://labs.google/fx/tools/flow"}) as c:
+        r = await c.get("https://labs.google/fx/api/auth/session")
+    has_user = bool(json.loads(r.text).get("user")) if r.text.strip().startswith("{") else None
+    print(f"A) labs session -> {r.status_code} {len(r.text)}B has_user={has_user}")
+
+    # B) DOM truth on the migrated host — httpx sees only the SPA shell, so use a browser
+    from playwright.async_api import async_playwright
+    async with async_playwright() as pw:
+        ctx = await pw.chromium.launch_persistent_context(
+            user_data_dir=str(PROFILE), channel="chrome", headless=False,
+            args=["--password-store=basic"])
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        await page.goto("https://flow.google.com/", wait_until="domcontentloaded")
+        await page.wait_for_timeout(9000)
+        print("B) flow.google.com ->", await page.evaluate("""() => ({
+            url: location.href,
+            avatar: document.querySelectorAll("img[src*='googleusercontent']").length,
+            signin_cta: document.querySelectorAll("a[href*='ServiceLogin']").length,
+        })"""))
+        await ctx.close()
+
+asyncio.run(main())
+```
+
+**DIVERGENCE CONFIRMED** iff `A) has_user=False` **and** `B) avatar > 0`.
+Anything else is a normal session state.
+
+> Instrument note: `httpx.get("https://flow.google.com/")` returns ~146 KB of Angular
+> SPA shell with `WIZ_global_data` for signed-in and signed-out alike. It is **not** an
+> auth signal — the 2026-09-03 measurement flagged the same trap. Use the rendered DOM.

--- a/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
+++ b/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
@@ -158,6 +158,13 @@ Failure sequence once labs stops minting Flow sessions:
    speculative write, when the marker did not pre-exist).
 4. The user is told to re-run `gflow auth login`. → goto 1, forever.
 
+**Precision, because this is easy to misread** (I did, first time): step 3 fires only
+when the marker did **not** pre-exist — i.e. a *first* login on a fresh profile. A
+returning profile that was verified once keeps its marker through any probe failure, so
+it is not degraded. And the first-login deletion is correct, not a gap: gflow genuinely
+could not confirm a session, so it declines to certify the profile. The loop is real,
+but its fix is a working oracle (#642), **not** a retained marker.
+
 Step 3 is the load-bearing damage: without that marker `channel_for_profile` stops
 returning `"chrome"`, so `FlowApiClient` downgrades to bundled Chromium — which the
 code's own comment identifies as the `[[real-browser-auth-mandatory]]` failure. A labs
@@ -194,13 +201,53 @@ signal is already in hand), the failure is unrecoverable by the user, and it **c
 shipped after the deprecation** — by then every affected user is already stuck on a
 version that loops.
 
-**Recommended next step:** `/gflow:predict` on *"decouple profile validity from the
-labs.google BFF"* before any implementation. Two candidate slices, smallest first:
+### Predict verdict (2026-09-06): STOP on both slices
 
-1. **Never let a probe failure delete a marker that a successful browser login just
-   earned** — narrow, defensible today, and removes the degradation in step 3.
-2. **Give `GOOGLE_SESSION_ONLY` / `VERIFICATION_ERROR` an escape hatch** so a user with
-   a live SSO session is not told to repeat an action that cannot help.
+`/gflow:predict` ran a five-persona council on *"decouple profile validity from the
+labs.google BFF"*. Mean confidence 8.2, **−2** because the Devil's Advocate found a
+simpler path the other four missed, and one hard STOP. **Verdict: STOP.**
+
+Both originally-proposed slices were withdrawn:
+
+1. ~~*Never let a probe failure delete a marker a successful browser login just
+   earned.*~~ **Already shipped, and the rest would be a bug.** The `marker_preexisted`
+   guard has protected returning profiles since `a86a335` (2026-07-06, v0.25.0) and is
+   pinned by name in
+   `tests/auth/strategies/test_strategies.py::test_real_chrome_preserves_preexisting_marker_on_transient_failure`.
+   The first-login deletion is *deliberate* — the marker is written speculatively, the
+   probe never confirmed a session, and `AuthMissingError` says so. Keeping it would
+   leave `.gflow_browser_strategy=chrome` on a profile with no `.gflow_account`, a state
+   nothing downstream expects, and would break a passing test. The assertion directly
+   above that test pins the deletion.
+2. ~~*Give `GOOGLE_SESSION_ONLY` / `VERIFICATION_ERROR` an escape hatch.*~~ **Deferred.**
+   It would add control flow to a fail-closed auth path for a state that has never been
+   observed, and there is no account in which to write its e2e test — the Iron Law
+   cannot be satisfied. If it is ever built, the MCP twin (`gflow_auth_status`, which
+   maps `GOOGLE_SESSION_ONLY` → `AuthExpiredError`/401 → "re-run login") must change in
+   lockstep, or the loop closes for humans and stays open for agents.
+
+**What shipped instead — the one thing all of this actually justified.** The rollback at
+`real_chrome.py` emitted *nothing*. A load-bearing state change that silently downgrades
+generation to bundled Chromium, with zero telemetry. It now logs
+`auth_chrome_marker_rolled_back` with the `FlowSessionOutcome` value, which separates
+"the probe endpoint was unreachable" from "genuinely signed out". Zero behaviour change,
+and it is the instrument that would turn #644 from *unobserved* into *observed* on the
+day it first happens.
+
+Explicitly **out of scope**, flagged HIGH by the security persona: widening
+`cookies.py`'s `flow_only=True` harvest. `SAPISID` is account-wide SAPISIDHASH material,
+and Q1b already measured that the target origin ignores a wrong-origin cookie anyway —
+all blast radius, no benefit.
+
+### Open follow-up: the probe's retry budget is sized for the wrong failure
+
+`verification.py` retries `_MAX_ATTEMPTS = 3` with a 15 s timeout and 1 s/2 s backoff, and
+its `except Exception` retries *any* error rather than only `_RETRYABLE_STATUSES`. So a
+hung endpoint costs **~48 s** and an instantly-refused one still burns ~3 s of pure
+sleep — on all three call sites (`auth status`, the MCP twin, and the tail of every
+login). That budget suits a transient 503, not a deprecated host, and a deprecated host
+is more likely to hang at the edge than to 404 cleanly. Not fixed here; worth its own
+change if the BFF starts degrading.
 
 ---
 

--- a/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
+++ b/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
@@ -3,8 +3,31 @@
 **Date:** 2026-09-06 · **Issue:** #644 (Refs #639, #642) · **Cost:** $0, read-only, no credits
 **Profile:** `denon82` (migrated account) · **Verdict:** NO — and #644 stays LATENT
 
-This spike answers the question a future #644 fix must not re-derive, and records the
-one arm of the experiment the 2026-09-03 measurement could not reach.
+This spike answers the question a future #644 fix must not re-derive.
+
+> ### ⚠️ Read this first — a retraction, and the trap that caused it
+>
+> The **first pass of this spike measured the wrong directory.** It read
+> `%LOCALAPPDATA%\gflow-cli\profile_denon82`. The real home is
+> `%LOCALAPPDATA%\`**`ffroliva`**`\gflow-cli\` — `paths.default_home()` is
+> `user_data_dir(APP_NAME, APP_AUTHOR)` with `APP_AUTHOR = "ffroliva"`, and on
+> Windows that author segment is part of the path.
+>
+> The author-less path also exists, holds a single stale `profile_denon82`, and has
+> none of the real home's scaffolding (`auth/`, `locks/`, `incidents/`, nine other
+> profiles). Reading it returned a plausible, entirely misleading "expired session".
+>
+> **What was retracted:** the original Q2 finding — *"both hosts agree on signed-out,
+> therefore evidence against independent session lifetimes"* — was measured on an
+> abandoned profile and proves nothing. It is struck below.
+>
+> **Rule for the next run:** never hardcode a profile path. Resolve it:
+> ```python
+> from gflow_cli.paths import default_home, profile_subdir
+> PROFILE = profile_subdir(default_home(), "denon82")
+> ```
+> A stale profile fails *quietly* — it decrypts, yields cookies, and answers every
+> probe. Nothing in the output says "wrong account".
 
 ---
 
@@ -27,45 +50,66 @@ The token is scoped to domain `labs.google`; `flow.google.com` is under `google.
 a different registrable domain. Domain-matching never attaches it. **The two hosts
 receive disjoint credential sets** — this is the correct half of #644's premise.
 
-### 1b. It would not be honoured if forced (mechanism, NOT measured)
+### 1b. It is not honoured when forced — **MEASURED**
 
-It is an Auth.js/NextAuth session handle minted by and validated against the
-`labs.google` BFF's own signing secret. `flow.google.com` is a Google-internal
-Angular frontend authenticating on the standard Google SSO cookie set — different
-issuer, different validator.
+Re-run against the correct profile with a **live, verified session**
+(`denon82@gmail.com`, verified 11:09). Each request sends exactly one credential set
+to `https://flow.google.com/`:
 
-> **Unverified.** Testing acceptance requires forcing the token onto a
-> `flow.google.com` request *while a live session exists*. This profile's session is
-> dead (Q2), so the test would be vacuous — both arms return signed-out regardless.
-> Re-run 1b after a fresh `gflow auth login`.
+| credential sent | bytes | account email in body | GAIA id in body |
+|---|---|---|---|
+| labs `__Secure-next-auth.session-token` only | 146,488 | ❌ | ❌ |
+| Google SSO cookies only | 150,744 | ✅ | ✅ |
+| **no cookies at all (control)** | 146,497 | ❌ | ❌ |
+
+**The labs token is indistinguishable from sending nothing** — 9 bytes off the
+anonymous control, nonce-level noise, and carrying no identity. The SSO set embeds
+the account email and GAIA id directly in the shell.
+
+This upgrades 1b from reasoned to measured: the token confers **zero** authentication
+on `flow.google.com`. Consistent with the mechanism — it is an Auth.js/NextAuth handle
+minted by and validated against the `labs.google` BFF's own signing secret, while
+`flow.google.com` authenticates on Google's standard SSO cookie set.
 
 ---
 
 ## Q2. Did the divergence #644 predicts appear?
 
-**No.** The discriminating experiment requires **Google SSO alive + labs Flow session
-dead**. What was measured is **everything dead** — a plain expiry, not a divergence.
+**No — and no evidence either way.** ~~Both hosts agree on signed-out, which is evidence
+against independent session lifetimes.~~ **RETRACTED** — that was the stray-directory
+read (see the warning at the top). An abandoned profile being logged out says nothing
+about the account.
 
-```
-labs.google/fx/api/auth/session   -> 200, 2 bytes ({}), has_user=False
-flow.google.com/                  -> redirects to /about (marketing), avatar=0, signin_cta=1
-labs.google/fx/tools/flow         -> rendered, avatar=0, no editor
-myaccount.google.com/             -> redirects to www.google.com/account/about (signed out)
-```
+The divergence needs **Google SSO alive + labs Flow session dead**. A fresh login
+cannot produce it — login makes *both* alive — so this remains **unobserved**, exactly
+as the 2026-09-03 triage concluded. No new evidence for or against.
 
-Remaining `labs.google` cookies: `__Host-next-auth.csrf-token`,
-`__Secure-next-auth.callback-url`, `email`. The session token itself is **gone** —
-Chrome dropped it on expiry.
+### What the live run did establish: the instrument works
 
-**New information vs 2026-09-03.** That measurement could only observe the
-`has_user=true` arm. This one reaches the `has_user=false` arm and finds the two hosts
-**agree**: when the Google SSO session dies, the migrated host reports signed-out too.
-That is evidence *against* the two hosts having independent session lifetimes — the
-mechanism #644's false-negative scenario depends on.
+The pass condition recorded below was, until this run, an **unvalidated guess**. It is
+now calibrated against both arms on the same profile:
 
-**Still unobserved, still the only thing that makes #644 actionable:** an account where
-`labs.google/fx/api/auth/session` returns `{}`/no-user **while** `flow.google.com`
-renders authenticated (avatar present, editor rendered).
+| profile state | `flow.google.com/` lands on | `avatar` | `signin_cta` | `aria_buttons` |
+|---|---|---|---|---|
+| logged out (stray dir) | `/about` (marketing) | 0 | 1 | 90 |
+| **live session** | `/` (app) | **1** | **0** | 47 |
+
+The DOM signal cleanly separates authenticated from anonymous. A future
+"no divergence" result from this probe can now be trusted to mean *no divergence*,
+rather than *broken instrument*.
+
+### New finding: the frontend has migrated, the auth BFF has not
+
+Navigating to `https://labs.google/fx/tools/flow` **redirected to
+`https://flow.google.com/`**, while `labs.google/fx/api/auth/session` still answered
+`200 / 653 B / has_user=True` for the same profile at the same moment.
+
+So for this account Google has already moved the **frontend** off `labs.google` while
+leaving the **auth BFF** on it. gflow's only auth oracle now lives on the host the user
+is actively being redirected away from. That is not the #644 divergence, but it is the
+precise coupling that makes **Q4** load-bearing — and it means Q4's trigger is no longer
+purely hypothetical: the migration is visibly in progress, with the auth BFF the last
+piece still on the old host.
 
 ---
 
@@ -135,13 +179,18 @@ is unreachable:
 
 ### Not built here, deliberately
 
-The trigger is **unobserved** — Q2 found the two hosts share a session lifetime, so the
-"SSO alive + labs dead" state may not even be reachable while labs is healthy. Building
-a host-aware fallback now would guard a failure nobody can demonstrate, which is the
-same trap #644's own triage refused.
+The precise failure — a live SSO session that the labs BFF refuses — is still
+**unobserved**, and building a host-aware fallback for it would guard something nobody
+can demonstrate. That is the trap #644's own triage refused, and it still applies.
 
-But the asymmetry is worth the owner's attention: the check is nearly free (the signal
-is already in hand), the failure is unrecoverable by the user, and it **cannot be
+**But the trigger is no longer hypothetical.** Q2's live run found the frontend already
+migrated for this account (`labs.google/fx/tools/flow` → `flow.google.com`) while the
+auth BFF stayed behind. The single oracle gating every profile now sits on the host
+Google is actively moving users off. The remaining step to the Q4 failure is that one
+endpoint following the frontend it belongs to.
+
+The asymmetry is what deserves the owner's attention: the check is nearly free (the
+signal is already in hand), the failure is unrecoverable by the user, and it **cannot be
 shipped after the deprecation** — by then every affected user is already stuck on a
 version that loops.
 
@@ -157,16 +206,17 @@ labs.google BFF"* before any implementation. Two candidate slices, smallest firs
 
 ## Re-running this probe
 
-Needs a profile under `GFLOW_CLI_HOME` and nothing else. Adjust `PROFILE`.
+Needs a profile under `GFLOW_CLI_HOME` and nothing else. **Resolve the path — never
+hardcode it** (see the retraction at the top).
 
 ```python
 import asyncio, json
-from pathlib import Path
 import browser_cookie3, httpx
 from gflow_cli.auth.cookies import get_chrome_cookie_snapshot
-from gflow_cli.paths import get_cookies_path
+from gflow_cli.paths import default_home, profile_subdir
 
-PROFILE = Path.home() / "AppData/Local/gflow-cli/profile_<name>"
+PROFILE = profile_subdir(default_home(), "<name>")
+assert (PROFILE / "Local State").exists(), f"no such profile: {PROFILE}"
 
 async def main():
     snap = await get_chrome_cookie_snapshot(PROFILE)

--- a/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
+++ b/docs/superpowers/spikes/2026-09-06-labs-vs-migrated-session-credential.md
@@ -87,8 +87,71 @@ there:
   for its only consumer (an httpx client that talks solely to `labs.google`). Widening
   it would send `.google.com` SSO cookies to `labs.google` — a regression, not a fix.
 
-**No code change is warranted.** The harvest becomes wrong only when a browserless path
-to the migrated host exists; that is #642's scope, and the fix belongs there.
+**No code change is warranted *for #644 as filed*.** The harvest becomes wrong only when
+a browserless path to the migrated host exists; that is #642's scope.
+
+But tracing it surfaced a larger risk that #644 only gestures at — see Q4.
+
+---
+
+## Q4. What actually breaks if `labs.google` is deprecated?
+
+**A re-login loop that the user cannot escape, plus silent profile degradation.**
+This is the sharper form of #644's concern, and it is a design question for the owner
+rather than something to build speculatively.
+
+`RealChromeStrategy.login` (`auth/real_chrome.py:255`) ends every login with
+`verify_flow_profile`, whose **sole oracle** is `labs.google/fx/api/auth/session`.
+So that one host's BFF is the gate on every profile's usability — *including profiles
+whose actual generation path never touches it* (UI automation, the migrated composer).
+
+Failure sequence once labs stops minting Flow sessions:
+
+1. User runs `gflow auth login` and signs in fully. SSO cookies land;
+   `flow.google.com` renders authenticated.
+2. `verify_flow_profile` asks labs → no user → `verified = False`.
+3. `real_chrome.py:262` **unlinks `.gflow_browser_strategy`** (rollback of the
+   speculative write, when the marker did not pre-exist).
+4. The user is told to re-run `gflow auth login`. → goto 1, forever.
+
+Step 3 is the load-bearing damage: without that marker `channel_for_profile` stops
+returning `"chrome"`, so `FlowApiClient` downgrades to bundled Chromium — which the
+code's own comment identifies as the `[[real-browser-auth-mandatory]]` failure. A labs
+outage therefore does not merely block login; it **degrades a profile that would still
+work through the browser**.
+
+### The discriminator already exists
+
+`ChromeCookieSnapshot.google_session` (`SAPISID` present, computed from the full jar)
+already separates the states. What is missing is only that the last row's remediation
+is unreachable:
+
+| labs BFF | SSO cookies | outcome today | remediation correct? |
+|---|---|---|---|
+| user present | — | `AUTHENTICATED` | ✅ |
+| `{}` | no `SAPISID` | `NO_SESSION` → re-login | ✅ re-login fixes it |
+| `{}` | `SAPISID` | `GOOGLE_SESSION_ONLY` → re-login | ✅ today · ❌ under deprecation, never |
+| non-200 | any | `VERIFICATION_ERROR` → "network" | ✅ today · ❌ under deprecation, permanent |
+
+### Not built here, deliberately
+
+The trigger is **unobserved** — Q2 found the two hosts share a session lifetime, so the
+"SSO alive + labs dead" state may not even be reachable while labs is healthy. Building
+a host-aware fallback now would guard a failure nobody can demonstrate, which is the
+same trap #644's own triage refused.
+
+But the asymmetry is worth the owner's attention: the check is nearly free (the signal
+is already in hand), the failure is unrecoverable by the user, and it **cannot be
+shipped after the deprecation** — by then every affected user is already stuck on a
+version that loops.
+
+**Recommended next step:** `/gflow:predict` on *"decouple profile validity from the
+labs.google BFF"* before any implementation. Two candidate slices, smallest first:
+
+1. **Never let a probe failure delete a marker that a successful browser login just
+   earned** — narrow, defensible today, and removes the degradation in step 3.
+2. **Give `GOOGLE_SESSION_ONLY` / `VERIFICATION_ERROR` an escape hatch** so a user with
+   a live SSO session is not told to repeat an action that cannot help.
 
 ---
 

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -251,9 +251,13 @@ class RealChromeStrategy(AuthStrategy):
         marker_preexisted = marker.exists()
         marker.write_text("chrome", encoding="utf-8")
         verified = False
+        # Bound before the `try` so the `finally` can log it even when an
+        # interrupt cuts the probe short and `status` never gets assigned.
+        outcome: str | None = None
         try:
             status = await verify_flow_profile(profile_dir, source=self.name)
             verified = status.authenticated
+            outcome = status.outcome.value
         finally:
             # `finally` (not `except`) so an interrupt — KeyboardInterrupt /
             # asyncio.CancelledError, both BaseException — also rolls back a
@@ -261,6 +265,19 @@ class RealChromeStrategy(AuthStrategy):
             # the chrome strategy.
             if not verified and not marker_preexisted:
                 marker.unlink(missing_ok=True)
+                # #644: this rollback flips channel_for_profile away from
+                # 'chrome', silently downgrading generation to bundled
+                # Chromium. It used to emit nothing, so the first real
+                # occurrence was only ever visible as a user report. `outcome`
+                # separates "the probe endpoint was unreachable" (labs.google's
+                # session BFF is the sole oracle, and the Flow frontend has
+                # already migrated off that host) from "genuinely signed out".
+                # It is an enum value — never response content.
+                logger.warning(
+                    "auth_chrome_marker_rolled_back",
+                    strategy=self.name,
+                    outcome=outcome,
+                )
         if status.authenticated:
             logger.info(
                 "auth_flow_session_verified",

--- a/tests/auth/strategies/test_strategies.py
+++ b/tests/auth/strategies/test_strategies.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 
 from gflow_cli.auth.real_chrome import _UNVERIFIED_HINT, _UNVERIFIED_MESSAGE, GEMINI_URL
 from gflow_cli.auth.strategies import InternalChromiumStrategy, RealChromeStrategy
@@ -247,6 +248,78 @@ class TestRealChromeStrategy:
         # The marker the profile already had must survive the transient failure.
         assert marker.exists(), "pre-existing chrome marker must survive a transient failure"
         assert marker.read_text(encoding="utf-8") == "chrome"
+
+    @pytest.mark.asyncio
+    async def test_real_chrome_marker_rollback_is_logged(self, tmp_path: Path) -> None:
+        """#644: rolling the speculative marker back must be observable.
+
+        The rollback flips ``channel_for_profile`` away from 'chrome', which
+        silently downgrades generation to bundled Chromium. It previously
+        emitted nothing at all, so the first real occurrence was visible only
+        as a user report weeks later.
+        """
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        gflow_home.mkdir()
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch(
+                "gflow_cli.auth.real_chrome.find_chrome_executable",
+                return_value=r"C:\fake\chrome.exe",
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=_build_mock_proc()),
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_profile",
+                AsyncMock(return_value=_status(FlowSessionOutcome.VERIFICATION_ERROR)),
+            ),
+            capture_logs() as logs,
+        ):
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(AuthMissingError):
+                await strategy.login(profile_dir, headless=False)
+
+        rollbacks = [e for e in logs if e.get("event") == "auth_chrome_marker_rolled_back"]
+        assert len(rollbacks) == 1, f"expected exactly one rollback event, got {logs}"
+        # The outcome separates "the probe endpoint was unreachable" from
+        # "genuinely signed out" — the #644 discriminator. It is an enum value,
+        # never response content, so it cannot carry a token or cookie.
+        assert rollbacks[0]["outcome"] == FlowSessionOutcome.VERIFICATION_ERROR.value
+
+    @pytest.mark.asyncio
+    async def test_real_chrome_no_rollback_event_when_marker_survives(self, tmp_path: Path) -> None:
+        """No rollback happened, so no rollback event — the signal must stay rare."""
+        strategy = RealChromeStrategy()
+        gflow_home = tmp_path / "gflow_home"
+        profile_dir = gflow_home / "profile_default"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
+
+        with (
+            patch("gflow_cli.auth.real_chrome.get_settings") as mock_settings,
+            patch(
+                "gflow_cli.auth.real_chrome.find_chrome_executable",
+                return_value=r"C:\fake\chrome.exe",
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=_build_mock_proc()),
+            ),
+            patch(
+                "gflow_cli.auth.real_chrome.verify_flow_profile",
+                AsyncMock(return_value=_status(FlowSessionOutcome.VERIFICATION_ERROR)),
+            ),
+            capture_logs() as logs,
+        ):
+            mock_settings.return_value.home = gflow_home
+            with pytest.raises(AuthMissingError):
+                await strategy.login(profile_dir, headless=False)
+
+        assert not [e for e in logs if e.get("event") == "auth_chrome_marker_rolled_back"]
 
     @pytest.mark.asyncio
     async def test_real_chrome_privacy_guard(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Read-only spike for #644 (2026-09-06, migrated profile, $0), a five-persona `/gflow:predict` council on what it found, and the **one** code change that survived that council.

## What shipped

**One structlog event.** The speculative-marker rollback in `RealChromeStrategy.login` emitted *nothing*, despite flipping `channel_for_profile` away from `chrome` and silently downgrading generation to bundled Chromium. It now logs `auth_chrome_marker_rolled_back` with the `FlowSessionOutcome` value — which separates "the probe endpoint was unreachable" from "genuinely signed out". Zero behaviour change; two tests cover fires/doesn't-fire.

## Predict verdict: STOP on both originally-proposed slices

Mean confidence 8.2, −2 for a simpler path the Devil's Advocate found, one hard STOP.

1. ~~*Never let a probe failure delete a marker a successful login earned.*~~ **Already shipped.** The `marker_preexisted` guard has protected returning profiles since `a86a335` (2026-07-06, v0.25.0), pinned by `test_real_chrome_preserves_preexisting_marker_on_transient_failure`. The first-login deletion is deliberate — keeping the marker would leave `.gflow_browser_strategy=chrome` with no `.gflow_account` and break a passing test.
2. ~~*Escape hatch for `GOOGLE_SESSION_ONLY`/`VERIFICATION_ERROR`.*~~ **Deferred** — control flow on a fail-closed auth path for a state never observed, with no account in which to write its e2e test.

## Spike findings

- **The labs token is not a `flow.google.com` credential** (measured): sent alone it yields 146,488 bytes with no email and no GAIA id — 9 bytes off the *no-cookies* control (146,497). SSO cookies yield 150,744 carrying both.
- **The divergence #644 predicts is still unobserved**, no evidence either way.
- **Retraction, called out at the top of the doc:** the first pass measured `%LOCALAPPDATA%\gflow-cli\...` instead of `%LOCALAPPDATA%\ffroliva\gflow-cli\...`. A stale profile fails *quietly* — it decrypts and answers every probe. The doc now resolves paths via `profile_subdir(default_home(), name)`.
- **New:** `labs.google/fx/tools/flow` now redirects to `flow.google.com` while the auth BFF still answers on `labs.google`. The frontend has migrated; the sole auth oracle has not.
- **Follow-up recorded:** the probe retries 3×/15s and `except Exception` catches everything, so a hung BFF costs ~48s and an instantly-refused one still burns ~3s — on all three call sites.

## MCP parity

**No MCP surface.** `RealChromeStrategy.login` is the interactive CLI-only path, and the MCP tool docstring already states login/logout stay CLI-only. Stated explicitly rather than left silent, per the second law.

## Test plan

- [x] All nine Impeccable Routine gates green (`uv run pyright src` → 0 errors)
- [x] `tests/auth` + `tests/scripts` — 303 passed
- [x] New tests fail before the change, pass after (TDD)
- [x] `tests/e2e/test_auth_verification_e2e.py -m e2e` run against a live profile: 2 passed, 1 failed — **failure is pre-existing**, reproduced identically with this branch stashed, and is unrelated to this change (it is `health_check()`, not `verify_flow_profile`)

> ⚠️ That e2e run surfaced a **separate present-day bug**, reported below rather than fixed here to keep this PR scoped.

Refs #644, #642 — not `Closes`: #644 stays open as a documented latent risk.