### PR TITLE
fix(690): health_check() rejected every migrated flow.google.com account

### DIFF
--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -2701,7 +2701,12 @@ class FlowApiClient:
             page = await self._checkout_page()
             try:
                 hostname: str = await page.evaluate("() => document.location.hostname")
-                return hostname.endswith(".google") or hostname == "google.com"
+                # #690: ".google" alone covered only the OLD host (labs.google).
+                # A migrated account sits on flow.google.com, which ends in
+                # ".com" and is not "google.com", so a perfectly healthy page
+                # was reported unhealthy. The leading dot is load-bearing —
+                # it is what keeps "evilgoogle.com" out.
+                return hostname == "google.com" or hostname.endswith((".google", ".google.com"))
             finally:
                 self._checkin_page(page)
         except Exception:

--- a/tests/api/test_client_image.py
+++ b/tests/api/test_client_image.py
@@ -859,6 +859,46 @@ class TestHealthCheck:
 
         assert result is False
 
+    @pytest.mark.parametrize(
+        ("hostname", "expected"),
+        [
+            # Old host — the only one the original check anticipated.
+            ("labs.google", True),
+            ("google.com", True),
+            # #690: the MIGRATED host. Ends with ".com", is not "google.com",
+            # so the original check called a perfectly healthy page unhealthy.
+            ("flow.google.com", True),
+            ("aisandbox-pa.googleapis.com", False),
+            # Lookalikes must stay rejected — the leading dot is load-bearing.
+            ("evilgoogle.com", False),
+            ("notlabs.google.com.evil.net", False),
+            ("google.com.evil.net", False),
+            ("example.com", False),
+        ],
+    )
+    async def test_health_check_hostname_boundary(
+        self, tmp_path: Path, hostname: str, expected: bool
+    ) -> None:
+        """#690: every host a real page can legitimately sit on must pass, and
+        every lookalike must fail.
+
+        The pre-existing "returns True on a Google domain" test mocked
+        ``labs.google`` — the old host — so the unit suite encoded the same
+        assumption as the code and stayed green while migrated accounts were
+        reported unhealthy. Enumerating the boundary is what stops that
+        recurring; a single mocked hostname only ever tests the host the author
+        already had in mind.
+        """
+        transport = _FakeTransport()
+        client = _client_with_transport(tmp_path, transport)
+
+        fake_page = MagicMock()
+        fake_page.evaluate = AsyncMock(return_value=hostname)
+        client._page_queue = asyncio.Queue(maxsize=1)
+        client._page_queue.put_nowait(fake_page)
+
+        assert await client.health_check() is expected
+
     async def test_health_check_returns_false_on_evaluate_exception(self, tmp_path: Path) -> None:
         """If page.evaluate raises (e.g. TargetClosedError) → False, never raises."""
         transport = _FakeTransport()


### PR DESCRIPTION
## Summary

`FlowApiClient.health_check()` accepted only the **old** host, so it returned `False` for every migrated account while `verify_flow_profile` correctly reported `AUTHENTICATED` — breaking the "verified ⇒ usable" invariant on exactly the accounts Google is migrating everyone toward.

```python
# before — labs.google only
return hostname.endswith(".google") or hostname == "google.com"

# after
return hostname == "google.com" or hostname.endswith((".google", ".google.com"))
```

| account | page hostname | before | after |
|---|---|---|---|
| old host | `labs.google` | `True` | `True` |
| **migrated** | `flow.google.com` | **`False`** | `True` |
| lookalike | `evilgoogle.com` | `False` | `False` |

The leading dot is load-bearing — `evilgoogle.com` does not end with `.google.com`. The new parametrized test pins **both** directions, including `google.com.evil.net` and `aisandbox-pa.googleapis.com`.

## Impact

No production caller in `src/` today, so nothing is currently mis-reporting in the daemon. But the docstring promises the method is *"safe to call from long-lived workers"*, and two e2e tests assert on it — so the suite went red on any migrated account through no fault of whoever ran it. That is noise landing on migrated-host work such as #683.

## Why the unit suite stayed green

`test_health_check_returns_true_on_google_domain` mocks the hostname as **`labs.google`** — the old host. The unit test didn't merely miss the bug, it **encoded the same stale assumption as the code**. A mocked hostname can only ever test the host the author already thought of.

Every offline gate was green while this was broken: `ruff`, `pyright` 0 errors, 1501 unit tests, all doc gates. It was found only by running the live e2e — a concrete second data point for the Iron Law.

## Test plan

- [x] New parametrized boundary test **fails before** the change (`flow.google.com-True`), passes after — TDD
- [x] `tests/api` — **1501 passed**, 3 skipped
- [x] `ruff check` / `ruff format --check` / `uv run pyright src` (0 errors) / repo hygiene — green
- [x] **Live e2e, migrated profile:** `tests/e2e/test_auth_verification_e2e.py -m e2e` → **3 passed** (was 1 failed)
- [x] **Live e2e:** `tests/e2e/test_transports_e2e.py -k health_check -m e2e` → **2 passed**

## MCP parity

**No MCP surface.** `health_check()` is an internal `FlowApiClient` method with no CLI leaf and no MCP tool; it is not reachable from either door. Stated explicitly rather than left silent, per the second law.

Closes #690 · Refs #644, #639