### PR TITLE
fix(692): re-classify a reCAPTCHA mint that fails after the migrated-host hop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A reCAPTCHA mint that fails after the migrated-host handoff now reports exit 36, not exit 1**
+  ([#692](https://github.com/ffroliva/gflow-cli/issues/692)). The `raise_if_migrated` guard added
+  in #678 is a point-in-time read of `page.url`, and Flow's handoff to `flow.google.com` is a
+  **client-side** navigation that can land after it. The bootstrap's own `await_url_settled` does
+  not close that window either — it is skipped entirely for a profile latched at
+  `NOT_REDIRECTED`. The guard is now re-run on the mint's failure path, which costs nothing when
+  the mint succeeds and classifies correctly whenever the hop lands, rather than depending on it
+  landing before one particular line. A genuine labs-side reCAPTCHA failure still surfaces as
+  `RecaptchaError`.
+
+  **Scope, stated honestly:** the reporter's failure could **not** be reproduced locally. On a
+  migrated, `NOT_REDIRECTED`-latched profile the hop wins the race and v0.69.0 already returns
+  exit 36 — verified live, before and after this change. So this hardens a race that is real in
+  the code but unobserved here; it is not a confirmed fix for #692, which stays open.
+
+### Added
+
+- **`recaptcha_mint_failed_off_migrated_host`** — when a mint fails and the page still reads as
+  `labs.google`, the page URL is now logged. That is the one observation which distinguishes the
+  race above from a genuine labs-side reCAPTCHA break, and it makes the next incident bundle
+  self-sufficient instead of costing a round trip to the reporter.
+
 ## [0.69.0] — 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   landing before one particular line. A genuine labs-side reCAPTCHA failure still surfaces as
   `RecaptchaError`.
 
+  The re-check catches **any** mint failure, not just `RecaptchaError`. `TokenMinter.mint` guards
+  only its second `page.evaluate`: `site_key()` → `discover_site_key` runs an unguarded one, and
+  the minter is rebuilt per call so that unguarded call runs every time. A hop mid-mint destroys
+  the execution context, so the likeliest shape of this failure is a **raw Playwright error** —
+  which a `RecaptchaError`-only net would miss entirely. Nothing is swallowed: the original
+  exception propagates untouched unless the page turns out to be migrated.
+
   **Scope, stated honestly:** the reporter's failure could **not** be reproduced locally. On a
   migrated, `NOT_REDIRECTED`-latched profile the hop wins the race and v0.69.0 already returns
   exit 36 — verified live, before and after this change. So this hardens a race that is real in

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -54,7 +54,7 @@ from gflow_cli.api.image_upscale import (
     UpsampleImageRequest,
     build_upsample_image_body,
 )
-from gflow_cli.api.recaptcha import RecaptchaError, TokenMinter
+from gflow_cli.api.recaptcha import TokenMinter
 from gflow_cli.api.scene import ConcatInput, Scene, SceneWorkflow
 from gflow_cli.api.transports import (
     STANDALONE_ONLY_TRANSPORTS,
@@ -87,6 +87,7 @@ from gflow_cli.errors import (
     ConfigurationError,
     ContentPolicyError,
     FlowApiError,  # re-exported via gflow_cli.api.__init__
+    FlowHostMigratedError,
     NetworkError,
     ProfileLockedError,
     RateLimitError,
@@ -2416,7 +2417,16 @@ class FlowApiClient:
             minter = TokenMinter(page, mint_evaluate_kwargs=mint_evaluate_kwargs())
             try:
                 return await minter.mint(action)
-            except RecaptchaError:
+            # Deliberately broad. `TokenMinter.mint` guards only its SECOND
+            # evaluate: `site_key()` -> `discover_site_key` runs an unguarded
+            # `page.evaluate`, and the minter is rebuilt per call so `_site_key`
+            # is always None and that unguarded call runs every time. A hop
+            # mid-mint destroys the execution context, so the likeliest shape of
+            # this failure is a RAW Playwright error, not RecaptchaError —
+            # catching only the latter would miss the very race this exists for.
+            # Nothing is swallowed: the original propagates untouched unless the
+            # page turns out to be migrated.
+            except Exception:
                 # #692: the guard above is a point-in-time read, and the handoff
                 # to flow.google.com is a CLIENT-SIDE navigation that can land
                 # while we are minting. The bootstrap's own `await_url_settled`
@@ -2430,17 +2440,30 @@ class FlowApiClient:
                 # succeeds, and correct whenever the hop lands, rather than
                 # depending on it landing before a particular line. A genuine
                 # labs-side reCAPTCHA failure still propagates as RecaptchaError.
-                raise_if_migrated(page, at="mint_recaptcha_token_after_failure")
-                # Still reads as labs. That is the discriminating observation for
-                # #692 — the reporter's failure could NOT be reproduced here (the
-                # hop wins the race on this machine and the guard classifies
-                # correctly), so record where the page actually was rather than
-                # spending a round trip asking. The URL is the same value
-                # ``raise_if_migrated`` already logs on the bail path.
-                logger.warning(
-                    "recaptcha_mint_failed_off_migrated_host",
-                    url=getattr(page, "url", None),
-                )
+                try:
+                    raise_if_migrated(page, at="mint_recaptcha_token_after_failure")
+                    probed_url = getattr(page, "url", None)
+                except FlowHostMigratedError:
+                    raise
+                except Exception:
+                    # The re-check is a PROBE, and `page.url` can itself raise on a
+                    # dead page. `_common.flow_host_kind` is total by construction
+                    # for exactly this reason — "a probe error must never displace
+                    # the real failure" — but reaching it requires the URL read.
+                    # Swallowed so the caller still sees what actually went wrong;
+                    # widening the outer handler is what made this reachable.
+                    logger.debug("recaptcha_mint_migration_probe_failed", exc_info=True)
+                else:
+                    # Still reads as labs. That is the discriminating observation
+                    # for #692 — the reporter's failure could NOT be reproduced
+                    # here (the hop wins the race on this machine and the guard
+                    # classifies correctly), so record where the page actually was
+                    # rather than spending a round trip asking. The URL is the same
+                    # value ``raise_if_migrated`` already logs on the bail path.
+                    logger.warning(
+                        "recaptcha_mint_failed_off_migrated_host",
+                        url=probed_url,
+                    )
                 raise
         finally:
             self._checkin_page(page)

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -54,7 +54,7 @@ from gflow_cli.api.image_upscale import (
     UpsampleImageRequest,
     build_upsample_image_body,
 )
-from gflow_cli.api.recaptcha import TokenMinter
+from gflow_cli.api.recaptcha import RecaptchaError, TokenMinter
 from gflow_cli.api.scene import ConcatInput, Scene, SceneWorkflow
 from gflow_cli.api.transports import (
     STANDALONE_ONLY_TRANSPORTS,
@@ -2414,7 +2414,34 @@ class FlowApiClient:
             # page's main-world ``grecaptcha`` global is undefined; the resolver
             # supplies ``isolated_context=False`` for patchright ({} for playwright).
             minter = TokenMinter(page, mint_evaluate_kwargs=mint_evaluate_kwargs())
-            return await minter.mint(action)
+            try:
+                return await minter.mint(action)
+            except RecaptchaError:
+                # #692: the guard above is a point-in-time read, and the handoff
+                # to flow.google.com is a CLIENT-SIDE navigation that can land
+                # while we are minting. The bootstrap's own `await_url_settled`
+                # does not close the window either — it is skipped entirely for a
+                # profile latched at NOT_REDIRECTED (`settle = cached !=
+                # NOT_REDIRECTED`), which is the population #643 was written for.
+                # So a moved account can read as labs at the guard, hop, and then
+                # fail here for want of `recaptcha/enterprise.js`.
+                #
+                # Re-classify on the FAILURE path only: free when the mint
+                # succeeds, and correct whenever the hop lands, rather than
+                # depending on it landing before a particular line. A genuine
+                # labs-side reCAPTCHA failure still propagates as RecaptchaError.
+                raise_if_migrated(page, at="mint_recaptcha_token_after_failure")
+                # Still reads as labs. That is the discriminating observation for
+                # #692 — the reporter's failure could NOT be reproduced here (the
+                # hop wins the race on this machine and the guard classifies
+                # correctly), so record where the page actually was rather than
+                # spending a round trip asking. The URL is the same value
+                # ``raise_if_migrated`` already logs on the bail path.
+                logger.warning(
+                    "recaptcha_mint_failed_off_migrated_host",
+                    url=getattr(page, "url", None),
+                )
+                raise
         finally:
             self._checkin_page(page)
 

--- a/tests/api/test_client_migrated_mint.py
+++ b/tests/api/test_client_migrated_mint.py
@@ -13,9 +13,11 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from structlog.testing import capture_logs
 
 from gflow_cli.api import client as client_mod
 from gflow_cli.api.client import FlowApiClient
+from gflow_cli.api.recaptcha import RecaptchaError
 from gflow_cli.errors import FlowHostMigratedError
 
 
@@ -60,3 +62,94 @@ async def test_mint_on_labs_host_still_mints(monkeypatch: pytest.MonkeyPatch) ->
     c = _client_on("https://labs.google/fx/en/tools/flow")
     assert await c._mint_recaptcha_token("IMAGE_GENERATION") == "tok"
     mint.assert_awaited_once_with("IMAGE_GENERATION")  # the action is threaded through
+
+
+class _HopsDuringMint:
+    """Flow's client-side handoff lands WHILE the token is being minted.
+
+    #692: ``page.goto`` returns before the hop, and the bootstrap's
+    ``await_url_settled`` is SKIPPED for a profile latched at ``NOT_REDIRECTED``
+    (``client.py`` ``settle = cached != NOT_REDIRECTED``). So the guard can read a
+    still-labs URL, wave the mint through, and only then does the page land on
+    ``flow.google.com`` — where there is no ``recaptcha/enterprise.js``.
+    """
+
+    def __init__(self, page: Any, **_: Any) -> None:
+        self._page = page
+
+    async def mint(self, _action: str) -> str:
+        self._page.url = "https://flow.google.com/"
+        raise RecaptchaError("recaptcha/enterprise.js not found")
+
+
+@pytest.mark.asyncio
+async def test_mint_reclassifies_when_the_migrated_hop_lands_mid_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#692: a mint that fails because the page hopped mid-flight is exit 36, not exit 1.
+
+    The reporter ran v0.69.0 — which HAS the #678 guard — and still got a bare
+    ``RecaptchaError``, because that guard is a point-in-time read racing a
+    client-side navigation. Re-checking on the failure path costs nothing when
+    the mint succeeds and is robust regardless of when the hop lands.
+    """
+    monkeypatch.setattr(client_mod, "TokenMinter", _HopsDuringMint)
+    c = _client_on("https://labs.google/fx/en/tools/flow")
+    returned: list[Any] = []
+    monkeypatch.setattr(c, "_checkin_page", returned.append)
+
+    with pytest.raises(FlowHostMigratedError) as info:
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+    assert "flow.google.com" in info.value.detail
+    assert returned == [c._page], "the pool page must not leak on the reclassified path"
+
+
+class _FailsOnLabs:
+    """A genuine labs-side reCAPTCHA failure — the page never hops."""
+
+    def __init__(self, _page: Any, **_: Any) -> None: ...
+
+    async def mint(self, _action: str) -> str:
+        raise RecaptchaError("site key not discoverable")
+
+
+@pytest.mark.asyncio
+async def test_mint_failure_on_labs_still_raises_recaptcha_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reclassification must NOT swallow real reCAPTCHA failures.
+
+    Turning every mint failure into exit 36 would hide the labs-side breakage
+    this error exists to report.
+    """
+    monkeypatch.setattr(client_mod, "TokenMinter", _FailsOnLabs)
+    c = _client_on("https://labs.google/fx/en/tools/flow")
+    monkeypatch.setattr(c, "_checkin_page", lambda _p: None)
+
+    with pytest.raises(RecaptchaError):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+
+@pytest.mark.asyncio
+async def test_mint_failure_off_migrated_host_records_where_the_page_was(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#692: when the re-check does NOT fire, log the URL that defeated it.
+
+    The reporter's failure could not be reproduced locally — the hop wins the
+    race on this machine and the guard classifies correctly. So the mint failing
+    on a page that reads as *labs* is the discriminating observation, and without
+    it every future report costs a round trip to the reporter. Emitting the URL
+    here turns the next incident bundle into evidence on its own.
+    """
+    monkeypatch.setattr(client_mod, "TokenMinter", _FailsOnLabs)
+    c = _client_on("https://labs.google/fx/en/tools/flow")
+    monkeypatch.setattr(c, "_checkin_page", lambda _p: None)
+
+    with capture_logs() as logs, pytest.raises(RecaptchaError):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+    recorded = [e for e in logs if e.get("event") == "recaptcha_mint_failed_off_migrated_host"]
+    assert len(recorded) == 1, f"expected the diagnostic, got {logs}"
+    assert recorded[0]["url"] == "https://labs.google/fx/en/tools/flow"

--- a/tests/api/test_client_migrated_mint.py
+++ b/tests/api/test_client_migrated_mint.py
@@ -153,3 +153,102 @@ async def test_mint_failure_off_migrated_host_records_where_the_page_was(
     recorded = [e for e in logs if e.get("event") == "recaptcha_mint_failed_off_migrated_host"]
     assert len(recorded) == 1, f"expected the diagnostic, got {logs}"
     assert recorded[0]["url"] == "https://labs.google/fx/en/tools/flow"
+
+
+class _ContextDestroyedDuringMint:
+    """The mid-mint navigation destroys the execution context.
+
+    #692 review finding: ``TokenMinter.mint`` guards only its SECOND evaluate.
+    ``site_key()`` -> ``discover_site_key`` runs an unguarded
+    ``page.evaluate`` (``recaptcha.py``), and ``TokenMinter`` is rebuilt per
+    call so ``_site_key`` is always ``None`` — meaning the unguarded call runs
+    every time. A hop mid-mint therefore surfaces as a RAW Playwright error,
+    not ``RecaptchaError``, which is the likeliest shape of the reporter's
+    failure and the one a ``except RecaptchaError`` net misses entirely.
+    """
+
+    def __init__(self, page: Any, **_: Any) -> None:
+        self._page = page
+
+    async def mint(self, _action: str) -> str:
+        self._page.url = "https://flow.google.com/"
+        raise RuntimeError("Execution context was destroyed, most likely because of a navigation")
+
+
+@pytest.mark.asyncio
+async def test_mint_reclassifies_a_non_recaptcha_failure_after_the_hop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any mint failure on a page that turns out to be migrated is exit 36."""
+    monkeypatch.setattr(client_mod, "TokenMinter", _ContextDestroyedDuringMint)
+    c = _client_on("https://labs.google/fx/en/tools/flow")
+    returned: list[Any] = []
+    monkeypatch.setattr(c, "_checkin_page", returned.append)
+
+    with pytest.raises(FlowHostMigratedError):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+    assert returned == [c._page], "the pool page must not leak on the reclassified path"
+
+
+class _RaisesRuntimeOnLabs:
+    def __init__(self, _page: Any, **_: Any) -> None: ...
+
+    async def mint(self, _action: str) -> str:
+        raise RuntimeError("some unrelated playwright failure")
+
+
+@pytest.mark.asyncio
+async def test_non_recaptcha_failure_on_labs_propagates_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Widening the net must not swallow or reshape unrelated failures."""
+    monkeypatch.setattr(client_mod, "TokenMinter", _RaisesRuntimeOnLabs)
+    c = _client_on("https://labs.google/fx/en/tools/flow")
+    monkeypatch.setattr(c, "_checkin_page", lambda _p: None)
+
+    with pytest.raises(RuntimeError, match="some unrelated playwright failure"):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+
+class _DiesDuringMint:
+    """Readable at the pre-mint guard, then the target dies mid-mint.
+
+    A page that is dead from the start fails at the FIRST guard, which is
+    pre-existing behaviour. The case this widened handler newly makes reachable
+    is a page that classifies fine going in and whose ``url`` read raises on the
+    way out.
+    """
+
+    def __init__(self) -> None:
+        self._reads = 0
+
+    @property
+    def url(self) -> str:
+        self._reads += 1
+        if self._reads == 1:
+            return "https://labs.google/fx/en/tools/flow"
+        msg = "Target page, context or browser has been closed"
+        raise RuntimeError(msg)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_url_probe_never_displaces_the_real_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The migration re-check is a PROBE; it must never mask the original error.
+
+    ``_common.flow_host_kind`` is total by construction for exactly this reason
+    ("a probe error must never displace the real failure"), but the re-check
+    reads ``page.url`` to get there — and that read can raise on a dead page.
+    Widening the handler to ``except Exception`` made that reachable, so the
+    probe is guarded and the caller still sees what actually went wrong.
+    """
+    monkeypatch.setattr(client_mod, "TokenMinter", _RaisesRuntimeOnLabs)
+    c = FlowApiClient.__new__(FlowApiClient)
+    c._page_queue = None
+    c._page = _DiesDuringMint()  # type: ignore[assignment]
+    monkeypatch.setattr(c, "_checkin_page", lambda _p: None)
+
+    with pytest.raises(RuntimeError, match="some unrelated playwright failure"):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")

--- a/tests/e2e/test_migrated_host_e2e.py
+++ b/tests/e2e/test_migrated_host_e2e.py
@@ -179,7 +179,16 @@ async def test_e2e_image_on_a_moved_account_exits_36_not_recaptcha(
     bails = [
         e for e in install_log_capture.entries if e.get("event") == "ui_driver.migrated_host_bail"
     ]
-    assert bails and bails[0].get("at") == "mint_recaptcha_token", bails
+    # #692: the bail can legitimately come from EITHER site now. The pre-mint
+    # guard catches the common case; the re-check on the mint's failure path
+    # catches the race where Flow's client-side hop lands mid-mint (the guard is
+    # a point-in-time URL read, so it cannot see a navigation that has not
+    # happened yet). Pinning this to the pre-mint site alone would make the test
+    # REJECT the very scenario #692 reports.
+    assert bails and bails[0].get("at") in {
+        "mint_recaptcha_token",
+        "mint_recaptcha_token_after_failure",
+    }, bails
     # The page the mint saw is the migrated origin (the grid, route "/", in the
     # reporter's bundle) — not a labs page that merely lost its script.
     assert flow_host_kind(str(bails[0].get("url"))) == "migrated", bails[0]


### PR DESCRIPTION
## Summary

Hardening plus a diagnostic for [#692](https://github.com/ffroliva/gflow-cli/issues/692). **Deliberately `Refs`, not `Closes` — read the scope section.**

#678 added `raise_if_migrated` to `_mint_recaptcha_token`, but that guard is a **point-in-time read** of `page.url`, and Flow's handoff to `flow.google.com` is a **client-side** navigation that can land after it. The bootstrap's `await_url_settled` does not close the window either — it is skipped entirely for a profile latched at `NOT_REDIRECTED`.

A race against a client-side redirect **cannot be won by checking earlier**. Any pre-mint URL read is inherently racy; checking on the *failure* path is inherently correct, and costs nothing when the mint succeeds.

## Two corrections after the first push — both past green gates

**1. The original `except RecaptchaError` could not catch its own bug.** `TokenMinter.mint` guards only its **second** `page.evaluate`. `site_key()` → `discover_site_key` (`recaptcha.py:64`) runs an **unguarded** one, and the minter is rebuilt per call so `_site_key` is always `None` — that unguarded call runs every time. A hop mid-mint destroys the execution context and raises a **raw Playwright error**, which a `RecaptchaError`-only net misses entirely.

Found by an adversarial review of this PR, not by any gate — the unit test monkeypatched `TokenMinter` wholesale and therefore shared the fix's own assumption. Same family as #690's test mocking `labs.google`.

**2. Widening to `except Exception` then made a new failure reachable.** The re-check reads `page.url` to classify, and that read can itself raise on a page that died mid-mint — **displacing the real error**. `_common.flow_host_kind` is total by construction for exactly this reason ("a probe error must never displace the real failure"); this restores that guarantee at the call site. Only `FlowHostMigratedError` escapes the probe; anything else is logged at debug and the original mint failure propagates untouched.

The first test written for (2) was *also* wrong — a page dead from the start fails at the **pre-mint** guard, which is pre-existing. The fake now models the real shape: readable going in, dead coming out.

Also widened the existing e2e assertion, which pinned `bails[0].at` to `"mint_recaptcha_token"` exactly and so would have **rejected the reclassified path** — a test written from the same assumption as the code it guards.

## ⚠️ Scope — NOT a confirmed fix for #692

The reporter's failure **could not be reproduced**. Measured live on a migrated profile confirmed latched at `NOT_REDIRECTED` (`.gflow_locale` is 0 bytes — the precondition the theory requires):

| tree | result |
|---|---|
| unfixed `develop` @ `9fba962` | **exit 36** |
| this branch | **exit 36** |

The hop wins the race here, so v0.69.0 **already** classifies correctly on this account. This hardens a race that is real in the code but unobserved locally.

That is why the diagnostic matters more than the fix: **`recaptcha_mint_failed_off_migrated_host`** records where the page actually was when a mint failed while still reading as labs — the one observation separating this race from a genuine labs-side reCAPTCHA break, making the reporter's next bundle self-sufficient.

## Test plan

- [x] **TDD** — 9 tests, each watched fail first; regression test for (2) proven revert→fail→restore→pass
- [x] Covers: hop mid-mint (RecaptchaError **and** raw Playwright error) → exit 36; labs failures propagate unchanged; probe error never masks the real failure; diagnostic emits the URL
- [x] **Full offline suite — 4006 passed**, 24 skipped
- [x] `ruff` / `ruff format --check` / `uv run pyright src` (0 errors) / all 5 doc gates
- [x] **Live e2e on a migrated account — 3 passed**, $0 (`test_e2e_image_on_a_moved_account_exits_36_not_recaptcha` is the #692-shaped one)

> Note: `test_e2e_t2v_runs_on_flow_google_com_by_default` fails on this account with the duration-control cohort `ConfigurationError` (#451/#288/#630). Verified identical on unfixed `develop` — pre-existing, unrelated.

## MCP parity

**No MCP surface.** `_mint_recaptcha_token` is internal to `FlowApiClient`, below both doors — the MCP `gflow_generate_image` path reaches the identical method and inherits this automatically. No leaf, option, payload key or docstring changes. Stated explicitly per the second law.

## Follow-up worth its own issue

`discover_site_key` (`recaptcha.py:64`) runs an unguarded `page.evaluate` while its docstring promises it "Raises `RecaptchaError`". Any caller can therefore get a raw Playwright error instead. Out of scope here — this PR defends against it rather than reshaping `recaptcha.py`'s contract.

Refs #692, #678, #639