### PR TITLE
test(e2e): skip labs-only sidebar tests on a migrated profile

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -28,16 +28,19 @@ See docs/E2E_TESTING.md for the full layer reference.
 
 from __future__ import annotations
 
+import functools
 import os
 import shutil
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from pathlib import Path
+from typing import ParamSpec
 
 import pytest
 
 from gflow_cli.config import get_settings, reset_settings
+from gflow_cli.errors import FlowHostMigratedError
 
 _E2E_PROFILE_ENV = "GFLOW_CLI_E2E_PROFILE"
 
@@ -138,3 +141,36 @@ def e2e_env(tmp_path: Path) -> Iterator[dict[str, str]]:
     env["GFLOW_CLI_PROFILE"] = name
     env["GFLOW_CLI_HISTORY_PROMPTS"] = "store"
     yield env
+
+
+_P = ParamSpec("_P")
+
+
+def skip_on_migrated_host(
+    fn: Callable[_P, Awaitable[None]],
+) -> Callable[_P, Awaitable[None]]:
+    """Skip a labs-frontend e2e test when the profile has moved to flow.google.com.
+
+    Some e2e tests drive affordances that exist only on ``labs.google`` — the
+    Agent toggle, the sidebar, ``mode_control``. The migrated host renders none
+    of them, so on a moved account these tests raise
+    :class:`FlowHostMigratedError` and can never pass, however healthy the
+    product is. That is a missing precondition, not selector drift.
+
+    Left unguarded they report RED nightly: in issue #559 (2026-09-06) three of
+    five canary failures were exactly this, and a canary that cries wolf stops
+    being read.
+
+    Catching the typed error rather than probing the URL is deliberate — the
+    bail can fire at client setup, at ``get_ui_driver``, or at ``mode_control``,
+    and the exception is the only thing common to all three.
+    """
+
+    @functools.wraps(fn)
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
+        try:
+            await fn(*args, **kwargs)
+        except FlowHostMigratedError:
+            pytest.skip("labs-only affordance; this profile is on the migrated host")
+
+    return wrapper

--- a/tests/e2e/test_sidebar_recovery_e2e.py
+++ b/tests/e2e/test_sidebar_recovery_e2e.py
@@ -37,6 +37,7 @@ import pytest
 
 from gflow_cli.api.transports import mode_control
 from gflow_cli.api.transports.mode_control import AGENT_TOGGLE_SELECTOR, CROP_SELECTORS
+from tests.e2e.conftest import skip_on_migrated_host
 
 pytestmark = [pytest.mark.e2e, pytest.mark.e2e_auth]
 
@@ -126,6 +127,7 @@ async def _drive_into_sidebar_state(page: Any) -> bool:
 
 
 @pytest.mark.asyncio
+@skip_on_migrated_host
 async def test_expanded_sidebar_hides_both_affordances_and_is_recoverable(
     e2e_profile_dir: Path,
 ) -> None:
@@ -149,6 +151,7 @@ async def test_expanded_sidebar_hides_both_affordances_and_is_recoverable(
 
 
 @pytest.mark.asyncio
+@skip_on_migrated_host
 async def test_recovers_when_the_scoped_close_selector_misses(
     e2e_profile_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

The nightly canary ([#559](https://github.com/ffroliva/gflow-cli/issues/559)) went RED on 2026-09-06 with five failures. I re-ran all five on `develop` against a migrated profile and triaged them:

| Failure | Cause |
|---|---|
| `test_e2e_verify_flow_profile_authenticated` | ✅ already fixed by #693 |
| `test_e2e_health_check_false_after_close` | ✅ already fixed by #693 |
| `test_expanded_sidebar_hides_both_affordances_and_is_recoverable` | **this PR** |
| `test_recovers_when_the_scoped_close_selector_misses` | **this PR** |
| `test_incident_bundle_diagnostic_quality` | ❌ **a real regression — filed separately, deliberately not silenced** |

## The two this PR fixes

They drive affordances that exist only on `labs.google` — the Agent toggle, the sidebar, `mode_control`. The migrated host renders none of them, so on a moved account they fail with:

```
ui_driver.migrated_host_bail  at=mode_control  url=https://flow.google.com/project/<id>
gflow_cli.errors.FlowHostMigratedError  (_common.py:131)
```

That is a **missing precondition, not selector drift**. The product is behaving correctly; the tests have an unstated assumption about which frontend they are pointed at. No amount of selector work would fix them, and left unguarded they report RED every night — which is worse than useless, because a canary that cries wolf stops being read.

`skip_on_migrated_host` catches the **typed error** rather than probing the URL, deliberately: the bail can fire at client setup, at `get_ui_driver`, or at `mode_control`, and the exception is the only thing common to all three.

## What is NOT in this PR, and why

`test_incident_bundle_diagnostic_quality` was the fifth failure. **I initially assumed it shared the sidebar's cause** — both appeared in a run whose log carried `migrated_host_bail` — and said so on #559. Verifying it on its own showed that was wrong:

```
AssertionError: UI bundle fidelity 0.667 — captured noise, not real state
notes=['Q1 partial: manifest.command is null (direct-capture path?)']
```

That is a genuine incident-bundle quality regression. Wrapping it in a skip would have converted a real defect into a permanent green — exactly the failure mode this PR exists to prevent. It gets its own issue.

Also worth noting for whoever reads #559 next: `test_e2e_verify_flow_profile_authenticated` only fails the way it did on a **migrated** profile, so the canary's own account has been moved. That is what makes these two permanent rather than flaky.

## Test plan

- [x] Both sidebar tests now **SKIP** on a migrated profile (were: 2 failed) — verified live
- [x] Full offline suite — **4006 passed**, 24 skipped
- [x] `ruff` / `ruff format --check` / `uv run pyright src` (0 errors) / doc links / repo hygiene
- [x] Unaffected e2e in the same files still run and pass (not blanket-skipped)

## MCP parity

**No MCP surface** — test-only change, no CLI leaf, option, payload key or docstring touched.

Refs #559