### PR TITLE
fix(autopilot): stop re-alerting a deferred PR on every push

### DIFF
--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -275,6 +275,24 @@ def get_ledger_entries(ledger_path: Path) -> list[dict]:
     return entries
 
 
+def latest_status(ledger_entries: list[dict], pr_num: int) -> str | None:
+    """Status of the most recent ledger entry for this PR, or None.
+
+    Gate alerts (DEFERRED_SIZE / NEEDS-HUMAN) dedupe on this instead of on
+    (pr, head_sha): an oversized PR keeps getting pushes, and every new SHA
+    re-sent a byte-identical "needs a manual review" mail on the next hourly
+    cycle. PR #683 produced three of them on 2026-09-06 — same verdict, same
+    action, only the line count moved. Nothing after the first is signal.
+
+    Keyed on the LATEST entry, not any entry, so a PR that trips the gate,
+    gets fixed and reviewed, then regresses is alerted again.
+    """
+    for entry in reversed(ledger_entries):
+        if entry.get("pr") == pr_num:
+            return entry.get("status")
+    return None
+
+
 def append_ledger_entry(ledger_path: Path, entry: dict) -> None:
     """Append a new entry atomically to the JSONL ledger."""
     entry["timestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
@@ -547,13 +565,8 @@ def run_triage_cycle(
             continue
 
         if verdict == "DEFERRED_SIZE":
-            if any(
-                e.get("pr") == pr_num
-                and e.get("head_sha") == gate_sha
-                and e.get("status") == "DEFERRED_SIZE"
-                for e in ledger_entries
-            ):
-                logger.info("PR already deferred at this SHA; skipping re-alert", pr=pr_num)
+            if latest_status(ledger_entries, pr_num) == "DEFERRED_SIZE":
+                logger.info("PR already deferred; skipping re-alert", pr=pr_num)
                 continue
             logger.warning(
                 "PR deferred due to oversized diff", pr=pr_num, reason=gate_res["reasons"]
@@ -577,13 +590,8 @@ def run_triage_cycle(
             continue
 
         if verdict == "NEEDS-HUMAN":
-            if any(
-                e.get("pr") == pr_num
-                and e.get("head_sha") == gate_sha
-                and e.get("status") == "NEEDS-HUMAN"
-                for e in ledger_entries
-            ):
-                logger.info("PR already flagged at this SHA; skipping re-alert", pr=pr_num)
+            if latest_status(ledger_entries, pr_num) == "NEEDS-HUMAN":
+                logger.info("PR already flagged; skipping re-alert", pr=pr_num)
                 continue
             logger.warning(
                 "PR flagged for human triage in Stage 0", pr=pr_num, reason=gate_res["reasons"]

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -568,7 +568,7 @@ def test_send_email_alert_never_raises_on_subprocess_error(tmp_path, monkeypatch
     m_run.assert_called_once()
 
 
-def test_needs_human_dedupes_by_gate_sha(tmp_path):
+def test_needs_human_dedupes_across_pushes(tmp_path):
     mocks = _cycle_mocks()
     with (
         mocks[0] as m_email,
@@ -602,8 +602,20 @@ def test_needs_human_dedupes_by_gate_sha(tmp_path):
         assert m_email.call_count == 1
         assert m_comment.call_count == 1
 
+        # Third tick: a NEW push, still flagged -> still no re-alert.
+        m_gh.return_value = [{"number": 7, "headRefOid": "sha-y"}]
+        with patch(
+            "pr_triage_autopilot.get_ledger_entries",
+            return_value=[{"pr": 7, "head_sha": "sha-x", "status": "NEEDS-HUMAN"}],
+        ):
+            pr_triage_autopilot.run_triage_cycle(
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
+            )
+        assert m_email.call_count == 1
+        assert m_comment.call_count == 1
 
-def test_deferred_size_dedupes_by_gate_sha(tmp_path):
+
+def test_deferred_size_dedupes_across_pushes(tmp_path):
     mocks = _cycle_mocks()
     with (
         mocks[0] as m_email,
@@ -635,6 +647,31 @@ def test_deferred_size_dedupes_by_gate_sha(tmp_path):
             )
         assert m_email.call_count == 1
         assert m_comment.call_count == 0
+
+        # Third tick: a NEW push, still oversized -> still no re-alert.
+        # PR #683 sent three identical mails this way on 2026-09-06.
+        m_gh.return_value = [{"number": 7, "headRefOid": "sha-y"}]
+        with patch(
+            "pr_triage_autopilot.get_ledger_entries",
+            return_value=[{"pr": 7, "head_sha": "sha-x", "status": "DEFERRED_SIZE"}],
+        ):
+            pr_triage_autopilot.run_triage_cycle(
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
+            )
+        assert m_email.call_count == 1
+
+        # Fourth tick: the PR was reviewed in between, then regressed -> alert again.
+        with patch(
+            "pr_triage_autopilot.get_ledger_entries",
+            return_value=[
+                {"pr": 7, "head_sha": "sha-x", "status": "DEFERRED_SIZE"},
+                {"pr": 7, "head_sha": "sha-y", "status": "COMPLETED"},
+            ],
+        ):
+            pr_triage_autopilot.run_triage_cycle(
+                "org/repo", tmp_path, tmp_path, tmp_path / "l.jsonl", "tok"
+            )
+        assert m_email.call_count == 2
 
 
 # --- Claude subscription auth via CLAUDE_CODE_OAUTH_TOKEN (2026-08-02) -------


### PR DESCRIPTION
## Summary

The PR-triage autopilot mailed the operator three identical "Deferred: diff too large" notices for PR #683 on 2026-09-06 (01:00, 13:00, 14:00 UTC). Same verdict, same required action — only the line count moved (2130 → 2500 → 3066).

**Root cause:** the `DEFERRED_SIZE` and `NEEDS-HUMAN` gate branches deduped on `(pr, head_sha, status)`. An oversized PR keeps getting pushes, so every new SHA looked new to the ledger check and re-sent the alert on the next hourly cycle.

**Fix:** dedupe on the PR's *latest* ledger status via a new `latest_status()` helper. One alert per gate trip. Keyed on the latest entry rather than any entry, so a PR that trips the gate, gets fixed and reviewed (`COMPLETED`), then regresses is alerted again.

## Test plan
- [x] `tests/autopilot/test_pr_triage_autopilot.py` — both dedupe tests extended with a third tick that pushes a **new SHA** while the PR stays oversized/flagged (the actual regression), and the deferred test with a fourth tick proving a post-review regression re-alerts. 62 passed.
- [x] `ruff check src tests` / `ruff format --check src tests` clean.
- [x] **Verified against the real deployed code on cgserver01** with a before/after control: pre-fix code sent 2 mails for one PR pushed twice, deployed code sent 1.