### PR TITLE
fix: -o with an existing directory no longer costs a clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`-o <existing directory>` no longer costs you a clip.** `--output` on `video t2v` / `i2v` /
+  `r2v` and on `image t2i` / `i2i` accepted a path that was already a directory. Nothing checked
+  it until `_relocate_video_output` called `Path.replace()` onto the target, long after Flow had
+  rendered and billed the clip: `PermissionError: [WinError 5]`, surfaced as a bare
+  "Unexpected error" (exit 1), with the paid mp4 orphaned under a bare UUID name in the working
+  directory. Found by dogfooding an r2v run on 2026-09-06 — two clips billed, neither saveable.
+  All five option declarations now carry `dir_okay=False`, which Click enforces while parsing, so
+  the run aborts in under a second at zero cost. (A sixth declaration already had it; the rest had
+  drifted from it.)
+
+- **PR-triage autopilot: stop re-alerting a deferred PR on every push.** The `DEFERRED_SIZE` and
+  `NEEDS-HUMAN` gate branches deduped on `(pr, head_sha, status)`, so every push to an oversized
+  PR looked new to the ledger and re-sent a byte-identical "needs a manual review" mail on the
+  next hourly cycle. PR #683 produced three on 2026-09-06 (2130 / 2500 / 3066 lines) — same
+  verdict, same required action. Now dedupes on the PR's latest ledger status via a new
+  `latest_status()` helper: one alert per gate trip, and a PR that trips, gets fixed and reviewed,
+  then regresses still alerts again. Ops tooling under `scripts/autopilot/`, not a Flow surface,
+  so no e2e applies. ([#697](https://github.com/ffroliva/gflow-cli/issues/697))
+
 - **A reCAPTCHA mint that fails after the migrated-host handoff now reports exit 36, not exit 1**
   ([#692](https://github.com/ffroliva/gflow-cli/issues/692)). The `raise_if_migrated` guard added
   in #678 is a point-in-time read of `page.url`, and Flow's handoff to `flow.google.com` is a

--- a/src/gflow_cli/cli_image.py
+++ b/src/gflow_cli/cli_image.py
@@ -873,7 +873,7 @@ _ui_mode_option = click.option(
     "-o",
     "--output",
     "output_file",
-    type=click.Path(path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help="Explicit output file path for the generated asset.",
 )
@@ -1667,7 +1667,7 @@ class _I2IParams:
     "-o",
     "--output",
     "output_file",
-    type=click.Path(path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help="Explicit output file path for the generated asset.",
 )

--- a/src/gflow_cli/cli_video.py
+++ b/src/gflow_cli/cli_video.py
@@ -126,7 +126,7 @@ def _shared_gen_tail_options(f: Any) -> Any:
                 "--output",
                 "output_file",
                 default=None,
-                type=click.Path(path_type=Path),
+                type=click.Path(dir_okay=False, path_type=Path),
                 help="Explicit output file path for the generated asset.",
             ),
             click.option(
@@ -1488,7 +1488,7 @@ def i2v(  # NOSONAR
     "-o",
     "--output",
     "output_file",
-    type=click.Path(path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help="Explicit output file path for the generated asset.",
 )
@@ -1666,7 +1666,7 @@ def r2v(
     "-o",
     "--output",
     "output_file",
-    type=click.Path(path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help="Explicit output file path for the generated chain clips.",
 )

--- a/tests/cli/test_cli_video.py
+++ b/tests/cli/test_cli_video.py
@@ -1701,3 +1701,38 @@ class TestDurationCapabilityGuard:
             ],
         )
         assert "caps at" not in result.output
+
+
+@pytest.mark.parametrize("sub", ["t2v", "i2v", "r2v"])
+def test_output_rejects_an_existing_directory_before_generating(tmp_path: Path, sub: str) -> None:
+    """`-o <existing dir>` must fail at parse time, not after a paid generation.
+
+    `_relocate_video_output` calls `Path.replace()` onto the target, which raises
+    `PermissionError: [WinError 5]` when the target is a directory. That happens
+    AFTER Flow has rendered and billed the clip, so it surfaced as a bare
+    "Unexpected error" exit 1 and left the paid mp4 orphaned under a UUID name at
+    the repo root. Measured 2026-09-06 on a live r2v run: two clips billed, both
+    unsaveable.
+
+    Click checks `dir_okay=False` while parsing, so the run aborts at $0.
+    """
+    runner = CliRunner()
+    outdir = tmp_path / "already-a-directory"
+    outdir.mkdir()
+    ref = tmp_path / "r.png"
+    ref.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    args = [sub, "a prompt", "-o", str(outdir)]
+    if sub == "i2v":
+        args += ["--initial-frame", str(ref)]
+    if sub == "r2v":
+        args += ["--ref", str(ref)]
+
+    with (
+        patch("gflow_cli.cli_video._resolve_profile", return_value="default"),
+        patch("gflow_cli.cli_video._make_provider_dir", return_value=tmp_path),
+    ):
+        result = runner.invoke(video, args)
+
+    assert result.exit_code == 2, result.output
+    assert "directory" in result.output.lower(), result.output


### PR DESCRIPTION
## Summary

`--output` on `video t2v` / `i2v` / `r2v` and on `image t2i` / `i2i` accepted a path that was already a directory. Nothing checked it until `_relocate_video_output` called `Path.replace()` onto the target, **long after Flow had rendered and billed the clip**. That raises `PermissionError: [WinError 5]`, surfaced as a bare "Unexpected error" (exit 1), leaving the paid mp4 orphaned under a UUID name in the working directory.

```
# before: ~2 minutes, one clip billed, unsaveable
Unexpected error. Re-run with GFLOW_CLI_DEBUG_TRACEBACK=1 to see the real error.   exit 1

# after
Error: Invalid value for '-o' / '--output': File 'tmp/promo' is a directory.       exit 2, 0.8s, $0
```

## How it was found

Dogfooding. An `r2v` run on the migrated host on 2026-09-06 **billed two clips, neither saveable** — because the failure lands after generation, and the natural response is to retry.

## Root cause: drift, not omission

One of the six `--output` declarations (`scene create`) **already carried `dir_okay=False`**. The other five had drifted from it. Click enforces `dir_okay` while parsing, so the run now aborts before any browser launches.

| file | declarations fixed |
|---|---|
| `cli_video.py` | 3 (shared t2v/i2v/r2v decorator, + 2) |
| `cli_image.py` | 2 |

## Test plan

- [x] 3 new parametrized tests (t2v/i2v/r2v), each **watched fail first**
- [x] The real CLI command that cost two clips now exits 2 in 0.8s, no browser, no credits
- [x] `tests/cli` — **574 passed**
- [x] `ruff` / `ruff format --check` / `uv run pyright src` (0 errors) / doc links

## Two findings from the same run that are NOT fixed here

Recorded rather than guessed at, both on refusal paths that cost nothing:

1. **The migrated model picker missed `arrow_drop_down` once** (exit 23), then worked on retry. Transient, not reproduced. Failing is free but *succeeding costs a clip*, so there is no zero-cost way to bisect it yet.
2. **Scraped model names carry the Material icon ligature** (`volume_upVeo 3.1 - Lite`) because `all_text_contents()` returns `textContent`. Matching is unaffected (`ModelMenuMatcher` is a substring test), so it is diagnostic-only. The clean fix needs the menu item's DOM shape to select the label apart from the icon, which has not been inspected — a regex strip would be a guess. Separately, the hint tells the user to pass those names to `--model`, but they were **never** valid `--model` values (Click takes `omni-flash|veo-lite|veo-fast|veo-quality|veo-lite-lp`), and fixing that properly means the transport importing CLI alias tables, which is a layering question worth deciding rather than rushing.

## MCP parity

**No MCP surface.** `--output` is a CLI-only convenience for where the file lands locally; the MCP tools return the artifact path rather than taking an output path. No leaf, option, payload key or docstring changes.