### PR TITLE
fix(696): the fidelity ligature signal was labs-only

### DIFF
--- a/scripts/dev/incident_bundle_quality.py
+++ b/scripts/dev/incident_bundle_quality.py
@@ -235,7 +235,16 @@ def score_bundle(bundle: Path, secrets: list[str] | None = None) -> QualityRepor
         fidelity_signals.append(bool(cats & _KNOWN_HOST_CATEGORIES))
         ui = _as_dict(_load(bundle, "ui.json"))
         if ui:
-            fidelity_signals.append(_int(ui.get("ligature_count")) > 0)
+            # "Did we snapshot a rendered page, or noise?" The Material icon
+            # ligature count was the proxy, and it is labs-only: the migrated
+            # flow.google.com frontend renders no `i.google-symbols` at all, so a
+            # good capture there scored 0.667 and read as "captured noise"
+            # (#696, measured — `ligatures: []` beside `div: 28, button: 5`).
+            # Ask the host-agnostic question instead: did the DOM have controls?
+            # A genuinely blank page still has neither, so this keeps discriminating.
+            tags = _as_dict(ui.get("tag_counts"))
+            rendered = _int(ui.get("ligature_count")) > 0 or _int(tags.get("button")) > 0
+            fidelity_signals.append(rendered)
             fidelity_signals.append(_as_dict(ui.get("url")).get("host_category") != "other")
     report.fidelity = (
         round(sum(fidelity_signals) / len(fidelity_signals), 3) if fidelity_signals else 1.0

--- a/tests/scripts/test_incident_bundle_quality.py
+++ b/tests/scripts/test_incident_bundle_quality.py
@@ -282,7 +282,10 @@ class TestDegradedBundles:
         ui["url"]["host_category"] = "other"
         (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
         report = score_bundle(b)
-        assert report.fidelity < 0.5  # 1 of 3 fidelity signals (ligatures) survives
+        # 1 of 3 signals survives: the DOM-rendered check. The fixture carries
+        # BOTH ligature_count 25 and button 36, so since #696 that signal is
+        # satisfied twice over — do not read this as isolating ligatures.
+        assert report.fidelity < 0.5
 
 
 def test_null_command_is_a_note_not_a_q1_failure(tmp_path: Path) -> None:
@@ -291,3 +294,56 @@ def test_null_command_is_a_note_not_a_q1_failure(tmp_path: Path) -> None:
     report = score_bundle(_ui_failure_bundle(tmp_path, extra={"command": None}))
     assert report.q1_what_failed is True
     assert any("command is null" in n for n in report.notes)
+
+
+def test_a_migrated_host_page_without_ligatures_is_still_real_state(tmp_path: Path) -> None:
+    """#696: `flow.google.com` renders no `i.google-symbols`, so a good capture scored 0.667.
+
+    The fidelity signal asked "did we snapshot a real rendered page, or noise?"
+    and used the Material icon ligature count as its proxy. That proxy is
+    labs-only. Measured on a live migrated bundle 2026-09-06: `ligatures: []`
+    and `ligature_count: 0`, while the very same snapshot carried
+    `div: 28, button: 5, iframe: 1, img: 3` and a Flow page title — a real page,
+    well captured, scored as "captured noise, not real state".
+
+    Same shape as #690, where `health_check` only recognised the old host.
+    """
+    b = _ui_failure_bundle(tmp_path)
+    ui = json.loads((b / "ui.json").read_text())
+    ui["ligatures"] = []
+    ui["ligature_count"] = 0
+    ui["tag_counts"] = {"div": 28, "button": 5, "iframe": 1, "img": 3}
+    ui["url"] = {"host_category": "flow_app", "route": "/"}
+    (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
+
+    report = score_bundle(b)
+
+    assert report.fidelity == 1.0, f"{report.fidelity} — notes: {report.notes}"
+
+
+def test_a_genuinely_empty_snapshot_still_drops_fidelity(tmp_path: Path) -> None:
+    """No ligatures AND no controls is noise, and must stay scored as noise.
+
+    Honest about what this is: a **characterization guard**, not a regression
+    test for #696. It passes against the pre-#696 expression too, because
+    nothing here distinguishes `ligature_count > 0` from
+    `ligature_count > 0 or button > 0` — both are False on an empty DOM.
+
+    It earns its place by pinning the arithmetic against a *future* widening.
+    The tempting next "fix" is to reach for `div > 0`, or to drop the signal to
+    a constant, either of which would score a blank page as real state and
+    silently retire the check. Asserting the exact value catches that; asserting
+    `< 1.0` would not.
+    """
+    b = _ui_failure_bundle(tmp_path)
+    ui = json.loads((b / "ui.json").read_text())
+    ui["ligatures"] = []
+    ui["ligature_count"] = 0
+    ui["tag_counts"] = {"div": 0, "button": 0}
+    (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
+
+    report = score_bundle(b)
+
+    # Exactly one of the three signals drops: the DOM is empty, while the
+    # network hosts and the page URL are still recognised.
+    assert report.fidelity == round(2 / 3, 3), f"{report.fidelity} — notes: {report.notes}"


### PR DESCRIPTION
## Summary

`score_bundle` scored a **real** migrated-host capture at `fidelity 0.667` — *"captured noise, not real state"* — failing the live e2e ([#696](https://github.com/ffroliva/gflow-cli/issues/696)).

Fidelity is three boolean signals. Signal 2 asked *"did we snapshot a rendered page?"* using the Material icon ligature count as its proxy. **That proxy is labs-only** — the migrated `flow.google.com` frontend renders no `i.google-symbols` at all, so a good capture scored 2 of 3.

Measured on a real bundle (2026-09-06, `image t2i` on a moved account):

| field | value | |
|---|---|---|
| `ligatures` / `ligature_count` | `[]` / `0` | ❌ signal 2 |
| `tag_counts` | `div 28, button 5, iframe 1, img 3` | a real page |
| `title.category` | `flow` | |
| `url` | `flow_app`, route `/` | ✅ signal 3 |
| network hosts | `flow_app, aisandbox, google_auth, google_cdn` | ✅ signal 1 |

The fix asks the host-agnostic question — **did the DOM have controls** — keeping the ligature clause so labs behaviour is unchanged.

## `manifest.command` was a red herring

The issue title named it. It is **populated** (`"image t2i"`), it is **not** in `q1_fields`, and a null there only appends a note. I filed the issue pointing at the wrong field; the real cause is above.

## Same shape as two other bugs today

- **#690** — `health_check` matched only `".google"`, so it rejected every `flow.google.com` account.
- **#694** — a handler that caught only `RecaptchaError`, when the race raises a raw Playwright error.
- **This** — a fidelity proxy that only knows the old host.

Each is a check encoding an assumption that was true on `labs.google`.

## Test plan

- [x] 2 new tests; the migrated-host one **watched fail (0.667) then pass (1.0)**
- [x] **Live e2e** `tests/e2e/test_incident_quality_e2e.py -m e2e` → **1 passed** (was failing)
- [x] 11/11 in the file; `ruff` + `ruff format --check` clean on `src tests` and on the changed script

## From adversarial review — two fixed, one recorded

1. **The "genuinely empty" test passed against the OLD code too**, so it guarded nothing about this change. It is now honest about being a **characterization guard** against a future widening, and asserts the exact value. Verified by forcing the signal to `True`, which the test then catches; `< 1.0` would not have.
2. **The sibling test's comment claimed "1 of 3 signals (ligatures) survives."** The fixture carries `ligature_count: 25` **and** `button: 36`, so that signal is now satisfied twice over. Comment corrected rather than left to mislead.
3. **Not closed:** whether a Google sign-in/consent interstitial on the migrated host renders buttons with no ligatures, which would score as "rendered". No bundle evidence exists either way, so the discrimination question stays open rather than being claimed proven.

## Why `ligature_count` is kept rather than dropped as redundant

Every account available here is migrated, so **no labs bundle can be produced** to prove a rendered labs page always has `button > 0`. Keeping the clause is the conservative choice under that evidence gap, not inertia.

## MCP parity

**No MCP surface.** `scripts/dev/incident_bundle_quality.py` is a dev scorer plus its tests; no CLI leaf, option, payload key or docstring is touched.

Closes #696