### PR TITLE
docs(skill): correct video-production drift found by using it

### DIFF
--- a/scripts/dev/incident_bundle_quality.py
+++ b/scripts/dev/incident_bundle_quality.py
@@ -235,7 +235,16 @@ def score_bundle(bundle: Path, secrets: list[str] | None = None) -> QualityRepor
         fidelity_signals.append(bool(cats & _KNOWN_HOST_CATEGORIES))
         ui = _as_dict(_load(bundle, "ui.json"))
         if ui:
-            fidelity_signals.append(_int(ui.get("ligature_count")) > 0)
+            # "Did we snapshot a rendered page, or noise?" The Material icon
+            # ligature count was the proxy, and it is labs-only: the migrated
+            # flow.google.com frontend renders no `i.google-symbols` at all, so a
+            # good capture there scored 0.667 and read as "captured noise"
+            # (#696, measured — `ligatures: []` beside `div: 28, button: 5`).
+            # Ask the host-agnostic question instead: did the DOM have controls?
+            # A genuinely blank page still has neither, so this keeps discriminating.
+            tags = _as_dict(ui.get("tag_counts"))
+            rendered = _int(ui.get("ligature_count")) > 0 or _int(tags.get("button")) > 0
+            fidelity_signals.append(rendered)
             fidelity_signals.append(_as_dict(ui.get("url")).get("host_category") != "other")
     report.fidelity = (
         round(sum(fidelity_signals) / len(fidelity_signals), 3) if fidelity_signals else 1.0

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -85,7 +85,7 @@ Load `https://labs.google/fx/tools/flow/project/<id>` in the profile's Chrome an
 | Lands on | Lane | What runs there |
 |---|---|---|
 | `labs.google/fx/…` | **A, full** | everything |
-| `flow.google.com/project/…` | **B, partial** | `video t2v --project` and `video i2v --initial-frame <local file> --project`. Everything else — `image`, `character create`, `r2v`, `extend`, `scene create`, `movie run`, and i2v by media UUID / `@Name` or with `--end-frame` — exits 36 **[CONSTRAINT]** |
+| `flow.google.com/project/…` | **B, partial** | `video t2v --project`, `video i2v --initial-frame <local file> --project`, and **`video r2v --ref <local file> --project`** (ported in v0.70.0, #683). Everything else — `image`, `character create`, `extend`, `scene create`, `movie run`, r2v by `@Name` or `--reference-entity`, and i2v by media UUID / `@Name` or with `--end-frame` — exits 36 **[CONSTRAINT]** |
 
 Lane B grows as forms are ported, so **confirm the row rather than trusting it**: the
 maintained list is [CONFIGURATION § `GFLOW_CLI_FLOW_HOST`](../../docs/CONFIGURATION.md#gflow_cli_flow_host)
@@ -141,6 +141,7 @@ One row per clip: id, camera setup, action, lines with delivery, duration, model
 `style → setting → geometry → cast → setup → action → dialogue → avoid`.
 
 - **Never name a film format** — "35mm", "IMAX", "film grain" draw a sprocket-hole border or change the medium **[CALIBRATED]**. Say "full-frame 16:9 image edge to edge" and put border, letterbox and vignette in the avoid list.
+- **That avoid-list entry is not sufficient on its own [CALIBRATED, 4 clips, veo-quality].** A shot opening "Cinematic close portrait…" returned 72 px letterbox bars top and bottom *while* carrying "full-frame 16:9 image edge to edge" and "letterbox bars" first in its avoid list. The word **cinematic** appears to be enough on its own; no format was named. Restating it positively and explicitly — **"full-frame 16:9 image filling the entire frame edge to edge, no bars, no border"** — returned three consecutive bar-free shots with everything else held constant. Measure it, do not eyeball it: `cropdetect` reported nothing on the bar-carrying clip, so check the frame's own dark-row extents instead. A plate cut from a barred clip carries the bars into every shot that references it.
 - **No age words near a person [CONSTRAINT].** One age phrasing failed eight generations running; a relational or role noun passed immediately with everything else held constant. Minors are refused outright.
 - Dialogue as prose with the delivery **before** the words: `NAME says, weary: …`. Levers, most to least reliable: volume, emotional state, pace, register, physical condition, accent.
 - The avoid list holds artefacts only. **Negations that name an action do not suppress it** — restate positively.
@@ -160,6 +161,18 @@ python clip_qa.py <clips_dir>            # fluidity, lip sync, A/V drift, per cl
 python clip_qa.py final.mp4              # the assembled cut
 python clip_qa.py --selftest <clip.mp4>  # prove the detector before believing it
 ```
+
+Directory mode matches **exactly** `[a-z]{2}\d{2}.mp4` — two letters then two digits, e.g.
+`ka01.mp4`. Descriptive names and `0100.mp4` both silently match nothing and report
+"no clips matched", which reads like a path error.
+
+**On a clip with no speech, run `--selftest` before acting on a sync verdict [CALIBRATED].**
+A wordless close-up flagged `DRIFT sync=+0.500s r=0.7` — correlation above the 0.3 threshold,
+so the gate applied. `--selftest` on that same clip then failed to recover a **known injected
+0.2 s** shift (`saw -0.500s`), which disqualifies the reading rather than confirming it. The
+detector correlates face-region motion against audio; with only wind on the track there is
+nothing for it to lock onto, and it locks onto noise. This is the skill's own listed weak spot
+("a lip-sync detector trusted without first proving it against a known delay") reproduced.
 
 | Gate | Threshold | Tier |
 |---|---|---|

--- a/skills/video-production/consistency.md
+++ b/skills/video-production/consistency.md
@@ -45,6 +45,19 @@ gflow character create --project <id> --name <Name> \
 
 The face prompt generates the first reference image. The body prompt is wrapped into a front/side/back triptych seeded by that face, so one generation yields all three angles on-model.
 
+**It is two generations but one unit of work.** `services/character_create.py` runs a
+persist-before-spend saga: create entity, persist STARTED, then face (slot 0) and body
+(slot 1) **sequentially, never gathered**. A crashed run resumes and skips the slots it
+already recorded, so re-running does not re-spend on a completed slot. You do not need to
+sequence or recover this yourself.
+
+**`--body-prompt` is optional, and omitting it is the quiet mistake.** A face-only entity
+still creates and still locks the face, so nothing fails — the cost only shows up later, as
+a cast with no on-model turnaround to reference. Pass it unless you have a reason not to.
+Note the ceiling this does *not* lift: per the wardrobe rule below, the triptych does **not**
+make the entity carry clothing, so the wardrobe token still has to be repeated verbatim in
+every prompt.
+
 ### The rules that make it hold
 
 - **Face prompt carries unchangeable features only** — build, hair, facial structure, eye colour, defining marks — on a plain or segmented background, which is also Flow's own documented guidance for references. No hats, glasses or props unless permanent.

--- a/tests/scripts/test_incident_bundle_quality.py
+++ b/tests/scripts/test_incident_bundle_quality.py
@@ -282,7 +282,10 @@ class TestDegradedBundles:
         ui["url"]["host_category"] = "other"
         (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
         report = score_bundle(b)
-        assert report.fidelity < 0.5  # 1 of 3 fidelity signals (ligatures) survives
+        # 1 of 3 signals survives: the DOM-rendered check. The fixture carries
+        # BOTH ligature_count 25 and button 36, so since #696 that signal is
+        # satisfied twice over — do not read this as isolating ligatures.
+        assert report.fidelity < 0.5
 
 
 def test_null_command_is_a_note_not_a_q1_failure(tmp_path: Path) -> None:
@@ -291,3 +294,56 @@ def test_null_command_is_a_note_not_a_q1_failure(tmp_path: Path) -> None:
     report = score_bundle(_ui_failure_bundle(tmp_path, extra={"command": None}))
     assert report.q1_what_failed is True
     assert any("command is null" in n for n in report.notes)
+
+
+def test_a_migrated_host_page_without_ligatures_is_still_real_state(tmp_path: Path) -> None:
+    """#696: `flow.google.com` renders no `i.google-symbols`, so a good capture scored 0.667.
+
+    The fidelity signal asked "did we snapshot a real rendered page, or noise?"
+    and used the Material icon ligature count as its proxy. That proxy is
+    labs-only. Measured on a live migrated bundle 2026-09-06: `ligatures: []`
+    and `ligature_count: 0`, while the very same snapshot carried
+    `div: 28, button: 5, iframe: 1, img: 3` and a Flow page title — a real page,
+    well captured, scored as "captured noise, not real state".
+
+    Same shape as #690, where `health_check` only recognised the old host.
+    """
+    b = _ui_failure_bundle(tmp_path)
+    ui = json.loads((b / "ui.json").read_text())
+    ui["ligatures"] = []
+    ui["ligature_count"] = 0
+    ui["tag_counts"] = {"div": 28, "button": 5, "iframe": 1, "img": 3}
+    ui["url"] = {"host_category": "flow_app", "route": "/"}
+    (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
+
+    report = score_bundle(b)
+
+    assert report.fidelity == 1.0, f"{report.fidelity} — notes: {report.notes}"
+
+
+def test_a_genuinely_empty_snapshot_still_drops_fidelity(tmp_path: Path) -> None:
+    """No ligatures AND no controls is noise, and must stay scored as noise.
+
+    Honest about what this is: a **characterization guard**, not a regression
+    test for #696. It passes against the pre-#696 expression too, because
+    nothing here distinguishes `ligature_count > 0` from
+    `ligature_count > 0 or button > 0` — both are False on an empty DOM.
+
+    It earns its place by pinning the arithmetic against a *future* widening.
+    The tempting next "fix" is to reach for `div > 0`, or to drop the signal to
+    a constant, either of which would score a blank page as real state and
+    silently retire the check. Asserting the exact value catches that; asserting
+    `< 1.0` would not.
+    """
+    b = _ui_failure_bundle(tmp_path)
+    ui = json.loads((b / "ui.json").read_text())
+    ui["ligatures"] = []
+    ui["ligature_count"] = 0
+    ui["tag_counts"] = {"div": 0, "button": 0}
+    (b / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
+
+    report = score_bundle(b)
+
+    # Exactly one of the three signals drops: the DOM is empty, while the
+    # network hosts and the page URL are still recognised.
+    assert report.fidelity == round(2 / 3, 3), f"{report.fidelity} — notes: {report.notes}"


### PR DESCRIPTION
## Summary

Four corrections to `skills/video-production`, all found while producing a real two-character piece on a migrated account today. The skill says *"confirm the row rather than trusting it"* — confirming it is what turned these up.

### 1. Lane B was stale, and it ruled out the only path that works

The table listed `r2v` as exit 36 on `flow.google.com`. **#683 ported it in v0.70.0** — `r2v` from local `--ref` files runs there now. An agent reading that row would rule out the only reference-driven path the lane actually has, and fall back to prompt-only. `r2v` by `@Name` / `--reference-entity` *does* still exit 36, so the row now distinguishes the two.

### 2. The letterbox avoid-list entry is not sufficient on its own

A shot opening *"Cinematic close portrait…"* returned **72 px bars top and bottom** while carrying `full-frame 16:9 image edge to edge` **and** `letterbox bars` first in its avoid list. No film format was named — **"cinematic" alone appears to be enough**.

Restating it positively (`filling the entire frame edge to edge, no bars, no border`) gave three consecutive clean shots with everything else held constant.

Two traps recorded with it: **`cropdetect` reported nothing** on the barred clip, so measure the frame's own dark-row extents instead; and never cut a reference plate from a barred clip, because the bars ride into every shot that references it.

### 3. `clip_qa` directory mode silently matches nothing

Doc says `<xx00>.mp4`; the regex is `[a-z]{2}\d{2}`. Both a descriptive name and `0100.mp4` match nothing and report "no clips matched", which reads like a path error.

### 4. A sync verdict on a wordless clip is not trustworthy

A close-up with no dialogue flagged `DRIFT sync=+0.500s r=0.7` — correlation above the 0.3 threshold, so the gate applied. `--selftest` on that same clip then **failed to recover a known injected 0.2 s shift** (`saw -0.500s`), which disqualifies the reading rather than confirming it.

The skill already lists this weak spot ("a lip-sync detector trusted without first proving it against a known delay"). This is it reproduced, now with the instruction to selftest **before** acting.

## `consistency.md` — two facts about character creation that were written down nowhere

- **It is two generations but one unit of work.** `services/character_create.py` runs a persist-before-spend saga: create entity, persist STARTED, then face (slot 0) and body (slot 1) **sequentially, never gathered**, resuming and skipping already-recorded slots. Nobody needs to sequence or recover it by hand.
- **`--body-prompt` is optional and omitting it is the quiet mistake.** A face-only entity still succeeds, so the cost only appears later as a cast with no on-model turnaround. Flagged together with the ceiling it does *not* lift: per the existing wardrobe rule, the triptych does **not** make the entity carry clothing, so the wardrobe token still repeats verbatim.

## Test plan

- [x] `check_doc_links.py`, `check_repo_hygiene.py`, `generate_website_docs.py --check` — green
- [x] Documentation/skill tests — 23 passed
- [x] Every claim added is from a run performed today, with the measurement stated inline; no claim is inferred

## MCP parity

**No MCP surface** — skill documentation only. No CLI leaf, option, payload key or tool docstring is touched.

Refs #683, #685