### PR TITLE
fix: close the migrated-host race, and stop character create exiting 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the run aborts in under a second at zero cost. (A sixth declaration already had it; the rest had
   drifted from it.)
 
+- **`character create` on a moved account now exits 36 instead of 1, and 20 s sooner.** The Flow
+  character editor is a labs-only surface: `flow.google.com` renders no prompt textbox for it,
+  ever. The readiness gate burned its full 20 s timeout and then raised a bare
+  `RuntimeError("Character editor not ready…")`, which the CLI reports as "Unexpected error"
+  (exit 1) rather than the typed, non-retryable exit 36 that names the migration and says why.
+  `raise_if_migrated` now runs after the post-`goto` settles and before the wait, so the user is
+  told something knowable immediately instead of paying 20 s for a worse answer. Found by
+  dogfooding a two-character production on a moved account.
+
 - **PR-triage autopilot: stop re-alerting a deferred PR on every push.** The `DEFERRED_SIZE` and
   `NEEDS-HUMAN` gate branches deduped on `(pr, head_sha, status)`, so every push to an oversized
   PR looked new to the ledger and re-sent a byte-identical "needs a manual review" mail on the
@@ -37,6 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the mint succeeds and classifies correctly whenever the hop lands, rather than depending on it
   landing before one particular line. A genuine labs-side reCAPTCHA failure still surfaces as
   `RecaptchaError`.
+
+  **The re-check now polls for a bounded 1.5 s rather than reading once.** A single instantaneous
+  read still lost the race: Playwright updates `page.url` on `framenavigated`, so a mint that dies
+  *while* the navigation is committing reads the old host on an account that is in fact migrated,
+  and the run exited 1. Polling turns "who won this instant" into "did the hop land at all". It is
+  the error path, so a successful mint never waits.
 
   The re-check catches **any** mint failure, not just `RecaptchaError`. `TokenMinter.mint` guards
   only its second `page.evaluate`: `site_key()` → `discover_site_key` runs an unguarded one, and

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -210,6 +210,12 @@ _SESSION_API_URL = "https://labs.google/fx/api/auth/session"
 # issue #222: the NextAuth Flow session cookie + the URL used to seed it.
 _FLOW_SESSION_COOKIE = "__Secure-next-auth.session-token"
 _FLOW_COOKIE_URL = _LABS_ORIGIN
+# #692: how long the post-failure migration re-check keeps watching `page.url`
+# for a hop that was still committing when the mint died. Error path only, so a
+# successful mint never waits. Small enough that a genuine labs-side reCAPTCHA
+# failure is not meaningfully delayed on its way to the user.
+_MIGRATION_RECHECK_BUDGET_S = 1.5
+_MIGRATION_RECHECK_POLL_S = 0.25
 
 
 def _parse_iso_to_epoch(value: object) -> float:
@@ -2440,9 +2446,21 @@ class FlowApiClient:
                 # succeeds, and correct whenever the hop lands, rather than
                 # depending on it landing before a particular line. A genuine
                 # labs-side reCAPTCHA failure still propagates as RecaptchaError.
+                # One instantaneous read still loses the race. Playwright updates
+                # `page.url` on `framenavigated`, so a mint that dies WHILE the
+                # navigation is committing reads the old host on an account that
+                # is in fact migrated. Poll for a bounded moment instead: this is
+                # already the error path, so the wait costs a successful run
+                # nothing, and it turns "who won this instant" into "did the hop
+                # land at all".
                 try:
-                    raise_if_migrated(page, at="mint_recaptcha_token_after_failure")
-                    probed_url = getattr(page, "url", None)
+                    deadline = time.monotonic() + _MIGRATION_RECHECK_BUDGET_S
+                    while True:
+                        raise_if_migrated(page, at="mint_recaptcha_token_after_failure")
+                        probed_url = getattr(page, "url", None)
+                        if time.monotonic() >= deadline:
+                            break
+                        await asyncio.sleep(_MIGRATION_RECHECK_POLL_S)
                 except FlowHostMigratedError:
                     raise
                 except Exception:

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -37,6 +37,7 @@ from gflow_cli.api.transports._common import (
     flow_host_kind,
     generation_error,
     offered_menu_labels,
+    raise_if_migrated,
 )
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
@@ -3566,6 +3567,16 @@ class UiAutomationTransport(VideoGenerationMixin):
         await self._settle_if_redirecting(page)
         await self._dismiss_blocking_overlays(page, self._out_dir)
         await self._settle_on_character_route(page, entity_id=entity_id, url=url)
+
+        # The character editor is a labs-only surface: the migrated host renders
+        # no prompt textbox for it, ever. Without this the readiness gate below
+        # burned its full 20 s and then raised a bare RuntimeError, which the CLI
+        # reports as "Unexpected error" (exit 1) instead of the typed,
+        # non-retryable exit 36 that names the migration. Measured live
+        # 2026-09-06 on a moved account. Placed AFTER the settles so the
+        # post-goto client-side hop has landed, and BEFORE the wait so the user
+        # does not pay 20 s to be told something knowable now.
+        raise_if_migrated(page, at="character_editor")
 
         # Wait for the Slate editor to mount — the prompt textbox is the
         # reliable "editor ready" anchor for the character editor surface.

--- a/tests/api/test_client_migrated_mint.py
+++ b/tests/api/test_client_migrated_mint.py
@@ -252,3 +252,52 @@ async def test_a_failing_url_probe_never_displaces_the_real_failure(
 
     with pytest.raises(RuntimeError, match="some unrelated playwright failure"):
         await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+
+class _HopsLateDuringMint:
+    """The hop is still committing when the mint dies.
+
+    #692 residual: the re-check read `page.url` once, at the instant of failure.
+    Playwright updates `page.url` on `framenavigated`, so a mint that dies while
+    the navigation is still committing sees the OLD host and the run exits 1 on
+    an account that is in fact migrated. The first reads return labs; the hop
+    lands a moment later.
+    """
+
+    reads_before_hop = 3
+
+    def __init__(self, page: Any, **_: Any) -> None:
+        self._page = page
+
+    async def mint(self, _action: str) -> str:
+        raise RecaptchaError("recaptcha/enterprise.js not found")
+
+
+class _LateHopPage:
+    def __init__(self) -> None:
+        self._reads = 0
+
+    @property
+    def url(self) -> str:
+        self._reads += 1
+        if self._reads <= _HopsLateDuringMint.reads_before_hop:
+            return "https://labs.google/fx/en/tools/flow"
+        return "https://flow.google.com/"
+
+
+@pytest.mark.asyncio
+async def test_a_hop_that_lands_just_after_the_failure_is_still_exit_36(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single instantaneous read loses the race; a bounded re-poll does not."""
+    monkeypatch.setattr(client_mod, "TokenMinter", _HopsLateDuringMint)
+    c = FlowApiClient.__new__(FlowApiClient)
+    c._page_queue = None
+    c._page = _LateHopPage()  # type: ignore[assignment]
+    returned: list[Any] = []
+    monkeypatch.setattr(c, "_checkin_page", returned.append)
+
+    with pytest.raises(FlowHostMigratedError):
+        await c._mint_recaptcha_token("IMAGE_GENERATION")
+
+    assert returned == [c._page], "the pool page must not leak on the reclassified path"

--- a/tests/api/transports/drivers/test_ui_mode.py
+++ b/tests/api/transports/drivers/test_ui_mode.py
@@ -413,3 +413,45 @@ class TestMigratedOriginFailsFast:
 
         page = _page_with_present({_CROP})  # MagicMock .url, never assigned
         assert await detect_ui_mode(page, timeout_s=0.1, poll_interval_s=0.01) == "classic"
+
+
+class TestCharacterEditorOnMigratedOriginFailsFast:
+    """`character create` on a moved account died as a bare RuntimeError, exit 1.
+
+    The character editor is a labs-only surface: `flow.google.com` renders no
+    prompt textbox for it, ever. So the readiness gate burned its full 20 s
+    timeout and then raised `RuntimeError("Character editor not ready: prompt
+    textbox not visible within 20 s")`, which the CLI reports as "Unexpected
+    error" (exit 1) rather than the typed, non-retryable exit 36 that names the
+    migration and tells the user why.
+
+    Measured live 2026-09-06 on a moved account. Fourth instance of the same
+    shape as #673 (image path) and #692 (the reCAPTCHA mint): a labs-only path
+    that fails unclassified on the migrated host.
+    """
+
+    @pytest.mark.asyncio
+    async def test_raises_exit_36_before_waiting_on_the_textbox(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+        from gflow_cli.errors import EXIT_CODE_MAP, FlowHostMigratedError, is_retryable
+
+        t = UiAutomationTransport.__new__(UiAutomationTransport)
+        t._out_dir = None  # type: ignore[attr-defined]
+        t._settle_if_redirecting = AsyncMock()  # type: ignore[attr-defined]
+        t._dismiss_blocking_overlays = AsyncMock()  # type: ignore[attr-defined]
+        t._settle_on_character_route = AsyncMock()  # type: ignore[attr-defined]
+
+        page = MagicMock()
+        page.goto = AsyncMock()
+        page.url = "https://flow.google.com/project/abc-123"
+        # The readiness gate must never be reached: that is the 20 s the user paid.
+        page.locator = MagicMock(side_effect=AssertionError("must not probe the DOM"))
+
+        with pytest.raises(FlowHostMigratedError) as exc_info:
+            await t._enter_character_editor(page, project_id="p-1", entity_id="e-1", locale="en")
+
+        page.locator.assert_not_called()
+        assert EXIT_CODE_MAP[FlowHostMigratedError] == 36
+        assert not is_retryable(exc_info.value)


### PR DESCRIPTION
## Summary

Two fixes, same family: **a labs-only path that fails unclassified on the migrated host instead of exiting 36.**

### 1. The reCAPTCHA re-check lost a race it did not need to ([#692](https://github.com/ffroliva/gflow-cli/issues/692) residual)

#694 re-checks migration when a mint fails, but read `page.url` **once**, at the instant of failure. Playwright updates `page.url` on `framenavigated`, so a mint that dies *while* the navigation is committing reads the old host on an account that is in fact migrated — and the run exits 1 anyway.

It now polls for a bounded **1.5 s** (0.25 s interval), turning *"who won this instant"* into *"did the hop land at all"*. Error path only: a successful mint never waits.

### 2. `character create` died as a bare `RuntimeError`, exit 1, after 20 seconds

The character editor is labs-only — `flow.google.com` renders no prompt textbox for it, ever. The readiness gate burned its full 20 s timeout, then raised `RuntimeError("Character editor not ready: prompt textbox not visible within 20 s")`, which the CLI reports as **"Unexpected error"**.

`raise_if_migrated` now runs **after** the post-`goto` settles (so the client-side hop has landed) and **before** the wait (so nobody pays 20 s to be told something knowable immediately).

```
# before
Unexpected error. Re-run with GFLOW_CLI_DEBUG_TRACEBACK=1…     exit 1, ~20s

# after, verified live on a moved account
Flow served the migrated flow.google.com frontend: …            exit 36, immediate
```

## How both were found

**Dogfooding.** Producing a real two-character piece on a moved account, where `character create` is the first thing you reach for.

## Fourth instance of one shape

| | |
|---|---|
| #673 | image path minted reCAPTCHA before the migration guard |
| #690 | `health_check` matched only `".google"` |
| #694 | a handler catching only `RecaptchaError` |
| **this** | a 20 s wait for a labs-only editor, and a single-read re-check |

Each is a check encoding an assumption that was true on `labs.google`.

## Test plan

- [x] 2 new tests, each **watched fail first**
- [x] The character test asserts the guard fires **before the DOM is probed** (`page.locator` must never be called), mirroring the existing `TestMigratedOriginFailsFast`, and pins exit 36 + non-retryable
- [x] **Live:** `gflow character create` on a moved account → **exit 36** with the migration message (was exit 1 after 20 s)
- [x] `tests/api` — **1525 passed**; `test_ui_mode.py` — 32 passed
- [x] `ruff check` / `ruff format --check` / `uv run pyright src` (0 errors) / doc links

## MCP parity

**No MCP surface.** Both changes are inside the transport/client error-classification paths, below both doors. The MCP tools reach the identical code and inherit the corrected exit class automatically. No leaf, option, payload key or docstring changes.

Refs #692, #639