### PR TITLE
feat(autopilot): pin the council review model to opus

### DIFF
--- a/scripts/autopilot/pr_triage_autopilot.py
+++ b/scripts/autopilot/pr_triage_autopilot.py
@@ -34,6 +34,22 @@ LOCK_FILE_PATH = "/tmp/pr_triage_autopilot.lock"
 SUPPORTED_ENGINES = ("council-claude",)
 DEFAULT_ENGINE = SUPPORTED_ENGINES[0]
 
+# Council model. Pinned in run_sandboxed_review.sh; mirrored here so the ledger
+# records WHICH model produced a verdict -- an unattributable verdict cannot be
+# re-examined after a model change. The orchestrator exports this into the
+# sandbox's environment, so for the automated path this value is the single
+# source of truth; the shell default only covers a hand-run of the script.
+# test_council_model_default_matches_the_shell_script pins the two together --
+# two defaults that can silently disagree is how a ledger starts lying.
+COUNCIL_MODEL_ENV = "GFLOW_TRIAGE_MODEL"
+DEFAULT_COUNCIL_MODEL = "opus"
+
+
+def council_model() -> str:
+    """The model the council runs on."""
+    return os.environ.get(COUNCIL_MODEL_ENV) or DEFAULT_COUNCIL_MODEL
+
+
 # Claude auth is the SUBSCRIPTION token minted by `claude setup-token`, read
 # from CLAUDE_CODE_OAUTH_TOKEN. This deployment has no ANTHROPIC_API_KEY
 # (operator decision, 2026-08-02).
@@ -412,8 +428,15 @@ def run_docker_sandbox(pr_num: int, repo_dir: Path, memory_dir: Path, gh_token: 
         gh_token,
     ]
 
-    logger.info("Running sandboxed Docker review", pr=pr_num)
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    model = council_model()
+    logger.info("Running sandboxed Docker review", pr=pr_num, model=model)
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, COUNCIL_MODEL_ENV: model},
+    )
     if proc.returncode != 0:
         raise RuntimeError(
             f"Docker sandbox failed (exit {proc.returncode}): {proc.stderr.strip()}\n{proc.stdout}"
@@ -689,6 +712,7 @@ def run_triage_cycle(
                     "verdict": parsed_verdict,
                     "must_fixes": must_fixes,
                     "engine": engine,
+                    "model": council_model(),
                 },
             )
 

--- a/scripts/autopilot/run_sandboxed_review.sh
+++ b/scripts/autopilot/run_sandboxed_review.sh
@@ -34,6 +34,21 @@ if [ -z "$PR_NUM" ] || [ -z "$HOST_REPO" ] || [ -z "$HOST_MEMORY" ] || [ -z "$GH
   usage
 fi
 
+# Council model. PINNED, not left to the CLI default.
+#
+# The review is the only thing standing between an unread PR and `develop`, and
+# it is exactly the kind of judgement that degrades quietly on a weaker model:
+# a thin verdict still parses, still posts, and still reads like a review. Until
+# now no --model flag was passed anywhere in scripts/autopilot/, so the council
+# ran on whatever the Claude CLI happened to default to for this subscription --
+# a value that can change under us on a CLI upgrade, with no commit, no alert,
+# and no way to tell after the fact which model produced a given verdict.
+#
+# `opus` verified available on this subscription 2026-09-06 (`claude -p --model
+# opus` -> exit 0). Override for a deliberate experiment; do not weaken it to
+# save quota -- a cheap review that misses a defect costs more than it saves.
+COUNCIL_MODEL="${GFLOW_TRIAGE_MODEL:-opus}"
+
 # Claude auth: the subscription token minted by `claude setup-token`, read from
 # the environment (sourced from /opt/hermes/.env by the cron line). Deliberately
 # NOT a CLI flag -- an argv secret is visible to every local user via `ps`,
@@ -127,7 +142,7 @@ else
   echo "Warning: iptables or network subnet lookup not available. Firewall rules skipped." >&2
 fi
 
-echo "Launching sandboxed review for PR $PR_NUM..." >&2
+echo "Launching sandboxed review for PR $PR_NUM on model $COUNCIL_MODEL..." >&2
 COUNCIL_TOOLS="Bash(gh auth status:*) Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checks:*) Bash(gh pr list:*) Bash(git show:*) Bash(git rev-parse:*) Bash(git diff:*) Bash(git log:*) Bash(git ls-remote:*) Bash(grep:*) Bash(sort:*) Bash(head:*) Bash(tail:*) Bash(wc:*) Bash(awk:*) Bash(jq:*) Bash(cat:*) Bash(ls:*) Bash(comm:*) Bash(cut:*) Bash(uniq:*) Bash(tr:*) Read Grep Glob Task TodoWrite"
 COUNCIL_MEMORY_DIR="/home/nonroot/.claude/projects/C--development-github-gflow-cli/memory"
 # The council memory mount target is not arbitrary: SKILL.md D5 tells the
@@ -168,5 +183,6 @@ docker run --rm \
   -e GITHUB_TOKEN="$GH_TOKEN" \
   gflow-triage:latest \
   claude -p "Conduct a multi-dimensional council review of PR $PR_NUM in autonomous mode following /workspace/skills/pr-council-review/SKILL.md." \
+  --model "$COUNCIL_MODEL" \
   --add-dir "$COUNCIL_MEMORY_DIR" \
   --allowedTools "$COUNCIL_TOOLS"

--- a/tests/autopilot/test_pr_triage_autopilot.py
+++ b/tests/autopilot/test_pr_triage_autopilot.py
@@ -1100,3 +1100,50 @@ def test_entrypoint_has_no_dangling_memory_symlink():
         "entrypoint still links /memory, which nothing mounts since the memory tree "
         "moved to the path SKILL.md reads"
     )
+
+
+# --- Council model pinning (2026-09-06) --------------------------------------
+#
+# No --model flag was passed anywhere in scripts/autopilot/, so the council ran
+# on whatever the Claude CLI defaulted to for the subscription -- a value that
+# can change on a CLI upgrade with no commit and no alert, and that leaves no
+# record of which model produced a given verdict.
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SANDBOX_SCRIPT = ROOT / "scripts" / "autopilot" / "run_sandboxed_review.sh"
+
+
+def test_sandbox_pins_the_model_on_the_claude_invocation():
+    script = SANDBOX_SCRIPT.read_text(encoding="utf-8")
+    assert '--model "$COUNCIL_MODEL"' in script, "the council invocation must pin a model"
+
+
+def test_council_model_default_matches_the_shell_script():
+    # Two defaults that can drift apart is how the ledger starts lying about
+    # which model produced a verdict.
+    script = SANDBOX_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r'COUNCIL_MODEL="\$\{GFLOW_TRIAGE_MODEL:-([^}]+)\}"', script)
+    assert match, "run_sandboxed_review.sh must default COUNCIL_MODEL from GFLOW_TRIAGE_MODEL"
+    assert match.group(1) == pr_triage_autopilot.DEFAULT_COUNCIL_MODEL
+
+
+def test_council_model_is_overridable(monkeypatch):
+    monkeypatch.setenv(pr_triage_autopilot.COUNCIL_MODEL_ENV, "sonnet")
+    assert pr_triage_autopilot.council_model() == "sonnet"
+
+
+def test_council_model_falls_back_when_the_override_is_blank(monkeypatch):
+    # An empty env var must not silently unpin the model back to the CLI default.
+    monkeypatch.setenv(pr_triage_autopilot.COUNCIL_MODEL_ENV, "")
+    assert pr_triage_autopilot.council_model() == pr_triage_autopilot.DEFAULT_COUNCIL_MODEL
+
+
+def test_sandbox_subprocess_receives_the_pinned_model(tmp_path, monkeypatch):
+    monkeypatch.setenv(pr_triage_autopilot.COUNCIL_MODEL_ENV, "opus")
+    with patch("pr_triage_autopilot.subprocess.run") as m_run:
+        m_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="ok", stderr=""
+        )
+        pr_triage_autopilot.run_docker_sandbox(7, tmp_path, tmp_path, "tok")
+    env = m_run.call_args.kwargs["env"]
+    assert env[pr_triage_autopilot.COUNCIL_MODEL_ENV] == "opus"


### PR DESCRIPTION
## Summary

The PR-triage council ran on **whatever model the Claude CLI defaulted to**. There was no `--model` flag anywhere in `scripts/autopilot/` (grepped `--model`, `ANTHROPIC_MODEL`, `CLAUDE_MODEL` — zero hits).

That matters more here than in most places: a weaker model does not fail loudly on a code review. It returns a thinner verdict that still parses, still posts, and still reads authoritative. The default can also move on a CLI upgrade with no commit and no alert, and nothing recorded which model produced a given verdict.

- `run_sandboxed_review.sh` pins `--model "$COUNCIL_MODEL"`, default `opus`, overridable via `GFLOW_TRIAGE_MODEL`.
- The orchestrator exports the same value into the sandbox env (one source of truth for the automated path) and records `model` on the `COMPLETED` ledger entry, so verdicts become attributable.
- `test_council_model_default_matches_the_shell_script` pins the shell default to `DEFAULT_COUNCIL_MODEL`. Mutation-checked: flipping the shell default to `haiku` fails it.

## Test plan
- [x] 67 autopilot tests pass; `ruff check`/`format` clean; `bash -n` clean.
- [x] **Live on cgserver01:** `claude -p --model opus` → exit 0 on the host *and* inside `gflow-triage:latest` with the real subscription token.
- [ ] E2E: not applicable — `scripts/autopilot/` is ops tooling on the hermes VPS, not a Flow surface.

## Note on the fallback chain
This is half of the ask. The `claude → agy → freellmapi` chain is **blocked on the sandbox egress model**, not on the orchestrator: the firewall allowlists resolved IPs for `api.anthropic.com` and `github.com` only, and agy's endpoints (`antigravity.goog`, `oauth2.googleapis.com`, `accounts.google.com`) are Google IP pools that rotate. A `getent` snapshot would pass sometimes and DROP other times — a flaky fallback is worse than none. Fixing it means moving from IP rules to a domain-allowlisting egress proxy, which deserves its own change.