### PR TITLE
fix: drive character create on the migrated Flow host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,11 @@ website/site/
 
 # Local git hooks dir (core.hooksPath target) — machine-local tooling, never shipped
 .githooks/
+
+# HAR/DOM spike harness (scripts/dev/har-spike/) — the vendored scripts ARE
+# tracked; everything they generate is not. Captures carry auth cookies, Bearer
+# tokens and prompts, and the npm/agent-browser caches are 34 MB of noise.
+scripts/dev/har-spike/artifacts/
+scripts/dev/har-spike/.agent-browser/
+scripts/dev/har-spike/.npm-cache/
+!scripts/dev/har-spike/artifacts/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,34 @@ extension does not currently load plugins, so IDE-only users should include the 
 
 The SkillOpt harness at `scripts/dev/skillopt/` measures how accurately each skill guides an agent. It drives any OpenAI-compatible endpoint — OpenAI, a gateway (OpenRouter, LiteLLM, freellmapi), a local model, or Google's compat endpoint — through the project's own `GFLOW_CLI_LLM_*` settings, the same ones the prompt tools use; there is no separate provider configuration. See [`scripts/dev/skillopt/README.md`](scripts/dev/skillopt/README.md).
 
+## Spiking a blackbox surface — the two modes
+
+This project reverse-engineers Google Flow, so "go and look at the real thing" is a
+first-class development activity, not a last resort. Two harnesses exist. **Use one of
+them before writing a capture script from scratch.**
+
+| Mode | Where | Driver | Who clicks | Use when |
+|---|---|---|---|---|
+| **In-process** | `scripts/dev/spike_*.py` | Playwright, via gflow's own transport | the script | you can already drive the surface, or you want to see exactly what gflow sees |
+| **HAR + DOM** | [`scripts/dev/har-spike/`](scripts/dev/har-spike/README.md) | CDP-attached **real Chrome** through a pinned `agent-browser` | **a human, by hand** | the driver cannot reach the surface yet, or a capture is ambiguous and you need ground truth |
+
+Start in-process; escalate to the HAR harness when the driver cannot get far enough to
+observe anything. A hand-driven HAR is the tiebreaker.
+
+Both write to **gitignored** output — `scripts/dev/_spike_out/` and
+`scripts/dev/har-spike/artifacts/`. Captures carry Bearer tokens, cookies and prompts:
+`*.har` is gitignored repo-wide, and a capture must never be committed or pasted into an
+issue unredacted. Use `scripts/dev/har-spike/extract_har_summary.py` for the redacted
+summary that IS shareable. Findings belong in `docs/superpowers/spikes/`; the evidence
+that produced them stays local.
+
+> **The harness is vendored in for discoverability, and that is the whole point.** It
+> lived in a sibling directory outside git until 2026-09-06. Being outside the repo, no
+> agent could find it, nothing pinned its `agent-browser` version, and its one test ran
+> nowhere. A session that day wrote three capture scripts from scratch and only learned
+> the harness existed because the user said so — after concluding, wrongly, that a
+> working Flow feature was impossible. Keep it in-tree, keep its data disposable.
+
 ## Where to look next
 
 - **Architecture & target shape** → [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
@@ -317,6 +345,7 @@ The SkillOpt harness at `scripts/dev/skillopt/` measures how accurately each ski
 - **Known issues** (read before touching auth / reCAPTCHA) → [KNOWN_ISSUES.md](KNOWN_ISSUES.md)
 - **Current task** → `/gflow:status` · **Create a feature plan** → `/gflow:plan <feature>` · **Full roadmap** → [PLAN.md](PLAN.md)
 - **Release protocol** → [RELEASE.md](RELEASE.md)
+- **Spiking a live Flow surface** (HAR + DOM capture) → [scripts/dev/har-spike/README.md](scripts/dev/har-spike/README.md)
 
 ## Claude Code-specific notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the run aborts in under a second at zero cost. (A sixth declaration already had it; the rest had
   drifted from it.)
 
-- **`character create` on a moved account now exits 36 instead of 1, and 20 s sooner.** The Flow
-  character editor is a labs-only surface: `flow.google.com` renders no prompt textbox for it,
-  ever. The readiness gate burned its full 20 s timeout and then raised a bare
-  `RuntimeError("Character editor not ready…")`, which the CLI reports as "Unexpected error"
-  (exit 1) rather than the typed, non-retryable exit 36 that names the migration and says why.
-  `raise_if_migrated` now runs after the post-`goto` settles and before the wait, so the user is
-  told something knowable immediately instead of paying 20 s for a worse answer. Found by
-  dogfooding a two-character production on a moved account.
+- **`gflow character create` works on the migrated `flow.google.com` host.** It had never been
+  broken there — gflow was not driving it. The readiness gate waited for
+  `div[role="textbox"][data-slate-editor="true"]`, a React/**Slate** anchor; the migrated
+  frontend is Angular and renders the same editor with **ProseMirror**, so the gate timed out
+  after 20 s and the surface was read as absent. v0.69.0 then hardened that misreading into a
+  `raise_if_migrated` guard that aborted with exit 36 *before* probing the DOM, turning "our
+  selector missed" into a confident, non-retryable "this host will never do it". The gate now
+  accepts both anchors, the guard is gone, and the picker/result paths follow:
+
+  - body mode is anchored on the migrated editor's `<flow-slot-chip-button>` component
+    boundary (there is no `add_2` control there at all), its settle signal is the face
+    reference mounting from `flow-content.google/image/…`, and the prompt-box counter now
+    counts through the readiness anchor instead of Slate only — it reported 0 boxes on an
+    editor whose box was mounted and visible. `--body-prompt`, `--voice` and `--personality`
+    all complete on the migrated host as a result.
+  - each slot takes **its own** `primaryMediaId`, read from the project listing. The entity
+    exposes only a thumbnail id, and handing that to every slot made the body slot claim the
+    face's media — which `commit_workflow` then PATCHed onto the body workflow, corrupting it.
+    Reading Flow's own value makes that commit a no-op.
+  - the portrait is read back off the **entity** when the labs `batchGenerateImages` wire stays
+    silent. The migrated host generates over its own `batchexecute` (rpcid `ogiZ0b`), so the
+    listener timed out on work that had already succeeded — the entity carried a workflow id and
+    a thumbnail media id the moment the timeout fired. The ids now come off the entity itself,
+    which proves the character binding by construction rather than trusting a self-reported
+    `parentEntityId`, and the image is downloaded so `--output` and `image_paths` behave the
+    same on both hosts.
+
+  Verified live on a moved account: `display_name` patched, workflow id and thumbnail bound,
+  file on disk, and `--model nano2` / `--model nanopro` each selecting the tier asked for.
+  Recon: `scripts/dev/spike_migrated_character_*.py`.
+
+- **`character create --model` is now deterministic: it applies the tier you asked for, or it
+  fails.** The character model picker was best-effort — every failure path logged a warning and
+  let the generation run on whatever tier the editor happened to show, so `--model nano2` could
+  quietly return a Nano Banana Pro image with nothing in the output saying so. Three separate
+  faults did exactly that: it skipped the click entirely when `nano2` was requested (assuming
+  Nano Banana 2 was the editor default, which is true on labs and false on `flow.google.com`);
+  its option selector `:has-text('…')` was unanchored, so `.first` resolved to `<html>`; and its
+  menu-item lookup was unscoped, so `[role='menuitem']` mixed the open menu's entries with
+  hidden ones from the editor's other menus and `nth(i)` clicked a node that could not be
+  clicked. The menu also offers **three** tiers, not the documented two, and `Nano Banana 2` is
+  a prefix of `Nano Banana 2 Lite`.
+
+  Now: entries are read from the *visible* menu, matched in Python with an explicit exclusion,
+  an ambiguous or absent match refuses rather than guessing, and the selection is **verified by
+  re-reading the chip** rather than trusting the click. Anything else raises — `ConfigurationError`
+  for a tier the menu does not offer, `UiSelectorDriftError` for a picker that cannot be driven.
+  Aborting here is free: the picker runs before the prompt is submitted, so a refusal costs no
+  quota and no credits, while proceeding produces a paid artifact from the wrong model. Verified
+  live: four consecutive runs alternating `--model nano2` / `--model nanopro`, correct tier every
+  time.
+
+- **A failed `character create` no longer strands an "Untitled Character" in the project.** The
+  saga persists before it spends, and deliberately keeps its STARTED row so a retry can resume —
+  but that row is keyed on `(project_id, name)`, so a retry under any other name missed it and
+  minted a second entity, leaving the first orphaned with `refs=0` forever. A failure with no
+  slot committed now rolls the free entity back and marks the row FAILED. It asks the **backend**
+  first: an empty local `workflow_ids` means only that this process failed to read a result, and
+  on the migrated host a portrait generated fine while the client timed out — deleting on the
+  local signal alone would have destroyed finished work.
 
 - **PR-triage autopilot: stop re-alerting a deferred PR on every push.** The `DEFERRED_SIZE` and
   `NEEDS-HUMAN` gate branches deduped on `(pr, head_sha, status)`, so every push to an oversized

--- a/scripts/dev/har-spike/README.md
+++ b/scripts/dev/har-spike/README.md
@@ -1,0 +1,126 @@
+# HAR + DOM spike harness (agent-browser over CDP)
+
+**This is the second of gflow's two spike modes. Read [Which spike mode](#which-spike-mode)
+before writing a new capture script — the first mode is usually cheaper.**
+
+Drives a CDP-attached **real Chrome** through `agent-browser` to capture a full HAR of a
+Flow generation you trigger **by hand**. Nothing here is imported by `gflow_cli`: the
+harness adds no Node.js packages, no `node_modules`, no `package.json` and no
+`agent-browser.json` to the project. Scripts call a pinned package through:
+
+```powershell
+npx --yes --package agent-browser@0.27.0 agent-browser
+```
+
+npm cache, agent-browser sockets and generated evidence all stay inside this folder, and
+all three are gitignored.
+
+## Which spike mode
+
+| | `scripts/dev/spike_*.py` | this harness |
+|---|---|---|
+| Driver | in-process Playwright, gflow's own transport | CDP-attached real Chrome |
+| Who clicks | the script | **you**, by hand |
+| Sees | requests/responses the page makes while your code drives it | the complete HAR of a real user's generation |
+| Reach for it when | you can drive the surface, or want to observe gflow's own path | the driver cannot reach the surface yet, or you need ground truth for an undocumented wire |
+
+Start with a `spike_*.py`. Escalate here when a capture is ambiguous or the driver cannot
+get far enough to observe anything — a hand-driven HAR is the ground truth that settles it.
+
+Worked example: `spike_migrated_character_*.py` found the migrated character portrait
+generation on `batchexecute` rpcid `ogiZ0b` (2026-09-06) by listening on gflow's own page.
+
+## Goal
+
+The questions this harness was built to answer, kept because they document the technique:
+
+1. Does CDP-attached real Chrome report `navigator.webdriver === false`?
+2. Can `agent-browser` see a logged-in Flow page when attached to a gflow profile?
+3. Can it capture useful HAR/network evidence during a manual Flow generation?
+
+## Prerequisites
+
+- Node/npm available for `npx`.
+- Google Chrome installed.
+- A logged-in gflow profile created with `gflow auth login --browser chrome`.
+
+## 1. Launch Chrome With CDP
+
+From `scripts/dev/har-spike/`:
+
+```powershell
+.\scripts\launch-flow-chrome.ps1 -ProfileName default -Port 9334
+```
+
+If the script cannot infer the profile path, pass it explicitly:
+
+```powershell
+.\scripts\launch-flow-chrome.ps1 -ProfileDir "C:\path\to\profile_default" -Port 9334
+```
+
+Keep this Chrome window open while running the smoke script.
+
+## 2. Run The Smoke Test
+
+```powershell
+.\scripts\run-cdp-smoke.ps1 -Port 9334
+```
+
+## 3. Capture A Manual Flow Generation
+
+```powershell
+.\scripts\start-har-capture.ps1 -Port 9334
+```
+
+The start script opens Flow through the existing CDP-attached Chrome session, clears the
+request tracker, starts HAR recording, writes capture state under `artifacts/`, then
+exits. Use the Chrome window to trigger exactly one Flow generation. When the generation
+request has fired, stop and summarize the capture:
+
+```powershell
+.\scripts\stop-har-capture.ps1
+```
+
+The stop script saves:
+
+- raw HAR: `artifacts/flow-generation-<capture-id>.har`
+- filtered request list: `artifacts/network-requests-<capture-id>.json`
+- redacted comparison summary: `artifacts/flow-generation-<capture-id>.summary.json`
+
+Raw HAR and request artifacts are sensitive because they can contain auth cookies,
+headers, tokens, prompts, and generation metadata. **Keep them local.** `artifacts/`,
+`.agent-browser/` and `.npm-cache/` here are gitignored, and `*.har` is gitignored
+repo-wide, so a capture cannot be committed by accident. Use the redacted summary for
+transport comparison notes.
+
+You can also summarize an existing HAR directly:
+
+```powershell
+python .\scripts\extract_har_summary.py .\artifacts\capture.har --host aisandbox-pa.googleapis.com --out .\artifacts\capture.summary.json
+```
+
+## Expected Signal
+
+Good:
+
+```text
+navigator.webdriver: false
+```
+
+Bad:
+
+```text
+navigator.webdriver: true
+```
+
+If the value is `true`, CDP attach likely has no advantage over the current Playwright
+launch path for reCAPTCHA scoring.
+
+## Cleanup
+
+Close Chrome manually, then remove generated evidence if needed:
+
+```powershell
+Remove-Item -Recurse -Force .\.agent-browser, .\.npm-cache
+Remove-Item -Force .\artifacts\* -Exclude .gitkeep
+```

--- a/scripts/dev/har-spike/capture-agent-ui.ps1
+++ b/scripts/dev/har-spike/capture-agent-ui.ps1
@@ -1,0 +1,165 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ProjectUrl,
+    [string]$ProfileName = $env:GFLOW_CLI_PROFILE,
+    [string]$Locale = "en",
+    [string]$Engine = "cdp-real-chrome",
+    [int]$Port = 9334,
+    [string]$Session = "gflow-agent-ui",
+    [string]$AgentBrowserVersion = "0.27.0"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir | Out-Null
+
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = Join-Path $AgentStateDir "sockets"
+$env:AGENT_BROWSER_SESSION = $Session
+$env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "120000"
+
+New-Item -ItemType Directory -Force $env:AGENT_BROWSER_SOCKET_DIR | Out-Null
+
+function Invoke-AgentBrowser {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$CommandArgs
+    )
+
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) { throw "agent-browser failed with exit code $exitCode for: $($CommandArgs -join ' ')" }
+    return ($output -join [Environment]::NewLine)
+}
+
+function Get-EvalResult {
+    param([string]$Expr)
+    $json = Invoke-AgentBrowser @("--cdp", "$Port", "--json", "eval", $Expr)
+    $parsed = $json | ConvertFrom-Json
+    if (-not $parsed.PSObject.Properties['data']) {
+        throw "Unexpected agent-browser response (no .data field): $json"
+    }
+    return $parsed.data.result
+}
+
+# ---------------------------------------------------------------------------
+# Startup banner
+# ---------------------------------------------------------------------------
+
+Write-Host "Using isolated workspace:"
+Write-Host "  project:     $ProjectRoot"
+Write-Host "  artifacts:   $ArtifactsDir"
+Write-Host "  sockets:     $env:AGENT_BROWSER_SOCKET_DIR"
+Write-Host "  session:     $Session"
+Write-Host "  CDP target:  127.0.0.1:$Port"
+Write-Host "  profile:     $ProfileName"
+Write-Host "  project URL: $ProjectUrl"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Eval expressions
+# ---------------------------------------------------------------------------
+
+$signalsExpr = @'
+(() => {
+  const lig = (s) => Array.from(document.querySelectorAll(s)).map(e => (e.textContent||'').trim());
+  const all = lig('i.google-symbols, i.material-symbols-outlined');
+  const cropPresent = Array.from(document.querySelectorAll("button i.google-symbols"))
+      .some(e => (e.textContent||'').trim().startsWith('crop_'));
+  const agentPill = /\bAgent\b/.test(document.body.innerText||'') && !!document.querySelector("div[role='textbox']");
+  const chatPanel = all.includes('edit_square') && all.includes('close');
+  return { cropPresent, agentPill, chatPanel, url: location.href,
+           ligatures: Array.from(new Set(all)).filter(Boolean).sort() };
+})()
+'@
+
+$gatingExpr = @'
+(() => {
+  const next = document.getElementById('__NEXT_DATA__');
+  let keys = [];
+  try { const p = JSON.parse(next ? next.textContent : '{}');
+        keys = Object.keys((p.props && p.props.pageProps) || {}).sort(); } catch (e) { keys = ['<unparseable>']; }
+  return {
+    localStorage: Object.fromEntries(Object.entries(localStorage)),
+    sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+    documentCookieNames: (document.cookie || '').split('; ').map(c => c.split('=')[0]).filter(Boolean).sort(),
+    nextDataPagePropKeys: keys
+  };
+})()
+'@
+
+# ---------------------------------------------------------------------------
+# Capture flow
+# ---------------------------------------------------------------------------
+
+$ts = Get-Date -Format "yyyyMMdd-HHmmss"
+
+Write-Host "Opening project URL in attached Chrome..."
+Invoke-AgentBrowser @("--cdp", "$Port", "--json", "open", $ProjectUrl) | Out-Null
+Start-Sleep -Seconds 4
+
+Write-Host "Probing navigator.webdriver..."
+$webdriver = Get-EvalResult 'navigator.webdriver'
+
+Write-Host "Capturing signals (before recovery attempt)..."
+$signalsBefore = Get-EvalResult $signalsExpr
+
+Write-Host "Capturing gating data..."
+$gating = Get-EvalResult $gatingExpr
+
+Write-Host "Taking accessibility snapshot..."
+$snapPath = Join-Path $ArtifactsDir "agentui-snapshot-$ts.txt"
+Invoke-AgentBrowser @("--cdp", "$Port", "snapshot", "-i") | Set-Content -LiteralPath $snapPath -Encoding UTF8
+Write-Host "snapshot written: $snapPath"
+
+Write-Host ""
+Write-Host "Try to leave Agent mode in the Chrome window (click the Agent pill / close the chat panel)."
+Read-Host "Press Enter after attempting to reach the classic image controls"
+
+Write-Host "Capturing signals (after recovery attempt)..."
+$signalsAfter = Get-EvalResult $signalsExpr
+
+Write-Host "Starting HAR recording..."
+Invoke-AgentBrowser @("--cdp", "$Port", "--json", "network", "requests", "--clear") | Out-Null
+Invoke-AgentBrowser @("--cdp", "$Port", "--json", "network", "har", "start") | Out-Null
+
+Write-Host ""
+Write-Host "Now trigger exactly ONE image generation through the agentic UI (image gen is free)."
+Read-Host "Press Enter after the generation request has fired"
+
+$harFile = "flow-generation-$ts.har"
+Invoke-AgentBrowser @("--cdp", "$Port", "--json", "network", "har", "stop", (Join-Path $ArtifactsDir $harFile)) | Out-Null
+Write-Host "HAR written: $harFile"
+
+# ---------------------------------------------------------------------------
+# Assemble combined output JSON
+# ---------------------------------------------------------------------------
+
+$capture = [ordered]@{
+    profile            = $ProfileName
+    locale             = $Locale
+    engine             = $Engine
+    capturedAt         = $ts
+    projectUrl         = $ProjectUrl
+    navigatorWebdriver = $webdriver
+    signals            = [ordered]@{
+        cropPresent     = [bool]$signalsBefore.cropPresent
+        agentPill       = [bool]$signalsBefore.agentPill
+        chatPanel       = [bool]$signalsBefore.chatPanel
+        cropRecoverable = [bool]$signalsAfter.cropPresent
+    }
+    gating             = $gating
+    ligatures          = $signalsBefore.ligatures
+    harFile            = $harFile
+}
+
+$outPath = Join-Path $ArtifactsDir "agentui-capture-$ProfileName-$Locale-$ts.json"
+$capture | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $outPath -Encoding UTF8
+Write-Host "capture written: $outPath"

--- a/scripts/dev/har-spike/capture-media-scrape.ps1
+++ b/scripts/dev/har-spike/capture-media-scrape.ps1
@@ -1,0 +1,215 @@
+<#
+.SYNOPSIS
+  Capture before/after media-DOM evidence around ONE agentic-UI generation.
+
+.DESCRIPTION
+  The open question blocking AgenticFlowUiDriver.await_images is: when a generation
+  completes in the agentic cohort, do the resulting assets appear as countable DOM
+  nodes with a *remote* https src that can be scraped — or only as blob:/data: URIs,
+  background-image divs, or canvas pixels that defeat count-delta scraping?
+
+  This script attaches to an already-running CDP Chrome (launched via
+  launch-flow-chrome.ps1), snapshots all media nodes BEFORE a generation, waits for
+  you to trigger exactly one generation in the Chrome window, then snapshots AFTER and
+  computes the delta. It also records any dialog / warning text so we can validate the
+  content-policy fail-fast path.
+
+  Eval expressions are base64-wrapped (eval(atob('...'))) because multi-line eval args
+  get mangled through npx (see docs/AGENT_UI_RECON.md "How it was captured").
+
+.EXAMPLE
+  .\scripts\launch-flow-chrome.ps1 -ProfileName default -Port 9334
+  .\scripts\capture-media-scrape.ps1 -ProjectUrl "https://labs.google/fx/tools/flow/project/<uuid>" -ProfileName default -Port 9334
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ProjectUrl,
+    [string]$ProfileName = $env:GFLOW_CLI_PROFILE,
+    [string]$Locale = "en",
+    [int]$Port = 9334,
+    [string]$Session = "gflow-media-scrape",
+    [string]$AgentBrowserVersion = "0.27.0"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir | Out-Null
+
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = Join-Path $AgentStateDir "sockets"
+$env:AGENT_BROWSER_SESSION = $Session
+$env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "180000"
+
+New-Item -ItemType Directory -Force $env:AGENT_BROWSER_SOCKET_DIR | Out-Null
+
+function Invoke-AgentBrowser {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$CommandArgs)
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) { throw "agent-browser failed (exit $exitCode) for: $($CommandArgs -join ' ')" }
+    return ($output -join [Environment]::NewLine)
+}
+
+function Get-EvalResult {
+    # Base64-wrap the expression so multi-line JS survives npx arg parsing.
+    param([string]$Expr)
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Expr))
+    $wrapped = "eval(atob('$b64'))"
+    $json = Invoke-AgentBrowser @("--cdp", "$Port", "--json", "eval", $wrapped)
+    $parsed = $json | ConvertFrom-Json
+    if (-not $parsed.PSObject.Properties['data']) {
+        throw "Unexpected agent-browser response (no .data field): $json"
+    }
+    return $parsed.data.result
+}
+
+# ---------------------------------------------------------------------------
+# Eval expressions
+# ---------------------------------------------------------------------------
+
+# Cohort signal (same rule as capture-agent-ui.ps1) so the artifact records whether
+# this was genuinely the agentic UI.
+$signalsExpr = @'
+(() => {
+  const all = Array.from(document.querySelectorAll('i.google-symbols, i.material-symbols-outlined'))
+      .map(e => (e.textContent||'').trim());
+  const cropPresent = Array.from(document.querySelectorAll("button i.google-symbols"))
+      .some(e => (e.textContent||'').trim().startsWith('crop_'));
+  const agentPill = /\bAgent\b/.test(document.body.innerText||'') && !!document.querySelector("div[role='textbox']");
+  const chatPanel = all.includes('edit_square') && all.includes('close');
+  return { cropPresent, agentPill, chatPanel, agentic: (!cropPresent && (agentPill || chatPanel)) };
+})()
+'@
+
+# Media probe: every img/video + background-image div, classified by src kind, plus any
+# dialog / warning text for the content-policy fail-fast path.
+$mediaExpr = @'
+(() => {
+  const pick = (e) => {
+    const raw = e.currentSrc || e.getAttribute('src') || '';
+    let kind = 'other';
+    if (/^blob:/.test(raw)) kind = 'blob';
+    else if (/^data:/.test(raw)) kind = 'data';
+    else if (/^https?:/.test(raw)) kind = 'remote';
+    return {
+      tag: e.tagName.toLowerCase(), kind, src: raw.slice(0, 300),
+      w: e.naturalWidth || e.videoWidth || 0, h: e.naturalHeight || e.videoHeight || 0,
+      alt: (e.getAttribute('alt') || '').slice(0, 80),
+      cls: (e.className || '').toString().slice(0, 140),
+      testid: e.getAttribute('data-testid') || ''
+    };
+  };
+  const imgs = Array.from(document.querySelectorAll('img')).map(pick);
+  const vids = Array.from(document.querySelectorAll('video')).map(pick);
+  const bg = Array.from(document.querySelectorAll('[style*="background-image"]')).map((e) => {
+    const m = (e.getAttribute('style') || '').match(/url\((["']?)([^"')]+)\1\)/);
+    return { url: (m ? m[2] : '').slice(0, 300), cls: (e.className || '').toString().slice(0, 140) };
+  }).filter((x) => x.url && !/^data:/.test(x.url));
+  const dialogs = Array.from(document.querySelectorAll('[role="dialog"],[role="alert"],[aria-live="assertive"],[aria-live="polite"]'))
+    .map((e) => (e.innerText || '').trim()).filter(Boolean).map((t) => t.slice(0, 240));
+  const warnSymbols = Array.from(document.querySelectorAll('i.google-symbols, i.material-symbols-outlined'))
+    .map((e) => (e.textContent || '').trim()).filter((t) => ['warning', 'error', 'report', 'flag', 'block'].includes(t));
+  return {
+    url: location.href,
+    counts: { img: imgs.length, video: vids.length, bg: bg.length },
+    remoteImg: imgs.filter((x) => x.kind === 'remote').length,
+    blobImg: imgs.filter((x) => x.kind === 'blob').length,
+    canvasCount: document.querySelectorAll('canvas').length,
+    imgs, vids, bg, dialogs, warnSymbols
+  };
+})()
+'@
+
+# ---------------------------------------------------------------------------
+# Capture flow
+# ---------------------------------------------------------------------------
+
+$ts = Get-Date -Format "yyyyMMdd-HHmmss"
+
+Write-Host "Isolated workspace:"
+Write-Host "  artifacts:  $ArtifactsDir"
+Write-Host "  CDP target: 127.0.0.1:$Port"
+Write-Host "  profile:    $ProfileName"
+Write-Host "  projectURL: $ProjectUrl"
+Write-Host ""
+
+Write-Host "Opening project URL in attached Chrome..."
+Invoke-AgentBrowser @("--cdp", "$Port", "--json", "open", $ProjectUrl) | Out-Null
+Start-Sleep -Seconds 4
+
+$signals = Get-EvalResult $signalsExpr
+if ($signals.agentic) {
+    Write-Host "Cohort: AGENTIC (cropPresent=$($signals.cropPresent) agentPill=$($signals.agentPill) chatPanel=$($signals.chatPanel))" -ForegroundColor Green
+}
+else {
+    Write-Host "Cohort: CLASSIC (cropPresent=$($signals.cropPresent)). Re-run until the agentic UI is served — the cohort flaps per page load." -ForegroundColor Yellow
+}
+
+Write-Host "Capturing media snapshot BEFORE generation..."
+$before = Get-EvalResult $mediaExpr
+Write-Host "  before: img=$($before.counts.img) (remote=$($before.remoteImg) blob=$($before.blobImg)) video=$($before.counts.video) bg=$($before.counts.bg) canvas=$($before.canvasCount)"
+
+Write-Host ""
+Write-Host "Now trigger exactly ONE image generation through the agentic UI (image gen is free)."
+Write-Host "Wait until the generated image is fully visible (or an error/warning appears), THEN continue."
+Read-Host "Press Enter once the generation has completed (or failed)"
+
+Write-Host "Capturing media snapshot AFTER generation..."
+$after = Get-EvalResult $mediaExpr
+Write-Host "  after:  img=$($after.counts.img) (remote=$($after.remoteImg) blob=$($after.blobImg)) video=$($after.counts.video) bg=$($after.counts.bg) canvas=$($after.canvasCount)"
+
+# ---------------------------------------------------------------------------
+# Delta analysis — the actual evidence for/against count-delta DOM scraping
+# ---------------------------------------------------------------------------
+
+$beforeSrcs = @($before.imgs | ForEach-Object { $_.src })
+$newImgs = @($after.imgs | Where-Object { $beforeSrcs -notcontains $_.src })
+$newRemote = @($newImgs | Where-Object { $_.kind -eq 'remote' })
+$newBlob = @($newImgs | Where-Object { $_.kind -eq 'blob' })
+
+$beforeBg = @($before.bg | ForEach-Object { $_.url })
+$newBg = @($after.bg | Where-Object { $beforeBg -notcontains $_.url })
+
+$verdict =
+if ($newRemote.Count -gt 0) { "SCRAPEABLE: $($newRemote.Count) new <img> with remote https src" }
+elseif ($newBlob.Count -gt 0) { "PARTIAL: $($newBlob.Count) new <img> but blob: src (needs different extraction)" }
+elseif ($newBg.Count -gt 0) { "BG-IMAGE: assets surface as background-image divs, not <img>" }
+elseif (($after.canvasCount - $before.canvasCount) -gt 0) { "CANVAS: assets rendered to <canvas> — count-delta scraping will NOT work" }
+else { "INCONCLUSIVE: no new media nodes detected — check dialogs/warnings for a block/error" }
+
+Write-Host ""
+Write-Host "VERDICT: $verdict" -ForegroundColor Cyan
+
+$capture = [ordered]@{
+    profile      = $ProfileName
+    locale       = $Locale
+    capturedAt   = $ts
+    projectUrl   = $ProjectUrl
+    cohort       = if ($signals.agentic) { "agentic" } else { "classic" }
+    signals      = $signals
+    scrapeVerdict = $verdict
+    delta        = [ordered]@{
+        imgCountBefore = $before.counts.img
+        imgCountAfter  = $after.counts.img
+        newImgTotal    = $newImgs.Count
+        newImgRemote   = $newRemote.Count
+        newImgBlob     = $newBlob.Count
+        newBgImages    = $newBg.Count
+        canvasDelta    = ($after.canvasCount - $before.canvasCount)
+        newRemoteSrcs  = @($newRemote | ForEach-Object { $_.src })
+        newImgClasses  = @($newImgs | ForEach-Object { $_.cls } | Select-Object -Unique)
+    }
+    before       = $before
+    after        = $after
+}
+
+$outPath = Join-Path $ArtifactsDir "media-scrape-$ProfileName-$Locale-$ts.json"
+$capture | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $outPath -Encoding UTF8
+Write-Host "capture written: $outPath"

--- a/scripts/dev/har-spike/extract_har_summary.py
+++ b/scripts/dev/har-spike/extract_har_summary.py
@@ -1,0 +1,169 @@
+"""Create a redacted, transport-comparison summary from a HAR file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+SENSITIVE_HEADERS = {
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-goog-authuser",
+    "x-origin",
+}
+
+SENSITIVE_KEY_PARTS = (
+    "auth",
+    "batchid",
+    "bearer",
+    "cookie",
+    "credential",
+    "idtoken",
+    "key",
+    "nonce",
+    "recaptcha",
+    "sapisid",
+    "secret",
+    "session",
+    "sid",
+    "token",
+)
+
+PROMPT_KEYS = {"prompt", "textPrompt", "negativePrompt"}
+
+
+def _safe_url(url: str) -> tuple[str, str, list[str]]:
+    parsed = urlsplit(url)
+    query_keys = sorted({key for key, _value in parse_qsl(parsed.query, keep_blank_values=True)})
+    safe = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+    return safe, parsed.netloc, query_keys
+
+
+def _redact_header(name: str, value: str) -> str:
+    lowered = name.lower()
+    if lowered in SENSITIVE_HEADERS or any(part in lowered for part in SENSITIVE_KEY_PARTS):
+        return "<redacted:present>" if value else "<redacted:empty>"
+    return value
+
+
+def _headers_to_dict(headers: list[dict[str, Any]]) -> dict[str, str]:
+    safe: dict[str, str] = {}
+    for header in headers:
+        name = str(header.get("name", "")).strip()
+        if not name:
+            continue
+        value = str(header.get("value", ""))
+        safe[name.lower()] = _redact_header(name, value)
+    return safe
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in SENSITIVE_KEY_PARTS)
+
+
+def _redact_json(value: Any, key: str | None = None) -> Any:
+    if key in PROMPT_KEYS:
+        return "<redacted:prompt>"
+
+    if isinstance(value, dict):
+        return {str(k): _redact_json(v, str(k)) for k, v in value.items()}
+
+    if isinstance(value, list):
+        return [_redact_json(item) for item in value]
+
+    if key is not None and _is_sensitive_key(key):
+        return f"<redacted:{key}>"
+
+    return value
+
+
+def _summarize_body(post_data: dict[str, Any] | None) -> dict[str, Any]:
+    if not post_data:
+        return {"present": False}
+
+    text = post_data.get("text")
+    mime_type = post_data.get("mimeType")
+    summary: dict[str, Any] = {
+        "present": bool(text),
+        "mimeType": mime_type,
+        "length": len(text) if isinstance(text, str) else 0,
+    }
+
+    if isinstance(text, str) and text.strip():
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            summary["textPreview"] = "<redacted:non-json>"
+        else:
+            summary["json"] = _redact_json(parsed)
+
+    return summary
+
+
+def summarize_har(har_path: Path, *, host_filter: str | None = None) -> dict[str, Any]:
+    har = json.loads(har_path.read_text(encoding="utf-8"))
+    entries = har.get("log", {}).get("entries", [])
+    safe_entries: list[dict[str, Any]] = []
+
+    for entry in entries:
+        request = entry.get("request", {})
+        response = entry.get("response", {})
+        url = str(request.get("url", ""))
+        safe_url, host, query_keys = _safe_url(url)
+
+        if host_filter and host_filter not in host:
+            continue
+
+        safe_entries.append(
+            {
+                "request": {
+                    "method": request.get("method"),
+                    "url": safe_url,
+                    "host": host,
+                    "query_keys": query_keys,
+                    "headers": _headers_to_dict(request.get("headers", [])),
+                    "body": _summarize_body(request.get("postData")),
+                },
+                "response": {
+                    "status": response.get("status"),
+                    "headers": _headers_to_dict(response.get("headers", [])),
+                    "mimeType": response.get("content", {}).get("mimeType"),
+                },
+            }
+        )
+
+    return {
+        "source": str(har_path),
+        "host_filter": host_filter,
+        "entry_count": len(safe_entries),
+        "entries": safe_entries,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("har", type=Path, help="HAR file to summarize")
+    parser.add_argument("--host", default="aisandbox-pa.googleapis.com", help="Host substring filter")
+    parser.add_argument("--out", type=Path, help="Output JSON path")
+    args = parser.parse_args()
+
+    summary = summarize_har(args.har, host_filter=args.host)
+    output = json.dumps(summary, indent=2, sort_keys=True)
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/har-spike/launch-flow-chrome.ps1
+++ b/scripts/dev/har-spike/launch-flow-chrome.ps1
@@ -1,0 +1,104 @@
+[CmdletBinding()]
+param(
+    [string]$ProfileName = $env:GFLOW_CLI_PROFILE,
+    [string]$ProfileDir,
+    [string]$ProfileDirectory = "Default",
+    [int]$Port = 9334,
+    [string]$Url = "https://labs.google/fx/tools/flow?hl=en",
+    [switch]$NoNavigate
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Find-Chrome {
+    $candidates = @(
+        (Join-Path $env:ProgramFiles "Google\Chrome\Application\chrome.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"),
+        (Join-Path $env:LOCALAPPDATA "Google\Chrome\Application\chrome.exe")
+    )
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate)) {
+            return $candidate
+        }
+    }
+
+    $cmd = Get-Command chrome.exe -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+
+    throw "Google Chrome was not found. Pass a Chrome path manually by editing this script, or install Chrome."
+}
+
+function Get-CandidateGFlowHomes {
+    $candidateHomes = @()
+
+    if ($env:GFLOW_CLI_HOME) {
+        $candidateHomes += $env:GFLOW_CLI_HOME
+    }
+
+    if ($env:LOCALAPPDATA) {
+        $candidateHomes += (Join-Path $env:LOCALAPPDATA "gflow-cli")
+        $candidateHomes += (Join-Path $env:LOCALAPPDATA "ffroliva\gflow-cli")
+    }
+
+    if ($HOME) {
+        $candidateHomes += (Join-Path $HOME ".local\share\gflow-cli")
+    }
+
+    return $candidateHomes | Where-Object { $_ } | Select-Object -Unique
+}
+
+function Resolve-GFlowProfileDir {
+    param(
+        [string]$Name,
+        [string]$ExplicitDir
+    )
+
+    if ($ExplicitDir) {
+        $resolved = Resolve-Path -LiteralPath $ExplicitDir -ErrorAction Stop
+        return $resolved.Path
+    }
+
+    if (-not $Name) {
+        $Name = "default"
+    }
+
+    foreach ($candidateHome in Get-CandidateGFlowHomes) {
+        $candidate = Join-Path $candidateHome "profile_$Name"
+        if (Test-Path -LiteralPath $candidate) {
+            $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction Stop
+            return $resolved.Path
+        }
+    }
+
+    $searched = (Get-CandidateGFlowHomes | ForEach-Object { Join-Path $_ "profile_$Name" }) -join "`n  "
+    throw "Could not find gflow profile '$Name'. Searched:`n  $searched`nPass -ProfileDir explicitly."
+}
+
+$chrome = Find-Chrome
+$resolvedProfileDir = Resolve-GFlowProfileDir -Name $ProfileName -ExplicitDir $ProfileDir
+
+$argsList = @(
+    "--remote-debugging-port=$Port",
+    "--user-data-dir=$resolvedProfileDir",
+    "--profile-directory=$ProfileDirectory",
+    "--no-first-run",
+    "--no-default-browser-check"
+)
+
+if (-not $NoNavigate) {
+    $argsList += $Url
+}
+
+Write-Host "Launching Chrome:"
+Write-Host "  chrome:  $chrome"
+Write-Host "  profile: $resolvedProfileDir"
+Write-Host "  dir:     $ProfileDirectory"
+Write-Host "  CDP:     http://127.0.0.1:$Port"
+Write-Host ""
+Write-Host "Keep this Chrome window open while running scripts\run-cdp-smoke.ps1."
+
+Start-Process -FilePath $chrome -ArgumentList $argsList | Out-Null

--- a/scripts/dev/har-spike/probe-agent-mode.ps1
+++ b/scripts/dev/har-spike/probe-agent-mode.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+    [int]$Port = 9334,
+    [string]$Session = "gflow-agent-probe",
+    [string]$AgentBrowserVersion = "0.27.0"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSCommandPath
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = Join-Path $ProjectRoot ".agent-browser\sockets"
+$env:AGENT_BROWSER_SESSION = $Session
+
+New-Item -ItemType Directory -Force $env:AGENT_BROWSER_SOCKET_DIR | Out-Null
+
+function Invoke-AgentBrowser {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$CommandArgs
+    )
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "agent-browser failed with exit code $exitCode for: $($CommandArgs -join ' ')"
+    }
+    return ($output -join [Environment]::NewLine)
+}
+
+function Get-EvalResult {
+    param([string]$Expr)
+    $json = Invoke-AgentBrowser @("--cdp", "$Port", "--json", "eval", $Expr)
+    $parsed = $json | ConvertFrom-Json
+    if (-not $parsed.PSObject.Properties['data']) {
+        throw "Unexpected agent-browser response (no .data field): $json"
+    }
+    return $parsed.data.result
+}
+
+Write-Host "Probing Agent Mode and Sidebar layout on Flow (CDP port $Port)..."
+Write-Host "Please ensure Chrome is running on port $Port and loaded with a Flow project page."
+Write-Host ""
+
+# JS script to find Agent Mode toggle buttons, sparkle buttons, switches, and instruction panels in the DOM.
+$probeJs = @'
+(() => {
+  const results = [];
+  
+  // 1. Search for any buttons containing "Agent" or symbols related to spark
+  const elements = Array.from(document.querySelectorAll('button, div[role="button"], span, i, div[role="switch"]'));
+  elements.forEach((el, index) => {
+    const text = (el.innerText || el.textContent || '').trim();
+    const html = el.outerHTML;
+    const isSpark = /spark|article_spark|close/i.test(text) || /spark|article_spark|close/i.test(html);
+    const hasAgent = /agent/i.test(text);
+    
+    if (isSpark || hasAgent) {
+      results.push({
+        index,
+        tag: el.tagName,
+        text: text.substring(0, 50),
+        role: el.getAttribute('role'),
+        ariaChecked: el.getAttribute('aria-checked'),
+        className: el.className,
+        selector: el.id ? `#${el.id}` : `${el.tagName.toLowerCase()}[class="${el.className}"]`
+      });
+    }
+  });
+
+  // 2. Query specific known components
+  const closeBtn = document.querySelector("button:has(i.google-symbols:text-is('close'))");
+  const agentBtn = document.querySelector("button:has(i.google-symbols:text-is('article_spark'))");
+  const addCardBtn = document.querySelector("#instruction-add-card");
+  
+  return {
+    foundElements: results,
+    knownSelectors: {
+      closeBtnPresent: !!closeBtn,
+      agentBtnPresent: !!agentBtn,
+      addCardBtnPresent: !!addCardBtn
+    }
+  };
+})()
+'@
+
+try {
+  $res = Get-EvalResult $probeJs
+  Write-Host "=== DOM Probe Results ==="
+  Write-Host "Known elements present:"
+  Write-Host "  article_spark button (opens sidebar): $($res.knownSelectors.agentBtnPresent)"
+  Write-Host "  close button (closes sidebar):         $($res.knownSelectors.closeBtnPresent)"
+  Write-Host "  #instruction-add-card button:         $($res.knownSelectors.addCardBtnPresent)"
+  Write-Host ""
+  Write-Host "Details of matched elements:"
+  foreach ($el in $res.foundElements) {
+    Write-Host " - Tag: $($el.tag), Text: '$($el.text)', Role: $($el.role), Selector: $($el.selector)"
+  }
+} catch {
+  Write-Error "Failed to probe DOM: $_"
+}

--- a/scripts/dev/har-spike/probe_agent_mode.py
+++ b/scripts/dev/har-spike/probe_agent_mode.py
@@ -1,0 +1,120 @@
+"""Probe whether a gflow profile lands Flow in agent mode (manual, headed).
+
+Takes the profile by NAME and resolves it through gflow's own profile store,
+so the script runs on any machine and any account. It used to hardcode one
+developer's absolute Windows path — unrunnable for anyone else, and a
+repo-hygiene violation caught by scripts/ci/check_repo_hygiene.py the moment
+this harness moved in-tree.
+
+    python scripts/dev/har-spike/probe_agent_mode.py [profile-name]
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _spike_common import resolve_profile_dir  # noqa: E402
+
+
+async def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", nargs="?", default="default", help="gflow profile name")
+    args = parser.parse_args()
+
+    profile_dir = str(resolve_profile_dir(args.profile))
+    if not Path(profile_dir).exists():
+        print(f"Error: Profile directory does not exist: {profile_dir}")
+        sys.exit(1)
+
+    print(f"Launching Chrome with profile: {profile_dir}...")
+    async with async_playwright() as p:
+        # Launch persistent context using system Google Chrome
+        try:
+            context = await p.chromium.launch_persistent_context(
+                user_data_dir=profile_dir,
+                channel="chrome",
+                headless=False,
+                no_viewport=True
+            )
+        except Exception as e:
+            print(f"Error: Could not launch Chrome. Is another Chrome instance using this profile? Details: {e}")
+            sys.exit(1)
+
+        page = await context.new_page()
+        url = "https://labs.google/fx/tools/flow?hl=en"
+        print(f"Opening Flow URL: {url}...")
+        await page.goto(url)
+
+        print("\n" + "="*80)
+        print("Please use the opened Chrome window to navigate to a Flow project.")
+        print("Once you are on the project page, return here.")
+        print("="*80 + "\n")
+
+        input("Press Enter once you have loaded a Flow project...")
+
+        print("-" * 60)
+        print(f"Active page URL: {page.url}")
+        print(f"Active page title: {await page.title()}")
+        print("-" * 60)
+
+        # 1. Probe the DOM of the active project page
+        body_text = await page.inner_text("body")
+        has_agent_text = "agent" in body_text.lower()
+        print(f"Contains 'Agent' text on page: {has_agent_text}")
+
+        close_btn_selector = "button:has(i.google-symbols:text-is('close'))"
+        agent_btn_selector = "button:has(i.google-symbols:text-is('article_spark'))"
+        add_card_selector = "#instruction-add-card"
+
+        close_btn = page.locator(close_btn_selector).first
+        agent_btn = page.locator(agent_btn_selector).first
+        add_card = page.locator(add_card_selector).first
+
+        close_present = await close_btn.count() > 0
+        agent_present = await agent_btn.count() > 0
+        add_card_present = await add_card.count() > 0
+
+        print(f"article_spark button (opens sidebar) present: {agent_present}")
+        print(f"close button (closes sidebar) present: {close_present}")
+        print(f"instruction-add-card present: {add_card_present}")
+        print("-" * 60)
+
+        # Check if the sidebar button is present
+        if agent_present:
+            print("Clicking article_spark button to toggle sidebar...")
+            await agent_btn.click()
+            await asyncio.sleep(2)
+
+            close_present_after = await page.locator(close_btn_selector).first.count() > 0
+            add_card_present_after = await page.locator(add_card_selector).first.count() > 0
+
+            print("After click:")
+            print(f"  close button present: {close_present_after}")
+            print(f"  instruction-add-card present: {add_card_present_after}")
+
+            # Print active instruction cards if present
+            if add_card_present_after:
+                textareas = await page.locator("textarea[placeholder='Create a guideline for your agent'], textarea.gCefUl").all()
+                print(f"  Found {len(textareas)} instruction card textareas.")
+                for i, ta in enumerate(textareas):
+                    val = await ta.input_value()
+                    print(f"    Card {i}: '{val}'")
+
+            # Click close to restore original state
+            if close_present_after:
+                print("Clicking close to restore sidebar state...")
+                await page.locator(close_btn_selector).first.click()
+                await asyncio.sleep(1)
+        else:
+            print("Could not find article_spark button. Make sure Agent Mode is enabled on the project.")
+
+        print("\nClosing browser...")
+        await context.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/dev/har-spike/run-cdp-smoke.ps1
+++ b/scripts/dev/har-spike/run-cdp-smoke.ps1
@@ -1,0 +1,147 @@
+[CmdletBinding()]
+param(
+    [int]$Port = 9334,
+    [string]$Session = "gflow-cdp-spike",
+    [string]$AgentBrowserVersion = "0.27.0",
+    [string]$Url = "https://labs.google/fx/tools/flow?hl=en",
+    [switch]$ManualGeneration,
+    [switch]$SkipSnapshot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir | Out-Null
+
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = Join-Path $AgentStateDir "sockets"
+$env:AGENT_BROWSER_SESSION = $Session
+$env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "60000"
+
+New-Item -ItemType Directory -Force $env:AGENT_BROWSER_SOCKET_DIR | Out-Null
+
+function Invoke-AgentBrowser {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$CommandArgs
+    )
+
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        throw "agent-browser failed with exit code $exitCode for: $($CommandArgs -join ' ')"
+    }
+
+    return ($output -join [Environment]::NewLine)
+}
+
+function Save-Text {
+    param(
+        [string]$Name,
+        [string]$Text
+    )
+
+    $path = Join-Path $ArtifactsDir $Name
+    Set-Content -LiteralPath $path -Value $Text -Encoding UTF8
+    return $path
+}
+
+function Invoke-AgentBrowserJson {
+    param(
+        [string]$Name,
+        [string[]]$CommandArgs
+    )
+
+    $json = Invoke-AgentBrowser @CommandArgs
+    $path = Save-Text -Name $Name -Text $json
+    try {
+        $parsed = $json | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Could not parse JSON from agent-browser command '$($CommandArgs -join ' ')'. Saved raw output to $path."
+    }
+    return [pscustomobject]@{
+        Path = $path
+        Json = $parsed
+        Raw  = $json
+    }
+}
+
+Write-Host "Using isolated workspace:"
+Write-Host "  project:     $ProjectRoot"
+Write-Host "  npm cache:   $NpmCacheDir"
+Write-Host "  sockets:     $env:AGENT_BROWSER_SOCKET_DIR"
+Write-Host "  artifacts:   $ArtifactsDir"
+Write-Host "  session:     $Session"
+Write-Host "  CDP target:  127.0.0.1:$Port"
+Write-Host ""
+
+$version = Invoke-AgentBrowser @("--version")
+$versionPath = Save-Text -Name "agent-browser-version.txt" -Text $version
+Write-Host "agent-browser: $version"
+Write-Host "version saved: $versionPath"
+
+$open = Invoke-AgentBrowserJson `
+    -Name "open-flow.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "open", $Url)
+Write-Host "open saved: $($open.Path)"
+
+$webdriver = Invoke-AgentBrowserJson `
+    -Name "navigator-webdriver.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "eval", "navigator.webdriver")
+$webdriverValue = $webdriver.Json.data.result
+Write-Host "navigator.webdriver: $webdriverValue"
+
+$pageProbeExpression = '({url:location.href,title:document.title,host:location.host,onAccounts:location.host.includes("accounts.google.com"),bodyIncludesFlow:document.body.innerText.includes("Flow"),bodyIncludesSignIn:document.body.innerText.toLowerCase().includes("sign in")})'
+
+$pageProbe = Invoke-AgentBrowserJson `
+    -Name "flow-page-probe.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "eval", $pageProbeExpression)
+Write-Host "page probe saved: $($pageProbe.Path)"
+
+if (-not $SkipSnapshot) {
+    $snapshot = Invoke-AgentBrowser @("--cdp", "$Port", "snapshot", "-i")
+    $snapshotPath = Save-Text -Name "snapshot-interactive.txt" -Text $snapshot
+    Write-Host "snapshot saved: $snapshotPath"
+}
+
+$requestsClear = Invoke-AgentBrowserJson `
+    -Name "network-requests-cleared.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "network", "requests", "--clear")
+Write-Host "network request tracker cleared: $($requestsClear.Path)"
+
+if ($ManualGeneration) {
+    $started = Invoke-AgentBrowserJson `
+        -Name "har-start.json" `
+        -CommandArgs @("--cdp", "$Port", "--json", "network", "har", "start")
+    Write-Host "HAR recording started: $($started.Path)"
+    Write-Host ""
+    Write-Host "Use the Chrome window to trigger one Flow generation now."
+    Read-Host "Press Enter here after the generation request has fired"
+
+    $requests = Invoke-AgentBrowserJson `
+        -Name "network-requests-after-generation.json" `
+        -CommandArgs @("--cdp", "$Port", "--json", "network", "requests", "--filter", "aisandbox-pa")
+    Write-Host "filtered network requests saved: $($requests.Path)"
+
+    $harPath = Join-Path $ArtifactsDir ("flow-generation-" + (Get-Date -Format "yyyyMMdd-HHmmss") + ".har")
+    $stopped = Invoke-AgentBrowserJson `
+        -Name "har-stop.json" `
+        -CommandArgs @("--cdp", "$Port", "--json", "network", "har", "stop", $harPath)
+    Write-Host "HAR stop response saved: $($stopped.Path)"
+    Write-Host "HAR file target: $harPath"
+}
+
+if (Test-Path -LiteralPath (Join-Path $ProjectRoot "nul")) {
+    Remove-Item -LiteralPath (Join-Path $ProjectRoot "nul") -Force
+}
+
+Write-Host ""
+Write-Host "Done. Evidence is under: $ArtifactsDir"

--- a/scripts/dev/har-spike/start-background-capture.ps1
+++ b/scripts/dev/har-spike/start-background-capture.ps1
@@ -1,0 +1,218 @@
+[CmdletBinding()]
+param(
+    [int]$Port = 9557,
+    [string]$ProfileName = $env:GFLOW_CLI_PROFILE,
+    [string]$ProfileDir,
+    [string]$ProfileDirectory = "Default",
+    [string]$Session = "gflow-cdp-spike",
+    [string]$AgentBrowserVersion = "0.27.0",
+    [string]$Url = "https://labs.google/fx/tools/flow?hl=en",
+    [string]$CaptureId = (Get-Date -Format "yyyyMMdd-HHmmss"),
+    [int]$CommandTimeoutSeconds = 45
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+$SocketDir = Join-Path $AgentStateDir "sockets"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir, $SocketDir | Out-Null
+
+function Find-Chrome {
+    $candidates = @(
+        (Join-Path $env:ProgramFiles "Google\Chrome\Application\chrome.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"),
+        (Join-Path $env:LOCALAPPDATA "Google\Chrome\Application\chrome.exe")
+    )
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate)) {
+            return $candidate
+        }
+    }
+
+    $cmd = Get-Command chrome.exe -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+
+    throw "Google Chrome was not found."
+}
+
+function Get-CandidateGFlowHomes {
+    $candidateHomes = @()
+
+    if ($env:GFLOW_CLI_HOME) {
+        $candidateHomes += $env:GFLOW_CLI_HOME
+    }
+
+    if ($env:LOCALAPPDATA) {
+        $candidateHomes += (Join-Path $env:LOCALAPPDATA "gflow-cli")
+        $candidateHomes += (Join-Path $env:LOCALAPPDATA "ffroliva\gflow-cli")
+    }
+
+    if ($HOME) {
+        $candidateHomes += (Join-Path $HOME ".local\share\gflow-cli")
+    }
+
+    return $candidateHomes | Where-Object { $_ } | Select-Object -Unique
+}
+
+function Resolve-GFlowProfileDir {
+    param(
+        [string]$Name,
+        [string]$ExplicitDir
+    )
+
+    if ($ExplicitDir) {
+        return (Resolve-Path -LiteralPath $ExplicitDir -ErrorAction Stop).Path
+    }
+
+    if (-not $Name) {
+        $Name = "default"
+    }
+
+    foreach ($candidateHome in Get-CandidateGFlowHomes) {
+        $candidate = Join-Path $candidateHome "profile_$Name"
+        if (Test-Path -LiteralPath $candidate) {
+            return (Resolve-Path -LiteralPath $candidate -ErrorAction Stop).Path
+        }
+    }
+
+    throw "Could not find gflow profile '$Name'. Pass -ProfileDir explicitly."
+}
+
+function Wait-ForCdp {
+    param(
+        [int]$TargetPort,
+        [int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            Invoke-RestMethod -Uri "http://127.0.0.1:$TargetPort/json/version" -TimeoutSec 1 | Out-Null
+            return
+        }
+        catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+
+    throw "CDP endpoint did not become ready on port $TargetPort."
+}
+
+function Invoke-DetachedCommand {
+    param(
+        [string]$Name,
+        [string[]]$Arguments,
+        [int]$TimeoutSeconds
+    )
+
+    $stdout = Join-Path $ArtifactsDir "$CaptureId-$Name.out.log"
+    $stderr = Join-Path $ArtifactsDir "$CaptureId-$Name.err.log"
+    $npx = (Get-Command npx.cmd -ErrorAction Stop).Source
+
+    $env:npm_config_cache = $NpmCacheDir
+    $env:AGENT_BROWSER_SOCKET_DIR = $SocketDir
+    $env:AGENT_BROWSER_SESSION = $Session
+    $env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "60000"
+
+    $process = Start-Process `
+        -FilePath $npx `
+        -ArgumentList $Arguments `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr `
+        -PassThru
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        throw "Command '$Name' timed out after $TimeoutSeconds seconds. Logs: $stdout, $stderr"
+    }
+
+    if ($process.ExitCode -ne 0) {
+        throw "Command '$Name' failed with exit code $($process.ExitCode). Logs: $stdout, $stderr"
+    }
+
+    return [pscustomobject]@{
+        stdout = $stdout
+        stderr = $stderr
+    }
+}
+
+$chrome = Find-Chrome
+$resolvedProfileDir = Resolve-GFlowProfileDir -Name $ProfileName -ExplicitDir $ProfileDir
+$chromeLog = Join-Path $ArtifactsDir "$CaptureId-chrome.log"
+$env:CHROME_LOG_FILE = $chromeLog
+
+$chromeArgs = @(
+    "--remote-debugging-port=$Port",
+    "--user-data-dir=$resolvedProfileDir",
+    "--profile-directory=$ProfileDirectory",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--enable-logging=stderr",
+    "--v=1",
+    "--new-window",
+    $Url
+)
+
+$chromeProcess = Start-Process -FilePath $chrome -ArgumentList $chromeArgs -PassThru
+Wait-ForCdp -TargetPort $Port -TimeoutSeconds 30
+
+$package = "agent-browser@$AgentBrowserVersion"
+$agentPrefix = @("--yes", "--package", $package, "agent-browser", "--cdp", "$Port", "--json")
+
+Invoke-DetachedCommand `
+    -Name "open-flow" `
+    -Arguments ($agentPrefix + @("open", $Url)) `
+    -TimeoutSeconds $CommandTimeoutSeconds | Out-Null
+
+Invoke-DetachedCommand `
+    -Name "network-clear" `
+    -Arguments ($agentPrefix + @("network", "requests", "--clear")) `
+    -TimeoutSeconds $CommandTimeoutSeconds | Out-Null
+
+Invoke-DetachedCommand `
+    -Name "har-start" `
+    -Arguments ($agentPrefix + @("network", "har", "start")) `
+    -TimeoutSeconds $CommandTimeoutSeconds | Out-Null
+
+$harPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.har"
+$summaryPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.summary.json"
+$statePath = Join-Path $ArtifactsDir "har-capture-$CaptureId.json"
+$currentPath = Join-Path $ArtifactsDir "har-capture-current.json"
+
+$state = [ordered]@{
+    captureId           = $CaptureId
+    port                = $Port
+    session             = $Session
+    url                 = $Url
+    startedAt           = (Get-Date).ToString("o")
+    agentBrowserVersion = $AgentBrowserVersion
+    hostFilter          = "aisandbox-pa.googleapis.com"
+    harPath             = $harPath
+    summaryPath         = $summaryPath
+    chromePid           = $chromeProcess.Id
+    chromeLog           = $chromeLog
+    profileDir          = $resolvedProfileDir
+    profileDirectory    = $ProfileDirectory
+}
+
+$stateJson = $state | ConvertTo-Json -Depth 6
+Set-Content -LiteralPath $statePath -Value $stateJson -Encoding UTF8
+Set-Content -LiteralPath $currentPath -Value $stateJson -Encoding UTF8
+
+if (Test-Path -LiteralPath (Join-Path $ProjectRoot "nul")) {
+    Remove-Item -LiteralPath (Join-Path $ProjectRoot "nul") -Force
+}
+
+Write-Host "Background capture is recording."
+Write-Host "Use the Chrome window with CDP port $Port."
+Write-Host "Capture id: $CaptureId"
+Write-Host "State: $statePath"

--- a/scripts/dev/har-spike/start-har-capture.ps1
+++ b/scripts/dev/har-spike/start-har-capture.ps1
@@ -1,0 +1,153 @@
+[CmdletBinding()]
+param(
+    [int]$Port = 9334,
+    [string]$Session = "gflow-cdp-spike",
+    [string]$AgentBrowserVersion = "0.27.0",
+    [string]$Url = "https://labs.google/fx/tools/flow?hl=en",
+    [string]$CaptureId = (Get-Date -Format "yyyyMMdd-HHmmss"),
+    [switch]$SkipSnapshot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+$SocketDir = Join-Path $AgentStateDir "sockets"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir, $SocketDir | Out-Null
+
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = $SocketDir
+$env:AGENT_BROWSER_SESSION = $Session
+$env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "60000"
+
+function Invoke-AgentBrowser {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$CommandArgs
+    )
+
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        throw "agent-browser failed with exit code $exitCode for: $($CommandArgs -join ' ')"
+    }
+
+    return ($output -join [Environment]::NewLine)
+}
+
+function Save-Text {
+    param(
+        [string]$Name,
+        [string]$Text
+    )
+
+    $path = Join-Path $ArtifactsDir $Name
+    Set-Content -LiteralPath $path -Value $Text -Encoding UTF8
+    return $path
+}
+
+function Invoke-AgentBrowserJson {
+    param(
+        [string]$Name,
+        [string[]]$CommandArgs
+    )
+
+    $json = Invoke-AgentBrowser @CommandArgs
+    $path = Save-Text -Name $Name -Text $json
+    try {
+        $parsed = $json | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Could not parse JSON from agent-browser command '$($CommandArgs -join ' ')'. Saved raw output to $path."
+    }
+    return [pscustomobject]@{
+        Path = $path
+        Json = $parsed
+        Raw  = $json
+    }
+}
+
+Write-Host "Starting HAR capture:"
+Write-Host "  project:     $ProjectRoot"
+Write-Host "  npm cache:   $NpmCacheDir"
+Write-Host "  sockets:     $SocketDir"
+Write-Host "  artifacts:   $ArtifactsDir"
+Write-Host "  session:     $Session"
+Write-Host "  CDP target:  127.0.0.1:$Port"
+Write-Host "  capture id:  $CaptureId"
+Write-Host ""
+
+$version = Invoke-AgentBrowser @("--version")
+$versionPath = Save-Text -Name "agent-browser-version.txt" -Text $version
+Write-Host "agent-browser: $version"
+Write-Host "version saved: $versionPath"
+
+$open = Invoke-AgentBrowserJson `
+    -Name "open-flow-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "open", $Url)
+Write-Host "open saved: $($open.Path)"
+
+$webdriver = Invoke-AgentBrowserJson `
+    -Name "navigator-webdriver-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "eval", "navigator.webdriver")
+Write-Host "navigator.webdriver: $($webdriver.Json.data.result)"
+
+$pageProbeExpression = '({url:location.href,title:document.title,host:location.host,onAccounts:location.host.includes("accounts.google.com"),bodyIncludesFlow:document.body.innerText.includes("Flow"),bodyIncludesSignIn:document.body.innerText.toLowerCase().includes("sign in")})'
+$pageProbe = Invoke-AgentBrowserJson `
+    -Name "flow-page-probe-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "eval", $pageProbeExpression)
+Write-Host "page probe saved: $($pageProbe.Path)"
+
+if (-not $SkipSnapshot) {
+    $snapshot = Invoke-AgentBrowser @("--cdp", "$Port", "snapshot", "-i")
+    $snapshotPath = Save-Text -Name "snapshot-interactive-$CaptureId.txt" -Text $snapshot
+    Write-Host "snapshot saved: $snapshotPath"
+}
+
+$requestsClear = Invoke-AgentBrowserJson `
+    -Name "network-requests-cleared-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "network", "requests", "--clear")
+Write-Host "network request tracker cleared: $($requestsClear.Path)"
+
+$started = Invoke-AgentBrowserJson `
+    -Name "har-start-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "network", "har", "start")
+Write-Host "HAR recording started: $($started.Path)"
+
+$harPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.har"
+$summaryPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.summary.json"
+$statePath = Join-Path $ArtifactsDir "har-capture-$CaptureId.json"
+$currentPath = Join-Path $ArtifactsDir "har-capture-current.json"
+
+$state = [ordered]@{
+    captureId           = $CaptureId
+    port                = $Port
+    session             = $Session
+    url                 = $Url
+    startedAt           = (Get-Date).ToString("o")
+    agentBrowserVersion = $AgentBrowserVersion
+    hostFilter          = "aisandbox-pa.googleapis.com"
+    harPath             = $harPath
+    summaryPath         = $summaryPath
+}
+
+$stateJson = $state | ConvertTo-Json -Depth 6
+Set-Content -LiteralPath $statePath -Value $stateJson -Encoding UTF8
+Set-Content -LiteralPath $currentPath -Value $stateJson -Encoding UTF8
+
+if (Test-Path -LiteralPath (Join-Path $ProjectRoot "nul")) {
+    Remove-Item -LiteralPath (Join-Path $ProjectRoot "nul") -Force
+}
+
+Write-Host ""
+Write-Host "Capture is recording. Use the Chrome window to trigger one Flow generation."
+Write-Host "Then stop and summarize it with:"
+Write-Host "  .\scripts\stop-har-capture.ps1 -CaptureId $CaptureId"
+Write-Host ""
+Write-Host "State saved: $statePath"

--- a/scripts/dev/har-spike/stop-background-capture.ps1
+++ b/scripts/dev/har-spike/stop-background-capture.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [string]$CaptureId = "",
+    [int]$CommandTimeoutSeconds = 45
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+$SocketDir = Join-Path $AgentStateDir "sockets"
+
+if ($CaptureId) {
+    $statePath = Join-Path $ArtifactsDir "har-capture-$CaptureId.json"
+}
+else {
+    $statePath = Join-Path $ArtifactsDir "har-capture-current.json"
+}
+
+if (-not (Test-Path -LiteralPath $statePath)) {
+    throw "Capture state was not found: $statePath"
+}
+
+$state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -ErrorAction Stop
+$CaptureId = [string]$state.captureId
+$Port = [int]$state.port
+$Session = [string]$state.session
+$AgentBrowserVersion = [string]$state.agentBrowserVersion
+$HostFilter = [string]$state.hostFilter
+$HarPath = [string]$state.harPath
+$SummaryPath = [string]$state.summaryPath
+
+function Invoke-DetachedCommand {
+    param(
+        [string]$Name,
+        [string[]]$Arguments,
+        [int]$TimeoutSeconds,
+        [switch]$AllowTimeout
+    )
+
+    $stdout = Join-Path $ArtifactsDir "$CaptureId-$Name.out.log"
+    $stderr = Join-Path $ArtifactsDir "$CaptureId-$Name.err.log"
+    $npx = (Get-Command npx.cmd -ErrorAction Stop).Source
+
+    $env:npm_config_cache = $NpmCacheDir
+    $env:AGENT_BROWSER_SOCKET_DIR = $SocketDir
+    $env:AGENT_BROWSER_SESSION = $Session
+    $env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "60000"
+
+    $process = Start-Process `
+        -FilePath $npx `
+        -ArgumentList $Arguments `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr `
+        -PassThru
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        if (-not $AllowTimeout) {
+            throw "Command '$Name' timed out after $TimeoutSeconds seconds. Logs: $stdout, $stderr"
+        }
+    }
+    elseif ($process.ExitCode -ne 0) {
+        throw "Command '$Name' failed with exit code $($process.ExitCode). Logs: $stdout, $stderr"
+    }
+
+    return [pscustomobject]@{
+        stdout = $stdout
+        stderr = $stderr
+    }
+}
+
+$package = "agent-browser@$AgentBrowserVersion"
+$agentPrefix = @("--yes", "--package", $package, "agent-browser", "--cdp", "$Port", "--json")
+
+Invoke-DetachedCommand `
+    -Name "network-requests" `
+    -Arguments ($agentPrefix + @("network", "requests", "--filter", $HostFilter)) `
+    -TimeoutSeconds $CommandTimeoutSeconds `
+    -AllowTimeout | Out-Null
+
+Invoke-DetachedCommand `
+    -Name "har-stop" `
+    -Arguments ($agentPrefix + @("network", "har", "stop", $HarPath)) `
+    -TimeoutSeconds $CommandTimeoutSeconds `
+    -AllowTimeout | Out-Null
+
+if (-not (Test-Path -LiteralPath $HarPath)) {
+    throw "HAR file was not created: $HarPath"
+}
+
+$extractor = Join-Path $ProjectRoot "scripts\extract_har_summary.py"
+& python $extractor $HarPath --host $HostFilter --out $SummaryPath
+$pythonExitCode = $LASTEXITCODE
+if ($pythonExitCode -ne 0) {
+    throw "HAR summary extraction failed with exit code $pythonExitCode"
+}
+
+$state | Add-Member -NotePropertyName stoppedAt -NotePropertyValue (Get-Date).ToString("o") -Force
+$state | Add-Member -NotePropertyName harPath -NotePropertyValue $HarPath -Force
+$state | Add-Member -NotePropertyName summaryPath -NotePropertyValue $SummaryPath -Force
+$stateJson = $state | ConvertTo-Json -Depth 6
+Set-Content -LiteralPath $statePath -Value $stateJson -Encoding UTF8
+Set-Content -LiteralPath (Join-Path $ArtifactsDir "har-capture-current.json") -Value $stateJson -Encoding UTF8
+
+if (Test-Path -LiteralPath (Join-Path $ProjectRoot "nul")) {
+    Remove-Item -LiteralPath (Join-Path $ProjectRoot "nul") -Force
+}
+
+Write-Host "Capture stopped."
+Write-Host "HAR: $HarPath"
+Write-Host "Summary: $SummaryPath"

--- a/scripts/dev/har-spike/stop-har-capture.ps1
+++ b/scripts/dev/har-spike/stop-har-capture.ps1
@@ -1,0 +1,181 @@
+[CmdletBinding()]
+param(
+    [int]$Port = 9334,
+    [string]$Session = "",
+    [string]$AgentBrowserVersion = "0.27.0",
+    [string]$CaptureId = "",
+    [string]$HarPath = "",
+    [string]$HostFilter = "aisandbox-pa.googleapis.com"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$ArtifactsDir = Join-Path $ProjectRoot "artifacts"
+$AgentStateDir = Join-Path $ProjectRoot ".agent-browser"
+$NpmCacheDir = Join-Path $ProjectRoot ".npm-cache"
+$SocketDir = Join-Path $AgentStateDir "sockets"
+
+New-Item -ItemType Directory -Force $ArtifactsDir, $AgentStateDir, $NpmCacheDir, $SocketDir | Out-Null
+
+$state = $null
+$statePath = $null
+
+if ($CaptureId) {
+    $statePath = Join-Path $ArtifactsDir "har-capture-$CaptureId.json"
+}
+else {
+    $statePath = Join-Path $ArtifactsDir "har-capture-current.json"
+}
+
+if (Test-Path -LiteralPath $statePath) {
+    $state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    if (-not $CaptureId -and $state.captureId) {
+        $CaptureId = [string]$state.captureId
+    }
+}
+
+if (-not $CaptureId) {
+    $CaptureId = Get-Date -Format "yyyyMMdd-HHmmss"
+}
+
+if ($state) {
+    if (-not $PSBoundParameters.ContainsKey("Port") -and $state.port) {
+        $Port = [int]$state.port
+    }
+    if (-not $PSBoundParameters.ContainsKey("Session") -and $state.session) {
+        $Session = [string]$state.session
+    }
+    if (-not $PSBoundParameters.ContainsKey("AgentBrowserVersion") -and $state.agentBrowserVersion) {
+        $AgentBrowserVersion = [string]$state.agentBrowserVersion
+    }
+    if (-not $PSBoundParameters.ContainsKey("HostFilter") -and $state.hostFilter) {
+        $HostFilter = [string]$state.hostFilter
+    }
+}
+
+if (-not $Session) {
+    $Session = "gflow-cdp-spike"
+}
+
+if (-not $HarPath) {
+    if ($state -and $state.harPath) {
+        $HarPath = [string]$state.harPath
+    }
+    else {
+        $HarPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.har"
+    }
+}
+
+if ($state -and $state.summaryPath) {
+    $summaryPath = [string]$state.summaryPath
+}
+else {
+    $summaryPath = Join-Path $ArtifactsDir "flow-generation-$CaptureId.summary.json"
+}
+
+$env:npm_config_cache = $NpmCacheDir
+$env:AGENT_BROWSER_SOCKET_DIR = $SocketDir
+$env:AGENT_BROWSER_SESSION = $Session
+$env:AGENT_BROWSER_IDLE_TIMEOUT_MS = "60000"
+
+function Invoke-AgentBrowser {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$CommandArgs
+    )
+
+    $package = "agent-browser@$AgentBrowserVersion"
+    $output = & npx --yes --package $package agent-browser @CommandArgs
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        throw "agent-browser failed with exit code $exitCode for: $($CommandArgs -join ' ')"
+    }
+
+    return ($output -join [Environment]::NewLine)
+}
+
+function Save-Text {
+    param(
+        [string]$Name,
+        [string]$Text
+    )
+
+    $path = Join-Path $ArtifactsDir $Name
+    Set-Content -LiteralPath $path -Value $Text -Encoding UTF8
+    return $path
+}
+
+function Invoke-AgentBrowserJson {
+    param(
+        [string]$Name,
+        [string[]]$CommandArgs
+    )
+
+    $json = Invoke-AgentBrowser @CommandArgs
+    $path = Save-Text -Name $Name -Text $json
+    try {
+        $parsed = $json | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Could not parse JSON from agent-browser command '$($CommandArgs -join ' ')'. Saved raw output to $path."
+    }
+    return [pscustomobject]@{
+        Path = $path
+        Json = $parsed
+        Raw  = $json
+    }
+}
+
+Write-Host "Stopping HAR capture:"
+Write-Host "  project:     $ProjectRoot"
+Write-Host "  session:     $Session"
+Write-Host "  CDP target:  127.0.0.1:$Port"
+Write-Host "  capture id:  $CaptureId"
+Write-Host "  HAR path:    $HarPath"
+Write-Host ""
+
+$requests = Invoke-AgentBrowserJson `
+    -Name "network-requests-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "network", "requests", "--filter", $HostFilter)
+Write-Host "filtered network requests saved: $($requests.Path)"
+
+$stopped = Invoke-AgentBrowserJson `
+    -Name "har-stop-$CaptureId.json" `
+    -CommandArgs @("--cdp", "$Port", "--json", "network", "har", "stop", $HarPath)
+Write-Host "HAR stop response saved: $($stopped.Path)"
+
+if (-not (Test-Path -LiteralPath $HarPath)) {
+    throw "HAR file was not created: $HarPath"
+}
+
+$extractor = Join-Path $ProjectRoot "scripts\extract_har_summary.py"
+& python $extractor $HarPath --host $HostFilter --out $summaryPath
+$pythonExitCode = $LASTEXITCODE
+if ($pythonExitCode -ne 0) {
+    throw "HAR summary extraction failed with exit code $pythonExitCode"
+}
+
+if ($state) {
+    $state | Add-Member -NotePropertyName stoppedAt -NotePropertyValue (Get-Date).ToString("o") -Force
+    $state | Add-Member -NotePropertyName harPath -NotePropertyValue $HarPath -Force
+    $state | Add-Member -NotePropertyName summaryPath -NotePropertyValue $summaryPath -Force
+    $stateJson = $state | ConvertTo-Json -Depth 6
+    Set-Content -LiteralPath $statePath -Value $stateJson -Encoding UTF8
+
+    $captureStatePath = Join-Path $ArtifactsDir "har-capture-$CaptureId.json"
+    if ($captureStatePath -ne $statePath) {
+        Set-Content -LiteralPath $captureStatePath -Value $stateJson -Encoding UTF8
+    }
+}
+
+if (Test-Path -LiteralPath (Join-Path $ProjectRoot "nul")) {
+    Remove-Item -LiteralPath (Join-Path $ProjectRoot "nul") -Force
+}
+
+Write-Host ""
+Write-Host "HAR saved: $HarPath"
+Write-Host "Redacted summary saved: $summaryPath"
+Write-Host "Treat raw HAR and request artifacts as sensitive; do not commit or share them."

--- a/scripts/dev/spike_migrated_body_reference_chip.py
+++ b/scripts/dev/spike_migrated_body_reference_chip.py
@@ -1,0 +1,148 @@
+r"""What proves body mode settled on the migrated character editor? ($0)
+
+With the `<flow-slot-chip-button>` anchor in place, `character create
+--body-prompt` now clicks **Create body** on flow.google.com and fails one step
+later:
+
+    "Create Body was selected, but its generated-face reference did not mount."
+
+That settle check exists for a real reason (#395): activating body mode reuses
+the SAME prompt box, so editing it before the transition lands types the body
+prompt into the face composer. The signal it waits for is labs-shaped:
+
+    button[data-card-open]:has(img[src*='media.getMediaUrlRedirect'])
+                          :has(i.google-symbols:text-is('cancel'))
+
+This dumps what actually appears on the migrated host, before and after the
+click, for an entity that ALREADY HAS a portrait (the chip is `disabled`
+without one). It records every image-bearing control and every custom element,
+so the replacement signal can be a component boundary rather than a guess.
+
+Pass an existing character's entity id with --entity.
+
+Credit-free: navigation, one click on a mode control, DOM reads. Nothing is
+typed and nothing is submitted.
+
+    python scripts/dev/spike_migrated_body_reference_chip.py \
+        --profile ci-probe --project <p> --entity <e>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MIGRATED_ROOT = "https://flow.google.com"
+
+_SNAPSHOT_JS = r"""() => {
+  const LIG = '.google-symbols, .material-symbols-outlined, .material-icons, mat-icon';
+  const ligs = (el) => [...el.querySelectorAll(LIG)]
+    .map(e => (e.textContent || '').trim())
+    .filter(t => /^[a-z0-9_]{2,40}$/.test(t));
+  // Custom elements are the component boundaries an anchor should use.
+  const customs = {};
+  for (const el of document.querySelectorAll('*')) {
+    const tag = el.tagName.toLowerCase();
+    if (!tag.includes('-')) continue;
+    customs[tag] = (customs[tag] || 0) + 1;
+  }
+  const imaged = [];
+  for (const img of document.querySelectorAll('img')) {
+    const ctl = img.closest('button, [role="button"], flow-slot-chip-button, *[class*="chip"]');
+    const host = ctl || img.parentElement;
+    if (!host) continue;
+    const r = host.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) continue;
+    const attrs = {};
+    for (const a of host.attributes) attrs[a.name] = (a.value || '').slice(0, 50);
+    imaged.push({
+      host_tag: host.tagName.toLowerCase(),
+      host_attrs: attrs,
+      host_ligatures: ligs(host).slice(0, 5),
+      img_src_head: (img.getAttribute('src') || '').slice(0, 90),
+      parent_tag: host.parentElement ? host.parentElement.tagName.toLowerCase() : null,
+      text: (host.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 40),
+    });
+  }
+  return {
+    custom_elements: Object.entries(customs)
+      .filter(([t]) => t.startsWith('flow-') || t.startsWith('mat-'))
+      .sort((a, b) => b[1] - a[1]).slice(0, 25),
+    imaged_controls: imaged.slice(0, 25),
+    textboxes: document.querySelectorAll(
+      'div[role="textbox"], textarea, .ProseMirror[contenteditable="true"]').length,
+  };
+}"""
+
+
+async def _main(profile: str, project: str, entity: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project, "entity": entity}
+
+    async with build_client(profile_dir) as client:
+        context = client._context  # noqa: SLF001 - spike reads the live context
+        page = await context.new_page()
+        url = f"{_MIGRATED_ROOT}/project/{project}/character/{entity}"
+        await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=20_000)
+        except Exception:  # noqa: BLE001 - settle is best-effort
+            pass
+        await page.wait_for_timeout(3000)
+        step("landed", page.url)
+
+        findings["before"] = await page.evaluate(_SNAPSHOT_JS)
+        step("before", f"imaged_controls={len(findings['before']['imaged_controls'])}")
+        for c in findings["before"]["imaged_controls"][:6]:
+            step("  img", f"<{c['host_tag']}> {sorted(c['host_attrs'])} src={c['img_src_head'][:60]}")
+
+        body_sel = "flow-slot-chip-button:has(mat-icon:text-is('accessibility_new')) button"
+        chip = page.locator(body_sel).first
+        if not await chip.count():
+            step("abort", "Create body chip not found — does this entity have a portrait?")
+        else:
+            disabled = await chip.get_attribute("disabled")
+            step("chip", f"found; disabled={disabled!r}")
+            await chip.click(timeout=5000)
+            await page.wait_for_timeout(4000)
+            findings["after"] = await page.evaluate(_SNAPSHOT_JS)
+            step("after", f"imaged_controls={len(findings['after']['imaged_controls'])}")
+            for c in findings["after"]["imaged_controls"][:8]:
+                step(
+                    "  img",
+                    f"<{c['host_tag']}> parent=<{c['parent_tag']}> "
+                    f"ligs={c['host_ligatures']} attrs={sorted(c['host_attrs'])} "
+                    f"src={c['img_src_head'][:55]}",
+                )
+            step("customs", str(findings["after"]["custom_elements"][:12]))
+            shot = default_out_path("migrated_body_reference", ".png")
+            await page.screenshot(path=str(shot))
+            findings["screenshot"] = shot.name
+
+        out = default_out_path("migrated_body_reference")
+        out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+        step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--entity", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project, args.entity)))

--- a/scripts/dev/spike_migrated_character_body_controls.py
+++ b/scripts/dev/spike_migrated_character_body_controls.py
@@ -1,0 +1,150 @@
+r"""How is "Create body" anchored on the migrated character editor? ($0)
+
+`character create --body-prompt` fails on flow.google.com at body-mode
+activation: `character_slot_add_failed`, then "Body prompt box did not mount
+within 10s". The face slot works, so this is the last gap to a full character
+(name + personality + voice + portrait + body).
+
+The selectors in play were written against labs.google:
+
+    _CHARACTER_SLOT_ADD_SELECTOR   [role='button']:has(i.google-symbols:text-is('add_2'))
+    _CHARACTER_BODY_MODE_SELECTOR  button:has(img) + button:has(…'accessibility_new')
+
+Both assume labs' ligature carrier (`<i class="google-symbols">`) and labs' DOM
+shape. A bare `accessibility_new` selector is NOT an acceptable fallback: the
+project-level Characters navigation carries the same ligature, and clicking it
+navigates away instead of activating body mode. So the replacement has to be
+*scoped*, which means knowing the real structure rather than guessing it.
+
+This dumps, for every control carrying `portrait`, `accessibility_new`, `add_2`
+or `upload`: its tag, its ligature carrier tag, its own attributes, and its
+parent + previous/next sibling — enough to write a scoped, locale-invariant
+anchor.
+
+Credit-free: one free createEntity, navigation, DOM reads, one free delete.
+
+    python scripts/dev/spike_migrated_character_body_controls.py \
+        --profile ci-probe --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MIGRATED_ROOT = "https://flow.google.com"
+
+_CONTROLS_JS = r"""() => {
+  const WANTED = new Set(['portrait', 'accessibility_new', 'add_2', 'upload', 'arrow_drop_down']);
+  const LIG = '.google-symbols, .material-symbols-outlined, .material-icons, mat-icon';
+  const desc = (el) => {
+    if (!el) return null;
+    const ligs = [...el.querySelectorAll(LIG)]
+      .map(e => (e.textContent || '').trim())
+      .filter(t => /^[a-z0-9_]{2,40}$/.test(t));
+    return {
+      tag: el.tagName.toLowerCase(),
+      cls: (el.className || '').toString().slice(0, 80),
+      ligatures: ligs.slice(0, 4),
+      text: (el.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 40),
+    };
+  };
+  const out = [];
+  for (const icon of document.querySelectorAll(LIG)) {
+    const lig = (icon.textContent || '').trim();
+    if (!WANTED.has(lig)) continue;
+    const ctl = icon.closest('button, a, [role="button"], [role="tab"], [role="radio"]');
+    if (!ctl) continue;
+    const rect = ctl.getBoundingClientRect();
+    const attrs = {};
+    for (const a of ctl.attributes) attrs[a.name] = (a.value || '').slice(0, 60);
+    out.push({
+      ligature: lig,
+      carrier_tag: icon.tagName.toLowerCase(),
+      carrier_cls: (icon.className || '').toString().slice(0, 60),
+      control_tag: ctl.tagName.toLowerCase(),
+      control_attrs: attrs,
+      control_text: (ctl.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 40),
+      visible: rect.width > 0 && rect.height > 0,
+      parent: desc(ctl.parentElement),
+      prev: desc(ctl.previousElementSibling),
+      next: desc(ctl.nextElementSibling),
+    });
+  }
+  return out;
+}"""
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        entity_id = await client.create_entity(project)
+        step("entity", f"created {entity_id} (free tRPC)")
+        try:
+            context = client._context  # noqa: SLF001 - spike reads the live context
+            page = await context.new_page()
+            url = f"{_MIGRATED_ROOT}/project/{project}/character/{entity_id}"
+            await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=20_000)
+            except Exception:  # noqa: BLE001 - settle is best-effort
+                pass
+            await page.wait_for_timeout(3000)
+            step("landed", page.url)
+
+            controls = await page.evaluate(_CONTROLS_JS)
+            findings["controls"] = controls
+            shot = default_out_path("migrated_body_controls", ".png")
+            await page.screenshot(path=str(shot))
+            findings["screenshot"] = shot.name
+
+            for c in controls:
+                step(
+                    c["ligature"],
+                    f"<{c['control_tag']}> carrier=<{c['carrier_tag']}> "
+                    f"vis={c['visible']} text={c['control_text']!r} "
+                    f"attrs={sorted(c['control_attrs'])}",
+                )
+                step(
+                    "  ctx",
+                    f"parent={c['parent'] and c['parent']['tag']}"
+                    f"({c['parent'] and c['parent']['ligatures']}) "
+                    f"prev={c['prev'] and c['prev']['tag']}"
+                    f"({c['prev'] and c['prev']['ligatures']}) "
+                    f"next={c['next'] and c['next']['tag']}"
+                    f"({c['next'] and c['next']['ligatures']})",
+                )
+        finally:
+            try:
+                await client.delete_characters(project, [entity_id])
+                step("cleanup", f"deleted {entity_id}")
+            except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                step("cleanup", f"FAILED to delete {entity_id}: {exc}")
+            out = default_out_path("migrated_body_controls")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/scripts/dev/spike_migrated_character_editor_anchor.py
+++ b/scripts/dev/spike_migrated_character_editor_anchor.py
@@ -1,0 +1,183 @@
+r"""What IS the prompt box on the migrated character editor, and what hides it? ($0)
+
+Follow-up to ``spike_migrated_character_surface.py``, which established that
+``flow.google.com/project/P/character/E`` does NOT redirect and renders a real
+character editor (ligatures ``portrait``, ``accessibility_new``,
+``voice_selection``, ``upload``). Two facts from that run need nailing down
+before any driver work:
+
+  1. the route's ARIA role tally contained **no ``textbox``** — yet three
+     textbox-ish elements existed. gflow's readiness gate waits for
+     ``div[role="textbox"][data-slate-editor="true"]``, a Slate anchor. If the
+     migrated editor is a ``<textarea>`` or a bare ``contenteditable``, the gate
+     can never pass and the surface looks absent when it is merely different.
+  2. the body text carried a cookie-consent banner. A consent overlay would keep
+     an element that EXISTS from ever being ``visible``, which is what the gate
+     actually waits on.
+
+This spike creates a real entity over tRPC (free, and proven to work on the
+migrated host), navigates straight to its editor route, dumps every candidate
+prompt element with its tag / attributes / visibility / occluder, then deletes
+the entity again so nothing is left behind.
+
+Credit-free: one free createEntity, navigation, DOM reads, one free delete.
+Nothing is typed and nothing is submitted.
+
+    python scripts/dev/spike_migrated_character_editor_anchor.py \
+        --profile ci-probe --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MIGRATED_ROOT = "https://flow.google.com"
+
+# Every element that could plausibly be "the prompt box", with the facts a
+# selector needs: tag, the attributes that are locale-invariant, whether it is
+# actually visible, and — when it is not — what is sitting on top of it.
+_CANDIDATES_JS = r"""() => {
+  const SEL = 'div[role="textbox"], textarea, [contenteditable="true"], input[type="text"]';
+  const out = [];
+  for (const el of document.querySelectorAll(SEL)) {
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    const visible = r.width > 0 && r.height > 0 &&
+                    cs.visibility !== 'hidden' && cs.display !== 'none' &&
+                    cs.opacity !== '0';
+    let occluder = null;
+    if (r.width > 0 && r.height > 0) {
+      const top = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+      if (top && top !== el && !el.contains(top)) {
+        occluder = {
+          tag: top.tagName.toLowerCase(),
+          cls: (top.className || '').toString().slice(0, 120),
+          role: top.getAttribute('role'),
+          text: (top.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+        };
+      }
+    }
+    const attrs = {};
+    for (const a of el.attributes) attrs[a.name] = (a.value || '').slice(0, 100);
+    out.push({
+      tag: el.tagName.toLowerCase(),
+      attrs,
+      visible,
+      rect: {w: Math.round(r.width), h: Math.round(r.height),
+             x: Math.round(r.left), y: Math.round(r.top)},
+      slate: el.hasAttribute('data-slate-editor'),
+      placeholder: el.getAttribute('placeholder') || el.getAttribute('data-placeholder'),
+      occluder,
+    });
+  }
+  return out;
+}"""
+
+# Consent / cookie / dialog overlays, anchored structurally (never on text).
+_OVERLAY_JS = r"""() => {
+  const out = [];
+  const sels = ['[role="dialog"]', '[role="alertdialog"]', 'dialog',
+                '[aria-modal="true"]', 'iframe'];
+  for (const s of sels) {
+    for (const el of document.querySelectorAll(s)) {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) continue;
+      out.push({
+        sel: s,
+        tag: el.tagName.toLowerCase(),
+        src: el.getAttribute('src') ? el.getAttribute('src').slice(0, 120) : null,
+        cls: (el.className || '').toString().slice(0, 120),
+        rect: {w: Math.round(r.width), h: Math.round(r.height)},
+        text: (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 120),
+      });
+    }
+  }
+  return out;
+}"""
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        entity_id = await client.create_entity(project)
+        step("entity", f"created {entity_id} (free tRPC)")
+        findings["entity_id"] = entity_id
+        try:
+            context = client._context  # noqa: SLF001 - spike reads the live context
+            page = await context.new_page()
+            url = f"{_MIGRATED_ROOT}/project/{project}/character/{entity_id}"
+            step("goto", f"DIRECT {url}")
+            await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=20_000)
+            except Exception:  # noqa: BLE001 - settle is best-effort
+                pass
+            await page.wait_for_timeout(3000)
+            step("landed", page.url)
+            findings["landed_url"] = page.url
+            findings["entity_still_in_url"] = entity_id in page.url
+
+            findings["candidates"] = await page.evaluate(_CANDIDATES_JS)
+            findings["overlays"] = await page.evaluate(_OVERLAY_JS)
+
+            # What gflow actually waits for, asked directly.
+            gate = 'div[role="textbox"][data-slate-editor="true"]'
+            findings["gflow_gate_selector"] = gate
+            findings["gflow_gate_count"] = await page.locator(gate).count()
+            shot = default_out_path("migrated_char_anchor", ".png")
+            await page.screenshot(path=str(shot))
+            findings["screenshot"] = shot.name
+
+            step(
+                "gate",
+                f"gflow selector matches {findings['gflow_gate_count']} element(s); "
+                f"{len(findings['candidates'])} candidate box(es); "
+                f"{len(findings['overlays'])} overlay(s)",
+            )
+            for c in findings["candidates"]:
+                step(
+                    "candidate",
+                    f"<{c['tag']}> visible={c['visible']} slate={c['slate']} "
+                    f"rect={c['rect']['w']}x{c['rect']['h']} "
+                    f"occluder={(c['occluder'] or {}).get('tag')} "
+                    f"attrs={sorted(c['attrs'])}",
+                )
+            for o in findings["overlays"]:
+                step("overlay", f"{o['tag']} {o['rect']} src={o['src']} text={o['text'][:60]!r}")
+        finally:
+            try:
+                await client.delete_characters(project, [entity_id])
+                step("cleanup", f"deleted {entity_id}")
+                findings["cleaned_up"] = True
+            except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                step("cleanup", f"FAILED to delete {entity_id}: {exc}")
+                findings["cleaned_up"] = False
+            out = default_out_path("migrated_char_anchor")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/scripts/dev/spike_migrated_character_ogiz0b_schema.py
+++ b/scripts/dev/spike_migrated_character_ogiz0b_schema.py
@@ -1,0 +1,158 @@
+r"""Full wire capture for the migrated character portrait generation (image quota).
+
+``spike_migrated_character_submit_wire.py`` established that the portrait submit
+on flow.google.com answers over ``batchexecute`` rpcid **ogiZ0b**, whose response
+echoes the prompt back alongside two UUIDs. gflow meanwhile waits 180 s for the
+labs ``batchGenerateImages`` wire that never fires there.
+
+To drive it we need the schema, not a 220-char head. This spike records, in full:
+
+  * the REQUEST body of every batchexecute after the click (the submit shape)
+  * the RESPONSE body of every batchexecute (the result shape)
+  * whether the entity picks up workflow ids server-side regardless of what the
+    client managed to read — i.e. did the generation actually happen?
+  * the project's media before and after, so a produced portrait is visible even
+    if the client never parsed it
+
+Bodies go to a JSON file, never to stdout — some are 30 KB. Console output is a
+one-line-per-call index.
+
+Cost: one real portrait generation — image quota, zero credits.
+
+    python scripts/dev/spike_migrated_character_ogiz0b_schema.py \
+        --profile ci-probe --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gflow_cli.api.character import CharacterImageRequest  # noqa: E402
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_TARGETS = {"ogiZ0b", "WuwhI", "yBhWQ", "ngNC2", "Zzl0ze", "tRARke", "HTrJv"}
+
+
+def _rpcids(url: str) -> list[str]:
+    if "batchexecute" not in url or "rpcids=" not in url:
+        return []
+    raw = url.split("rpcids=", 1)[1].split("&", 1)[0]
+    return [p for p in raw.split("%2C") if p]
+
+
+async def _entity_snapshot(client: Any, project: str, entity_id: str) -> dict[str, Any]:
+    """Ask the BACKEND what it thinks of the entity — independent of the driver."""
+    try:
+        chars = await client.list_characters(project)
+    except Exception as exc:  # noqa: BLE001 - snapshot is diagnostic
+        return {"error": f"{type(exc).__name__}: {exc}"}
+    for c in chars:
+        if getattr(c, "entity_id", None) == entity_id:
+            return {
+                "found": True,
+                "display_name": getattr(c, "display_name", None),
+                "workflow_ids": list(getattr(c, "workflow_ids", []) or []),
+                "thumbnail_media_id": getattr(c, "thumbnail_media_id", None),
+            }
+    return {"found": False, "entity_count": len(chars)}
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        entity_id = await client.create_entity(project)
+        step("entity", f"created {entity_id} (free tRPC)")
+        findings["entity_id"] = entity_id
+        findings["entity_before"] = await _entity_snapshot(client, project, entity_id)
+
+        transport = client.transport
+        page = transport._page  # noqa: SLF001 - spike watches the real page
+        if page is None:
+            step("abort", "transport exposed no page")
+            return 1
+
+        captured: list[dict[str, Any]] = []
+
+        async def _on_response(resp: Any) -> None:
+            if "batchexecute" not in resp.url:
+                return
+            ids = _rpcids(resp.url)
+            if not (set(ids) & _TARGETS):
+                return
+            rec: dict[str, Any] = {"rpcids": ids, "status": resp.status}
+            try:
+                rec["response_body"] = await resp.text()
+            except Exception as exc:  # noqa: BLE001 - body may be gone
+                rec["response_body"] = f"<unavailable: {exc}>"
+            try:
+                req = resp.request
+                rec["request_post_data"] = req.post_data
+            except Exception as exc:  # noqa: BLE001 - post data may be gone
+                rec["request_post_data"] = f"<unavailable: {exc}>"
+            captured.append(rec)
+            step(
+                "captured",
+                f"{ids} status={resp.status} "
+                f"req={len(rec['request_post_data'] or '')}B "
+                f"resp={len(rec['response_body'] or '')}B",
+            )
+
+        page.on("response", lambda r: asyncio.create_task(_on_response(r)))
+
+        try:
+            step("drive", "generate_character_images (expect the 180 s labs-wire timeout)")
+            req = CharacterImageRequest(
+                prompt="a calm portrait of a woman, neutral background",
+                model="nano2",
+            )
+            try:
+                await transport.generate_character_images(  # type: ignore[attr-defined]
+                    project_id=project,
+                    entity_id=entity_id,
+                    request=req,
+                    image_reference_index=0,
+                    locale=None,
+                )
+                findings["production_path"] = "succeeded"
+            except Exception as exc:  # noqa: BLE001 - the failure IS the measurement
+                findings["production_path"] = f"{type(exc).__name__}: {str(exc)[:200]}"
+            step("drive", str(findings["production_path"])[:120])
+
+            await page.wait_for_timeout(5000)
+            findings["captured"] = captured
+            findings["entity_after"] = await _entity_snapshot(client, project, entity_id)
+            step("entity_after", json.dumps(findings["entity_after"])[:200])
+        finally:
+            try:
+                await client.delete_characters(project, [entity_id])
+                step("cleanup", f"deleted {entity_id}")
+            except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                step("cleanup", f"FAILED to delete {entity_id}: {exc}")
+            out = default_out_path("migrated_character_ogiz0b_schema")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/scripts/dev/spike_migrated_character_submit_wire.py
+++ b/scripts/dev/spike_migrated_character_submit_wire.py
@@ -1,0 +1,167 @@
+r"""What wire carries the migrated character portrait generation? (image quota, 0 credits)
+
+Live 2026-09-06, `character create` on flow.google.com now reaches:
+
+    character_editor_ready -> character_model_selected -> prompt_input_found
+    -> prompt_submitted -> "No batchGenerateImages response within 180.0s"
+
+Everything up to and including the submit works. Only the *listener* is wrong:
+gflow waits for ``aisandbox-pa.googleapis.com/.../flowMedia:batchGenerateImages``,
+the labs wire. The provenance spike showed the migrated frontend adds a
+``flow.google.com/.../batchexecute`` wire on top of the shared backend, so the
+portrait submit almost certainly lands there instead.
+
+This spike drives the REAL production path — the transport's own
+``generate_character_images`` — with a recorder attached to every request and
+response, so what we learn is what gflow itself would see. It records:
+
+  * every batchexecute rpcid fired after the click, in order
+  * every aisandbox call, to confirm whether the labs wire is truly silent
+  * response body heads, scanned for a workflow id / media id shape
+
+The entity is deleted afterwards. Cost: one real portrait generation — image
+quota, zero credits (see AGENTS.md "two cost currencies").
+
+    python scripts/dev/spike_migrated_character_submit_wire.py \
+        --profile ci-probe --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gflow_cli.api.character import CharacterImageRequest  # noqa: E402
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+# A Flow workflow name looks like `projects/<uuid>/workflows/<uuid>`; media ids
+# are bare uuids. Both are what the entity PATCH needs, so both are worth
+# spotting in a response body we do not yet know the schema of.
+_WORKFLOW_RE = re.compile(r"projects/[0-9a-f-]{36}/workflows/[0-9a-zA-Z_-]{6,}")
+_UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+
+
+def _rpcids(url: str) -> list[str]:
+    if "batchexecute" not in url or "rpcids=" not in url:
+        return []
+    raw = url.split("rpcids=", 1)[1].split("&", 1)[0]
+    return [p for p in raw.split("%2C") if p]
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        entity_id = await client.create_entity(project)
+        step("entity", f"created {entity_id} (free tRPC)")
+        findings["entity_id"] = entity_id
+
+        transport = client.transport
+        page = transport._page  # noqa: SLF001 - spike watches the real page
+        if page is None:
+            step("abort", "transport exposed no page")
+            return 1
+
+        calls: list[dict[str, Any]] = []
+
+        async def _on_response(resp: Any) -> None:
+            url = resp.url
+            host = urlsplit(url).netloc
+            is_batch = "batchexecute" in url
+            is_sandbox = "aisandbox" in host
+            if not (is_batch or is_sandbox):
+                return
+            rec: dict[str, Any] = {
+                "kind": "batchexecute" if is_batch else "aisandbox",
+                "status": resp.status,
+                "rpcids": _rpcids(url),
+                "path": urlsplit(url).path[:80],
+            }
+            try:
+                body = await resp.text()
+            except Exception:  # noqa: BLE001 - body may be consumed/streamed
+                body = ""
+            rec["len"] = len(body)
+            rec["workflows"] = sorted(set(_WORKFLOW_RE.findall(body)))[:5]
+            # uuids are noisy; only record them when a workflow-ish key is near
+            if '"workflow' in body.lower() or "mediaid" in body.lower().replace("_", ""):
+                rec["uuid_sample"] = sorted(set(_UUID_RE.findall(body)))[:5]
+            rec["head"] = body[:220]
+            calls.append(rec)
+
+        page.on("response", lambda r: asyncio.create_task(_on_response(r)))
+
+        try:
+            step("drive", "invoking the transport's own generate_character_images")
+            req = CharacterImageRequest(
+                prompt="a calm portrait of a woman, neutral background",
+                model="nano2",
+            )
+            try:
+                await transport.generate_character_images(  # type: ignore[attr-defined]
+                    project_id=project,
+                    entity_id=entity_id,
+                    request=req,
+                    image_reference_index=0,
+                    locale=None,
+                )
+                step("drive", "returned WITHOUT error — the labs wire answered after all")
+                findings["production_path"] = "succeeded"
+            except Exception as exc:  # noqa: BLE001 - the failure IS the measurement
+                step("drive", f"failed as expected: {type(exc).__name__}: {str(exc)[:120]}")
+                findings["production_path"] = f"{type(exc).__name__}: {str(exc)[:200]}"
+
+            await page.wait_for_timeout(3000)
+            findings["calls"] = calls
+            batch = [c for c in calls if c["kind"] == "batchexecute"]
+            sandbox = [c for c in calls if c["kind"] == "aisandbox"]
+            step("wire", f"batchexecute responses={len(batch)}  aisandbox responses={len(sandbox)}")
+            for c in batch:
+                if c["rpcids"] or c["workflows"]:
+                    step(
+                        "batchexecute",
+                        f"rpcids={c['rpcids']} status={c['status']} len={c['len']} "
+                        f"workflows={c['workflows']}",
+                    )
+            for c in sandbox:
+                step("aisandbox", f"{c['path']} status={c['status']} len={c['len']}")
+            hits = [c for c in calls if c["workflows"]]
+            step(
+                "verdict",
+                f"{len(hits)} response(s) carried a workflow name -> "
+                + (str(hits[0]["rpcids"] or hits[0]["path"]) if hits else "NONE FOUND"),
+            )
+        finally:
+            try:
+                await client.delete_characters(project, [entity_id])
+                step("cleanup", f"deleted {entity_id}")
+            except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                step("cleanup", f"FAILED to delete {entity_id}: {exc}")
+            out = default_out_path("migrated_character_submit_wire")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/scripts/dev/spike_migrated_character_surface.py
+++ b/scripts/dev/spike_migrated_character_surface.py
@@ -1,0 +1,193 @@
+r"""Does flow.google.com have a character surface at all, and what drives it? ($0)
+
+The claim on the table — "the character editor is labs-only, ever" — comes from a
+selector that timed out, not from a recon. Two things were never separated:
+
+  1. flow.google.com has no cast/character feature.
+  2. flow.google.com HAS one, and gflow is asking for the wrong URL.
+
+gflow builds a **labs** route (``labs.google/fx/<locale>/tools/flow/project/P/
+character/E``) and lets the app hand off. The handoff strips ``/fx/<locale>/
+tools/flow``, so we land on ``flow.google.com/project/P/character/E`` — a path we
+never verified exists on that app. A SPA serving its shell for an unknown path
+renders no prompt box and looks exactly like "no feature".
+
+This spike goes **straight to flow.google.com** — no labs bounce — and asks:
+
+* what does the migrated project page expose (ligatures, roles, routes)?
+* is there a cast/character affordance, and what URL does it navigate to?
+* does ``/project/P/character/E`` render an editor, a 404, or the bare shell?
+* which ``batchexecute`` rpcids fire while we look?
+
+Credit-free: navigation, clicks on navigation affordances, and DOM reads. Nothing
+is typed and nothing is submitted.
+
+    python scripts/dev/spike_migrated_character_surface.py --profile ci-probe \
+        --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MIGRATED_ROOT = "https://flow.google.com"
+
+# Locale-invariant only: ligature text, ARIA roles, hrefs. aria-labels are
+# recorded so we know what NOT to anchor on (AGENTS.md locale-invariance rule).
+_INVENTORY_JS = r"""() => {
+  const tally = (items) => {
+    const m = new Map();
+    for (const k of items) m.set(k, (m.get(k) || 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]).map(([k, n]) => ({k, n}));
+  };
+  const LIG = '.google-symbols, .material-symbols-outlined, .material-icons, mat-icon';
+  const ligEls = [...document.querySelectorAll(LIG)];
+  const isLig = (t) => /^[a-z0-9_]{2,40}$/.test(t);
+  return {
+    url: location.href,
+    path: location.pathname,
+    title: document.title,
+    ligatures: tally(ligEls.map(e => (e.textContent || '').trim()).filter(isLig)),
+    roles: tally([...document.querySelectorAll('[role]')].map(e => e.getAttribute('role'))),
+    hrefs: tally([...document.querySelectorAll('a[href]')]
+      .map(a => a.getAttribute('href'))
+      .filter(h => h && !h.startsWith('http') && h.length < 120)),
+    aria_labels: tally([...document.querySelectorAll('[aria-label]')]
+      .map(e => e.getAttribute('aria-label')).filter(Boolean)).slice(0, 60),
+    textboxes: document.querySelectorAll(
+      'div[role="textbox"], textarea, [contenteditable="true"]').length,
+    buttons: document.querySelectorAll('button').length,
+    body_head: (document.body.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 500),
+  };
+}"""
+
+# Anything whose ligature or href smells like a cast/character/person surface.
+_CAST_PROBE_JS = r"""() => {
+  const LIG = '.google-symbols, .material-symbols-outlined, .material-icons, mat-icon';
+  const WORDS = /(cast|character|person|face|actor|people|account_box|theater)/i;
+  const out = [];
+  for (const el of document.querySelectorAll(LIG)) {
+    const t = (el.textContent || '').trim();
+    if (!WORDS.test(t)) continue;
+    const btn = el.closest('button, a, [role="button"], [role="tab"]');
+    out.push({
+      ligature: t,
+      carrier: el.tagName.toLowerCase(),
+      clickable: !!btn,
+      tag: btn ? btn.tagName.toLowerCase() : null,
+      href: btn ? btn.getAttribute('href') : null,
+      aria: btn ? btn.getAttribute('aria-label') : null,
+    });
+  }
+  for (const a of document.querySelectorAll('a[href]')) {
+    const h = a.getAttribute('href') || '';
+    if (WORDS.test(h)) out.push({ligature: null, href: h, tag: 'a', clickable: true,
+                                 aria: a.getAttribute('aria-label')});
+  }
+  return out;
+}"""
+
+
+def _rpcids(url: str) -> list[str]:
+    """Pull the ``rpcids=`` query values out of a batchexecute URL."""
+    if "batchexecute" not in url or "rpcids=" not in url:
+        return []
+    raw = url.split("rpcids=", 1)[1].split("&", 1)[0]
+    return [p for p in raw.split("%2C") if p]
+
+
+async def _main(profile: str, project: str, entity: str | None) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+    seen_rpcs: list[str] = []
+
+    async with build_client(profile_dir) as client:
+        context = client._context  # noqa: SLF001 - spike reads the live context
+        page = await context.new_page()
+
+        def _on_request(req: Any) -> None:
+            for rid in _rpcids(req.url):
+                if rid not in seen_rpcs:
+                    seen_rpcs.append(rid)
+
+        page.on("request", _on_request)
+
+        async def _settle() -> None:
+            try:
+                await page.wait_for_load_state("networkidle", timeout=20_000)
+            except Exception:  # noqa: BLE001 - settle is best-effort
+                pass
+            await page.wait_for_timeout(2000)
+
+        try:
+            # --- 1. the project page, DIRECT (no labs bounce) ----------------
+            direct = f"{_MIGRATED_ROOT}/project/{project}"
+            step("goto", f"DIRECT {direct}")
+            await page.goto(direct, wait_until="domcontentloaded", timeout=45_000)
+            await _settle()
+            step("landed", page.url)
+            findings["project_page"] = await page.evaluate(_INVENTORY_JS)
+            findings["project_page"]["cast_candidates"] = await page.evaluate(_CAST_PROBE_JS)
+            shot = default_out_path("migrated_project_direct", ".png")
+            await page.screenshot(path=str(shot))
+            findings["project_page"]["screenshot"] = shot.name
+            step(
+                "project",
+                f"textboxes={findings['project_page']['textboxes']} "
+                f"buttons={findings['project_page']['buttons']} "
+                f"cast_candidates={len(findings['project_page']['cast_candidates'])}",
+            )
+
+            # --- 2. the character route gflow currently asks for -------------
+            if entity:
+                char_url = f"{_MIGRATED_ROOT}/project/{project}/character/{entity}"
+                step("goto", f"DIRECT {char_url}")
+                await page.goto(char_url, wait_until="domcontentloaded", timeout=45_000)
+                await _settle()
+                step("landed", page.url)
+                findings["character_route"] = await page.evaluate(_INVENTORY_JS)
+                findings["character_route"]["redirected"] = entity not in page.url
+                shot2 = default_out_path("migrated_character_route", ".png")
+                await page.screenshot(path=str(shot2))
+                findings["character_route"]["screenshot"] = shot2.name
+                step(
+                    "character_route",
+                    f"path={findings['character_route']['path']} "
+                    f"textboxes={findings['character_route']['textboxes']} "
+                    f"redirected={findings['character_route']['redirected']}",
+                )
+
+            findings["batchexecute_rpcids"] = seen_rpcs
+            step("rpcs", ", ".join(seen_rpcs) or "(none seen)")
+
+        finally:
+            out = default_out_path("migrated_character_surface")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--entity", default=None, help="existing entity id to probe the route with")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project, args.entity)))

--- a/scripts/dev/spike_migrated_vs_labs_provenance.py
+++ b/scripts/dev/spike_migrated_vs_labs_provenance.py
@@ -1,0 +1,195 @@
+r"""Is flow.google.com the same app on a new DNS name, or a different frontend? ($0)
+
+The working hypothesis to test: *"this is just a DNS redirect — the system is the
+same, only the root DNS and the namespace changed; the internals barely moved."*
+
+That hypothesis makes three checkable predictions:
+
+  P1  the hop is a server redirect (30x) from labs.google to flow.google.com,
+      not a client-side hand-off by a different app
+  P2  the same frontend framework renders both (same markers in the DOM)
+  P3  the page talks to the same backend hosts and routes
+      (``aisandbox-pa.googleapis.com`` REST + labs tRPC)
+
+Each is recorded separately, because they can disagree — a shared BACKEND with a
+rewritten FRONTEND would satisfy P3 and fail P2, and that distinction decides
+whether gflow needs a new driver, a new transport, or only a new selector.
+
+Every request is logged (method, host, path, status) so the answer is the
+network's, not a guess. Credit-free: navigation and DOM reads only; nothing is
+typed and nothing is submitted.
+
+    python scripts/dev/spike_migrated_vs_labs_provenance.py \
+        --profile ci-probe --project 1e4efe0d-afcf-4e0d-ae4d-b4431f2d73de
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gflow_cli.api.routes import character_editor_url  # noqa: E402
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+# Framework fingerprints. Each is a build-tool artefact, not a display string,
+# so none of them translate — safe to compare across locales.
+_MARKERS_JS = r"""() => {
+  const has = (sel) => document.querySelectorAll(sel).length;
+  const root = document.documentElement;
+  const reactKeyed = [...document.querySelectorAll('div')].slice(0, 400)
+    .some(e => Object.keys(e).some(k => k.startsWith('__react')));
+  return {
+    angular_ngcontent: [...document.querySelectorAll('*')].slice(0, 2000)
+      .filter(e => [...e.attributes].some(a => a.name.startsWith('_ngcontent'))).length,
+    angular_version: root.getAttribute('ng-version'),
+    angular_app_root: has('app-root, [ng-version]'),
+    react_root_attr: has('[data-reactroot]'),
+    react_fiber_keys: reactKeyed,
+    next_data: has('#__NEXT_DATA__'),
+    slate_editors: has('[data-slate-editor]'),
+    prosemirror: has('.ProseMirror'),
+    mat_icon: has('mat-icon'),
+    google_symbols_i: has('i.google-symbols'),
+    scripts: [...document.querySelectorAll('script[src]')]
+      .map(s => (s.getAttribute('src') || '').split('/').pop()).slice(0, 25),
+  };
+}"""
+
+
+def _bucket(url: str) -> str:
+    """Group a URL into the coarse backend it belongs to."""
+    host = urlsplit(url).netloc
+    path = urlsplit(url).path
+    if "aisandbox" in host:
+        return f"aisandbox-pa{path.rsplit('/', 1)[0][:40]}"
+    if "batchexecute" in path:
+        return f"{host} batchexecute"
+    if "/trpc/" in path:
+        return f"{host} tRPC"
+    if "recaptcha" in host or "recaptcha" in path:
+        return "recaptcha"
+    return host
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        entity_id = await client.create_entity(project)
+        step("entity", f"created {entity_id} (free tRPC)")
+        findings["entity_id"] = entity_id
+        try:
+            context = client._context  # noqa: SLF001 - spike reads the live context
+            page = await context.new_page()
+
+            requests: list[dict[str, Any]] = []
+            page.on(
+                "request",
+                lambda r: requests.append(
+                    {"method": r.method, "url": r.url, "type": r.resource_type}
+                ),
+            )
+            redirects: list[dict[str, Any]] = []
+            page.on(
+                "response",
+                lambda r: (
+                    redirects.append(
+                        {"status": r.status, "url": r.url, "location": r.headers.get("location")}
+                    )
+                    if 300 <= r.status < 400
+                    else None
+                ),
+            )
+            frame_navs: list[str] = []
+            page.on("framenavigated", lambda f: frame_navs.append(f.url) if not f.parent_frame else None)
+
+            # --- P1: how does the labs URL become the flow URL? --------------
+            labs_url = character_editor_url("en", project, entity_id)
+            step("goto", f"LABS {labs_url}")
+            mark = len(requests)
+            await page.goto(labs_url, wait_until="domcontentloaded", timeout=45_000)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=25_000)
+            except Exception:  # noqa: BLE001 - settle is best-effort
+                pass
+            await page.wait_for_timeout(3000)
+
+            doc_redirects = [
+                r for r in redirects if "labs.google" in r["url"] or "flow.google" in r["url"]
+            ]
+            findings["P1_hop"] = {
+                "requested": labs_url,
+                "landed": page.url,
+                "server_redirects": doc_redirects,
+                "top_frame_navigations": frame_navs,
+                "verdict": (
+                    "server-redirect"
+                    if any(
+                        r.get("location") and "flow.google.com" in (r.get("location") or "")
+                        for r in doc_redirects
+                    )
+                    else "client-side handoff"
+                ),
+            }
+            step("P1", f"{findings['P1_hop']['verdict']}  landed={page.url}")
+            step("P1", f"top-frame navigations: {frame_navs}")
+            for r in doc_redirects:
+                step("P1", f"  {r['status']} {r['url'][:70]} -> {(r['location'] or '')[:70]}")
+
+            # --- P2: which frontend rendered it? -----------------------------
+            findings["P2_markers"] = await page.evaluate(_MARKERS_JS)
+            m = findings["P2_markers"]
+            step(
+                "P2",
+                f"angular_ngcontent={m['angular_ngcontent']} ng-version={m['angular_version']} "
+                f"react_fiber={m['react_fiber_keys']} next_data={m['next_data']} "
+                f"slate={m['slate_editors']} prosemirror={m['prosemirror']}",
+            )
+
+            # --- P3: which backends does it call? ----------------------------
+            after = requests[mark:]
+            buckets = Counter(_bucket(r["url"]) for r in after if r["type"] in {"xhr", "fetch"})
+            findings["P3_backends"] = dict(buckets)
+            findings["P3_sample_api_urls"] = [
+                r["url"][:150]
+                for r in after
+                if r["type"] in {"xhr", "fetch"}
+                and ("aisandbox" in r["url"] or "batchexecute" in r["url"] or "/trpc/" in r["url"])
+            ][:20]
+            step("P3", f"xhr/fetch by backend: {dict(buckets)}")
+            for u in findings["P3_sample_api_urls"][:8]:
+                step("P3", f"  {u[:120]}")
+        finally:
+            try:
+                await client.delete_characters(project, [entity_id])
+                step("cleanup", f"deleted {entity_id}")
+            except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                step("cleanup", f"FAILED to delete {entity_id}: {exc}")
+            out = default_out_path("migrated_vs_labs_provenance")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/scripts/dev/spike_video_tab_dom.py
+++ b/scripts/dev/spike_video_tab_dom.py
@@ -27,7 +27,7 @@ from gflow_cli.api.transports.ui_automation_video import (  # noqa: E402
     MODE_SWITCH_TRIGGER_SELECTORS,
 )
 
-_DUMP_TABS = """
+_DUMP_TABS = r"""
 () => ({
   tabs: Array.from(document.querySelectorAll("[role='tab']")).map(e => ({
     id: e.id || null,

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -3033,6 +3033,119 @@ class FlowApiClient:
         except Exception as e:
             await self._raise_with_incident(e, phase="character_generation")
 
+    async def _workflow_primary_media_id(self, project_id: str, workflow_id: str) -> str | None:
+        """Flow's own ``metadata.primaryMediaId`` for *workflow_id*, or ``None``.
+
+        Read from the project listing rather than inferred, because inferring it
+        is what corrupted a body workflow: the entity exposes one thumbnail id,
+        and reusing it across slots wrote the portrait's media onto the body.
+        Best-effort — a listing fault leaves the caller to fall back.
+        """
+        try:
+            listing = await self.fetch_project_listing(project_id)
+        except Exception:  # noqa: BLE001 - diagnostic read, never fatal
+            logger.warning("character.workflow_media_lookup_failed", exc_info=True)
+            return None
+        payload = _unwrap_trpc(listing)
+        contents = payload.get("projectContents")
+        if not isinstance(contents, dict):
+            return None
+        raw_workflows = cast("JsonObject", contents).get("workflows")
+        if not isinstance(raw_workflows, list):
+            return None
+        workflows = cast("list[object]", raw_workflows)
+        for entry in workflows:
+            if not isinstance(entry, dict):
+                continue
+            record = cast("JsonObject", entry)
+            if record.get("name") != workflow_id:
+                continue
+            metadata = record.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            media = cast("JsonObject", metadata).get("primaryMediaId")
+            if isinstance(media, str) and media:
+                return media
+        return None
+
+    async def _character_slot_from_entity(
+        self,
+        *,
+        project_id: str,
+        entity_id: str,
+        image_reference_index: int,
+    ) -> tuple[str, str, AnyPath | None] | None:
+        """Read a generated slot's ids back off the entity, or ``None``.
+
+        Returns ``(workflow_id, primary_media_id, local_path)`` in the shape
+        :meth:`_generate_character_image_impl` returns, with ``local_path``
+        always ``None`` — this path binds ids, it does not download a file.
+
+        ``None`` means "the backend has nothing for this slot", which is the
+        honest answer when a generation really did fail: the caller re-raises
+        the original timeout rather than inventing a success. A fault in the
+        read-back itself is swallowed for the same reason — it is a rescue
+        attempt, and it must never displace the failure the user came to see.
+        """
+        try:
+            character = await self.get_character(project_id, entity_id=entity_id)
+        except Exception:  # noqa: BLE001 - a rescue must not mask the real error
+            logger.warning(
+                "character.result_read_back_failed",
+                entity_id=entity_id,
+                exc_info=True,
+            )
+            return None
+        workflow_ids = tuple(character.workflow_ids or ())
+        if len(workflow_ids) <= image_reference_index:
+            logger.info(
+                "character.result_read_back_empty",
+                entity_id=entity_id,
+                bound_workflows=len(workflow_ids),
+                image_reference_index=image_reference_index,
+            )
+            return None
+        workflow_id = workflow_ids[image_reference_index]
+        # Each workflow carries its OWN primaryMediaId; the entity carries only the
+        # thumbnail. Handing the thumbnail to every slot made the body slot claim
+        # the face's media, and the saga's commit_workflow then PATCHed that id
+        # onto the body workflow — corrupting it (observed live 2026-09-06).
+        # Reading Flow's value instead makes that commit a no-op.
+        media_id = await self._workflow_primary_media_id(project_id, workflow_id) or ""
+        if not media_id and image_reference_index == 0:
+            # Slot 0 IS the thumbnail by definition, so it is a safe last resort.
+            media_id = character.thumbnail_media_id or ""
+
+        # The ids are the character; the file is a convenience. Download it so
+        # `--output` and `image_paths` behave the same on both hosts, but never
+        # let a CDN hiccup cost the user a generation they already spent quota
+        # on — a failed fetch degrades to `None`, it does not raise.
+        #
+        # `media.getMediaUrlRedirect` is a labs route, and migrated_composer
+        # records it 404-ing for a migrated media id. That was measured on a
+        # VIDEO id and does not generalise: probed live 2026-09-06 against this
+        # path's own portrait id, it answered HTTP 200 with 696 767 bytes of
+        # JFIF. Re-probe before assuming either way for a new media kind.
+        local_path: AnyPath | None = None
+        if media_id:
+            try:
+                local_path = await self.download(
+                    media_id,
+                    character_output_path(
+                        self.settings.output_dir,
+                        entity_id=entity_id,
+                        slot=image_reference_index,
+                    ),
+                )
+            except Exception:  # noqa: BLE001 - a missing file never loses the ids
+                logger.warning(
+                    "character.result_read_back_download_failed",
+                    entity_id=entity_id,
+                    slot=image_reference_index,
+                    exc_info=True,
+                )
+        return workflow_id, media_id, local_path
+
     async def _generate_character_image_impl(
         self,
         *,
@@ -3090,17 +3203,44 @@ class FlowApiClient:
             )
             raise RuntimeError(msg)
 
-        _raw = await self.transport.generate_character_images(  # type: ignore[attr-defined]
-            project_id=project_id,
-            entity_id=entity_id,
-            request=req,
-            image_reference_index=image_reference_index,
-            # #580: caller override wins; otherwise the ACCOUNT's own locale.
-            # Never "en-US" — a wrong segment bounces the character route, which
-            # is how #395 presented.
-            locale=locale if locale is not None else self._account_locale,
-            format_prompt=format_prompt,
-        )
+        try:
+            _raw = await self.transport.generate_character_images(  # type: ignore[attr-defined]
+                project_id=project_id,
+                entity_id=entity_id,
+                request=req,
+                image_reference_index=image_reference_index,
+                # #580: caller override wins; otherwise the ACCOUNT's own locale.
+                # Never "en-US" — a wrong segment bounces the character route, which
+                # is how #395 presented.
+                locale=locale if locale is not None else self._account_locale,
+                format_prompt=format_prompt,
+            )
+        except TimeoutError:
+            # The passive capture listens for `flowMedia:batchGenerateImages`,
+            # which is the LABS wire. flow.google.com generates the portrait
+            # over its own `batchexecute` (rpcid ogiZ0b) and never calls it, so
+            # the listener times out on work that SUCCEEDED — measured live
+            # 2026-09-06 on ci-probe, where the entity carried a workflow id and
+            # a thumbnail media id the moment the timeout fired.
+            #
+            # Ask the backend instead of decoding an undocumented envelope. The
+            # ids come off the entity itself, so the binding this method exists
+            # to verify is true by construction — strictly stronger than the
+            # labs path's self-reported parentEntityId.
+            bound = await self._character_slot_from_entity(
+                project_id=project_id,
+                entity_id=entity_id,
+                image_reference_index=image_reference_index,
+            )
+            if bound is None:
+                raise
+            logger.info(
+                "character.result_read_back_from_entity",
+                entity_id=entity_id,
+                workflow_id=bound[0],
+                image_reference_index=image_reference_index,
+            )
+            return bound
         _images, workflows = cast(
             "tuple[list[GeneratedImage], list[JsonObject]]",
             _raw,

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -20,13 +20,13 @@ import random
 import re
 import secrets
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from urllib.parse import urlparse
 
 import structlog
 
 from gflow_cli.api._retry import parse_retry_after
-from gflow_cli.api.character import CHARACTER_MODELS, CharacterImageRequest
+from gflow_cli.api.character import CharacterImageRequest
 from gflow_cli.api.dto import BatchSubmissionResult, GeneratedImage
 from gflow_cli.api.image import Aspect, GenerateImageRequest, Model
 from gflow_cli.api.transports._common import (
@@ -37,8 +37,8 @@ from gflow_cli.api.transports._common import (
     flow_host_kind,
     generation_error,
     offered_menu_labels,
-    raise_if_migrated,
 )
+from gflow_cli.api.transports.migrated_composer import MENU_ITEM, ModelMenuMatcher
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
@@ -50,6 +50,7 @@ from gflow_cli.api.transports.ui_automation_video import (
 from gflow_cli.errors import (
     AuthExpiredError,
     BatchPartialError,
+    ConfigurationError,
     ContentPolicyError,
     FlowAppError,
     GFlowError,
@@ -1766,8 +1767,15 @@ class UiAutomationTransport(VideoGenerationMixin):
         await self._click_submit(page)
 
     async def _count_character_prompt_boxes(self, page: Page) -> int:
-        """Count Slate prompt boxes (legacy body-mode baseline)."""
-        return int(await page.locator(PROMPT_INPUT_SELECTORS[0]).count())
+        """Count the editor's prompt boxes (legacy body-mode baseline).
+
+        Counts through the SAME anchor the readiness gate accepts, so both
+        frontends are seen: labs mounts Slate, flow.google.com mounts
+        ProseMirror. Counting only Slate reported 0 boxes on the migrated host
+        and aborted the body step with "Body prompt box did not mount" — on an
+        editor whose box was mounted and visible the whole time (2026-09-06).
+        """
+        return int(await page.locator(self._CHARACTER_EDITOR_READY_SELECTOR).count())
 
     async def _locate_body_prompt_box(
         self,
@@ -1790,7 +1798,8 @@ class UiAutomationTransport(VideoGenerationMixin):
         cohorts mount a second box, so their count must exceed
         ``boxes_before``. In either case the LAST mounted box is the target.
         """
-        loc = page.locator(PROMPT_INPUT_SELECTORS[0])
+        # Both frontends' anchors — see _count_character_prompt_boxes.
+        loc = page.locator(self._CHARACTER_EDITOR_READY_SELECTOR)
         deadline = time.monotonic() + _BODY_SLOT_MOUNT_TIMEOUT_S
         count = int(await loc.count())
         required_count = 0 if shared_body_box else boxes_before
@@ -1809,7 +1818,7 @@ class UiAutomationTransport(VideoGenerationMixin):
             msg = (
                 f"Body prompt box did not mount within "
                 f"{_BODY_SLOT_MOUNT_TIMEOUT_S:.0f}s after body-mode activation "
-                f"(Slate boxes: {count}, before slot-add: {boxes_before}). "
+                f"(prompt boxes: {count}, before slot-add: {boxes_before}). "
                 f"The body-mode settle check reported that {settle_signal}. "
                 "Typing now would land in the portrait prompt box and "
                 "overwrite the stored portrait prompt — aborting the body "
@@ -1878,7 +1887,10 @@ class UiAutomationTransport(VideoGenerationMixin):
         sentinel = _BODY_TRIPTYCH_PREAMBLE[:24]
         try:
             target_text = str(await input_box.inner_text() or "")
-            boxes = page.locator(PROMPT_INPUT_SELECTORS[0])
+            # Readiness anchor, not the Slate-only selector: on the migrated
+            # editor the latter counts 0 boxes, so the portrait-overwrite guard
+            # below silently compared against an empty string.
+            boxes = page.locator(self._CHARACTER_EDITOR_READY_SELECTOR)
             box_count = int(await boxes.count())
             portrait_text = str(await boxes.first.inner_text() or "") if box_count > 1 else ""
         except Exception as e:
@@ -3329,10 +3341,20 @@ class UiAutomationTransport(VideoGenerationMixin):
     # ------------------------------------------------------------------
 
     # Selector for the character editor's Slate prompt textbox — used as the
-    # "editor mounted" readiness anchor.  This IS PROMPT_INPUT_SELECTORS[0];
+    # "editor mounted" readiness anchor.  Its first alternative IS
+    # PROMPT_INPUT_SELECTORS[0];
     # duplicated here as a named constant so the character-editor path is
     # self-documenting without importing the tuple.
-    _CHARACTER_EDITOR_READY_SELECTOR = 'div[role="textbox"][data-slate-editor="true"]'
+    # Two frontends, one feature. labs.google renders the character editor with
+    # React + Slate; flow.google.com renders the SAME editor — same tRPC backend,
+    # same aisandbox REST, same entities — with Angular + ProseMirror (recon
+    # 2026-09-06, scripts/dev/spike_migrated_character_editor_anchor.py). Asking
+    # only for Slate made a present feature look absent for 20 s and then get
+    # reported as "labs-only, ever", which was wrong. Both anchors are library
+    # build artefacts rather than display strings, so neither translates.
+    _CHARACTER_EDITOR_READY_SELECTOR = (
+        'div[role="textbox"][data-slate-editor="true"], div.ProseMirror[contenteditable="true"]'
+    )
 
     # Slot-add button for character image slots 1+ (body / accessories).
     #
@@ -3360,7 +3382,13 @@ class UiAutomationTransport(VideoGenerationMixin):
     # [[flow-locale-leak-icon-ligatures]] — it may only serve as a positional
     # hint.  ``text-is`` (exact match) is used so partial-ligature collisions
     # (e.g. ``add_2_box``) cannot match.
-    _CHARACTER_SLOT_ADD_SELECTOR = "[role='button']:has(i.google-symbols:text-is('add_2'))"
+    #: Both ligature carriers: labs uses `<i class="google-symbols">`, the migrated
+    #: Angular frontend uses `<mat-icon>`. Anchoring on one host's carrier is what
+    #: made the whole character surface look absent on the other (2026-09-06).
+    _CHARACTER_SLOT_ADD_SELECTOR = (
+        "[role='button']:has(i.google-symbols:text-is('add_2')), "
+        "[role='button']:has(mat-icon:text-is('add_2'))"
+    )
     # The exact ligature an icon-only slot-add candidate's inner_text reduces to.
     _CHARACTER_SLOT_ADD_LIGATURE = "add_2"
 
@@ -3369,12 +3397,38 @@ class UiAutomationTransport(VideoGenerationMixin):
     # language-independent ``accessibility_new`` icon activates body mode; the
     # generated-face reference chip (image + ``cancel`` icon) proves the mode
     # transition settled before the shared prompt box is safe to edit.
+    #: Stays SCOPED on both hosts. The project-level "Characters" navigation control
+    #: carries the same ``accessibility_new`` ligature, so a bare selector activates
+    #: navigation instead of body mode.
+    #:
+    #: labs scopes it as the sibling of the portrait image button. The migrated
+    #: editor gives us something better: each slot control is wrapped in its own
+    #: ``<flow-slot-chip-button>`` custom element (recon 2026-09-06,
+    #: ``scripts/dev/spike_migrated_character_body_controls.py``), which is a
+    #: component boundary rather than a layout accident — the navigation control is
+    #: not a slot chip, so it cannot match. The migrated host has **no** ``add_2``
+    #: control at all; body mode is entered through this chip directly.
+    #:
+    #: The chip ships ``disabled`` until a portrait exists, which is why callers
+    #: must wait for it to become enabled rather than clicking on sight.
     _CHARACTER_BODY_MODE_SELECTOR = (
-        "button:has(img) + button:has(i.google-symbols:text-is('accessibility_new'))"
+        "button:has(img) + button:has(i.google-symbols:text-is('accessibility_new')), "
+        "flow-slot-chip-button:has(mat-icon:text-is('accessibility_new')) button"
     )
+    #: The settle signal for body mode: proof the generated face actually mounted as
+    #: a reference, so the SHARED prompt box now belongs to body mode. Editing it
+    #: earlier types the body prompt into the face composer (#395).
+    #:
+    #: labs mounts a dismissable card around a ``media.getMediaUrlRedirect`` image.
+    #: The migrated host serves reference images from a different origin entirely —
+    #: ``flow-content.google/image/<id>`` — and mounts a bare ``<img>`` with no card
+    #: chrome. Measured 2026-09-06 (``spike_migrated_body_reference_chip.py``):
+    #: absent before the Create body click, present after it, so it is a genuine
+    #: transition signal and not something that is simply always on the page.
     _CHARACTER_BODY_REFERENCE_SELECTOR = (
         "button[data-card-open]:has(img[src*='media.getMediaUrlRedirect'])"
-        ":has(i.google-symbols:text-is('cancel'))"
+        ":has(i.google-symbols:text-is('cancel')), "
+        "img[src*='flow-content.google/image/']"
     )
 
     # Character-editor model picker.  The editor shows a model chip ("🍌 Nano
@@ -3385,10 +3439,66 @@ class UiAutomationTransport(VideoGenerationMixin):
     # ⚠️ NOT yet spiked from the live DOM — this is a reasonable best-effort
     # selector cascade, live-confirmed later.  A failed pick is NON-FATAL:
     # generation proceeds with Flow's default model.
+    #: The ligature carrier differs by host — labs renders `<i class="google-symbols">`,
+    #: flow.google.com renders `<mat-icon>` — so both are listed. A run that omitted the
+    #: mat-icon variants logged `model-picker trigger not found` on the migrated host and
+    #: generated on whatever tier the editor happened to open on (live 2026-09-06).
     _CHARACTER_MODEL_PICKER_TRIGGER_SELECTORS = (
         "button:has(i.google-symbols:text-is('arrow_drop_down'))",
+        "button:has(mat-icon:text-is('arrow_drop_down'))",
         "[role='button']:has(i.google-symbols:text-is('arrow_drop_down'))",
+        "[role='button']:has(mat-icon:text-is('arrow_drop_down'))",
     )
+
+    #: Every character model is a "Nano Banana …" tier, so the model chip is the one
+    #: `arrow_drop_down` control whose own text names one. The editor renders several
+    #: such controls; picking `.first` blindly is how a picker ends up driving the
+    #: wrong menu. Product names are not localized (see :data:`CHARACTER_MODELS`).
+    _CHARACTER_MODEL_CHIP_HINT = "Nano Banana"
+
+    #: How each CLI alias is recognised among the editor's menu entries. Reuses the
+    #: migrated composer's matcher so both hosts obey the same #539 rule: match in
+    #: Python, and REFUSE an ambiguous hit rather than resolving `.first`.
+    #: "Nano Banana 2" is a prefix of "Nano Banana 2 Lite", so it must exclude it;
+    #: "Nano Banana Pro" shares no prefix and needs no exclusion. Product names are
+    #: not localized, which is why matching entries by display text is permitted
+    #: here where the locale-invariance rule otherwise forbids it.
+    _CHARACTER_MODEL_MATCHERS: ClassVar[dict[str, ModelMenuMatcher]] = {
+        "nano2": ModelMenuMatcher("Nano Banana 2", excludes="Lite"),
+        "nanopro": ModelMenuMatcher("Nano Banana Pro", excludes=None),
+    }
+
+    async def _find_character_model_chip(self, page: Any) -> tuple[Any | None, str]:
+        """Return the model chip and the text it currently shows.
+
+        Prefers a candidate whose text names a model tier over a bare positional
+        `.first`, so a page carrying several `arrow_drop_down` controls cannot
+        hand the picker somebody else's menu. Falls back to the first candidate
+        when none names a tier — better to try than to skip the selection.
+        """
+        # Wait for SOMETHING to mount before enumerating. A bare count() races the
+        # editor: the readiness gate only proves the prompt box exists, and the
+        # model chip lands after it. Dropping this wait during a refactor turned a
+        # working picker back into "model-picker trigger not found" (2026-09-06).
+        for trig_sel in self._CHARACTER_MODEL_PICKER_TRIGGER_SELECTORS:
+            try:
+                await page.locator(trig_sel).first.wait_for(state="visible", timeout=4000)
+                break
+            except Exception:  # noqa: BLE001,PERF203 - try the next carrier
+                continue
+
+        fallback: Any | None = None
+        fallback_text = ""
+        for trig_sel in self._CHARACTER_MODEL_PICKER_TRIGGER_SELECTORS:
+            locator = page.locator(trig_sel)
+            for index in range(await locator.count()):
+                candidate = locator.nth(index)
+                text = (await candidate.text_content() or "").strip()
+                if self._CHARACTER_MODEL_CHIP_HINT.casefold() in text.casefold():
+                    return candidate, text
+                if fallback is None:
+                    fallback, fallback_text = candidate, text
+        return fallback, fallback_text
 
     async def _select_character_model(
         self,
@@ -3396,80 +3506,154 @@ class UiAutomationTransport(VideoGenerationMixin):
         model_alias: str,
         out_dir: Any = None,
     ) -> None:
-        """Best-effort select the character model via the editor's model picker.
+        """Apply the requested character model, or raise. Never silently proceed.
 
-        ``model_alias`` is the friendly CLI alias (``"nano2"`` / ``"nanopro"``);
-        it is mapped through :data:`CHARACTER_MODELS` to the UI display name.
+        ``model_alias`` is the friendly CLI alias (``"nano2"`` / ``"nanopro"``).
 
-        If the requested model is the DEFAULT (``nano2`` / "Nano Banana 2") the
-        picker is left untouched — it is already selected, so an extra click is
-        wasteful and risks closing nothing useful.
+        **This is a hard gate, deliberately.** It used to be best-effort: every
+        failure logged a warning and let the generation run on whatever tier the
+        editor happened to show. For a CLI that is the worst outcome — the user
+        gets a paid artifact from a model they did not ask for, and nothing in
+        the output says so. Both halves of that were seen live on 2026-09-06:
+        ``--model nano2`` generating on Pro because the picker assumed nano2 was
+        the default, and a later run whose menu-item click timed out, leaving the
+        tier unchanged while the generation proceeded.
 
-        Otherwise the dropdown is opened (the element bearing the
-        ``arrow_drop_down`` ligature near the model chip) and the option whose
-        visible text contains the display name is clicked.
+        Aborting is **free**. Everything here happens before the prompt is
+        submitted, so a raise costs no quota and no credits.
 
-        NON-FATAL: if the alias is unknown, or the dropdown / option cannot be
-        found, a warning is logged and generation proceeds with Flow's default
-        model.  The picker DOM is not yet spiked — see the selector constants.
+        The selection is verified by re-reading the chip afterwards rather than
+        trusting the click, because the click is exactly what was observed to
+        fail. One retry absorbs a menu that re-renders under us; anything else
+        raises.
+
+        Raises:
+            :class:`~gflow_cli.errors.ConfigurationError`: the alias is unknown,
+                or the menu does not offer exactly one entry matching it.
+            :class:`~gflow_cli.errors.UiSelectorDriftError`: the picker or its
+                menu could not be driven, or the tier did not apply.
         """
-        display_name = CHARACTER_MODELS.get(model_alias.lower())
-        if display_name is None:
-            log.warning(
-                "ui_automation.character_model_picker_not_found",
-                model=model_alias,
-                reason="unknown_alias",
+        matcher = self._CHARACTER_MODEL_MATCHERS.get(model_alias.lower())
+        if matcher is None:
+            raise ConfigurationError(
+                detail=(
+                    f"unknown character model {model_alias!r}; "
+                    f"known aliases: {', '.join(sorted(self._CHARACTER_MODEL_MATCHERS))}"
+                ),
+                remediation_hint="Pass --model nano2 or --model nanopro.",
             )
-            return
 
-        # nano2 / "Nano Banana 2" is the editor default — already selected.
-        default_display = CHARACTER_MODELS["nano2"]
-        if display_name == default_display:
-            log.info(
-                "ui_automation.character_model_selected",
-                model=display_name,
-                via="default_no_click",
-            )
-            return
-
-        try:
-            opened = False
-            for trig_sel in self._CHARACTER_MODEL_PICKER_TRIGGER_SELECTORS:
-                try:
-                    trigger = page.locator(trig_sel).first
-                    await trigger.wait_for(state="visible", timeout=4000)
-                    await trigger.click()
-                    await page.wait_for_timeout(400)
-                    opened = True
-                    break
-                except Exception:
-                    continue
-            if not opened:
-                raise RuntimeError("model-picker trigger not found")
-
-            option_sel = f":has-text('{display_name}')"
-            option = page.locator(option_sel).first
-            await option.wait_for(state="visible", timeout=4000)
-            await option.click()
-            await page.wait_for_timeout(400)
-            log.info(
-                "ui_automation.character_model_selected",
-                model=display_name,
-                via=option_sel,
-            )
-        except Exception as e:
-            log.warning(
-                "ui_automation.character_model_picker_not_found",
-                model=model_alias,
-                display_name=display_name,
-                error=str(e)[:120],
-                note="Flow default model applies",
-            )
+        trigger, current = await self._find_character_model_chip(page)
+        if trigger is None:
             await _capture_debug_screenshot(page, out_dir, "debug_character_model_picker.png")
+            raise UiSelectorDriftError(
+                detail=(
+                    "character editor: the model picker (an arrow_drop_down control naming a "
+                    f"model tier) was not found, so --model {model_alias} could not be applied. "
+                    f"URL: {page.url}."
+                ),
+            )
+
+        if matcher.matches(current):
+            # Logged because the path is otherwise invisible: a run that
+            # short-circuits emits no model event, and a field timeline cannot
+            # tell "already on the tier you asked for" from "never looked".
+            log.info(
+                "ui_automation.character_model_already_selected",
+                model=current,
+                requested=model_alias,
+            )
+            return
+
+        last_seen = current
+        for attempt in (1, 2):
+            await trigger.click(timeout=4000)
+            # ``:visible`` is load-bearing. The editor keeps several menus in the
+            # DOM at once (two `flow-add-menu`s plus the model `mat-menu`), so an
+            # unscoped `[role='menuitem']` list mixes the open overlay's items
+            # with hidden ones from the others. The text list and the clickable
+            # list then disagree, and `nth(i)` — an index into the text list —
+            # lands on a hidden node: `Locator.click: Timeout 4000ms exceeded`,
+            # every time, while the same selector worked whenever the other menus
+            # happened not to be mounted. Measured live 2026-09-06.
+            items = page.locator(f"{MENU_ITEM}:visible")
             try:
-                await page.keyboard.press("Escape")
-            except Exception:
-                pass
+                await items.first.wait_for(state="visible", timeout=5000)
+            except Exception as e:
+                await _capture_debug_screenshot(page, out_dir, "debug_character_model_picker.png")
+                raise UiSelectorDriftError(
+                    detail=(
+                        "character editor: the model menu ([role='menuitem']) did not open, so "
+                        f"--model {model_alias} could not be applied. URL: {page.url}."
+                    ),
+                ) from e
+
+            # Matched in Python rather than through a `has_text` filter: an
+            # *exclusion* is not expressible as has_text, the menu is read back for
+            # the refusal diagnostic anyway, and more than one hit must REFUSE
+            # instead of resolving `.first` (#539 — a `.first` on an ambiguous
+            # selector picks a tier the user never asked for, and Flow bills it).
+            offered = [t.strip() for t in await items.all_text_contents()]
+            hits = [i for i, text in enumerate(offered) if matcher.matches(text)]
+            if len(hits) != 1:
+                await self._dismiss_character_model_menu(page)
+                raise ConfigurationError(
+                    detail=(
+                        f"--model {model_alias} matched {len(hits)} entries in the character "
+                        f"model menu; offered: {', '.join(offered) or '(none)'}"
+                    ),
+                    remediation_hint=(
+                        "Pass a --model that names exactly one offered entry."
+                        if hits
+                        else "Pass --model with one of the offered names."
+                    ),
+                )
+
+            try:
+                await items.nth(hits[0]).click(timeout=4000)
+            except Exception:  # noqa: BLE001 - a flaky click is what the retry is for
+                log.warning(
+                    "ui_automation.character_model_click_failed",
+                    requested=model_alias,
+                    attempt=attempt,
+                )
+                await self._dismiss_character_model_menu(page)
+                continue
+            await page.wait_for_timeout(400)
+
+            # Verify, never assume: the click is precisely what was seen to fail.
+            _, last_seen = await self._find_character_model_chip(page)
+            if matcher.matches(last_seen):
+                log.info(
+                    "ui_automation.character_model_selected",
+                    model=last_seen,
+                    requested=model_alias,
+                    attempt=attempt,
+                )
+                return
+            log.warning(
+                "ui_automation.character_model_not_applied",
+                requested=model_alias,
+                chip=last_seen,
+                attempt=attempt,
+            )
+
+        await _capture_debug_screenshot(page, out_dir, "debug_character_model_picker.png")
+        raise UiSelectorDriftError(
+            detail=(
+                f"character editor: --model {model_alias} did not apply — the model chip still "
+                f"reads {last_seen!r} after two attempts. Refusing to generate on a tier you did "
+                f"not ask for. URL: {page.url}."
+            ),
+        )
+
+    async def _dismiss_character_model_menu(self, page: Any) -> None:
+        """Close an open model menu; never fatal."""
+        try:
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(200)
+        except Exception:  # noqa: BLE001 - dismissal is a courtesy
+            log.debug("ui_automation.character_model_menu_dismiss_failed", exc_info=True)
 
     _CHARACTER_ROUTE_ATTEMPTS = 4
     _CHARACTER_ROUTE_BACKOFF_MS = 2_500
@@ -3568,15 +3752,18 @@ class UiAutomationTransport(VideoGenerationMixin):
         await self._dismiss_blocking_overlays(page, self._out_dir)
         await self._settle_on_character_route(page, entity_id=entity_id, url=url)
 
-        # The character editor is a labs-only surface: the migrated host renders
-        # no prompt textbox for it, ever. Without this the readiness gate below
-        # burned its full 20 s and then raised a bare RuntimeError, which the CLI
-        # reports as "Unexpected error" (exit 1) instead of the typed,
-        # non-retryable exit 36 that names the migration. Measured live
-        # 2026-09-06 on a moved account. Placed AFTER the settles so the
-        # post-goto client-side hop has landed, and BEFORE the wait so the user
-        # does not pay 20 s to be told something knowable now.
-        raise_if_migrated(page, at="character_editor")
+        # NO migrated-host guard here, deliberately. One stood here and was
+        # wrong: flow.google.com renders the character editor in full — name,
+        # voice, personality, Upload / Add from project, Create portrait /
+        # Create body — against the SAME labs tRPC and aisandbox backend
+        # (recon 2026-09-06, scripts/dev/spike_migrated_vs_labs_provenance.py:
+        # the migrated page itself calls flow.projectInitialData and
+        # v1:checkAppAvailability). What differed was the view layer, React +
+        # Slate vs Angular + ProseMirror, so the readiness selector missed and
+        # a present feature was read as an absent one. The guard then turned
+        # that misreading into a confident, non-retryable "this host will never
+        # do it". Do not reinstate it without live evidence that the editor is
+        # actually gone.
 
         # Wait for the Slate editor to mount — the prompt textbox is the
         # reliable "editor ready" anchor for the character editor surface.

--- a/src/gflow_cli/data/recorder.py
+++ b/src/gflow_cli/data/recorder.py
@@ -1247,6 +1247,21 @@ class OperationRecorder:
                 image_paths=image_paths,
             )
 
+    def record_character_abandoned(self, *, row_id: str, exc: BaseException) -> None:
+        """Flip a zero-progress character STARTED row to FAILED (#703).
+
+        Only the saga's rollback path calls this: the run failed before the
+        first slot committed, so the row records no workflow id and buys no
+        resume.  Leaving it STARTED keeps ``find_incomplete_character``
+        pointing at an entity the saga has just deleted.  Classification goes
+        through the same ``_classify_failure`` taxonomy as every other FAILED
+        row, so nothing parallel can drift.
+        """
+        error_type, error_detail = _classify_failure(exc)
+        self.repository.update_operation_status(
+            row_id, OperationStatus.FAILED, _now_utc_iso(), error_type, error_detail
+        )
+
     def _record_character_local_files(
         self,
         *,

--- a/src/gflow_cli/services/character_create.py
+++ b/src/gflow_cli/services/character_create.py
@@ -14,6 +14,11 @@ contains the entity_id and any workflow/media ids already recorded.  On the
 next invocation, :func:`character_create` detects the incomplete row, reuses
 the entity_id, and skips any generation steps whose ids are already recorded.
 
+A failure with NO slot committed is the one case that cannot be resumed: the
+row's key is (project_id, name), so a retry under a different name never finds
+it.  That case rolls the free entity back and flips the row to FAILED, instead
+of leaving an ``Untitled Character  refs=0`` behind on every failed attempt.
+
 Scenario coverage (mirrors the plan's test-scenario numbering):
   #3  recovery – resume finds entity_id, skips create_entity
   #4  recovery – resume skips already-recorded face slot
@@ -37,6 +42,27 @@ if TYPE_CHECKING:
     from gflow_cli.data.recorder import OperationRecorder
 
 log = structlog.get_logger(__name__)
+
+
+async def _entity_has_bound_work(client: FlowApiClient, project_id: str, entity_id: str) -> bool:
+    """Does the BACKEND think this entity has a generated reference bound to it?
+
+    Guards the rollback below. Errs on the side of keeping the entity: an
+    unreadable backend returns ``True``, because deleting real work is worse
+    than leaving an orphan the user can remove with ``gflow character rm``.
+    """
+    try:
+        character = await client.get_character(project_id, entity_id=entity_id)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 - unreadable means "do not delete"
+        log.warning(
+            "character_create.rollback_check_failed",
+            entity_id=entity_id,
+            exc_info=True,
+        )
+        return True
+    return bool(
+        getattr(character, "workflow_ids", ()) or getattr(character, "thumbnail_media_id", None)
+    )
 
 
 async def character_create(
@@ -289,6 +315,35 @@ async def character_create(
             workflow_ids=list(workflow_ids),
             primary_media_ids=list(media_ids),
         )
+        if not workflow_ids and not await _entity_has_bound_work(client, project_id, entity_id):
+            # Zero progress: no credit spent, no workflow id, so the STARTED row
+            # offers no resume — and its key is (project_id, NAME), so a retry
+            # under any other name misses it and mints a second entity.  Roll the
+            # free entity back instead of stranding an "Untitled Character
+            # refs=0" in the project on every failed attempt.  Best-effort: a
+            # rollback fault must never mask the failure the user came to see.
+            #
+            # The backend check is not belt-and-braces.  An empty `workflow_ids`
+            # here means only that THIS process failed to read a result — on the
+            # migrated host a portrait generated fine while the client timed out
+            # on the labs wire (live 2026-09-06), and deleting on the local
+            # signal alone destroys finished work.
+            try:
+                await client.delete_characters(project_id, [entity_id])  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001 — rollback is advisory, never fatal
+                log.warning(
+                    "character_create.orphan_rollback_failed",
+                    entity_id=entity_id,
+                    project_id=project_id,
+                    exc_info=True,
+                )
+            else:
+                log.info(
+                    "character_create.orphan_rolled_back",
+                    entity_id=entity_id,
+                    project_id=project_id,
+                )
+            recorder.record_character_abandoned(row_id=row_id, exc=exc)
         log.error(
             "character_create.failed",
             entity_id=entity_id,

--- a/tests/api/test_character_readback_fallback.py
+++ b/tests/api/test_character_readback_fallback.py
@@ -1,0 +1,254 @@
+"""The migrated host answers on its own wire, so the ENTITY is the result (#703).
+
+Live 2026-09-06 on ``ci-probe`` (a moved account), a character portrait generation
+completed end to end on ``flow.google.com`` — and gflow reported failure. The
+driver reached the editor, selected the model, typed the prompt and submitted;
+then it waited 180 s for ``aisandbox .../flowMedia:batchGenerateImages``, the
+**labs** wire, which that frontend never calls. Reading the entity back from the
+backend immediately afterwards returned::
+
+    {"workflow_ids": ["04654114-…"], "thumbnail_media_id": "7e27413f-…"}
+
+Both ids the saga needs, already bound to the entity, while the client raised
+``TimeoutError``. The fix is not to decode ``flow.google.com``'s ``batchexecute``
+rpcid ``ogiZ0b`` envelope — it is to ask the backend what it did. The ids come
+from the entity itself, so binding is proven **by construction**, which is a
+stronger guarantee than the labs path's self-reported ``parentEntityId``.
+
+Evidence: ``scripts/dev/spike_migrated_character_ogiz0b_schema.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gflow_cli.api.character import Character, CharacterImageRequest
+
+PROJECT = "proj-1"
+ENTITY = "ent-1"
+WF0 = "04654114-5889-4014-baac-8daeb406f5d3"
+MEDIA0 = "7e27413f-1841-440e-88ab-bb54e34d8e2d"
+
+REQ = CharacterImageRequest(prompt="a calm portrait", model="nano2")
+
+
+def _character(*, workflow_ids: tuple[str, ...], thumb: str | None) -> Character:
+    return Character(
+        entity_id=ENTITY,
+        display_name="Untitled Character",
+        project_id=PROJECT,
+        workflow_ids=workflow_ids,
+        voice=None,
+        personality=None,
+        thumbnail_media_id=thumb,
+    )
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, *, transport_exc: Exception | None) -> Any:
+    """A FlowApiClient with its transport stubbed and REST reads faked."""
+    from gflow_cli.api.client import FlowApiClient
+
+    client = FlowApiClient.__new__(FlowApiClient)
+    client._account_locale = "en"  # noqa: SLF001
+    transport = MagicMock()
+    if transport_exc is not None:
+        transport.generate_character_images = AsyncMock(side_effect=transport_exc)
+    client.transport = transport
+    return client
+
+
+@pytest.mark.asyncio
+async def test_labs_wire_timeout_falls_back_to_reading_the_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout on the labs wire is not a failure if the backend bound the work."""
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(return_value=_character(workflow_ids=(WF0,), thumb=MEDIA0))
+
+    wf, media, path = await client._generate_character_image_impl(  # noqa: SLF001
+        project_id=PROJECT,
+        entity_id=ENTITY,
+        req=REQ,
+        image_reference_index=0,
+    )
+
+    assert wf == WF0
+    assert media == MEDIA0
+    # No settings/download stubbed here, so the fetch degrades — which is the
+    # point: the ids survive a download that cannot run.
+    assert path is None
+    client.get_character.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_timeout_with_an_unbound_entity_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No workflow on the entity means the generation really did not happen.
+
+    The fallback must never invent success — if the backend has nothing for this
+    slot, the original timeout is the honest answer.
+    """
+    exc = TimeoutError("No batchGenerateImages response")
+    client = _client(monkeypatch, transport_exc=exc)
+    client.get_character = AsyncMock(return_value=_character(workflow_ids=(), thumb=None))
+
+    with pytest.raises(TimeoutError):
+        await client._generate_character_image_impl(  # noqa: SLF001
+            project_id=PROJECT,
+            entity_id=ENTITY,
+            req=REQ,
+            image_reference_index=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fallback_reads_the_slot_it_generated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slot 1 (body) must take workflow_ids[1], not the face's id."""
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(
+        return_value=_character(workflow_ids=(WF0, "wf-body-1"), thumb=MEDIA0)
+    )
+
+    wf, _media, _path = await client._generate_character_image_impl(  # noqa: SLF001
+        project_id=PROJECT,
+        entity_id=ENTITY,
+        req=REQ,
+        image_reference_index=1,
+    )
+
+    assert wf == "wf-body-1"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_readback_does_not_mask_the_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The read-back is a rescue attempt; its own fault must not replace the cause."""
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(side_effect=RuntimeError("trpc 500"))
+
+    with pytest.raises(TimeoutError):
+        await client._generate_character_image_impl(  # noqa: SLF001
+            project_id=PROJECT,
+            entity_id=ENTITY,
+            req=REQ,
+            image_reference_index=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fallback_downloads_the_portrait_by_media_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """The read-back path must still put a file on disk (#703).
+
+    Binding ids without a file left `image_paths: [null]`, so `--output` got
+    nothing on the migrated host. `media.getMediaUrlRedirect` DOES resolve a
+    migrated portrait id — probed live 2026-09-06 on the Naia Verde portrait:
+    HTTP 200, 696 767 bytes, JFIF magic. (The 404 that
+    `migrated_composer.py` records for that route was measured on a *video*
+    media id; it does not generalise.)
+    """
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(return_value=_character(workflow_ids=(WF0,), thumb=MEDIA0))
+    client.settings = MagicMock(output_dir=tmp_path)
+    downloaded: list[tuple[str, Any]] = []
+
+    async def _download(name: str, out_path: Any) -> Any:
+        downloaded.append((name, out_path))
+        return out_path
+
+    client.download = AsyncMock(side_effect=_download)
+
+    _wf, _media, path = await client._generate_character_image_impl(  # noqa: SLF001
+        project_id=PROJECT,
+        entity_id=ENTITY,
+        req=REQ,
+        image_reference_index=0,
+    )
+
+    assert downloaded and downloaded[0][0] == MEDIA0
+    assert path is not None, "read-back path must return the downloaded file"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_download_still_returns_the_bound_ids(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """A missing file is a degraded success, never a lost character.
+
+    The ids are what bind the portrait to the entity; the local copy is a
+    convenience. Losing the ids over a CDN hiccup would strand a generation the
+    user already paid quota for.
+    """
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(return_value=_character(workflow_ids=(WF0,), thumb=MEDIA0))
+    client.settings = MagicMock(output_dir=tmp_path)
+    client.download = AsyncMock(side_effect=RuntimeError("CDN 503"))
+
+    wf, media, path = await client._generate_character_image_impl(  # noqa: SLF001
+        project_id=PROJECT,
+        entity_id=ENTITY,
+        req=REQ,
+        image_reference_index=0,
+    )
+
+    assert (wf, media) == (WF0, MEDIA0)
+    assert path is None
+
+
+@pytest.mark.asyncio
+async def test_each_slot_gets_its_own_media_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Slot 1 must not inherit the face's media id (#703).
+
+    The entity exposes a single ``thumbnail_media_id`` — the portrait. Returning
+    it for every slot made the body slot claim the face's media, and the saga
+    then PATCHed that id onto the body workflow through ``commit_workflow``,
+    which writes ``metadata.primaryMediaId``. Confirmed live 2026-09-06: after a
+    full create, the body workflow ``0e8e2a8e…`` carried the FACE's media
+    ``4daaf9ed…`` with an updateTime matching the run, while its own
+    ``displayName``/``batchId`` proved the body image had generated correctly.
+
+    Flow already sets each workflow's own ``primaryMediaId``, so read it from
+    the project listing instead of guessing — which also makes the subsequent
+    commit a no-op rather than a corruption.
+    """
+    client = _client(monkeypatch, transport_exc=TimeoutError("No batchGenerateImages response"))
+    client.get_character = AsyncMock(
+        return_value=_character(workflow_ids=(WF0, "wf-body-1"), thumb=MEDIA0)
+    )
+    client.settings = MagicMock(output_dir=tmp_path)
+    client.download = AsyncMock(side_effect=lambda _n, out: out)
+    client.fetch_project_listing = AsyncMock(
+        return_value={
+            "result": {
+                "data": {
+                    "json": {
+                        "projectContents": {
+                            "workflows": [
+                                {"name": WF0, "metadata": {"primaryMediaId": MEDIA0}},
+                                {"name": "wf-body-1", "metadata": {"primaryMediaId": "media-body"}},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    _wf, media, _path = await client._generate_character_image_impl(  # noqa: SLF001
+        project_id=PROJECT,
+        entity_id=ENTITY,
+        req=REQ,
+        image_reference_index=1,
+    )
+
+    assert media == "media-body", f"slot 1 took the face's media id: {media}"

--- a/tests/api/transports/drivers/test_ui_mode.py
+++ b/tests/api/transports/drivers/test_ui_mode.py
@@ -415,27 +415,33 @@ class TestMigratedOriginFailsFast:
         assert await detect_ui_mode(page, timeout_s=0.1, poll_interval_s=0.01) == "classic"
 
 
-class TestCharacterEditorOnMigratedOriginFailsFast:
-    """`character create` on a moved account died as a bare RuntimeError, exit 1.
+class TestCharacterEditorOnTheMigratedOrigin:
+    """`character create` WORKS on flow.google.com. It must not be gated off.
 
-    The character editor is a labs-only surface: `flow.google.com` renders no
-    prompt textbox for it, ever. So the readiness gate burned its full 20 s
-    timeout and then raised `RuntimeError("Character editor not ready: prompt
-    textbox not visible within 20 s")`, which the CLI reports as "Unexpected
-    error" (exit 1) rather than the typed, non-retryable exit 36 that names the
-    migration and tells the user why.
+    This class previously asserted the opposite — that the editor is "a labs-only
+    surface: flow.google.com renders no prompt textbox for it, ever", and pinned a
+    `raise_if_migrated` guard that returned exit 36 before probing the DOM.
 
-    Measured live 2026-09-06 on a moved account. Fourth instance of the same
-    shape as #673 (image path) and #692 (the reCAPTCHA mint): a labs-only path
-    that fails unclassified on the migrated host.
+    That premise was false, and the guard was the defect. Recon on 2026-09-06
+    (`scripts/dev/spike_migrated_character_editor_anchor.py`) found the editor
+    fully rendered on the migrated host — name, voice, personality, Upload / Add
+    from project, Create portrait / Create body — driven by the SAME labs tRPC and
+    aisandbox backend. What differed was the view layer: labs is React + Slate,
+    flow.google.com is Angular + ProseMirror, so the readiness selector missed and
+    a 20 s timeout got read as "the feature does not exist here". With the anchor
+    widened and the guard removed, a full create succeeded end to end on
+    `ci-probe` — display_name patched, workflow id and thumbnail media id bound.
+
+    The lesson worth keeping: a selector that does not match is evidence about the
+    selector, never about the feature.
     """
 
     @pytest.mark.asyncio
-    async def test_raises_exit_36_before_waiting_on_the_textbox(self) -> None:
+    async def test_the_migrated_origin_does_not_short_circuit_the_editor(self) -> None:
+        """The DOM must be probed, not pre-judged by the host."""
         from unittest.mock import AsyncMock
 
         from gflow_cli.api.transports.ui_automation import UiAutomationTransport
-        from gflow_cli.errors import EXIT_CODE_MAP, FlowHostMigratedError, is_retryable
 
         t = UiAutomationTransport.__new__(UiAutomationTransport)
         t._out_dir = None  # type: ignore[attr-defined]
@@ -443,15 +449,23 @@ class TestCharacterEditorOnMigratedOriginFailsFast:
         t._dismiss_blocking_overlays = AsyncMock()  # type: ignore[attr-defined]
         t._settle_on_character_route = AsyncMock()  # type: ignore[attr-defined]
 
+        probed: list[str] = []
+
+        def _locator(sel: str) -> MagicMock:
+            probed.append(sel)
+            loc = MagicMock()
+            loc.first = loc
+            loc.wait_for = AsyncMock()
+            return loc
+
         page = MagicMock()
         page.goto = AsyncMock()
-        page.url = "https://flow.google.com/project/abc-123"
-        # The readiness gate must never be reached: that is the 20 s the user paid.
-        page.locator = MagicMock(side_effect=AssertionError("must not probe the DOM"))
+        page.url = "https://flow.google.com/project/abc-123/character/e-1"
+        page.locator = MagicMock(side_effect=_locator)
 
-        with pytest.raises(FlowHostMigratedError) as exc_info:
-            await t._enter_character_editor(page, project_id="p-1", entity_id="e-1", locale="en")
+        await t._enter_character_editor(page, project_id="p-1", entity_id="e-1", locale="en")
 
-        page.locator.assert_not_called()
-        assert EXIT_CODE_MAP[FlowHostMigratedError] == 36
-        assert not is_retryable(exc_info.value)
+        assert probed, "the migrated host must be driven, not bailed on"
+        assert any("ProseMirror" in sel for sel in probed), (
+            f"the readiness gate must offer the migrated anchor; probed {probed}"
+        )

--- a/tests/api/transports/test_character_model_picker.py
+++ b/tests/api/transports/test_character_model_picker.py
@@ -1,0 +1,221 @@
+"""The character model picker is DETERMINISTIC: it applies the tier, or it fails.
+
+It used to be "best effort" — every failure path logged a warning and let the
+generation proceed on whatever tier the editor happened to be showing. That is
+the worst possible behaviour for a CLI: `--model nano2` would quietly produce a
+Nano Banana Pro image, with nothing in the output to say so. A run on 2026-09-06
+did exactly that on the migrated host, and a later run failed to click the menu
+item and generated on the default anyway.
+
+Failing here is **free**. The picker runs before the prompt is submitted, so an
+abort costs no quota and no credits, while proceeding produces a paid artifact
+the user did not ask for. So every unhappy path now raises a typed error.
+
+Three defects fixed alongside, all found live on flow.google.com:
+
+1. It never clicked when `--model nano2` was requested, assuming Nano Banana 2
+   was the editor default. The migrated editor opens on **Nano Banana Pro**.
+2. `Nano Banana 2` is a prefix of `Nano Banana 2 Lite`, and the menu offers
+   three tiers, not the documented two — the #539 ambiguity.
+3. The option selector `:has-text('…')` was unanchored, so `.first` matched
+   `<html>`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport
+from gflow_cli.errors import ConfigurationError, UiSelectorDriftError
+
+
+def _picker_page(
+    *,
+    current: str,
+    options: list[str],
+    trigger_found: bool = True,
+    menu_opens: bool = True,
+    click_applies: bool = True,
+) -> MagicMock:
+    """A fake editor whose chip reads ``current`` and whose menu lists ``options``.
+
+    ``click_applies`` models the real failure we saw: the item click lands (or
+    times out) but the chip never changes. The picker must notice.
+    """
+    page = MagicMock()
+    page.url = "https://flow.google.com/project/p1/character/e1"
+    page.wait_for_timeout = AsyncMock()
+    page.screenshot = AsyncMock(return_value=b"")
+    page.keyboard = MagicMock()
+    page.keyboard.press = AsyncMock()
+
+    state = {"current": current}
+    clicked: list[int] = []
+
+    trigger = MagicMock()
+    trigger.first = trigger
+    trigger.nth = MagicMock(return_value=trigger)
+    trigger.count = AsyncMock(return_value=1 if trigger_found else 0)
+    trigger.text_content = AsyncMock(side_effect=lambda: state["current"])
+    trigger.wait_for = AsyncMock(
+        side_effect=None if trigger_found else Exception("trigger never visible")
+    )
+    trigger.click = AsyncMock()
+
+    items = MagicMock()
+    items.first = MagicMock()
+    items.first.wait_for = AsyncMock(
+        side_effect=None if menu_opens else Exception("menu never opened")
+    )
+    items.all_text_contents = AsyncMock(return_value=list(options))
+
+    def _nth(i: int) -> MagicMock:
+        node = MagicMock()
+
+        async def _click(**_kw: Any) -> None:
+            clicked.append(i)
+            if click_applies:
+                state["current"] = options[i]
+
+        node.click = AsyncMock(side_effect=_click)
+        return node
+
+    items.nth = MagicMock(side_effect=_nth)
+
+    page.locator = MagicMock(side_effect=lambda sel: items if "menuitem" in sel else trigger)
+    page.clicked = clicked
+    page.trigger = trigger
+    page.state = state
+    return page
+
+
+def _transport(page: MagicMock) -> UiAutomationTransport:
+    t = UiAutomationTransport()
+    t._setup_done = True  # type: ignore[attr-defined]
+    t._page = page  # type: ignore[attr-defined]
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nano2_is_applied_even_though_it_is_the_cli_default() -> None:
+    """The migrated editor opens on Pro; asking for nano2 must actually switch."""
+    page = _picker_page(
+        current="Nano Banana Pro",
+        options=["Nano Banana Pro", "Nano Banana 2", "Nano Banana 2 Lite"],
+    )
+    await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+    assert page.clicked == [1], f"expected 'Nano Banana 2' (index 1), clicked {page.clicked}"
+    assert page.state["current"] == "Nano Banana 2"
+
+
+@pytest.mark.asyncio
+async def test_no_click_when_the_chip_already_reads_the_requested_model() -> None:
+    page = _picker_page(
+        current="Nano Banana 2",
+        options=["Nano Banana Pro", "Nano Banana 2", "Nano Banana 2 Lite"],
+    )
+    await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+    page.trigger.click.assert_not_awaited()
+    assert page.clicked == []
+
+
+@pytest.mark.asyncio
+async def test_nano2_does_not_match_the_lite_tier() -> None:
+    """`Nano Banana 2` is a prefix of `Nano Banana 2 Lite` — take the exact tier."""
+    page = _picker_page(current="Nano Banana Pro", options=["Nano Banana 2 Lite", "Nano Banana 2"])
+    await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+    assert page.clicked == [1], f"matched the Lite tier: clicked {page.clicked}"
+
+
+@pytest.mark.asyncio
+async def test_nanopro_selects_pro() -> None:
+    page = _picker_page(
+        current="Nano Banana 2",
+        options=["Nano Banana Pro", "Nano Banana 2", "Nano Banana 2 Lite"],
+    )
+    await _transport(page)._select_character_model(page, "nanopro")  # noqa: SLF001
+
+    assert page.clicked == [0]
+
+
+# ---------------------------------------------------------------------------
+# Every unhappy path RAISES — silence here bills the user for the wrong tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_click_that_does_not_change_the_chip_raises() -> None:
+    """The observed flake: the item click times out and the tier never applies.
+
+    Previously logged and carried on, so the generation ran on the editor's
+    default and nothing said so.
+    """
+    page = _picker_page(
+        current="Nano Banana Pro",
+        options=["Nano Banana Pro", "Nano Banana 2"],
+        click_applies=False,
+    )
+    with pytest.raises(UiSelectorDriftError, match="did not apply"):
+        await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_a_model_the_menu_does_not_offer_raises_and_names_the_options() -> None:
+    page = _picker_page(current="Nano Banana Pro", options=["Something Else"])
+    with pytest.raises(ConfigurationError, match="Something Else"):
+        await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+    assert page.clicked == []
+
+
+@pytest.mark.asyncio
+async def test_an_ambiguous_match_refuses_rather_than_guessing() -> None:
+    """Two entries match: never resolve `.first` — that is how #539 billed a tier."""
+    # The chip must NOT already read Pro, or the picker rightly short-circuits
+    # before ever opening the menu.
+    page = _picker_page(
+        current="Nano Banana 2",
+        options=["Nano Banana Pro (new)", "Nano Banana Pro"],
+    )
+    with pytest.raises(ConfigurationError, match="matched 2"):
+        await _transport(page)._select_character_model(page, "nanopro")  # noqa: SLF001
+
+    assert page.clicked == []
+
+
+@pytest.mark.asyncio
+async def test_a_missing_trigger_raises() -> None:
+    page = _picker_page(current="", options=["Nano Banana 2"], trigger_found=False)
+    with pytest.raises(UiSelectorDriftError, match="model picker"):
+        await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_a_menu_that_never_opens_raises() -> None:
+    page = _picker_page(
+        current="Nano Banana Pro",
+        options=["Nano Banana 2"],
+        menu_opens=False,
+    )
+    with pytest.raises(UiSelectorDriftError, match="menu"):
+        await _transport(page)._select_character_model(page, "nano2")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_alias_raises_before_touching_the_picker() -> None:
+    page = _picker_page(current="Nano Banana Pro", options=["Nano Banana 2"])
+    with pytest.raises(ConfigurationError, match="not-a-model"):
+        await _transport(page)._select_character_model(page, "not-a-model")  # noqa: SLF001
+
+    page.trigger.click.assert_not_awaited()

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -76,7 +76,12 @@ def _make_page(
     def _locator(sel: str) -> MagicMock:
         loc = MagicMock()
         loc.first = loc
-        if sel in vis:
+        # A CSS selector list matches when ANY of its alternatives does. The fake
+        # used to compare the whole string, so widening a production selector to
+        # cover a second frontend silently stopped matching here — the mock, not
+        # the code, decided the test. Split the list instead.
+        parts = {p.strip() for p in sel.split(",")}
+        if sel in vis or parts & vis:
             loc.wait_for = AsyncMock()
             loc.is_visible = AsyncMock(return_value=True)
         else:
@@ -256,6 +261,28 @@ class TestEnterCharacterEditor:
 
         with pytest.raises(RuntimeError, match="Character editor not ready"):
             await t._enter_character_editor(page, project_id="p", entity_id="e", locale="en")
+
+    @pytest.mark.asyncio
+    async def test_ready_gate_accepts_the_migrated_prosemirror_editor(self) -> None:
+        """The readiness gate must not be Slate-only.
+
+        Recon 2026-09-06 (`scripts/dev/spike_migrated_character_editor_anchor.py`,
+        live on ci-probe): flow.google.com renders the character editor in full —
+        `input.name-input`, `textarea.personality-textarea`, a voice picker and an
+        upload affordance — but as **Angular + ProseMirror**, where labs is
+        React + Slate. `[data-slate-editor]` matched 0 elements there while
+        `.ProseMirror[contenteditable="true"]` matched 1, with nothing occluding
+        it. The 20 s timeout was never "no character editor on this host"; it was
+        this gate asking for the wrong library's anchor.
+
+        Both anchors are library/build artefacts, not display strings, so this
+        stays inside the locale-invariance rule.
+        """
+        page = _make_page(visible_selectors={'div.ProseMirror[contenteditable="true"]'})
+        t = _make_transport(page=page)
+        t._dismiss_blocking_overlays = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+
+        await t._enter_character_editor(page, project_id="p1", entity_id="e1", locale="en")
 
     @pytest.mark.asyncio
     async def test_does_not_call_enter_editor(self) -> None:
@@ -597,119 +624,13 @@ class TestCharacterImageRequestFieldContract:
 
 # ---------------------------------------------------------------------------
 # Tests: _select_character_model — editor model picker (best-effort, non-fatal)
-# ---------------------------------------------------------------------------
-
-
-class _FakeMenuOption:
-    """A clickable model-menu option."""
-
-    def __init__(self, *, visible: bool = True) -> None:
-        self.clicked = False
-        self.first = self
-        self.click = AsyncMock(side_effect=self._record)
-        if visible:
-            self.wait_for = AsyncMock()
-        else:
-            self.wait_for = AsyncMock(side_effect=Exception("not visible"))
-
-    async def _record(self, *_a: Any, **_kw: Any) -> None:
-        self.clicked = True
-
-
-class _FakeTrigger:
-    """The arrow_drop_down dropdown trigger."""
-
-    def __init__(self, *, visible: bool = True) -> None:
-        self.clicked = False
-        self.first = self
-        self.click = AsyncMock(side_effect=self._record)
-        if visible:
-            self.wait_for = AsyncMock()
-        else:
-            self.wait_for = AsyncMock(side_effect=Exception("not visible"))
-
-    async def _record(self, *_a: Any, **_kw: Any) -> None:
-        self.clicked = True
-
-
-def _make_model_picker_page(
-    *,
-    trigger_visible: bool = True,
-    option_visible: bool = True,
-) -> tuple[MagicMock, _FakeTrigger, _FakeMenuOption]:
-    """Fake page wiring the model-picker trigger + the Nano Banana Pro option."""
-    trigger = _FakeTrigger(visible=trigger_visible)
-    option = _FakeMenuOption(visible=option_visible)
-
-    trigger_sels = set(UiAutomationTransport._CHARACTER_MODEL_PICKER_TRIGGER_SELECTORS)
-
-    page = MagicMock()
-    page.url = "https://labs.google/fx/pt/tools/flow/project/p1/character/e1"
-    page.wait_for_timeout = AsyncMock()
-    page.screenshot = AsyncMock(return_value=b"")
-    page.keyboard = MagicMock()
-    page.keyboard.press = AsyncMock()
-
-    def _locator(sel: str) -> Any:
-        if sel in trigger_sels:
-            return trigger
-        if "Nano Banana Pro" in sel:
-            return option
-        loc = MagicMock()
-        loc.first = loc
-        loc.wait_for = AsyncMock(side_effect=Exception("not visible"))
-        loc.click = AsyncMock()
-        return loc
-
-    page.locator = MagicMock(side_effect=_locator)
-    return page, trigger, option
-
-
-class TestSelectCharacterModel:
-    @pytest.mark.asyncio
-    async def test_nano2_default_does_not_click_dropdown(self) -> None:
-        """nano2 (the default) must be a no-op — no dropdown trigger click."""
-        page, trigger, option = _make_model_picker_page()
-        t = _make_transport(page=page)
-
-        await t._select_character_model(page, "nano2", None)  # type: ignore[attr-defined]
-
-        assert not trigger.clicked, "default model must NOT open the dropdown"
-        assert not option.clicked
-
-    @pytest.mark.asyncio
-    async def test_nanopro_opens_dropdown_and_clicks_option(self) -> None:
-        """nanopro must open the dropdown and click the Nano Banana Pro option."""
-        page, trigger, option = _make_model_picker_page()
-        t = _make_transport(page=page)
-
-        await t._select_character_model(page, "nanopro", None)  # type: ignore[attr-defined]
-
-        assert trigger.clicked, "nanopro must open the model dropdown"
-        assert option.clicked, "the Nano Banana Pro option must be clicked"
-
-    @pytest.mark.asyncio
-    async def test_picker_not_found_is_non_fatal(self) -> None:
-        """If neither the trigger nor the option is found, no exception escapes."""
-        page, trigger, option = _make_model_picker_page(trigger_visible=False)
-        t = _make_transport(page=page)
-
-        # MUST NOT raise — best-effort model selection.
-        await t._select_character_model(page, "nanopro", None)  # type: ignore[attr-defined]
-
-        assert not option.clicked, "no trigger → no option click"
-
-    @pytest.mark.asyncio
-    async def test_unknown_alias_is_non_fatal_no_click(self) -> None:
-        """An unknown alias must NOT crash and must not touch the dropdown."""
-        page, trigger, option = _make_model_picker_page()
-        t = _make_transport(page=page)
-
-        await t._select_character_model(page, "totally-unknown", None)  # type: ignore[attr-defined]
-
-        assert not trigger.clicked
-        assert not option.clicked
-
+# The character model picker's own tests now live in
+# tests/api/transports/test_character_model_picker.py. The class that stood here
+# asserted `nano2` must NOT click the dropdown, on the belief that Nano Banana 2
+# is the editor's default. flow.google.com opens on Nano Banana Pro, so that
+# assertion pinned the bug: `--model nano2` silently generated on Pro. The
+# replacement reads the chip instead of assuming, and covers the three-tier menu
+# and the Lite-prefix ambiguity the old fake could not express.
 
 # ---------------------------------------------------------------------------
 # Tests: _click_character_slot_add selector logic (live-DOM grounded)
@@ -838,10 +759,19 @@ class TestClickCharacterSlotAddSelector:
     async def test_ignores_unscoped_accessibility_button(self) -> None:
         """The project-level Characters control shares ``accessibility_new``;
         body activation must use the button beside the portrait image."""
-        scoped_selector = (
-            "button:has(img) + button:has(i.google-symbols:text-is('accessibility_new'))"
-        )
+        # The production selector is a list of SCOPED forms (one per host). The
+        # bare form below is the trap: it must never be asked for, because the
+        # project-level Characters nav carries the same ligature.
+        scoped_selector = UiAutomationTransport._CHARACTER_BODY_MODE_SELECTOR
         unscoped_selector = "button:has(i.google-symbols:text-is('accessibility_new'))"
+        assert unscoped_selector not in scoped_selector.split(", "), (
+            "body activation must stay scoped; a bare accessibility_new selector "
+            "matches the Characters navigation control"
+        )
+        assert "flow-slot-chip-button" in scoped_selector, (
+            "the migrated host scopes body mode by its <flow-slot-chip-button> "
+            "component boundary; without it the Characters nav matches"
+        )
         body_mode = _FakeCandidate(inner_text="accessibility_new Create Body")
         navigation = _FakeCandidate(inner_text="accessibility_new Characters")
         face_reference = _FakeCandidate(inner_text="cancel")
@@ -994,7 +924,7 @@ class _FakeSlateBox:
 
 
 class _FakeSlateBoxList:
-    """The locator for ``PROMPT_INPUT_SELECTORS[0]``: N mounted Slate boxes."""
+    """The locator for the character readiness anchor: N mounted prompt boxes."""
 
     def __init__(self, boxes: list[_FakeSlateBox]) -> None:
         self.boxes = boxes
@@ -1028,7 +958,6 @@ def _make_body_prompt_page(
     currently-FOCUSED box; ``submit_clicks`` records submit-button clicks.
     """
     from gflow_cli.api.transports.ui_automation import (
-        PROMPT_INPUT_SELECTORS,
         SUBMIT_BUTTON_SELECTORS,
     )
 
@@ -1062,7 +991,10 @@ def _make_body_prompt_page(
     boxes = [portrait, body][:box_count]
     box_list = _FakeSlateBoxList(boxes)
 
-    prompt_sel = PROMPT_INPUT_SELECTORS[0]
+    # The body path now counts through the readiness anchor, which covers BOTH
+    # frontends (labs Slate, migrated ProseMirror) — not PROMPT_INPUT_SELECTORS[0],
+    # which is Slate-only and reported 0 boxes on a migrated editor.
+    prompt_sel = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
     submit_sels = set(SUBMIT_BUTTON_SELECTORS)
     submit_clicks: list[str] = []
 

--- a/tests/data/test_find_incomplete_character.py
+++ b/tests/data/test_find_incomplete_character.py
@@ -215,3 +215,29 @@ def test_most_recent_started_row_returned(tmp_path: Path) -> None:
         assert result["entity_id"] == "ent-new", (
             "ORDER BY started_at DESC LIMIT 1 must return the most recent row"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test: an abandoned (zero-progress) row stops being resumable
+# ---------------------------------------------------------------------------
+
+
+def test_abandoned_row_is_not_returned(tmp_path: Path) -> None:
+    """record_character_abandoned flips the row out of STARTED (#703).
+
+    The saga deletes the free entity in the zero-progress case, so the row must
+    stop matching — otherwise the next run resumes onto an entity id that no
+    longer exists in the project.
+    """
+    with DataStore.open(tmp_path / "gflow.db") as store:
+        repo = DataRepository(store)
+        recorder = OperationRecorder(repo, prompt_mode="store")
+
+        row_id = _start(recorder, tmp_path, project_id="P1", entity_id="ent-001", name="Ana")
+        assert repo.find_incomplete_character("P1", "Ana") is not None
+
+        recorder.record_character_abandoned(row_id=row_id, exc=RuntimeError("editor never ready"))
+
+        assert repo.find_incomplete_character("P1", "Ana") is None
+        row = store.conn.execute("SELECT status FROM operations WHERE id = ?", (row_id,)).fetchone()
+        assert row["status"] == "failed"

--- a/tests/e2e/test_character_create_e2e.py
+++ b/tests/e2e/test_character_create_e2e.py
@@ -50,6 +50,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -525,3 +526,84 @@ def test_character_create_format_prompt_clicks_format_button(e2e_env: dict[str, 
     )
     for miss in ("ui_automation.format_button_not_found", "ui_automation.format_button_disabled"):
         assert miss not in events, f"format button was skipped ({miss}), not clicked"
+
+
+# ---------------------------------------------------------------------------
+# A create leaves a NAMED character or nothing — never an "Untitled" orphan
+# ---------------------------------------------------------------------------
+
+
+def test_create_never_leaves_an_untitled_orphan(e2e_env: dict[str, str]) -> None:
+    """Whatever happens, the project must not gain an unnamed, ref-less entity.
+
+    The saga creates its entity up front (free) and only names it in the final
+    PATCH, so a failure anywhere in between used to leave an "Untitled Character
+    refs=0" behind — every time, because the resume row is keyed on
+    ``(project_id, name)`` and a retry under a different name never finds it.
+
+    This asserts the invariant from the outside, so it holds for BOTH outcomes
+    and needs no injected failure:
+
+      * exit 0  -> exactly one new entity, carrying the name we asked for
+      * non-zero -> no new entity at all (the free one was rolled back)
+
+    Live A/B on 2026-09-06 (``ci-probe``, migrated host) showed the old code
+    going 1 -> 2 entities on a failed create and the fixed code holding at 2.
+
+    Cost: one portrait generation on the success path — image quota, zero
+    credits.
+    """
+    _require_character_optin()
+    project_id = _require_project()
+    env = _character_env(e2e_env)
+    name = f"e2e-orphan-{uuid.uuid4().hex[:8]}"
+
+    def _entities() -> dict[str, str]:
+        listed = _run_gflow(
+            ["character", "list", "--project", project_id, "--json"], env, _SHOW_TIMEOUT_S
+        )
+        assert listed.returncode == 0, (
+            f"character list failed (exit {listed.returncode}): {listed.stderr[-500:]}"
+        )
+        payload = _parse_json_stdout(listed, "character list")
+        rows = cast("list[dict[str, object]]", payload["characters"])
+        return {str(r["entity_id"]): str(r.get("display_name") or "") for r in rows}
+
+    before = _entities()
+
+    created = _run_gflow(
+        [
+            "character",
+            "create",
+            "--project",
+            project_id,
+            "--name",
+            name,
+            "--face-prompt",
+            os.environ.get(_FACE_ENV, _DEFAULT_FACE_PROMPT),
+            "--json",
+        ],
+        env,
+        _CREATE_TIMEOUT_S,
+    )
+
+    after = _entities()
+    new_ids = set(after) - set(before)
+
+    if created.returncode != 0:
+        assert not new_ids, (
+            f"a FAILED create (exit {created.returncode}) stranded {len(new_ids)} entity/entities "
+            f"in project {project_id}: {sorted(new_ids)} — the rollback did not run. "
+            f"STDERR: {created.stderr[-1200:]}"
+        )
+        return
+
+    assert len(new_ids) == 1, (
+        f"a successful create should add exactly one entity, "
+        f"added {len(new_ids)}: {sorted(new_ids)}"
+    )
+    created_name = after[next(iter(new_ids))]
+    assert created_name == name, (
+        f"the new entity is named {created_name!r}, not {name!r} — the final PATCH did not land, "
+        "which is exactly what an orphan looks like"
+    )

--- a/tests/scripts/test_extract_har_summary.py
+++ b/tests/scripts/test_extract_har_summary.py
@@ -1,0 +1,166 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+# Load the extractor by path, matching test_analyze_agent_ui_capture.py: scripts/
+# is deliberately outside pyright's include and is not an importable package, so
+# `from scripts...` is unresolvable under the project config.
+_MOD_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "dev" / "har-spike" / "extract_har_summary.py"
+)
+_spec = importlib.util.spec_from_file_location("extract_har_summary", _MOD_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+summarize_har = _mod.summarize_har
+
+
+class HarSummaryTests(unittest.TestCase):
+    def test_redacts_sensitive_headers_and_body_values(self) -> None:
+        har = {
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "method": "POST",
+                            "url": "https://aisandbox-pa.googleapis.com/v1/flow:batchGenerateImages?key=secret",
+                            "headers": [
+                                {"name": "Content-Type", "value": "text/plain;charset=UTF-8"},
+                                {"name": "Cookie", "value": "SID=secret; SAPISID=secret"},
+                                {"name": "Authorization", "value": "Bearer secret"},
+                                {"name": "Origin", "value": "https://labs.google"},
+                            ],
+                            "postData": {
+                                "mimeType": "text/plain;charset=UTF-8",
+                                "text": json.dumps(
+                                    {
+                                        "clientContext": {
+                                            "recaptchaContext": {"token": "0cAFsecret"},
+                                            "sessionId": "session-secret",
+                                        },
+                                        "requests": [
+                                            {
+                                                "prompt": "hello",
+                                                "mediaGenerationContext": {
+                                                    "batchId": "batch-secret"
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ),
+                            },
+                        },
+                        "response": {
+                            "status": 200,
+                            "headers": [
+                                {"name": "Content-Type", "value": "application/json"},
+                                {"name": "Set-Cookie", "value": "private=value"},
+                            ],
+                            "content": {"mimeType": "application/json"},
+                        },
+                    }
+                ]
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            har_path = Path(tmp) / "capture.har"
+            har_path.write_text(json.dumps(har), encoding="utf-8")
+
+            summary = summarize_har(har_path, host_filter="aisandbox-pa.googleapis.com")
+
+        self.assertEqual(summary["entry_count"], 1)
+        entry = summary["entries"][0]
+        self.assertEqual(entry["request"]["method"], "POST")
+        self.assertEqual(
+            entry["request"]["url"],
+            "https://aisandbox-pa.googleapis.com/v1/flow:batchGenerateImages",
+        )
+        self.assertEqual(entry["request"]["query_keys"], ["key"])
+        self.assertEqual(entry["response"]["status"], 200)
+        self.assertEqual(entry["request"]["headers"]["cookie"], "<redacted:present>")
+        self.assertEqual(entry["request"]["headers"]["authorization"], "<redacted:present>")
+        self.assertEqual(entry["response"]["headers"]["set-cookie"], "<redacted:present>")
+        self.assertEqual(
+            entry["request"]["body"]["json"]["clientContext"]["recaptchaContext"]["token"],
+            "<redacted:token>",
+        )
+        self.assertEqual(
+            entry["request"]["body"]["json"]["clientContext"]["sessionId"],
+            "<redacted:sessionId>",
+        )
+        self.assertEqual(
+            entry["request"]["body"]["json"]["requests"][0]["mediaGenerationContext"]["batchId"],
+            "<redacted:batchId>",
+        )
+        self.assertEqual(
+            entry["request"]["body"]["json"]["requests"][0]["prompt"], "<redacted:prompt>"
+        )
+
+    def test_filters_to_requested_host(self) -> None:
+        har = {
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "method": "GET",
+                            "url": "https://example.com/api",
+                            "headers": [],
+                        },
+                        "response": {"status": 200, "headers": []},
+                    },
+                    {
+                        "request": {
+                            "method": "POST",
+                            "url": "https://aisandbox-pa.googleapis.com/v1/flow:generate",
+                            "headers": [],
+                        },
+                        "response": {"status": 401, "headers": []},
+                    },
+                ]
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            har_path = Path(tmp) / "capture.har"
+            har_path.write_text(json.dumps(har), encoding="utf-8")
+
+            summary = summarize_har(har_path, host_filter="aisandbox-pa.googleapis.com")
+
+        self.assertEqual(summary["entry_count"], 1)
+        self.assertEqual(summary["entries"][0]["request"]["host"], "aisandbox-pa.googleapis.com")
+
+    def test_redacts_non_json_body_preview(self) -> None:
+        har = {
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "method": "POST",
+                            "url": "https://aisandbox-pa.googleapis.com/v1/flow:generate",
+                            "headers": [],
+                            "postData": {
+                                "mimeType": "text/plain",
+                                "text": "prompt=private&token=secret",
+                            },
+                        },
+                        "response": {"status": 200, "headers": []},
+                    }
+                ]
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            har_path = Path(tmp) / "capture.har"
+            har_path.write_text(json.dumps(har), encoding="utf-8")
+
+            summary = summarize_har(har_path, host_filter="aisandbox-pa.googleapis.com")
+
+        body = summary["entries"][0]["request"]["body"]
+        self.assertEqual(body["textPreview"], "<redacted:non-json>")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/services/test_character_create_saga.py
+++ b/tests/services/test_character_create_saga.py
@@ -64,6 +64,12 @@ def _make_client(
         client.generate_character_image = AsyncMock(side_effect=[face_result, body_result])
     client.commit_workflow = AsyncMock(return_value=None)
     client.patch_entity = AsyncMock(return_value=None)
+    client.delete_characters = AsyncMock(return_value=None)
+    # Default: the backend agrees nothing was bound. Tests that model a
+    # generation which succeeded server-side override this explicitly.
+    client.get_character = AsyncMock(
+        return_value=MagicMock(workflow_ids=(), thumbnail_media_id=None)
+    )
     return client
 
 
@@ -72,6 +78,7 @@ def _make_recorder(*, row_id: str = ROW_ID) -> MagicMock:
     recorder.record_character_started = MagicMock(return_value=row_id)
     recorder.record_character_partial = MagicMock(return_value=None)
     recorder.record_character_completed = MagicMock(return_value=None)
+    recorder.record_character_abandoned = MagicMock(return_value=None)
     # By default: no prior incomplete op
     recorder.repository = MagicMock()
     recorder.repository.find_incomplete_character = MagicMock(return_value=None)
@@ -474,3 +481,89 @@ async def test_format_prompt_defaults_off_and_forwards_when_set() -> None:
     assert all(c.kwargs["format_prompt"] is True for c in calls), (
         "format_prompt must be forwarded to both the face and body slot"
     )
+
+
+# ---------------------------------------------------------------------------
+# Orphan rollback: a failure with NOTHING to resume must not strand an entity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_progress_failure_deletes_the_orphan_entity() -> None:
+    """Face generation fails on the first slot → the free entity is rolled back.
+
+    Nothing was spent and no workflow id exists, so the STARTED row buys the
+    user no resume.  Keeping it strands an ``Untitled Character  refs=0`` in
+    the project forever (the user retries under a different name, which misses
+    ``find_incomplete_character``'s (project, name) key).
+    """
+    exc = WireFormatError("editor never became ready", route="test")
+    client = _make_client(generate_side_effect=exc)
+    recorder = _make_recorder()
+
+    with pytest.raises(WireFormatError):
+        await character_create(client, recorder, **_saga_kwargs())
+
+    client.delete_characters.assert_awaited_once_with(PROJECT_ID, [ENTITY_ID])
+    recorder.record_character_abandoned.assert_called_once_with(row_id=ROW_ID, exc=exc)
+
+
+@pytest.mark.asyncio
+async def test_partial_progress_failure_keeps_the_entity_for_resume() -> None:
+    """Face succeeded, body failed → a credit was spent; the entity MUST survive."""
+    exc = WireFormatError("body slot rejected", route="test")
+
+    async def _generate_side_effect(**kwargs: object) -> tuple[str, str, str | None]:
+        if kwargs.get("image_reference_index") == 0:
+            return (WF0, M0, "/tmp/face_slot0.png")
+        raise exc
+
+    client = _make_client()
+    client.generate_character_image = AsyncMock(side_effect=_generate_side_effect)
+    recorder = _make_recorder()
+
+    with pytest.raises(WireFormatError):
+        await character_create(client, recorder, **_saga_kwargs(body=BODY_REQ))
+
+    client.delete_characters.assert_not_called()
+    recorder.record_character_abandoned.assert_not_called()
+    last_partial = recorder.record_character_partial.call_args
+    assert last_partial.kwargs["workflow_ids"] == [WF0]
+
+
+@pytest.mark.asyncio
+async def test_rollback_failure_never_masks_the_original_error() -> None:
+    """batchDeleteAssets is best-effort — its own failure must stay invisible."""
+    exc = WireFormatError("editor never became ready", route="test")
+    client = _make_client(generate_side_effect=exc)
+    client.delete_characters = AsyncMock(side_effect=RuntimeError("aisandbox 503"))
+    recorder = _make_recorder()
+
+    with pytest.raises(WireFormatError):
+        await character_create(client, recorder, **_saga_kwargs())
+
+    # The row is still flipped, so the dead entity_id stops being resumed.
+    recorder.record_character_abandoned.assert_called_once_with(row_id=ROW_ID, exc=exc)
+
+
+@pytest.mark.asyncio
+async def test_rollback_spares_an_entity_the_backend_has_bound(monkeypatch: object) -> None:
+    """Client-side "zero progress" is not proof the generation did not happen.
+
+    Live 2026-09-06: a portrait generated fine on flow.google.com while the
+    client timed out on the labs wire, so `workflow_ids` was empty HERE and
+    non-empty on the entity. Deleting on that signal alone destroys finished,
+    paid-for work. Ask the backend before rolling back.
+    """
+    exc = WireFormatError("labs wire never answered", route="test")
+    client = _make_client(generate_side_effect=exc)
+    client.get_character = AsyncMock(
+        return_value=MagicMock(workflow_ids=("wf-bound-0",), thumbnail_media_id="m0")
+    )
+    recorder = _make_recorder()
+
+    with pytest.raises(WireFormatError):
+        await character_create(client, recorder, **_saga_kwargs())
+
+    client.delete_characters.assert_not_called()
+    recorder.record_character_abandoned.assert_not_called()


### PR DESCRIPTION
## Summary

`gflow character create` was believed impossible on `flow.google.com`. It was not. The editor is fully present there, backed by the **same** labs tRPC and aisandbox APIs — the migrated page calls `flow.projectInitialData` and `v1:checkAppAvailability` itself. Only the view layer differs: labs renders React + **Slate**, flow.google.com renders Angular + **ProseMirror**. Our selectors missed, the 20 s readiness gate timed out, and the absence of a *match* was recorded as the absence of the *feature*.

v0.69.0 then hardened that misreading: a `raise_if_migrated` guard aborted with exit 36 **before** probing the DOM, so the premise could never be disproved by running the code. That guard was the defect. It is gone.

## What changed

Seven anchors, all the same class of mistake:

| | was | now |
|---|---|---|
| readiness gate | Slate only | also `div.ProseMirror[contenteditable]` |
| migrated-host guard | aborted before probing | removed from `_enter_character_editor` |
| result listener | labs `batchGenerateImages` (never fires there) | read the ids off the **entity** |
| model chip | `i.google-symbols` | also `mat-icon` |
| body mode | labs sibling-of-image | `<flow-slot-chip-button>` component boundary |
| body settle signal | `media.getMediaUrlRedirect` | also `flow-content.google/image/` |
| prompt-box counter | Slate only (reported 0 on a mounted editor) | the readiness anchor |

Reading the result off the entity also **proves the character binding by construction**, which is stronger than trusting the labs path's self-reported `parentEntityId`.

### `--model` is now deterministic

The picker was best-effort: every failure logged a warning and let the generation run on whatever tier the editor showed, so `--model nano2` could silently return a Nano Banana Pro image. Three faults did exactly that — it skipped the click entirely for `nano2` (assuming it was the editor default, true on labs, false on migrated); its option selector `:has-text(...)` was unanchored so `.first` resolved to `<html>`; and its menu lookup was unscoped, so `[role='menuitem']` mixed the open menu with hidden entries from the editor's other menus and `nth(i)` clicked an unclickable node.

It now reads the **visible** menu, matches in Python with an explicit exclusion (`Nano Banana 2` is a prefix of `Nano Banana 2 Lite`; the menu offers three tiers, not the documented two), refuses an ambiguous or absent match, and **verifies by re-reading the chip** rather than trusting the click. Anything else raises `ConfigurationError` or `UiSelectorDriftError`. Aborting is free — the picker runs before submit, so a refusal costs no quota, while proceeding produces a paid artifact from the wrong model.

### Two data-integrity fixes

- **Each slot takes its own `primaryMediaId`**, read from the project listing. The entity exposes only a thumbnail id; reusing it across slots made the body slot claim the face's media, which `commit_workflow` then PATCHed onto the body workflow, corrupting it.
- **A failed create no longer strands an "Untitled Character."** The saga keeps its STARTED row for resume, but that row is keyed on `(project_id, name)`, so a retry under any other name missed it and minted a second entity. A zero-progress failure now rolls the free entity back and marks the row FAILED — after asking the **backend**, because an empty local workflow list means only that this process failed to read a result.

### HAR/DOM spike harness vendored in

`scripts/dev/har-spike/` (88 KB) with its `agent-browser` version pinned, artifacts and caches gitignored, its test now running in `tests/scripts/`, and AGENTS.md documenting the two spike modes. It lived outside git, so no agent could discover it and nothing pinned it — which is why this session wrote three capture scripts from scratch before learning it existed. Repo hygiene immediately caught a hardcoded user path in it.

## Test plan

Live on a moved account (`ci-probe`), verified by independent read-back:

- [x] **Complete character** — name, personality (UTF-8 round-tripped), voice, portrait **and** body; two distinct workflow ids, two distinct media ids, both images on disk with different checksums
- [x] **Model determinism** — four consecutive runs alternating `--model nano2` / `--model nanopro`, correct tier every time
- [x] **Orphan rollback A/B control** — 1 → 2 entities without the fix, 2 → 2 with it
- [x] `media.getMediaUrlRedirect` probed against a migrated portrait id: HTTP 200, 696 767 bytes, JFIF (the 404 recorded in `migrated_composer.py` was measured on a *video* id and does not generalise)
- [x] e2e rewritten as a two-sided invariant that never skips: a create leaves a correctly-named character or nothing
- [x] ruff clean, pyright 0 errors, all six doc/hygiene gates, 4051 passed / 92% coverage

**Not verified:** the labs.google path. All three accounts here are migrated, so the labs branches of these selectors are covered by unit tests only. Named as a blocker rather than claimed.

Recon: `scripts/dev/spike_migrated_character_*.py`, `spike_migrated_vs_labs_provenance.py`.