### PR TITLE
docs(recon): the migrated mint guard refuses a host that can mint (#692)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,8 @@ website/site/
 # HAR/DOM spike harness (scripts/dev/har-spike/) — the vendored scripts ARE
 # tracked; everything they generate is not. Captures carry auth cookies, Bearer
 # tokens and prompts, and the npm/agent-browser caches are 34 MB of noise.
+# (No .gitkeep negation here: git never descends into an ignored directory, so a
+# negation for a file inside one is inert. The capture scripts create the dir.)
 scripts/dev/har-spike/artifacts/
 scripts/dev/har-spike/.agent-browser/
 scripts/dev/har-spike/.npm-cache/
-!scripts/dev/har-spike/artifacts/.gitkeep

--- a/scripts/dev/spike_migrated_image_capability.py
+++ b/scripts/dev/spike_migrated_image_capability.py
@@ -1,0 +1,192 @@
+r"""Can the migrated project composer generate an IMAGE at all? ($0)
+
+This decides the shape of the fix for #692.
+
+Established already: `flow.google.com` CAN mint a reCAPTCHA Enterprise token on
+`/project/<id>` (`spike_migrated_recaptcha_mint.py`), so the mint guard refuses
+the host when the pooled page is merely on the root grid. But `gflow image` is
+UI-driven — mint, then drive the composer — so the mint is only worth routing if
+there is an image mode to drive.
+
+A first inventory of the migrated project page found `movie`, `apps_spark_2`,
+`crop_16_9`, `[role=tab]` = 0 and no obvious image control, which suggests
+video-only. That is NOT proof: the page carries two `<flow-add-menu>` elements
+and a settings overlay built from `[role=radio]` rather than tabs, so an image
+mode could sit inside either. The character editor demonstrably generates images
+on this host, so the capability exists somewhere on the origin.
+
+So: enumerate the closed surfaces instead of inferring from the default view.
+
+  1. the composer's own controls and any radiogroup submodes
+  2. every `<flow-add-menu>` — opened, then read
+  3. the settings overlay — opened, then read
+
+If an image submode exists, #692 becomes "route the mint and drive it" — images
+would work on the migrated host. If none exists, #692 is a diagnostics fix: the
+host genuinely cannot serve `gflow image` yet, and the honest outcome is exit 36
+with a message that names the migration rather than a bare RecaptchaError.
+
+Credit-free: navigation, clicks on menu/settings affordances, DOM reads. Nothing
+typed, nothing submitted.
+
+    python scripts/dev/spike_migrated_image_capability.py \
+        --profile ci-probe --project <uuid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MIGRATED_ROOT = "https://flow.google.com"
+
+# Anything that could plausibly name an image mode, by ligature or by role.
+_SURFACE_JS = r"""() => {
+  const LIG = '.google-symbols, .material-symbols-outlined, .material-icons, mat-icon';
+  const ligOf = (el) => [...el.querySelectorAll(LIG)]
+    .map(e => (e.textContent || '').trim())
+    .filter(t => /^[a-z0-9_]{2,40}$/.test(t));
+  const vis = (el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+  const describe = (el) => ({
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute('role'),
+    ligatures: ligOf(el).slice(0, 3),
+    text: (el.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 48),
+    checked: el.getAttribute('aria-checked'),
+    visible: vis(el),
+  });
+  return {
+    radios: [...document.querySelectorAll('[role="radio"]')].map(describe),
+    radiogroups: [...document.querySelectorAll('[role="radiogroup"]')].map(describe),
+    menuitems: [...document.querySelectorAll('[role="menuitem"]')].map(describe),
+    add_menus: [...document.querySelectorAll('flow-add-menu')].map(describe),
+    // The tell we actually care about: does anything name an image capability?
+    image_ligatures: [...document.querySelectorAll(LIG)]
+      .map(e => (e.textContent || '').trim())
+      .filter(t => /(image|photo|picture|palette|brush|draw|frame|camera|art)/i.test(t)),
+    all_ligatures: [...new Set([...document.querySelectorAll(LIG)]
+      .map(e => (e.textContent || '').trim())
+      .filter(t => /^[a-z0-9_]{2,40}$/.test(t)))],
+  };
+}"""
+
+
+async def _snapshot(page: Any, label: str, findings: dict[str, Any]) -> dict[str, Any]:
+    data = await page.evaluate(_SURFACE_JS)
+    findings[label] = data
+    step(
+        label,
+        f"radios={len(data['radios'])} menuitems={len(data['menuitems'])} "
+        f"add_menus={len(data['add_menus'])} image_ligatures={data['image_ligatures']}",
+    )
+    for r in data["radios"][:8]:
+        step("  radio", f"{r['ligatures']} checked={r['checked']} text={r['text']!r}")
+    for m in data["menuitems"][:10]:
+        step("  menuitem", f"{m['ligatures']} text={m['text']!r}")
+    return data
+
+
+async def _main(profile: str, project: str) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "project": project}
+
+    async with build_client(profile_dir) as client:
+        context = client._context  # noqa: SLF001 - spike reads the live context
+        page = await context.new_page()
+        try:
+            await page.goto(
+                f"{_MIGRATED_ROOT}/project/{project}",
+                wait_until="domcontentloaded",
+                timeout=45_000,
+            )
+            try:
+                await page.wait_for_load_state("networkidle", timeout=20_000)
+            except Exception:  # noqa: BLE001 - settle is best-effort
+                pass
+            await page.wait_for_timeout(3000)
+            step("landed", page.url)
+
+            await _snapshot(page, "default_view", findings)
+
+            # Open each add menu in turn and read what it offers.
+            menus = page.locator("flow-add-menu button")
+            count = await menus.count()
+            step("add_menus", f"{count} button(s) inside <flow-add-menu>")
+            for i in range(min(count, 3)):
+                try:
+                    await menus.nth(i).click(timeout=4000)
+                    await page.wait_for_timeout(1500)
+                    await _snapshot(page, f"add_menu_{i}_open", findings)
+                    await page.keyboard.press("Escape")
+                    await page.wait_for_timeout(600)
+                except Exception as exc:  # noqa: BLE001,PERF203 - a menu may not open
+                    step("add_menu", f"[{i}] could not open: {type(exc).__name__}")
+
+            # The settings overlay is where the migrated composer keeps submodes.
+            trig = page.locator(
+                "button[aria-label='Settings trigger'], .settings-trigger-button, "
+                "button:has(mat-icon:text-is('settings_2'))"
+            ).first
+            if await trig.count():
+                try:
+                    await trig.click(timeout=4000)
+                    await page.wait_for_timeout(1800)
+                    await _snapshot(page, "settings_open", findings)
+                except Exception as exc:  # noqa: BLE001 - overlay is best-effort
+                    step("settings", f"could not open: {type(exc).__name__}")
+            else:
+                step("settings", "no settings trigger found")
+
+            found = sorted(
+                {
+                    lig
+                    for key, sec in findings.items()
+                    if isinstance(sec, dict)
+                    for lig in sec.get("image_ligatures", [])
+                }
+            )
+            step(
+                "verdict",
+                f"image-naming ligatures across all surfaces: {found or 'NONE'} -> "
+                + (
+                    "an image capability may be drivable — investigate"
+                    if found
+                    else "no image mode surfaced; the migrated composer looks VIDEO-ONLY"
+                ),
+            )
+        finally:
+            shot = default_out_path("migrated_image_capability", ".png")
+            try:
+                await page.screenshot(path=str(shot))
+                findings["screenshot"] = shot.name
+            except Exception:  # noqa: BLE001 - screenshot is a courtesy
+                pass
+            out = default_out_path("migrated_image_capability")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.project)))

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -2412,10 +2412,27 @@ class FlowApiClient:
         try:
             # #673: this runs BEFORE the UI transport, so none of its migration
             # guards can fire first. On a moved account the pool page is the
-            # flow.google.com grid (client-side handoff) with no
-            # recaptcha/enterprise.js — bail to exit 36 here instead of a bare
-            # RecaptchaError. (/project/<id> on that host does carry the script,
-            # but no path that mints is ported there yet.)
+            # flow.google.com ROOT GRID, which carries no recaptcha/enterprise.js —
+            # bail to exit 36 here instead of a bare RecaptchaError.
+            #
+            # Be precise about WHY, because the imprecise version misdirects whoever
+            # ports this next: flow.google.com is NOT unable to mint. Measured
+            # 2026-09-06 (scripts/dev/spike_migrated_recaptcha_mint.py) on the same
+            # page pool — `/project/<id>` there carries the enterprise script and
+            # site key 6LdsFiUsAAAA…, and a mint returns a 2404-char token. Only the
+            # root grid, which is where the client-side handoff leaves the pooled
+            # bootstrap page, has no script at all.
+            #
+            # So this guard refuses a HOST that can mint, standing in for the real
+            # constraint: `gflow image` is UI-driven, and the migrated project
+            # composer has no image-generation mode. Its add menu is a media
+            # library (Scenes / Images / Videos / Upload media) and its settings
+            # radios are grid/batch and size — measured, not assumed
+            # (scripts/dev/spike_migrated_image_capability.py). Image generation
+            # does exist on that host, but only inside the character editor.
+            #
+            # When the composer gains an image mode, the fix is to route the mint
+            # to a project page — NOT to keep refusing the origin.
             raise_if_migrated(page, at="mint_recaptcha_token")
             # Patchright evaluates in an isolated world by default, where the
             # page's main-world ``grecaptcha`` global is undefined; the resolver


### PR DESCRIPTION
## Summary

Two `$0` probes and a corrected comment. **No behavioural change** — deliberately.

#692's reporter gets `RecaptchaError` + exit 1 where they expect `FlowHostMigratedError` + exit 36. #694 hardened that path, but the failure still cannot be reproduced here, so this PR does not stack a speculative fix on top of it. Per the Iron Law, a fix for a failure never observed is a guess with formatting.

What it does add is evidence that changes what we can tell the reporter — and corrects a comment that would misdirect whoever ports `gflow image` next.

## flow.google.com CAN mint

Measured on `ci-probe`, on the same page pool the client uses:

| route | recaptcha scripts | site key | `grecaptcha.enterprise` | mint |
|---|---|---|---|---|
| `flow.google.com/` (root grid) | **0** | — | false | ❌ `RecaptchaError` |
| `flow.google.com/project/<id>` | **2** | `6LdsFiUsAAAA…` | **true** | ✅ **OK, 2404-char token** |

The mint runs on the pooled **bootstrap** page, which the client-side handoff leaves on the **root grid** — and only the root grid carries no script. That is also why the reporter's bundle shows `route: "/"`: `diagnostics.py` maps *both* hosts to `host_category: flow_app`, so the route is the only tell.

So the guard's stated reason — "the migrated host has no `recaptcha/enterprise.js`" — is **false about the host** and true only about one route on it.

## The outcome is still right, for a different reason

`gflow image` is UI-driven (mint → drive the composer), and the migrated project composer has **no image-generation mode**. Enumerated by opening the closed surfaces rather than inferring from the default view:

- the add menu is a media **library**: `movie Scenes` · `image Images` · `videocam Videos` · `upload Upload media`
- the settings overlay's radios are `dashboard Grid` / `campaign_all Batch` and S/M/L — layout, not mode
- `[role=tab]` = 0, and no image-generation ligature anywhere

Image generation *does* exist on that host — but only inside the character editor (see #703).

So exit 36 is correct today. When the composer gains an image mode, the fix is to **route the mint to a project page**, not to keep refusing the origin. That sentence is now in the code, where the wrong one used to be.

## Test plan

- [x] `scripts/dev/spike_migrated_recaptcha_mint.py` — A/B of both routes, re-runnable, `$0`
- [x] `scripts/dev/spike_migrated_image_capability.py` — opens every closed surface (add menus, settings overlay) rather than reading the default view, `$0`
- [x] ruff, `ruff format --check`, pyright **0 errors**, repo hygiene over 1012 files
- [x] `tests/api/test_client_migrated_mint.py` — 10 passed (unchanged behaviour, as intended)
- [x] Comment-and-scripts only; no Flow surface behaviour changed, so no e2e applies

Refs #692 — stays open. The reporter's failure is still unreproduced, and this changes nothing about whether #694 fixes it.