### PR TITLE
docs(contributing): tell contributors how to produce evidence, not just tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,44 @@ Four rules the pipeline enforces that catch first-time contributors most often:
 The PR template's *Lifecycle* checklist mirrors this table. Tick what applies, strike what
 does not, and say why — a reviewer can then start from your evidence instead of re-deriving it.
 
+### Reporting that something is broken? Spike it first
+
+An e2e test proves a **fix**. A spike proves a **diagnosis** — and it is what turns "this
+does not work for me" into something a maintainer can act on without owning your account.
+
+gflow drives a product we do not control, so the single most useful thing in a bug report is
+what Flow actually rendered or called on your machine. Two harnesses exist, and both are `$0`
+(navigation and DOM reads spend no credits and no quota):
+
+| | where | who drives | use when |
+|---|---|---|---|
+| **In-process probe** | `scripts/dev/spike_*.py` | the script, through gflow's own transport | you can reach the surface and want to see what gflow sees |
+| **HAR + DOM capture** | [`scripts/dev/har-spike/`](scripts/dev/har-spike/README.md) | **you**, by hand, in real Chrome over CDP | gflow cannot get far enough to observe anything |
+
+The protocol is [`skills/spike/SKILL.md`](skills/spike/SKILL.md) (`/gflow:spike` in Claude
+Code). The rule it exists to enforce:
+
+> **A selector that does not match is evidence about the selector. It is never evidence
+> about the feature.**
+
+A timeout, an exception or an exit code tells us an anchor missed — not that the thing is
+gone. Saying "X is not supported on this host" without a DOM or network observation behind it
+is how a *working* feature gets documented as impossible, which has happened here and cost a
+day to undo.
+
+**Redact before you attach.** Raw captures carry cookies, Bearer tokens and prompts, and
+`*.har` is gitignored repo-wide for that reason. Run
+`python scripts/dev/har-spike/extract_har_summary.py <capture>.har --host <host>` and attach
+the **summary** — it is redacted by design and is what a maintainer needs anyway. Never paste
+a raw HAR or an unredacted incident bundle into an issue.
+
+> **Windows-only today.** The CDP harness is nine PowerShell scripts; a portable Python twin
+> is being ported one script at a time (`probe_agent_mode.py` is the pattern). On macOS or
+> Linux, use the in-process probes, or attach an **incident bundle** — gflow writes one
+> automatically on operational failures under `<GFLOW_CLI_HOME>/incidents/`; see
+> [DEBUGGING § Automatic incident bundles](docs/DEBUGGING.md#automatic-incident-bundles) for
+> the layout. Redact account ids and any cookie or token value first.
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` told contributors how to prove a **fix** (the E2E evidence layer, #675) and nothing about how to prove a **diagnosis** — which is what a bug report is actually made of. The spike harnesses became first-class for *agents* in #704; this makes them findable by *people*.

Adds one section under the existing evidence table:

- **the two harnesses** — in-process `scripts/dev/spike_*.py` vs the hand-driven CDP/HAR capture in `scripts/dev/har-spike/` — and which to reach for
- **the rule**: *a selector that does not match is evidence about the selector, never about the feature*. A timeout tells us an anchor missed, not that the thing is gone. Saying "X is not supported on this host" without a DOM or network observation is how a **working** feature got documented as impossible here, and it cost a day to undo (#703).
- **redaction, explicitly** — this is the one place we invite someone to attach a capture. Raw HARs carry cookies, Bearer tokens and prompts, so attach `extract_har_summary.py`'s redacted summary, never the raw file. `*.har` is gitignored repo-wide for the same reason.

## The limitation, stated rather than discovered

The CDP harness is **nine PowerShell scripts and Windows-only today** (`launch-flow-chrome.ps1` alone hardcodes four Windows paths). Rather than let a macOS or Linux contributor find that out the hard way, the section says so and points them at the in-process probes or an incident bundle.

A portable Python twin is worth doing — Playwright's `channel="chrome"` and `_spike_common.resolve_profile_dir()` already solve both Windows-bound problems, and `probe_agent_mode.py` is the existing pattern — but incrementally, one script at a time when a spike needs it, not as a 1691-line rewrite nobody can review. Not in this PR.

## Test plan

- [x] `check_doc_links.py` — all links resolved across 29 files (caught nothing, but the
      `docs/DEBUGGING.md#automatic-incident-bundles` anchor is real)
- [x] `check_repo_hygiene.py` — 1012 tracked files, no violations
- [x] 10 documentation-gate tests pass
- [x] Verified rather than guessed: my first draft invented `~/.local/share/gflow-cli/incidents/`
      as the bundle path. The canonical form is `<GFLOW_CLI_HOME>/incidents/`, per
      `docs/CONFIGURATION.md` and `docs/DEBUGGING.md`. Corrected before commit.
- [x] Docs-only, no Flow surface touched, so no e2e applies