### PR TITLE
docs(plan): spike tooling reorg — tested library, no Node, probe lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,7 @@ All AI agents and harnesses working on `gflow-cli` follow this standard 10-phase
 
 | Phase | Skill / Command | Purpose | Output Artifact |
 |---|---|---|---|
-| 0. Recon | `/gflow:spike <question>` | Evidence from the live surface (DOM / network / HAR) whenever a claim of absence is in play | `scripts/dev/spike_*.py` + `docs/superpowers/spikes/<date>-<slug>.md` |
+| 0. Spike | `/gflow:spike <question>` | Evidence from the live surface (DOM / network / HAR) whenever a claim of absence is in play | `scripts/dev/spike_*.py` + `docs/superpowers/spikes/<date>-<slug>.md` |
 | 1. Triage | `/gflow:issue-assessment <N>` | Read-only issue analysis & root cause hypothesis | `issue_assessment_<N>.md` |
 | 2. Pre-Implementation | `/gflow:predict <proposal>` | Adversarial audit (D14 YAGNI, security, risks) | GO / CAUTION / STOP verdict |
 | 3. BDD Scaffolding | `/gflow:scenario <feature>` | Edge-case explorer & BDD Gherkin spec | `Scenario:` blocks & test scaffold |

--- a/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
+++ b/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
@@ -6,21 +6,22 @@
 **Goal:** A spike tool a contributor on any OS can run to produce redacted evidence for a bug
 report — backed by a tested library instead of 88 untested scripts and a Node dependency.
 
-**Architecture:** The reusable machinery goes into the **existing** `src/gflow_cli/diagnostics`
-module, promoted to a package. That module is already 1890 shipped lines owning `sanitize_url`,
-`_HOST_CATEGORIES`, `_ROUTE_PATTERNS`, `classify_title` and `reduce_error_body` — URL
-redaction, host/route classification and evidence summarisation. In other words **the domain
-already exists and already ships**; a new `_spike/` package would have been a third home for
-it, alongside `redaction.py` and `extract_har_summary.py`, which is exactly the drift this plan
-exists to remove.
+**Architecture:** Live capture goes into a **new** `src/gflow_cli/recon/` package (CDP attach,
+HAR capture, DOM inventory). `recon` is already this repo's word for it — 16 doc occurrences,
+plus the "Phase 0: Recon" the workflow gained in #704 — and it means precisely what this does:
+observing terrain we do not control.
 
-It is also where [#707](https://github.com/ffroliva/gflow-cli/issues/707) lands: that issue's
-first design question is "new command, or better incident bundles?", and bundles are
-diagnostics. Any other location guarantees a later move across a package boundary.
+**`diagnostics.py` is deliberately left alone.** An earlier draft folded this into it, and that
+was conflation rather than consolidation: `diagnostics` classifies and summarises what already
+went wrong, post-hoc, for an incident bundle; recon actively drives a browser to observe a live
+surface. Different activity, different lifecycle. Promoting a shipped 1890-line module with 4
+importers to a package would have been risk taken for no benefit.
 
-Naming matters here too — `_spike` names a *process* (a time-boxed investigation), not a
-capability. In six months this is the CDP/HAR/DOM library, and a module named after the
-activity that created it reads like archaeology.
+**What genuinely needed consolidating was redaction, and it still does.** There are three
+implementations today — `redaction.py` (14 lines), `diagnostics.sanitize_url`, and
+`extract_har_summary`'s header/URL redaction. Task 2 merges them into `redaction.py`, which both
+`diagnostics` and `recon` then share. That was always the real drift risk; the module count
+never was.
 
 One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
 Node/`agent-browser`/PowerShell harness is deleted script by script as each Python twin lands.
@@ -43,8 +44,8 @@ piece that could have killed the port is retired.
 | **HIGH** | Redaction regression leaks a Bearer token or cookie into an issue attachment | Consolidate to ONE implementation; property-style tests over a corpus of real header/URL shapes; Task 2 lands before anything that produces a shareable artefact |
 | **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live response bodies | `record_har_content="omit"` is the default; the CDP-shaped path (95 KB for the same traffic) is what the contributor-facing entry point uses |
 | MED | Moving 67 probes breaks a doc link or a `tests/scripts/` import | `check_doc_links.py` is a merge gate; move with `git mv`, run gates per task |
-| MED | Promoting a 1890-line module to a package breaks its 4 importers | `diagnostics/__init__.py` re-exports every current name; the move is mechanical and the existing tests are the check |
-| MED | `diagnostics` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
+| MED | `recon` and `diagnostics` drift into two redaction implementations again | Task 2 makes `redaction.py` the single home BEFORE either uses it; no capture code lands first |
+| MED | `recon` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
 | LOW | Ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
 
 ---
@@ -54,20 +55,20 @@ piece that could have killed the port is retired.
 ### New files
 
 ```
-src/gflow_cli/diagnostics/cdp.py      launch/attach a real Chrome over CDP; profile resolution
-src/gflow_cli/diagnostics/har.py      capture -> HAR (body-free by default), shape CDP events
-src/gflow_cli/diagnostics/dom.py      ligature / ARIA role / custom-element inventory
-tests/diagnostics/test_cdp.py         attach/launch contract, no real browser
-tests/diagnostics/test_har.py         CDP-event -> HAR shaping; size discipline
-tests/diagnostics/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
+src/gflow_cli/recon/cdp.py            launch/attach a real Chrome over CDP; profile resolution
+src/gflow_cli/recon/har.py            capture -> HAR (body-free by default), shape CDP events
+src/gflow_cli/recon/dom.py            ligature / ARIA role / custom-element inventory
+tests/recon/test_cdp.py         attach/launch contract, no real browser
+tests/recon/test_har.py         CDP-event -> HAR shaping; size discipline
+tests/recon/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
 scripts/dev/probes/README.md          what a probe is, and the retention rule
 ```
 
 ### Modified files
 
 ```
-src/gflow_cli/diagnostics.py          -> diagnostics/__init__.py, re-exporting every current
-                                      name so all 4 importers keep working unchanged
+src/gflow_cli/diagnostics.py          sanitize_url delegates to redaction.py; otherwise
+                                      UNCHANGED — its 4 importers are not touched
 src/gflow_cli/redaction.py            EXTENDED to own header/URL/HAR-entry redaction
                                       (absorbs extract_har_summary's second implementation;
                                       diagnostics.sanitize_url delegates to it)
@@ -84,10 +85,10 @@ AGENTS.md                             two-modes table points at the new paths
 
 **What:** Red tests defining the contract before any code exists.
 
-**Files:** `tests/diagnostics/test_cdp.py`, `tests/diagnostics/test_har.py`
+**Files:** `tests/recon/test_cdp.py`, `tests/recon/test_har.py`
 
 **Steps:**
-- [ ] `tests/diagnostics/` package with a `conftest.py` fixture for a fake CDP session
+- [ ] `tests/recon/` package with a `conftest.py` fixture for a fake CDP session
 - [ ] Assert `har.from_cdp_events()` emits `log.entries[].request/response` (the shape
       `summarize_har` reads) and nothing more
 - [ ] Assert the capture default is **body-free** — a fixture with a 5 MB response body
@@ -105,7 +106,7 @@ AGENTS.md                             two-modes table points at the new paths
 **What:** One redaction implementation. `src/gflow_cli/redaction.py` absorbs the header, URL
 and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_summary.py`.
 
-**Files:** `src/gflow_cli/redaction.py`, `tests/diagnostics/test_har_redaction.py`,
+**Files:** `src/gflow_cli/redaction.py`, `tests/recon/test_har_redaction.py`,
 `scripts/dev/har-spike/extract_har_summary.py` (delegates)
 
 **Steps:**
@@ -124,11 +125,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 3 — `diagnostics/cdp.py`: attach and launch
+## Task 3 — `recon/cdp.py`: attach and launch
 
 **What:** The Chrome-discovery and CDP-attach machinery, cross-platform.
 
-**Files:** `src/gflow_cli/diagnostics/cdp.py`, `src/gflow_cli/diagnostics/__init__.py`
+**Files:** `src/gflow_cli/recon/cdp.py      `, `src/gflow_cli/diagnostics/__init__.py`
 
 **Steps:**
 - [ ] `launch_with_cdp(profile, port)` — `channel="chrome"` (no path hunting) +
@@ -143,11 +144,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 4 — `diagnostics/har.py`: capture without Node
+## Task 4 — `recon/har.py`: capture without Node
 
 **What:** Both capture routes, with the size discipline baked in.
 
-**Files:** `src/gflow_cli/diagnostics/har.py`
+**Files:** `src/gflow_cli/recon/har.py      `
 
 **Steps:**
 - [ ] `from_cdp_events(events)` — shape `Network.requestWillBeSent` /
@@ -162,11 +163,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 5 — `diagnostics/dom.py`: inventory helpers
+## Task 5 — `recon/dom.py`: inventory helpers
 
 **What:** The DOM-reading JS that tonight's probes each re-implemented.
 
-**Files:** `src/gflow_cli/diagnostics/dom.py`
+**Files:** `src/gflow_cli/recon/dom.py      `
 
 **Steps:**
 - [ ] `inventory(page)` — ligatures + carrier tag, ARIA roles, custom elements, `href`s
@@ -188,7 +189,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 `scripts/dev/har-spike/launch-flow-chrome.ps1`
 
 **Steps:**
-- [ ] Thin CLI over `diagnostics.cdp.launch_with_cdp`
+- [ ] Thin CLI over `recon.cdp.launch_with_cdp`
 - [ ] Exercise once against live Chrome; paste the result in the PR
 - [ ] Delete the `.ps1` in the same commit — two implementations is the drift we are removing
 
@@ -229,7 +230,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
       finding, or it does not merge.** Findings are permanent; probes are prunable once
       written up
 - [ ] Drop the Windows-only caveat from CONTRIBUTING; the harness is Python now
-- [ ] AGENTS.md two-modes table points at `diagnostics/` and `probes/`
+- [ ] AGENTS.md two-modes table points at `recon/` and `probes/`
 - [ ] Add a one-line cost + question header convention for probes
 
 **Tests:**
@@ -244,7 +245,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
       full pytest)
 - [ ] CHANGELOG entry under `[Unreleased]`
 - [ ] Confirm no Click command and no MCP tool was added — the user-facing decision belongs
-      to #707. `diagnostics` already shipped, so the wheel gains capability, not a new surface
+      to #707. `recon` adds ~40 KB to the wheel and no user-visible surface
 
 **Tests:**
 - [ ] `uv run python -m pytest -q --cov=gflow_cli` — coverage floor held
@@ -257,6 +258,6 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
   [#707](https://github.com/ffroliva/gflow-cli/issues/707), and it gets `/gflow:predict`
   first. This plan deliberately ships **no** new CLI surface, which is also why it needs no
   MCP mirror task: there is nothing user-facing to mirror.
-- Rewriting existing probes to use `diagnostics/` — they keep working as they are; convert on
+- Rewriting existing probes to use `recon/` — they keep working as they are; convert on
   next touch.
 - Changing what incident bundles contain — overlaps #707's first design question.

--- a/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
+++ b/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
@@ -3,56 +3,72 @@
 > **For agentic workers:** Run `/gflow:status --feature spike-tooling-reorg` to find the next
 > unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
 
-**Goal:** A spike tool a contributor on any OS can run to produce redacted evidence for a bug
-report — backed by a tested library instead of 88 untested scripts and a Node dependency.
+**Goal:** A spike tool a contributor on any OS can run to produce redacted evidence — backed by
+a small tested library, with probes that stop accumulating.
 
-**Architecture:** Live capture goes into a new `src/gflow_cli/spike/` package (CDP attach, HAR
-capture, DOM inventory). **`spike` because that is already the word here** — `/gflow:spike`,
-`skills/spike/SKILL.md`, 48 `scripts/dev/spike_*.py` since July, and `docs/superpowers/spikes/`
-for the findings. One word across command, protocol, scripts, findings and module beats a
-taxonomically neater name that matches nothing else; a contributor grepping for "spike" should
-land on all of it.
+**Architecture:** A new `src/gflow_cli/spike/` package holds the two capabilities that are
+genuinely reused: CDP attach/launch (`cdp.py`) and HAR capture/shaping (`har.py`). Probes become
+**ephemeral by default** — the *finding* is the durable artefact, not the script. The
+Node/`agent-browser`/PowerShell harness is deleted as each Python twin lands.
 
-Named `spike/`, **not** `_spike/`. The underscore would claim it is private, and it is not:
-[#707](https://github.com/ffroliva/gflow-cli/issues/707) builds a user-facing capture path on
-exactly this code.
+`spike` because it is already the word everywhere a human looks: `/gflow:spike`,
+`skills/spike/SKILL.md`, 48 `scripts/dev/spike_*.py`, `docs/superpowers/spikes/`. Named `spike/`,
+not `_spike/` — [#707](https://github.com/ffroliva/gflow-cli/issues/707) builds a user-facing
+path on this code, so it is not private.
 
-**`diagnostics.py` is deliberately left alone.** An earlier draft folded this into it, and that
-was conflation rather than consolidation: `diagnostics` classifies and summarises what already
-went wrong, post-hoc, for an incident bundle; a spike actively drives a browser to observe a
-live surface. Different activity, different lifecycle. Promoting a shipped 1890-line module
-with 4 importers to a package would have been risk taken for no benefit.
+**Predict verdict:** pending — dev tooling, not a transport/auth/selector/schema change, so the
+AGENTS.md routing table does not require `/gflow:predict`. Run it before #707, which does.
 
-**What genuinely needed consolidating was redaction, and it still does.** There are three
-implementations today — `redaction.py` (14 lines), `diagnostics.sanitize_url`, and
-`extract_har_summary`'s header/URL redaction. Task 2 merges them into `redaction.py`, which both
-`diagnostics` and `spike` then share. That was always the real drift risk; the module name never
-was.
+**Portability proven before planning** (`scripts/dev/spike_cdp_har_without_node.py`, live on a
+migrated account): `connect_over_cdp` attaches to a real gflow profile and sees the human's page
+(`contexts=1, pages=1, sees_human_page=True`); `record_har_path` works on a CDP-attached browser;
+and raw CDP `Network.*` events shape into a HAR that `extract_har_summary.summarize_har` consumes
+**unchanged** (38 entries). The Node layer can go.
 
-One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
-Node/`agent-browser`/PowerShell harness is deleted script by script as each Python twin lands.
+---
 
-**Predict verdict:** pending — this is dev tooling, not a transport/auth/selector/schema
-change, so the AGENTS.md routing table does not require `/gflow:predict`. Run it before
-[#707](https://github.com/ffroliva/gflow-cli/issues/707), which does.
+## Council review changed this plan substantially
 
-**Portability proven before planning** (2026-09-06,
-`scripts/dev/spike_cdp_har_without_node.py`): Playwright can attach to a CDP Chrome running a
-real gflow profile and see the human's page (`contexts=1, pages=1, sees_human_page=True`);
-`record_har_path` works on a CDP-attached browser; and raw CDP `Network.*` events shape into a
-HAR that the harness's own `extract_har_summary.summarize_har` consumes **unchanged**. The one
-piece that could have killed the port is retired.
+Two reviewers ran before implementation. **Both falsified assumptions in the first draft**, and
+the plan is smaller as a result. Recorded because the reasoning matters more than the conclusion.
+
+**1. The DOM-JS duplication this plan was built around does not exist.** Measured: 40 embedded JS
+blocks / 954 lines across 28 scripts; trigram-Jaccard over all 780 pairs found **only 2 above
+0.35**. The single literal repeat is one line — the `LIG` constant, 6 occurrences.
+`elementFromPoint` appears **once** in 40 blocks. That is a constant, not a module.
+→ **`spike/dom.py` is cut.** Three modules become two.
+
+**2. "Three redaction implementations" was a miscount — it is two**, and the proposed fix was
+itself the conflation this plan forbids. `src/gflow_cli/redaction.py` is already a 14-line
+re-export shim over `data/redaction.py`, which **already owns** `SENSITIVE_URL_KEYS` /
+`SENSITIVE_QUERY_KEYS` (`data/redaction.py:11-12`) — extending the shim would add a third layer.
+And `diagnostics.sanitize_url` (`diagnostics.py:209-225`) is not a redactor: it returns
+`SanitizedUrl(host_category, route)` via `CommandHasher` for the observability schema. Making it
+delegate would drag `CommandHasher` into a module 14 `src/` files import.
+→ **`diagnostics` is not touched at all.** The HAR header constants land beside their siblings.
+
+**3. The real duplication is entry boilerplate, and it is bigger.** 70 scripts run their own
+`sys.path.insert` while importing `_spike_common`, which already bootstraps `src/` at
+`_spike_common.py:33-37` — **50 are provably redundant** (~460 lines). Separately **726 lines**
+of `ArgumentParser` across 87 scripts, with `--profile` spelled 65× in **10 distinct ways**.
+→ **New Task 2:** one `spike_parser()` helper. **~600 lines deleted, zero new modules.**
+
+**4. Probes are not re-run, so committing them buys little.** **52 of 67 have exactly one commit
+ever**; 65 of 67 have a first→last span under 14 days. Only **14 findings exist for 67 probes
+(21%)**, and **29 scripts hardcode an account name** (`ffroliva` ×15 as an argparse default,
+`denon82` ×7, `ci-probe` ×9), so a stranger cannot re-run them anyway.
+→ **The retention rule inverts** (Task 6), and `skills/spike/SKILL.md`'s claim that "a question
+worth asking once gets asked again" is **false as written** and gets corrected.
 
 **Risk register:**
 
 | Severity | Risk | Mitigation |
 |---|---|---|
-| **HIGH** | Redaction regression leaks a Bearer token or cookie into an issue attachment | Consolidate to ONE implementation; property-style tests over a corpus of real header/URL shapes; Task 2 lands before anything that produces a shareable artefact |
-| **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live response bodies | `record_har_content="omit"` is the default; the CDP-shaped path (95 KB for the same traffic) is what the contributor-facing entry point uses |
-| MED | Moving 67 probes breaks a doc link or a `tests/scripts/` import | `check_doc_links.py` is a merge gate; move with `git mv`, run gates per task |
-| MED | `spike` and `diagnostics` drift into two redaction implementations again | Task 2 makes `redaction.py` the single home BEFORE either uses it; no capture code lands first |
+| **HIGH** | Redaction regression leaks a Bearer token into an issue attachment | Task 3 lands before any capture code; corpus tests; constants live with their siblings, not in a new layer |
+| **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live bodies | body-free default; the CDP-shaped route (95 KB for the same traffic) is the contributor path |
+| MED | Deleting probes loses something still wanted | Delete only single-commit probes whose logic is in `spike/` or whose finding exists; git keeps history either way |
 | MED | `spike` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
-| LOW | Ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
+| LOW | A ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
 
 ---
 
@@ -61,209 +77,170 @@ piece that could have killed the port is retired.
 ### New files
 
 ```
-src/gflow_cli/spike/cdp.py            launch/attach a real Chrome over CDP; profile resolution
-src/gflow_cli/spike/har.py            capture -> HAR (body-free by default), shape CDP events
-src/gflow_cli/spike/dom.py            ligature / ARIA role / custom-element inventory
-tests/spike/test_cdp.py         attach/launch contract, no real browser
-tests/spike/test_har.py         CDP-event -> HAR shaping; size discipline
-tests/spike/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
-scripts/dev/probes/README.md          what a probe is, and the retention rule
+src/gflow_cli/spike/__init__.py   attach() / capture() — the two verbs
+src/gflow_cli/spike/cdp.py        launch/attach real Chrome over CDP; the LIG constant
+src/gflow_cli/spike/har.py        capture -> HAR (body-free default), shape CDP events
+tests/spike/test_cdp.py           attach/launch contract, no real browser
+tests/spike/test_har.py           CDP-event -> HAR shaping; size discipline
+tests/spike/test_har_redaction.py header/URL redaction over a real-shaped corpus
 ```
 
 ### Modified files
 
 ```
-src/gflow_cli/diagnostics.py          sanitize_url delegates to redaction.py; otherwise
-                                      UNCHANGED — its 4 importers are not touched
-src/gflow_cli/redaction.py            EXTENDED to own header/URL/HAR-entry redaction
-                                      (absorbs extract_har_summary's second implementation;
-                                      diagnostics.sanitize_url delegates to it)
-scripts/dev/har-spike/                shrinks per task; DELETED at Task 7
-skills/spike/SKILL.md                 retention rule + new paths
-CONTRIBUTING.md                       drop the Windows-only caveat once Task 6 lands
-AGENTS.md                             two-modes table points at the new paths
-.gitignore                            probes/ output + har-spike rules removed at Task 7
+src/gflow_cli/data/redaction.py   gains SENSITIVE_HEADERS / SENSITIVE_KEY_PARTS beside the
+                                  SENSITIVE_URL_KEYS it already owns
+scripts/dev/_spike_common.py      gains spike_parser(); ~600 lines of boilerplate deleted
+                                  across the probe scripts
+scripts/dev/har-spike/            shrinks per task; DELETED at Task 5
+skills/spike/SKILL.md             the false "gets asked again" claim corrected; new rule
+CONTRIBUTING.md                   Windows-only caveat dropped once Task 4 lands
+.gitignore                        probe scratch gitignored by default
+src/gflow_cli/diagnostics.py      NOT TOUCHED — recorded because an earlier draft did
 ```
 
 ---
 
-## Task 1 — Test scaffold for the spike library (red)
-
-**What:** Red tests defining the contract before any code exists.
+## Task 1 — Test scaffold (red)
 
 **Files:** `tests/spike/test_cdp.py`, `tests/spike/test_har.py`
 
 **Steps:**
-- [ ] `tests/spike/` package with a `conftest.py` fixture for a fake CDP session
-- [ ] Assert `har.from_cdp_events()` emits `log.entries[].request/response` (the shape
-      `summarize_har` reads) and nothing more
-- [ ] Assert the capture default is **body-free** — a fixture with a 5 MB response body
-      produces a HAR that does not contain it
-- [ ] Assert `cdp.attach()` surfaces a typed error, not a raw Playwright exception, when no
-      CDP endpoint answers
+- [ ] `tests/spike/` with a fake-CDP-session fixture
+- [ ] Assert `har.from_cdp_events()` emits exactly the `log.entries[].request/response` shape
+      `summarize_har` reads
+- [ ] Assert the default is **body-free**: a 5 MB response body does not appear in the HAR
+- [ ] Assert `cdp.attach()` raises a typed error, not a raw Playwright exception
 
 **Tests:**
-- [ ] `uv run python -m pytest tests/diagnostics -q` — red, and red for the stated reason
+- [ ] `uv run python -m pytest tests/spike -q` — red, for the stated reason
 
 ---
 
-## Task 2 — Consolidate redaction (the safety-critical task)
+## Task 2 — `spike_parser()`: delete ~600 lines of boilerplate
 
-**What:** One redaction implementation. `src/gflow_cli/redaction.py` absorbs the header, URL
-and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_summary.py`.
+**What:** The highest line-count win in the plan, and it adds no module.
 
-**Files:** `src/gflow_cli/redaction.py`, `tests/spike/test_har_redaction.py`,
-`scripts/dev/har-spike/extract_har_summary.py` (delegates)
+**Files:** `scripts/dev/_spike_common.py`, probe scripts
 
 **Steps:**
-- [ ] Move `SENSITIVE_HEADERS`, `SENSITIVE_KEY_PARTS`, `_safe_url`, `_redact_header` into
-      `redaction.py` as public functions
+- [ ] `spike_parser(*, project=False, out=False)` returning a configured `ArgumentParser` — one
+      spelling of `--profile` / `--project` / `--out` instead of ten
+- [ ] **No account defaults.** `--profile` is required, killing the 29 hardcoded
+      `ffroliva`/`denon82`/`ci-probe` values that make probes unrunnable for anyone else
+- [ ] Delete the 50 redundant `sys.path.insert` preambles (`_spike_common.py:33-37` already
+      bootstraps `src/`)
+- [ ] Convert probes opportunistically — no big-bang rewrite
+
+**Tests:**
+- [ ] `tests/scripts/test_spike_parser.py` — `--profile` required, no account default
+- [ ] A converted probe still answers `--help`
+
+---
+
+## Task 3 — Redaction constants, in the module that already owns them
+
+**What:** The safety-critical task. **Not** a new layer.
+
+**Files:** `src/gflow_cli/data/redaction.py`, `tests/spike/test_har_redaction.py`,
+`scripts/dev/har-spike/extract_har_summary.py` (imports them)
+
+**Steps:**
+- [ ] `SENSITIVE_HEADERS` + `SENSITIVE_KEY_PARTS` (`extract_har_summary.py:11,20`) move beside
+      `SENSITIVE_URL_KEYS` / `SENSITIVE_QUERY_KEYS` (`data/redaction.py:11-12`)
 - [ ] `extract_har_summary.py` imports them — behaviour unchanged, one source of truth
-- [ ] Keep `redact_sensitive_text` as-is; its one existing caller must not change
+- [ ] **`diagnostics.sanitize_url` is not touched** — it is route canonicalisation, not redaction
 
 **Tests:**
-- [ ] Corpus test: `authorization`, `cookie`, `set-cookie`, `x-goog-api-key`, `sapisid`,
-      query params containing `key`/`token`/`sid` — each redacted, presence-vs-absence
-      preserved (`<redacted:present>` vs `<redacted:empty>`)
-- [ ] A URL with no sensitive parts round-trips unchanged (no over-redaction)
-- [ ] `tests/scripts/test_extract_har_summary.py` still passes untouched — proves the move
-      is behaviour-preserving
+- [ ] Corpus: `authorization`, `cookie`, `set-cookie`, `x-goog-api-key`, `sapisid`, and query
+      params containing `key`/`token`/`sid` — each redacted, presence-vs-absence preserved
+- [ ] A clean URL round-trips unchanged (no over-redaction)
+- [ ] `tests/scripts/test_extract_har_summary.py` passes **untouched** — proves behaviour is preserved
 
 ---
 
-## Task 3 — `spike/cdp.py`: attach and launch
+## Task 4 — `spike/cdp.py` + `spike/har.py`, and the first `.ps1` dies
 
-**What:** The Chrome-discovery and CDP-attach machinery, cross-platform.
-
-**Files:** `src/gflow_cli/spike/cdp.py      `, `src/gflow_cli/diagnostics/__init__.py`
-
-**Steps:**
-- [ ] `launch_with_cdp(profile, port)` — `channel="chrome"` (no path hunting) +
-      `--remote-debugging-port`
-- [ ] `attach(port)` — `connect_over_cdp`, typed error on failure
-- [ ] Profile resolution delegates to the existing profile store, never `LOCALAPPDATA`
-- [ ] Docstring records the proven facts and cites the PoC spike
-
-**Tests:**
-- [ ] Task 1's tests go green
-- [ ] No real browser in unit tests; live exercise is Task 6
-
----
-
-## Task 4 — `spike/har.py`: capture without Node
-
-**What:** Both capture routes, with the size discipline baked in.
-
-**Files:** `src/gflow_cli/spike/har.py      `
-
-**Steps:**
-- [ ] `from_cdp_events(events)` — shape `Network.requestWillBeSent` /
-      `responseReceived` into the HAR subset (proven compatible with `summarize_har`)
-- [ ] `record_context_har(context, path, *, bodies=False)` — native route, bodies **off** by
-      default; the docstring names the measurement: 59.5 MB with bodies vs 95 KB without
-- [ ] Every capture passes through `redaction` before it is written
-
-**Tests:**
-- [ ] Task 1's shaping and size tests go green
-- [ ] A shaped HAR fed to `summarize_har` produces entries (the compatibility contract)
-
----
-
-## Task 5 — `spike/dom.py`: inventory helpers
-
-**What:** The DOM-reading JS that tonight's probes each re-implemented.
-
-**Files:** `src/gflow_cli/spike/dom.py      `
-
-**Steps:**
-- [ ] `inventory(page)` — ligatures + carrier tag, ARIA roles, custom elements, `href`s
-- [ ] `candidates(page, selectors)` — visibility **and occluder** (`elementFromPoint`), the
-      check that proved the character editor was reachable
-- [ ] Docstring carries the anchor rule: structure over labels; custom elements are the best
-      anchors; the carrier differs per host (`i.google-symbols` vs `mat-icon`)
-
-**Tests:**
-- [ ] Pure-function tests over captured DOM fixtures (no browser)
-
----
-
-## Task 6 — Port `launch-flow-chrome.ps1`, delete it
-
-**What:** First `.ps1` retired. Establishes the pattern for the rest.
-
-**Files:** `scripts/dev/probes/launch_flow_chrome.py`, delete
+**Files:** `src/gflow_cli/spike/{__init__,cdp,har}.py`, delete
 `scripts/dev/har-spike/launch-flow-chrome.ps1`
 
 **Steps:**
-- [ ] Thin CLI over `spike.cdp.launch_with_cdp`
-- [ ] Exercise once against live Chrome; paste the result in the PR
-- [ ] Delete the `.ps1` in the same commit — two implementations is the drift we are removing
+- [ ] `launch_with_cdp(profile, port)` — `channel="chrome"`, no path hunting
+- [ ] `attach(port)` — `connect_over_cdp`, typed error
+- [ ] `from_cdp_events()` and `record_context_har(..., bodies=False)`; the docstring names the
+      59.5 MB vs 95 KB measurement
+- [ ] Every capture passes through `data.redaction` before it is written
+- [ ] `LIG` lives here as a constant — its only real duplication (6 occurrences)
+- [ ] Exercise against live Chrome once, paste the result in the PR, delete the `.ps1` in the
+      same commit
 
 **Tests:**
-- [ ] Live exercise recorded in the PR (this is a Flow-adjacent surface; a run, not a claim)
+- [ ] Task 1 goes green
+- [ ] A shaped HAR still feeds `summarize_har`
 
 ---
 
-## Task 7 — Retire the rest of `har-spike/`, move probes
-
-**What:** Finish the port; give probes a home and a lifecycle.
-
-**Files:** `scripts/dev/probes/` (67 moved), `scripts/dev/har-spike/` (deleted), `.gitignore`
+## Task 5 — Retire `har-spike/`
 
 **Steps:**
-- [ ] Port or drop each remaining `.ps1`; drop rather than port anything with no caller
-- [ ] `git mv` the 67 `spike_*` / `capture_*` scripts into `scripts/dev/probes/`
-- [ ] Prune the 7 named after closed issues **only if** their finding exists in
-      `docs/superpowers/spikes/`; otherwise write the finding first
-- [ ] `scripts/dev/probes/README.md` — what a probe is, cost header, retention rule
-- [ ] `.gitignore`: remove the `har-spike/` rules, keep `_spike_out/` and `*.har`
+- [ ] Delete `probe-agent-mode.ps1`, `start-background-capture.ps1`,
+      `stop-background-capture.ps1` — **0 references repo-wide**, and the first already has a
+      live Python twin
+- [ ] Port or drop each remaining `.ps1`; drop anything with no caller
+- [ ] Delete `character_create_spike.py` (344 lines, superseded by `_v2`; live references are
+      comments only, `api/client.py:297`)
+- [ ] `.gitignore`: drop the `har-spike/` rules
 
 **Tests:**
-- [ ] `check_doc_links.py`, `check_repo_hygiene.py` green (14 doc references point at these
-      paths — this is where a move breaks)
-- [ ] `tests/scripts/` still imports what it imports
+- [ ] `check_doc_links.py`, `check_repo_hygiene.py` green (14 doc references point here)
 
 ---
 
-## Task 8 — Docs, skill, and the retention rule
+## Task 6 — Invert the retention rule; stop the accumulation
 
-**What:** Make the new shape the documented one.
+**What:** The behavioural change that stops this recurring.
 
-**Files:** `skills/spike/SKILL.md`, `CONTRIBUTING.md`, `AGENTS.md`
+**Files:** `skills/spike/SKILL.md`, `.gitignore`, `CONTRIBUTING.md`, `AGENTS.md`
 
 **Steps:**
-- [ ] Retention rule into the skill: **a probe merges with its `docs/superpowers/spikes/`
-      finding, or it does not merge.** Findings are permanent; probes are prunable once
-      written up
-- [ ] Drop the Windows-only caveat from CONTRIBUTING; the harness is Python now
-- [ ] AGENTS.md two-modes table points at `spike/` and `probes/`
-- [ ] Add a one-line cost + question header convention for probes
+- [ ] Correct the false claim. The skill currently says *"The spike script itself → committed. A
+      question worth asking once gets asked again."* **52 of 67 probes have exactly one commit
+      ever.** Replace with: **compose `gflow_cli.spike`; commit the finding, not the probe.**
+- [ ] New rule: a probe is committed **only if** it takes arguments and hardcodes no account.
+      Otherwise it is scratch.
+- [ ] Gitignore probe scratch by default
+- [ ] Delete single-commit probes whose logic now lives in `spike/` or whose finding exists;
+      **write the finding first** where it does not. (An earlier draft assumed closed-issue
+      probes could be pruned on sight — checked, and none of the 14 findings covers issues
+      170/313/314/404, so that prune was a no-op.)
+- [ ] Drop the Windows-only caveat from CONTRIBUTING
+- [ ] `check_repo_hygiene.py` gains a check for hardcoded account names under `scripts/`
 
 **Tests:**
-- [ ] `check_doc_links.py`, documentation-gate tests green
+- [ ] Doc gates + documentation-gate tests green
+- [ ] The new hygiene check fails on a planted `default="ffroliva"`
 
 ---
 
-## Task 9 — Full gates and CHANGELOG
+## Task 7 — Full gates and CHANGELOG
 
 **Steps:**
-- [ ] `/gflow:check` fully green (all six gates, ruff, pyright strict on the new package,
-      full pytest)
+- [ ] `/gflow:check` fully green
 - [ ] CHANGELOG entry under `[Unreleased]`
-- [ ] Confirm no Click command and no MCP tool was added — the user-facing decision belongs
-      to #707. `spike` adds ~40 KB to the wheel and no user-visible surface
+- [ ] Confirm no Click command and no MCP tool was added — that is #707's call
 
 **Tests:**
-- [ ] `uv run python -m pytest -q --cov=gflow_cli` — coverage floor held
+- [ ] `uv run python -m pytest -q --cov=gflow_cli`, coverage floor held
 
 ---
 
 ## Explicitly out of scope
 
-- **`gflow capture` / any user-facing command** — that is
-  [#707](https://github.com/ffroliva/gflow-cli/issues/707), and it gets `/gflow:predict`
-  first. This plan deliberately ships **no** new CLI surface, which is also why it needs no
-  MCP mirror task: there is nothing user-facing to mirror.
-- Rewriting existing probes to use `spike/` — they keep working as they are; convert on
-  next touch.
-- Changing what incident bundles contain — overlaps #707's first design question.
+- **Any user-facing command** — [#707](https://github.com/ffroliva/gflow-cli/issues/707), which
+  gets `/gflow:predict` first. This plan ships no user-facing surface, which is why it needs no
+  MCP mirror task.
+- **`python -m gflow_cli.spike` as a probe CLI** — a reviewer ranked this second and it is
+  attractive (~30 lines, would remove most future probe files). Deliberately deferred: it is
+  only worth designing once `cdp.py` / `har.py` exist and their real call shapes are known.
+  Revisit after Task 4.
+- **`diagnostics.py`** — see the council notes above.

--- a/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
+++ b/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
@@ -6,22 +6,28 @@
 **Goal:** A spike tool a contributor on any OS can run to produce redacted evidence for a bug
 report — backed by a tested library instead of 88 untested scripts and a Node dependency.
 
-**Architecture:** Live capture goes into a **new** `src/gflow_cli/recon/` package (CDP attach,
-HAR capture, DOM inventory). `recon` is already this repo's word for it — 16 doc occurrences,
-plus the "Phase 0: Recon" the workflow gained in #704 — and it means precisely what this does:
-observing terrain we do not control.
+**Architecture:** Live capture goes into a new `src/gflow_cli/spike/` package (CDP attach, HAR
+capture, DOM inventory). **`spike` because that is already the word here** — `/gflow:spike`,
+`skills/spike/SKILL.md`, 48 `scripts/dev/spike_*.py` since July, and `docs/superpowers/spikes/`
+for the findings. One word across command, protocol, scripts, findings and module beats a
+taxonomically neater name that matches nothing else; a contributor grepping for "spike" should
+land on all of it.
+
+Named `spike/`, **not** `_spike/`. The underscore would claim it is private, and it is not:
+[#707](https://github.com/ffroliva/gflow-cli/issues/707) builds a user-facing capture path on
+exactly this code.
 
 **`diagnostics.py` is deliberately left alone.** An earlier draft folded this into it, and that
 was conflation rather than consolidation: `diagnostics` classifies and summarises what already
-went wrong, post-hoc, for an incident bundle; recon actively drives a browser to observe a live
-surface. Different activity, different lifecycle. Promoting a shipped 1890-line module with 4
-importers to a package would have been risk taken for no benefit.
+went wrong, post-hoc, for an incident bundle; a spike actively drives a browser to observe a
+live surface. Different activity, different lifecycle. Promoting a shipped 1890-line module
+with 4 importers to a package would have been risk taken for no benefit.
 
 **What genuinely needed consolidating was redaction, and it still does.** There are three
 implementations today — `redaction.py` (14 lines), `diagnostics.sanitize_url`, and
 `extract_har_summary`'s header/URL redaction. Task 2 merges them into `redaction.py`, which both
-`diagnostics` and `recon` then share. That was always the real drift risk; the module count
-never was.
+`diagnostics` and `spike` then share. That was always the real drift risk; the module name never
+was.
 
 One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
 Node/`agent-browser`/PowerShell harness is deleted script by script as each Python twin lands.
@@ -44,8 +50,8 @@ piece that could have killed the port is retired.
 | **HIGH** | Redaction regression leaks a Bearer token or cookie into an issue attachment | Consolidate to ONE implementation; property-style tests over a corpus of real header/URL shapes; Task 2 lands before anything that produces a shareable artefact |
 | **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live response bodies | `record_har_content="omit"` is the default; the CDP-shaped path (95 KB for the same traffic) is what the contributor-facing entry point uses |
 | MED | Moving 67 probes breaks a doc link or a `tests/scripts/` import | `check_doc_links.py` is a merge gate; move with `git mv`, run gates per task |
-| MED | `recon` and `diagnostics` drift into two redaction implementations again | Task 2 makes `redaction.py` the single home BEFORE either uses it; no capture code lands first |
-| MED | `recon` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
+| MED | `spike` and `diagnostics` drift into two redaction implementations again | Task 2 makes `redaction.py` the single home BEFORE either uses it; no capture code lands first |
+| MED | `spike` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
 | LOW | Ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
 
 ---
@@ -55,12 +61,12 @@ piece that could have killed the port is retired.
 ### New files
 
 ```
-src/gflow_cli/recon/cdp.py            launch/attach a real Chrome over CDP; profile resolution
-src/gflow_cli/recon/har.py            capture -> HAR (body-free by default), shape CDP events
-src/gflow_cli/recon/dom.py            ligature / ARIA role / custom-element inventory
-tests/recon/test_cdp.py         attach/launch contract, no real browser
-tests/recon/test_har.py         CDP-event -> HAR shaping; size discipline
-tests/recon/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
+src/gflow_cli/spike/cdp.py            launch/attach a real Chrome over CDP; profile resolution
+src/gflow_cli/spike/har.py            capture -> HAR (body-free by default), shape CDP events
+src/gflow_cli/spike/dom.py            ligature / ARIA role / custom-element inventory
+tests/spike/test_cdp.py         attach/launch contract, no real browser
+tests/spike/test_har.py         CDP-event -> HAR shaping; size discipline
+tests/spike/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
 scripts/dev/probes/README.md          what a probe is, and the retention rule
 ```
 
@@ -85,10 +91,10 @@ AGENTS.md                             two-modes table points at the new paths
 
 **What:** Red tests defining the contract before any code exists.
 
-**Files:** `tests/recon/test_cdp.py`, `tests/recon/test_har.py`
+**Files:** `tests/spike/test_cdp.py`, `tests/spike/test_har.py`
 
 **Steps:**
-- [ ] `tests/recon/` package with a `conftest.py` fixture for a fake CDP session
+- [ ] `tests/spike/` package with a `conftest.py` fixture for a fake CDP session
 - [ ] Assert `har.from_cdp_events()` emits `log.entries[].request/response` (the shape
       `summarize_har` reads) and nothing more
 - [ ] Assert the capture default is **body-free** — a fixture with a 5 MB response body
@@ -106,7 +112,7 @@ AGENTS.md                             two-modes table points at the new paths
 **What:** One redaction implementation. `src/gflow_cli/redaction.py` absorbs the header, URL
 and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_summary.py`.
 
-**Files:** `src/gflow_cli/redaction.py`, `tests/recon/test_har_redaction.py`,
+**Files:** `src/gflow_cli/redaction.py`, `tests/spike/test_har_redaction.py`,
 `scripts/dev/har-spike/extract_har_summary.py` (delegates)
 
 **Steps:**
@@ -125,11 +131,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 3 — `recon/cdp.py`: attach and launch
+## Task 3 — `spike/cdp.py`: attach and launch
 
 **What:** The Chrome-discovery and CDP-attach machinery, cross-platform.
 
-**Files:** `src/gflow_cli/recon/cdp.py      `, `src/gflow_cli/diagnostics/__init__.py`
+**Files:** `src/gflow_cli/spike/cdp.py      `, `src/gflow_cli/diagnostics/__init__.py`
 
 **Steps:**
 - [ ] `launch_with_cdp(profile, port)` — `channel="chrome"` (no path hunting) +
@@ -144,11 +150,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 4 — `recon/har.py`: capture without Node
+## Task 4 — `spike/har.py`: capture without Node
 
 **What:** Both capture routes, with the size discipline baked in.
 
-**Files:** `src/gflow_cli/recon/har.py      `
+**Files:** `src/gflow_cli/spike/har.py      `
 
 **Steps:**
 - [ ] `from_cdp_events(events)` — shape `Network.requestWillBeSent` /
@@ -163,11 +169,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 5 — `recon/dom.py`: inventory helpers
+## Task 5 — `spike/dom.py`: inventory helpers
 
 **What:** The DOM-reading JS that tonight's probes each re-implemented.
 
-**Files:** `src/gflow_cli/recon/dom.py      `
+**Files:** `src/gflow_cli/spike/dom.py      `
 
 **Steps:**
 - [ ] `inventory(page)` — ligatures + carrier tag, ARIA roles, custom elements, `href`s
@@ -189,7 +195,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 `scripts/dev/har-spike/launch-flow-chrome.ps1`
 
 **Steps:**
-- [ ] Thin CLI over `recon.cdp.launch_with_cdp`
+- [ ] Thin CLI over `spike.cdp.launch_with_cdp`
 - [ ] Exercise once against live Chrome; paste the result in the PR
 - [ ] Delete the `.ps1` in the same commit — two implementations is the drift we are removing
 
@@ -230,7 +236,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
       finding, or it does not merge.** Findings are permanent; probes are prunable once
       written up
 - [ ] Drop the Windows-only caveat from CONTRIBUTING; the harness is Python now
-- [ ] AGENTS.md two-modes table points at `recon/` and `probes/`
+- [ ] AGENTS.md two-modes table points at `spike/` and `probes/`
 - [ ] Add a one-line cost + question header convention for probes
 
 **Tests:**
@@ -245,7 +251,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
       full pytest)
 - [ ] CHANGELOG entry under `[Unreleased]`
 - [ ] Confirm no Click command and no MCP tool was added — the user-facing decision belongs
-      to #707. `recon` adds ~40 KB to the wheel and no user-visible surface
+      to #707. `spike` adds ~40 KB to the wheel and no user-visible surface
 
 **Tests:**
 - [ ] `uv run python -m pytest -q --cov=gflow_cli` — coverage floor held
@@ -258,6 +264,6 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
   [#707](https://github.com/ffroliva/gflow-cli/issues/707), and it gets `/gflow:predict`
   first. This plan deliberately ships **no** new CLI surface, which is also why it needs no
   MCP mirror task: there is nothing user-facing to mirror.
-- Rewriting existing probes to use `recon/` — they keep working as they are; convert on
+- Rewriting existing probes to use `spike/` — they keep working as they are; convert on
   next touch.
 - Changing what incident bundles contain — overlaps #707's first design question.

--- a/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
+++ b/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
@@ -6,12 +6,23 @@
 **Goal:** A spike tool a contributor on any OS can run to produce redacted evidence for a bug
 report — backed by a tested library instead of 88 untested scripts and a Node dependency.
 
-**Architecture:** Extract the reusable machinery into `src/gflow_cli/_spike/` (CDP attach, HAR
-capture, DOM inventory) so it is covered by the existing pyright-strict / ruff / pytest gates
-and is already in the package when [#707](https://github.com/ffroliva/gflow-cli/issues/707)
-needs it. **Redaction is consolidated into the existing `src/gflow_cli/redaction.py`, not
-duplicated** — there are already two implementations and a third would be the drift AGENTS.md
-warns about. One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
+**Architecture:** The reusable machinery goes into the **existing** `src/gflow_cli/diagnostics`
+module, promoted to a package. That module is already 1890 shipped lines owning `sanitize_url`,
+`_HOST_CATEGORIES`, `_ROUTE_PATTERNS`, `classify_title` and `reduce_error_body` — URL
+redaction, host/route classification and evidence summarisation. In other words **the domain
+already exists and already ships**; a new `_spike/` package would have been a third home for
+it, alongside `redaction.py` and `extract_har_summary.py`, which is exactly the drift this plan
+exists to remove.
+
+It is also where [#707](https://github.com/ffroliva/gflow-cli/issues/707) lands: that issue's
+first design question is "new command, or better incident bundles?", and bundles are
+diagnostics. Any other location guarantees a later move across a package boundary.
+
+Naming matters here too — `_spike` names a *process* (a time-boxed investigation), not a
+capability. In six months this is the CDP/HAR/DOM library, and a module named after the
+activity that created it reads like archaeology.
+
+One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
 Node/`agent-browser`/PowerShell harness is deleted script by script as each Python twin lands.
 
 **Predict verdict:** pending — this is dev tooling, not a transport/auth/selector/schema
@@ -32,7 +43,8 @@ piece that could have killed the port is retired.
 | **HIGH** | Redaction regression leaks a Bearer token or cookie into an issue attachment | Consolidate to ONE implementation; property-style tests over a corpus of real header/URL shapes; Task 2 lands before anything that produces a shareable artefact |
 | **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live response bodies | `record_har_content="omit"` is the default; the CDP-shaped path (95 KB for the same traffic) is what the contributor-facing entry point uses |
 | MED | Moving 67 probes breaks a doc link or a `tests/scripts/` import | `check_doc_links.py` is a merge gate; move with `git mv`, run gates per task |
-| MED | `_spike/` in the wheel grows into a second product surface | It stays private (leading underscore), has no Click commands, and no MCP tools until #707 decides deliberately |
+| MED | Promoting a 1890-line module to a package breaks its 4 importers | `diagnostics/__init__.py` re-exports every current name; the move is mechanical and the existing tests are the check |
+| MED | `diagnostics` grows into a product surface by accident | No Click command, no MCP tool, until #707 decides deliberately |
 | LOW | Ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
 
 ---
@@ -42,21 +54,23 @@ piece that could have killed the port is retired.
 ### New files
 
 ```
-src/gflow_cli/_spike/__init__.py      public surface: attach(), capture(), inventory()
-src/gflow_cli/_spike/cdp.py           launch/attach a real Chrome over CDP; profile resolution
-src/gflow_cli/_spike/har.py           capture -> HAR (body-free by default), shape CDP events
-src/gflow_cli/_spike/dom.py           ligature / ARIA role / custom-element inventory
-tests/spike/test_cdp.py               attach/launch contract, no real browser
-tests/spike/test_har.py               CDP-event -> HAR shaping; size discipline
-tests/spike/test_redaction_har.py     header/URL/body redaction over a real-shaped corpus
+src/gflow_cli/diagnostics/cdp.py      launch/attach a real Chrome over CDP; profile resolution
+src/gflow_cli/diagnostics/har.py      capture -> HAR (body-free by default), shape CDP events
+src/gflow_cli/diagnostics/dom.py      ligature / ARIA role / custom-element inventory
+tests/diagnostics/test_cdp.py         attach/launch contract, no real browser
+tests/diagnostics/test_har.py         CDP-event -> HAR shaping; size discipline
+tests/diagnostics/test_har_redaction.py  header/URL/body redaction over a real-shaped corpus
 scripts/dev/probes/README.md          what a probe is, and the retention rule
 ```
 
 ### Modified files
 
 ```
+src/gflow_cli/diagnostics.py          -> diagnostics/__init__.py, re-exporting every current
+                                      name so all 4 importers keep working unchanged
 src/gflow_cli/redaction.py            EXTENDED to own header/URL/HAR-entry redaction
-                                      (absorbs extract_har_summary's second implementation)
+                                      (absorbs extract_har_summary's second implementation;
+                                      diagnostics.sanitize_url delegates to it)
 scripts/dev/har-spike/                shrinks per task; DELETED at Task 7
 skills/spike/SKILL.md                 retention rule + new paths
 CONTRIBUTING.md                       drop the Windows-only caveat once Task 6 lands
@@ -70,10 +84,10 @@ AGENTS.md                             two-modes table points at the new paths
 
 **What:** Red tests defining the contract before any code exists.
 
-**Files:** `tests/spike/test_cdp.py`, `tests/spike/test_har.py`
+**Files:** `tests/diagnostics/test_cdp.py`, `tests/diagnostics/test_har.py`
 
 **Steps:**
-- [ ] `tests/spike/` package with a `conftest.py` fixture for a fake CDP session
+- [ ] `tests/diagnostics/` package with a `conftest.py` fixture for a fake CDP session
 - [ ] Assert `har.from_cdp_events()` emits `log.entries[].request/response` (the shape
       `summarize_har` reads) and nothing more
 - [ ] Assert the capture default is **body-free** — a fixture with a 5 MB response body
@@ -82,7 +96,7 @@ AGENTS.md                             two-modes table points at the new paths
       CDP endpoint answers
 
 **Tests:**
-- [ ] `uv run python -m pytest tests/spike -q` — red, and red for the stated reason
+- [ ] `uv run python -m pytest tests/diagnostics -q` — red, and red for the stated reason
 
 ---
 
@@ -91,7 +105,7 @@ AGENTS.md                             two-modes table points at the new paths
 **What:** One redaction implementation. `src/gflow_cli/redaction.py` absorbs the header, URL
 and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_summary.py`.
 
-**Files:** `src/gflow_cli/redaction.py`, `tests/spike/test_redaction_har.py`,
+**Files:** `src/gflow_cli/redaction.py`, `tests/diagnostics/test_har_redaction.py`,
 `scripts/dev/har-spike/extract_har_summary.py` (delegates)
 
 **Steps:**
@@ -110,11 +124,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 3 — `_spike/cdp.py`: attach and launch
+## Task 3 — `diagnostics/cdp.py`: attach and launch
 
 **What:** The Chrome-discovery and CDP-attach machinery, cross-platform.
 
-**Files:** `src/gflow_cli/_spike/cdp.py`, `src/gflow_cli/_spike/__init__.py`
+**Files:** `src/gflow_cli/diagnostics/cdp.py`, `src/gflow_cli/diagnostics/__init__.py`
 
 **Steps:**
 - [ ] `launch_with_cdp(profile, port)` — `channel="chrome"` (no path hunting) +
@@ -129,11 +143,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 4 — `_spike/har.py`: capture without Node
+## Task 4 — `diagnostics/har.py`: capture without Node
 
 **What:** Both capture routes, with the size discipline baked in.
 
-**Files:** `src/gflow_cli/_spike/har.py`
+**Files:** `src/gflow_cli/diagnostics/har.py`
 
 **Steps:**
 - [ ] `from_cdp_events(events)` — shape `Network.requestWillBeSent` /
@@ -148,11 +162,11 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 
 ---
 
-## Task 5 — `_spike/dom.py`: inventory helpers
+## Task 5 — `diagnostics/dom.py`: inventory helpers
 
 **What:** The DOM-reading JS that tonight's probes each re-implemented.
 
-**Files:** `src/gflow_cli/_spike/dom.py`
+**Files:** `src/gflow_cli/diagnostics/dom.py`
 
 **Steps:**
 - [ ] `inventory(page)` — ligatures + carrier tag, ARIA roles, custom elements, `href`s
@@ -174,7 +188,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 `scripts/dev/har-spike/launch-flow-chrome.ps1`
 
 **Steps:**
-- [ ] Thin CLI over `_spike.cdp.launch_with_cdp`
+- [ ] Thin CLI over `diagnostics.cdp.launch_with_cdp`
 - [ ] Exercise once against live Chrome; paste the result in the PR
 - [ ] Delete the `.ps1` in the same commit — two implementations is the drift we are removing
 
@@ -215,7 +229,7 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
       finding, or it does not merge.** Findings are permanent; probes are prunable once
       written up
 - [ ] Drop the Windows-only caveat from CONTRIBUTING; the harness is Python now
-- [ ] AGENTS.md two-modes table points at `_spike/` and `probes/`
+- [ ] AGENTS.md two-modes table points at `diagnostics/` and `probes/`
 - [ ] Add a one-line cost + question header convention for probes
 
 **Tests:**
@@ -229,8 +243,8 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
 - [ ] `/gflow:check` fully green (all six gates, ruff, pyright strict on the new package,
       full pytest)
 - [ ] CHANGELOG entry under `[Unreleased]`
-- [ ] Confirm the wheel contains `_spike/` and no Click command or MCP tool was added — the
-      user-facing decision belongs to #707
+- [ ] Confirm no Click command and no MCP tool was added — the user-facing decision belongs
+      to #707. `diagnostics` already shipped, so the wheel gains capability, not a new surface
 
 **Tests:**
 - [ ] `uv run python -m pytest -q --cov=gflow_cli` — coverage floor held
@@ -243,6 +257,6 @@ and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_s
   [#707](https://github.com/ffroliva/gflow-cli/issues/707), and it gets `/gflow:predict`
   first. This plan deliberately ships **no** new CLI surface, which is also why it needs no
   MCP mirror task: there is nothing user-facing to mirror.
-- Rewriting existing probes to use `_spike/` — they keep working as they are; convert on
+- Rewriting existing probes to use `diagnostics/` — they keep working as they are; convert on
   next touch.
 - Changing what incident bundles contain — overlaps #707's first design question.

--- a/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
+++ b/docs/superpowers/plans/2026-09-06-spike-tooling-reorg/PLAN.md
@@ -1,0 +1,248 @@
+# Spike Tooling Reorg Implementation Plan
+
+> **For agentic workers:** Run `/gflow:status --feature spike-tooling-reorg` to find the next
+> unchecked task. Implement one task at a time. Run `/gflow:check` before every commit.
+
+**Goal:** A spike tool a contributor on any OS can run to produce redacted evidence for a bug
+report — backed by a tested library instead of 88 untested scripts and a Node dependency.
+
+**Architecture:** Extract the reusable machinery into `src/gflow_cli/_spike/` (CDP attach, HAR
+capture, DOM inventory) so it is covered by the existing pyright-strict / ruff / pytest gates
+and is already in the package when [#707](https://github.com/ffroliva/gflow-cli/issues/707)
+needs it. **Redaction is consolidated into the existing `src/gflow_cli/redaction.py`, not
+duplicated** — there are already two implementations and a third would be the drift AGENTS.md
+warns about. One-shot probes move to `scripts/dev/probes/` and gain a retention rule. The
+Node/`agent-browser`/PowerShell harness is deleted script by script as each Python twin lands.
+
+**Predict verdict:** pending — this is dev tooling, not a transport/auth/selector/schema
+change, so the AGENTS.md routing table does not require `/gflow:predict`. Run it before
+[#707](https://github.com/ffroliva/gflow-cli/issues/707), which does.
+
+**Portability proven before planning** (2026-09-06,
+`scripts/dev/spike_cdp_har_without_node.py`): Playwright can attach to a CDP Chrome running a
+real gflow profile and see the human's page (`contexts=1, pages=1, sees_human_page=True`);
+`record_har_path` works on a CDP-attached browser; and raw CDP `Network.*` events shape into a
+HAR that the harness's own `extract_har_summary.summarize_har` consumes **unchanged**. The one
+piece that could have killed the port is retired.
+
+**Risk register:**
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| **HIGH** | Redaction regression leaks a Bearer token or cookie into an issue attachment | Consolidate to ONE implementation; property-style tests over a corpus of real header/URL shapes; Task 2 lands before anything that produces a shareable artefact |
+| **HIGH** | A 59.5 MB HAR (measured) is attached to an issue, full of live response bodies | `record_har_content="omit"` is the default; the CDP-shaped path (95 KB for the same traffic) is what the contributor-facing entry point uses |
+| MED | Moving 67 probes breaks a doc link or a `tests/scripts/` import | `check_doc_links.py` is a merge gate; move with `git mv`, run gates per task |
+| MED | `_spike/` in the wheel grows into a second product surface | It stays private (leading underscore), has no Click commands, and no MCP tools until #707 decides deliberately |
+| LOW | Ported script behaves differently from its `.ps1` twin | Delete each `.ps1` only after its twin is exercised against live Chrome once |
+
+---
+
+## File structure
+
+### New files
+
+```
+src/gflow_cli/_spike/__init__.py      public surface: attach(), capture(), inventory()
+src/gflow_cli/_spike/cdp.py           launch/attach a real Chrome over CDP; profile resolution
+src/gflow_cli/_spike/har.py           capture -> HAR (body-free by default), shape CDP events
+src/gflow_cli/_spike/dom.py           ligature / ARIA role / custom-element inventory
+tests/spike/test_cdp.py               attach/launch contract, no real browser
+tests/spike/test_har.py               CDP-event -> HAR shaping; size discipline
+tests/spike/test_redaction_har.py     header/URL/body redaction over a real-shaped corpus
+scripts/dev/probes/README.md          what a probe is, and the retention rule
+```
+
+### Modified files
+
+```
+src/gflow_cli/redaction.py            EXTENDED to own header/URL/HAR-entry redaction
+                                      (absorbs extract_har_summary's second implementation)
+scripts/dev/har-spike/                shrinks per task; DELETED at Task 7
+skills/spike/SKILL.md                 retention rule + new paths
+CONTRIBUTING.md                       drop the Windows-only caveat once Task 6 lands
+AGENTS.md                             two-modes table points at the new paths
+.gitignore                            probes/ output + har-spike rules removed at Task 7
+```
+
+---
+
+## Task 1 — Test scaffold for the spike library (red)
+
+**What:** Red tests defining the contract before any code exists.
+
+**Files:** `tests/spike/test_cdp.py`, `tests/spike/test_har.py`
+
+**Steps:**
+- [ ] `tests/spike/` package with a `conftest.py` fixture for a fake CDP session
+- [ ] Assert `har.from_cdp_events()` emits `log.entries[].request/response` (the shape
+      `summarize_har` reads) and nothing more
+- [ ] Assert the capture default is **body-free** — a fixture with a 5 MB response body
+      produces a HAR that does not contain it
+- [ ] Assert `cdp.attach()` surfaces a typed error, not a raw Playwright exception, when no
+      CDP endpoint answers
+
+**Tests:**
+- [ ] `uv run python -m pytest tests/spike -q` — red, and red for the stated reason
+
+---
+
+## Task 2 — Consolidate redaction (the safety-critical task)
+
+**What:** One redaction implementation. `src/gflow_cli/redaction.py` absorbs the header, URL
+and HAR-entry redaction currently living in `scripts/dev/har-spike/extract_har_summary.py`.
+
+**Files:** `src/gflow_cli/redaction.py`, `tests/spike/test_redaction_har.py`,
+`scripts/dev/har-spike/extract_har_summary.py` (delegates)
+
+**Steps:**
+- [ ] Move `SENSITIVE_HEADERS`, `SENSITIVE_KEY_PARTS`, `_safe_url`, `_redact_header` into
+      `redaction.py` as public functions
+- [ ] `extract_har_summary.py` imports them — behaviour unchanged, one source of truth
+- [ ] Keep `redact_sensitive_text` as-is; its one existing caller must not change
+
+**Tests:**
+- [ ] Corpus test: `authorization`, `cookie`, `set-cookie`, `x-goog-api-key`, `sapisid`,
+      query params containing `key`/`token`/`sid` — each redacted, presence-vs-absence
+      preserved (`<redacted:present>` vs `<redacted:empty>`)
+- [ ] A URL with no sensitive parts round-trips unchanged (no over-redaction)
+- [ ] `tests/scripts/test_extract_har_summary.py` still passes untouched — proves the move
+      is behaviour-preserving
+
+---
+
+## Task 3 — `_spike/cdp.py`: attach and launch
+
+**What:** The Chrome-discovery and CDP-attach machinery, cross-platform.
+
+**Files:** `src/gflow_cli/_spike/cdp.py`, `src/gflow_cli/_spike/__init__.py`
+
+**Steps:**
+- [ ] `launch_with_cdp(profile, port)` — `channel="chrome"` (no path hunting) +
+      `--remote-debugging-port`
+- [ ] `attach(port)` — `connect_over_cdp`, typed error on failure
+- [ ] Profile resolution delegates to the existing profile store, never `LOCALAPPDATA`
+- [ ] Docstring records the proven facts and cites the PoC spike
+
+**Tests:**
+- [ ] Task 1's tests go green
+- [ ] No real browser in unit tests; live exercise is Task 6
+
+---
+
+## Task 4 — `_spike/har.py`: capture without Node
+
+**What:** Both capture routes, with the size discipline baked in.
+
+**Files:** `src/gflow_cli/_spike/har.py`
+
+**Steps:**
+- [ ] `from_cdp_events(events)` — shape `Network.requestWillBeSent` /
+      `responseReceived` into the HAR subset (proven compatible with `summarize_har`)
+- [ ] `record_context_har(context, path, *, bodies=False)` — native route, bodies **off** by
+      default; the docstring names the measurement: 59.5 MB with bodies vs 95 KB without
+- [ ] Every capture passes through `redaction` before it is written
+
+**Tests:**
+- [ ] Task 1's shaping and size tests go green
+- [ ] A shaped HAR fed to `summarize_har` produces entries (the compatibility contract)
+
+---
+
+## Task 5 — `_spike/dom.py`: inventory helpers
+
+**What:** The DOM-reading JS that tonight's probes each re-implemented.
+
+**Files:** `src/gflow_cli/_spike/dom.py`
+
+**Steps:**
+- [ ] `inventory(page)` — ligatures + carrier tag, ARIA roles, custom elements, `href`s
+- [ ] `candidates(page, selectors)` — visibility **and occluder** (`elementFromPoint`), the
+      check that proved the character editor was reachable
+- [ ] Docstring carries the anchor rule: structure over labels; custom elements are the best
+      anchors; the carrier differs per host (`i.google-symbols` vs `mat-icon`)
+
+**Tests:**
+- [ ] Pure-function tests over captured DOM fixtures (no browser)
+
+---
+
+## Task 6 — Port `launch-flow-chrome.ps1`, delete it
+
+**What:** First `.ps1` retired. Establishes the pattern for the rest.
+
+**Files:** `scripts/dev/probes/launch_flow_chrome.py`, delete
+`scripts/dev/har-spike/launch-flow-chrome.ps1`
+
+**Steps:**
+- [ ] Thin CLI over `_spike.cdp.launch_with_cdp`
+- [ ] Exercise once against live Chrome; paste the result in the PR
+- [ ] Delete the `.ps1` in the same commit — two implementations is the drift we are removing
+
+**Tests:**
+- [ ] Live exercise recorded in the PR (this is a Flow-adjacent surface; a run, not a claim)
+
+---
+
+## Task 7 — Retire the rest of `har-spike/`, move probes
+
+**What:** Finish the port; give probes a home and a lifecycle.
+
+**Files:** `scripts/dev/probes/` (67 moved), `scripts/dev/har-spike/` (deleted), `.gitignore`
+
+**Steps:**
+- [ ] Port or drop each remaining `.ps1`; drop rather than port anything with no caller
+- [ ] `git mv` the 67 `spike_*` / `capture_*` scripts into `scripts/dev/probes/`
+- [ ] Prune the 7 named after closed issues **only if** their finding exists in
+      `docs/superpowers/spikes/`; otherwise write the finding first
+- [ ] `scripts/dev/probes/README.md` — what a probe is, cost header, retention rule
+- [ ] `.gitignore`: remove the `har-spike/` rules, keep `_spike_out/` and `*.har`
+
+**Tests:**
+- [ ] `check_doc_links.py`, `check_repo_hygiene.py` green (14 doc references point at these
+      paths — this is where a move breaks)
+- [ ] `tests/scripts/` still imports what it imports
+
+---
+
+## Task 8 — Docs, skill, and the retention rule
+
+**What:** Make the new shape the documented one.
+
+**Files:** `skills/spike/SKILL.md`, `CONTRIBUTING.md`, `AGENTS.md`
+
+**Steps:**
+- [ ] Retention rule into the skill: **a probe merges with its `docs/superpowers/spikes/`
+      finding, or it does not merge.** Findings are permanent; probes are prunable once
+      written up
+- [ ] Drop the Windows-only caveat from CONTRIBUTING; the harness is Python now
+- [ ] AGENTS.md two-modes table points at `_spike/` and `probes/`
+- [ ] Add a one-line cost + question header convention for probes
+
+**Tests:**
+- [ ] `check_doc_links.py`, documentation-gate tests green
+
+---
+
+## Task 9 — Full gates and CHANGELOG
+
+**Steps:**
+- [ ] `/gflow:check` fully green (all six gates, ruff, pyright strict on the new package,
+      full pytest)
+- [ ] CHANGELOG entry under `[Unreleased]`
+- [ ] Confirm the wheel contains `_spike/` and no Click command or MCP tool was added — the
+      user-facing decision belongs to #707
+
+**Tests:**
+- [ ] `uv run python -m pytest -q --cov=gflow_cli` — coverage floor held
+
+---
+
+## Explicitly out of scope
+
+- **`gflow capture` / any user-facing command** — that is
+  [#707](https://github.com/ffroliva/gflow-cli/issues/707), and it gets `/gflow:predict`
+  first. This plan deliberately ships **no** new CLI surface, which is also why it needs no
+  MCP mirror task: there is nothing user-facing to mirror.
+- Rewriting existing probes to use `_spike/` — they keep working as they are; convert on
+  next touch.
+- Changing what incident bundles contain — overlaps #707's first design question.

--- a/scripts/dev/spike_cdp_har_without_node.py
+++ b/scripts/dev/spike_cdp_har_without_node.py
@@ -1,0 +1,230 @@
+r"""Can Python + Playwright replace the Node/agent-browser HAR harness? ($0)
+
+`scripts/dev/har-spike/` is 1691 lines across 9 PowerShell scripts driving a pinned
+`agent-browser@0.27.0` over `npx`. It is Windows-only, which undercuts the point of
+shipping it: contributors on macOS and Linux cannot produce evidence with it.
+
+Only two of those scripts contain genuinely OS-bound code (Chrome discovery, profile
+paths), and this repo already solves both in Python. Playwright — already a dependency —
+also advertises `BrowserType.connect_over_cdp` and `record_har_path`. So the port looks
+easy. **The one piece that is not obviously portable is the piece the harness exists
+for**, and that is what this spike measures rather than assumes:
+
+    `record_har_path` is a NEW-CONTEXT option. Attaching to a human's already-running
+    Chrome gives you their EXISTING context, and you cannot retrofit HAR recording onto
+    it. So can we still capture?
+
+Three questions, answered in order. Any NO is a real finding — it is cheaper to learn it
+here than after porting nine scripts.
+
+  Q1  Can Playwright attach to a CDP Chrome running a real gflow profile, and SEE the
+      page a human is driving?
+  Q2  Does `browser.new_context(record_har_path=...)` work on a CDP-attached browser?
+      (Expected: not for the persistent profile context — measure it.)
+  Q3  Can a raw CDP session (`Network.*` events) be shaped into a HAR that the harness's
+      OWN `extract_har_summary.summarize_har` consumes unchanged?
+
+If Q1 and Q3 hold, the Node layer can go entirely and the port is mechanical.
+
+Credit-free: launches Chrome, navigates to a Flow page, reads network metadata. Nothing
+is typed, generated or submitted.
+
+    python scripts/dev/spike_cdp_har_without_node.py --profile ci-probe
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from playwright.async_api import async_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_FLOW_URL = "https://labs.google/fx/tools/flow?hl=en"
+
+
+def _load_summarizer() -> Any:
+    """Import the harness's own summariser, by path (scripts/ is not a package)."""
+    mod_path = Path(__file__).resolve().parent / "har-spike" / "extract_har_summary.py"
+    spec = importlib.util.spec_from_file_location("extract_har_summary", mod_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _har_from_cdp(events: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Shape captured CDP Network events into the HAR subset the summariser reads.
+
+    Deliberately minimal: `summarize_har` reads `log.entries[].request.{method,url,
+    headers,postData}` and `.response.{status,headers,content}`. Producing more than it
+    consumes would be inventing a format nobody validates.
+    """
+    entries: list[dict[str, Any]] = []
+    for rec in events.values():
+        req = rec.get("request") or {}
+        resp = rec.get("response") or {}
+        if not req.get("url"):
+            continue
+        entries.append(
+            {
+                "request": {
+                    "method": req.get("method"),
+                    "url": req.get("url"),
+                    "headers": [
+                        {"name": k, "value": v} for k, v in (req.get("headers") or {}).items()
+                    ],
+                    "postData": {"text": req.get("postData", "")} if req.get("postData") else {},
+                },
+                "response": {
+                    "status": resp.get("status"),
+                    "headers": [
+                        {"name": k, "value": v} for k, v in (resp.get("headers") or {}).items()
+                    ],
+                    "content": {"mimeType": (resp.get("mimeType") or "")},
+                },
+            }
+        )
+    return {"log": {"version": "1.2", "creator": {"name": "gflow-cdp-spike"}, "entries": entries}}
+
+
+async def _main(profile: str, port: int) -> int:
+    profile_dir = resolve_profile_dir(profile)
+    step("profile", f"{profile} -> {profile_dir}")
+    findings: dict[str, Any] = {"profile": profile, "port": port}
+
+    async with async_playwright() as pw:
+        # Stand in for "a human has Chrome open": a real Chrome (channel), real profile,
+        # CDP port. This is also the answer to Chrome discovery — no path hunting.
+        step("launch", f"chrome channel, --remote-debugging-port={port}")
+        ctx = await pw.chromium.launch_persistent_context(
+            user_data_dir=str(profile_dir),
+            channel="chrome",
+            headless=False,
+            args=[f"--remote-debugging-port={port}"],
+            no_viewport=True,
+        )
+        try:
+            page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+            await page.goto(_FLOW_URL, wait_until="domcontentloaded", timeout=45_000)
+            await page.wait_for_timeout(2500)
+            step("human_page", page.url[:80])
+
+            # --- Q1: attach a SECOND Playwright client over CDP -----------------
+            async with async_playwright() as pw2:
+                try:
+                    browser = await pw2.chromium.connect_over_cdp(f"http://127.0.0.1:{port}")
+                    contexts = browser.contexts
+                    pages = [p for c in contexts for p in c.pages]
+                    findings["Q1_attach"] = {
+                        "ok": True,
+                        "contexts": len(contexts),
+                        "pages": len(pages),
+                        "sees_human_page": any(
+                            "labs.google" in p.url or "flow.google" in p.url for p in pages
+                        ),
+                    }
+                    step(
+                        "Q1",
+                        f"attached: contexts={len(contexts)} pages={len(pages)} "
+                        f"sees_human_page={findings['Q1_attach']['sees_human_page']}",
+                    )
+                except Exception as exc:  # noqa: BLE001 - the failure IS the measurement
+                    findings["Q1_attach"] = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+                    step("Q1", f"ATTACH FAILED — {type(exc).__name__}: {str(exc)[:120]}")
+                    return 1
+
+                # --- Q2: can we record a HAR on the attached browser? -----------
+                try:
+                    har_path = default_out_path("cdp_native_har", ".har")
+                    probe_ctx = await browser.new_context(record_har_path=str(har_path))
+                    p2 = await probe_ctx.new_page()
+                    await p2.goto(_FLOW_URL, wait_until="domcontentloaded", timeout=45_000)
+                    await p2.wait_for_timeout(2000)
+                    await probe_ctx.close()  # flushes the HAR
+                    size = har_path.stat().st_size if har_path.exists() else 0
+                    findings["Q2_native_har"] = {"ok": size > 0, "bytes": size}
+                    step("Q2", f"native record_har_path on a NEW context: {size} bytes")
+                except Exception as exc:  # noqa: BLE001 - expected to be limited
+                    findings["Q2_native_har"] = {
+                        "ok": False,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                    step("Q2", f"native HAR unavailable — {type(exc).__name__}: {str(exc)[:110]}")
+
+                # --- Q3: CDP session on the HUMAN's own page --------------------
+                target = next(
+                    (p for c in browser.contexts for p in c.pages if "google" in p.url), None
+                )
+                if target is None:
+                    step("Q3", "no page to attach a CDP session to")
+                    findings["Q3_cdp_har"] = {"ok": False, "error": "no target page"}
+                else:
+                    events: dict[str, dict[str, Any]] = {}
+                    cdp = await target.context.new_cdp_session(target)
+                    await cdp.send("Network.enable")
+
+                    def _on_req(ev: dict[str, Any]) -> None:
+                        events.setdefault(ev["requestId"], {})["request"] = ev.get("request", {})
+
+                    def _on_resp(ev: dict[str, Any]) -> None:
+                        events.setdefault(ev["requestId"], {})["response"] = ev.get("response", {})
+
+                    cdp.on("Network.requestWillBeSent", _on_req)
+                    cdp.on("Network.responseReceived", _on_resp)
+
+                    await target.reload(wait_until="domcontentloaded", timeout=45_000)
+                    await target.wait_for_timeout(4000)
+                    await cdp.detach()
+
+                    har = _har_from_cdp(events)
+                    out_har = default_out_path("cdp_shaped", ".har")
+                    out_har.write_text(json.dumps(har), encoding="utf-8")
+                    step("Q3", f"captured {len(har['log']['entries'])} entries -> {out_har.name}")
+
+                    # The real test: does the HARNESS's OWN summariser consume it?
+                    summarizer = _load_summarizer()
+                    summary = summarizer.summarize_har(out_har, host_filter="google")
+                    n = len(summary.get("entries", summary.get("safe_entries", [])) or [])
+                    findings["Q3_cdp_har"] = {
+                        "ok": len(har["log"]["entries"]) > 0,
+                        "entries": len(har["log"]["entries"]),
+                        "summariser_accepted": True,
+                        "summarised_entries": n,
+                    }
+                    step("Q3", f"extract_har_summary.summarize_har accepted it — {n} entries")
+
+                await browser.close()
+        finally:
+            await ctx.close()
+            out = default_out_path("cdp_har_without_node")
+            out.write_text(json.dumps(findings, indent=2, ensure_ascii=False), encoding="utf-8")
+            step("wrote", str(out))
+
+    q1 = findings.get("Q1_attach", {}).get("ok")
+    q3 = findings.get("Q3_cdp_har", {}).get("ok")
+    step(
+        "verdict",
+        "PORTABLE: Node/agent-browser can go" if (q1 and q3) else "NOT proven — see findings",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", default="ci-probe")
+    ap.add_argument("--port", type=int, default=9335)
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(_main(args.profile, args.port)))


### PR DESCRIPTION
## Summary

Plan + the proof it rests on. **No implementation yet** — this is a reviewable plan and one `$0` spike.

`scripts/dev/` is 22 MB, 88 top-level `.py`, **67 probe scripts, zero of them tested**, two months of accumulation and nothing ever pruned — plus a 1691-line PowerShell/Node harness that is Windows-only, which defeats the point of shipping it to contributors.

## Portability proven BEFORE planning

`scripts/dev/spike_cdp_har_without_node.py`, live on `ci-probe`. The piece that could have killed the port is the piece the harness exists for: `record_har_path` is a new-context option, so attaching to a human's running Chrome shouldn't be able to record.

| | question | result |
|---|---|---|
| Q1 | `connect_over_cdp` to a real gflow profile, see the human's page? | ✅ `contexts=1, pages=1, sees_human_page=True` |
| Q2 | `record_har_path` on a CDP-attached browser? | ✅ works — 59,543,835 bytes |
| Q3 | Raw CDP `Network.*` → HAR that `extract_har_summary.summarize_har` eats **unchanged**? | ✅ 38 entries, accepted |

So the Node / `npx` / `agent-browser@0.27.0` layer can go entirely, and the Windows-only limitation with it.

Q2 also produced the second constraint: **59.5 MB for one page load** (bodies embedded) vs **95 KB** for the CDP-shaped route. Body-free is the default in the plan. Both `.har` files were deleted immediately — they carry live cookies and Bearer tokens.

## Structure

```
src/gflow_cli/redaction.py     ONE home; merges 3 implementations (Task 2, first)
src/gflow_cli/diagnostics.py   UNCHANGED; its 4 importers untouched
src/gflow_cli/spike/           NEW: cdp.py / har.py / dom.py
scripts/dev/probes/            the 67 one-shot scripts + a retention rule
scripts/dev/har-spike/         DELETED at Task 7
```

Three drafts got here, and the first two were wrong:

- **`_spike/`** — the underscore claimed private, but #707 builds a user-facing path on this code.
- **folding it into `diagnostics/`** — conflation, not consolidation. `diagnostics` summarises what already went wrong, post-hoc; a spike actively drives a browser at a live surface. And `diagnostics.py` is 1890 shipped lines with 4 importers — promoting it to a package was risk for no benefit.
- **`recon/`** — jargon.

`spike` because it is already the word everywhere a human looks: `/gflow:spike`, `skills/spike/SKILL.md`, 48 `scripts/dev/spike_*.py`, `docs/superpowers/spikes/`. Also renames "Phase 0: Recon" → "Phase 0: Spike" for the same reason.

**What actually needed consolidating was never the module count — it was redaction**, which has three implementations today. Task 2 fixes that and is sequenced before any capture code lands.

## Test plan

- [x] `check_doc_links.py`, `check_repo_hygiene.py`, documentation-gate tests green
- [x] ruff clean on the new spike script
- [x] The PoC was run live; its findings are in the plan and the commit messages
- [x] Docs + one probe script; no Flow surface behaviour changed, so no e2e applies
- [ ] Council review — including whether 67 one-shot scripts is the right model at all

## Out of scope

Any user-facing command. That is [#707](https://github.com/ffroliva/gflow-cli/issues/707), which gets `/gflow:predict` first — and is why this plan needs no MCP mirror task.