### PR TITLE
docs(spike): never kill a browser on a profile you do not hold

### DIFF
--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -92,6 +92,33 @@ Navigation, DOM reads, `flow.createEntity`, `batchDeleteAssets` and a reCAPTCHA 
 all **free**. Image generation costs daily **quota**, zero credits. Video costs
 **credits**. Say which in the spike's docstring, and delete anything the spike created.
 
+## Profile etiquette — never kill a browser on a profile you do not hold
+
+**`ProfileLockedError` is the lease working, not a stale lock.** It means another
+process owns that profile right now, and the error carries the holder's evidence. Read
+it. Then wait, or spike on a different profile. Both are cheap; neither can corrupt
+anything.
+
+**Never kill Chrome processes to clear the way.** Two Chrome instances on one
+`user_data_dir` is the corruption the lease exists to prevent, and a process list cannot
+tell you which browser belongs to whom — so "these look like my orphans" is a guess made
+against a fact the lease already gave you.
+
+> **Written from the incident it prevents.** On 2026-09-07 two sessions worked this repo
+> at once. One ran the e2e suite on `denon82` and held its lease. The other hit
+> `ProfileLockedError`, read the resulting Chrome processes as orphans of its own spike,
+> and killed eighteen of them in two batches; nine belonged to the running suite. It then
+> diagnosed the cause as "spike scripts do not take the lease" — but its own spike went
+> through `FlowApiClient`, which acquires at `api/client.py` before Chrome starts, so it
+> *had* held the lease. **The tool was correct and was overruled by a process list.**
+> A real defect did surface underneath — three scripts launched Chrome outside any lease,
+> fixed with a guard test in #717 — but it was not what caused the incident, and fixing it
+> would not have prevented it. This rule would have.
+
+If you write a spike that launches Chrome itself rather than through `FlowApiClient`,
+wrap it: `async with ProfileLease(profile_dir), async_playwright() as pw:`. Chrome must
+never start on a profile this process does not own.
+
 ## Output
 
 - Evidence → `scripts/dev/_spike_out/` (**gitignored**; captures carry Bearer tokens,

--- a/tests/test_documentation_gate.py
+++ b/tests/test_documentation_gate.py
@@ -120,3 +120,20 @@ def test_current_docs_describe_headed_default_and_waf_safe_mode() -> None:
     assert "GFLOW_CLI_HEADLESS=false" in text
     assert "headed" in text.lower()
     assert "**Default:** `false`" in text
+
+
+# 2026-09-07: two sessions worked this repo at once. One held the `denon82`
+# lease; the other read `ProfileLockedError` as a stale lock, took a process
+# list as better evidence than the lease, and killed eighteen Chrome processes
+# — nine of them belonging to the running e2e suite. The lease was correct
+# throughout. `tests/scripts/test_spike_profile_lease.py` pins the code half
+# (no dev script launches Chrome outside a lease); nothing pins the half that
+# would actually have prevented it, which is an instruction to an operator.
+# A rule that lives only in a postmortem is a rule the next session never sees.
+def test_spike_skill_forbids_killing_browsers_on_an_unheld_profile() -> None:
+    text = (ROOT / "skills/spike/SKILL.md").read_text(encoding="utf-8")
+    assert "Never kill Chrome processes to clear the way." in text
+    assert "`ProfileLockedError` is the lease working, not a stale lock." in text
+    # The alternatives must stay named: a prohibition with no cheap next step
+    # is the kind an operator under pressure talks itself out of.
+    assert "wait, or spike on a different profile" in text


### PR DESCRIPTION
## Summary

On 2026-09-07 two sessions worked this repo at once. One ran the e2e suite on `denon82` and held its lease. The other hit `ProfileLockedError`, read the resulting Chrome processes as orphans of its own spike, and killed eighteen of them in two batches — nine belonged to the running suite.

**The lease was correct throughout.** The killing session's spike went through `FlowApiClient`, which acquires before Chrome starts, so it *held* the lease. The `ProfileLockedError` it kept hitting was the lease working and naming a busy profile. A correct tool was overruled by a process list, which cannot say whose browser is whose.

A real defect surfaced underneath — three dev scripts launched Chrome outside any lease, fixed with a guard test in #717 — but it was not the cause, and fixing it would not have prevented this. The missing piece was an instruction to an operator, and nothing in the repo carried it.

## What changed

`skills/spike/SKILL.md` gains a **Profile etiquette** section stating two rules and, deliberately, the cheap alternative to each:

- `ProfileLockedError` is the lease working, not a stale lock — read the holder's evidence, then wait or spike on a different profile.
- Never kill Chrome to clear the way — two Chrome instances on one `user_data_dir` is the corruption the lease exists to prevent.

## Test plan

- [x] `tests/test_documentation_gate.py` pins all three strings, including the named alternative, on the reasoning that a prohibition with no cheap next step is one an operator under pressure talks itself out of
- [x] Guard watched **RED** with the section stashed, **GREEN** with it restored — a guard never seen red is not a guard
- [x] Offline suite: 3990 passed, 7 skipped, exit 0
- [x] `ruff check` / `ruff format` / `pyright src` clean
- [x] repo hygiene, doc links, website PII, website mirror, council memory all exit 0
- [x] **E2E: not applicable** — no Flow surface is touched (a skill doc and a documentation-gate test)

## Notes

Authored in an isolated worktree off `develop`, which is itself the fix for the third defect this incident exposed: two sessions sharing one working tree.