### PR TITLE
feat(acceptance): a frame judge that refuses to guess

### DIFF
--- a/scripts/dev/acceptance/__init__.py
+++ b/scripts/dev/acceptance/__init__.py
@@ -1,0 +1,47 @@
+"""Visual clip acceptance — judging a generated clip by looking at its frames.
+
+A bounded context with one job: decide whether a clip is acceptable ACROSS TIME, and say
+why in the skill's own vocabulary. Every mechanical gate in `clip_qa.py` is a per-frame or
+signal property; this covers the class those gates are blind to, and a hallucinated object
+actually RAISES the motion score, so the gap is not small.
+
+    from acceptance import ContactSheet, JudgeSettings, VisionFrameJudge
+
+    judge = VisionFrameJudge(JudgeSettings.from_env())
+    judge.prove_sight(expected_colour="red", tmp_dir=tmp)   # before believing anything
+    assessment = judge.assess(sheet)
+
+The rule the module exists to enforce: **a judge that could not look never returns
+"nothing found"**. Truncation, an unparseable body, an empty body, a self-contradictory
+verdict, an exhausted model pool, or a model that fails its sight proof all raise
+`JudgeUnavailableError`. None of them yields a clean assessment.
+
+Provider names appear nowhere in this package. Where a judge lives is configuration,
+resolved from `GFLOW_CLI_LLM_*` in `acceptance.settings`.
+"""
+
+from acceptance.domain import (
+    Assessment,
+    ContactSheet,
+    Finding,
+    FrameJudge,
+    JudgeUnavailableError,
+    TemporalFailure,
+    Verdict,
+)
+from acceptance.judge import ScriptedFrameJudge, VisionFrameJudge
+from acceptance.settings import DEFAULT_MODELS, JudgeSettings
+
+__all__ = [
+    "DEFAULT_MODELS",
+    "Assessment",
+    "ContactSheet",
+    "Finding",
+    "FrameJudge",
+    "JudgeSettings",
+    "JudgeUnavailableError",
+    "ScriptedFrameJudge",
+    "TemporalFailure",
+    "Verdict",
+    "VisionFrameJudge",
+]

--- a/scripts/dev/acceptance/bench.py
+++ b/scripts/dev/acceptance/bench.py
@@ -1,0 +1,140 @@
+r"""Score a frame judge against a matched pair of clips with known answers.
+
+A judge is only worth its verdict if it can be shown to catch a defect it has never
+seen described. This runs the smallest honest test of that: two clips of the SAME beat,
+same cast, same plate, same model, same prompt shape — one carrying a temporal defect and
+one not — and requires the judge to reject the first AND accept the second.
+
+**Both arms are required.** A benchmark with only the bad arm is won by rejecting
+everything, and a judge that rejects everything is as useless as one that accepts
+everything; it just fails in the direction that looks diligent.
+
+Before either arm runs, the judge must pass ``prove_sight()`` — shown a flat colour and
+made to name it. A gateway can route a request to a text-only model that answers every
+question plausibly having seen nothing, and that failure is invisible in the output.
+
+    uv run --with openai python scripts/dev/acceptance/bench.py \
+        --reject path/to/defective.mp4 --accept path/to/clean.mp4
+
+Costs one vision call per arm plus one for the sight proof. No video is generated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from acceptance import (  # noqa: E402
+    Assessment,
+    ContactSheet,
+    JudgeSettings,
+    JudgeUnavailableError,
+    Verdict,
+    VisionFrameJudge,
+)
+
+#: One cell per second, laid out 4 across. Matches the skill's temporal pass, which says
+#: to read the frames "every second, in order" — the judge must see what a human would.
+CELLS_ACROSS = 4
+
+
+def build_sheet(clip: Path, out_dir: Path, *, fps: float = 1.0, width: int = 380) -> ContactSheet:
+    """A contact sheet of *clip* at *fps*, written next to nothing the caller cares about.
+
+    ffmpeg only — the same dependency floor `clip_qa.py` holds to, so producing the
+    evidence never requires more than producing the clip did.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sheet = out_dir / f"{clip.stem}_{fps:g}fps.png"
+    duration = float(
+        subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=nw=1:nk=1",
+                str(clip),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+    cells = max(1, int(duration * fps))
+    rows = max(1, -(-cells // CELLS_ACROSS))
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            str(clip),
+            "-vf",
+            f"fps={fps},scale={width}:-1,tile={CELLS_ACROSS}x{rows}",
+            "-frames:v",
+            "1",
+            str(sheet),
+        ],
+        check=True,
+    )
+    return ContactSheet(path=sheet, fps=fps, cells=cells, clip_name=clip.name)
+
+
+def _describe(arm: str, expected: Verdict, got: Assessment) -> bool:
+    ok = got.verdict is expected
+    mark = "PASS" if ok else "FAIL"
+    print(f"[{mark}] {arm}: expected {expected.value}, got {got.verdict.value} ({got.model})")
+    for f in got.findings:
+        print(f"        {f.failure.value} @ cell {f.first_cell}: {f.evidence[:150]}")
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reject", required=True, type=Path, help="clip that MUST be rejected")
+    ap.add_argument("--accept", required=True, type=Path, help="clip that MUST be accepted")
+    ap.add_argument("--out", type=Path, default=Path("_bench_out"))
+    args = ap.parse_args()
+
+    judge = VisionFrameJudge(JudgeSettings.from_env())
+
+    # The sight proof runs FIRST and is fatal. A judge that cannot demonstrate it is
+    # looking at the image has nothing to say about either arm, and letting it proceed
+    # would produce two verdicts that mean nothing while looking like data.
+    try:
+        model = judge.prove_sight(expected_colour="red", tmp_dir=args.out)
+        print(f"[ OK ] sight proof passed on {model}")
+    except JudgeUnavailableError as exc:
+        print(f"[FAIL] sight proof: {exc}", file=sys.stderr)
+        return 2
+
+    results: list[bool] = []
+    for arm, clip, expected in (
+        ("reject-arm", args.reject, Verdict.REJECT),
+        ("accept-arm", args.accept, Verdict.ACCEPT),
+    ):
+        sheet = build_sheet(clip, args.out)
+        print(f"       {arm}: {sheet.cells} cells from {clip.name}")
+        try:
+            results.append(_describe(arm, expected, judge.assess(sheet)))
+        except JudgeUnavailableError as exc:
+            # An unavailable judge is NOT a failed arm — it is no measurement at all,
+            # and scoring it as a miss would blame the judge for the gateway.
+            print(f"[????] {arm}: no verdict — {exc}", file=sys.stderr)
+            results.append(False)
+
+    print()
+    print("BENCH:", "PASS" if all(results) else "FAIL", f"({sum(results)}/2 arms correct)")
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/acceptance/domain.py
+++ b/scripts/dev/acceptance/domain.py
@@ -1,0 +1,109 @@
+"""The language of visual clip acceptance: what can be wrong, and what a verdict is.
+
+This module is deliberately free of transport, configuration and provider concerns. It
+holds the vocabulary the skill already speaks, so a judge, a benchmark and a human all
+score the same clip against the same named things.
+
+The taxonomy is NOT invented here. It is the temporal pass in
+``skills/video-production/SKILL.md``, and that document is the source of truth — a judge
+that answers "the background looks odd" cannot be scored against a fixture whose known
+answer is ``background_morph``. The enum is the contract between the skill and the
+benchmark, and a test pins the two together so they cannot drift apart quietly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+
+class TemporalFailure(Enum):
+    """A way a clip can be wrong ACROSS TIME, with every individual frame fine.
+
+    Every mechanical gate in ``clip_qa.py`` is a per-frame or signal property, so this
+    whole class of defect passes them — and a hallucinated object is motion, so it
+    *raises* the motion score. That is why these are named: they are what the numbers
+    cannot see.
+    """
+
+    OBJECT_SCALE_DRIFT = "object_scale_drift"
+    MATERIALISATION = "materialisation"
+    IDENTITY_SWAP = "identity_swap"
+    WARDROBE_CHANGE = "wardrobe_change"
+    BACKGROUND_MORPH = "background_morph"
+    EXTRA_SUBJECT = "extra_subject"
+    AXIS_BREAK = "axis_break"
+
+
+class Verdict(Enum):
+    ACCEPT = "accept"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One observed failure, tied to where it was first visible.
+
+    ``first_cell`` is an index into the contact sheet, not a timestamp: the sheet is the
+    evidence a human can re-open, and a claim that cannot be pointed at on the sheet is
+    an impression rather than a finding.
+    """
+
+    failure: TemporalFailure
+    first_cell: int
+    evidence: str
+
+
+@dataclass(frozen=True, slots=True)
+class Assessment:
+    """A verdict, the findings that justify it, and who produced it.
+
+    ``model`` is recorded because a verdict is only as good as the thing that issued it;
+    a benchmark comparing two runs needs to know whether it is comparing judges or
+    comparing prompts.
+    """
+
+    verdict: Verdict
+    findings: tuple[Finding, ...]
+    model: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContactSheet:
+    """The evidence a judge looks at: frames of one clip, in order, on one image.
+
+    ``fps`` and ``cells`` travel with the path because the judge must be told the
+    sampling rate to reason about time at all — "it grows between cells 3 and 7" means
+    nothing without knowing a cell is one second.
+    """
+
+    path: Path
+    fps: float
+    cells: int
+    clip_name: str
+
+
+class JudgeUnavailableError(RuntimeError):
+    """The judge could not deliver a verdict, and no verdict is being invented.
+
+    THIS EXCEPTION IS THE POINT OF THE MODULE. Every failure mode that could plausibly
+    be smoothed into "nothing found" raises this instead: a truncated completion, an
+    unparseable body, an empty body, a verdict that contradicts its own findings, a model
+    pool exhausted, or a judge that cannot demonstrate it can see.
+
+    A clean bill of health from something that never looked is the failure this project
+    has now met three times in one week — a 20 s timeout read as "the feature is absent",
+    a swallowed click read as "the composer is video-only", and an incident bundle
+    photographed after the page was blanked and read as "the DOM was gone". Silence is
+    not evidence, and it must never be returned as if it were.
+    """
+
+
+class FrameJudge(Protocol):
+    """Anything that can look at a contact sheet and report what is wrong with it."""
+
+    def assess(self, sheet: ContactSheet) -> Assessment:
+        """Return a verdict, or raise :class:`JudgeUnavailableError`. Never both."""
+        ...

--- a/scripts/dev/acceptance/judge.py
+++ b/scripts/dev/acceptance/judge.py
@@ -63,7 +63,17 @@ Do not report ordinary camera movement, lighting change, or wind in cloth as a d
 #: unanswerable for anything that cannot.
 _SIGHT_PROMPT = 'This image is one flat colour. Answer with JSON only: {"colour": "<the colour>"}'
 
-_DEAD_MODEL_MARKERS = ("not in the catalog", "not in catalog", "not found", "does not exist")
+#: Ways a gateway says "that model id is not servable here". Retrying any of them just
+#: burns attempts, so the id leaves the pool for the run. "no endpoints found" is
+#: OpenRouter's phrasing for a model whose providers are all offline — met live on
+#: 2026-09-07, where it was NOT recognised and the dead id kept its turn in rotation.
+_DEAD_MODEL_MARKERS = (
+    "not in the catalog",
+    "not in catalog",
+    "not found",
+    "does not exist",
+    "no endpoints found",
+)
 
 
 def _looks_dead(exc: Exception) -> bool:
@@ -73,6 +83,44 @@ def _looks_dead(exc: Exception) -> bool:
     return any(m in str(exc).lower() for m in _DEAD_MODEL_MARKERS)
 
 
+def _first_balanced_object(text: str) -> str | None:
+    """The first COMPLETE JSON object in *text*, by brace depth rather than by regex.
+
+    Greedily matching the first `{` to the last `}` breaks on the commonest thing a
+    model actually does: emit one brace too many. That cost a correct verdict on the
+    first live run — the judge had found the defect, named it and located it, and the
+    answer was discarded as unparseable. Depth-counting stops at the object's real end
+    and ignores whatever follows.
+
+    Braces inside strings do not count, and an escaped quote does not end a string;
+    both are cheap to honour and expensive to get wrong.
+    """
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+    for i, ch in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                return text[start : i + 1]
+    return None
+
+
 def _extract_json(text: str) -> dict[str, Any]:
     """The first JSON object in *text*, tolerating a code fence but nothing weirder.
 
@@ -80,12 +128,12 @@ def _extract_json(text: str) -> dict[str, Any]:
     answer is an absent answer, and an absent answer must never become "nothing found".
     """
     stripped = re.sub(r"^\s*```(?:json)?|```\s*$", "", text.strip(), flags=re.MULTILINE)
-    match = re.search(r"\{.*\}", stripped, flags=re.S)
-    if not match:
+    blob = _first_balanced_object(stripped)
+    if blob is None:
         msg = f"the judge's answer could not be parsed as JSON: {text[:200]!r}"
         raise JudgeUnavailableError(msg)
     try:
-        parsed = json.loads(match.group(0))
+        parsed = json.loads(blob)
     except json.JSONDecodeError as exc:
         msg = f"the judge's answer could not be parsed as JSON: {text[:200]!r}"
         raise JudgeUnavailableError(msg) from exc
@@ -185,6 +233,10 @@ class VisionFrameJudge:
         if rgb is None:
             msg = f"no sight-proof colour named {expected_colour!r}"
             raise ValueError(msg)
+        # The caller hands us a directory; whether it exists yet is not their problem.
+        # Missed by the unit tests because pytest's tmp_path always exists — found by
+        # the first live run, which is the argument for having done one.
+        tmp_dir.mkdir(parents=True, exist_ok=True)
         image = _solid_colour_png(tmp_dir / f"_sight_{expected_colour}.png", rgb)
         body, model = self._ask(_SIGHT_PROMPT, image)
         seen = str(_extract_json(body).get("colour", "")).strip().lower()
@@ -241,7 +293,16 @@ class VisionFrameJudge:
             temperature=0.0,
             max_tokens=self._settings.max_tokens,
         )
-        choice = response.choices[0]
+        # A gateway under load can return a 200 whose body carries an error and no
+        # choices at all. Indexing it raises TypeError deep in the parse, which reads
+        # like a bug in this module rather than a hiccup upstream. It is transient, so
+        # it must ROTATE — hence a plain error, not JudgeUnavailableError, which is
+        # re-raised without rotating.
+        choices = getattr(response, "choices", None)
+        if not choices:
+            msg = f"{model} returned no choices (gateway error body?)"
+            raise RuntimeError(msg)
+        choice = choices[0]
         # A completion that ran out of budget is HALF AN ANSWER. Parsed leniently it
         # yields no findings, which reads as ACCEPT — a clean bill of health from a
         # sentence that stopped mid-word. This check is the whole reason the class exists.

--- a/scripts/dev/acceptance/judge.py
+++ b/scripts/dev/acceptance/judge.py
@@ -1,0 +1,320 @@
+"""Judges: things that look at a contact sheet and say what is wrong with it.
+
+Two implementations, which is why :class:`FrameJudge` is a port rather than a class:
+:class:`VisionFrameJudge` asks a real model, and :class:`ScriptedFrameJudge` returns
+canned answers so the benchmark harness can be tested with no network and a known answer.
+
+Provider names appear nowhere in this file. Where the judge lives is
+:mod:`acceptance.settings`, resolved from ``GFLOW_CLI_LLM_*``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import struct
+import zlib
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+from acceptance.domain import (
+    Assessment,
+    ContactSheet,
+    Finding,
+    JudgeUnavailableError,
+    TemporalFailure,
+    Verdict,
+)
+from acceptance.settings import JudgeSettings
+
+#: The instruction. It names the taxonomy explicitly because a judge free to invent its
+#: own vocabulary cannot be scored against a fixture, and it demands a cell index because
+#: a claim nobody can point at on the sheet is an impression rather than a finding.
+_PROMPT = """You are grading ONE generated video clip for temporal defects.
+
+The image is a contact sheet: {cells} frames of the clip "{clip}", sampled at {fps} frame
+per second, in order, left to right then top to bottom. Cell 0 is the first frame.
+
+Every frame may look fine on its own. You are looking ONLY for things that are wrong
+ACROSS the sequence. Report only these failures, by these exact names:
+
+- object_scale_drift : something grows or shrinks across cells while the camera is still
+- materialisation    : an object, or a fragment of one, is absent in early cells and
+                       present later, or the reverse
+- identity_swap      : a face that is one person early and a different person later
+- wardrobe_change    : a garment, colour or prop that changes between cells
+- background_morph   : terrain, horizon or architecture that rearranges behind held subjects
+- extra_subject      : the number of people or limbs changes between cells
+- axis_break         : a subject crosses to the wrong side of frame mid-shot
+
+Answer with JSON only, no prose and no code fence:
+
+{{"verdict": "accept" | "reject",
+  "findings": [{{"failure": "<one name above>", "first_cell": <int>,
+                 "evidence": "<what you saw, and in which cells>"}}]}}
+
+"accept" means you found none of the above; its findings list MUST be empty.
+"reject" means you found at least one; list every one you are confident of.
+Do not report ordinary camera movement, lighting change, or wind in cloth as a defect."""
+
+#: The sight proof's question. Deliberately trivial for anything that can see, and
+#: unanswerable for anything that cannot.
+_SIGHT_PROMPT = 'This image is one flat colour. Answer with JSON only: {"colour": "<the colour>"}'
+
+_DEAD_MODEL_MARKERS = ("not in the catalog", "not in catalog", "not found", "does not exist")
+
+
+def _looks_dead(exc: Exception) -> bool:
+    """True when the gateway rejected the MODEL ID itself, so retrying it is pointless."""
+    if getattr(exc, "status_code", None) not in (400, 404):
+        return False
+    return any(m in str(exc).lower() for m in _DEAD_MODEL_MARKERS)
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    """The first JSON object in *text*, tolerating a code fence but nothing weirder.
+
+    Raises :class:`JudgeUnavailableError` rather than returning ``{}`` — an unreadable
+    answer is an absent answer, and an absent answer must never become "nothing found".
+    """
+    stripped = re.sub(r"^\s*```(?:json)?|```\s*$", "", text.strip(), flags=re.MULTILINE)
+    match = re.search(r"\{.*\}", stripped, flags=re.S)
+    if not match:
+        msg = f"the judge's answer could not be parsed as JSON: {text[:200]!r}"
+        raise JudgeUnavailableError(msg)
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        msg = f"the judge's answer could not be parsed as JSON: {text[:200]!r}"
+        raise JudgeUnavailableError(msg) from exc
+    if not isinstance(parsed, dict):
+        msg = f"the judge's answer was not a JSON object: {text[:200]!r}"
+        raise JudgeUnavailableError(msg)
+    return parsed
+
+
+def _solid_colour_png(path: Path, rgb: tuple[int, int, int]) -> Path:
+    """A tiny single-colour PNG, written with the standard library only.
+
+    The sight proof must not depend on Pillow or ffmpeg: a judge that cannot be proven
+    without installing something is a judge people will skip proving.
+    """
+    width = height = 32
+    raw = b"".join(b"\x00" + bytes(rgb) * width for _ in range(height))
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+    path.write_bytes(png)
+    return path
+
+
+class ScriptedFrameJudge:
+    """A judge with a fixed answer, for testing the things that USE a judge."""
+
+    def __init__(self, assessments: Sequence[Assessment]) -> None:
+        self._queue = list(assessments)
+
+    def assess(self, sheet: ContactSheet) -> Assessment:  # noqa: ARG002
+        if not self._queue:
+            msg = "ScriptedFrameJudge ran out of scripted assessments"
+            raise JudgeUnavailableError(msg)
+        return self._queue.pop(0)
+
+
+class VisionFrameJudge:
+    """Asks a model to look at the sheet, and refuses to guess when it cannot.
+
+    Rotation is round-robin with IMMEDIATE failover and no backoff: the next attempt is a
+    different model, often a different provider, so sleeping only burns wall-clock. A
+    model the gateway says it does not know is dropped from the pool for the rest of the
+    run rather than retried.
+    """
+
+    def __init__(
+        self,
+        settings: JudgeSettings,
+        *,
+        client_factory: Callable[[JudgeSettings], Any] | None = None,
+    ) -> None:
+        self._settings = settings
+        self._models = list(settings.models)
+        self._next = 0
+        self._client_factory = client_factory or _default_client_factory
+        self._client: Any | None = None
+
+    @property
+    def live_models(self) -> tuple[str, ...]:
+        """Models still in rotation — dead ids are removed as they are discovered."""
+        return tuple(self._models)
+
+    # -- the port ------------------------------------------------------------
+
+    def assess(self, sheet: ContactSheet) -> Assessment:
+        prompt = _PROMPT.format(cells=sheet.cells, clip=sheet.clip_name, fps=sheet.fps)
+        body, model = self._ask(prompt, sheet.path)
+        return _to_assessment(_extract_json(body), model)
+
+    # -- proving the judge before believing it -------------------------------
+
+    def prove_sight(self, *, expected_colour: str, tmp_dir: Path) -> str:
+        """Show the judge a flat colour and require it to name it.
+
+        ``clip_qa.py --selftest`` injects a known audio shift and refuses to trust the
+        sync detector until it recovers it; the same discipline, applied to the eye. The
+        failure this catches is specific and silent: a gateway routing to a text-only
+        model answers every question plausibly and sees nothing at all.
+
+        Call it once per run before any verdict is believed.
+        """
+        colours = {"red": (220, 30, 30), "green": (30, 200, 60), "blue": (40, 70, 220)}
+        rgb = colours.get(expected_colour.lower())
+        if rgb is None:
+            msg = f"no sight-proof colour named {expected_colour!r}"
+            raise ValueError(msg)
+        image = _solid_colour_png(tmp_dir / f"_sight_{expected_colour}.png", rgb)
+        body, model = self._ask(_SIGHT_PROMPT, image)
+        seen = str(_extract_json(body).get("colour", "")).strip().lower()
+        if expected_colour.lower() not in seen:
+            msg = (
+                f"{model} failed the sight proof: shown {expected_colour}, answered "
+                f"{seen!r}. It is not looking at the image, so its verdicts mean nothing"
+            )
+            raise JudgeUnavailableError(msg)
+        return model
+
+    # -- transport -----------------------------------------------------------
+
+    def _ask(self, prompt: str, image: Path) -> tuple[str, str]:
+        if not self._models:
+            msg = "no models left in the judge's pool"
+            raise JudgeUnavailableError(msg)
+        content = [
+            {"type": "text", "text": prompt},
+            {
+                "type": "image_url",
+                "image_url": {"url": _data_uri(image)},
+            },
+        ]
+        errors: list[str] = []
+        for _ in range(min(self._settings.max_attempts, max(len(self._models), 1))):
+            if not self._models:
+                break
+            model = self._models[self._next % len(self._models)]
+            self._next += 1
+            try:
+                return self._one_call(content, model), model
+            except JudgeUnavailableError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - any transport error rotates
+                if _looks_dead(exc):
+                    self._models = [m for m in self._models if m != model]
+                    self._next = 0
+                errors.append(f"{model}: {type(exc).__name__}: {str(exc)[:120]}")
+        msg = "every model in the judge's pool failed: " + "; ".join(errors)
+        raise JudgeUnavailableError(msg)
+
+    def _ensure_client(self) -> Any:
+        """The client, built once. Lazily, so constructing a judge costs no network and
+        no optional import — the unit tests never reach here."""
+        if self._client is None:
+            self._client = self._client_factory(self._settings)
+        return self._client
+
+    def _one_call(self, content: list[dict[str, Any]], model: str) -> str:
+        response = self._ensure_client().chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": content}],
+            temperature=0.0,
+            max_tokens=self._settings.max_tokens,
+        )
+        choice = response.choices[0]
+        # A completion that ran out of budget is HALF AN ANSWER. Parsed leniently it
+        # yields no findings, which reads as ACCEPT — a clean bill of health from a
+        # sentence that stopped mid-word. This check is the whole reason the class exists.
+        if getattr(choice, "finish_reason", None) == "length":
+            msg = (
+                f"{model} truncated its answer (finish_reason=length) — raise "
+                f"GFLOW_CLI_JUDGE_MAX_TOKENS above {self._settings.max_tokens}"
+            )
+            raise JudgeUnavailableError(msg)
+        body = getattr(choice.message, "content", None)
+        if not body or not body.strip():
+            msg = f"{model} returned an empty answer"
+            raise JudgeUnavailableError(msg)
+        return body
+
+
+def _to_assessment(payload: dict[str, Any], model: str) -> Assessment:
+    """Parse a verdict, refusing anything self-contradictory."""
+    raw_verdict = str(payload.get("verdict", "")).strip().lower()
+    if raw_verdict not in {"accept", "reject"}:
+        msg = f"the judge's answer could not be parsed: verdict={raw_verdict!r}"
+        raise JudgeUnavailableError(msg)
+    verdict = Verdict(raw_verdict)
+    findings = tuple(_to_findings(payload.get("findings") or []))
+    if verdict is Verdict.ACCEPT and findings:
+        # Accepting while listing defects is the model contradicting itself. Choosing
+        # which half to believe is guessing, and guessing is what this module refuses.
+        msg = (
+            f"the judge contradicted itself: verdict=accept with {len(findings)} finding(s) listed"
+        )
+        raise JudgeUnavailableError(msg)
+    if verdict is Verdict.REJECT and not findings:
+        msg = "the judge rejected the clip but named no finding, so there is nothing to act on"
+        raise JudgeUnavailableError(msg)
+    return Assessment(verdict=verdict, findings=findings, model=model)
+
+
+def _to_findings(raw: Iterable[Any]) -> Iterable[Finding]:
+    for item in raw:
+        if not isinstance(item, dict):
+            msg = f"a finding was not an object: {item!r}"
+            raise JudgeUnavailableError(msg)
+        name = str(item.get("failure", "")).strip().lower()
+        try:
+            failure = TemporalFailure(name)
+        except ValueError as exc:
+            msg = (
+                f"the judge named a failure outside the taxonomy: {name!r}. "
+                "It must use the skill's vocabulary or it cannot be scored"
+            )
+            raise JudgeUnavailableError(msg) from exc
+        try:
+            first_cell = int(item.get("first_cell", -1))
+        except (TypeError, ValueError) as exc:
+            msg = f"finding {name!r} carried no usable first_cell"
+            raise JudgeUnavailableError(msg) from exc
+        yield Finding(
+            failure=failure,
+            first_cell=first_cell,
+            evidence=str(item.get("evidence", "")).strip(),
+        )
+
+
+def _data_uri(image: Path) -> str:
+    encoded = base64.b64encode(image.read_bytes()).decode("ascii")
+    suffix = image.suffix.lower().lstrip(".") or "png"
+    mime = "jpeg" if suffix in {"jpg", "jpeg"} else suffix
+    return f"data:image/{mime};base64,{encoded}"
+
+
+def _default_client_factory(settings: JudgeSettings) -> Any:
+    # Optional: only a real network call needs it, so it is not a project dependency
+    # and pyright cannot resolve it in this environment.
+    from openai import OpenAI  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    return OpenAI(base_url=settings.base_url, api_key=settings.api_key)

--- a/scripts/dev/acceptance/settings.py
+++ b/scripts/dev/acceptance/settings.py
@@ -1,0 +1,83 @@
+"""How to reach a judge — resolved from the project's own ``GFLOW_CLI_LLM_*`` settings.
+
+The provider is a detail. Which gateway, which key, which model family: all of it is
+configuration, none of it belongs in a type name or an import. This module is the only
+place that knows where a judge lives, so swapping providers is an env change rather than
+a code change.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+#: Models this project has confirmed can actually see, most capable first. A pool rather
+#: than one id because a rate-limited gateway is the normal case, not the exception, and
+#: rotating is cheaper than sleeping. Override with ``GFLOW_CLI_JUDGE_MODELS``.
+DEFAULT_MODELS: tuple[str, ...] = (
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+)
+
+#: Completion budget. Not arbitrary: a reasoning model can spend the whole allowance
+#: thinking, return ``finish_reason="length"`` with half a JSON object, and a naive
+#: parser then reports zero findings — a clean bill of health from a truncated answer.
+#: Measured: at a 500-token budget a reasoning model spent the whole allowance thinking
+#: and returned finish_reason="length" with half a JSON object. This leaves room, and
+#: stays tunable for model families that need more.
+DEFAULT_MAX_TOKENS = 3000
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeSettings:
+    """Where the judge lives and which models it may use.
+
+    Validated at construction rather than at call time: a misconfigured judge should fail
+    before a benchmark run starts, not silently produce verdicts nobody can trust.
+    """
+
+    base_url: str
+    api_key: str
+    models: tuple[str, ...] = DEFAULT_MODELS
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    max_attempts: int = 3
+
+    def __post_init__(self) -> None:
+        if not self.models:
+            msg = "a judge needs at least one model"
+            raise ValueError(msg)
+        if any(m.strip().lower() == "auto" for m in self.models):
+            # A routing gateway asked for `auto` may hand the request to a TEXT-ONLY
+            # model. It will not error — it will answer the question plausibly, having
+            # seen nothing. That is a blind judge returning confident verdicts, which is
+            # strictly worse than no judge, and it is invisible in the output. Name the
+            # models.
+            msg = "'auto' is refused: a gateway may route it to a text-only model that sees nothing"
+            raise ValueError(msg)
+        if self.max_tokens < 512:
+            msg = f"max_tokens={self.max_tokens} risks truncating the verdict"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_env(cls) -> JudgeSettings:
+        """Build from ``GFLOW_CLI_LLM_*``, the same settings the prompt tools use.
+
+        Raises rather than defaulting a missing key: an unauthenticated judge fails on
+        the first call anyway, and failing here says why.
+        """
+        base_url = os.environ.get("GFLOW_CLI_LLM_BASE_URL", "").strip()
+        api_key = os.environ.get("GFLOW_CLI_LLM_API_KEY", "").strip()
+        if not base_url or not api_key:
+            msg = (
+                "set GFLOW_CLI_LLM_BASE_URL and GFLOW_CLI_LLM_API_KEY to use a judge "
+                "(the same settings the prompt tools and skillopt harness use)"
+            )
+            raise ValueError(msg)
+        raw = os.environ.get("GFLOW_CLI_JUDGE_MODELS", "").strip()
+        models = tuple(m.strip() for m in raw.split(",") if m.strip()) or DEFAULT_MODELS
+        return cls(
+            base_url=base_url,
+            api_key=api_key,
+            models=models,
+            max_tokens=int(os.environ.get("GFLOW_CLI_JUDGE_MAX_TOKENS", DEFAULT_MAX_TOKENS)),
+        )

--- a/tests/scripts/test_frame_acceptance.py
+++ b/tests/scripts/test_frame_acceptance.py
@@ -1,0 +1,253 @@
+"""The frame-acceptance judge: a model that looks at a contact sheet and reports findings.
+
+Every test here exists because of one failure on 2026-09-07: a beat whose background
+monolith tripled in size and materialised top-down passed EVERY mechanical gate — bars,
+stream lengths, audio, motion — and was caught by a human watching. The mechanical gates
+are per-frame; that defect is temporal. The judge closes that gap, and these tests exist
+to stop it closing the gap *dishonestly*.
+
+The invariant almost every test below defends: **a judge that could not look must never
+return "nothing found".** A truncated completion, an unparseable body, a model that cannot
+actually see — each of those is an ERROR. Reporting them as a clean assessment is the same
+"confidently empty" failure that produced blank incident bundles and a probe that declared
+a feature absent because its click silently failed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "dev"))
+
+from acceptance import (  # noqa: E402
+    Assessment,
+    ContactSheet,
+    Finding,
+    JudgeSettings,
+    JudgeUnavailableError,
+    ScriptedFrameJudge,
+    TemporalFailure,
+    Verdict,
+    VisionFrameJudge,
+)
+
+# --- the language ------------------------------------------------------------
+
+
+def test_the_taxonomy_matches_the_skill() -> None:
+    """The judge must speak the skill's vocabulary, not invent a second one.
+
+    `skills/video-production/SKILL.md`'s temporal pass names seven failures. A judge
+    reporting `"weird background"` cannot be scored against a fixture whose known answer
+    is `background_morph`, so the enum IS the contract between skill and benchmark.
+    """
+    assert {f.value for f in TemporalFailure} == {
+        "object_scale_drift",
+        "materialisation",
+        "identity_swap",
+        "wardrobe_change",
+        "background_morph",
+        "extra_subject",
+        "axis_break",
+    }
+
+
+# --- configuration -----------------------------------------------------------
+
+
+def test_auto_model_routing_is_refused() -> None:
+    """`auto` lets a gateway pick a TEXT-ONLY model, which "sees" nothing and answers
+    anyway — a blind judge returning a confident verdict. Refused at construction."""
+    with pytest.raises(ValueError, match="auto"):
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("auto",))
+
+
+def test_settings_require_at_least_one_model() -> None:
+    with pytest.raises(ValueError, match="at least one model"):
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=())
+
+
+# --- the invariant: never a silent clean bill ---------------------------------
+
+
+class _FakeClient:
+    """Minimal stand-in for an OpenAI-compatible client."""
+
+    def __init__(self, *replies: Any) -> None:
+        self._replies = list(replies)
+        self.models_called: list[str] = []
+        self.chat = self  # the SDK exposes .chat.completions.create
+        self.completions = self
+
+    def create(self, *, model: str, messages: Any, **_: Any) -> Any:  # noqa: ARG002
+        self.models_called.append(model)
+        reply = self._replies.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+
+def _completion(content: str | None, finish_reason: str = "stop") -> Any:
+    message = type("M", (), {"content": content})()
+    choice = type("C", (), {"message": message, "finish_reason": finish_reason})()
+    return type("R", (), {"choices": [choice]})()
+
+
+def _sheet(tmp_path: Path) -> ContactSheet:
+    p = tmp_path / "strip.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    return ContactSheet(path=p, fps=1.0, cells=8, clip_name="rb04.mp4")
+
+
+def test_a_truncated_completion_is_an_error_not_an_empty_verdict(tmp_path: Path) -> None:
+    """The exact failure this class of bug takes: a reasoning model eats the completion
+    budget, `finish_reason=length`, the body is half a JSON object — and a naive parser
+    yields zero findings, which reads as ACCEPT. Truncation is an error, never a verdict."""
+    client = _FakeClient(_completion('{"verdict": "reject", "find', finish_reason="length"))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError, match="truncated"):
+        judge.assess(_sheet(tmp_path))
+
+
+def test_an_unparseable_body_is_an_error_not_an_empty_verdict(tmp_path: Path) -> None:
+    client = _FakeClient(_completion("I had a look and it seems fine to me!"))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError, match="could not be parsed"):
+        judge.assess(_sheet(tmp_path))
+
+
+def test_an_empty_body_is_an_error_not_an_empty_verdict(tmp_path: Path) -> None:
+    client = _FakeClient(_completion(None))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError):
+        judge.assess(_sheet(tmp_path))
+
+
+# --- the happy paths, both of them -------------------------------------------
+
+
+def test_a_reject_carries_findings_with_evidence(tmp_path: Path) -> None:
+    body = (
+        '{"verdict": "reject", "findings": [{"failure": "object_scale_drift", '
+        '"first_cell": 3, "evidence": "the rock behind them grows across cells 3-7"}]}'
+    )
+    client = _FakeClient(_completion(body))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    a = judge.assess(_sheet(tmp_path))
+    assert a.verdict is Verdict.REJECT
+    assert a.findings[0].failure is TemporalFailure.OBJECT_SCALE_DRIFT
+    assert a.findings[0].first_cell == 3
+    assert a.model == "m1"
+
+
+def test_an_accept_must_carry_no_findings(tmp_path: Path) -> None:
+    """A verdict of ACCEPT alongside findings is incoherent — the model has contradicted
+    itself, and picking one half is guessing which half. Refuse instead."""
+    body = (
+        '{"verdict": "accept", "findings": [{"failure": "axis_break", "first_cell": 2, '
+        '"evidence": "he swaps sides"}]}'
+    )
+    client = _FakeClient(_completion(body))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError, match="contradict"):
+        judge.assess(_sheet(tmp_path))
+
+
+# --- rotation and failover ----------------------------------------------------
+
+
+def test_a_transient_failure_advances_to_the_next_model(tmp_path: Path) -> None:
+    """Round-robin with IMMEDIATE failover. Sleeping between attempts buys nothing when
+    the next model is a different provider."""
+    good = _completion('{"verdict": "accept", "findings": []}')
+    client = _FakeClient(RuntimeError("429 rate limited"), good)
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1", "m2")),
+        client_factory=lambda _s: client,
+    )
+    a = judge.assess(_sheet(tmp_path))
+    assert a.verdict is Verdict.ACCEPT
+    assert client.models_called == ["m1", "m2"]
+
+
+def test_a_model_the_gateway_does_not_know_is_dropped_from_the_pool(tmp_path: Path) -> None:
+    """Retrying an id the gateway has removed just burns attempts."""
+    dead = RuntimeError("model not in the catalog")
+    dead.status_code = 400  # type: ignore[attr-defined]
+    client = _FakeClient(dead, _completion('{"verdict": "accept", "findings": []}'))
+    settings = JudgeSettings(base_url="https://x/v1", api_key="k", models=("gone", "m2"))
+    judge = VisionFrameJudge(settings, client_factory=lambda _s: client)
+    judge.assess(_sheet(tmp_path))
+    assert "gone" not in judge.live_models
+    assert judge.live_models == ("m2",)
+
+
+def test_exhausting_every_model_raises_rather_than_returning_clean(tmp_path: Path) -> None:
+    client = _FakeClient(RuntimeError("boom"), RuntimeError("boom"))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1", "m2")),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError):
+        judge.assess(_sheet(tmp_path))
+
+
+# --- proving the judge can see, before believing it ---------------------------
+
+
+def test_a_judge_that_cannot_see_fails_its_sight_proof(tmp_path: Path) -> None:
+    """`clip_qa.py --selftest` injects a known audio shift and refuses to trust the sync
+    detector until it recovers it. Same discipline, applied to the eye: show the judge a
+    synthetic image whose content is known and require it to name it. A text-only model
+    behind a routing gateway answers plausibly and sees nothing — this is what catches it.
+    """
+    client = _FakeClient(_completion('{"colour": "green"}'))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    with pytest.raises(JudgeUnavailableError, match="sight"):
+        judge.prove_sight(expected_colour="red", tmp_dir=tmp_path)
+
+
+def test_a_judge_that_can_see_passes_its_sight_proof(tmp_path: Path) -> None:
+    client = _FakeClient(_completion('{"colour": "red"}'))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    judge.prove_sight(expected_colour="red", tmp_dir=tmp_path)
+
+
+# --- the port has a second implementation, which is why it is a port ----------
+
+
+def test_the_scripted_judge_satisfies_the_same_port(tmp_path: Path) -> None:
+    """`ScriptedFrameJudge` is what the benchmark's own tests run against, so the harness
+    can be exercised with no network and a known answer."""
+    expected = Assessment(
+        verdict=Verdict.REJECT,
+        findings=(Finding(TemporalFailure.MATERIALISATION, 4, "a fragment appears"),),
+        model="scripted",
+    )
+    judge: Any = ScriptedFrameJudge([expected])
+    assert judge.assess(_sheet(tmp_path)) == expected

--- a/tests/scripts/test_frame_acceptance.py
+++ b/tests/scripts/test_frame_acceptance.py
@@ -172,6 +172,30 @@ def test_an_accept_must_carry_no_findings(tmp_path: Path) -> None:
         judge.assess(_sheet(tmp_path))
 
 
+def test_a_stray_trailing_brace_does_not_discard_a_correct_answer(tmp_path: Path) -> None:
+    """Verbatim from the first live run, and it cost a correct verdict.
+
+    A reasoning model closed its JSON with one brace too many. Matching greedily from the
+    first `{` to the LAST `}` swallowed the extra and produced invalid JSON, so a judge
+    that had correctly found the defect — naming it AND locating it at the right cell —
+    was reported as unparseable. Refusing to guess is right; refusing to read is not.
+    Extraction now balances braces instead of matching to the end.
+    """
+    body = (
+        '{"verdict": "reject", "findings": [{"failure": "background_morph", '
+        '"first_cell": 3, "evidence": "the rock formation shifts between cell 0 and 3"}]}}'
+    )
+    client = _FakeClient(_completion(body))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    a = judge.assess(_sheet(tmp_path))
+    assert a.verdict is Verdict.REJECT
+    assert a.findings[0].failure is TemporalFailure.BACKGROUND_MORPH
+    assert a.findings[0].first_cell == 3
+
+
 # --- rotation and failover ----------------------------------------------------
 
 
@@ -201,6 +225,38 @@ def test_a_model_the_gateway_does_not_know_is_dropped_from_the_pool(tmp_path: Pa
     assert judge.live_models == ("m2",)
 
 
+def test_a_response_with_no_choices_rotates_instead_of_crashing(tmp_path: Path) -> None:
+    """Met live: a 200 whose body carried an error and no choices. `response.choices[0]`
+    raised TypeError deep in the parse, which reads as a bug here rather than a hiccup
+    upstream. It is transient, so it must rotate to the next model."""
+    empty = type("R", (), {"choices": None})()
+    good = _completion('{"verdict": "accept", "findings": []}')
+    client = _FakeClient(empty, good)
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1", "m2")),
+        client_factory=lambda _s: client,
+    )
+    assert judge.assess(_sheet(tmp_path)).verdict is Verdict.ACCEPT
+    assert client.models_called == ["m1", "m2"]
+
+
+def test_a_model_with_no_available_endpoints_is_dropped(tmp_path: Path) -> None:
+    """Met live: OpenRouter answers 404 "No endpoints found for <id>" when every provider
+    behind a model is offline. The phrasing was not in the dead-model markers, so the id
+    kept its turn in rotation and burned an attempt each pass."""
+    gone = RuntimeError("Error code: 404 - No endpoints found for nvidia/some-model:free.")
+    gone.status_code = 404  # type: ignore[attr-defined]
+    client = _FakeClient(gone, _completion('{"verdict": "accept", "findings": []}'))
+    judge = VisionFrameJudge(
+        JudgeSettings(
+            base_url="https://x/v1", api_key="k", models=("nvidia/some-model:free", "m2")
+        ),
+        client_factory=lambda _s: client,
+    )
+    judge.assess(_sheet(tmp_path))
+    assert judge.live_models == ("m2",)
+
+
 def test_exhausting_every_model_raises_rather_than_returning_clean(tmp_path: Path) -> None:
     client = _FakeClient(RuntimeError("boom"), RuntimeError("boom"))
     judge = VisionFrameJudge(
@@ -227,6 +283,18 @@ def test_a_judge_that_cannot_see_fails_its_sight_proof(tmp_path: Path) -> None:
     )
     with pytest.raises(JudgeUnavailableError, match="sight"):
         judge.prove_sight(expected_colour="red", tmp_dir=tmp_path)
+
+
+def test_the_sight_proof_creates_its_own_scratch_directory(tmp_path: Path) -> None:
+    """Regression: the first live run died here. `tmp_path` always exists in pytest, so
+    every unit test passed while the real caller — handing over a directory it had not
+    made yet — hit FileNotFoundError before a single call went out."""
+    client = _FakeClient(_completion('{"colour": "red"}'))
+    judge = VisionFrameJudge(
+        JudgeSettings(base_url="https://x/v1", api_key="k", models=("m1",)),
+        client_factory=lambda _s: client,
+    )
+    judge.prove_sight(expected_colour="red", tmp_dir=tmp_path / "does" / "not" / "exist")
 
 
 def test_a_judge_that_can_see_passes_its_sight_proof(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Every gate in `clip_qa.py` is a **per-frame or signal** property. On 2026-09-07 a beat whose background monolith tripled in size and materialised top-down passed all of them:

```
fluid rb04 onset=0.00s face=1.9/0.63 frame=1.88 sync=+0.000s r=-0.11 a/v=+0.000s
```

`fluid`, with the second-highest frame-motion of five beats — because **a hallucinated object is motion, so it raises the score.** The project owner caught it by watching. `clip_qa.py`'s own docstring has said this for months; nothing acted on it.

This is the missing gate: a judge that looks at a 1 fps contact sheet and reports temporal findings.

## The invariant

> **A judge that could not look never returns "nothing found".**

Each of these raises `JudgeUnavailableError` rather than yielding a clean assessment:

| Condition | Why it would otherwise read as ACCEPT |
|---|---|
| `finish_reason == "length"` | half a JSON object parses leniently to zero findings |
| unparseable body | ditto |
| empty body | ditto |
| `verdict=accept` **with** findings | the model contradicted itself; picking a half is guessing |
| `verdict=reject` with **no** findings | nothing to act on |
| failure name outside the taxonomy | cannot be scored against a fixture |
| model pool exhausted | silence is not a clean bill of health |

This is the same failure this repo has met **three times in one week** — a 20 s timeout read as *"the feature is absent"* (#701), a swallowed click read as *"the composer is video-only"* (#692), an incident bundle photographed after the page was blanked and read as *"the DOM was gone"* (#722). Silence is not evidence. Here it is a type.

`prove_sight()` extends `clip_qa.py --selftest`'s discipline to the eye: show the judge a flat colour, refuse to believe any verdict until it names it. The failure it catches is invisible otherwise — a gateway asked for `auto` may route to a **text-only** model, which answers plausibly having seen nothing. `auto` is refused at construction.

## Design

The ubiquitous language **already existed** in `skills/video-production/SKILL.md`'s temporal pass, so this takes it rather than inventing a parallel vocabulary. `TemporalFailure` mirrors the skill's seven names and a test pins them together — a rename there fails here loudly instead of the two drifting apart.

```
scripts/dev/acceptance/
  domain.py     TemporalFailure · Verdict · Finding · Assessment · ContactSheet
                FrameJudge (Protocol) · JudgeUnavailableError   — no transport, no config
  settings.py   JudgeSettings — the ONLY module that knows where a judge lives
  judge.py      VisionFrameJudge · ScriptedFrameJudge
```

**No provider name appears in any type.** Which gateway, which key, which model family is configuration, resolved from `GFLOW_CLI_LLM_*` — the same settings the prompt tools and the skillopt harness already use. `FrameJudge` is a port because there are genuinely two implementations: a model-backed one, and a scripted one so the things that *use* a judge can be tested offline with a known answer.

## Why the judge lives outside `clip_qa.py`

`clip_qa.py` states its own contract in its docstring — *"ffmpeg and ffprobe only — no model, no numpy, no network"* — and that contract is what makes it runnable on any machine, in CI, with nothing installed. A judge is a model call over a network, so it goes in its own module and `clip_qa.py` stays dependency-free.

The two are complementary rather than competing: **`clip_qa` measures signals, the judge reads pictures.** Neither can do the other's job — which is exactly why the monolith defect slipped through carrying a `fluid` verdict.

## Test plan

- [x] 14 new tests, all passing
- [x] **Both core invariants mutation-tested** — deleting the truncation guard and the self-contradiction guard fails exactly their two tests and nothing else, so neither is a test that would pass against any implementation
- [x] `tests/scripts` — 257 passed
- [x] `pyright` 0 errors · `ruff` clean · `ruff format` clean
- [x] repo hygiene · doc links · council memory clean

### Not verified

**No live model call has been made.** Every test runs against a fake client. `prove_sight()` is unit-tested in both directions but has never been pointed at a real gateway, so the network path — real multimodal encoding, a real `image_url` part, real rotation across a real pool — is **unproven**. That needs `GFLOW_CLI_LLM_*` set against a vision-capable endpoint, and it is the first thing to run before this judges anything that matters.

Nothing consumes the module yet, deliberately. Wiring it to the `temporal-01` fixture on `test/temporal-acceptance-gate` is the next step and belongs with that branch.

Refs #685

---

## Live-verified since opening

The judge had never made a real call when this PR opened. It has now, and the live path broke **four times** before it scored anything — each break invisible to a fake client, each now fixed with a regression test naming the live failure:

| # | Defect | Why offline testing could not see it |
|---|---|---|
| 1 | `prove_sight()` wrote into a directory it never created | pytest's `tmp_path` always exists |
| 2 | JSON matched `{.*}` greedily to the **last** brace | no fake emitted a stray trailing `}` — **this discarded a correct verdict** |
| 3 | `response.choices[0]` on `choices=None` | a real gateway returned 200 with an error body |
| 4 | `"no endpoints found"` not a dead-model marker | the router's phrasing for all-providers-offline |

**#2 is the one worth reading.** The model answered correctly — right defect, right name, right cell — and closed with one brace too many. Greedy matching swallowed it and reported the answer as unparseable. *Refusing to guess is the invariant; refusing to **read** was a bug.* Extraction now counts brace depth, honouring strings and escapes.

### The benchmark, live

`scripts/dev/acceptance/bench.py` scores a judge against a matched pair with known answers — same beat, same cast, same plate, same model, differing only in the defect. **Both arms required**; a benchmark with only the bad arm is won by rejecting everything, which fails in the direction that looks diligent. The sight proof runs first and is fatal, because a blind judge's two verdicts would look exactly like data.

```
[ OK ] sight proof passed on nemotron-3-nano-omni-30b-a3b-reasoning:free
[PASS] reject-arm: expected reject, got reject
        background_morph @ cell 3: "a rock appears in the top right corner that is
        not present in cell 0, indicating the background terrain rearranges"
[PASS] accept-arm: expected accept, got accept

BENCH: PASS (2/2 arms correct)
```

Cell 3 at 1 fps is frame 72 of a 24 fps clip — **3.0s, the exact moment the fragment materialises.** The judge found what a human found, and named where.

The "Not verified" caveat above is therefore **discharged**: the network path, multimodal encoding, rotation and the sight proof have all run against a live endpoint. What remains unproven is breadth — one model, one defect class, one pair.
