### PR TITLE
fix(character): re-anchor the Format button on its custom element, not a tag that moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   degraded to a no-op: `ui_automation.format_button_not_found`, exit **0**, prompt submitted as
   typed, and the image quota spent on a run whose requested prompt-engineering step never
   happened. The button was never absent. Measured on 2026-09-07 with
-  `scripts/dev/spike_character_prompt_format.py` (`$0` — DOM read only, with a control anchor
-  so a flat zero could not be mistaken for absence): it renders as
+  `scripts/dev/spike_character_prompt_format.py` (`$0` — navigation, one free `createEntity`,
+  DOM reads and typing; two control anchors, so a flat zero could not be mistaken for
+  absence): it renders as
   `<flow-format-prompt-button>`, and the Angular frontend carries the unchanged
   `personal_recommendations` ligature in **`<mat-icon>`** rather than `<i>` — the same carrier
   split fixed for `add_2` / `arrow_drop_down` / `accessibility_new` in #703, which this constant
   was not swept with. The EN `span:text-is('Format')` fallback missed too and is **deleted**
   rather than translated: the button's own `aria-label` reads `"Formatar"` on a pt account, and
   display labels are banned as anchors. The cascade now leads with the custom element and covers
-  both carriers. ([#727](https://github.com/ffroliva/gflow-cli/issues/727))
+  both carriers. ([#727](https://github.com/ffroliva/gflow-cli/issues/727),
+  [spike](docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md))
 
 - **`video t2v --reference-entity` no longer bills a clip that ignores the entity.** On the
   migrated `flow.google.com` host the "character references are not ported" refusal lived inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`character create --format-prompt` clicks Flow's Format button again.** On the migrated
+  `flow.google.com` host all three entries of `PROMPT_FORMAT_SELECTORS` missed, so the flag
+  degraded to a no-op: `ui_automation.format_button_not_found`, exit **0**, prompt submitted as
+  typed, and the image quota spent on a run whose requested prompt-engineering step never
+  happened. The button was never absent. Measured on 2026-09-07 with
+  `scripts/dev/spike_character_prompt_format.py` (`$0` — DOM read only, with a control anchor
+  so a flat zero could not be mistaken for absence): it renders as
+  `<flow-format-prompt-button>`, and the Angular frontend carries the unchanged
+  `personal_recommendations` ligature in **`<mat-icon>`** rather than `<i>` — the same carrier
+  split fixed for `add_2` / `arrow_drop_down` / `accessibility_new` in #703, which this constant
+  was not swept with. The EN `span:text-is('Format')` fallback missed too and is **deleted**
+  rather than translated: the button's own `aria-label` reads `"Formatar"` on a pt account, and
+  display labels are banned as anchors. The cascade now leads with the custom element and covers
+  both carriers. ([#727](https://github.com/ffroliva/gflow-cli/issues/727))
+
 - **`video t2v --reference-entity` no longer bills a clip that ignores the entity.** On the
   migrated `flow.google.com` host the "character references are not ported" refusal lived inside
   the r2v branch of the routing gate, so a t2v request returned from that gate before its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`character create --format-prompt` clicks Flow's Format button again.** On the migrated
-  `flow.google.com` host all three entries of `PROMPT_FORMAT_SELECTORS` missed, so the flag
-  degraded to a no-op: `ui_automation.format_button_not_found`, exit **0**, prompt submitted as
+- **`character create --format-prompt` finds and clicks Flow's Format button again.** Scoped
+  deliberately: this fixes the *anchor*, and **`--format-prompt` still does not deliver a
+  reshaped prompt** — see the Known-issues note below. On the migrated `flow.google.com` host
+  all three entries of `PROMPT_FORMAT_SELECTORS` missed, so the flag degraded to a no-op:
+  `ui_automation.format_button_not_found`, exit **0**, prompt submitted as
   typed, and the image quota spent on a run whose requested prompt-engineering step never
   happened. The button was never absent. Measured on 2026-09-07 with
   `scripts/dev/spike_character_prompt_format.py` (`$0` — navigation, one free `createEntity`,
@@ -86,6 +88,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a dead cookie.
 - `scripts/dev/spike_migrated_composer_mode_axis.py` — hard-error probe that opens the migrated
   composer's settings overlay and enumerates its radiogroups.
+- `scripts/dev/spike_format_prompt_effect.py` — measures whether clicking Format actually
+  rewrites the prompt, and when. `$0`, never submits.
+
+### Known issues
+
+- **`character create --format-prompt` still submits the prompt as typed, even when the button
+  is found and clicked.** The anchor fix above is necessary and not sufficient. Flow rewrites
+  **server-side** — a `batchexecute` round trip whose result reaches the composer at **~5.4s**
+  (measured, `denon82`, `$0`) — while `format_character_prompt` waits `_jitter_ms(500)` and
+  `_send_prompt` submits on the next line. The reshaped text arrives after the submit has
+  already gone.
+
+  **The defect is not that the wait is too short. It is that gflow reports success without
+  observing it**: `ui_automation.prompt_formatted` is emitted on the *click*, so the absence of
+  a completion inside a window we chose is recorded as a completion. That is the same class as a
+  20 s selector timeout read as "the feature is absent" and a bundle photographed after teardown
+  read as "the DOM was gone" — a measurement that could not be taken, recorded as a measurement.
+  This one is the worst of them because it fails toward **success**: a premature green looks
+  exactly like the feature working, and nobody investigates a pass. The e2e is green for this
+  reason and is not wrong to be — it asserts the click, which was the only observable when it
+  was written.
+
+  A `/gflow:predict` on the fix returned **GO with conditions** (8.2/10): poll the composer
+  until its text differs from the string gflow inserted, guarded by a length delta rather than
+  raw inequality, and emit `prompt_formatted` on the observed rewrite. Not gating on the
+  `batchexecute` response — it arrives **4.2s before** the DOM settles, so a wire-level gate
+  reproduces the same early submit.
+  ([#727](https://github.com/ffroliva/gflow-cli/issues/727),
+  [spike](docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md))
 
 ## [0.70.0] — 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`character create --format-prompt` finds and clicks Flow's Format button again.** Scoped
-  deliberately: this fixes the *anchor*, and **`--format-prompt` still does not deliver a
-  reshaped prompt** — see the Known-issues note below. On the migrated `flow.google.com` host
+- **`character create --format-prompt` works again — both halves of it.** The flag had two
+  independent faults, and fixing only the first would have left it just as useless. On the
+  migrated `flow.google.com` host
   all three entries of `PROMPT_FORMAT_SELECTORS` missed, so the flag degraded to a no-op:
   `ui_automation.format_button_not_found`, exit **0**, prompt submitted as
   typed, and the image quota spent on a run whose requested prompt-engineering step never
@@ -60,6 +60,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`--format-prompt` now waits for the rewrite, and `ui_automation.prompt_formatted` means it
+  happened.** This is the second half of the #727 fix and the half that made the flag useful.
+  Flow rewrites **server-side** — a `batchexecute` round trip reaching the composer at ~5.4s
+  (measured, `denon82`) — while the old code waited `_jitter_ms(500)`, logged
+  `prompt_formatted` and returned; `_send_prompt` submits on the very next line. So the flag
+  shipped the prompt the user typed and discarded the rewrite on **every** run, with a success
+  event in the log and exit 0.
+
+  **The defect was never the duration. It was reporting a success we had not observed** — the
+  absence of a completion inside a window we chose, recorded as a completion. Same class as a
+  20s selector timeout read as "the feature is absent" and a bundle captured after teardown
+  read as "the DOM was gone". This one was the worst of the three because it failed toward
+  **success**: a premature green looks exactly like the feature working, so nobody investigates
+  a pass.
+
+  `format_character_prompt` now polls the bound composer until its text actually changes, and
+  returns `True` only then. The gate is the DOM, not the wire — the `batchexecute` response
+  arrives **4.2s before** the text settles, so awaiting it would reproduce the same early
+  submit. Comparing against the string gflow inserted is locale-invariant by construction, and
+  a **length delta** rather than `!=` keeps Slate's whitespace normalisation from re-reporting
+  the same false success. Telemetry carries lengths and a stable hash, never the prompt text:
+  Flow *elaborates* a terse description into a detailed physical one, so the rewrite is more
+  PII-dense than the input.
+
+  New events: `format_button_clicked` (the old semantics), `format_not_observed` (clicked, no
+  rewrite inside the budget — it does not claim Flow failed, since an unchanged box also covers
+  Flow declining or judging the prompt already formatted).
+
+  **Two user-visible consequences.** A create with `--format-prompt` takes a few seconds longer
+  for the rewrite itself, and — because the reshaped prompt is longer and more detailed — the
+  generation is materially slower: **406s vs a 210s control** on the same account and prompt,
+  live-verified 2026-09-07.
+  ([#727](https://github.com/ffroliva/gflow-cli/issues/727),
+  [spike](docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md))
+
 - **Retracted a false "measured" claim about the migrated composer.** A code comment asserted, as
   "measured, not assumed", that the migrated project composer "has no image-generation mode".
   Falsified live on 2026-09-07: its settings overlay opens to six radiogroups / sixteen radios and
@@ -90,33 +125,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   composer's settings overlay and enumerates its radiogroups.
 - `scripts/dev/spike_format_prompt_effect.py` — measures whether clicking Format actually
   rewrites the prompt, and when. `$0`, never submits.
-
-### Known issues
-
-- **`character create --format-prompt` still submits the prompt as typed, even when the button
-  is found and clicked.** The anchor fix above is necessary and not sufficient. Flow rewrites
-  **server-side** — a `batchexecute` round trip whose result reaches the composer at **~5.4s**
-  (measured, `denon82`, `$0`) — while `format_character_prompt` waits `_jitter_ms(500)` and
-  `_send_prompt` submits on the next line. The reshaped text arrives after the submit has
-  already gone.
-
-  **The defect is not that the wait is too short. It is that gflow reports success without
-  observing it**: `ui_automation.prompt_formatted` is emitted on the *click*, so the absence of
-  a completion inside a window we chose is recorded as a completion. That is the same class as a
-  20 s selector timeout read as "the feature is absent" and a bundle photographed after teardown
-  read as "the DOM was gone" — a measurement that could not be taken, recorded as a measurement.
-  This one is the worst of them because it fails toward **success**: a premature green looks
-  exactly like the feature working, and nobody investigates a pass. The e2e is green for this
-  reason and is not wrong to be — it asserts the click, which was the only observable when it
-  was written.
-
-  A `/gflow:predict` on the fix returned **GO with conditions** (8.2/10): poll the composer
-  until its text differs from the string gflow inserted, guarded by a length delta rather than
-  raw inequality, and emit `prompt_formatted` on the observed rewrite. Not gating on the
-  `batchexecute` response — it arrives **4.2s before** the DOM settles, so a wire-level gate
-  reproduces the same early submit.
-  ([#727](https://github.com/ffroliva/gflow-cli/issues/727),
-  [spike](docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md))
 
 ## [0.70.0] — 2026-09-06
 

--- a/docs/superpowers/memory/flow-locale-leak-icon-ligatures.md
+++ b/docs/superpowers/memory/flow-locale-leak-icon-ligatures.md
@@ -5,7 +5,14 @@ description: Flow renders dialog labels in the Chrome PROFILE language; --lang=e
 
 Flow's editor UI renders dialog labels in the Chrome **profile** language preference (set in `chrome://settings/languages`), NOT the Google **account** language and NOT the `--lang=en-US` Chromium launch arg. Any selector that matches localized text breaks on non-EN profiles. The fail-loud `RuntimeError` in `_attach_references` (PR #60) correctly distinguishes these — keep that hint when adding similar guards.
 
-The durable selector pattern is `button:has(i.google-symbols:text('<icon_ligature>'))`. Known Material Symbols ligatures used in Flow's UI (locale-stable):
+The durable part of the selector is the **ligature**, not the tag that carries it. Flow's two frontends render the same Material Symbols ligature under different carriers — labs (React) `<i class="google-symbols">`, migrated `flow.google.com` (Angular) `<mat-icon class="… google-symbols …">` — so a cascade must cover **both**:
+
+```
+button:has(i.google-symbols:text('<icon_ligature>'))   # labs
+button:has(mat-icon:text('<icon_ligature>'))           # migrated
+```
+
+Anchoring on one carrier returns a flat zero on the other host while the control is fully visible. See [[ligature-carrier-differs-by-host]] — that split cost #727, because #703 swept three constants for it and missed a fourth. Known Material Symbols ligatures used in Flow's UI (locale-stable):
 
 - `add_2` — project "+" button AND editor Add Media button (disambiguate via `aria-haspopup="dialog"` + `aria-controls^="radix-"` for the editor variant)
 - `upload` — "Upload media" item in the media-attach popover (use **`:text-is('upload')` exact match** — `:text` would also match `drive_folder_upload` of the Uploads tab)

--- a/docs/superpowers/memory/ligature-carrier-differs-by-host.md
+++ b/docs/superpowers/memory/ligature-carrier-differs-by-host.md
@@ -1,0 +1,45 @@
+---
+name: ligature-carrier-differs-by-host
+description: Flow's two frontends render the same Material Symbols ligature under different carrier tags — labs `<i class="google-symbols">`, migrated `<mat-icon>`. A cascade anchored on one carrier returns a flat zero on the other host while the control is visible, and degrades silently.
+---
+
+Flow ships two frontends over one backend. They render the **same** Material Symbols
+ligature under **different carrier tags**:
+
+| host | framework | carrier |
+|---|---|---|
+| `labs.google` | React / Next.js | `<i class="google-symbols">` |
+| `flow.google.com` (migrated) | Angular | `<mat-icon class="… google-symbols …">` |
+
+`mat-icon` **also** carries the `google-symbols` class, so the class was never the
+discriminator — the **tag** is. `button:has(i.google-symbols:text-is('x'))` therefore
+matches zero elements on the migrated host while the control sits there fully visible,
+and `button:has(.google-symbols:text-is('x'))` would have matched both all along.
+
+**Why:** #703 swept three constants for exactly this (`add_2`, `arrow_drop_down`,
+`accessibility_new`) and missed `PROMPT_FORMAT_SELECTORS`. That miss made
+`character create --format-prompt` a **silent no-op** for an unknown period — the flag
+logged `ui_automation.format_button_not_found`, submitted the prompt as typed and exited
+**0**, having spent image quota on a prompt-engineering step that never ran (#727). The
+failure mode is the dangerous one: not an error, a degrade behind a green exit code.
+
+**How to apply:**
+
+- Touching **any** selector constant: sweep both carriers, not just the one your account's
+  host renders. `git grep "i\.google-symbols" src/gflow_cli` returned **55** single-carrier
+  literals after #727 — across `ui_automation.py`, `ui_automation_video.py`,
+  `mode_control.py`, `diagnostics.py` and `drivers/`. Two consecutive PRs have now fixed
+  one of these by hand, which makes it a **registry/sweep** problem, not a selector problem;
+  `src/gflow_cli/flow_selectors/registry.py` (driven nightly by `selector-probe.yml`) is
+  where a real fix belongs.
+- **Prefer a custom element over either carrier.** `<flow-format-prompt-button>`,
+  `<flow-slot-chip-button>`, `<flow-generate-icon-button>` are component boundaries, not
+  layout accidents — they survive a carrier change AND a translation. Pin uniqueness with a
+  captured-DOM fixture, never with a comment ([[flow-locale-leak-icon-ligatures]]).
+- A cascade that misses is evidence about the **cascade**. Probe the live DOM before
+  concluding the control is gone — [[flow-locale-leak-icon-ligatures]] and
+  `skills/spike/SKILL.md`. The carrier split looks exactly like a removed feature, and has
+  twice been mistaken for one.
+
+Related: [[flow-locale-leak-icon-ligatures]], [[migrated-host-driver-wire-lessons]],
+[[ui-selector-drift-error-exit-23]].

--- a/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
+++ b/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
@@ -106,8 +106,6 @@ The disabled-until-typed behaviour from 2026-07-27 still holds on the migrated h
 types before calling `format_character_prompt`, so the enabled check is correct as
 written and needed no change.
 
-No occluder: `elementFromPoint` over the prompt box returns a child of the box itself.
-
 ## 6. What this did NOT measure
 
 - **The labs frontend.** No unmoved account exists here, so the two `<i>` entries are
@@ -116,8 +114,20 @@ No occluder: `elementFromPoint` over the prompt box returns a child of the box i
 - **The content of Flow's rewrite.** The probe never submits. That the button is found,
   enabled and clicked is what the e2e test asserts; whether Flow's reshaped prompt is
   *better* stays a human read.
-- **Every other selector constant.** This spike swept one. The #703 carrier sweep
-  demonstrably missed at least one constant, and nothing proves this was the last.
+- **The network.** No request/response capture was taken, so nothing here establishes
+  that clicking Format reaches a backend — only that the button is found, enabled and
+  clickable. A click is not proof of a downstream effect
+  ([[playwright-click-no-downstream-event-signature]]); the e2e's
+  `ui_automation.prompt_formatted` event is the click, not the rewrite.
+- **Occlusion of the Format button.** The probe's `elementFromPoint` read was pointed at
+  the *prompt box*, not the button — it answered a question nobody asked, and the check
+  has been removed rather than left to be misread. The live e2e click landing is the
+  stronger evidence anyway.
+- **Every other selector constant.** This spike swept one. `git grep "i\.google-symbols"`
+  still returns **55** single-carrier literals across `ui_automation.py`,
+  `ui_automation_video.py`, `mode_control.py`, `diagnostics.py` and `drivers/`. The #703
+  carrier sweep demonstrably missed at least one, and this is the second consecutive PR
+  to fix one by hand — which makes it a registry/sweep problem, not a selector problem.
 
 ## 7. The rule this re-earns
 

--- a/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
+++ b/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
@@ -123,11 +123,11 @@ written and needed no change.
   the *prompt box*, not the button — it answered a question nobody asked, and the check
   has been removed rather than left to be misread. The live e2e click landing is the
   stronger evidence anyway.
-- **Every other selector constant.** This spike swept one. `git grep "i\.google-symbols"`
-  still returns **55** single-carrier literals across `ui_automation.py`,
-  `ui_automation_video.py`, `mode_control.py`, `diagnostics.py` and `drivers/`. The #703
-  carrier sweep demonstrably missed at least one, and this is the second consecutive PR
-  to fix one by hand — which makes it a registry/sweep problem, not a selector problem.
+- **Every other selector constant.** This spike swept one, and many more remain
+  single-carrier — the #703 sweep demonstrably missed at least one, and this is the
+  second consecutive PR to fix one by hand, which makes it a registry/sweep problem
+  rather than a selector problem. Current count and file list live in
+  [[ligature-carrier-differs-by-host]] and #730, not here — it is a number that rots.
 
 ## 7. The rule this re-earns
 

--- a/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
+++ b/docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md
@@ -1,0 +1,135 @@
+# The character-editor Format button never left — its carrier changed
+
+**Date:** 2026-09-07 · **Issue:** [#727](https://github.com/ffroliva/gflow-cli/issues/727)
+· **Account:** `denon82` (migrated `flow.google.com`, funded, idle machine) ·
+**Cost:** `$0` — navigation, one free tRPC `flow.createEntity`, DOM reads and typing.
+Nothing submitted, nothing generated, no credit and no image quota spent.
+
+**Script:** `scripts/dev/spike_character_prompt_format.py` (rewritten for this run) ·
+**Capture:** `scripts/dev/_spike_out/char_format_anchor_denon82_20260907_141440.json`
+(gitignored)
+
+---
+
+## 1. The question, and the control that makes the answer readable
+
+`gflow character create --format-prompt` had degraded to a silent no-op:
+`ui_automation.format_button_not_found` on every run, exit 0, prompt submitted as
+typed. All three entries of `PROMPT_FORMAT_SELECTORS` missed.
+
+A cascade returning zero is evidence about the cascade. To make a zero mean anything,
+the probe hard-errors unless the editor-ready anchor resolves first:
+
+```
+control_check  count=1  selector='div[role="textbox"][data-slate-editor="true"],
+                                  div.ProseMirror[contenteditable="true"]'
+```
+
+One prompt box. The probe was standing in the editor. Every count below is therefore a
+measurement, not a failure to arrive.
+
+## 2. What was measured
+
+Three shipped selectors, both before and after typing (the button ships `disabled` on
+an empty box, so the empty read is the control for the enabled one):
+
+| selector | empty | typed |
+|---|---|---|
+| `button:has(i.google-symbols:text-is('personal_recommendations'))` | **0** | **0** |
+| `button:has(i:text-is('personal_recommendations'))` | **0** | **0** |
+| `button:has(span:text-is('Format'))` | **0** | **0** |
+| `button:has-text("Format")` *(locator only, never a candidate)* | 1, `enabled=False` | 1, `enabled=True` |
+
+The button was visible the entire time. Its actual DOM:
+
+```html
+<flow-format-prompt-button>
+  <button flow-button matbutton class="… format-chip-button …" aria-label="Formatar">
+    <mat-icon class="mat-icon notranslate flow-icon-s google-symbols …">
+      personal_recommendations
+    </mat-icon>
+    <span>Formatar</span>
+  </button>
+</flow-format-prompt-button>
+```
+
+## 3. Two independent misses, either one fatal
+
+**a. The carrier tag.** The migrated Angular frontend renders the ligature in
+`<mat-icon>`, not `<i>`. The ligature itself is unchanged — `personal_recommendations`,
+still unique document-wide (1 of 17 ligatures in the editor). `mat-icon` even carries
+the `google-symbols` class, so the *class* was never the problem; the `i` tag was.
+
+This is the same carrier split fixed for `add_2`, `arrow_drop_down` and
+`accessibility_new` in #703. `PROMPT_FORMAT_SELECTORS` was simply not swept with them —
+a retraction that reached the places someone remembered and missed the one nobody
+looked at.
+
+**b. The localised label.** The button now *has* an `aria-label`, which it did not on
+2026-07-27 — but Flow localises it: `aria-label="Formatar"`, `<span>Formatar</span>`, on
+an account whose Flow locale is `pt` even though the run passed `--locale en-US`
+(account locale wins). The EN text fallback could never have matched this profile.
+
+## 4. The anchor that replaces them
+
+`<flow-format-prompt-button>` — a **custom element**, i.e. a component boundary rather
+than a layout accident, and unique: one of six buttons in the composer subtree.
+
+| composer button | host element | aria-label (pt) |
+|---|---|---|
+| clear prompt | `div` | `Apagar comando` |
+| add elements | `div` | `Adicionar elementos à caixa de comando` |
+| **format** | **`flow-format-prompt-button`** | `Formatar` |
+| model family | `div` | `Selecionar família de modelos` |
+| settings | `div` | `Gatilho de configurações` |
+| submit | `flow-generate-icon-button` | `Iniciar geração` |
+
+Shipped cascade:
+
+```python
+PROMPT_FORMAT_SELECTORS = (
+    "flow-format-prompt-button button",                                  # migrated: component boundary
+    "button:has(mat-icon:text-is('personal_recommendations'))",          # migrated: ligature
+    "button:has(i.google-symbols:text-is('personal_recommendations'))",  # labs
+    "button:has(i:text-is('personal_recommendations'))",                 # labs
+)
+```
+
+`button:has(span:text-is('Format'))` is **deleted**, not translated. It is banned as an
+anchor by the locale-invariance rule in AGENTS.md and it demonstrably matches nothing on
+a non-EN account.
+
+## 5. Also confirmed, not assumed
+
+The disabled-until-typed behaviour from 2026-07-27 still holds on the migrated host:
+`enabled=False` on an empty box, `enabled=True` after `insert_text`. `_send_prompt`
+types before calling `format_character_prompt`, so the enabled check is correct as
+written and needed no change.
+
+No occluder: `elementFromPoint` over the prompt box returns a child of the box itself.
+
+## 6. What this did NOT measure
+
+- **The labs frontend.** No unmoved account exists here, so the two `<i>` entries are
+  carried forward on the 2026-07-27 capture alone. They were not re-verified today and
+  are not asserted to still work.
+- **The content of Flow's rewrite.** The probe never submits. That the button is found,
+  enabled and clicked is what the e2e test asserts; whether Flow's reshaped prompt is
+  *better* stays a human read.
+- **Every other selector constant.** This spike swept one. The #703 carrier sweep
+  demonstrably missed at least one constant, and nothing proves this was the last.
+
+## 7. The rule this re-earns
+
+```
+A SELECTOR THAT DOES NOT MATCH IS EVIDENCE ABOUT THE SELECTOR.
+```
+
+Nothing here was absent. The feature, the button, the ligature and the backend were all
+exactly where they were in July. One tag name changed, one label got translated, and a
+paid-for prompt-engineering step quietly stopped happening behind a green exit code for
+an unknown number of runs — because `e2e_character` is opt-in and the nightly canary
+runs `e2e_auth` only.
+
+See also: [2026-09-06 — migrated character surface](2026-09-06-migrated-character-surface-and-recaptcha.md)
+(the carrier split), [`skills/spike/SKILL.md`](../../../skills/spike/SKILL.md).

--- a/docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md
+++ b/docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md
@@ -1,0 +1,106 @@
+# The Format button was fixed, and `--format-prompt` still does nothing
+
+**Date:** 2026-09-07 · **Follows:** [#727](https://github.com/ffroliva/gflow-cli/issues/727),
+[#729](https://github.com/ffroliva/gflow-cli/pull/729) ·
+**Account:** `denon82` (migrated `flow.google.com`) · **Cost:** `$0` — never submits, no
+image, no video, no credit.
+
+**Script:** `scripts/dev/spike_format_prompt_effect.py` ·
+**Capture:** `scripts/dev/_spike_out/format_prompt_effect_denon82_20260907_163552.json`
+(gitignored)
+
+---
+
+## 1. Why this was measured at all
+
+#727 fixed the *anchor*: `format_character_prompt` now finds and clicks Flow's Format
+button. It then waits `_jitter_ms(500)`, logs `ui_automation.prompt_formatted`, and
+returns — and `_send_prompt` calls `_click_submit` on the next line.
+
+That event proves **a click**. It has never proved **a rewrite**
+([[playwright-click-no-downstream-event-signature]]). The PR council's D6 reviewer
+flagged exactly this gap: the #727 spike captured no network, so nothing established
+that the click reached a backend, let alone that its result arrived before the submit.
+
+## 2. What was measured
+
+Seed a deliberately terse prompt, confirm it landed, click Format through the **shipped**
+cascade, then poll the box every 250 ms for 20 s while recording every request:
+
+```
+baseline        'girl, red hair, sad'                       19 chars
+format_clicked  flow-format-prompt-button button
+box_text        t=0.011   chars=19    'girl, red hair, sad'      <- unchanged
+box_text        t=5.355   chars=651   'Medium studio shot of a young girl with…'
+verdict         changed=True  changed_at_s=5.355  within_current_wait=False
+```
+
+Two states, one discrete swap — no streaming, no intermediate text. The request that
+does it:
+
+```
+t=1.191  POST https://flow.google.com/_/AiSandboxAngularFrontend/data/batchexecute
+         ?rpcids=eAenfb&source-path=/project/<id>
+```
+
+**The rewrite is a server round trip on `batchexecute` rpcid `eAenfb`, and the DOM
+settles ~5.4 s after the click.**
+
+## 3. The finding
+
+```
+gflow waits ~0.5 s. Flow answers in ~5.4 s. The submit fires in between.
+```
+
+`--format-prompt` therefore submits the prompt **the user typed**, discarding the
+reshaped one, on every run — including runs where the button is found, enabled, clicked,
+and `ui_automation.prompt_formatted` is emitted. The flag has never worked on this host:
+before #727 it missed the button, and after #727 it clicks a button whose answer it
+throws away.
+
+**The e2e does not catch this.** `test_character_create_format_prompt_clicks_format_button`
+asserts `prompt_formatted` is present and the two failure events are absent. All three
+hold. The test is green and the feature is broken — it asserts the click because, at the
+time it was written, the click was the only observable.
+
+## 4. What makes this fixable
+
+The rewrite is **observable in the DOM**: the prompt box text changes, in one step, from
+what we typed to something else. So the settle signal is a condition, not a duration —
+poll the box until its text differs from the text we inserted, with a timeout.
+
+That also upgrades the telemetry: `prompt_formatted` can be emitted on the **observed
+rewrite** rather than on the click, which makes it mean what its name has always claimed,
+and makes the existing e2e assertion meaningful rather than incidental.
+
+Anchoring on the text changing is locale-invariant by construction — it compares Flow's
+output against **our own** inserted string and never reads a display label.
+
+## 5. What this did NOT measure
+
+- **How variable ~5.4 s is.** One observation, one prompt, one account, one moment. A
+  timeout has to be chosen against a distribution nobody has sampled yet; 5.4 s is a
+  single point, not a budget.
+- **Failure modes of the rewrite.** What the box does if `eAenfb` errors, rate-limits, or
+  returns empty was never provoked. A poll-until-changed loop needs to know whether
+  "unchanged" can also mean "Flow declined".
+- **The labs frontend.** No unmoved account exists here. Whether labs rewrites in-place,
+  at what latency, and on what rpcid is unknown.
+- **Whether the rewrite draws on any quota.** Nothing observable here says. No image is
+  generated.
+- **Idempotency.** Clicking Format twice, or clicking it on already-formatted text, was
+  not tried.
+
+## 6. The rule this re-earns
+
+```
+A CLICK IS NOT AN EFFECT.
+```
+
+#727 replaced "the selector missed" with "the selector matched" and stopped there, because
+matching was what the ticket asked for. The council caught that the evidence chain ended
+at the click; measuring one step further showed the feature still does not work. A green
+test that asserts the last thing you happened to be able to observe is not a green feature.
+
+See also: [2026-09-07 — the Format button's anchor](2026-09-07-character-format-button-anchor.md),
+[`skills/spike/SKILL.md`](../../../skills/spike/SKILL.md).

--- a/docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md
+++ b/docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md
@@ -1,4 +1,11 @@
-# The Format button was fixed, and `--format-prompt` still does nothing
+# The Format button was fixed, and `--format-prompt` still did nothing
+
+> **RESOLVED in the same PR ([#729](https://github.com/ffroliva/gflow-cli/pull/729)).** This
+> records the measurement that found the second fault, not a standing limitation.
+> `format_character_prompt` now polls the composer until the text actually changes, and the
+> live e2e passes (`1 passed in 406.20s`, `denon82`, 2026-09-07) asserting the **observed
+> rewrite** rather than the click. Kept because the measurement is what makes the fix
+> defensible, and because the failure class it names outlived it.
 
 **Date:** 2026-09-07 · **Follows:** [#727](https://github.com/ffroliva/gflow-cli/issues/727),
 [#729](https://github.com/ffroliva/gflow-cli/pull/729) ·
@@ -99,8 +106,15 @@ A CLICK IS NOT AN EFFECT.
 
 #727 replaced "the selector missed" with "the selector matched" and stopped there, because
 matching was what the ticket asked for. The council caught that the evidence chain ended
-at the click; measuring one step further showed the feature still does not work. A green
+at the click; measuring one step further showed the feature still did not work. A green
 test that asserts the last thing you happened to be able to observe is not a green feature.
+
+**What the fix cost, measured after the fact.** Making the flag work made the run slower in
+two places: the rewrite itself (~4-5 s), and the generation, because Flow is now given a
+608-character elaboration instead of the 102 characters the user typed. Live: **406 s with
+`--format-prompt` against a 210 s control** on the same account and face prompt. That is not
+a regression to fix — it is the actual cost of the feature, which was free only while it was
+doing nothing. It did overrun the e2e's 300 s budget, which is why that budget moved to 480 s.
 
 See also: [2026-09-07 — the Format button's anchor](2026-09-07-character-format-button-anchor.md),
 [`skills/spike/SKILL.md`](../../../skills/spike/SKILL.md).

--- a/scripts/dev/capture_i2v_frame_slots_dom.py
+++ b/scripts/dev/capture_i2v_frame_slots_dom.py
@@ -66,114 +66,121 @@ async def capture(profile_name: str, out_dir: Path) -> int:
         if transport is None:
             sys.exit("FlowApiClient.transport is None — transport wiring broken")
         page = await client._checkout_page()
-        print("FlowApiClient ready, page checked out.")
+        try:
+            print("FlowApiClient ready, page checked out.")
 
-        print("Entering editor...")
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        print("Dismissing blocking overlays...")
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        print("Switching to video mode...")
-        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
-        print("Waiting for video editor SPA to mount...")
-        await VideoGenerationMixin._wait_video_editor_ready(page)
+            print("Entering editor...")
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            print("Dismissing blocking overlays...")
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            print("Switching to video mode...")
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+            print("Waiting for video editor SPA to mount...")
+            await VideoGenerationMixin._wait_video_editor_ready(page)
 
-        # Frame slots only appear AFTER the "frames" sub-mode is selected in the
-        # settings panel — that's what `generate_video` does for I2V.  We mirror
-        # the production sequence here to give the probe a real I2V editor.
-        print("Switching to I2V 'frames' sub-mode (settings panel)...")
-        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
-        print("Closing settings panel (Escape) — slots live in the main editor...")
-        await page.keyboard.press("Escape")
-        await page.wait_for_timeout(600)
+            # Frame slots only appear AFTER the "frames" sub-mode is selected in the
+            # settings panel — that's what `generate_video` does for I2V.  We mirror
+            # the production sequence here to give the probe a real I2V editor.
+            print("Switching to I2V 'frames' sub-mode (settings panel)...")
+            await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+            print("Closing settings panel (Escape) — slots live in the main editor...")
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(600)
 
-        # Probe the selector tiers. `SWAP_CONTAINER_PR70` is the broken PR #70
-        # anchor — kept for forensic comparison (must match 0 on real Flow DOMs).
-        # `FRAME_SLOTS_STRUCT` is the post-#63 production primary; the text
-        # fallback only fires on EN profiles.
-        swap_pr70_count = await page.locator(SWAP_CONTAINER_PR70).count()
-        struct_count = await page.locator(FRAME_SLOTS_STRUCT).count()
-        text_start = await page.locator(FRAME_SLOT_BY_LABEL.format(label="Start")).count()
-        text_end = await page.locator(FRAME_SLOT_BY_LABEL.format(label="End")).count()
-        print()
-        print("=== Selector cascade match counts ===")
-        print(f"  SWAP_CONTAINER_PR70 (historical, broken)     → {swap_pr70_count}")
-        print(f"  FRAME_SLOTS_STRUCT  (post-#63 primary)        → {struct_count}")
-        print(f"  FRAME_SLOT_BY_LABEL (Start text, EN-only)     → {text_start}")
-        print(f"  FRAME_SLOT_BY_LABEL (End text, EN-only)       → {text_end}")
-        print()
+            # Probe the selector tiers. `SWAP_CONTAINER_PR70` is the broken PR #70
+            # anchor — kept for forensic comparison (must match 0 on real Flow DOMs).
+            # `FRAME_SLOTS_STRUCT` is the post-#63 production primary; the text
+            # fallback only fires on EN profiles.
+            swap_pr70_count = await page.locator(SWAP_CONTAINER_PR70).count()
+            struct_count = await page.locator(FRAME_SLOTS_STRUCT).count()
+            text_start = await page.locator(FRAME_SLOT_BY_LABEL.format(label="Start")).count()
+            text_end = await page.locator(FRAME_SLOT_BY_LABEL.format(label="End")).count()
+            print()
+            print("=== Selector cascade match counts ===")
+            print(f"  SWAP_CONTAINER_PR70 (historical, broken)     → {swap_pr70_count}")
+            print(f"  FRAME_SLOTS_STRUCT  (post-#63 primary)        → {struct_count}")
+            print(f"  FRAME_SLOT_BY_LABEL (Start text, EN-only)     → {text_start}")
+            print(f"  FRAME_SLOT_BY_LABEL (End text, EN-only)       → {text_end}")
+            print()
 
-        # If Tier 1 found at least 2 dialog-divs inside the swap_horiz
-        # container we have evidence #63 is closed on this locale.
-        verdict = "PASS" if struct_count >= 2 else "FAIL"
-        print(f"Tier 1 (structural) verdict for issue #63 on locale {locale!r}: {verdict}")
+            # If Tier 1 found at least 2 dialog-divs inside the swap_horiz
+            # container we have evidence #63 is closed on this locale.
+            verdict = "PASS" if struct_count >= 2 else "FAIL"
+            print(f"Tier 1 (structural) verdict for issue #63 on locale {locale!r}: {verdict}")
 
-        # Dump the matched element outerHTML for forensic value.
-        struct_html: list[str] = []
-        if struct_count > 0:
-            struct_html = await page.locator(FRAME_SLOTS_STRUCT).evaluate_all(
-                "els => els.map(el => el.outerHTML)"
+            # Dump the matched element outerHTML for forensic value.
+            struct_html: list[str] = []
+            if struct_count > 0:
+                struct_html = await page.locator(FRAME_SLOTS_STRUCT).evaluate_all(
+                    "els => els.map(el => el.outerHTML)"
+                )
+
+            # Forensic dump: when the cascade misses, the slots may still exist with
+            # a different anchor (different icon ligature or different DOM shape).
+            # Pull every aria-haspopup='dialog' div + every google-symbols ligature
+            # near the prompt-textbox area so we can discover the real anchor.
+            # Filter to elements inside the bottom prompt-bar region (last 500px of
+            # the viewport height) to avoid 100s of unrelated matches.
+            forensics = await page.evaluate(
+                """() => {
+                    const vh = window.innerHeight;
+                    const inPromptArea = (el) => {
+                        const r = el.getBoundingClientRect();
+                        return r.top > vh * 0.55 && r.top < vh && r.left < window.innerWidth;
+                    };
+                    const haspopups = [...document.querySelectorAll("div[aria-haspopup='dialog']")]
+                        .filter(inPromptArea)
+                        .map(el => ({
+                            outerHTML: el.outerHTML.slice(0, 600),
+                            text: (el.innerText || '').trim().slice(0, 100),
+                            rect: (() => { const r = el.getBoundingClientRect(); return {x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height)}; })(),
+                        }));
+                    const ligatures = [...document.querySelectorAll('i.google-symbols, i.material-symbols-outlined, i.material-icons')]
+                        .filter(inPromptArea)
+                        .map(el => ({
+                            text: (el.innerText || '').trim(),
+                            outerHTML: el.outerHTML.slice(0, 300),
+                            parent: el.parentElement ? el.parentElement.tagName + (el.parentElement.id ? '#' + el.parentElement.id : '') : null,
+                        }));
+                    return {haspopups, ligatures};
+                }"""
             )
 
-        # Forensic dump: when the cascade misses, the slots may still exist with
-        # a different anchor (different icon ligature or different DOM shape).
-        # Pull every aria-haspopup='dialog' div + every google-symbols ligature
-        # near the prompt-textbox area so we can discover the real anchor.
-        # Filter to elements inside the bottom prompt-bar region (last 500px of
-        # the viewport height) to avoid 100s of unrelated matches.
-        forensics = await page.evaluate(
-            """() => {
-                const vh = window.innerHeight;
-                const inPromptArea = (el) => {
-                    const r = el.getBoundingClientRect();
-                    return r.top > vh * 0.55 && r.top < vh && r.left < window.innerWidth;
-                };
-                const haspopups = [...document.querySelectorAll("div[aria-haspopup='dialog']")]
-                    .filter(inPromptArea)
-                    .map(el => ({
-                        outerHTML: el.outerHTML.slice(0, 600),
-                        text: (el.innerText || '').trim().slice(0, 100),
-                        rect: (() => { const r = el.getBoundingClientRect(); return {x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height)}; })(),
-                    }));
-                const ligatures = [...document.querySelectorAll('i.google-symbols, i.material-symbols-outlined, i.material-icons')]
-                    .filter(inPromptArea)
-                    .map(el => ({
-                        text: (el.innerText || '').trim(),
-                        outerHTML: el.outerHTML.slice(0, 300),
-                        parent: el.parentElement ? el.parentElement.tagName + (el.parentElement.id ? '#' + el.parentElement.id : '') : null,
-                    }));
-                return {haspopups, ligatures};
-            }"""
-        )
+            print("\n=== Forensic DOM dump (bottom 45% of viewport) ===")
+            print(f"  div[aria-haspopup='dialog'] near prompt: {len(forensics['haspopups'])}")
+            for h in forensics["haspopups"]:
+                print(f"    text={h['text']!r}  rect={h['rect']}")
+            print(
+                f"  google-symbols / material-symbols ligatures near prompt: {len(forensics['ligatures'])}"
+            )
+            for lig in forensics["ligatures"]:
+                print(f"    ligature={lig['text']!r}  parent={lig['parent']}")
 
-        print("\n=== Forensic DOM dump (bottom 45% of viewport) ===")
-        print(f"  div[aria-haspopup='dialog'] near prompt: {len(forensics['haspopups'])}")
-        for h in forensics["haspopups"]:
-            print(f"    text={h['text']!r}  rect={h['rect']}")
-        print(
-            f"  google-symbols / material-symbols ligatures near prompt: {len(forensics['ligatures'])}"
-        )
-        for lig in forensics["ligatures"]:
-            print(f"    ligature={lig['text']!r}  parent={lig['parent']}")
-
-        evidence = {
-            "profile_name": profile_name,
-            "locale": locale,
-            "swap_container_pr70_count": swap_pr70_count,
-            "frame_slots_struct_count": struct_count,
-            "frame_slot_by_label_start_count": text_start,
-            "frame_slot_by_label_end_count": text_end,
-            "verdict": verdict,
-            "frame_slots_struct_outer_html": struct_html,
-            "forensics_haspopup_dialog": forensics["haspopups"],
-            "forensics_ligatures": forensics["ligatures"],
-        }
-        (out_dir / "frame_slots_evidence.json").write_text(
-            json.dumps(evidence, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        await page.screenshot(path=str(out_dir / "video_editor.png"), full_page=True)
-        print(f"Evidence: {out_dir / 'frame_slots_evidence.json'}")
-        print(f"Screenshot: {out_dir / 'video_editor.png'}")
-        return 0 if verdict == "PASS" else 2
+            evidence = {
+                "profile_name": profile_name,
+                "locale": locale,
+                "swap_container_pr70_count": swap_pr70_count,
+                "frame_slots_struct_count": struct_count,
+                "frame_slot_by_label_start_count": text_start,
+                "frame_slot_by_label_end_count": text_end,
+                "verdict": verdict,
+                "frame_slots_struct_outer_html": struct_html,
+                "forensics_haspopup_dialog": forensics["haspopups"],
+                "forensics_ligatures": forensics["ligatures"],
+            }
+            (out_dir / "frame_slots_evidence.json").write_text(
+                json.dumps(evidence, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            await page.screenshot(path=str(out_dir / "video_editor.png"), full_page=True)
+            print(f"Evidence: {out_dir / 'frame_slots_evidence.json'}")
+            print(f"Screenshot: {out_dir / 'video_editor.png'}")
+            return 0 if verdict == "PASS" else 2
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> None:

--- a/scripts/dev/capture_i2v_frame_slots_dom.py
+++ b/scripts/dev/capture_i2v_frame_slots_dom.py
@@ -176,10 +176,8 @@ async def capture(profile_name: str, out_dir: Path) -> int:
             print(f"Screenshot: {out_dir / 'video_editor.png'}")
             return 0 if verdict == "PASS" else 2
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/scripts/dev/capture_i2v_intercept_submit.py
+++ b/scripts/dev/capture_i2v_intercept_submit.py
@@ -100,123 +100,130 @@ async def capture(
         if transport is None:
             sys.exit("FlowApiClient.transport is None")
         page = await client._checkout_page()
+        try:
 
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
-        await VideoGenerationMixin._wait_video_editor_ready(page)
-        # Select model BEFORE attaching frames — mirrors _generate_video_locked
-        # order. Critical for the issue #125 model+i2v compatibility probe:
-        # omni-flash silently drops refs at submit, veo-3.1-* preserves them.
-        if model_alias:
-            chosen = VideoModel.from_cli(model_alias)
-            if chosen is None:
-                sys.exit(f"Unknown CLI model alias: {model_alias!r}")
-            evidence["selected_model"] = model_alias
-            print(f"Selecting model {model_alias!r} ({chosen.value})...")
-            await VideoGenerationMixin._select_video_model(page, chosen, out_dir=None)
-        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
-        await page.keyboard.press("Escape")
-        await page.wait_for_timeout(600)
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+            await VideoGenerationMixin._wait_video_editor_ready(page)
+            # Select model BEFORE attaching frames — mirrors _generate_video_locked
+            # order. Critical for the issue #125 model+i2v compatibility probe:
+            # omni-flash silently drops refs at submit, veo-3.1-* preserves them.
+            if model_alias:
+                chosen = VideoModel.from_cli(model_alias)
+                if chosen is None:
+                    sys.exit(f"Unknown CLI model alias: {model_alias!r}")
+                evidence["selected_model"] = model_alias
+                print(f"Selecting model {model_alias!r} ({chosen.value})...")
+                await VideoGenerationMixin._select_video_model(page, chosen, out_dir=None)
+            await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(600)
 
-        async def type_prompt() -> None:
-            print("Typing prompt...")
-            boxes = page.locator(PROMPT_INPUT_SELECTOR)
-            box = boxes.first
-            await box.click()
-            await page.keyboard.press("Control+A")
-            await page.keyboard.press("Delete")
-            await page.keyboard.insert_text(prompt_text)
-            await page.wait_for_timeout(500)
+            async def type_prompt() -> None:
+                print("Typing prompt...")
+                boxes = page.locator(PROMPT_INPUT_SELECTOR)
+                box = boxes.first
+                await box.click()
+                await page.keyboard.press("Control+A")
+                await page.keyboard.press("Delete")
+                await page.keyboard.insert_text(prompt_text)
+                await page.wait_for_timeout(500)
 
-        async def bind_frames() -> None:
-            print("Attaching Start...")
-            await VideoGenerationMixin._attach_frame(page, 0, "Start", probe_image, out_dir=out_dir)
-            if start_only:
-                print("Skipping End (start-only mode).")
-                return
-            print("Attaching End...")
-            await VideoGenerationMixin._attach_frame(page, 1, "End", probe_image, out_dir=out_dir)
+            async def bind_frames() -> None:
+                print("Attaching Start...")
+                await VideoGenerationMixin._attach_frame(page, 0, "Start", probe_image, out_dir=out_dir)
+                if start_only:
+                    print("Skipping End (start-only mode).")
+                    return
+                print("Attaching End...")
+                await VideoGenerationMixin._attach_frame(page, 1, "End", probe_image, out_dir=out_dir)
 
-        # Sequence selection — this is what the probe is testing.
-        if reorder:
-            await type_prompt()
-            await bind_frames()
-        else:
-            await bind_frames()
-            await type_prompt()
-
-        evidence["slot_count_at_t_pre_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        await page.screenshot(path=str(out_dir / "01-pre-submit.png"))
-
-        # Install network-layer interceptor + request observer.
-        captured_requests: list[dict[str, Any]] = []
-
-        async def on_request(req: Any) -> None:
-            if "batchAsync" in req.url or "video:batch" in req.url:
-                summary = _summarize_request_image_inputs(req)
-                captured_requests.append(
-                    {
-                        "url": req.url,
-                        "method": req.method,
-                        "image_inputs": summary,
-                    }
-                )
-                print(f"  REQUEST observed: {req.url}")
-
-        async def on_route(route: Any) -> None:
-            # Block the request from reaching Veo so no credit consumed.
-            url = route.request.url
-            if "video:batchAsync" in url:
-                print(f"  ABORTING: {url}")
-                await route.abort()
+            # Sequence selection — this is what the probe is testing.
+            if reorder:
+                await type_prompt()
+                await bind_frames()
             else:
-                await route.continue_()
+                await bind_frames()
+                await type_prompt()
 
-        await page.route(ENDPOINT_GLOB, on_route)
-        page.on("request", on_request)
+            evidence["slot_count_at_t_pre_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            await page.screenshot(path=str(out_dir / "01-pre-submit.png"))
 
-        # Now click submit via the production selector cascade.
-        print("Clicking submit (XHR will be aborted before reaching Veo)...")
-        for sel in SUBMIT_BUTTON_SELECTORS:
-            try:
-                btn = page.locator(sel).first
-                await btn.wait_for(state="visible", timeout=2_000)
-                if await btn.is_disabled():
-                    print(f"  submit '{sel}' still disabled, skipping")
-                    continue
-                await btn.click()
-                print(f"  clicked via {sel}")
-                break
-            except Exception as e:
-                print(f"  miss {sel}: {e}")
+            # Install network-layer interceptor + request observer.
+            captured_requests: list[dict[str, Any]] = []
 
-        # Give the browser ~3s to fire the request before we close.
-        await asyncio.sleep(3)
-        await page.screenshot(path=str(out_dir / "02-post-submit-attempt.png"))
+            async def on_request(req: Any) -> None:
+                if "batchAsync" in req.url or "video:batch" in req.url:
+                    summary = _summarize_request_image_inputs(req)
+                    captured_requests.append(
+                        {
+                            "url": req.url,
+                            "method": req.method,
+                            "image_inputs": summary,
+                        }
+                    )
+                    print(f"  REQUEST observed: {req.url}")
 
-        evidence["slot_count_at_t_post_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        evidence["captured_requests"] = captured_requests
+            async def on_route(route: Any) -> None:
+                # Block the request from reaching Veo so no credit consumed.
+                url = route.request.url
+                if "video:batchAsync" in url:
+                    print(f"  ABORTING: {url}")
+                    await route.abort()
+                else:
+                    await route.continue_()
 
-        (out_dir / "evidence.json").write_text(
-            json.dumps(evidence, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+            await page.route(ENDPOINT_GLOB, on_route)
+            page.on("request", on_request)
 
-        print("\n=== summary ===")
-        print(f"Pre-submit slot count:  {evidence['slot_count_at_t_pre_submit']}  (expect 0)")
-        print(f"Post-submit slot count: {evidence['slot_count_at_t_post_submit']}")
-        print(f"Captured generate requests: {len(captured_requests)}")
-        for r in captured_requests:
-            ep = r["url"].split("/")[-1].split("?")[0]
-            ii = r["image_inputs"]
-            print(
-                f"  {ep}  startImage={ii.get('startImage')!r}  endImage={ii.get('endImage')!r}  refs={ii.get('referenceCount')}"
+            # Now click submit via the production selector cascade.
+            print("Clicking submit (XHR will be aborted before reaching Veo)...")
+            for sel in SUBMIT_BUTTON_SELECTORS:
+                try:
+                    btn = page.locator(sel).first
+                    await btn.wait_for(state="visible", timeout=2_000)
+                    if await btn.is_disabled():
+                        print(f"  submit '{sel}' still disabled, skipping")
+                        continue
+                    await btn.click()
+                    print(f"  clicked via {sel}")
+                    break
+                except Exception as e:
+                    print(f"  miss {sel}: {e}")
+
+            # Give the browser ~3s to fire the request before we close.
+            await asyncio.sleep(3)
+            await page.screenshot(path=str(out_dir / "02-post-submit-attempt.png"))
+
+            evidence["slot_count_at_t_post_submit"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            evidence["captured_requests"] = captured_requests
+
+            (out_dir / "evidence.json").write_text(
+                json.dumps(evidence, indent=2, ensure_ascii=False),
+                encoding="utf-8",
             )
 
-        print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
-        print("All requests to Veo were aborted at the browser — zero credits.")
-        return 0
+            print("\n=== summary ===")
+            print(f"Pre-submit slot count:  {evidence['slot_count_at_t_pre_submit']}  (expect 0)")
+            print(f"Post-submit slot count: {evidence['slot_count_at_t_post_submit']}")
+            print(f"Captured generate requests: {len(captured_requests)}")
+            for r in captured_requests:
+                ep = r["url"].split("/")[-1].split("?")[0]
+                ii = r["image_inputs"]
+                print(
+                    f"  {ep}  startImage={ii.get('startImage')!r}  endImage={ii.get('endImage')!r}  refs={ii.get('referenceCount')}"
+                )
+
+            print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
+            print("All requests to Veo were aborted at the browser — zero credits.")
+            return 0
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> int:

--- a/scripts/dev/capture_i2v_intercept_submit.py
+++ b/scripts/dev/capture_i2v_intercept_submit.py
@@ -219,10 +219,8 @@ async def capture(
             print("All requests to Veo were aborted at the browser — zero credits.")
             return 0
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/scripts/dev/capture_i2v_model_select_repro.py
+++ b/scripts/dev/capture_i2v_model_select_repro.py
@@ -54,41 +54,48 @@ async def capture(profile_name: str, model_alias: str, settle_ms: int) -> int:
         if transport is None:
             sys.exit("FlowApiClient.transport is None")
         page = await client._checkout_page()
-
-        # PRODUCTION order (mirrors _generate_video_locked exactly).
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        await VideoGenerationMixin._wait_video_editor_ready(page)
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
-
-        if settle_ms > 0:
-            print(f"Inserting {settle_ms}ms settle between switch and select...")
-            await page.wait_for_timeout(settle_ms)
-
-        # Enumerate menu items right before select (diagnostic).
         try:
-            items = await page.locator("[role='menuitem']").all_inner_texts()
-            print(f"menuitems visible before select ({len(items)}): {[t[:30] for t in items][:12]}")
-        except Exception as e:
-            print(f"menuitem enumeration failed: {e}")
 
-        # Try selection. _select_video_model logs model_selected OR
-        # model_option_not_found — both visible on stderr.
-        try:
-            await VideoGenerationMixin._select_video_model(
-                page, model, out_dir=None, required=False
-            )
-        except Exception as e:  # noqa: BLE001
-            print(f"_select_video_model raised: {e}")
+            # PRODUCTION order (mirrors _generate_video_locked exactly).
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            await VideoGenerationMixin._wait_video_editor_ready(page)
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
 
-        # Report what the model picker now shows (its label reflects the choice).
-        try:
-            items_after = await page.locator("[role='menuitem']").all_inner_texts()
-            print(f"menuitems after select attempt ({len(items_after)})")
-        except Exception:
-            pass
-        print("Done (no Generate — zero credits).")
-        return 0
+            if settle_ms > 0:
+                print(f"Inserting {settle_ms}ms settle between switch and select...")
+                await page.wait_for_timeout(settle_ms)
+
+            # Enumerate menu items right before select (diagnostic).
+            try:
+                items = await page.locator("[role='menuitem']").all_inner_texts()
+                print(f"menuitems visible before select ({len(items)}): {[t[:30] for t in items][:12]}")
+            except Exception as e:
+                print(f"menuitem enumeration failed: {e}")
+
+            # Try selection. _select_video_model logs model_selected OR
+            # model_option_not_found — both visible on stderr.
+            try:
+                await VideoGenerationMixin._select_video_model(
+                    page, model, out_dir=None, required=False
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"_select_video_model raised: {e}")
+
+            # Report what the model picker now shows (its label reflects the choice).
+            try:
+                items_after = await page.locator("[role='menuitem']").all_inner_texts()
+                print(f"menuitems after select attempt ({len(items_after)})")
+            except Exception:
+                pass
+            print("Done (no Generate — zero credits).")
+            return 0
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> int:

--- a/scripts/dev/capture_i2v_model_select_repro.py
+++ b/scripts/dev/capture_i2v_model_select_repro.py
@@ -91,10 +91,8 @@ async def capture(profile_name: str, model_alias: str, settle_ms: int) -> int:
             print("Done (no Generate — zero credits).")
             return 0
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/scripts/dev/capture_i2v_post_bind_state.py
+++ b/scripts/dev/capture_i2v_post_bind_state.py
@@ -270,10 +270,8 @@ async def capture(profile_name: str, probe_image: Path, out_dir: Path) -> int:
             print("Closing browser (no Generate clicked — zero credits).")
             return 0
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/scripts/dev/capture_i2v_post_bind_state.py
+++ b/scripts/dev/capture_i2v_post_bind_state.py
@@ -124,150 +124,157 @@ async def capture(profile_name: str, probe_image: Path, out_dir: Path) -> int:
         if transport is None:
             sys.exit("FlowApiClient.transport is None")
         page = await client._checkout_page()
-        print("Editor ready.")
+        try:
+            print("Editor ready.")
 
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
-        await VideoGenerationMixin._wait_video_editor_ready(page)
-        await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
-        await page.keyboard.press("Escape")
-        await page.wait_for_timeout(600)
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)
+            await VideoGenerationMixin._wait_video_editor_ready(page)
+            await VideoGenerationMixin._switch_video_sub_mode(page, "frames", out_dir=None)
+            await page.keyboard.press("Escape")
+            await page.wait_for_timeout(600)
 
-        # T0 — empty editor, before any slot interaction.
-        evidence["t0_slot_count"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        await page.screenshot(path=str(out_dir / "01-t0-empty.png"))
-        print(f"t0 slot count (expect 2): {evidence['t0_slot_count']}")
+            # T0 — empty editor, before any slot interaction.
+            evidence["t0_slot_count"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            await page.screenshot(path=str(out_dir / "01-t0-empty.png"))
+            print(f"t0 slot count (expect 2): {evidence['t0_slot_count']}")
 
-        # T1 — bind START via the PRODUCTION code path (full attach incl. commit).
-        print("Attaching Start frame via production _attach_frame...")
-        await VideoGenerationMixin._attach_frame(
-            page,
-            0,
-            "Start",
-            probe_image,
-            out_dir=out_dir,
-        )
-        await page.wait_for_timeout(500)
-        evidence["t1_slot_count_after_start_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        await page.screenshot(path=str(out_dir / "02-t1-after-start.png"))
-        print(
-            f"t1 slot count after Start bind (expect 1): {evidence['t1_slot_count_after_start_bind']}"
-        )
-
-        # T2 — bind END via the PRODUCTION code path.
-        print("Attaching End frame via production _attach_frame...")
-        await VideoGenerationMixin._attach_frame(
-            page,
-            1,
-            "End",
-            probe_image,
-            out_dir=out_dir,
-        )
-        await page.wait_for_timeout(500)
-        evidence["t2_slot_count_after_end_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        await page.screenshot(path=str(out_dir / "03-t2-after-end.png"))
-        print(
-            f"t2 slot count after End bind  (expect 0): {evidence['t2_slot_count_after_end_bind']}"
-        )
-
-        # T3 — both frames bound, prompt textbox in focus. Enumerate every
-        # arrow_forward submit candidate. Production picks .first.
-        print("Enumerating arrow_forward submit candidates...")
-        slot_state: dict = {}
-        await _enumerate_arrow_forward(page, slot_state)
-        evidence["t3_submit_candidates"] = slot_state
-        await page.screenshot(path=str(out_dir / "04-t3-submit-candidates.png"))
-        print(f"arrow_forward buttons found in editor: {slot_state['arrow_forward_count']}")
-        for b in slot_state["arrow_forward_buttons"]:
-            vis = "visible" if b["visible"] else "hidden"
-            dis = " disabled" if b["disabled"] else ""
+            # T1 — bind START via the PRODUCTION code path (full attach incl. commit).
+            print("Attaching Start frame via production _attach_frame...")
+            await VideoGenerationMixin._attach_frame(
+                page,
+                0,
+                "Start",
+                probe_image,
+                out_dir=out_dir,
+            )
+            await page.wait_for_timeout(500)
+            evidence["t1_slot_count_after_start_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            await page.screenshot(path=str(out_dir / "02-t1-after-start.png"))
             print(
-                f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+                f"t1 slot count after Start bind (expect 1): {evidence['t1_slot_count_after_start_bind']}"
             )
 
-        # T4 — enumerate all prompt textboxes (production picks .first).
-        print("Enumerating Slate textbox candidates...")
-        boxes = page.locator(PROMPT_INPUT_SELECTOR)
-        nbox = await boxes.count()
-        textboxes = []
-        for i in range(nbox):
-            b = boxes.nth(i)
-            try:
-                visible = await b.is_visible()
-            except Exception:
-                visible = False
-            cls = (await b.get_attribute("class") or "")[:80]
-            bbox = await b.bounding_box()
-            parent_classes: list[str] = []
-            try:
-                cur = b
-                for _ in range(3):
-                    parent = cur.locator("xpath=..")
-                    parent_classes.append((await parent.get_attribute("class") or "")[:80])
-                    cur = parent
-            except Exception:
-                pass
-            textboxes.append(
-                {
-                    "idx": i,
-                    "visible": visible,
-                    "class_prefix": cls,
-                    "bbox_y": int(bbox["y"]) if bbox else None,
-                    "bbox_x": int(bbox["x"]) if bbox else None,
-                    "parent_classes": parent_classes,
-                }
+            # T2 — bind END via the PRODUCTION code path.
+            print("Attaching End frame via production _attach_frame...")
+            await VideoGenerationMixin._attach_frame(
+                page,
+                1,
+                "End",
+                probe_image,
+                out_dir=out_dir,
             )
-        evidence["t4_textbox_count"] = nbox
-        evidence["t4_textboxes"] = textboxes
-        print(f"prompt textboxes: {nbox}")
-        for b in textboxes:
-            vis = "visible" if b["visible"] else "hidden"
+            await page.wait_for_timeout(500)
+            evidence["t2_slot_count_after_end_bind"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            await page.screenshot(path=str(out_dir / "03-t2-after-end.png"))
             print(
-                f"  idx={b['idx']} {vis} bbox=({b['bbox_x']},{b['bbox_y']}) class={b['class_prefix']!r}"
+                f"t2 slot count after End bind  (expect 0): {evidence['t2_slot_count_after_end_bind']}"
             )
 
-        # T5 — type a non-paid prompt via production helper sequence, then
-        # measure slot state. Stop BEFORE the submit click — no Generate.
-        print("Typing test prompt into .first textbox (production sequence, no submit)...")
-        first_box = boxes.first
-        await first_box.click()
-        await page.keyboard.press("Control+A")
-        await page.keyboard.press("Delete")
-        await page.keyboard.insert_text("probe test prompt — do not submit")
-        await page.wait_for_timeout(500)
-        evidence["t5_slot_count_after_typing"] = await page.locator(FRAME_SLOTS_STRUCT).count()
-        post_typing: dict = {}
-        await _enumerate_arrow_forward(page, post_typing)
-        evidence["t5_submit_candidates_after_typing"] = post_typing
-        await page.screenshot(path=str(out_dir / "05-t5-after-typing.png"))
-        print(f"t5 slot count after typing (expect 0): {evidence['t5_slot_count_after_typing']}")
-        print(f"t5 arrow_forward count: {post_typing['arrow_forward_count']}")
-        for b in post_typing["arrow_forward_buttons"]:
-            vis = "visible" if b["visible"] else "hidden"
-            dis = " DISABLED" if b["disabled"] else " enabled"
+            # T3 — both frames bound, prompt textbox in focus. Enumerate every
+            # arrow_forward submit candidate. Production picks .first.
+            print("Enumerating arrow_forward submit candidates...")
+            slot_state: dict = {}
+            await _enumerate_arrow_forward(page, slot_state)
+            evidence["t3_submit_candidates"] = slot_state
+            await page.screenshot(path=str(out_dir / "04-t3-submit-candidates.png"))
+            print(f"arrow_forward buttons found in editor: {slot_state['arrow_forward_count']}")
+            for b in slot_state["arrow_forward_buttons"]:
+                vis = "visible" if b["visible"] else "hidden"
+                dis = " disabled" if b["disabled"] else ""
+                print(
+                    f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+                )
+
+            # T4 — enumerate all prompt textboxes (production picks .first).
+            print("Enumerating Slate textbox candidates...")
+            boxes = page.locator(PROMPT_INPUT_SELECTOR)
+            nbox = await boxes.count()
+            textboxes = []
+            for i in range(nbox):
+                b = boxes.nth(i)
+                try:
+                    visible = await b.is_visible()
+                except Exception:
+                    visible = False
+                cls = (await b.get_attribute("class") or "")[:80]
+                bbox = await b.bounding_box()
+                parent_classes: list[str] = []
+                try:
+                    cur = b
+                    for _ in range(3):
+                        parent = cur.locator("xpath=..")
+                        parent_classes.append((await parent.get_attribute("class") or "")[:80])
+                        cur = parent
+                except Exception:
+                    pass
+                textboxes.append(
+                    {
+                        "idx": i,
+                        "visible": visible,
+                        "class_prefix": cls,
+                        "bbox_y": int(bbox["y"]) if bbox else None,
+                        "bbox_x": int(bbox["x"]) if bbox else None,
+                        "parent_classes": parent_classes,
+                    }
+                )
+            evidence["t4_textbox_count"] = nbox
+            evidence["t4_textboxes"] = textboxes
+            print(f"prompt textboxes: {nbox}")
+            for b in textboxes:
+                vis = "visible" if b["visible"] else "hidden"
+                print(
+                    f"  idx={b['idx']} {vis} bbox=({b['bbox_x']},{b['bbox_y']}) class={b['class_prefix']!r}"
+                )
+
+            # T5 — type a non-paid prompt via production helper sequence, then
+            # measure slot state. Stop BEFORE the submit click — no Generate.
+            print("Typing test prompt into .first textbox (production sequence, no submit)...")
+            first_box = boxes.first
+            await first_box.click()
+            await page.keyboard.press("Control+A")
+            await page.keyboard.press("Delete")
+            await page.keyboard.insert_text("probe test prompt — do not submit")
+            await page.wait_for_timeout(500)
+            evidence["t5_slot_count_after_typing"] = await page.locator(FRAME_SLOTS_STRUCT).count()
+            post_typing: dict = {}
+            await _enumerate_arrow_forward(page, post_typing)
+            evidence["t5_submit_candidates_after_typing"] = post_typing
+            await page.screenshot(path=str(out_dir / "05-t5-after-typing.png"))
+            print(f"t5 slot count after typing (expect 0): {evidence['t5_slot_count_after_typing']}")
+            print(f"t5 arrow_forward count: {post_typing['arrow_forward_count']}")
+            for b in post_typing["arrow_forward_buttons"]:
+                vis = "visible" if b["visible"] else "hidden"
+                dis = " DISABLED" if b["disabled"] else " enabled"
+                print(
+                    f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+                )
+
+            # Write evidence + summary.
+            (out_dir / "evidence.json").write_text(
+                json.dumps(evidence, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            print("\n=== summary ===")
             print(
-                f"  idx={b['idx']} {vis}{dis} bbox=({b['bbox_x']},{b['bbox_y']}) text={b['text']!r}"
+                f"FRAME_SLOTS_STRUCT count transition: "
+                f"{evidence['t0_slot_count']} -> {evidence['t1_slot_count_after_start_bind']} -> "
+                f"{evidence['t2_slot_count_after_end_bind']}"
             )
-
-        # Write evidence + summary.
-        (out_dir / "evidence.json").write_text(
-            json.dumps(evidence, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-        print("\n=== summary ===")
-        print(
-            f"FRAME_SLOTS_STRUCT count transition: "
-            f"{evidence['t0_slot_count']} -> {evidence['t1_slot_count_after_start_bind']} -> "
-            f"{evidence['t2_slot_count_after_end_bind']}"
-        )
-        print(
-            f"arrow_forward submit candidates: {evidence['t3_submit_candidates']['arrow_forward_count']}"
-        )
-        print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
-        print("Closing browser (no Generate clicked — zero credits).")
-        return 0
+            print(
+                f"arrow_forward submit candidates: {evidence['t3_submit_candidates']['arrow_forward_count']}"
+            )
+            print(f"\nDOM evidence: {out_dir / 'evidence.json'}")
+            print("Closing browser (no Generate clicked — zero credits).")
+            return 0
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> int:

--- a/scripts/dev/capture_image_add_media_dom.py
+++ b/scripts/dev/capture_image_add_media_dom.py
@@ -103,9 +103,12 @@ async def capture(profile_name: str, out_html: Path, out_json: Path) -> None:
                     const [radixId, before] = args;
                     const popover = document.getElementById(radixId);
                     const openDialogs = Array.from(document.querySelectorAll(
-                        '[role=\"dialog\"][data-state=\"open\"], [data-state=\"open\"][role=\"dialog\"]'
+                        '[role=\"dialog\"][data-state=\"open\"], '
+                        + '[data-state=\"open\"][role=\"dialog\"]'
                     )).map(el => el.outerHTML.slice(0, 2500));
-                    const fileInputs = Array.from(document.querySelectorAll('input[type=\"file\"]'));
+                    const fileInputs = Array.from(
+                        document.querySelectorAll('input[type=\"file\"]')
+                    );
                     const fileInputsAfter = fileInputs.length;
                     // List buttons / clickable elements inside the popover — the
                     // candidates for the intermediate menu hypothesis.
@@ -171,10 +174,8 @@ async def capture(profile_name: str, out_html: Path, out_json: Path) -> None:
                 "Delta > 0 + no menu items = direct-chooser variant (svasakorn variant)."
             )
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/scripts/dev/capture_image_add_media_dom.py
+++ b/scripts/dev/capture_image_add_media_dom.py
@@ -51,124 +51,131 @@ async def capture(profile_name: str, out_html: Path, out_json: Path) -> None:
         if transport is None:
             sys.exit("FlowApiClient.transport is None")
         page = await client._checkout_page()
-        print("FlowApiClient ready, page checked out.")
+        try:
+            print("FlowApiClient ready, page checked out.")
 
-        # Reuse production sequence: enter editor (clicks +, waits for URL),
-        # dismiss any What's-new/changelog overlay, switch to image mode.
-        print("Entering editor (production _enter_editor)...")
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        print("Dismissing blocking overlays...")
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        print("Switching to image mode (production _switch_to_image_mode)...")
-        await transport._switch_to_image_mode(page, out_dir=None)  # type: ignore[attr-defined]
+            # Reuse production sequence: enter editor (clicks +, waits for URL),
+            # dismiss any What's-new/changelog overlay, switch to image mode.
+            print("Entering editor (production _enter_editor)...")
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            print("Dismissing blocking overlays...")
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            print("Switching to image mode (production _switch_to_image_mode)...")
+            await transport._switch_to_image_mode(page, out_dir=None)  # type: ignore[attr-defined]
 
-        print("Locating editor Add Media button (aria-haspopup=dialog add_2)...")
-        add_media = page.locator(EDITOR_ADD_MEDIA_BUTTON).first
-        await add_media.wait_for(state="visible", timeout=15000)
+            print("Locating editor Add Media button (aria-haspopup=dialog add_2)...")
+            add_media = page.locator(EDITOR_ADD_MEDIA_BUTTON).first
+            await add_media.wait_for(state="visible", timeout=15000)
 
-        button_meta = await add_media.evaluate(
-            """(el) => ({
-                outerHTML: el.outerHTML,
-                ariaHaspopup: el.getAttribute('aria-haspopup'),
-                ariaControls: el.getAttribute('aria-controls'),
-                ariaExpanded: el.getAttribute('aria-expanded'),
-                ariaLabel: el.getAttribute('aria-label'),
-                dataState: el.getAttribute('data-state'),
-                srOnlyText: el.querySelector('[style*=\"sr-only\"], .sr-only')?.innerText,
-            })"""
-        )
-        radix_id = button_meta["ariaControls"]
-        print(f"Add Media button aria-controls: {radix_id}")
-        print(f"Add Media a11y label / sr-only: {button_meta['srOnlyText']}")
-
-        # Count file inputs BEFORE click — for the delta.
-        file_inputs_before = await page.evaluate(
-            "() => document.querySelectorAll('input[type=\"file\"]').length"
-        )
-
-        print("Clicking Add Media (no upload — just to surface the popover)...")
-        await add_media.click()
-        print(f"Waiting for popover #{radix_id} to enter data-state='open'...")
-        await page.wait_for_function(
-            "(id) => document.getElementById(id)?.getAttribute('data-state') === 'open'",
-            arg=radix_id,
-            timeout=10000,
-        )
-        print("Popover open — sampling 1s for late-render content...")
-        await page.wait_for_timeout(1000)
-
-        capture_data = await page.evaluate(
-            """(args) => {
-                const [radixId, before] = args;
-                const popover = document.getElementById(radixId);
-                const openDialogs = Array.from(document.querySelectorAll(
-                    '[role=\"dialog\"][data-state=\"open\"], [data-state=\"open\"][role=\"dialog\"]'
-                )).map(el => el.outerHTML.slice(0, 2500));
-                const fileInputs = Array.from(document.querySelectorAll('input[type=\"file\"]'));
-                const fileInputsAfter = fileInputs.length;
-                // List buttons / clickable elements inside the popover — the
-                // candidates for the intermediate menu hypothesis.
-                const popoverButtons = popover ? Array.from(
-                    popover.querySelectorAll('button, [role=\"menuitem\"], [role=\"option\"]')
-                ).map(el => ({
-                    tag: el.tagName,
-                    role: el.getAttribute('role'),
-                    text: (el.innerText || '').trim().slice(0, 100),
+            button_meta = await add_media.evaluate(
+                """(el) => ({
+                    outerHTML: el.outerHTML,
+                    ariaHaspopup: el.getAttribute('aria-haspopup'),
+                    ariaControls: el.getAttribute('aria-controls'),
+                    ariaExpanded: el.getAttribute('aria-expanded'),
                     ariaLabel: el.getAttribute('aria-label'),
-                    dataTestid: el.getAttribute('data-testid'),
-                })) : [];
-                return {
-                    popoverOuterHTML: popover?.outerHTML ?? null,
-                    popoverDataState: popover?.getAttribute('data-state') ?? null,
-                    popoverRole: popover?.getAttribute('role') ?? null,
-                    popoverInnerTextPreview: (popover?.innerText || '').slice(0, 500),
-                    openDialogsCount: openDialogs.length,
-                    openDialogsOuterHTML: openDialogs,
-                    fileInputsBefore: before,
-                    fileInputsAfter,
-                    fileInputDelta: fileInputsAfter - before,
-                    fileInputAccept: fileInputs.map(i => i.getAttribute('accept')),
-                    popoverButtons,
-                };
-            }""",
-            arg=[radix_id, file_inputs_before],
-        )
+                    dataState: el.getAttribute('data-state'),
+                    srOnlyText: el.querySelector('[style*=\"sr-only\"], .sr-only')?.innerText,
+                })"""
+            )
+            radix_id = button_meta["ariaControls"]
+            print(f"Add Media button aria-controls: {radix_id}")
+            print(f"Add Media a11y label / sr-only: {button_meta['srOnlyText']}")
 
-        out_html.parent.mkdir(parents=True, exist_ok=True)
-        out_html.write_text(
-            f"<!-- Add Media button (ffroliva, en-US, Chrome strategy) -->\n"
-            f"{button_meta['outerHTML'] or ''}\n\n"
-            f"<!-- Popover after click (id={radix_id}, "
-            f"data-state={capture_data['popoverDataState']}, "
-            f"role={capture_data['popoverRole']}) -->\n"
-            f"{capture_data['popoverOuterHTML'] or '(popover element not found)'}\n\n"
-            f"<!-- file inputs delta: {capture_data['fileInputDelta']} "
-            f"(before {capture_data['fileInputsBefore']}, "
-            f"after {capture_data['fileInputsAfter']}) -->\n",
-            encoding="utf-8",
-        )
-        out_json.write_text(
-            json.dumps(
-                {"button_meta": button_meta, "capture": capture_data},
-                indent=2,
-            ),
-            encoding="utf-8",
-        )
-        print(f"\nWrote {out_html} ({out_html.stat().st_size} bytes)")
-        print(f"Wrote {out_json} ({out_json.stat().st_size} bytes)")
-        print(
-            f"\nFile inputs delta: {capture_data['fileInputDelta']} "
-            f"(before={capture_data['fileInputsBefore']}, "
-            f"after={capture_data['fileInputsAfter']})"
-        )
-        print(f"Popover buttons/menuitems: {len(capture_data['popoverButtons'])}")
-        for b in capture_data["popoverButtons"][:10]:
-            print(f"  - [{b['tag']} role={b['role']}] {b['text']!r}")
-        print(
-            "\nInterpretation: file-input delta == 0 + visible buttons in popover "
-            "= intermediate-menu variant (ffroliva hypothesis confirmed). "
-            "Delta > 0 + no menu items = direct-chooser variant (svasakorn variant)."
-        )
+            # Count file inputs BEFORE click — for the delta.
+            file_inputs_before = await page.evaluate(
+                "() => document.querySelectorAll('input[type=\"file\"]').length"
+            )
+
+            print("Clicking Add Media (no upload — just to surface the popover)...")
+            await add_media.click()
+            print(f"Waiting for popover #{radix_id} to enter data-state='open'...")
+            await page.wait_for_function(
+                "(id) => document.getElementById(id)?.getAttribute('data-state') === 'open'",
+                arg=radix_id,
+                timeout=10000,
+            )
+            print("Popover open — sampling 1s for late-render content...")
+            await page.wait_for_timeout(1000)
+
+            capture_data = await page.evaluate(
+                """(args) => {
+                    const [radixId, before] = args;
+                    const popover = document.getElementById(radixId);
+                    const openDialogs = Array.from(document.querySelectorAll(
+                        '[role=\"dialog\"][data-state=\"open\"], [data-state=\"open\"][role=\"dialog\"]'
+                    )).map(el => el.outerHTML.slice(0, 2500));
+                    const fileInputs = Array.from(document.querySelectorAll('input[type=\"file\"]'));
+                    const fileInputsAfter = fileInputs.length;
+                    // List buttons / clickable elements inside the popover — the
+                    // candidates for the intermediate menu hypothesis.
+                    const popoverButtons = popover ? Array.from(
+                        popover.querySelectorAll('button, [role=\"menuitem\"], [role=\"option\"]')
+                    ).map(el => ({
+                        tag: el.tagName,
+                        role: el.getAttribute('role'),
+                        text: (el.innerText || '').trim().slice(0, 100),
+                        ariaLabel: el.getAttribute('aria-label'),
+                        dataTestid: el.getAttribute('data-testid'),
+                    })) : [];
+                    return {
+                        popoverOuterHTML: popover?.outerHTML ?? null,
+                        popoverDataState: popover?.getAttribute('data-state') ?? null,
+                        popoverRole: popover?.getAttribute('role') ?? null,
+                        popoverInnerTextPreview: (popover?.innerText || '').slice(0, 500),
+                        openDialogsCount: openDialogs.length,
+                        openDialogsOuterHTML: openDialogs,
+                        fileInputsBefore: before,
+                        fileInputsAfter,
+                        fileInputDelta: fileInputsAfter - before,
+                        fileInputAccept: fileInputs.map(i => i.getAttribute('accept')),
+                        popoverButtons,
+                    };
+                }""",
+                arg=[radix_id, file_inputs_before],
+            )
+
+            out_html.parent.mkdir(parents=True, exist_ok=True)
+            out_html.write_text(
+                f"<!-- Add Media button (ffroliva, en-US, Chrome strategy) -->\n"
+                f"{button_meta['outerHTML'] or ''}\n\n"
+                f"<!-- Popover after click (id={radix_id}, "
+                f"data-state={capture_data['popoverDataState']}, "
+                f"role={capture_data['popoverRole']}) -->\n"
+                f"{capture_data['popoverOuterHTML'] or '(popover element not found)'}\n\n"
+                f"<!-- file inputs delta: {capture_data['fileInputDelta']} "
+                f"(before {capture_data['fileInputsBefore']}, "
+                f"after {capture_data['fileInputsAfter']}) -->\n",
+                encoding="utf-8",
+            )
+            out_json.write_text(
+                json.dumps(
+                    {"button_meta": button_meta, "capture": capture_data},
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            print(f"\nWrote {out_html} ({out_html.stat().st_size} bytes)")
+            print(f"Wrote {out_json} ({out_json.stat().st_size} bytes)")
+            print(
+                f"\nFile inputs delta: {capture_data['fileInputDelta']} "
+                f"(before={capture_data['fileInputsBefore']}, "
+                f"after={capture_data['fileInputsAfter']})"
+            )
+            print(f"Popover buttons/menuitems: {len(capture_data['popoverButtons'])}")
+            for b in capture_data["popoverButtons"][:10]:
+                print(f"  - [{b['tag']} role={b['role']}] {b['text']!r}")
+            print(
+                "\nInterpretation: file-input delta == 0 + visible buttons in popover "
+                "= intermediate-menu variant (ffroliva hypothesis confirmed). "
+                "Delta > 0 + no menu items = direct-chooser variant (svasakorn variant)."
+            )
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> None:

--- a/scripts/dev/spike_character_prompt_format.py
+++ b/scripts/dev/spike_character_prompt_format.py
@@ -15,14 +15,22 @@ Two runs behind this file:
   rewritten to be carrier-agnostic, to type into the prompt box (the button is disabled
   until then, so an empty-box read measures the wrong state), and to carry a **control**.
 
-The control is the point.  A selector sweep that returns zero everywhere is worthless
-unless something *known present* also resolved in the same run — otherwise "nothing
-matched" and "the probe never reached the editor" are the same observation.  This script
-hard-errors if the editor-ready anchor misses, so a flat zero can never be read as
-absence.
+**Two controls, and both fail AFTER the dump, never before it.**  A selector sweep that
+returns zero everywhere is worthless unless something *known present* also resolved in
+the same run — otherwise "nothing matched" and "the probe never reached the editor" are
+the same observation.  So the script records (1) that the editor-ready anchor resolves
+and (2) that the typed text actually landed in the box — the second is the load-bearing
+one, because a click that hits a consent overlay leaves the box empty, the Format button
+disabled, and produces a false absence indistinguishable from a real measurement.
+
+Both raise, but only from a ``finally`` that has already written the capture and the
+screenshots.  ``skills/spike/SKILL.md``: *never put a guard in front of a probe* — a
+fail-fast that runs before the evidence is collected deletes the evidence that would
+correct it, which is exactly how #701 made a false claim unfalsifiable.
 
 FREE — navigation, a free tRPC ``createEntity``, DOM reads and typing.  Nothing is
-submitted, nothing is generated, no credit and no image quota is spent.
+submitted, nothing is generated, no credit and no image quota is spent, and a scratch
+entity the spike minted is deleted again on the way out.
 
 Usage:
     uv run python scripts/dev/spike_character_prompt_format.py --project <id> [--entity <id>]
@@ -35,14 +43,19 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
-from datetime import UTC, datetime
+import sys
 from pathlib import Path
 from typing import Any, cast
 
 import structlog
 
-from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import default_out_path  # noqa: E402, isort: skip
+
+from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile  # noqa: E402
 from gflow_cli.api.client import FlowApiClient
 from gflow_cli.api.transports.ui_automation import (
     PROMPT_FORMAT_SELECTORS,
@@ -102,20 +115,6 @@ _COMPOSER_BUTTON_DUMP_JS = """(sel) => {
     }));
 }"""
 
-# Does anything sit on top of the element? Present + visible + not clickable is a
-# distinct failure from absent, and only elementFromPoint tells them apart.
-_OCCLUSION_JS = """(sel) => {
-    const el = document.querySelector(sel);
-    if (!el) return null;
-    const r = el.getBoundingClientRect();
-    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
-    return {
-        rect: {x: r.x, y: r.y, w: r.width, h: r.height},
-        hit_tag: hit ? hit.tagName.toLowerCase() : null,
-        hit_is_self_or_child: hit ? (el === hit || el.contains(hit)) : false,
-    };
-}"""
-
 
 async def _sweep(page: Any, phase: str) -> list[dict[str, Any]]:
     """Run the shipped cascade plus an EN-text locator and log every count."""
@@ -139,84 +138,122 @@ async def _sweep(page: Any, phase: str) -> list[dict[str, Any]]:
 async def run_spike(profile_name: str | None, project_id: str, entity_id: str | None) -> None:
     resolved_profile = _resolve_profile(profile_name)
     profile_dir = _make_provider_dir(resolved_profile)
-    stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-    out_dir = Path("./scripts/dev/_spike_out")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    # `default_out_path` anchors on the repo ROOT. Hand-rolling `Path("./scripts/dev/…")`
+    # is CWD-relative, and `.gitignore`'s `scripts/dev/_spike_out/` entry has a mid-pattern
+    # slash, so it anchors to the root too: run from `scripts/dev/` and the capture lands
+    # in an UNIGNORED `scripts/dev/scripts/dev/_spike_out/`, carrying the profile name, the
+    # live URL, entity ids and authenticated `outer_html` ([[git-add-all-sweeps-scratch-files]]).
+    dump = default_out_path(f"char_format_anchor_{Path(resolved_profile).name}")
+    out_dir = dump.parent
+
+    report: dict[str, Any] = {
+        "captured_at": dump.stem,
+        "profile": resolved_profile,
+        "project_id": project_id,
+    }
+    control_error: str | None = None
 
     # FlowApiClient acquires the profile lease before Chrome starts — never launch a
     # browser on a profile this process does not own (skills/spike/SKILL.md).
     async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+        scratch_entity: str | None = None
         if entity_id is None:
             # A character that already has images renders a saved-character view with
             # no prompt composer — and no Format button. The composer (and the button)
             # only exist on an entity with empty slots, which is the state the saga
             # navigates into. create_entity is FREE (tRPC, no credit, no generation).
-            entity_id = await client.create_entity(project_id)
+            entity_id = scratch_entity = await client.create_entity(project_id)
             logger.info("created_scratch_entity", entity_id=entity_id, project_id=project_id)
+        report["entity_id"] = entity_id
 
         transport = cast("UiAutomationTransport", client.transport)
         page = await client._checkout_page()
 
-        await transport._enter_character_editor(
-            page,
-            project_id=project_id,
-            entity_id=entity_id,
-            locale="en-US",
-        )
-        logger.info("page_state", url=page.url, title=await page.title())
-
-        # CONTROL — established before anything is counted. A zero here means the
-        # probe never reached the editor, not that the editor lacks a Format button.
-        control_count = await page.locator(_CONTROL_SELECTOR).count()
-        logger.info("control_check", selector=_CONTROL_SELECTOR, count=control_count)
-        if control_count == 0:
-            msg = (
-                "CONTROL MISSED: no prompt box on "
-                f"{page.url} — this run measures nothing. Do not read its zeros as absence."
+        try:
+            await transport._enter_character_editor(
+                page,
+                project_id=project_id,
+                entity_id=entity_id,
+                locale="en-US",
             )
-            raise RuntimeError(msg)
+            report["url"] = page.url
+            logger.info("page_state", url=page.url, title=await page.title())
 
-        report: dict[str, Any] = {
-            "captured_at": stamp,
-            "profile": resolved_profile,
-            "url": page.url,
-            "project_id": project_id,
-            "entity_id": entity_id,
-            "control_selector": _CONTROL_SELECTOR,
-            "control_count": control_count,
-        }
+            # CONTROL — recorded before anything is counted, but NOT raised on here.
+            # `skills/spike/SKILL.md`: never put a guard in front of a probe. A fail-fast
+            # that runs before the evidence is collected deletes the evidence that would
+            # correct it — that is the #701 failure this whole file exists to prevent. So
+            # the verdict is deferred to the `finally`, after the dump is on disk.
+            control_count = await page.locator(_CONTROL_SELECTOR).count()
+            report["control_selector"] = _CONTROL_SELECTOR
+            report["control_count"] = control_count
+            logger.info("control_check", selector=_CONTROL_SELECTOR, count=control_count)
+            if control_count == 0:
+                control_error = (
+                    f"CONTROL MISSED: no prompt box on {page.url} — this run measures "
+                    "nothing. Do not read its zeros as absence."
+                )
 
-        # Both sides of the transition. The button ships `disabled` on an empty box,
-        # so an empty-box read measures the wrong state — but the empty read is what
-        # proves the enabled state that follows is caused by the typing.
-        report["ligatures_empty"] = await page.evaluate(_LIGATURE_DUMP_JS)
-        report["sweep_empty"] = await _sweep(page, "empty")
-        await page.screenshot(path=str(out_dir / f"char_format_empty_{stamp}.png"))
+            report["sweep_empty"] = await _sweep(page, "empty")
+            await page.screenshot(path=str(out_dir / f"{dump.stem}_empty.png"))
 
-        box = page.locator(_CONTROL_SELECTOR).first
-        await box.click()
-        await page.keyboard.insert_text("a woman with short silver hair, studio portrait")
-        await page.wait_for_timeout(1500)
+            # Both sides of the transition: the button ships `disabled` on an empty box,
+            # so the empty read is what proves the enabled state that follows was caused
+            # by the typing.
+            box = page.locator(_CONTROL_SELECTOR).first
+            await box.click()
+            await page.keyboard.insert_text("a woman with short silver hair, studio portrait")
+            await page.wait_for_timeout(1500)
 
-        report["ligatures_typed"] = await page.evaluate(_LIGATURE_DUMP_JS)
-        report["sweep_typed"] = await _sweep(page, "typed")
-        report["composer_buttons"] = await page.evaluate(
-            _COMPOSER_BUTTON_DUMP_JS, _CONTROL_SELECTOR
-        )
-        report["control_occlusion"] = await page.evaluate(_OCCLUSION_JS, _CONTROL_SELECTOR)
-        await page.screenshot(path=str(out_dir / f"char_format_typed_{stamp}.png"))
+            # SECOND CONTROL, and the load-bearing one. If that click landed on a consent
+            # overlay instead of the box, the text never arrives, the button stays disabled
+            # and `sweep_typed` records a FALSE ABSENCE that looks exactly like a real
+            # measurement. Recorded, and raised on in the `finally` — never before the dump.
+            typed_text = (await box.inner_text()).strip()
+            report["typed_control_text"] = typed_text[:80]
+            logger.info("typed_control", chars=len(typed_text))
+            if not typed_text and control_error is None:
+                control_error = (
+                    "TYPED CONTROL MISSED: the prompt box is still empty after click + "
+                    "insert_text — the enabled/disabled reads below measure nothing."
+                )
 
-        for lig in report["ligatures_typed"]:
-            logger.info("ligature", **{k: ascii(v) for k, v in lig.items()})
+            report["ligatures_typed"] = await page.evaluate(_LIGATURE_DUMP_JS)
+            report["sweep_typed"] = await _sweep(page, "typed")
+            report["composer_buttons"] = await page.evaluate(
+                _COMPOSER_BUTTON_DUMP_JS, _CONTROL_SELECTOR
+            )
+            await page.screenshot(path=str(out_dir / f"{dump.stem}_typed.png"))
 
-        dump = out_dir / f"char_format_anchor_{resolved_profile}_{stamp}.json"
-        dump.write_text(json.dumps(report, indent=2), encoding="utf-8")
-        logger.info(
-            "report_written",
-            path=str(dump),
-            ligatures=len(report["ligatures_typed"]),
-            composer_buttons=len(report["composer_buttons"] or []),
-        )
+            for lig in report["ligatures_typed"]:
+                logger.info("ligature", **{k: ascii(v) for k, v in lig.items()})
+        finally:
+            # Evidence first, verdict second. Whatever DID render is itself the finding.
+            with contextlib.suppress(Exception):
+                await page.screenshot(path=str(out_dir / f"{dump.stem}_final.png"))
+            # Return the page BEFORE any `client.<verb>()` below. The pool holds one
+            # page and `_checkout_page()` waits forever on an empty queue, so a client
+            # call made while this script still holds the page deadlocks in silence —
+            # measured 2026-09-07: the capture and all three screenshots were on disk
+            # and the process never exited, holding the profile lease. `suppress` does
+            # not help; a block is not an exception.
+            # Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
+            dump.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            logger.info(
+                "report_written",
+                path=str(dump),
+                ligatures=len(report.get("ligatures_typed") or []),
+                composer_buttons=len(report.get("composer_buttons") or []),
+            )
+            if scratch_entity is not None:
+                # Delete what the spike created (skills/spike/SKILL.md). FREE.
+                with contextlib.suppress(Exception):
+                    await client.delete_characters(project_id, [scratch_entity])
+                    logger.info("deleted_scratch_entity", entity_id=scratch_entity)
+
+    if control_error is not None:
+        raise RuntimeError(control_error)
 
 
 def main() -> None:

--- a/scripts/dev/spike_character_prompt_format.py
+++ b/scripts/dev/spike_character_prompt_format.py
@@ -66,10 +66,10 @@ logger = structlog.get_logger("spike_character_prompt_format")
 
 # Editor-mounted anchor, both frontends (Slate on labs, ProseMirror on migrated).
 # This is the CONTROL: if it misses, the probe reached no editor and every other
-# count in this run is meaningless.
-_CONTROL_SELECTOR = (
-    'div[role="textbox"][data-slate-editor="true"], div.ProseMirror[contenteditable="true"]'
-)
+# count in this run is meaningless. Borrowed from the transport rather than copied —
+# a probe that asserts a DIFFERENT anchor than the code it is probing measures the
+# copy, not the code, which is the whole failure mode #727 is about.
+_CONTROL_SELECTOR = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
 
 # Every icon ligature in the document, whichever carrier renders it, with the button
 # hosting it. The Format button's ligature is whichever entry sits on a button whose

--- a/scripts/dev/spike_character_prompt_format.py
+++ b/scripts/dev/spike_character_prompt_format.py
@@ -1,20 +1,34 @@
-"""Spike: confirm the ligature behind Flow's character-editor "Format" button (#383).
+"""Spike: read the character-editor "Format" button's anchor off live DOM (#383, #727).
 
-Navigates to a character editor and dumps every ``i.google-symbols`` ligature with
-its host button, so the Format button's locale-stable anchor is read off live DOM
-instead of guessed.
+Dumps every icon-ligature carrier in the character editor with its host button, so the
+Format button's locale-stable anchor is measured instead of guessed — on **either**
+frontend. labs.google renders ligatures in ``<i class="google-symbols">``; the migrated
+``flow.google.com`` Angular frontend renders the same ligatures in ``<mat-icon>``.
 
-Ran 2026-07-27 — confirmed ``personal_recommendations``, and found that the button
-carries no aria-label and ships ``disabled`` on an empty prompt.  See
-``PROMPT_FORMAT_SELECTORS``.  Re-run this whenever the character editor drifts.
+Two runs behind this file:
 
-FREE — navigation + DOM read only.  Nothing is generated, nothing is clicked.
+* **2026-07-27 (labs)** — confirmed the ligature is ``personal_recommendations``, that
+  the button carries no ``aria-label`` (the label is a ``<span>`` child), and that it
+  ships ``disabled`` while the prompt box is empty.  See ``PROMPT_FORMAT_SELECTORS``.
+* **2026-09-07 (migrated, #727)** — ``PROMPT_FORMAT_SELECTORS`` stopped matching and
+  ``character create --format-prompt`` degraded to a silent no-op.  This probe was
+  rewritten to be carrier-agnostic, to type into the prompt box (the button is disabled
+  until then, so an empty-box read measures the wrong state), and to carry a **control**.
+
+The control is the point.  A selector sweep that returns zero everywhere is worthless
+unless something *known present* also resolved in the same run — otherwise "nothing
+matched" and "the probe never reached the editor" are the same observation.  This script
+hard-errors if the editor-ready anchor misses, so a flat zero can never be read as
+absence.
+
+FREE — navigation, a free tRPC ``createEntity``, DOM reads and typing.  Nothing is
+submitted, nothing is generated, no credit and no image quota is spent.
 
 Usage:
     uv run python scripts/dev/spike_character_prompt_format.py --project <id> [--entity <id>]
 
-Without ``--entity`` a fresh (free) scratch entity is minted: a character that
-already has images renders a saved view with no prompt composer and no button.
+Without ``--entity`` a fresh (free) scratch entity is minted: a character that already
+has images renders a saved view with no prompt composer and no button.
 """
 
 from __future__ import annotations
@@ -22,8 +36,9 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import structlog
 
@@ -36,28 +51,100 @@ from gflow_cli.api.transports.ui_automation import (
 
 logger = structlog.get_logger("spike_character_prompt_format")
 
-# Every google-symbols icon in the editor, with the button hosting it. The Format
-# button's ligature is whichever entry sits on a button whose label/tooltip reads
-# "Format" (or its localised equivalent) — that ligature is the durable anchor.
-_LIGATURE_DUMP_JS = """() => Array.from(document.querySelectorAll('i.google-symbols'))
-    .map(i => {
-        const host = i.closest('button,[role=button]');
-        return {
-            ligature: (i.textContent || '').trim(),
-            host_tag: host?.tagName || null,
-            host_label: host?.getAttribute('aria-label') || null,
-            host_title: host?.getAttribute('title') || null,
-            host_text: (host?.innerText || '').trim().slice(0, 60),
-        };
-    })"""
+# Editor-mounted anchor, both frontends (Slate on labs, ProseMirror on migrated).
+# This is the CONTROL: if it misses, the probe reached no editor and every other
+# count in this run is meaningless.
+_CONTROL_SELECTOR = (
+    'div[role="textbox"][data-slate-editor="true"], div.ProseMirror[contenteditable="true"]'
+)
+
+# Every icon ligature in the document, whichever carrier renders it, with the button
+# hosting it. The Format button's ligature is whichever entry sits on a button whose
+# label/tooltip reads "Format" (or its localised equivalent) — that ligature, paired
+# with its carrier tag, is the durable anchor.
+_LIGATURE_DUMP_JS = """() => Array.from(
+    document.querySelectorAll('i.google-symbols, span.google-symbols, mat-icon')
+).map(el => {
+    const host = el.closest('button,[role=button]');
+    return {
+        ligature: (el.textContent || '').trim(),
+        carrier_tag: el.tagName.toLowerCase(),
+        carrier_class: el.getAttribute('class'),
+        host_tag: host ? host.tagName.toLowerCase() : null,
+        host_custom_parent: host && host.parentElement
+            ? host.parentElement.tagName.toLowerCase() : null,
+        host_label: host?.getAttribute('aria-label') || null,
+        host_title: host?.getAttribute('title') || null,
+        host_disabled: host ? (host.hasAttribute('disabled')
+            || host.getAttribute('aria-disabled') === 'true') : null,
+        host_text: (host?.innerText || '').trim().slice(0, 60),
+    };
+})"""
+
+# Every button in the composer subtree (the prompt box's nearest common container),
+# ligature-carrying or not — so a Format control that dropped its icon entirely still
+# shows up. Walks up five levels from the prompt box; that is enough to clear the
+# toolbar row on both frontends without swallowing the whole page.
+_COMPOSER_BUTTON_DUMP_JS = """(sel) => {
+    const box = document.querySelector(sel);
+    if (!box) return null;
+    let root = box;
+    for (let i = 0; i < 5 && root.parentElement; i++) root = root.parentElement;
+    return Array.from(root.querySelectorAll('button,[role=button]')).map(b => ({
+        tag: b.tagName.toLowerCase(),
+        parent_tag: b.parentElement ? b.parentElement.tagName.toLowerCase() : null,
+        aria_label: b.getAttribute('aria-label'),
+        title: b.getAttribute('title'),
+        classes: b.getAttribute('class'),
+        disabled: b.hasAttribute('disabled') || b.getAttribute('aria-disabled') === 'true',
+        text: (b.innerText || '').trim().slice(0, 60),
+        child_tags: Array.from(b.children).map(c => c.tagName.toLowerCase()),
+    }));
+}"""
+
+# Does anything sit on top of the element? Present + visible + not clickable is a
+# distinct failure from absent, and only elementFromPoint tells them apart.
+_OCCLUSION_JS = """(sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+    return {
+        rect: {x: r.x, y: r.y, w: r.width, h: r.height},
+        hit_tag: hit ? hit.tagName.toLowerCase() : null,
+        hit_is_self_or_child: hit ? (el === hit || el.contains(hit)) : false,
+    };
+}"""
+
+
+async def _sweep(page: Any, phase: str) -> list[dict[str, Any]]:
+    """Run the shipped cascade plus an EN-text locator and log every count."""
+    rows: list[dict[str, Any]] = []
+    # The EN-text entry is NOT a candidate selector — it is here only to locate the
+    # button so its structure can be read off. Flow localises that label, so display
+    # text can never be the anchor (locale-invariance rule, AGENTS.md).
+    for sel in (*PROMPT_FORMAT_SELECTORS, 'button:has-text("Format")'):
+        loc = page.locator(sel)
+        count = await loc.count()
+        row: dict[str, Any] = {"phase": phase, "selector": sel, "count": count}
+        if count:
+            row["visible"] = await loc.first.is_visible()
+            row["enabled"] = await loc.first.is_enabled()
+            row["outer_html"] = (await loc.first.evaluate("el => el.outerHTML"))[:400]
+        logger.info("selector_check", **row)
+        rows.append(row)
+    return rows
 
 
 async def run_spike(profile_name: str | None, project_id: str, entity_id: str | None) -> None:
     resolved_profile = _resolve_profile(profile_name)
     profile_dir = _make_provider_dir(resolved_profile)
-    out_dir = Path("./tmp/spike_character_prompt_format")
+    stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    out_dir = Path("./scripts/dev/_spike_out")
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    # FlowApiClient acquires the profile lease before Chrome starts — never launch a
+    # browser on a profile this process does not own (skills/spike/SKILL.md).
     async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
         if entity_id is None:
             # A character that already has images renders a saved-character view with
@@ -69,48 +156,73 @@ async def run_spike(profile_name: str | None, project_id: str, entity_id: str | 
 
         transport = cast("UiAutomationTransport", client.transport)
         page = await client._checkout_page()
-        try:
-            await transport._enter_character_editor(
-                page,
-                project_id=project_id,
-                entity_id=entity_id,
-                locale="en-US",
-            )
-        except Exception as e:
-            # Non-fatal: the readiness gate is not the point of the spike. Dump
-            # whatever DID render — that is itself the finding.
-            logger.warning("editor_not_ready_dumping_anyway", error=str(e))
 
-        await page.wait_for_timeout(3000)
+        await transport._enter_character_editor(
+            page,
+            project_id=project_id,
+            entity_id=entity_id,
+            locale="en-US",
+        )
         logger.info("page_state", url=page.url, title=await page.title())
 
-        # The EN-text entries are NOT candidate selectors — they are here only to
-        # locate the button so its ligature can be read off. Flow localises the
-        # label ([[flow-locale-leak-icon-ligatures]]), so text can never be the anchor.
-        for sel in (*PROMPT_FORMAT_SELECTORS, 'button:has-text("Format")'):
-            loc = page.locator(sel)
-            count = await loc.count()
-            visible = await loc.first.is_visible() if count else False
-            logger.info("selector_check", selector=sel, count=count, visible=visible)
-            if visible:
-                html = await loc.first.evaluate("el => el.outerHTML")
-                logger.info("element_outer_html", selector=sel, html=html[:300])
+        # CONTROL — established before anything is counted. A zero here means the
+        # probe never reached the editor, not that the editor lacks a Format button.
+        control_count = await page.locator(_CONTROL_SELECTOR).count()
+        logger.info("control_check", selector=_CONTROL_SELECTOR, count=control_count)
+        if control_count == 0:
+            msg = (
+                "CONTROL MISSED: no prompt box on "
+                f"{page.url} — this run measures nothing. Do not read its zeros as absence."
+            )
+            raise RuntimeError(msg)
 
-        ligatures = await page.evaluate(_LIGATURE_DUMP_JS)
-        logger.info("google_symbols_ligatures", count=len(ligatures))
-        dump = out_dir / "ligatures.json"
-        dump.write_text(json.dumps(ligatures, indent=2), encoding="utf-8")
-        logger.info("ligatures_written", path=str(dump))
-        for lig in ligatures:
+        report: dict[str, Any] = {
+            "captured_at": stamp,
+            "profile": resolved_profile,
+            "url": page.url,
+            "project_id": project_id,
+            "entity_id": entity_id,
+            "control_selector": _CONTROL_SELECTOR,
+            "control_count": control_count,
+        }
+
+        # Both sides of the transition. The button ships `disabled` on an empty box,
+        # so an empty-box read measures the wrong state — but the empty read is what
+        # proves the enabled state that follows is caused by the typing.
+        report["ligatures_empty"] = await page.evaluate(_LIGATURE_DUMP_JS)
+        report["sweep_empty"] = await _sweep(page, "empty")
+        await page.screenshot(path=str(out_dir / f"char_format_empty_{stamp}.png"))
+
+        box = page.locator(_CONTROL_SELECTOR).first
+        await box.click()
+        await page.keyboard.insert_text("a woman with short silver hair, studio portrait")
+        await page.wait_for_timeout(1500)
+
+        report["ligatures_typed"] = await page.evaluate(_LIGATURE_DUMP_JS)
+        report["sweep_typed"] = await _sweep(page, "typed")
+        report["composer_buttons"] = await page.evaluate(
+            _COMPOSER_BUTTON_DUMP_JS, _CONTROL_SELECTOR
+        )
+        report["control_occlusion"] = await page.evaluate(_OCCLUSION_JS, _CONTROL_SELECTOR)
+        await page.screenshot(path=str(out_dir / f"char_format_typed_{stamp}.png"))
+
+        for lig in report["ligatures_typed"]:
             logger.info("ligature", **{k: ascii(v) for k, v in lig.items()})
 
-        await page.screenshot(path=str(out_dir / "character_editor.png"))
+        dump = out_dir / f"char_format_anchor_{resolved_profile}_{stamp}.json"
+        dump.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        logger.info(
+            "report_written",
+            path=str(dump),
+            ligatures=len(report["ligatures_typed"]),
+            composer_buttons=len(report["composer_buttons"] or []),
+        )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Spike: find the character-editor Format button")
     parser.add_argument("--project", required=True, help="Flow project id")
-    parser.add_argument("--entity", default=None, help="Character entity id (default: first)")
+    parser.add_argument("--entity", default=None, help="Character entity id (default: fresh)")
     parser.add_argument("--profile", default=None, help="Profile for the live Playwright session")
     args = parser.parse_args()
 

--- a/scripts/dev/spike_format_prompt_effect.py
+++ b/scripts/dev/spike_format_prompt_effect.py
@@ -55,9 +55,8 @@ from gflow_cli.api.transports.ui_automation import (  # noqa: E402
 
 logger = structlog.get_logger("spike_format_prompt_effect")
 
-_CONTROL_SELECTOR = (
-    'div[role="textbox"][data-slate-editor="true"], div.ProseMirror[contenteditable="true"]'
-)
+# Borrowed from the transport, never copied — see spike_character_prompt_format.py.
+_CONTROL_SELECTOR = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
 
 # Deliberately terse and unpolished — a rewrite has something to do, so a no-change
 # result cannot be explained away as "the prompt was already well formed".
@@ -104,10 +103,13 @@ async def run_spike(profile_name: str | None, project_id: str, entity_id: str | 
             requests: list[dict[str, Any]] = []
             t_zero = time.monotonic()
 
+            # One clock for requests AND polls, so the two timelines are directly
+            # comparable — the gap between them is the finding.
+            def _elapsed() -> float:
+                return round(time.monotonic() - t_zero, 3)
+
             def _on_request(req: Any) -> None:
-                requests.append(
-                    {"t": round(time.monotonic() - t_zero, 3), "method": req.method, "url": req.url}
-                )
+                requests.append({"t": _elapsed(), "method": req.method, "url": req.url})
 
             page.on("request", _on_request)
 
@@ -147,12 +149,13 @@ async def run_spike(profile_name: str | None, project_id: str, entity_id: str | 
                     "again. This run measures nothing about the rewrite."
                 )
 
-            t_click = time.monotonic()
+            click_at = _elapsed()
+            report["click_at_s"] = click_at
             timeline: list[dict[str, Any]] = []
             changed_at: float | None = None
-            while time.monotonic() - t_click < _POLL_WINDOW_S:
+            while _elapsed() - click_at < _POLL_WINDOW_S:
                 now = (await box.inner_text()).strip()
-                elapsed = round(time.monotonic() - t_click, 3)
+                elapsed = round(_elapsed() - click_at, 3)
                 if not timeline or timeline[-1]["text"] != now:
                     timeline.append({"t": elapsed, "text": now, "chars": len(now)})
                     logger.info("box_text", t=elapsed, chars=len(now), text=now[:70])
@@ -162,7 +165,7 @@ async def run_spike(profile_name: str | None, project_id: str, entity_id: str | 
 
             report["timeline"] = timeline
             report["changed_at_s"] = changed_at
-            report["text_after"] = timeline[-1]["text"] if timeline else None
+            report["text_after"] = timeline[-1]["text"]
             report["requests"] = requests
             await page.screenshot(path=str(out_dir / f"{dump.stem}.png"))
 
@@ -172,7 +175,7 @@ async def run_spike(profile_name: str | None, project_id: str, entity_id: str | 
                 changed_at_s=changed_at,
                 # The number that decides the design: gflow currently waits ~0.5 s.
                 within_current_wait=(changed_at is not None and changed_at <= 0.5),
-                requests_after_click=sum(1 for r in requests if r["t"] >= t_click - t_zero),
+                requests_after_click=sum(1 for r in requests if r["t"] >= click_at),
             )
         finally:
             with contextlib.suppress(Exception):

--- a/scripts/dev/spike_format_prompt_effect.py
+++ b/scripts/dev/spike_format_prompt_effect.py
@@ -1,0 +1,205 @@
+"""Spike: does clicking Flow's Format button actually REWRITE the prompt, and when?
+
+#727 fixed the anchor — `format_character_prompt` now finds and clicks the button. It
+then waits ~500 ms of jitter, logs `ui_automation.prompt_formatted`, and returns; the
+caller submits immediately. That event therefore proves **a click**, never **a rewrite**
+([[playwright-click-no-downstream-event-signature]]).
+
+If Flow's rewrite is a server round trip, ~500 ms may be short, and `_send_prompt` would
+submit the prompt the user typed while the reshaped text was still in flight — the
+`--format-prompt` flag silently doing nothing, again, behind a green exit code and a
+green e2e. This spike measures whether that is real:
+
+1. type a known prompt, and record it (CONTROL — a rewrite is only detectable against a
+   baseline we know landed);
+2. click Format;
+3. poll the box on a fixed cadence and record **when** the text changes, if it does;
+4. record every request the page makes in that window, so a rewrite that is a server
+   call is distinguishable from one that is local.
+
+A text that never changes is only meaningful with the polling timeline beside it: this
+script reports the full series, so "no change in N s" is a positive observation with a
+shape, not a wait that expired.
+
+**It never submits.** No image is generated, no video, no credit. Not measured: whether
+the rewrite call itself draws on any server-side quota — nothing observable here says,
+and the e2e has been clicking this button routinely for months.
+
+Usage:
+    uv run python scripts/dev/spike_format_prompt_effect.py --project <id> [--entity <id>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import default_out_path  # noqa: E402, isort: skip
+
+from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile  # noqa: E402
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.api.transports.ui_automation import (  # noqa: E402
+    PROMPT_FORMAT_SELECTORS,
+    UiAutomationTransport,
+)
+
+logger = structlog.get_logger("spike_format_prompt_effect")
+
+_CONTROL_SELECTOR = (
+    'div[role="textbox"][data-slate-editor="true"], div.ProseMirror[contenteditable="true"]'
+)
+
+# Deliberately terse and unpolished — a rewrite has something to do, so a no-change
+# result cannot be explained away as "the prompt was already well formed".
+_SEED_PROMPT = "girl, red hair, sad"
+
+_POLL_INTERVAL_S = 0.25
+_POLL_WINDOW_S = 20.0
+
+
+async def run_spike(profile_name: str | None, project_id: str, entity_id: str | None) -> None:
+    resolved_profile = _resolve_profile(profile_name)
+    profile_dir = _make_provider_dir(resolved_profile)
+    dump = default_out_path(f"format_prompt_effect_{Path(resolved_profile).name}")
+    out_dir = dump.parent
+
+    report: dict[str, Any] = {
+        "profile": resolved_profile,
+        "project_id": project_id,
+        "seed_prompt": _SEED_PROMPT,
+        "poll_interval_s": _POLL_INTERVAL_S,
+        "poll_window_s": _POLL_WINDOW_S,
+    }
+    control_error: str | None = None
+
+    async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+        scratch_entity: str | None = None
+        if entity_id is None:
+            entity_id = scratch_entity = await client.create_entity(project_id)
+            logger.info("created_scratch_entity", entity_id=entity_id)
+        report["entity_id"] = entity_id
+
+        transport = cast("UiAutomationTransport", client.transport)
+        page = await client._checkout_page()
+
+        try:
+            await transport._enter_character_editor(
+                page, project_id=project_id, entity_id=entity_id, locale="en-US"
+            )
+            report["url"] = page.url
+
+            # Every request the page makes from here on. This is what separates
+            # "the rewrite is a server round trip" from "it is local", which is the
+            # whole question behind how long the caller must wait.
+            requests: list[dict[str, Any]] = []
+            t_zero = time.monotonic()
+
+            def _on_request(req: Any) -> None:
+                requests.append(
+                    {"t": round(time.monotonic() - t_zero, 3), "method": req.method, "url": req.url}
+                )
+
+            page.on("request", _on_request)
+
+            box = page.locator(_CONTROL_SELECTOR).first
+            await box.click()
+            await page.keyboard.press("Control+A")
+            await page.keyboard.press("Delete")
+            await page.keyboard.insert_text(_SEED_PROMPT)
+            await page.wait_for_timeout(800)
+
+            # CONTROL — the baseline must be in the box, or a later "unchanged" reading
+            # is measuring an empty box, not an absent rewrite.
+            before = (await box.inner_text()).strip()
+            report["text_before"] = before
+            logger.info("baseline", text=before)
+            if before != _SEED_PROMPT:
+                control_error = (
+                    f"CONTROL MISSED: box holds {before!r}, expected {_SEED_PROMPT!r} — "
+                    "the seed never landed, so nothing below measures a rewrite."
+                )
+
+            # Find the button through the SHIPPED cascade, so this spike also re-tests
+            # the #727 anchor every time it runs.
+            clicked_via: str | None = None
+            for selector in PROMPT_FORMAT_SELECTORS:
+                loc = page.locator(selector).first
+                if await loc.count() and await loc.is_visible() and await loc.is_enabled():
+                    await loc.click()
+                    clicked_via = selector
+                    break
+            report["clicked_via"] = clicked_via
+            logger.info("format_clicked", selector=clicked_via)
+            if clicked_via is None and control_error is None:
+                control_error = (
+                    "CONTROL MISSED: no enabled Format button matched the shipped "
+                    f"cascade {PROMPT_FORMAT_SELECTORS} — the #727 anchor may have drifted "
+                    "again. This run measures nothing about the rewrite."
+                )
+
+            t_click = time.monotonic()
+            timeline: list[dict[str, Any]] = []
+            changed_at: float | None = None
+            while time.monotonic() - t_click < _POLL_WINDOW_S:
+                now = (await box.inner_text()).strip()
+                elapsed = round(time.monotonic() - t_click, 3)
+                if not timeline or timeline[-1]["text"] != now:
+                    timeline.append({"t": elapsed, "text": now, "chars": len(now)})
+                    logger.info("box_text", t=elapsed, chars=len(now), text=now[:70])
+                    if changed_at is None and now != before:
+                        changed_at = elapsed
+                await asyncio.sleep(_POLL_INTERVAL_S)
+
+            report["timeline"] = timeline
+            report["changed_at_s"] = changed_at
+            report["text_after"] = timeline[-1]["text"] if timeline else None
+            report["requests"] = requests
+            await page.screenshot(path=str(out_dir / f"{dump.stem}.png"))
+
+            logger.info(
+                "verdict",
+                changed=changed_at is not None,
+                changed_at_s=changed_at,
+                # The number that decides the design: gflow currently waits ~0.5 s.
+                within_current_wait=(changed_at is not None and changed_at <= 0.5),
+                requests_after_click=sum(1 for r in requests if r["t"] >= t_click - t_zero),
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await page.screenshot(path=str(out_dir / f"{dump.stem}_final.png"))
+            # Return the page BEFORE any client.<verb>() — the pool holds one page and
+            # `_checkout_page()` waits forever (tests/scripts/test_spike_page_pool.py).
+            client._checkin_page(page)
+            dump.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            logger.info("report_written", path=str(dump))
+            if scratch_entity is not None:
+                with contextlib.suppress(Exception):
+                    await client.delete_characters(project_id, [scratch_entity])
+                    logger.info("deleted_scratch_entity", entity_id=scratch_entity)
+
+    if control_error is not None:
+        raise RuntimeError(control_error)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Spike: does Format actually rewrite the prompt?")
+    parser.add_argument("--project", required=True, help="Flow project id")
+    parser.add_argument("--entity", default=None, help="Character entity id (default: fresh)")
+    parser.add_argument("--profile", default=None, help="Profile for the live Playwright session")
+    args = parser.parse_args()
+
+    asyncio.run(run_spike(args.profile, args.project, args.entity))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/spike_omni_flash_i2v_ui_recon.py
+++ b/scripts/dev/spike_omni_flash_i2v_ui_recon.py
@@ -179,138 +179,145 @@ async def recon(
         if transport is None:
             sys.exit("FlowApiClient.transport is None")
         page = await client._checkout_page()  # type: ignore[reportPrivateUsage]
+        try:
 
-        await transport._enter_editor(page, None)  # type: ignore[attr-defined]
-        await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-        await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)  # type: ignore[reportPrivateUsage]
-        await VideoGenerationMixin._wait_video_editor_ready(page)  # type: ignore[reportPrivateUsage]
+            await transport._enter_editor(page, None)  # type: ignore[attr-defined]
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            await VideoGenerationMixin._switch_to_video_mode(page, out_dir=None)  # type: ignore[reportPrivateUsage]
+            await VideoGenerationMixin._wait_video_editor_ready(page)  # type: ignore[reportPrivateUsage]
 
-        # ---- A1: default video-mode state --------------------------------
-        await _dump_tabs(page, evidence, "initial")
-        await page.screenshot(path=str(out_dir / "01-video-mode-initial.png"))
+            # ---- A1: default video-mode state --------------------------------
+            await _dump_tabs(page, evidence, "initial")
+            await page.screenshot(path=str(out_dir / "01-video-mode-initial.png"))
 
-        # ---- A2a: model inventory in the DEFAULT sub-mode ----------------
-        if await _open_model_menu(page):
-            await _dump_menuitems(page, evidence, "default_submode")
-            await page.screenshot(path=str(out_dir / "02-model-menu-default-submode.png"))
-            await page.keyboard.press("Escape")
-            await page.wait_for_timeout(300)
-
-        # ---- A2b: switch to Frames, model inventory again ----------------
-        await _ensure_settings_open(page)
-        frames_ok = await _click_submode(page, "frames")
-        evidence["frames_tab_clickable_default_model"] = frames_ok
-        print(f"[recon] frames sub-mode clickable (default model): {frames_ok}")
-        await _dump_tabs(page, evidence, "frames_active")
-        evidence["slot_count_frames_default_model"] = await _slot_count(page)
-        print(
-            f"[recon] frame slots visible (frames + default model): {evidence['slot_count_frames_default_model']}"
-        )
-
-        if await _open_model_menu(page):
-            items = await _dump_menuitems(page, evidence, "frames_submode")
-            await page.screenshot(path=str(out_dir / "03-model-menu-frames-submode.png"))
-
-            # Token match, not the literal 'Omni Flash': Flow renamed the tier
-            # to 'Omni 1.1 Flash' (2026-08-30) and versions the name in place,
-            # so a contiguous-substring probe reports the model MISSING and the
-            # recon silently skips A3/A4 instead of answering them.
-            # Lowercased because `:has-text` is case-INSENSITIVE: a case-exact
-            # probe would report the model missing on an 'OMNI 1.1 FLASH' render
-            # that the transport selects fine.
-            omni = [
-                m for m in items if "omni" in m["text"].lower() and "flash" in m["text"].lower()
-            ]
-            omni_listed = bool(omni)
-            omni_disabled = any(m["disabled"] not in (None, "false") for m in omni)
-            evidence["omni_listed_in_frames_menu"] = omni_listed
-            evidence["omni_disabled_in_frames_menu"] = omni_disabled
-            print(
-                f"[recon] Omni Flash listed={omni_listed} disabled={omni_disabled} (Frames active)"
-            )
-
-            # ---- A3: select Omni Flash while Frames is active ------------
-            if omni_listed and not omni_disabled:
-                opt = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.OMNI_FLASH]).first
-                try:
-                    await opt.click()
-                    await page.wait_for_timeout(1_000)
-                    evidence["omni_selected_in_frames"] = True
-                except Exception as e:
-                    evidence["omni_selected_in_frames"] = False
-                    evidence["omni_select_error"] = str(e)
-            else:
+            # ---- A2a: model inventory in the DEFAULT sub-mode ----------------
+            if await _open_model_menu(page):
+                await _dump_menuitems(page, evidence, "default_submode")
+                await page.screenshot(path=str(out_dir / "02-model-menu-default-submode.png"))
                 await page.keyboard.press("Escape")
                 await page.wait_for_timeout(300)
-                evidence["omni_selected_in_frames"] = False
 
-        await _dump_tabs(page, evidence, "after_omni_in_frames")
-        evidence["slot_count_after_omni"] = await _slot_count(page)
-        await _dump_toasts(page, evidence, "after_omni_in_frames")
-        await page.screenshot(path=str(out_dir / "04-after-omni-in-frames.png"))
-        print(
-            f"[recon] frame slots visible (after Omni select): {evidence['slot_count_after_omni']}"
-        )
-
-        # ---- A4: with Omni active, is Frames still clickable? ------------
-        await _ensure_settings_open(page)
-        await _click_submode(page, "references")
-        await _dump_tabs(page, evidence, "references_with_omni")
-        frames_again = await _click_submode(page, "frames")
-        evidence["frames_tab_clickable_with_omni"] = frames_again
-        print(f"[recon] frames sub-mode clickable (Omni active): {frames_again}")
-        await _dump_tabs(page, evidence, "frames_again_with_omni")
-        evidence["slot_count_frames_with_omni"] = await _slot_count(page)
-        await page.screenshot(path=str(out_dir / "05-frames-with-omni.png"))
-
-        # ---- B: bind a frame on veo-lite, then switch to Omni ------------
-        if with_frame_bind and probe_image is not None:
-            print("[recon] phase B: veo-lite + Frames + bind Start, then switch to Omni Flash")
-            if await _open_model_menu(page):
-                lite = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_LITE]).first
-                await lite.click()
-                await page.wait_for_timeout(800)
+            # ---- A2b: switch to Frames, model inventory again ----------------
             await _ensure_settings_open(page)
-            await _click_submode(page, "frames")
-            await page.keyboard.press("Escape")
-            await page.wait_for_timeout(600)
-            evidence["slots_before_bind"] = await _slot_count(page)
-            await VideoGenerationMixin._attach_frame(  # type: ignore[reportPrivateUsage]
-                page, 0, "Start", probe_image, out_dir=out_dir
-            )
-            evidence["slots_after_bind"] = await _slot_count(page)
+            frames_ok = await _click_submode(page, "frames")
+            evidence["frames_tab_clickable_default_model"] = frames_ok
+            print(f"[recon] frames sub-mode clickable (default model): {frames_ok}")
+            await _dump_tabs(page, evidence, "frames_active")
+            evidence["slot_count_frames_default_model"] = await _slot_count(page)
             print(
-                f"[recon] slots before bind={evidence['slots_before_bind']} "
-                f"after bind={evidence['slots_after_bind']} (expect 2 -> 1)"
+                f"[recon] frame slots visible (frames + default model): {evidence['slot_count_frames_default_model']}"
             )
-            await page.screenshot(path=str(out_dir / "06-start-bound-veo-lite.png"))
 
             if await _open_model_menu(page):
-                opt = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.OMNI_FLASH]).first
-                try:
-                    await opt.click()
-                    await page.wait_for_timeout(1_200)
-                    evidence["omni_selected_with_bound_frame"] = True
-                except Exception as e:
-                    evidence["omni_selected_with_bound_frame"] = False
-                    evidence["omni_switch_error"] = str(e)
-            evidence["slots_after_omni_switch"] = await _slot_count(page)
-            await _dump_tabs(page, evidence, "bound_frame_omni")
-            await _dump_toasts(page, evidence, "bound_frame_omni")
-            await page.screenshot(path=str(out_dir / "07-bound-frame-after-omni-switch.png"))
-            print(
-                f"[recon] slots after Omni switch={evidence['slots_after_omni_switch']} "
-                f"(1 = binding visually survived; 2 = Flow dropped it)"
-            )
-            await page.keyboard.press("Escape")
+                items = await _dump_menuitems(page, evidence, "frames_submode")
+                await page.screenshot(path=str(out_dir / "03-model-menu-frames-submode.png"))
 
-        # NO SUBMIT — this spike never clicks generate.
-        (out_dir / "evidence.json").write_text(
-            json.dumps(evidence, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        print(f"\n[recon] evidence written: {out_dir / 'evidence.json'}")
-        print("[recon] NO generate request was fired — zero credits.")
-        return 0
+                # Token match, not the literal 'Omni Flash': Flow renamed the tier
+                # to 'Omni 1.1 Flash' (2026-08-30) and versions the name in place,
+                # so a contiguous-substring probe reports the model MISSING and the
+                # recon silently skips A3/A4 instead of answering them.
+                # Lowercased because `:has-text` is case-INSENSITIVE: a case-exact
+                # probe would report the model missing on an 'OMNI 1.1 FLASH' render
+                # that the transport selects fine.
+                omni = [
+                    m for m in items if "omni" in m["text"].lower() and "flash" in m["text"].lower()
+                ]
+                omni_listed = bool(omni)
+                omni_disabled = any(m["disabled"] not in (None, "false") for m in omni)
+                evidence["omni_listed_in_frames_menu"] = omni_listed
+                evidence["omni_disabled_in_frames_menu"] = omni_disabled
+                print(
+                    f"[recon] Omni Flash listed={omni_listed} disabled={omni_disabled} (Frames active)"
+                )
+
+                # ---- A3: select Omni Flash while Frames is active ------------
+                if omni_listed and not omni_disabled:
+                    opt = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.OMNI_FLASH]).first
+                    try:
+                        await opt.click()
+                        await page.wait_for_timeout(1_000)
+                        evidence["omni_selected_in_frames"] = True
+                    except Exception as e:
+                        evidence["omni_selected_in_frames"] = False
+                        evidence["omni_select_error"] = str(e)
+                else:
+                    await page.keyboard.press("Escape")
+                    await page.wait_for_timeout(300)
+                    evidence["omni_selected_in_frames"] = False
+
+            await _dump_tabs(page, evidence, "after_omni_in_frames")
+            evidence["slot_count_after_omni"] = await _slot_count(page)
+            await _dump_toasts(page, evidence, "after_omni_in_frames")
+            await page.screenshot(path=str(out_dir / "04-after-omni-in-frames.png"))
+            print(
+                f"[recon] frame slots visible (after Omni select): {evidence['slot_count_after_omni']}"
+            )
+
+            # ---- A4: with Omni active, is Frames still clickable? ------------
+            await _ensure_settings_open(page)
+            await _click_submode(page, "references")
+            await _dump_tabs(page, evidence, "references_with_omni")
+            frames_again = await _click_submode(page, "frames")
+            evidence["frames_tab_clickable_with_omni"] = frames_again
+            print(f"[recon] frames sub-mode clickable (Omni active): {frames_again}")
+            await _dump_tabs(page, evidence, "frames_again_with_omni")
+            evidence["slot_count_frames_with_omni"] = await _slot_count(page)
+            await page.screenshot(path=str(out_dir / "05-frames-with-omni.png"))
+
+            # ---- B: bind a frame on veo-lite, then switch to Omni ------------
+            if with_frame_bind and probe_image is not None:
+                print("[recon] phase B: veo-lite + Frames + bind Start, then switch to Omni Flash")
+                if await _open_model_menu(page):
+                    lite = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.VEO_3_1_LITE]).first
+                    await lite.click()
+                    await page.wait_for_timeout(800)
+                await _ensure_settings_open(page)
+                await _click_submode(page, "frames")
+                await page.keyboard.press("Escape")
+                await page.wait_for_timeout(600)
+                evidence["slots_before_bind"] = await _slot_count(page)
+                await VideoGenerationMixin._attach_frame(  # type: ignore[reportPrivateUsage]
+                    page, 0, "Start", probe_image, out_dir=out_dir
+                )
+                evidence["slots_after_bind"] = await _slot_count(page)
+                print(
+                    f"[recon] slots before bind={evidence['slots_before_bind']} "
+                    f"after bind={evidence['slots_after_bind']} (expect 2 -> 1)"
+                )
+                await page.screenshot(path=str(out_dir / "06-start-bound-veo-lite.png"))
+
+                if await _open_model_menu(page):
+                    opt = page.locator(VIDEO_MODEL_OPTION_SELECTORS[VideoModel.OMNI_FLASH]).first
+                    try:
+                        await opt.click()
+                        await page.wait_for_timeout(1_200)
+                        evidence["omni_selected_with_bound_frame"] = True
+                    except Exception as e:
+                        evidence["omni_selected_with_bound_frame"] = False
+                        evidence["omni_switch_error"] = str(e)
+                evidence["slots_after_omni_switch"] = await _slot_count(page)
+                await _dump_tabs(page, evidence, "bound_frame_omni")
+                await _dump_toasts(page, evidence, "bound_frame_omni")
+                await page.screenshot(path=str(out_dir / "07-bound-frame-after-omni-switch.png"))
+                print(
+                    f"[recon] slots after Omni switch={evidence['slots_after_omni_switch']} "
+                    f"(1 = binding visually survived; 2 = Flow dropped it)"
+                )
+                await page.keyboard.press("Escape")
+
+            # NO SUBMIT — this spike never clicks generate.
+            (out_dir / "evidence.json").write_text(
+                json.dumps(evidence, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            print(f"\n[recon] evidence written: {out_dir / 'evidence.json'}")
+            print("[recon] NO generate request was fired — zero credits.")
+            return 0
+        finally:
+            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
+            # pool (api/client.py), so holding the only page arms a silent deadlock for the
+            # next caller that needs one -- including any `client.<verb>()`, which check one
+            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            client._checkin_page(page)
 
 
 def main() -> int:

--- a/scripts/dev/spike_omni_flash_i2v_ui_recon.py
+++ b/scripts/dev/spike_omni_flash_i2v_ui_recon.py
@@ -313,10 +313,8 @@ async def recon(
             print("[recon] NO generate request was fired — zero credits.")
             return 0
         finally:
-            # Return the page to the pool. `_checkout_page()` blocks FOREVER on an empty
-            # pool (api/client.py), so holding the only page arms a silent deadlock for the
-            # next caller that needs one -- including any `client.<verb>()`, which check one
-            # out internally. Pinned by tests/scripts/test_spike_page_pool.py.
+            # `_checkout_page()` blocks forever on an empty pool; pinned by
+            # tests/scripts/test_spike_page_pool.py.
             client._checkin_page(page)
 
 

--- a/skills/pr-council-review/SKILL.md
+++ b/skills/pr-council-review/SKILL.md
@@ -97,7 +97,7 @@ Pull in parallel via `ctx_batch_execute`:
 - `CLAUDE.md`, `AGENTS.md`, `docs/INDEX.md`
 
 **Memory traversal:** for each `TOUCHED_PATH`, look up relevant slugs:
-- `transports/` → `[[migrated-host-driver-wire-lessons]]`, `[[pr-must-verify-on-affected-surface]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[ui-selector-drift-error-exit-23]]`
+- `transports/` → `[[migrated-host-driver-wire-lessons]]`, `[[pr-must-verify-on-affected-surface]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[ligature-carrier-differs-by-host]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[ui-selector-drift-error-exit-23]]`
 - `data/` → `[[data-layer-overview]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]`, `[[on-started-callback-recorder-safety]]`
 - `auth/` → `[[real-browser-auth-mandatory]]`, `[[release-signing]]`
 - `cli` → `[[release-back-merge-gap-recovery]]`, `[[wheel-build-sanity-gate]]`
@@ -236,7 +236,7 @@ If you are NOT sure a finding is real because it depends on file content, VERIFY
 | D3 | `[[real-browser-auth-mandatory]]`, `[[release-signing]]` |
 | D4 | `[[e2e-evidence-is-a-contributor-deliverable]]`, `[[force-color-breaks-cli-tests]]`, `[[pr-must-verify-on-affected-surface]]`, `[[full-test-suite-ooms]]`, `[[stale-test-discovery]]`, `[[structlog-cache-logger-off-for-tests]]`, `[[windows-running-launcher-blocks-uv-upgrade]]` |
 | D5 | `[[memory-is-working-dir-keyed]]`, `[[release-spec-plan-memory-consolidation]]`, `[[pr-council-review-stale-tree-reads]]` (this very bug, as the council should self-improve) |
-| D6 | `[[ui-selector-drift-error-exit-23]]`, `[[credit-free-route-abort-verification]]`, `[[flow-credits-videos-only]]`, `[[flow-recon-must-run-on-denon82-ffroliva-migrated]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]`, `[[migrated-host-driver-wire-lessons]]` |
+| D6 | `[[ui-selector-drift-error-exit-23]]`, `[[credit-free-route-abort-verification]]`, `[[flow-credits-videos-only]]`, `[[flow-recon-must-run-on-denon82-ffroliva-migrated]]`, `[[flow-locale-leak-icon-ligatures]]`, `[[ligature-carrier-differs-by-host]]`, `[[playwright-click-no-downstream-event-signature]]`, `[[rest-transports-drop-ui-fields]]`, `[[image-video-mode-switch-symmetry]]`, `[[verification-ledger-5-layer]]`, `[[migrated-host-driver-wire-lessons]]` |
 | D7 | `[[on-started-callback-recorder-safety]]`, `[[data-layer-test-pollution-trap]]`, `[[exit-code-16-data-store]]` |
 | D8 | (none mandatory) |
 | D9 | `[[prose-conflicts-hide-in-disjoint-files]]`, `[[doc-examples-are-untested-fixtures]]`, `[[readme-hybrid-router-pattern]]`, `[[agents-md-vs-llms-txt]]`, `[[pypi-readme-staleness-fix]]` |

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -264,6 +264,24 @@ SUBMIT_BUTTON_SELECTORS = (
 #
 # `:text()` not `:has-text()` (invalid inside `:has()`); `text-is` exact match so a
 # longer ligature cannot partial-match.
+# Observed-rewrite gate for the Format button (#727). Flow rewrites SERVER-SIDE:
+# measured 2026-09-07 on the migrated host, the reshaped text reached the composer
+# at ~5.4s. The budget is deliberately generous rather than fitted to that single
+# sample -- the costs are asymmetric. Too long is bounded latency on an opt-in flag
+# whose expiry falls back to exactly the old behaviour; too short silently
+# reintroduces the bug, invisibly, which is what shipped. `elapsed_ms` is logged on
+# every success so a real distribution accrues in production instead of being
+# guessed here from n=1.
+_FORMAT_REWRITE_TIMEOUT_S = 30.0
+# Jittered, like every other wait in this module: a fixed cadence is a
+# deterministic signature in front of Google's anti-bot stack.
+_FORMAT_REWRITE_POLL_MS = 250
+# Slate/ProseMirror re-render and normalise whitespace, so a bare `!=` fires on
+# churn. Normalisation moves the length by a handful of characters; the observed
+# rewrite moved it by 632 (19 -> 651). 16 sits far above the former and far below
+# the latter.
+_FORMAT_REWRITE_MIN_DELTA = 16
+
 PROMPT_FORMAT_SELECTORS: tuple[str, ...] = (
     "flow-format-prompt-button button",
     "button:has(mat-icon:text-is('personal_recommendations'))",
@@ -1625,52 +1643,135 @@ class UiAutomationTransport(VideoGenerationMixin):
         log.info("ui_automation.prompt_submitted", via="enter_key_fallback")
         await page.keyboard.press("Enter")
 
-    async def format_character_prompt(self, page: Page) -> bool:
-        """Click Flow's prompt-format button, trying selectors in priority order.
+    async def format_character_prompt(
+        self,
+        page: Page,
+        *,
+        prompt_box: Any,
+        typed_text: str,
+    ) -> bool:
+        """Click Flow's Format button and WAIT for the rewrite to actually land.
 
         Best-effort, like :meth:`_select_character_model`: formatting is a nicety
-        on top of a prompt that already submits fine, so a missing button logs a
-        warning and returns ``False`` rather than failing the generation.
+        on top of a prompt that already submits fine, so every failure logs and
+        returns ``False`` rather than failing the generation. Callers submit
+        regardless — which is why the return value must not lie.
 
-        The enabled check is NOT redundant with the visible check.  Flow ships this
+        **Returning ``True`` means the composer's text changed, not that a button
+        was pressed.** Flow rewrites *server-side*: measured 2026-09-07 on the
+        migrated host, the click fires a ``batchexecute`` round trip and the
+        reshaped text reaches the composer at **~5.4 s**, while this method used to
+        wait ``_jitter_ms(500)`` and return. ``_send_prompt`` submits on the very
+        next line, so ``--format-prompt`` shipped the prompt the user typed and
+        discarded the rewrite — on every run, with ``prompt_formatted`` logged and
+        exit 0. The defect was never the duration. It was reporting a success we
+        had not observed: the absence of a completion inside a window we chose,
+        recorded as a completion. See
+        ``docs/superpowers/spikes/2026-09-07-format-click-is-not-a-format.md``.
+
+        The gate is the DOM, not the wire. ``eAenfb``'s response arrives **4.2 s
+        before** the text settles, so awaiting it would reproduce the same early
+        submit — and an undocumented ``batchexecute`` rpcid is not an anchor this
+        project is willing to depend on. Comparing the box against the string we
+        inserted is locale-invariant by construction: it never reads a display label.
+
+        A **length delta** rather than ``!=`` because Slate/ProseMirror re-render
+        and normalise whitespace; bare inequality would fire on that churn and
+        re-report the same false success with better telemetry.
+
+        The enabled check is NOT redundant with the visible check. Flow ships this
         button ``disabled`` while the prompt box is empty (verified 2026-07-27), and
         a disabled button is still *visible* — so visibility alone would hand a
         disabled element to ``click()``, which auto-waits for actionability and
-        stalls for the full timeout before failing.  Callers invoke this only after
-        inserting prompt text, so a disabled button here means the editor has not
-        settled: skip it rather than block the submit behind a doomed wait.
+        stalls for the full timeout. A disabled match means THAT anchor resolved to
+        the wrong element, so the cascade continues rather than aborting: the old
+        ``return False`` here let one stale anchor kill every selector behind it.
         """
+        button = await self._locate_format_button(page, prompt_box=prompt_box)
+        if button is None:
+            log.warning("ui_automation.format_button_not_found", selectors=PROMPT_FORMAT_SELECTORS)
+            return False
+
+        locator, selector = button
+        try:
+            # Explicit short timeout: never inherit Playwright's 30s default on
+            # a best-effort nicety sitting in front of the submit.
+            await locator.click(timeout=5000)
+        except Exception as e:
+            log.warning("ui_automation.format_click_failed", selector=selector, error=str(e))
+            return False
+        log.info("ui_automation.format_button_clicked", selector=selector)
+
+        typed = typed_text.strip()
+        deadline = time.monotonic() + _FORMAT_REWRITE_TIMEOUT_S
+        started = time.monotonic()
+        while time.monotonic() < deadline:
+            await page.wait_for_timeout(_jitter_ms(_FORMAT_REWRITE_POLL_MS))
+            try:
+                current = (await prompt_box.inner_text()).strip()
+            except Exception as e:
+                log.debug("ui_automation.format_readback_failed", error=str(e))
+                continue
+            if abs(len(current) - len(typed)) >= _FORMAT_REWRITE_MIN_DELTA and current != typed:
+                # Lengths and a stable hash only. Flow ELABORATES a terse
+                # description into a detailed physical one, so the rewrite is more
+                # PII-dense than the input, and structlog is not governed by
+                # GFLOW_CLI_HISTORY_PROMPTS — no operator control would apply to it.
+                log.info(
+                    "ui_automation.prompt_formatted",
+                    selector=selector,
+                    elapsed_ms=int((time.monotonic() - started) * 1000),
+                    prompt_len_before=len(typed),
+                    prompt_len_after=len(current),
+                    prompt_hash=_prompt_hash_stable(current),
+                )
+                return True
+
+        # Say what was observed, never what Flow "failed" to do: an unchanged box
+        # also covers Flow declining, erroring, or judging the prompt already
+        # formatted. None of those were provoked (2026-09-07), so none are claimed.
+        log.warning(
+            "ui_automation.format_not_observed",
+            selector=selector,
+            waited_s=_FORMAT_REWRITE_TIMEOUT_S,
+            prompt_len=len(typed),
+        )
+        return False
+
+    async def _locate_format_button(self, page: Page, *, prompt_box: Any) -> Any:
+        """Resolve the Format button belonging to the ACTIVE composer.
+
+        Returns ``(locator, selector)`` or ``None``.
+
+        Box identity matters here. :meth:`_locate_body_prompt_box` documents that
+        on a two-box cohort "the LAST mounted box is the target" — the body
+        composer, never the portrait's. A page-global ``.first`` on the format
+        button therefore resolves to the PORTRAIT composer's button while the body
+        prompt is the one that was just typed into, reshaping the wrong prompt (or
+        finding a disabled button and giving up). This mirrors that existing
+        convention rather than inventing a second one: when more than one prompt
+        box is mounted, take the last matching button.
+        """
+        try:
+            boxes = await page.locator(self._CHARACTER_EDITOR_READY_SELECTOR).count()
+        except Exception:
+            boxes = 1
         for selector in PROMPT_FORMAT_SELECTORS:
             try:
-                locator = page.locator(selector).first
+                matches = page.locator(selector)
+                locator = matches.last if boxes > 1 else matches.first
                 # No timeout argument: Playwright documents it as ignored here —
                 # `is_visible()` never waits, it answers from the current DOM, so a
                 # non-matching entry costs one round trip rather than a second.
-                #
-                # That is the cost of a MISS. A `click()` that times out is different:
-                # entries 0 and 1 resolve to the same element on the migrated host
-                # (the custom element wraps the button carrying the mat-icon), as do
-                # entries 2 and 3 on labs — so a timeout is retried on an identical
-                # element and the 5s budget is paid twice. Rare (visible + enabled but
-                # not actionable), untuned deliberately: this whole method is due to be
-                # rewritten around an observed-rewrite gate (#727), and de-duplicating
-                # resolved elements belongs with that change, not in front of it.
                 if not await locator.is_visible():
                     continue
                 if not await locator.is_enabled():
-                    log.warning("ui_automation.format_button_disabled", selector=selector)
-                    return False
-                # Explicit short timeout: never inherit Playwright's 30s default on
-                # a best-effort nicety sitting in front of the submit.
-                await locator.click(timeout=5000)
-                await page.wait_for_timeout(_jitter_ms(500))
-                log.info("ui_automation.prompt_formatted", selector=selector)
-                return True
+                    log.debug("ui_automation.format_button_disabled", selector=selector)
+                    continue
+                return (locator, selector)
             except Exception as e:
                 log.debug("ui_automation.format_selector_failed", selector=selector, error=str(e))
-
-        log.warning("ui_automation.format_button_not_found", selectors=PROMPT_FORMAT_SELECTORS)
-        return False
+        return None
 
     async def _send_prompt(
         self,
@@ -1710,7 +1811,10 @@ class UiAutomationTransport(VideoGenerationMixin):
         await page.wait_for_timeout(_jitter_ms(500))
 
         if format_prompt:
-            await self.format_character_prompt(page)
+            # The bound box and the exact string we inserted — the rewrite is only
+            # detectable against a baseline we know landed, and holding that baseline
+            # on `self` would couple it across generations on a reused page.
+            await self.format_character_prompt(page, prompt_box=input_box, typed_text=prompt_text)
 
         await self._click_submit(page)
 
@@ -1778,7 +1882,10 @@ class UiAutomationTransport(VideoGenerationMixin):
             prompt_len=len(full_prompt),
         )
         if format_prompt:
-            await self.format_character_prompt(page)
+            # `input_box` is the BODY composer, bound by _locate_body_prompt_box —
+            # passing it is what keeps the format click off the portrait's box on a
+            # two-box cohort.
+            await self.format_character_prompt(page, prompt_box=input_box, typed_text=full_prompt)
 
         await self._click_submit(page)
 

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -259,12 +259,39 @@ SUBMIT_BUTTON_SELECTORS = (
 #  3. The button ships ``disabled`` while the prompt box is empty — see
 #     :meth:`UiAutomationTransport.format_character_prompt` for why that matters.
 #
+# Re-measured 2026-09-07 on the MIGRATED host (#727), same script, denon82.  The
+# whole cascade returned 0/0/0 while the button was visible the entire time:
+#
+#   <flow-format-prompt-button>
+#     <button flow-button matbutton class="… format-chip-button …" aria-label="Formatar">
+#       <mat-icon class="… google-symbols …">personal_recommendations</mat-icon>
+#       <span>Formatar</span>
+#     </button>
+#   </flow-format-prompt-button>
+#
+# Two independent misses, either of which alone was fatal:
+#  a. **Carrier tag.** Angular renders the ligature in ``<mat-icon>``, not ``<i>``.
+#     ``mat-icon`` *does* carry the ``google-symbols`` class, so the class was never
+#     the problem — the ``i`` tag was.  This is the same carrier split already fixed
+#     for ``add_2`` / ``arrow_drop_down`` / ``accessibility_new`` in #703; this
+#     constant was simply not swept with them.
+#  b. **Localised label.** The button now HAS an ``aria-label``, but Flow localises
+#     it (``"Formatar"`` on a pt account) — as it does the ``<span>``.  So the EN
+#     text fallback missed too, and is deleted rather than translated: display
+#     labels are banned as anchors (locale-invariance rule, AGENTS.md).
+#
+# The primary anchor is now the **custom element** ``<flow-format-prompt-button>``
+# — a component boundary rather than a layout accident, unique in the editor
+# (1 of 6 composer buttons), and the strongest anchor class this frontend offers.
+# The ligature entries stay as the labs-frontend fallbacks they were proven to be.
+#
 # ``:text()`` not ``:has-text()`` (invalid inside ``:has()``); ``text-is`` exact
 # match so a longer ligature cannot partial-match.
 PROMPT_FORMAT_SELECTORS: tuple[str, ...] = (
+    "flow-format-prompt-button button",
+    "button:has(mat-icon:text-is('personal_recommendations'))",
     "button:has(i.google-symbols:text-is('personal_recommendations'))",
     "button:has(i:text-is('personal_recommendations'))",
-    "button:has(span:text-is('Format'))",
 )
 
 # Self-contained, locale-independent triptych instruction for body generation.

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -242,51 +242,28 @@ SUBMIT_BUTTON_SELECTORS = (
 # Prompt-format button in the character editor ("Format" in EN) — rewrites the
 # typed prompt into Flow's character prompt-engineering shape.
 #
-# Live DOM, verified 2026-07-27 via ``scripts/dev/spike_character_prompt_format.py``
-# against a fresh entity's editor:
+# Live DOM, two frontends, two captures by scripts/dev/spike_character_prompt_format.py:
 #
-#   <button type="button" disabled="">
-#     <i class="… google-symbols …">personal_recommendations</i><span>Format</span>
-#   </button>
+#   labs      2026-07-27:  <button disabled>
+#                            <i class="... google-symbols ...">personal_recommendations</i>
+#                            <span>Format</span></button>
+#   migrated  2026-09-07:  <flow-format-prompt-button>
+#                            <button ... aria-label="Formatar">
+#                              <mat-icon class="... google-symbols ...">
+#                                personal_recommendations</mat-icon>
+#                              <span>Formatar</span></button></flow-format-prompt-button>
 #
-# Three things that dump settled:
-#  1. The ligature IS ``personal_recommendations`` (1 match, unique in the editor).
-#  2. There is NO aria-label — the label is a ``<span>`` child, so an
-#     ``[aria-label*=Format]`` selector matches nothing at all.  The EN fallback has
-#     to be structural (``span:text-is('Format')``), and it is a fallback only:
-#     Flow localises that span to the Chrome *profile* language, which is the
-#     incident-#56 failure mode ([[flow-locale-leak-icon-ligatures]]).
-#  3. The button ships ``disabled`` while the prompt box is empty — see
-#     :meth:`UiAutomationTransport.format_character_prompt` for why that matters.
+# Same ligature, different carrier tag (`<i>` vs `<mat-icon>`) — and the label is
+# localised on both, so it is never an anchor. Hence: custom element first, then the
+# ligature under either carrier. Full evidence, including why the EN `span:text-is`
+# fallback was deleted rather than translated, in
+# docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md.
 #
-# Re-measured 2026-09-07 on the MIGRATED host (#727), same script, denon82.  The
-# whole cascade returned 0/0/0 while the button was visible the entire time:
+# The button ships `disabled` while the prompt box is empty (both hosts) — see
+# :meth:`UiAutomationTransport.format_character_prompt` for why that matters.
 #
-#   <flow-format-prompt-button>
-#     <button flow-button matbutton class="… format-chip-button …" aria-label="Formatar">
-#       <mat-icon class="… google-symbols …">personal_recommendations</mat-icon>
-#       <span>Formatar</span>
-#     </button>
-#   </flow-format-prompt-button>
-#
-# Two independent misses, either of which alone was fatal:
-#  a. **Carrier tag.** Angular renders the ligature in ``<mat-icon>``, not ``<i>``.
-#     ``mat-icon`` *does* carry the ``google-symbols`` class, so the class was never
-#     the problem — the ``i`` tag was.  This is the same carrier split already fixed
-#     for ``add_2`` / ``arrow_drop_down`` / ``accessibility_new`` in #703; this
-#     constant was simply not swept with them.
-#  b. **Localised label.** The button now HAS an ``aria-label``, but Flow localises
-#     it (``"Formatar"`` on a pt account) — as it does the ``<span>``.  So the EN
-#     text fallback missed too, and is deleted rather than translated: display
-#     labels are banned as anchors (locale-invariance rule, AGENTS.md).
-#
-# The primary anchor is now the **custom element** ``<flow-format-prompt-button>``
-# — a component boundary rather than a layout accident, unique in the editor
-# (1 of 6 composer buttons), and the strongest anchor class this frontend offers.
-# The ligature entries stay as the labs-frontend fallbacks they were proven to be.
-#
-# ``:text()`` not ``:has-text()`` (invalid inside ``:has()``); ``text-is`` exact
-# match so a longer ligature cannot partial-match.
+# `:text()` not `:has-text()` (invalid inside `:has()`); `text-is` exact match so a
+# longer ligature cannot partial-match.
 PROMPT_FORMAT_SELECTORS: tuple[str, ...] = (
     "flow-format-prompt-button button",
     "button:has(mat-icon:text-is('personal_recommendations'))",
@@ -1666,7 +1643,11 @@ class UiAutomationTransport(VideoGenerationMixin):
         for selector in PROMPT_FORMAT_SELECTORS:
             try:
                 locator = page.locator(selector).first
-                if not await locator.is_visible(timeout=1000):
+                # No timeout argument: Playwright documents it as ignored here —
+                # `is_visible()` never waits, it answers from the current DOM. Passing
+                # one invited the misreading that a 4-entry cascade costs 4s in front of
+                # the submit; a miss is one round trip.
+                if not await locator.is_visible():
                     continue
                 if not await locator.is_enabled():
                     log.warning("ui_automation.format_button_disabled", selector=selector)

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1644,9 +1644,17 @@ class UiAutomationTransport(VideoGenerationMixin):
             try:
                 locator = page.locator(selector).first
                 # No timeout argument: Playwright documents it as ignored here —
-                # `is_visible()` never waits, it answers from the current DOM. Passing
-                # one invited the misreading that a 4-entry cascade costs 4s in front of
-                # the submit; a miss is one round trip.
+                # `is_visible()` never waits, it answers from the current DOM, so a
+                # non-matching entry costs one round trip rather than a second.
+                #
+                # That is the cost of a MISS. A `click()` that times out is different:
+                # entries 0 and 1 resolve to the same element on the migrated host
+                # (the custom element wraps the button carrying the mat-icon), as do
+                # entries 2 and 3 on labs — so a timeout is retried on an identical
+                # element and the 5s budget is paid twice. Rare (visible + enabled but
+                # not actionable), untuned deliberately: this whole method is due to be
+                # rewritten around an observed-rewrite gate (#727), and de-duplicating
+                # resolved elements belongs with that change, not in front of it.
                 if not await locator.is_visible():
                     continue
                 if not await locator.is_enabled():

--- a/src/gflow_cli/cli_character.py
+++ b/src/gflow_cli/cli_character.py
@@ -99,9 +99,13 @@ def character() -> None:
     is_flag=True,
     default=False,
     help=(
-        "Click Flow's in-editor Format button before submitting, letting Flow "
+        "Click Flow's in-editor Format button before submitting, asking Flow to "
         "rewrite the prompt into its character prompt-engineering shape. "
-        "Best-effort: if the button is not found the prompt is submitted as typed."
+        "KNOWN LIMITATION (#727): Flow rewrites server-side and the reshaped text "
+        "arrives several seconds after the click, which is later than gflow waits "
+        "— so the prompt is currently submitted as typed even when the button is "
+        "found and clicked. Best-effort either way: a missing button is a warning "
+        "on stderr, never a failure."
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")

--- a/src/gflow_cli/cli_character.py
+++ b/src/gflow_cli/cli_character.py
@@ -99,13 +99,13 @@ def character() -> None:
     is_flag=True,
     default=False,
     help=(
-        "Click Flow's in-editor Format button before submitting, asking Flow to "
-        "rewrite the prompt into its character prompt-engineering shape. "
-        "KNOWN LIMITATION (#727): Flow rewrites server-side and the reshaped text "
-        "arrives several seconds after the click, which is later than gflow waits "
-        "— so the prompt is currently submitted as typed even when the button is "
-        "found and clicked. Best-effort either way: a missing button is a warning "
-        "on stderr, never a failure."
+        "Click Flow's in-editor Format button and wait for Flow to rewrite the "
+        "prompt into its character prompt-engineering shape before submitting. "
+        "Flow rewrites server-side, so this adds a few seconds, and the reshaped "
+        "prompt is longer and more detailed — which makes the generation itself "
+        "slower too (measured: roughly double). Best-effort: if the button is "
+        "missing, or the rewrite does not arrive in time, the prompt is submitted "
+        "as typed and a warning names which of the two happened."
     ),
 )
 @click.option("--profile", default=None, help="Profile name (overrides default).")

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -10,6 +10,7 @@ record calls, raise on demand, or stay silent.
 from __future__ import annotations
 
 import json
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -1429,9 +1430,25 @@ class TestFormatCharacterPrompt:
         """#727: the EN ``span:text-is('Format')`` fallback was dead weight — Flow
         localises that span (``"Formatar"`` on a pt account), so it can never
         match a non-EN profile.  Display labels are banned as anchors by the
-        locale-invariance rule in AGENTS.md; the cascade must stay structural."""
+        locale-invariance rule in AGENTS.md; the cascade must stay structural.
+
+        Enforced by whitelist, not by banning one spelling.  A guard that rejected
+        only the literal ``'Format'`` passed for ``"Format"``, for
+        ``[aria-label*="Format"]``, and — worst — for ``'Formatar'``, the exact
+        string this spike observed live.  Banning spellings loses to translation
+        by construction, so every text argument in the cascade must instead BE a
+        known Material Symbols ligature.
+        """
+        allowed_text_args = {"personal_recommendations"}
         for selector in PROMPT_FORMAT_SELECTORS:
-            assert "'Format'" not in selector, (
-                f"{selector!r} anchors on a localised display label — "
-                "use the custom element or the ligature instead"
+            assert "aria-label" not in selector, (
+                f"{selector!r} anchors on aria-label, which Flow localises "
+                '(observed: aria-label="Formatar" on a pt account)'
             )
+            for match in re.finditer(r"""(?:text-is|text|has-text)\(\s*['"](.*?)['"]""", selector):
+                arg = match.group(1)
+                assert arg in allowed_text_args, (
+                    f"{selector!r} matches on the text {arg!r}, which is not a known "
+                    f"locale-invariant ligature {sorted(allowed_text_args)} — Flow "
+                    "translates display labels, so this can only ever match one locale"
+                )

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -1298,6 +1298,8 @@ class _FakeFormatButton:
     def __init__(self, *, visible: bool = True, enabled: bool = True) -> None:
         self.clicked = False
         self.first = self
+        self.last = self
+        self.count = AsyncMock(return_value=1)
         self.is_visible = AsyncMock(return_value=visible)
         self.is_enabled = AsyncMock(return_value=enabled)
         self.click = AsyncMock(side_effect=self._record)
@@ -1306,12 +1308,47 @@ class _FakeFormatButton:
         self.clicked = True
 
 
+TYPED = "girl, red hair, sad"
+REWRITTEN = (
+    "Medium studio shot of a young girl with vibrant red hair and a sorrowful, "
+    "melancholic expression, captured with a 50mm lens on a neutral background."
+)
+
+
+class _FakePromptBox:
+    """The composer, whose text is replaced once Flow's rewrite lands.
+
+    Models the ONE thing the live measurement established: the swap is discrete
+    (19 -> 651 chars in a single step, 2026-09-07), and it happens some polls
+    after the click rather than within the click itself.
+    """
+
+    def __init__(self, before: str, after: str | None, *, change_after_reads: int = 2) -> None:
+        self._before = before
+        self._after = after
+        self._change_after_reads = change_after_reads
+        self.reads = 0
+
+    async def inner_text(self) -> str:
+        self.reads += 1
+        if self._after is not None and self.reads > self._change_after_reads:
+            return self._after
+        return self._before
+
+
 def _make_format_page(
     *,
     matching_selector: str | None = PROMPT_FORMAT_SELECTORS[0],
     enabled: bool = True,
+    disabled_selectors: tuple[str, ...] = (),
+    box_count: int = 1,
 ) -> tuple[MagicMock, _FakeFormatButton]:
-    """Fake page where only ``matching_selector`` resolves to a visible button."""
+    """Fake page where only ``matching_selector`` resolves to a visible button.
+
+    ``disabled_selectors`` resolve to a visible-but-DISABLED button, so a cascade
+    that aborts on the first disabled entry can be told apart from one that keeps
+    walking. ``box_count`` drives the prompt-box count the locator scoping reads.
+    """
     button = _FakeFormatButton(enabled=enabled)
 
     page = MagicMock()
@@ -1321,8 +1358,13 @@ def _make_format_page(
     def _locator(sel: str) -> Any:
         if sel == matching_selector:
             return button
+        if sel in disabled_selectors:
+            blocked = _FakeFormatButton(enabled=False)
+            return blocked
         miss = MagicMock()
         miss.first = miss
+        miss.last = miss
+        miss.count = AsyncMock(return_value=box_count if "textbox" in sel else 0)
         miss.is_visible = AsyncMock(return_value=False)
         miss.is_enabled = AsyncMock(return_value=False)
         miss.click = AsyncMock()
@@ -1333,6 +1375,20 @@ def _make_format_page(
 
 
 class TestFormatCharacterPrompt:
+    @pytest.fixture(autouse=True)
+    def _fast_rewrite_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Shrink the 30s production budget for the offline suite.
+
+        `page.wait_for_timeout` is a mock here, so the poll loop never sleeps — it
+        spins on `time.monotonic()` for the full wall-clock budget. Two
+        never-lands cases at 30s each is a minute added to every run. The VALUE is
+        not what these tests are about; the observe-or-report-failure behaviour is.
+        """
+        from gflow_cli.api.transports import ui_automation as mod
+
+        monkeypatch.setattr(mod, "_FORMAT_REWRITE_TIMEOUT_S", 0.3)
+        monkeypatch.setattr(mod, "_FORMAT_REWRITE_POLL_MS", 1)
+
     @pytest.mark.asyncio
     async def test_clicks_structural_selector_first(self) -> None:
         """The custom element is the primary anchor — not a ligature, not the EN label.
@@ -1344,10 +1400,16 @@ class TestFormatCharacterPrompt:
         page, button = _make_format_page()
         t = _make_transport(page=page)
 
-        assert await t.format_character_prompt(page) is True
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
         assert button.clicked
-        # The structural selector is tried before any ligature/aria-label/text selector.
-        assert page.locator.call_args_list[0].args[0] == PROMPT_FORMAT_SELECTORS[0]
+        # The structural selector is tried before any ligature/aria-label/text
+        # selector. Filtered to the cascade because the first locator() call is now
+        # the prompt-box count that decides first-vs-last scoping.
+        tried = [
+            c.args[0] for c in page.locator.call_args_list if c.args[0] in PROMPT_FORMAT_SELECTORS
+        ]
+        assert tried and tried[0] == PROMPT_FORMAT_SELECTORS[0]
         assert "flow-format-prompt-button" in PROMPT_FORMAT_SELECTORS[0]
 
     @pytest.mark.asyncio
@@ -1362,7 +1424,8 @@ class TestFormatCharacterPrompt:
         page, button = _make_format_page(matching_selector=PROMPT_FORMAT_SELECTORS[index])
         t = _make_transport(page=page)
 
-        assert await t.format_character_prompt(page) is True
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
         assert button.clicked
 
     @pytest.mark.asyncio
@@ -1371,7 +1434,8 @@ class TestFormatCharacterPrompt:
         page, button = _make_format_page(matching_selector=None)
         t = _make_transport(page=page)
 
-        assert await t.format_character_prompt(page) is False
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False
         assert not button.clicked
 
     @pytest.mark.asyncio
@@ -1382,7 +1446,8 @@ class TestFormatCharacterPrompt:
         page, button = _make_format_page(enabled=False)
         t = _make_transport(page=page)
 
-        assert await t.format_character_prompt(page) is False
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False
         assert not button.clicked, "a disabled button must never be handed to click()"
 
     @pytest.mark.asyncio
@@ -1391,7 +1456,8 @@ class TestFormatCharacterPrompt:
         page, button = _make_format_page()
         t = _make_transport(page=page)
 
-        await t.format_character_prompt(page)
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED)
 
         assert button.click.await_args is not None
         assert button.click.await_args.kwargs.get("timeout") is not None
@@ -1403,7 +1469,8 @@ class TestFormatCharacterPrompt:
         page.locator = MagicMock(side_effect=Exception("invalid selector"))
         t = _make_transport(page=page)
 
-        assert await t.format_character_prompt(page) is False
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False
 
     @pytest.mark.asyncio
     async def test_no_ligature_selector_uses_has_text(self) -> None:
@@ -1411,6 +1478,103 @@ class TestFormatCharacterPrompt:
         inside_has = [s for s in PROMPT_FORMAT_SELECTORS if ":has(" in s]
         assert inside_has, "cascade must carry at least one :has() ligature selector"
         assert all(":has-text(" not in s for s in inside_has)
+
+    @pytest.mark.asyncio
+    async def test_returns_true_only_when_the_rewrite_is_observed(self) -> None:
+        """#727 part 2: the click is not the effect.
+
+        Flow rewrites server-side — measured landing at ~5.4s via a `batchexecute`
+        round trip, while the old code waited ~0.5s and returned True. So a click
+        that succeeded still meant the reshaped prompt was discarded by the submit
+        on the very next line. `True` must now mean the composer's text actually
+        changed, not that a button was pressed.
+        """
+        page, button = _make_format_page()
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
+        assert button.clicked
+        assert box.reads > 1, "must poll the box, not return on the click"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_the_rewrite_never_lands(self) -> None:
+        """A click with no observable effect is a failure, reported as one.
+
+        This is the case the old code called success: it is the absence of a
+        completion inside a window we chose, and recording that as a completion
+        is the defect class, not the timeout value.
+        """
+        page, button = _make_format_page()
+        box = _FakePromptBox(TYPED, None)
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False
+        assert button.clicked, "the button was still clicked — only the effect is missing"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_churn_is_not_a_rewrite(self) -> None:
+        """Slate/ProseMirror re-render and normalise; raw `!=` would fire on that.
+
+        A length delta is the guard: the observed rewrite was 19 -> 651 chars, so
+        real reshaping moves the length by far more than normalisation can.
+        """
+        page, _button = _make_format_page()
+        box = _FakePromptBox(TYPED, TYPED + "  ")
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_entry_does_not_abort_the_cascade(self) -> None:
+        """A disabled match means THAT anchor is wrong, not that the feature is gone.
+
+        The old code `return False`d on the first visible-but-disabled entry, so a
+        stale anchor resolving to some other disabled button killed every remaining
+        selector — including the one that would have worked.
+        """
+        page, button = _make_format_page(
+            matching_selector=PROMPT_FORMAT_SELECTORS[2],
+            disabled_selectors=(PROMPT_FORMAT_SELECTORS[0],),
+        )
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
+        assert button.clicked
+
+    @pytest.mark.asyncio
+    async def test_never_logs_the_prompt_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Flow ELABORATES a terse description into a detailed physical one.
+
+        The rewrite is more PII-dense than the user's input, and structlog is not
+        governed by GFLOW_CLI_HISTORY_PROMPTS, so no operator control applies to it.
+        Lengths and the stable hash only — never the text, and never a truncated
+        head, which is exactly where the physical description lands.
+        """
+        from gflow_cli.api.transports import ui_automation as mod
+
+        recorded: list[tuple[str, dict[str, Any]]] = []
+
+        class _Spy:
+            def _capture(self, event: str, **kw: Any) -> None:
+                recorded.append((event, kw))
+
+            info = warning = debug = error = _capture
+
+        monkeypatch.setattr(mod, "log", _Spy())
+
+        page, _button = _make_format_page()
+        box = _FakePromptBox(TYPED, REWRITTEN)
+        t = _make_transport(page=page)
+        await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED)
+
+        assert recorded, "expected telemetry"
+        for event, kw in recorded:
+            blob = repr(kw)
+            assert TYPED not in blob, f"{event} leaked the typed prompt: {kw}"
+            for fragment in REWRITTEN.split(", "):
+                assert fragment not in blob, f"{event} leaked the rewritten prompt: {kw}"
 
     def test_cascade_covers_both_ligature_carriers(self) -> None:
         """#727: labs renders the ligature in ``<i class=google-symbols>``, the

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -1333,21 +1333,32 @@ def _make_format_page(
 
 class TestFormatCharacterPrompt:
     @pytest.mark.asyncio
-    async def test_clicks_ligature_selector_first(self) -> None:
-        """The Material Symbols ligature is the primary anchor, not the EN label."""
+    async def test_clicks_structural_selector_first(self) -> None:
+        """The custom element is the primary anchor — not a ligature, not the EN label.
+
+        `<flow-format-prompt-button>` is a component boundary rather than a layout
+        accident, so it survives both a carrier-tag change and a translation. The
+        ligature entries behind it are the per-frontend fallbacks (#727).
+        """
         page, button = _make_format_page()
         t = _make_transport(page=page)
 
         assert await t.format_character_prompt(page) is True
         assert button.clicked
-        # The structural selector is tried before any aria-label/text selector.
+        # The structural selector is tried before any ligature/aria-label/text selector.
         assert page.locator.call_args_list[0].args[0] == PROMPT_FORMAT_SELECTORS[0]
         assert "flow-format-prompt-button" in PROMPT_FORMAT_SELECTORS[0]
 
     @pytest.mark.asyncio
-    async def test_falls_through_cascade_to_later_selector(self) -> None:
-        """A miss on the primary anchor keeps walking the cascade."""
-        page, button = _make_format_page(matching_selector=PROMPT_FORMAT_SELECTORS[-1])
+    @pytest.mark.parametrize("index", range(len(PROMPT_FORMAT_SELECTORS)))
+    async def test_falls_through_cascade_to_later_selector(self, index: int) -> None:
+        """A miss on an earlier anchor keeps walking — every entry must be reachable.
+
+        Parametrized over the WHOLE cascade rather than just the last entry: #727's
+        `<mat-icon>` carrier sits at index 1, and a fall-through test pinned to
+        ``[-1]`` would never have driven it.
+        """
+        page, button = _make_format_page(matching_selector=PROMPT_FORMAT_SELECTORS[index])
         t = _make_transport(page=page)
 
         assert await t.format_character_prompt(page) is True

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -1340,9 +1340,9 @@ class TestFormatCharacterPrompt:
 
         assert await t.format_character_prompt(page) is True
         assert button.clicked
-        # The ligature selector is tried before any aria-label/text selector.
+        # The structural selector is tried before any aria-label/text selector.
         assert page.locator.call_args_list[0].args[0] == PROMPT_FORMAT_SELECTORS[0]
-        assert "personal_recommendations" in PROMPT_FORMAT_SELECTORS[0]
+        assert "flow-format-prompt-button" in PROMPT_FORMAT_SELECTORS[0]
 
     @pytest.mark.asyncio
     async def test_falls_through_cascade_to_later_selector(self) -> None:
@@ -1399,3 +1399,28 @@ class TestFormatCharacterPrompt:
         inside_has = [s for s in PROMPT_FORMAT_SELECTORS if ":has(" in s]
         assert inside_has, "cascade must carry at least one :has() ligature selector"
         assert all(":has-text(" not in s for s in inside_has)
+
+    def test_cascade_covers_both_ligature_carriers(self) -> None:
+        """#727: labs renders the ligature in ``<i class=google-symbols>``, the
+        migrated Angular frontend in ``<mat-icon>``.  Anchoring on one host's
+        carrier is what made this flag a silent no-op — the whole cascade
+        returned 0 matches on ``flow.google.com`` while the button was visible
+        (measured 2026-09-07, ``scripts/dev/spike_character_prompt_format.py``)."""
+        joined = " ".join(PROMPT_FORMAT_SELECTORS)
+        assert "mat-icon:text-is('personal_recommendations')" in joined, (
+            "cascade must carry the migrated-host <mat-icon> carrier"
+        )
+        assert "i.google-symbols:text-is('personal_recommendations')" in joined, (
+            "cascade must keep the labs <i class=google-symbols> carrier"
+        )
+
+    def test_cascade_carries_no_display_label_anchor(self) -> None:
+        """#727: the EN ``span:text-is('Format')`` fallback was dead weight — Flow
+        localises that span (``"Formatar"`` on a pt account), so it can never
+        match a non-EN profile.  Display labels are banned as anchors by the
+        locale-invariance rule in AGENTS.md; the cascade must stay structural."""
+        for selector in PROMPT_FORMAT_SELECTORS:
+            assert "'Format'" not in selector, (
+                f"{selector!r} anchors on a localised display label — "
+                "use the custom element or the ligature instead"
+            )

--- a/tests/e2e/test_character_create_e2e.py
+++ b/tests/e2e/test_character_create_e2e.py
@@ -562,9 +562,11 @@ def test_character_create_format_prompt_clicks_format_button(e2e_env: dict[str, 
         if line.strip().startswith("{")
     ]
     assert "ui_automation.prompt_formatted" in events, (
-        "--format-prompt did not click Flow's Format button — the selector "
-        "cascade (anchored on the `personal_recommendations` ligature) has "
-        f"likely drifted. Observed events: {sorted(set(events))}"
+        "--format-prompt did not click Flow's Format button — the selector cascade "
+        "(the `<flow-format-prompt-button>` custom element, then the "
+        "`personal_recommendations` ligature under either carrier tag) has likely "
+        "drifted. Probe it with scripts/dev/spike_character_prompt_format.py before "
+        f"assuming the button is gone. Observed events: {sorted(set(events))}"
     )
     for miss in ("ui_automation.format_button_not_found", "ui_automation.format_button_disabled"):
         assert miss not in events, f"format button was skipped ({miss}), not clicked"

--- a/tests/e2e/test_character_create_e2e.py
+++ b/tests/e2e/test_character_create_e2e.py
@@ -48,6 +48,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import uuid
 from pathlib import Path
 from typing import cast
@@ -74,7 +75,14 @@ _DEFAULT_PERSONALITY = "calma, atenciosa — fala pausado; née à Paris, crian�
 
 # Character create runs a real image generation then patches the entity over
 # REST. Generous because of real Flow latency (image-gen + entity PATCH).
-_CREATE_TIMEOUT_S = 300
+# A create drives TWO prompts (face, then body), and `--format-prompt` now waits for
+# Flow's server-side rewrite on each — up to `_FORMAT_REWRITE_TIMEOUT_S` (30s) apiece
+# when the rewrite never lands. That is +60s worst case on a run that already took
+# ~220s, which overran the old 300s budget and produced a hang rather than a failure:
+# `subprocess.run` times out, kills the child, then blocks draining pipes that
+# surviving Chrome grandchildren still hold open. Observed 2026-09-07, 32 minutes
+# before it was stopped by hand.
+_CREATE_TIMEOUT_S = 480
 _SHOW_TIMEOUT_S = 60
 
 
@@ -127,16 +135,45 @@ def _character_env(e2e_env: dict[str, str]) -> dict[str, str]:
 def _run_gflow(
     args: list[str], env: dict[str, str], timeout: float
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``gflow`` in a subprocess and capture stdout/stderr/exit-code."""
+    """Run ``gflow`` in a subprocess and capture stdout/stderr/exit-code.
+
+    A timeout must FAIL, and it must fail WITH the output. Pipes give neither here.
+    ``subprocess.run(timeout=...)`` kills the child and re-enters ``communicate()``
+    to drain — but a browser-driving child leaves Chrome grandchildren holding the
+    inherited write handles, so the drain never returns. Observed 2026-09-07: a
+    create that overran its budget sat for 32 minutes at near-zero CPU, looking
+    exactly like slow progress. Bounding that drain fixed the hang and then threw
+    the output away, which made the next failure diagnose nothing — the timeout
+    reported a command and a duration, and not one transport event.
+
+    Redirecting to files removes the class rather than the symptom: nothing blocks
+    on a reader, and whatever the run logged before it died is on disk and readable
+    afterwards. Five sibling e2e modules carry their own pipe-based ``_run_gflow``;
+    only this one drives a browser long enough today for the difference to show.
+    """
     cmd = [sys.executable, "-m", "gflow_cli", *args]
-    return subprocess.run(
-        cmd,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
+    with tempfile.TemporaryDirectory(prefix="gflow-e2e-") as td:
+        out_path = Path(td) / "stdout.txt"
+        err_path = Path(td) / "stderr.txt"
+        with (
+            out_path.open("w", encoding="utf-8") as out_f,
+            err_path.open("w", encoding="utf-8") as err_f,
+        ):
+            proc = subprocess.Popen(cmd, env=env, stdout=out_f, stderr=err_f)  # noqa: S603
+            timed_out = False
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                proc.kill()
+                proc.wait(timeout=30)
+        # Files are flushed and closed here, so the read sees everything the run
+        # emitted — including, on a timeout, the last event before it stalled.
+        stdout = out_path.read_text(encoding="utf-8", errors="replace")
+        stderr = err_path.read_text(encoding="utf-8", errors="replace")
+    if timed_out:
+        raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
 
 def _parse_json_stdout(result: subprocess.CompletedProcess[str], what: str) -> dict[str, object]:
@@ -561,15 +598,29 @@ def test_character_create_format_prompt_clicks_format_button(e2e_env: dict[str, 
         for line in result.stderr.splitlines()
         if line.strip().startswith("{")
     ]
+    # `prompt_formatted` is emitted only after the composer's text was OBSERVED to
+    # change (#727 part 2). Before that it fired on the click, so this same
+    # assertion passed for a year while the rewrite was discarded by the submit —
+    # a green test asserting the only thing that was observable at the time.
     assert "ui_automation.prompt_formatted" in events, (
-        "--format-prompt did not click Flow's Format button — the selector cascade "
-        "(the `<flow-format-prompt-button>` custom element, then the "
-        "`personal_recommendations` ligature under either carrier tag) has likely "
-        "drifted. Probe it with scripts/dev/spike_character_prompt_format.py before "
-        f"assuming the button is gone. Observed events: {sorted(set(events))}"
+        "--format-prompt did not produce a rewritten prompt. Two distinct causes, "
+        "and the events say which: `format_button_not_found` means the selector "
+        "cascade drifted (probe it with scripts/dev/spike_character_prompt_format.py "
+        "before assuming the button is gone); `format_not_observed` means the button "
+        "was clicked and Flow's rewrite never landed inside the budget — probe that "
+        f"with scripts/dev/spike_format_prompt_effect.py. Observed: {sorted(set(events))}"
     )
-    for miss in ("ui_automation.format_button_not_found", "ui_automation.format_button_disabled"):
-        assert miss not in events, f"format button was skipped ({miss}), not clicked"
+    # The button was clicked, so the click event must be there too — if
+    # `prompt_formatted` ever appears without it, the gate has been short-circuited.
+    assert "ui_automation.format_button_clicked" in events, (
+        f"prompt_formatted without format_button_clicked: {sorted(set(events))}"
+    )
+    for miss in (
+        "ui_automation.format_button_not_found",
+        "ui_automation.format_click_failed",
+        "ui_automation.format_not_observed",
+    ):
+        assert miss not in events, f"--format-prompt degraded ({miss}), see the events above"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_spike_page_pool.py
+++ b/tests/scripts/test_spike_page_pool.py
@@ -17,10 +17,8 @@ screenshots were on disk. It hung in teardown, holding the `denon82` profile
 lease, with no error and no traceback, because `contextlib.suppress(Exception)`
 cannot rescue a block.
 
-That failure mode is worse than it sounds. A wedged process holding a profile
-lease is exactly what makes an operator reach for the process list — the
-sequence that cost nine browsers belonging to a running e2e suite the same day,
-and that `test_spike_profile_lease.py` exists to prevent the other half of.
+A wedged process holding a profile lease is also what sends an operator to the
+process list; see `test_spike_profile_lease.py` for the other half of that.
 
 The 17 scripts that already pair the calls are the reference; `_post_json`'s own
 `attempt()` in `api/client.py` is the canonical shape:

--- a/tests/scripts/test_spike_page_pool.py
+++ b/tests/scripts/test_spike_page_pool.py
@@ -1,0 +1,83 @@
+"""Every dev script that checks a Page out of the pool must check it back in.
+
+`FlowApiClient._checkout_page` is documented as blocking forever
+(`api/client.py`: *"Waits indefinitely if the pool is exhausted (no Pages
+available). Callers that need a deadline must wrap the call themselves"*), and
+the pool is an `asyncio.Queue(maxsize=n)` that defaults to one page. So a script
+that takes the only page and never returns it has not leaked a resource — it has
+armed a deadlock that fires the moment anything else needs a page.
+
+Nothing else usually does, which is why this sat latent in seven scripts. Every
+`client.<verb>()` that talks to Flow goes through `_post_json` / `_patch_json`,
+and those check a page out themselves. On 2026-09-07 `spike_character_prompt_format.py`
+added a `client.delete_characters(...)` cleanup call in its `finally` — obeying
+`skills/spike/SKILL.md`'s "delete anything the spike created" — and the script
+stopped exiting. It had completed all of its work: the capture and all three
+screenshots were on disk. It hung in teardown, holding the `denon82` profile
+lease, with no error and no traceback, because `contextlib.suppress(Exception)`
+cannot rescue a block.
+
+That failure mode is worse than it sounds. A wedged process holding a profile
+lease is exactly what makes an operator reach for the process list — the
+sequence that cost nine browsers belonging to a running e2e suite the same day,
+and that `test_spike_profile_lease.py` exists to prevent the other half of.
+
+The 17 scripts that already pair the calls are the reference; `_post_json`'s own
+`attempt()` in `api/client.py` is the canonical shape:
+
+    page = await self._checkout_page()
+    try:
+        ...
+    finally:
+        self._checkin_page(page)
+
+Offline and text-level on purpose: milliseconds, no browser, fires before a
+spike is ever run. Watched failing against all seven scripts before the fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_DEV_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "dev"
+
+_CHECKOUT = "_checkout_page"
+_CHECKIN = "_checkin_page"
+
+# Enough to prove the scan still resolves. Without it, renaming the pool API
+# silently empties the offender set and the guard passes forever — the
+# enumeration gap `test_workflow_hardening.py` records as its own near-miss, and
+# which `test_spike_profile_lease.py` guards the same way.
+_MIN_EXPECTED_BORROWERS = 15
+
+
+def _borrower_scripts() -> list[Path]:
+    return sorted(
+        path for path in _DEV_SCRIPTS.glob("*.py") if _CHECKOUT in path.read_text(encoding="utf-8")
+    )
+
+
+def test_the_scan_still_finds_the_page_borrowers() -> None:
+    """A guard that matches nothing passes for the wrong reason."""
+    found = _borrower_scripts()
+    assert len(found) >= _MIN_EXPECTED_BORROWERS, (
+        f"only {len(found)} script(s) call {_CHECKOUT}() under {_DEV_SCRIPTS} — "
+        "the page-pool API was probably renamed, which would empty this guard "
+        "silently. Update _CHECKOUT/_CHECKIN."
+    )
+
+
+def test_every_page_borrower_returns_the_page() -> None:
+    offenders = [
+        path.name
+        for path in _borrower_scripts()
+        if _CHECKIN not in path.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        f"these scripts take a Page from the pool and never return it: {offenders}. "
+        "The pool defaults to ONE page and `_checkout_page()` waits forever, so the "
+        "next call that needs a page — including any `client.<verb>()`, which check "
+        "one out internally — deadlocks in silence while holding the profile lease. "
+        "Pair it: `page = await client._checkout_page()` / "
+        "`finally: client._checkin_page(page)`."
+    )


### PR DESCRIPTION
## Summary

> ### Both faults are fixed and live-verified
>
> `--format-prompt` had **two** independent faults. The anchor had drifted (the button was never found), and — once found — gflow clicked it and submitted **before Flow's server-side rewrite arrived**, so the reshaped prompt was discarded on every run behind a green exit code.
>
> Both are fixed here. Live e2e: **`1 passed in 406.20s`** on `denon82`, asserting the **observed rewrite** (`prompt_formatted`, now emitted only after the composer text actually changes) plus `format_button_clicked`, and rejecting `format_not_observed`, `format_click_failed` and `format_button_not_found`.
>
> Measured cost of making it work: **406s vs a 210s control** on the same account and face prompt. Partly the ~4-5s rewrite; mostly Flow generating from a 608-character elaboration instead of the 102 characters typed. That is the feature's actual price — it was free only while it did nothing — and it is why `_CREATE_TIMEOUT_S` moved 300 → 480.

## Lifecycle

- [x] Issue triaged — reproduces on **CLI only**; `character create` is an explicit `_MCP_EXEMPT` in `tests/mcp/test_cli_parity.py`, so there is no MCP twin to drift
- [x] `spike` run **before** any claim — `skills/spike/SKILL.md`, finding in `docs/superpowers/spikes/2026-09-07-character-format-button-anchor.md`
- [ ] ~~`predict`~~ — a selector re-anchor backed by a live DOM capture, not a transport/auth/schema change
- [ ] ~~`scenario` + `plan`~~ — single-constant fix with an existing drift canary already in place
- [x] `check` green, including the step 1b mirror sweep (all six axes below)
- [x] MCP twin: **reasoned exemption already recorded** for `character create`; zero hits for `format_prompt` under `src/gflow_cli/mcp/`
- [x] **E2E evidence** — `tests/e2e/test_character_create_e2e.py::test_character_create_format_prompt_clicks_format_button`, **`1 passed in 219.90s`** on `denon82`, real generation, zero credits. This test was RED before the fix and is green **by a live run** — the assertion was never relaxed.
- [x] Live-verified against real Flow; what could NOT be verified is stated below
- [ ] Council review — running next

## Validation

- [x] Two new unit tests pin the contract that was missing, both **watched red** against the old constant first:
  - `test_cascade_covers_both_ligature_carriers` — `AssertionError: cascade must carry the migrated-host <mat-icon> carrier`
  - `test_cascade_carries_no_display_label_anchor` — `AssertionError: "button:has(span:text-is('"'"'Format'"'"'))" anchors on a localised display label`
  - plus `test_clicks_ligature_selector_first`, updated to the new primary anchor
- [x] `uv run python scripts/ci/check_repo_hygiene.py` — 1017 files, no violations
- [x] `uv run python scripts/ci/check_doc_links.py` — all links resolved across 29 files
- [x] `uv run python scripts/ci/check_website_docs_pii.py` — no private identifiers, 25 files
- [x] `uv run python scripts/ci/generate_website_docs.py --check` — mirror in sync
- [x] `uv run python scripts/ci/check_council_memory.py` — 48 memory files, all cited
- [x] `uv run ruff check src tests` / `ruff format --check src tests`
- [x] `uv run pyright src` — 0 errors
- [x] `uv run python -m pytest -q --cov=gflow_cli` — **4009 passed, 7 skipped, 92% coverage**

### Step 1b blast radius — six axes

Grepped `format-prompt` / `format_prompt` / `personal_recommendations` across `src/gflow_cli/mcp/`, `docs/`, `website/docs/`, `README.md`, `KNOWN_ISSUES.md`, `skills/`.

| Axis | Verdict |
|---|---|
| A. Execution paths (CLI / MCP direct / MCP queued) | **N/A** — no option, param or payload key changed; a selector constant only |
| B. MCP surface truth | **N/A** — 0 hits in `src/gflow_cli/mcp/`; `character create` exempt |
| C. Agent-facing surfaces | **N/A** — 0 hits in `skills/`, `README.md`, `docs/INDEX.md`, AGENTS.md command surface |
| D. Error / exit-code surface | **N/A** — behaviour stays best-effort; no raise site, no `EXIT_CODE_MAP` entry |
| E. Declarative / template surfaces | **N/A** |
| F. Docs + published mirror | CHANGELOG entry added; mirror verified in sync. Remaining hits are dated historical records (`LIVE_VERIFICATION_v0.45.0.md`, `PROJECT_STATUS.md`, the 2026-07-26 PLAN) that correctly describe what was true then |

## What this does NOT prove

- **The labs frontend.** No unmoved account exists here, so the two `<i>` entries are carried forward on the 2026-07-27 capture alone. They were **not** re-verified today and are not asserted to still work.
- **The content of Flow'"'"'s rewrite.** The e2e asserts the button was found, enabled and clicked. Whether Flow'"'"'s reshaped prompt is *better* stays a human read.
- **That this was the last missed constant.** #703'"'"'s carrier sweep demonstrably skipped one; this PR sweeps one more.

## Open question, deliberately not acted on here

`--format-prompt` stays **best-effort**, which is what its help text promises and what #727 says is correct. But that is *why* this went unnoticed for an unknown period: a paid run silently skipped the step the user asked for behind exit 0, and only an opt-in e2e (`GFLOW_CLI_E2E_RUN_CHARACTER=1`, not in the nightly canary) could catch it. Whether a missed button should be loud — or fatal under an explicit `--format-prompt` — is a real design change and belongs in its own issue.

## Contribution Checklist

- [x] Targets `develop`
- [x] Real Git identity
- [x] No secrets, cookies, tokens, signed URLs or raw captures — the capture stays gitignored under `scripts/dev/_spike_out/`
- [x] Reviewed before submitting

