### PR TITLE
docs: .env.local is never loaded — stop telling people to put settings in it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ If you can help unblock a pure HTTP transport (especially for video generation, 
 ## Dev environment tips
 
 - `uv sync` then `uv run playwright install chromium`. No global Python install needed.
-- Copy `.env.template` to `.env.local`; never commit `.env.local`. It documents every env var.
+- Copy `.env.template` to **`.env`** — either in the directory you run `gflow` from (project-local) or at `$GFLOW_CLI_HOME/.env` (machine-wide); on conflict the CWD one wins. It documents every env var. Both are gitignored; never commit either.
+  **Not `.env.local` — nothing loads that file.** `config.py::_env_files()` returns exactly `(<home>/.env, .env)`, so `GFLOW_CLI_*` settings put in `.env.local` are silently ignored and `get_settings()` reports the default as though you had set nothing. Keeping a `.env.local` for credentials **you** read by hand (e.g. `SONAR_TOKEN`) is fine — it is only wrong as a home for gflow's own settings.
 - Output goes to `./tmp/` for scripts/tests or `$GFLOW_CLI_OUTPUT_DIR` for CLI outputs (defaults to `./out/`).
 - One-time auth: `gflow auth login --browser chrome` (recommended — a real-Chrome profile is what generation runs need; the default `--browser auto` can also pick the internal strategy, and generation later fails fast on profiles created with a non-chrome strategy).
 - Use `/gflow:status` to see the current task before starting work; `/gflow:known-issues` before touching auth or reCAPTCHA code paths.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -16,7 +16,7 @@ These are non-negotiable. They override default agent behavior where conflicts e
 - **TDD before code.** Write a failing test, then the minimum production code to make it pass, then refactor. Coverage floor: 80% overall. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 - **Documentation is first-class.** Any user-facing, operator-facing, architecture, configuration, workflow, or agent-rule change must update the matching docs, changelog/release note when relevant, and docs index if a new doc is added. If no docs change, record the reason in the PR/checklist. `scripts/ci/check_doc_links.py` must pass before merge.
 - **No raw `print()` or `import logging` in `src/`.** Structured logging via `structlog` only.
-- **No secrets in commits.** `.env.local` is gitignored; never commit it. `pre-commit` hooks run `detect-secrets` on staged content.
+- **No secrets in commits.** `.env`, `.env.local` and `$GFLOW_CLI_HOME/.env` are all gitignored; never commit any of them. Note gflow only READS `.env` (CWD and home) — see [CONFIGURATION.md](CONFIGURATION.md). `pre-commit` hooks run `detect-secrets` on staged content.
 - **No AI attribution in commit messages.** `Co-Authored-By:` trailers are fine when explicitly requested; auto-generated `🤖 Generated with…` footers are not.
 - **Branch naming.** `feature/`, `bugfix/`, `hotfix/`, `chore/`, `docs/`, `test/`, `release/`. Never `claude/` or unprefixed.
 - **Signed tags only.** Releases tag with `git tag -s vX.Y.Z`. CI rejects unsigned or lightweight tags.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -34,7 +34,7 @@ uv tool run --from gflow-cli playwright install chromium
 
 - **Output directory** — CLI outputs default to `./out/`; override with `GFLOW_CLI_OUTPUT_DIR`. Scripts/tests write to `./tmp/`.
 - **Batch pacing** — `GFLOW_CLI_JITTER_RANGE` (or `--jitter MIN-MAX`) tunes the delay between batch submissions.
-- **Environment** — copy the project's `.env.template` to `.env.local` for the full list of variables; never commit it.
+- **Environment** — copy the project's `.env.template` to **`.env`**, either beside where you run `gflow` or at `$GFLOW_CLI_HOME/.env`; the CWD one wins on conflict. It lists every variable. Both are gitignored; never commit either. A `.env.local` is **not** read by gflow.
 
 ## Upgrade
 


### PR DESCRIPTION
## The bug

`AGENTS.md` and the website installation page both say **"copy `.env.template` to `.env.local`"**. Nothing loads that file.

`config.py::_env_files()` returns exactly two paths:

```python
return (str(_resolve_home() / ".env"), ".env")
```

The home `.env` and the CWD `.env`, later winning. **`.env.local` appears nowhere in `src/` or `scripts/ci/`** — grep returns zero hits.

## Proven, not reasoned

With three `GFLOW_CLI_*` settings in `.env.local`, `get_settings().llm_base_url` returned the default as though nothing were set. Moving the **identical lines** into `.env` made it return the configured endpoint.

That is the whole defect: **it fails silently.** No error, no warning — the setting simply isn't there, so the reader concludes the feature is broken rather than that the file is ignored.

## It was already fixed once, partially

`CHANGELOG.md` v0.25.0:

> *"the `gflow serve` token hint no longer points at `.env.local`, **which was never a loaded file**"*

That sweep reconciled `docs/CONFIGURATION.md`, `docs/SECURITY.md` and `.env.template`. It missed `AGENTS.md` and `website/docs/installation.md` — **the two documents most likely to be a newcomer's first contact** — which kept the wrong instruction for four months.

A partial sweep of a known defect is how a fixed bug stays shipped. Same shape as the `#703` icon-carrier sweep that missed `PROMPT_FORMAT_SELECTORS`, found today.

## What is *not* wrong about `.env.local`

Keeping one for credentials a **human or agent reads by hand** is fine — the `SONAR_TOKEN` memories are unaffected, because nothing there pretends gflow loads it. The defect is specifically telling people to put **gflow's own settings** in a file gflow ignores.

## Changes

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | copy to `.env.local` | copy to `.env` (CWD or `$GFLOW_CLI_HOME`), CWD wins; explicit note that `.env.local` is not loaded and why that is silent |
| `website/docs/installation.md` | same | same, shortened for the site |
| `docs/AGENT_GUIDE.md` | named only `.env.local` as gitignored | all three are gitignored (`.gitignore:44-45`), and says which one gflow reads |

That last one mattered on its own: naming only `.env.local` as gitignored reads as though `.env` were safe to commit. It is not, and it is the one that holds real settings.

## Test plan

- [x] `check_doc_links.py` — all links resolved across 29 files
- [x] `generate_website_docs.py --check` — mirror in sync (`installation.md` is `WEBSITE_ONLY`, hand-authored, so not regenerated)
- [x] `check_website_docs_pii.py` — clean
- [x] `check_repo_hygiene.py` — 1017 files, no violations
- [x] `check_council_memory.py` — clean
- [x] **Behavioural proof** — `get_settings()` returns the configured `llm_base_url` from `.env` and did not from `.env.local`

Docs only; no code changes, so no e2e surface is touched.
