### PR TITLE
chore: ignore runtime state written into this repo by other tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,15 @@ secrets.json
 .env.local
 .env.*.local
 
+# Runtime state written into this repo by tools run FROM this directory.
+# social-publisher's queue defaults to a RELATIVE path (its cli.py: SP_QUEUE_DB,
+# default "state/queue.sqlite"), so invoking it — or its MCP server — with this repo
+# as CWD silently creates state/queue.sqlite here. On 2026-09-07 that produced a
+# second, EMPTY queue that a dry-run then read and reported as "nothing pending",
+# while the real queue sat in social-publisher/state/. Untracked and unignored, it
+# was also one `git add -A` from being committed.
+state/
+
 # Generated outputs
 out/
 tmp/


### PR DESCRIPTION
`state/queue.sqlite` sat untracked **and unignored** at the repo root.

**It is not gflow's.** social-publisher's queue defaults to a **relative** path (`SP_QUEUE_DB`, default `state/queue.sqlite`), so running that tool — or its MCP server — with this repo as CWD creates the file here.

**Two problems, and the second is the real one.**

1. Untracked + unignored is one `git add -A` from committing another project's database. Both sessions in this repo today used `git add -A` repeatedly.
2. **The stray file answers questions.** A publish dry-run invoked from this directory created the empty local copy, read it, and reported *"queue empty, would_post=0"* — which was accepted as evidence nothing was pending. The real queue (7 rows: 6 posted, 1 draft) was in `social-publisher/state/` the whole time.

The conclusion was right — nothing was due — but it came off the wrong instrument. **A correct answer read from the wrong file is not a verification.** Had a due entry existed, the check would have said the same thing.

Same shape as the rest of this week: a 20s timeout read as absence, a swallowed click read as absence, a bundle photographed after teardown read as absence, a 0.5s wait on a 5.4s round trip read as success. Here, a fresh empty database read as an empty queue.

**Scope:** this stops the accidental commit only. The real fix belongs in social-publisher (anchor the default, or require `SP_QUEUE_DB`) and is not made here.

**Verified:** `git check-ignore -v state/queue.sqlite` → `.gitignore:55`; repo hygiene clean, 1023 tracked files. One line plus its comment; no code touched.