### PR TITLE
fix(selectors): de-blind the diagnostics, and fix the two selectors hiding behind them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flow's own diagnostics were blind on the migrated host, and two selectors were broken behind
+  it.** `gflow`'s incident-bundle DOM dump queried `i.google-symbols, span.google-symbols`, and
+  `diagnostics.py`'s `STRUCTURAL_DOM_JS` queried `i.google-symbols` — so on `flow.google.com`,
+  where every Material Symbols ligature rides a `<mat-icon>`, **both reported zero ligatures**.
+  The instrument used to diagnose selector drift was blind to the host the drift lives on. That
+  is why [#727](https://github.com/ffroliva/gflow-cli/issues/727) and
+  [#731](https://github.com/ffroliva/gflow-cli/issues/731) stayed invisible, and why an incident
+  bundle from a migrated user named no ligatures at all. Both queries are now class-only.
+
+  Two selectors were broken behind that blindness. `SUBMIT_BUTTON_SELECTORS` was **working by
+  luck**: its two tag-qualified entries matched nothing on the migrated host and the submit only
+  landed because a third `has-text` entry matches the `<mat-icon>`'s *text* — observed live as
+  `prompt_submitted via="button:has-text('arrow_forward')"`, after paying two misses per submit.
+  `IMAGE_MODEL_PICKER_TRIGGER` had neither twin nor fallback, so its miss was total and silent:
+  the picker is best-effort, so generation simply proceeded on whatever model tier the editor
+  opened at. Both now anchor on the `google-symbols` **class**, which sits on the labs `<i>` and
+  the migrated `<mat-icon>` alike — verified against a real CSS engine, offline, in
+  `tests/api/transports/test_ligature_carrier.py`.
+
+  `SUBMIT_BUTTON_SELECTORS` also moves from `:text` to **`:text-is`**. `:text` is a substring
+  match and accepts `arrow_forward_ios`, a real Material Symbol; the `<i>` qualifier had been
+  containing that, and dropping it for the class-only carrier made the over-match reachable on
+  the submit path. The two-carrier fixture caught it as `matched 3 of 2` before it ran live.
+  ([#730](https://github.com/ffroliva/gflow-cli/issues/730),
+  [spike](docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md))
+
 - **`character create --format-prompt` works again — both halves of it.** The flag had two
   independent faults, and fixing only the first would have left it just as useless. On the
   migrated `flow.google.com` host

--- a/docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md
+++ b/docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md
@@ -1,0 +1,113 @@
+# The carrier is one character. The ligature NAME is the other half nobody counted
+
+**Date:** 2026-09-07 · **Issue:** [#730](https://github.com/ffroliva/gflow-cli/issues/730) ·
+**Account:** `denon82` (migrated `flow.google.com`) · **Cost:** `$0` — navigation, one free
+`createEntity` (deleted again), DOM reads. Nothing submitted, no credit, no image quota.
+
+**Script:** `scripts/dev/spike_ligature_carrier_sweep.py` ·
+**Capture:** `scripts/dev/_spike_out/ligature_carrier_sweep_denon82_20260907_*.json` (gitignored)
+
+---
+
+## 1. What was asked
+
+#727 and #731 both came from the labs/migrated **carrier split**: the same Material Symbols
+ligature rendered in `<i class="google-symbols">` on labs and `<mat-icon>` on the migrated
+host. A static sweep of `src/gflow_cli` found the real unit is the *constant*, not the literal:
+
+| | count |
+|---|---|
+| constants covering **both** carriers | 6 |
+| constants that are **`<i>`-only** | **24** |
+
+(#730 says "55 single-carrier literals". That number counts literals, and double-counts
+cascades that alternate carriers across entries. 24 constants is the actionable figure.)
+
+Static analysis cannot say which of the 24 *matter*. A selector whose surface does not exist
+on this host is not a bug; one whose miss is rescued by a fallback is a bug that is currently
+invisible. So the probe measured, per ligature, on two live surfaces.
+
+## 2. The carrier result — unambiguous
+
+Control: `prompt_boxes=1`, `ligature_hits=8`. The probe was standing on a real editor, so its
+zeros are about selectors, not arrival.
+
+```
+=== character editor ===
+ligature                i.gs   mat   .gs   any  carriers
+accessibility_new          0     1     1     1  mat-icon
+add                        0     2     2     2  mat-icon
+arrow_drop_down            0     1     1     1  mat-icon
+arrow_forward              0     1     1     1  mat-icon
+close                      0     1     1     1  mat-icon
+upload                     0     1     1     1  mat-icon
+voice_selection            0     1     1     1  mat-icon
+```
+
+**`i.google-symbols` matched zero, for every ligature, on both surfaces.** `mat-icon` matched,
+and **`.google-symbols` matched exactly the same count as `mat-icon`, every time**.
+
+The class is on both carriers. `.google-symbols:text-is(L)` therefore covers labs *and*
+migrated with no cascade entry at all — the fix for the 24 constants is **one character each**
+(`i.google-symbols` → `.google-symbols`), not 24 duplicated entries.
+
+Two selectors are confirmed broken-but-masked:
+
+- `SUBMIT_BUTTON_SELECTORS` — `arrow_forward` is `i.gs=0 / mat=1`. Both `<i>` entries miss;
+  only the third, `button:has-text('arrow_forward')`, fires, matching the `<mat-icon>`'s *text*
+  rather than its tag. Independently observed live the same day:
+  `prompt_submitted via="button:has-text('arrow_forward')"`. **It works by luck.**
+- `IMAGE_MODEL_PICKER_TRIGGER` — `arrow_drop_down` is `i.gs=0 / mat=1`, and the constant has no
+  twin and no text fallback.
+
+## 3. The finding that a carrier-only fix would have shipped past
+
+**The migrated host renders `add`. It does not render `add_2` anywhere.**
+
+```
+composer:  add = 1     add_2 = 0
+editor:    add = 2     add_2 = 0
+```
+
+That is a **ligature NAME change, not a carrier change.** Consequences:
+
+- `NEW_PROJECT_SELECTORS` (`add_2`) misses — which is why the first run of this very spike died
+  with `Could not find 'New project' CTA on Flow gallery` on `flow.google.com`.
+- `_CHARACTER_SLOT_ADD_SELECTOR` misses **even though it already covers both carriers**. It was
+  swept for the carrier in #703 and is still broken on this host.
+- `ADD_MEDIA_BUTTON` (`add_2`) is in the same position.
+
+Changing the carrier on those three would have produced a green sweep, a satisfied checklist,
+and three selectors that still match nothing. **The carrier was never the whole story; it was
+just the half that had a name.**
+
+## 4. What was NOT measured
+
+- **Ligatures absent from both surfaces are NOT proven absent from the product**:
+  `add_2`, `cancel`, `clear`, `edit_square`, `image`, `play_circle`, `tune`, `article_spark`,
+  `chrome_extension`, `crop_free` and most `crop_*` did not appear. They plausibly live behind
+  menus, dialogs or modes this probe never opened. The probe read two surfaces in their default
+  state, and that is all it can speak to. `add_2` is the exception only because a control that
+  *should* be on the surface it was probed on (`New project`, `slot add`) was independently
+  observed to fail.
+- **labs was not measured at all.** No unmoved account exists here. The claim that
+  `.google-symbols` also matches `<i class="google-symbols">` is CSS semantics, not an
+  observation — it should be verified on labs before anyone calls this closed.
+- **Whether broadening `i.google-symbols` → `.google-symbols` changes `.first` picks on labs.**
+  A wider match can select a different element where a cascade relies on document order.
+
+## 5. The rule this earns
+
+```
+SWEEPING FOR THE FAILURE YOU ALREADY NAMED FINDS ONLY THAT FAILURE.
+```
+
+The probe was built to compare two carriers. It found the name drift only because it also
+counted whether the ligature was present *at all* — the control column, added so a zero could
+not be misread as absence. That column, added for epistemic hygiene, is what turned up the
+second defect class.
+
+See also:
+[2026-09-07 — the Format button's anchor](2026-09-07-character-format-button-anchor.md),
+[2026-09-07 — a click is not an effect](2026-09-07-format-click-is-not-a-format.md),
+[`skills/spike/SKILL.md`](../../../skills/spike/SKILL.md).

--- a/scripts/dev/spike_ligature_carrier_sweep.py
+++ b/scripts/dev/spike_ligature_carrier_sweep.py
@@ -139,6 +139,62 @@ async def _sweep_surface(page: Any, surface: str) -> dict[str, Any]:
     return counts
 
 
+async def _verify_shipped_anchors(page: Any, surface: str) -> dict[str, Any]:
+    """Count the SHIPPED constants, plus the pre-#730 forms they replaced.
+
+    This is the proof half of the spike. The sweep above says what the DOM contains; this
+    says whether the code we actually ship resolves against it, and whether the form it
+    replaced did not. A fix asserted from a JSON dump is a fix nobody ran.
+    """
+    from gflow_cli.api.transports.ui_automation import (  # noqa: PLC0415
+        IMAGE_MODEL_PICKER_TRIGGER,
+        SUBMIT_BUTTON_SELECTORS,
+    )
+
+    pairs = {
+        "submit": (
+            SUBMIT_BUTTON_SELECTORS[0],
+            "button:has(i.google-symbols:text('arrow_forward'))",
+        ),
+        "image_model_picker": (
+            IMAGE_MODEL_PICKER_TRIGGER,
+            "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))",
+        ),
+    }
+    out: dict[str, Any] = {}
+    for name, (shipped, old) in pairs.items():
+        now = await page.locator(shipped).count()
+        before = await page.locator(old).count()
+        out[name] = {"shipped": shipped, "shipped_count": now, "pre_730_count": before}
+        logger.info(
+            "shipped_anchor",
+            surface=surface,
+            anchor=name,
+            shipped_count=now,
+            pre_730_count=before,
+            selector=shipped,
+        )
+
+    # The de-blinded diagnostics: the artifact an incident bundle would carry. Before #730
+    # this returned an empty list on the migrated host, so a bundle from a migrated user
+    # named no ligatures at all.
+    from gflow_cli.diagnostics import STRUCTURAL_DOM_JS  # noqa: PLC0415
+
+    dom = await page.evaluate(STRUCTURAL_DOM_JS)
+    ligatures = dom.get("ligatures") or []
+    out["structural_dom_ligature_count"] = dom.get("ligatureCount", 0)
+    out["structural_dom_ligatures"] = ligatures[:12]
+    out["structural_dom_crop_present"] = dom.get("cropPresent")
+    logger.info(
+        "structural_dom_capture",
+        surface=surface,
+        ligature_count=dom.get("ligatureCount", 0),
+        distinct=len(ligatures),
+        sample=ligatures[:8],
+    )
+    return out
+
+
 async def run_spike(profile_name: str | None, project_id: str) -> None:
     resolved_profile = _resolve_profile(profile_name)
     profile_dir = _make_provider_dir(resolved_profile)
@@ -176,9 +232,31 @@ async def run_spike(profile_name: str | None, project_id: str) -> None:
                 project_editor_url(None, project_id), wait_until="domcontentloaded", timeout=45_000
             )
             await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
-            await page.wait_for_timeout(3000)
+            # Wait for the icons themselves, not a fixed interval. A 3s sleep produced a
+            # zero-ligature composer once already; the thing being counted is the thing to
+            # wait for. Still bounded, and the control below reports the outcome either way.
+            with contextlib.suppress(Exception):
+                await page.locator(".google-symbols").first.wait_for(
+                    state="attached", timeout=20_000
+                )
+            await page.wait_for_timeout(2000)
             report["composer_url"] = page.url
             report["composer"] = await _sweep_surface(page, "composer")
+            report["composer_anchors"] = await _verify_shipped_anchors(page, "composer")
+            # PER-SURFACE CONTROL. The composer originally had none, and a run on
+            # 2026-09-07 came back with zero ligatures of ANY kind on it — the page had
+            # simply not rendered its icons yet at the 3s mark, while an earlier run on the
+            # same URL saw 8. Those zeros are "did not arrive", not "does not match", and
+            # without this they are indistinguishable from a real absence. Every surface
+            # needs its own control; one control on one surface certifies only that surface.
+            composer_hits = sum(v["any_element"] for v in report["composer"].values())
+            report["control_composer_ligature_hits"] = composer_hits
+            logger.info("control_check", surface="composer", ligature_hits=composer_hits)
+            if composer_hits == 0:
+                control_error = (
+                    f"CONTROL MISSED: composer at {page.url} rendered no ligatures at all — "
+                    "its counts measure nothing. Do not read its zeros as absence."
+                )
             await page.screenshot(path=str(out_dir / f"{dump.stem}_composer.png"))
 
             # --- Surface 2: the character editor -------------------------------
@@ -188,6 +266,7 @@ async def run_spike(profile_name: str | None, project_id: str) -> None:
             await page.wait_for_timeout(2000)
             report["editor_url"] = page.url
             report["editor"] = await _sweep_surface(page, "character_editor")
+            report["editor_anchors"] = await _verify_shipped_anchors(page, "character_editor")
             await page.screenshot(path=str(out_dir / f"{dump.stem}_editor.png"))
 
             # CONTROL — recorded, raised on only after the dump is written. A run where

--- a/scripts/dev/spike_ligature_carrier_sweep.py
+++ b/scripts/dev/spike_ligature_carrier_sweep.py
@@ -1,0 +1,236 @@
+"""Spike: which `<i>`-only ligature selectors actually miss on the migrated host (#730)?
+
+Two bugs in one week came from the same split: labs renders Material Symbols ligatures in
+``<i class="google-symbols">``, the migrated ``flow.google.com`` Angular frontend renders the
+SAME ligature in ``<mat-icon class="… google-symbols …">``. A cascade anchored on one carrier
+returns a flat zero on the other host while the control is fully visible (#727, #731).
+
+A static sweep says **24 constants** in ``src/gflow_cli`` are ``<i>``-only. It cannot say which
+of them matter: a selector whose surface does not exist on this host is not a bug, and one
+whose miss is rescued by a text fallback is a bug that is currently invisible —
+``SUBMIT_BUTTON_SELECTORS`` is exactly that, observed live 2026-09-07 firing its third entry
+``button:has-text('arrow_forward')`` because both ``<i>`` entries missed.
+
+So this measures, per ligature, on a live migrated surface:
+
+* ``i.google-symbols:text-is(L)``   — what we ship today
+* ``mat-icon:text-is(L)``           — the twin we would add
+* ``.google-symbols:text-is(L)``    — **the hypothesis**: the class is on BOTH carriers, so a
+  class-only anchor may cover both hosts with no cascade entry at all. If that holds, the fix
+  for 24 constants is one character each rather than 24 duplicated entries.
+* ``:text-is(L)`` on any element     — proves the ligature is present at all, so a zero in the
+  three above is about the SELECTOR and not about the feature.
+
+That last row is the control, and it is the point: a sweep that reports zeros everywhere is
+worthless unless something known-present resolved in the same run.
+
+Probes two surfaces because the constants split across them: the project composer and the
+character editor. Both are reported separately — a ligature absent from one may be present in
+the other, and collapsing them would manufacture a false absence.
+
+FREE — navigation, one free tRPC ``createEntity`` (deleted again), and DOM reads. Nothing is
+submitted, nothing generated, no credit and no image quota.
+
+Usage:
+    uv run python scripts/dev/spike_ligature_carrier_sweep.py --project <id> [--profile denon82]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import default_out_path  # noqa: E402, isort: skip
+
+from gflow_cli._cli_helpers import _make_provider_dir, _resolve_profile  # noqa: E402
+from gflow_cli.api.client import FlowApiClient  # noqa: E402
+from gflow_cli.api.routes import project_editor_url  # noqa: E402
+from gflow_cli.api.transports.ui_automation import UiAutomationTransport  # noqa: E402
+
+logger = structlog.get_logger("spike_ligature_carrier_sweep")
+
+# Every ligature reachable from an `<i>`-only constant, from the static sweep. Kept as a
+# literal list rather than re-derived at runtime so the probe measures a FIXED question and
+# a later refactor cannot silently shrink what it asks.
+_LIGATURES = [
+    "accessibility_new",
+    "add",
+    "add_2",
+    "apps_spark_2",
+    "arrow_drop_down",
+    "arrow_forward",
+    "article_spark",
+    "cancel",
+    "chrome_extension",
+    "clear",
+    "close",
+    "crop_16_9",
+    "crop_9_16",
+    "crop_free",
+    "crop_landscape",
+    "crop_original",
+    "crop_portrait",
+    "crop_square",
+    "dashboard",
+    "edit_square",
+    "image",
+    "left_panel_close",
+    "play_circle",
+    "tune",
+    "upload",
+    "voice_selection",
+]
+
+_CHAR_EDITOR_READY = UiAutomationTransport._CHARACTER_EDITOR_READY_SELECTOR
+
+# Counts every carrier form for one ligature in a single evaluate, so all four numbers
+# describe the SAME DOM instant. Four separate Playwright locators would each see a
+# slightly different page on a live Angular app.
+_SWEEP_JS = """(ligatures) => {
+    const exact = (el, lig) => (el.textContent || '').trim() === lig;
+    const out = {};
+    for (const lig of ligatures) {
+        const all = Array.from(
+            document.querySelectorAll('i, mat-icon, span, [class*=google-symbols]')
+        );
+        const hits = all.filter(el => exact(el, lig));
+        out[lig] = {
+            i_google_symbols: hits.filter(el =>
+                el.tagName === 'I' && el.classList.contains('google-symbols')).length,
+            mat_icon: hits.filter(el => el.tagName === 'MAT-ICON').length,
+            class_only: hits.filter(el => el.classList.contains('google-symbols')).length,
+            any_element: hits.length,
+            carrier_tags: Array.from(new Set(hits.map(el => el.tagName.toLowerCase()))),
+        };
+    }
+    return out;
+}"""
+
+
+async def _sweep_surface(page: Any, surface: str) -> dict[str, Any]:
+    counts = await page.evaluate(_SWEEP_JS, _LIGATURES)
+    present = {k: v for k, v in counts.items() if v["any_element"] > 0}
+    logger.info(
+        "surface_swept",
+        surface=surface,
+        url=page.url,
+        ligatures_present=len(present),
+        ligatures_probed=len(_LIGATURES),
+    )
+    for lig, c in sorted(present.items()):
+        logger.info(
+            "ligature",
+            surface=surface,
+            ligature=lig,
+            i_google_symbols=c["i_google_symbols"],
+            mat_icon=c["mat_icon"],
+            class_only=c["class_only"],
+            carriers=",".join(c["carrier_tags"]),
+        )
+    return counts
+
+
+async def run_spike(profile_name: str | None, project_id: str) -> None:
+    resolved_profile = _resolve_profile(profile_name)
+    profile_dir = _make_provider_dir(resolved_profile)
+    dump = default_out_path(f"ligature_carrier_sweep_{Path(resolved_profile).name}")
+    out_dir = dump.parent
+
+    report: dict[str, Any] = {
+        "profile": resolved_profile,
+        "project_id": project_id,
+        "ligatures_probed": _LIGATURES,
+    }
+    control_error: str | None = None
+
+    async with FlowApiClient(profile_dir=profile_dir, out_dir=out_dir) as client:
+        transport = cast("UiAutomationTransport", client.transport)
+        # Mint the scratch entity BEFORE taking the page. `create_entity` reaches Flow
+        # through `_post_json`, which checks a page out of the pool itself — and the pool
+        # holds ONE. Calling it while this script already holds that page is the deadlock
+        # that hung a spike for 32 minutes on 2026-09-07. The guard test cannot see this
+        # ordering: it only checks that `_checkin_page` appears somewhere in the file.
+        scratch_entity: str | None = await client.create_entity(project_id)
+        logger.info("created_scratch_entity", entity_id=scratch_entity)
+
+        page = await client._checkout_page()
+        try:
+            # --- Surface 1: the project composer -------------------------------
+            # Navigate straight to the project rather than going through
+            # `_enter_editor`, which clicks the gallery's "New project" CTA via
+            # NEW_PROJECT_SELECTORS — one of the very constants under test. A probe
+            # must not depend on the thing it is measuring: the first run of this
+            # spike died at exactly that CTA on the migrated root
+            # (`Could not find 'New project' CTA`, 2026-09-07), which is a finding
+            # about that selector and NOT a reason to lose both surfaces.
+            await page.goto(
+                project_editor_url(None, project_id), wait_until="domcontentloaded", timeout=45_000
+            )
+            await transport._dismiss_blocking_overlays(page, None)  # type: ignore[attr-defined]
+            await page.wait_for_timeout(3000)
+            report["composer_url"] = page.url
+            report["composer"] = await _sweep_surface(page, "composer")
+            await page.screenshot(path=str(out_dir / f"{dump.stem}_composer.png"))
+
+            # --- Surface 2: the character editor -------------------------------
+            await transport._enter_character_editor(
+                page, project_id=project_id, entity_id=scratch_entity, locale="en-US"
+            )
+            await page.wait_for_timeout(2000)
+            report["editor_url"] = page.url
+            report["editor"] = await _sweep_surface(page, "character_editor")
+            await page.screenshot(path=str(out_dir / f"{dump.stem}_editor.png"))
+
+            # CONTROL — recorded, raised on only after the dump is written. A run where
+            # the editor never mounted measures nothing, and its zeros must not be read
+            # as absence (skills/spike/SKILL.md: never put a guard in front of a probe).
+            boxes = await page.locator(_CHAR_EDITOR_READY).count()
+            report["control_prompt_boxes"] = boxes
+            total_hits = sum(
+                v["any_element"]
+                for v in report["editor"].values()  # type: ignore[union-attr]
+            )
+            report["control_total_ligature_hits"] = total_hits
+            logger.info("control_check", prompt_boxes=boxes, ligature_hits=total_hits)
+            if boxes == 0 or total_hits == 0:
+                control_error = (
+                    f"CONTROL MISSED: prompt_boxes={boxes}, ligature_hits={total_hits} on "
+                    f"{page.url} — this run measures nothing. Do not read its zeros as absence."
+                )
+        finally:
+            with contextlib.suppress(Exception):
+                await page.screenshot(path=str(out_dir / f"{dump.stem}_final.png"))
+            # Return the page BEFORE any client.<verb>(): the pool holds one page and
+            # `_checkout_page()` waits forever (tests/scripts/test_spike_page_pool.py).
+            client._checkin_page(page)
+            dump.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            logger.info("report_written", path=str(dump))
+            if scratch_entity is not None:
+                with contextlib.suppress(Exception):
+                    await client.delete_characters(project_id, [scratch_entity])
+                    logger.info("deleted_scratch_entity", entity_id=scratch_entity)
+
+    if control_error is not None:
+        raise RuntimeError(control_error)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Spike: ligature carrier sweep (#730)")
+    parser.add_argument("--project", required=True, help="Flow project id")
+    parser.add_argument("--profile", default=None, help="Profile for the live session")
+    args = parser.parse_args()
+
+    asyncio.run(run_spike(args.profile, args.project))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -101,8 +101,14 @@ _PROJECT_URL_FRAGMENT = "/project/"
 # 'Nano Banana Pro', so has-text is unambiguous across the three.
 # Tier 1 (structural) slots are reserved for data-* / aria-* anchors once a DOM
 # probe via scripts/dev/capture_locale_invariants.py confirms stable attributes.
+# Class-only carrier anchor (#730): `.google-symbols` matches the labs `<i>` AND the
+# migrated `<mat-icon>`, which both carry the class — verified against a real CSS engine in
+# tests/api/transports/test_ligature_carrier.py. The tag-qualified form matched ZERO on the
+# migrated host, and this constant has neither a carrier twin nor a text fallback, so the
+# miss was total and silent: the picker is best-effort, so generation simply proceeded on
+# whatever tier the editor happened to open at.
 IMAGE_MODEL_PICKER_TRIGGER = (
-    "button[aria-haspopup='menu']:has(i.google-symbols:text-is('arrow_drop_down'))"
+    "button[aria-haspopup='menu']:has(.google-symbols:text-is('arrow_drop_down'))"
 )
 # Verified live 2026-08-26 (menu read WHILE OPEN, profile denon82):
 #   ['Nano Banana Pro', 'Nano Banana 2', 'Nano Banana 2 Lite']
@@ -233,9 +239,27 @@ PROMPT_INPUT_SELECTORS = (
 # The ``arrow_forward`` ligature is a Material Symbols icon name (not a UI
 # label), so it renders identically regardless of the Chrome profile locale.
 # Use :text() inside :has() (not :has-text() which is invalid inside :has()).
+# Class-only carrier anchor (#730). `.google-symbols` covers the labs `<i>` and the migrated
+# `<mat-icon>` alike — both carry the class, verified against a real CSS engine in
+# tests/api/transports/test_ligature_carrier.py.
+#
+# This cascade was WORKING BY LUCK on the migrated host. Entries 0 and 1 were tag-qualified
+# and matched nothing there; the submit only ever landed because entry 2 matches the
+# `<mat-icon>`'s *text*. Observed live 2026-09-07:
+# `prompt_submitted via="button:has-text('arrow_forward')"`. Two misses at ~2s each were
+# paid on every submit before the fallback rescued it.
+#
+# The old `button:has(i:text(...))` entry is deleted, not kept: with entry 0 class-only it is
+# strictly dominated — anything a bare `<i>` carrying that text could match, the class-only
+# form matches too, and an `<i>` WITHOUT the class is not an icon carrier.
+# `:text-is` (exact), NOT `:text` (substring). The old entry was
+# `i.google-symbols:text('arrow_forward')`, whose substring match also accepts
+# `arrow_forward_ios` — a real Material Symbol. The `<i>` qualifier happened to contain that
+# on labs; dropping it for the class-only carrier made the over-match reachable, and the
+# two-carrier fixture caught it as `matched 3 of 2` before it ever ran live. Same trap as
+# `:text('upload')` accepting `drive_folder_upload` ([[flow-locale-leak-icon-ligatures]]).
 SUBMIT_BUTTON_SELECTORS = (
-    "button:has(i.google-symbols:text('arrow_forward'))",
-    "button:has(i:text('arrow_forward'))",
+    "button:has(.google-symbols:text-is('arrow_forward'))",
     "button:has-text('arrow_forward')",
 )
 
@@ -2385,7 +2409,13 @@ class UiAutomationTransport(VideoGenerationMixin):
                     }
                 }
                 // Google Symbols icons present anywhere — gives us the ligature names Flow uses.
-                const _gsQuery = 'i.google-symbols, span.google-symbols';
+                // Class-only, NOT tag-qualified. This query used to read
+                // 'i.google-symbols, span.google-symbols' and therefore returned ZERO on the
+                // migrated host, where every ligature rides a <mat-icon>. The instrument we
+                // reach for to diagnose selector drift was blind to the host the drift lives
+                // on — which is why #727 and #731 stayed invisible, and why an incident
+                // bundle from a migrated user reported no ligatures at all (#730).
+                const _gsQuery = '.google-symbols';
                 for (const el of document.querySelectorAll(_gsQuery)) {
                     const lig = (el.innerText || '').trim();
                     if (lig) result.google_symbols_ligatures.push({

--- a/src/gflow_cli/diagnostics.py
+++ b/src/gflow_cli/diagnostics.py
@@ -924,7 +924,12 @@ _NET_FAILURE_RE = re.compile(r"net::[A-Z0-9_]{1,64}")
 # ONE DOM engine (design §6.3) — the legacy ui_automation capture wrapper
 # consumes it too.
 STRUCTURAL_DOM_JS = r"""() => {
-  const syms = [...document.querySelectorAll('i.google-symbols')]
+  // Class-only, NOT tag-qualified. `i.google-symbols` returned ZERO on the migrated
+  // flow.google.com host, where every ligature rides a <mat-icon> that carries the same
+  // class. A diagnostic blind to the host the drift lives on is why #727 and #731 went
+  // unnoticed, and why an incident bundle from a migrated user reported no ligatures
+  // at all (#730).
+  const syms = [...document.querySelectorAll('.google-symbols')]
     .map(e => (e.textContent || '').trim()).filter(Boolean);
   const overlays = [...document.querySelectorAll(
       '[role="dialog"],[aria-modal="true"],dialog')].slice(0, 10).map(el => {
@@ -938,7 +943,7 @@ STRUCTURAL_DOM_JS = r"""() => {
       rect: {x: r.x, y: r.y, width: r.width, height: r.height},
       zIndex: parseInt(cs.zIndex, 10) || 0,
       pointerEvents: cs.pointerEvents,
-      ligatures: [...el.querySelectorAll('i.google-symbols')]
+      ligatures: [...el.querySelectorAll('.google-symbols')]
         .map(e => (e.textContent || '').trim()).filter(Boolean),
     };
   });

--- a/tests/api/transports/test_ligature_carrier.py
+++ b/tests/api/transports/test_ligature_carrier.py
@@ -1,0 +1,150 @@
+"""The ligature carrier differs by host, and the class-only anchor must span both (#730).
+
+Flow renders the SAME Material Symbols ligature under different tags depending on which
+frontend serves the account:
+
+* ``labs.google``           → ``<i class="google-symbols">arrow_forward</i>``
+* ``flow.google.com``       → ``<mat-icon class="… google-symbols …">arrow_forward</mat-icon>``
+
+A selector anchored on ``i.google-symbols`` therefore matches **zero** on the migrated host
+while the control is fully visible — measured 2026-09-07 on `denon82`, every ligature, both
+surfaces (``docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md``). That
+split shipped twice: #727 (`--format-prompt` a silent no-op) and #731 (published docs
+asserting stale selectors as VERIFIED).
+
+The fix rests on one claim: **the `google-symbols` class sits on both carriers, so a
+class-only anchor covers both hosts.** On the live migrated host that was observed —
+`.google-symbols` counted identically to `mat-icon`, every time. On **labs it was never
+observed**: no unmoved account exists here, so the `<i>` half is CSS semantics, asserted.
+
+This file settles it with a real CSS engine and no account, no network and no credits:
+a two-carrier fixture, headless Chromium, one `count()`. If the assertion below ever fails,
+the premise of #730 is wrong and the class-only anchors must be reverted to explicit
+per-carrier cascades.
+
+Deliberately a *precondition*, not a mock: a `MagicMock` page would happily agree with
+whatever the author believed, which is precisely how an unverified selector claim reaches
+production. Only a browser can answer whether a selector resolves.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gflow_cli.api.transports.ui_automation import (
+    IMAGE_MODEL_PICKER_TRIGGER,
+    SUBMIT_BUTTON_SELECTORS,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import AsyncIterator
+
+    from playwright.async_api import Page
+
+# Both carriers, same ligature, plus decoys: a span that also carries the class (the repo's
+# own `_gsQuery` already treats spans as carriers), and a longer ligature that must NOT be
+# matched by an exact `:text-is`.
+_TWO_CARRIER_PAGE = """
+<button id="labs"><i class="google-symbols">arrow_forward</i></button>
+<button id="migrated">
+  <mat-icon class="mat-icon notranslate google-symbols">arrow_forward</mat-icon>
+</button>
+<button id="span-carrier"><span class="google-symbols">arrow_drop_down</span></button>
+<button id="decoy-longer"><mat-icon class="google-symbols">arrow_forward_ios</mat-icon></button>
+<button id="decoy-no-class"><i>arrow_forward</i></button>
+"""
+
+
+@pytest.fixture
+async def page() -> AsyncIterator[Page]:
+    """A real headless Chromium page, or skip if the browser isn't installed."""
+    playwright_api = pytest.importorskip("playwright.async_api")
+    try:
+        async with playwright_api.async_playwright() as pw:
+            try:
+                browser = await pw.chromium.launch()
+            except Exception as exc:  # pragma: no cover - environment dependent
+                pytest.skip(f"chromium unavailable: {type(exc).__name__}: {exc}")
+            page = await browser.new_page()
+            try:
+                yield page
+            finally:
+                await browser.close()
+    except NotImplementedError as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"playwright cannot start here: {exc}")
+
+
+@pytest.mark.asyncio
+class TestClassOnlyAnchorSpansBothCarriers:
+    async def test_class_only_matches_i_and_mat_icon(self, page: Page) -> None:
+        """THE precondition for #730. If this fails, the class-only sweep is wrong."""
+        await page.set_content(_TWO_CARRIER_PAGE)
+
+        assert await page.locator(".google-symbols:text-is('arrow_forward')").count() == 2, (
+            "the class-only anchor must match BOTH the labs <i> and the migrated <mat-icon>"
+        )
+
+    async def test_the_tag_qualified_anchor_misses_the_migrated_carrier(self, page: Page) -> None:
+        """Why the sweep exists — reproduced offline, so it cannot be argued with.
+
+        This is the shipped `i.google-symbols` form. It sees the labs carrier and is
+        blind to the migrated one, which is the entire #727 / #731 failure in one number.
+        """
+        await page.set_content(_TWO_CARRIER_PAGE)
+
+        assert await page.locator("i.google-symbols:text-is('arrow_forward')").count() == 1
+        # One mat-icon holds the exact ligature; the other holds `arrow_forward_ios`, which
+        # `:text-is` correctly refuses. Asserting 2 here was my own error, caught by the
+        # fixture — the decoy is doing exactly the job it was added for.
+        assert await page.locator("mat-icon:text-is('arrow_forward')").count() == 1
+
+    async def test_exact_text_still_excludes_a_longer_ligature(self, page: Page) -> None:
+        """`:text-is` must stay exact — `arrow_forward_ios` is a real Material Symbol."""
+        await page.set_content(_TWO_CARRIER_PAGE)
+
+        ids = await page.locator(
+            "button:has(.google-symbols:text-is('arrow_forward'))"
+        ).evaluate_all("els => els.map(e => e.id)")
+        assert sorted(ids) == ["labs", "migrated"], f"unexpected match set: {ids}"
+
+    async def test_class_only_ignores_an_unclassed_carrier(self, page: Page) -> None:
+        """A bare `<i>` with no class is not an icon carrier and must not match."""
+        await page.set_content(_TWO_CARRIER_PAGE)
+
+        ids = await page.locator(
+            "button:has(.google-symbols:text-is('arrow_forward'))"
+        ).evaluate_all("els => els.map(e => e.id)")
+        assert "decoy-no-class" not in ids
+
+    async def test_shipped_submit_cascade_resolves_on_both_carriers(self, page: Page) -> None:
+        """The load-bearing submit path, against the SHIPPED constant.
+
+        `SUBMIT_BUTTON_SELECTORS[0]` is what fires first. On the migrated host it was
+        observed matching nothing, and only the third entry (`has-text`, which matches the
+        mat-icon's *text* rather than its tag) rescued the submit — working by luck.
+        """
+        await page.set_content(_TWO_CARRIER_PAGE)
+
+        matched = await page.locator(SUBMIT_BUTTON_SELECTORS[0]).count()
+        assert matched == 2, (
+            f"{SUBMIT_BUTTON_SELECTORS[0]!r} matched {matched} of 2 carriers — the submit "
+            "button is anchored on one frontend's carrier tag"
+        )
+
+    async def test_shipped_image_model_picker_resolves_on_both_carriers(self, page: Page) -> None:
+        """`IMAGE_MODEL_PICKER_TRIGGER` has no carrier twin and no text fallback."""
+        await page.set_content(
+            "<button aria-haspopup='menu' id='labs'>"
+            "<i class='google-symbols'>arrow_drop_down</i></button>"
+            "<button aria-haspopup='menu' id='migrated'>"
+            "<mat-icon class='google-symbols'>arrow_drop_down</mat-icon></button>"
+        )
+
+        matched = await page.locator(IMAGE_MODEL_PICKER_TRIGGER).count()
+        assert matched == 2, (
+            f"{IMAGE_MODEL_PICKER_TRIGGER!r} matched {matched} of 2 carriers — a miss here is "
+            "silent: the picker is best-effort and generation proceeds on whatever tier the "
+            "editor opened at"
+        )


### PR DESCRIPTION
## Summary

Scoped down from #730's "sweep 24 constants" after `/gflow:predict` returned **CAUTION 7.3/10** from three personas — unanimous: *right change, wrong blast radius*. Four changes ship, every one backed by a measurement.

Refs #730 (the full sweep stays open; see "Not touched" below)

## The one that matters: our diagnostics were blind

```
ui_automation.py   _gsQuery         = 'i.google-symbols, span.google-symbols'
diagnostics.py     STRUCTURAL_DOM_JS  querySelectorAll('i.google-symbols')
```

On `flow.google.com`, where every Material Symbols ligature rides a `<mat-icon>`, **both returned zero.**

The instrument we reach for to diagnose selector drift was blind to the host the drift lives on. That is why #727 and #731 stayed invisible for weeks, and why an incident bundle from a migrated user would have reported **no ligatures at all**. Both queries are now class-only.

## Two selectors were broken behind it

| Constant | State |
|---|---|
| `SUBMIT_BUTTON_SELECTORS` | **Working by luck.** Entries 0–1 matched nothing on migrated; the submit only landed because entry 2 matches the `<mat-icon>`'s *text*. Live: `prompt_submitted via="button:has-text('arrow_forward')"` — after paying two misses per submit |
| `IMAGE_MODEL_PICKER_TRIGGER` | No twin, no fallback → total silent miss. Best-effort, so generation proceeded on **whatever model tier the editor opened at** |

Both now anchor on the `google-symbols` **class**, which sits on the labs `<i>` and the migrated `<mat-icon>` alike.

## The premise is now observed, not asserted

The whole proposal rested on "`.google-symbols` matches both carriers" — CSS semantics, never checked. `tests/api/transports/test_ligature_carrier.py` proves it against a **real CSS engine** with a two-carrier fixture: no account, no network, no credits. If it ever fails, the premise is wrong and this reverts.

**It immediately caught a defect in my own fix: `matched 3 of 2`.** `SUBMIT_BUTTON_SELECTORS` used `:text`, a *substring* match, which also accepts `arrow_forward_ios` — a real Material Symbol. The `<i>` qualifier had been containing that; dropping it for the class-only carrier made the over-match reachable on the load-bearing submit path. Now `:text-is`.

So my own "one character each" framing was **wrong**: dropping a tag qualifier can expose a latent substring over-match, and each site needs its exactness checked too.

## Not touched, each for a measured reason

- **The negation sites** (`button:not(:has(i.google-symbols))`, and a `has_not` filter). Broadening **inverts** them — they would exclude *more* buttons, and on a dialog whose buttons carry mat-icons the iconless set collapses to zero → no include click → a **120s hang**. They are also already broken the other way on migrated.
- **The 10 mode-detection selectors.** They feed a classifier that calls `raise_if_migrated` every tick, so they never execute on the host this fixes. Zero upside, nonzero risk on labs — which is unmeasured.
- **The `add_2` constants.** A ligature **name** drift, not a carrier one, and `_CHARACTER_SLOT_ADD_LIGATURE` feeds a JS exact-match heuristic where a string swap is not the fix.

## Validation

- [x] `pytest -q --cov` — **4043 passed**, 7 skipped
- [x] `pyright src` — 0 errors · `ruff check` / `format --check` clean
- [x] hygiene 1030 files · doc links · website mirror · memory round trip · PII scan
- [x] New offline browser fixture, 6 tests, no credits

**E2E:** the changed selectors sit on the submit and model-picker paths, exercised by the character-create e2e. Not re-run here — the previous live run on this branch's parent predates these selector edits, so I am **not** claiming live coverage for them. The offline two-carrier fixture is what backs this PR; a live run belongs with whoever takes the remaining sweep.
