### PR TITLE
test(character): verify --voice and --personality actually attach

### DIFF
--- a/docs/CHARACTER.md
+++ b/docs/CHARACTER.md
@@ -262,12 +262,28 @@ token that drives the sample URL, so a canonical id round-trips to a playable sa
 `gflow character create --voice <Name>` validates the value **case-insensitively** (so `charon` and `Charon`
 both normalize to the canonical `Charon`) and sets `audioReferences[].presetVoiceId` via the entity PATCH.
 
-> **Wire-case caveat (open):** a prior live run sent a **lowercase** id (`"charon"`) and Flow persisted it,
-> but whether Flow applies the voice from a lowercase id vs the Capitalized canonical form is **UNVERIFIED**.
-> gflow adopts the Capitalized form as canonical per the UI. The voice list is currently a **hardcoded
-> constant**; fetching the live list from Flow's voice API and confirming the `presetVoiceId` wire-case are
-> tracked in the [Backlog](#14-backlog--not-yet-implemented). A "create new voice" flow ("Criar nova voz")
-> exists in the UI but is **not yet implemented**.
+> **Wire-case: Capitalized round-trips — VERIFIED 2026-09-07.** A live e2e
+> (`tests/e2e/test_character_create_e2e.py::test_character_create_attaches_voice_and_personality`,
+> profile `ffroliva`) created a character with `--voice Charon` and read it back from Flow:
+> `sent='Charon' stored='Charon' identical=True`. The Capitalized canonical form is stored
+> unchanged, so `CHARACTER_RECON.md`'s older note that "the preset id is the lowercased name"
+> does **not** describe what the wire does today.
+>
+> **Still untested:** whether a *lowercase* id is also accepted (gflow never sends one — it
+> normalizes to Capitalized before the PATCH), and — separately and more importantly —
+> whether a bound voice is actually **applied to generated video audio**. Attachment to the
+> entity is proven; application at render time is not.
+>
+> **`personalityNotes` is Agent-scoped.** Flow's own character editor labels the field
+> "Character info (optional) — Describe how your character acts…" and states underneath:
+> *"The Flow agent can use this information to help craft scenes with your character."*
+> It is an input to Flow's **agent** when it writes scenes, not a control on the audio engine
+> and not a documented input to a direct composer generation. Do not expect it to steer
+> performance on a `video t2v` / `r2v` call — put the direction in the prompt instead.
+>
+> The voice list is currently a **hardcoded constant**; fetching the live list from Flow's
+> voice API is tracked in the [Backlog](#14-backlog--not-yet-implemented). A "create new voice"
+> flow ("Criar nova voz") exists in the UI but is **not yet implemented**.
 
 ## 8. CLI surface (shipped v0.12.0)
 

--- a/docs/CHARACTER_RECON.md
+++ b/docs/CHARACTER_RECON.md
@@ -28,8 +28,13 @@ entity {
     entityType: "CHARACTER"
     displayName                  # "Denidra" (default "Untitled Character")
     characterInfo {
-      personalityNotes           # free text — guides actions when not specified in a prompt
-      audioReferences: [ { presetVoiceId: "gacrux" } ]      # voice; preset id is lowercased name
+      personalityNotes           # free text — Flow's editor says the AGENT uses it to craft
+                                 # scenes; NOT a documented input to a composer generation
+      audioReferences: [ { presetVoiceId: "Charon" } ]      # voice; Capitalized id round-trips
+                                 # unchanged (e2e-verified 2026-09-07: sent 'Charon', stored
+                                 # 'Charon'). The earlier "lowercased name" note above this
+                                 # line came from one capture and does NOT hold today; see
+                                 # CHARACTER.md § 7.
       imageReferences: [ { workflowId }, { workflowId } ]   # face + body (point to WORKFLOWS, not media)
     }
   }

--- a/scripts/dev/spike_entity_submit_rpcs.py
+++ b/scripts/dev/spike_entity_submit_rpcs.py
@@ -1,0 +1,215 @@
+"""Why does an entity-bound submit never reply? — logs EVERY batchexecute rpcid (#723).
+
+**The question.** `migrated_composer.attach_character_entities` works: it drives the `@`
+picker, commits a chip carrying ``data-reference-type="entity"`` with the requested id,
+and Flow loads the character's voice sample. The submit that follows then never produces a
+``YhhmEf`` / ``eb1hJf`` / ``MZZa6b`` reply — three runs, 60 s each, cause unknown. The
+guard in `_unported_form` therefore still refuses character references outright, so the
+whole point of a Character entity (its voice, server-side, durable) is unreachable on this
+host.
+
+**The hypothesis this probe exists to kill or confirm.** `SUBMIT_RPCS` watches exactly
+three rpcids. An entity-bound generation is a different form; if the app submits it on a
+**fourth** rpcid, the observer waits forever on RPCs that were never going to fire, and
+that is indistinguishable from "the submit did nothing". Nothing in an incident bundle
+could show this, because the video path parks the page at about:blank before the capture
+runs (#722) — which is why this reads the wire live instead.
+
+So: log every batchexecute request AND response, with its rpcid, stamped with the phase it
+fired in, straight through the submit. If an unrecognised rpcid appears after the click,
+the fix is a one-line addition to `SUBMIT_RPCS`. If literally nothing fires, the click is
+not reaching the button and the fix is in the submit gesture instead. Either answer ends a
+guess that has stood since 2026-09-07.
+
+**Cost.** This one DOES click submit, so a generation may start and bill. Run it on a
+profile whose credits you are willing to spend. It is the cheapest way to answer a
+question that has already cost three blind 60-second runs.
+
+Usage:
+    uv run python scripts/dev/spike_entity_submit_rpcs.py <profile> <project_id> \
+        --entity-id <uuid> --entity-name <Name> [--wait 90]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from gflow_cli.api.transports.migrated_composer import (  # noqa: E402
+    SUBMIT_RPCS,
+    MigratedComposer,
+    _ligature,
+)
+from gflow_cli.api.video import (  # noqa: E402
+    Aspect,
+    GenerateVideoRequest,
+    Mode,
+    VideoModel,
+)
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir  # noqa: E402, isort: skip
+
+PROMPT = (
+    "Warm golden-hour footage, full-frame 16:9 image filling the entire frame edge to "
+    "edge, no bars, no border. Setting: a high desert ridge of cracked red stone, still "
+    "air. Geometry: chest-up close framing, the camera fixed and completely still. "
+    "Action: he stands still and speaks to camera, calm and unhurried. Dialogue: he "
+    "says, low and unhurried: 'The wind has not turned once.' A single continuous shot. "
+    "Avoid: camera movement, any cut, letterbox bars, border, on-screen text."
+)
+
+
+def _stage(msg: str) -> None:
+    print(f"[spike] {msg}", flush=True)
+
+
+def _rpcid(url: str) -> str | None:
+    try:
+        return urllib.parse.parse_qs(urllib.parse.urlparse(url).query).get("rpcids", [None])[0]
+    except Exception:  # noqa: BLE001 - a malformed URL is not our frame
+        return None
+
+
+async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: float) -> dict:
+    seen: list[dict[str, Any]] = []
+    phase = {"now": "idle"}
+
+    def on_request(request: Any) -> None:
+        url = str(getattr(request, "url", ""))
+        if "batchexecute" not in url:
+            return
+        rid = _rpcid(url)
+        seen.append({
+            "dir": "request",
+            "phase": phase["now"],
+            "rpcid": rid,
+            "watched": rid in SUBMIT_RPCS,
+        })
+
+    async def on_response(response: Any) -> None:
+        url = str(getattr(response, "url", ""))
+        if "batchexecute" not in url:
+            return
+        rid = _rpcid(url)
+        try:
+            body = await response.text()
+        except Exception:  # noqa: BLE001 - streamed/aborted body
+            body = ""
+        seen.append({
+            "dir": "response",
+            "phase": phase["now"],
+            "rpcid": rid,
+            "watched": rid in SUBMIT_RPCS,
+            "status": getattr(response, "status", None),
+            "bytes": len(body),
+            "head": body[:400],
+        })
+
+    page.on("request", on_request)
+    page.on("response", lambda r: asyncio.create_task(on_response(r)))
+
+    composer = MigratedComposer()
+    phase["now"] = "ensure_editor"
+    await composer.ensure_editor(page, project_id)
+
+    # apply_video_settings is NOT optional here, and skipping it is its own bug: it
+    # selects the **Ingredients** submode whenever reference_entities is set, and the
+    # composer's own comment records that a character chip submitted from under Frames
+    # "clicked submit and got no reply at all". A spike that omits this stage measures
+    # the omission, not the port.
+    phase["now"] = "apply_settings"
+    request = GenerateVideoRequest(
+        prompt=PROMPT,
+        mode=Mode.T2V,
+        aspect=Aspect.LANDSCAPE,
+        model=VideoModel.OMNI_FLASH,
+        duration=8,
+        reference_entities=(entity_id,),
+        reference_entity_names=(name,),
+    )
+    await composer.apply_video_settings(page, request)
+    _stage("video settings applied (Ingredients submode, omni-flash, 16:9, 8s)")
+
+    phase["now"] = "attach_entity"
+    _stage(f"attaching entity {name} ({entity_id})")
+    await composer.attach_character_entities(
+        page, entity_ids=(entity_id,), names=(name,), clear=True
+    )
+    chips_after_attach = await composer.read_chips(page)
+    _stage(f"chips after attach: {chips_after_attach}")
+
+    phase["now"] = "prompt"
+    await composer.send_prompt(page, PROMPT, append=True)
+
+    phase["now"] = "submit"
+    _stage(f"clicking submit, then watching for {wait_s}s")
+    # The same locale-invariant gesture submit_and_observe uses: the icon ligature,
+    # never a text label (AGENTS.md forbids text-label selectors outright).
+    submit = page.locator("button").filter(has=_ligature(page, "arrow_forward")).first
+    await submit.click(timeout=10_000)
+    _stage("submit clicked")
+    await page.wait_for_timeout(int(wait_s * 1000))
+
+    phase["now"] = "done"
+    rpcids = sorted({e["rpcid"] for e in seen if e["rpcid"]})
+    after_submit = sorted({e["rpcid"] for e in seen if e["phase"] == "submit" and e["rpcid"]})
+    unwatched = [r for r in after_submit if r not in SUBMIT_RPCS]
+    return {
+        "project_id": project_id,
+        "entity_id": entity_id,
+        "entity_name": name,
+        "watched_rpcs": list(SUBMIT_RPCS),
+        "chips_after_attach": chips_after_attach,
+        "all_rpcids_seen": rpcids,
+        "rpcids_after_submit": after_submit,
+        "UNWATCHED_after_submit": unwatched,
+        "verdict": (
+            f"an UNWATCHED rpcid fired after submit: {unwatched} — add it to SUBMIT_RPCS"
+            if unwatched
+            else (
+                "no batchexecute fired after submit at all — the click is not reaching "
+                "the button, or the app refused client-side"
+                if not after_submit
+                else "only watched rpcids fired — the reply shape is the problem, not the id"
+            )
+        ),
+        "events": seen,
+    }
+
+
+async def _main(profile: str, project_id: str, entity_id: str, name: str,
+                wait_s: float, out_path: str) -> int:
+    async with build_client(resolve_profile_dir(profile)) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        report = await _probe(page, project_id, entity_id, name, wait_s)
+        Path(out_path).write_text(
+            json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        _stage(f"VERDICT: {report['verdict']}")
+        _stage(f"report written to {out_path}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("profile")
+    p.add_argument("project_id")
+    p.add_argument("--entity-id", required=True)
+    p.add_argument("--entity-name", required=True)
+    p.add_argument("--wait", type=float, default=90.0)
+    p.add_argument("--out", default=None)
+    a = p.parse_args()
+    out = a.out or str(default_out_path("entity_submit_rpcs"))
+    return asyncio.run(_main(a.profile, a.project_id, a.entity_id, a.entity_name, a.wait, out))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -260,16 +260,32 @@ def _unported_form(request: GenerateVideoRequest) -> str | None:
         # voice sample. A route-aborted capture showed the assembled MZZa6b payload
         # carrying that id in its own reference slot.
         #
-        # What does NOT work: the submit that follows never produces a
-        # YhhmEf/eb1hJf/MZZa6b reply. Three runs, 60 s each, with the submode forced to
-        # Ingredients and with the model both pinned and left to Flow's default. Cause
-        # unknown — and undiagnosable from an incident bundle today, because the video
-        # path parks the page at about:blank before the capture runs (#722), so every
-        # bundle reports an empty DOM.
+        # What does NOT work: the BACKEND rejects the generation. This was previously
+        # recorded here as "the submit never produces a YhhmEf/eb1hJf/MZZa6b reply,
+        # cause unknown, undiagnosable without fixing #722". Both halves of that were
+        # wrong, and `scripts/dev/spike_entity_submit_rpcs.py` shows why — it logs every
+        # batchexecute rpcid through the submit instead of only the three watched ones:
         #
-        # Relaxing this gate before that is understood trades a clear, instant exit 36
-        # for a 60-second timeout, which is strictly worse for the user. The refusal
-        # stays until an entity-bound generation has actually completed.
+        #   MZZa6b -> [["wrb.fr","MZZa6b",null,null,null,[5],"generic"]]
+        #   WuwhI  -> []
+        #   jwpduf -> the generation IS listed in the project, prompt prefixed with the
+        #             entity name
+        #
+        # So MZZa6b DOES reply — with a null result and an error slot — and the run
+        # enqueues and then fails. Flow's own UI says so: "Failed. Sorry, this video
+        # failed to generate. You have not been charged for this generation." There is
+        # nothing missing from SUBMIT_RPCS, and reading the wire live sidesteps the
+        # empty incident bundle entirely, so #722 was never on this path.
+        #
+        # Measured 2026-09-07 across three configurations, all identical:
+        #   - portrait-only character, settings not applied
+        #   - portrait-only character, Ingredients + omni_flash + 16:9 + 8s
+        #   - character with face AND body triptych, same settings
+        # Character completeness is not the variable; the backend refuses the form.
+        #
+        # Relaxing this gate therefore trades a clear, instant exit 36 for a failed card
+        # the user has to interpret, which is strictly worse. The refusal stays until an
+        # entity-bound generation has actually completed on this host.
         return "character references"
     if request.mode is Mode.T2V:
         return None

--- a/tests/e2e/test_character_create_e2e.py
+++ b/tests/e2e/test_character_create_e2e.py
@@ -702,3 +702,143 @@ def test_create_never_leaves_an_untitled_orphan(e2e_env: dict[str, str]) -> None
         f"the new entity is named {created_name!r}, not {name!r} — the final PATCH did not land, "
         "which is exactly what an orphan looks like"
     )
+
+
+# ---------------------------------------------------------------------------
+# Scenario #8 — `--voice` and `--personality` actually ATTACH (create -> read-back)
+# ---------------------------------------------------------------------------
+
+
+def test_character_create_attaches_voice_and_personality(e2e_env: dict[str, str]) -> None:
+    """Live ``create --voice --personality`` then ``show``: BOTH must survive the round trip.
+
+    **Until this test, ``--voice`` had never been exercised end-to-end.** A repo-wide
+    grep for ``--voice`` across ``tests/e2e/`` matched nothing. Every voice test in the
+    suite is a unit test of the hardcoded ``VOICES`` constant — list length,
+    capitalisation, the sample-URL string pattern, dataclass frozen-ness — and not one
+    reaches Flow. The single test that *looks* live (``chars[0].voice == "gacrux"``)
+    parses a fixture. So a voice that silently failed to attach was invisible to the
+    entire suite while ``character create`` exited 0, and the sibling test that covers
+    the parent-entity binding stops one field short of the voice.
+
+    Personality is asserted **hard** here on purpose. ``test_character_personality_utf8``
+    guards it as ``if shown_personality:`` — a soft check that passes vacuously when the
+    read-back omits the field entirely, which is precisely the failure worth catching.
+
+    **Voice case is compared case-INSENSITIVELY, deliberately.** The wire case of
+    ``presetVoiceId`` is unverified and the repo's own two documents disagree:
+    ``docs/CHARACTER.md`` calls the Capitalized UI name canonical (and flags the
+    question UNVERIFIED in the same section), while ``docs/CHARACTER_RECON.md`` records
+    ``presetVoiceId: "gacrux"`` from a live capture and states the preset id is the
+    lowercased name. gflow normalises to Capitalized and sends that. Pinning either
+    spelling would make this red for a reason that is not the defect it exists to catch
+    — the defect is a voice that does not attach AT ALL. The spelling Flow actually
+    returned is reported in the assertion message so a single run settles the
+    contradiction with evidence instead of another opinion.
+
+    Cost: one image generation, zero credits (no ``--body-prompt``); daily-capped.
+    """
+    _require_character_optin()
+    project_id = _require_project()
+    env = _character_env(e2e_env)
+    profile = env["GFLOW_CLI_PROFILE"]
+    locale = os.environ.get(_LOCALE_ENV, _DEFAULT_LOCALE)
+    face = os.environ.get(_FACE_ENV, _DEFAULT_FACE_PROMPT)
+
+    # A voice whose canonical spelling differs from its lowercase form, so the
+    # read-back tells us which one Flow stored.
+    voice = "Charon"
+    marker = uuid.uuid4().hex[:8]
+    name = f"voice-attach-{marker}"
+    # Unique marker so the read-back cannot match a leftover character.
+    personality = f"{_DEFAULT_PERSONALITY} — marcador {marker}"
+
+    result = _run_gflow(
+        [
+            "character",
+            "create",
+            "--project",
+            project_id,
+            "--name",
+            name,
+            "--face-prompt",
+            face,
+            "--voice",
+            voice,
+            "--personality",
+            personality,
+            "--locale",
+            locale,
+            "--profile",
+            profile,
+            "--json",
+        ],
+        env=env,
+        timeout=_CREATE_TIMEOUT_S,
+    )
+    assert result.returncode == 0, (
+        f"character create (voice) exited {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    payload = _parse_json_stdout(result, "character create (voice)")
+    created = cast(dict[str, object], payload["character"])
+    entity_id = created.get("entity_id")
+    assert entity_id, f"create returned empty entity_id: {created}"
+
+    # ---- the create payload reports what gflow believes it sent ----
+    created_voice = created.get("voice")
+    assert created_voice, (
+        f"create payload carries no voice at all: {created} — gflow was asked for "
+        f"{voice!r} and reported nothing, so the PATCH never carried audioReferences"
+    )
+
+    # ---- read-back from Flow: the authoritative check ----
+    show = _run_gflow(
+        [
+            "character",
+            "show",
+            "--project",
+            project_id,
+            "--id",
+            str(entity_id),
+            "--profile",
+            profile,
+            "--json",
+        ],
+        env=env,
+        timeout=_SHOW_TIMEOUT_S,
+    )
+    assert show.returncode == 0, (
+        f"character show (voice) exited {show.returncode}\n"
+        f"STDOUT:\n{show.stdout}\nSTDERR:\n{show.stderr}"
+    )
+    shown_payload = _parse_json_stdout(show, "character show (voice)")
+    shown = cast(dict[str, object], shown_payload["character"])
+
+    # THE assertion this test exists for: Flow itself must report a voice on the
+    # entity. A None here means `--voice` was accepted by the CLI, exited 0, and
+    # attached nothing — the silent failure the suite could not see.
+    shown_voice = shown.get("voice")
+    assert shown_voice, (
+        f"read-back reports NO voice on entity {entity_id}: {shown} — "
+        f"`--voice {voice}` exited 0 but nothing was attached server-side"
+    )
+    assert str(shown_voice).casefold() == voice.casefold(), (
+        f"read-back voice {shown_voice!r} is not {voice!r} (compared case-insensitively)"
+    )
+    # Evidence for the CHARACTER.md / CHARACTER_RECON.md contradiction: record the
+    # spelling Flow returned against the spelling gflow sent. Never fails on case.
+    print(  # noqa: T201 -- e2e evidence line, read from the run's captured output
+        f"[voice-case-evidence] sent={voice!r} stored={shown_voice!r} "
+        f"identical={shown_voice == voice}"
+    )
+
+    # ---- personality must survive too, asserted hard (no `if` guard) ----
+    shown_personality = shown.get("personality")
+    assert shown_personality, (
+        f"read-back reports NO personality on entity {entity_id}: {shown} — "
+        "`--personality` exited 0 but personalityNotes never landed"
+    )
+    assert shown_personality == personality, (
+        f"personality corrupted on read-back: sent {personality!r}, got {shown_personality!r}"
+    )

--- a/website/docs/CHARACTER.md
+++ b/website/docs/CHARACTER.md
@@ -262,12 +262,28 @@ token that drives the sample URL, so a canonical id round-trips to a playable sa
 `gflow character create --voice <Name>` validates the value **case-insensitively** (so `charon` and `Charon`
 both normalize to the canonical `Charon`) and sets `audioReferences[].presetVoiceId` via the entity PATCH.
 
-> **Wire-case caveat (open):** a prior live run sent a **lowercase** id (`"charon"`) and Flow persisted it,
-> but whether Flow applies the voice from a lowercase id vs the Capitalized canonical form is **UNVERIFIED**.
-> gflow adopts the Capitalized form as canonical per the UI. The voice list is currently a **hardcoded
-> constant**; fetching the live list from Flow's voice API and confirming the `presetVoiceId` wire-case are
-> tracked in the [Backlog](#14-backlog--not-yet-implemented). A "create new voice" flow ("Criar nova voz")
-> exists in the UI but is **not yet implemented**.
+> **Wire-case: Capitalized round-trips — VERIFIED 2026-09-07.** A live e2e
+> (`tests/e2e/test_character_create_e2e.py::test_character_create_attaches_voice_and_personality`,
+> profile `ffroliva`) created a character with `--voice Charon` and read it back from Flow:
+> `sent='Charon' stored='Charon' identical=True`. The Capitalized canonical form is stored
+> unchanged, so `CHARACTER_RECON.md`'s older note that "the preset id is the lowercased name"
+> does **not** describe what the wire does today.
+>
+> **Still untested:** whether a *lowercase* id is also accepted (gflow never sends one — it
+> normalizes to Capitalized before the PATCH), and — separately and more importantly —
+> whether a bound voice is actually **applied to generated video audio**. Attachment to the
+> entity is proven; application at render time is not.
+>
+> **`personalityNotes` is Agent-scoped.** Flow's own character editor labels the field
+> "Character info (optional) — Describe how your character acts…" and states underneath:
+> *"The Flow agent can use this information to help craft scenes with your character."*
+> It is an input to Flow's **agent** when it writes scenes, not a control on the audio engine
+> and not a documented input to a direct composer generation. Do not expect it to steer
+> performance on a `video t2v` / `r2v` call — put the direction in the prompt instead.
+>
+> The voice list is currently a **hardcoded constant**; fetching the live list from Flow's
+> voice API is tracked in the [Backlog](#14-backlog--not-yet-implemented). A "create new voice"
+> flow ("Criar nova voz") exists in the UI but is **not yet implemented**.
 
 ## 8. CLI surface (shipped v0.12.0)
 


### PR DESCRIPTION
## Summary

`--voice` had **never been exercised end-to-end**. A repo-wide grep for `--voice` across `tests/e2e/` matched nothing.

Every voice test in the suite is a unit test of the hardcoded `VOICES` constant — list length, capitalisation, the sample-URL string pattern, dataclass frozen-ness — and not one reaches Flow. The single test that *looks* live (`chars[0].voice == "gacrux"`) parses a fixture. A voice that silently failed to attach was therefore invisible to the whole suite while `character create` exited 0, and `test_character_create_binds_parent_entity` stops one field short of the voice.

This adds the missing coverage and corrects two documents with the evidence it produced.

## What the run proved

```
[voice-case-evidence] sent='Charon' stored='Charon' identical=True
1 passed in 227.92s (0:03:47)
```

Profile `ffroliva`, project `c5550ed7`, one image generation, zero credits.

| Question | Answer |
|---|---|
| Does `--voice` attach at all? | **Yes** — Flow's read-back reports the voice |
| Which case does the wire store? | **Capitalized, unchanged** |
| Does `--personality` attach? | **Yes** — asserted hard, no `if` guard |

## Docs corrected

Our own two documents disagreed, and one was wrong:

- `docs/CHARACTER.md` called the Capitalized name canonical while flagging the question **UNVERIFIED**.
- `docs/CHARACTER_RECON.md` recorded `presetVoiceId: "gacrux"` and stated *"preset id is lowercased name"*.

The caveat is now the measurement, and it names what remains **untested**: whether a lowercase id is also accepted (gflow never sends one), and — separately and more importantly — whether a bound voice is actually **applied to generated video audio**. Attachment is proven; application is not.

Both docs also now record that **`personalityNotes` is Agent-scoped**. Flow's own character editor states:

> "The Flow agent can use this information to help craft scenes with your character."

It is not a control on the audio engine and not a documented input to a direct composer generation. Nothing in our docs said this, which invites expecting it to steer a `t2v` / `r2v` performance — put that direction in the prompt instead.

## Design notes

- **Voice case is compared case-insensitively on purpose.** The defect worth catching is a voice that does not attach AT ALL; pinning either spelling would go red for a reason that is not that defect. The run prints the spelling Flow returned, so it settles the contradiction as evidence rather than opinion.
- **Personality is asserted hard.** `test_character_personality_utf8` guards it as `if shown_personality:` — a soft check that passes vacuously when the read-back omits the field, which is exactly the failure worth catching.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `ruff format --check src tests` — 456 files already formatted
- [x] `pyright src` — 0 errors
- [x] `check_repo_hygiene.py` — 1028 files, no violations
- [x] `check_doc_links.py` — 29 files resolved
- [x] `generate_website_docs.py --check` — mirror in sync (regenerated)
- [x] `check_website_docs_pii.py` — clean
- [x] `check_council_memory.py` — 49 files, all cited
- [x] Character unit tests — 66 passed
- [x] **e2e, live** — `test_character_create_attaches_voice_and_personality` passed against `ffroliva`

## Known follow-ups (not in this PR)

- The test leaves a `voice-attach-<hex>` entity behind per run; the file's other tests share that property.
- Whether a bound voice reaches rendered video audio is still unproven — the open question this test deliberately does not claim.