### PR TITLE
fix(migrated): name the host, not the selector, when the gallery has no New project CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A migrated-host gallery no longer reports a missing control as selector drift.**
+  `NEW_PROJECT_SELECTORS` anchors on the `add_2` ligature. The migrated `flow.google.com`
+  frontend renders **`add`** and renders `add_2` **nowhere** — composer `add=1/add_2=0`,
+  editor `add=2/add_2=0`, measured with per-surface controls. That is a ligature *name*
+  drift, not the carrier split, so a `mat-icon` twin would not have helped. Reaching the
+  sweep there produced `Could not find 'New project' CTA on Flow gallery`, whose remediation
+  is "check for a newer release, then file a frontend bug" — unfixable by the reader, and
+  pointing at the wrong culprit, exactly as a credit shortfall once reported as frontend
+  drift. It now raises `FlowHostMigratedError` naming the host and the way forward
+  (`--project`, which every migrated path already requires). On labs a missing CTA is still
+  reported as drift, because there it genuinely is.
+
+  No production path reaches this today — `migrated_can_serve` refuses without a
+  `project_id`, `ensure_editor` navigates straight to the project URL, and `character create`
+  requires `--project`. The `add_2` drift is therefore harmless **because of those guards**,
+  which is precisely what a future port relaxes; the measured fact now sits beside the
+  constant so the next person to un-guard a path meets it.
+  ([#730](https://github.com/ffroliva/gflow-cli/issues/730),
+  [spike](docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md))
+
 - **Flow's own diagnostics were blind on the migrated host, and two selectors were broken behind
   it.** `gflow`'s incident-bundle DOM dump queried `i.google-symbols, span.google-symbols`, and
   `diagnostics.py`'s `STRUCTURAL_DOM_JS` queried `i.google-symbols` — so on `flow.google.com`,

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -53,6 +53,7 @@ from gflow_cli.errors import (
     ConfigurationError,
     ContentPolicyError,
     FlowAppError,
+    FlowHostMigratedError,
     GFlowError,
     RateLimitError,
     UiSelectorDriftError,
@@ -343,6 +344,17 @@ _BODY_SLOT_MOUNT_POLL_MS = 250
 # only — anchoring prevents matching e.g. "+ Filter" or "+ Add member" rows
 # that contain extra words.  Text variants are ordered by onboarding-locale
 # list (same 14 as ``ONBOARDING_SELECTORS``).
+#
+# LABS-ONLY BY MEASUREMENT, not by intent. The migrated `flow.google.com` frontend renders
+# the ligature `add` and renders `add_2` NOWHERE — composer add=1/add_2=0, editor
+# add=2/add_2=0, per-surface controls passing (2026-09-07,
+# docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md). This is a ligature
+# NAME drift, not the carrier split #730 fixed, so adding a `mat-icon` twin would not help.
+#
+# It is harmless today only because no migrated path reaches here: `migrated_can_serve`
+# refuses without a `project_id`, `ensure_editor` navigates straight to the project URL, and
+# `character create` requires `--project`. Those guards are what a future port relaxes — so
+# `_enter_editor` now names the host rather than blaming this cascade when it is reached.
 NEW_PROJECT_SELECTORS = (
     # Tier 1 — structural / icon: locale-invariant.
     "button:has(i.google-symbols:text('add_2'))",
@@ -1566,6 +1578,25 @@ class UiAutomationTransport(VideoGenerationMixin):
                 continue
 
         shot_path = await _capture_debug_screenshot(page, out_dir, "debug_new_project.png")
+        # Name the host, not the selector. This cascade anchors on the `add_2` ligature;
+        # the migrated frontend renders `add` and renders `add_2` NOWHERE (measured
+        # 2026-09-07 on both surfaces with per-surface controls —
+        # docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md). So on
+        # that host the sweep cannot succeed, and reporting "Could not find the CTA"
+        # sends the reader after selector drift — remediation "check for a newer release,
+        # then file a frontend bug" — for a control that host does not render at all.
+        # Same misdiagnosis shape as a credit shortfall reported as frontend drift (#726).
+        if flow_host_kind(page.url) == "migrated":
+            raise FlowHostMigratedError(
+                detail=(
+                    "Flow served this account's gallery from flow.google.com, whose "
+                    "frontend renders no '+ New project' control gflow can drive, so a "
+                    "project cannot be created here. This is not selector drift and it is "
+                    "not transient — the handoff is a per-account setting. Pass --project "
+                    "with an existing project id, which every migrated-host path requires."
+                    f"{screenshot_clause(shot_path)}"
+                )
+            )
         msg = (
             f"Could not find 'New project' CTA on Flow gallery. "
             f"URL: {page.url}.{screenshot_clause(shot_path)}"

--- a/tests/api/transports/test_new_project_cta_migrated.py
+++ b/tests/api/transports/test_new_project_cta_migrated.py
@@ -1,0 +1,108 @@
+"""The migrated gallery has no "+ New project" CTA — say that, don't blame the selector.
+
+`NEW_PROJECT_SELECTORS` anchors on the ``add_2`` Material Symbols ligature. The migrated
+``flow.google.com`` frontend renders **`add`**, and renders ``add_2`` nowhere at all —
+measured 2026-09-07 on `denon82`, both surfaces, with per-surface controls
+(``docs/superpowers/spikes/2026-09-07-ligature-carrier-and-name-drift.md``). So on that host
+the sweep walks every selector, matches nothing, and raises:
+
+    RuntimeError: Could not find 'New project' CTA on Flow gallery. URL: https://flow.google.com/...
+
+That message is wrong in the way this repo keeps having to fix. It reports a **selector**
+problem — the remediation for which is "check for a newer gflow-cli release, then file a
+frontend bug" — when the truth is that this host does not render that control in any form.
+It is the same misdiagnosis shape as a credit shortfall reported as frontend drift (#726):
+a real, unfixable-by-the-reader error message pointing at the wrong culprit.
+
+No production path reaches this today: `migrated_can_serve` refuses without a `project_id`,
+`ensure_editor` navigates straight to the project URL, and `character create` requires
+`--project`. Those guards are what make the `add_2` name drift harmless *right now* — and
+they are exactly what a future port relaxes. A spike hit this on 2026-09-07 and got the
+misleading message; the next person to un-guard a path would get it too.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gflow_cli.api.transports.ui_automation import NEW_PROJECT_SELECTORS, UiAutomationTransport
+from gflow_cli.errors import FlowHostMigratedError
+
+_MIGRATED_GALLERY = "https://flow.google.com/?hl=en"
+_LABS_GALLERY = "https://labs.google/fx/en/tools/flow"
+
+
+def _gallery_page(url: str) -> MagicMock:
+    """A gallery page where NOTHING matches — the state the migrated host produces."""
+    page = MagicMock()
+    page.url = url
+    page.goto = AsyncMock()
+    page.wait_for_timeout = AsyncMock()
+    page.wait_for_url = AsyncMock()
+    page.screenshot = AsyncMock(return_value=b"")
+
+    def _locator(_sel: str) -> Any:
+        loc = MagicMock()
+        loc.first = loc
+        loc.wait_for = AsyncMock(side_effect=Exception("not visible"))
+        loc.click = AsyncMock()
+        loc.count = AsyncMock(return_value=0)
+        return loc
+
+    page.locator = MagicMock(side_effect=_locator)
+    return page
+
+
+def _transport(page: MagicMock) -> UiAutomationTransport:
+    t = UiAutomationTransport()
+    t._setup_done = True  # type: ignore[attr-defined]
+    t._page = page  # type: ignore[attr-defined]
+    # The gallery preamble is not what this test is about.
+    t._settle_if_redirecting = AsyncMock()  # type: ignore[attr-defined]
+    t._bypass_onboarding = AsyncMock()  # type: ignore[attr-defined]
+    t._dismiss_blocking_overlays = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+    t._require_unblocked = AsyncMock()  # type: ignore[attr-defined]
+    return t
+
+
+class TestNewProjectCtaOnMigratedHost:
+    @pytest.mark.asyncio
+    async def test_migrated_gallery_names_the_host_not_the_selector(self) -> None:
+        page = _gallery_page(_MIGRATED_GALLERY)
+        t = _transport(page)
+
+        with pytest.raises(FlowHostMigratedError) as excinfo:
+            await t._enter_editor(page)  # type: ignore[attr-defined]
+
+        detail = str(excinfo.value)
+        assert "flow.google.com" in detail
+        assert "--project" in detail, "the error must name the way forward, not just the wall"
+
+    @pytest.mark.asyncio
+    async def test_labs_gallery_still_reports_a_missing_cta(self) -> None:
+        """On labs the CTA genuinely should be there, so its absence IS selector drift.
+
+        The migrated branch must not swallow the real failure mode it was carved out of.
+        """
+        page = _gallery_page(_LABS_GALLERY)
+        t = _transport(page)
+
+        with pytest.raises(RuntimeError, match="Could not find 'New project' CTA") as excinfo:
+            await t._enter_editor(page)  # type: ignore[attr-defined]
+
+        assert not isinstance(excinfo.value, FlowHostMigratedError)
+
+    def test_the_cta_cascade_still_anchors_on_add_2(self) -> None:
+        """Pins WHY the migrated branch exists, so the two cannot drift apart.
+
+        If someone re-anchors this cascade on `add` (the ligature the migrated host
+        actually renders), this test fails and the branch above should be revisited
+        rather than silently kept.
+        """
+        assert any("add_2" in s for s in NEW_PROJECT_SELECTORS), (
+            "the migrated-host branch exists because this cascade anchors on `add_2`, "
+            "which flow.google.com does not render — re-anchoring it changes that premise"
+        )


### PR DESCRIPTION
## Summary

"Fix the `add_2` name drift" turned out to have **no selector to fix**. Tracing reachability before editing corrected two claims I had already made publicly on #730.

Refs #730

## The correction

| Constant | I claimed | Actually |
|---|---|---|
| `_CHARACTER_SLOT_ADD_SELECTOR` | broken on migrated | **Not broken.** `_click_character_slot_add` tries `_CHARACTER_BODY_MODE_SELECTOR` first, which already covers the migrated `flow-slot-chip-button`; the `add_2` path is the *legacy* fallback |
| `ADD_MEDIA_BUTTON` | broken on migrated | **Unreachable.** `ui_automation_video.py` returns `FlowHostMigratedError` before any of its ligature selectors run |
| `NEW_PROJECT_SELECTORS` | broken on migrated | Reached only without `--project` — and `migrated_can_serve` refuses without one |

All three are **labs-only in practice**, so the name drift has no live production impact today. That was the third time in this session my count was too high, each time the same mistake: generalising from a grep without checking reachability.

## The real defect, which my own spike hit

```
RuntimeError: Could not find 'New project' CTA on Flow gallery.
URL: https://flow.google.com/?hl=en
```

On the migrated host this blames the **selector** for a control that host does not render. Its remediation — *"check for a newer gflow-cli release, then file a frontend bug"* — is unfixable by the reader and points at the wrong culprit. The same misdiagnosis shape as a credit shortfall reported as frontend drift (#726).

It now raises `FlowHostMigratedError` naming the host **and the way forward** (`--project`, which every migrated path already requires).

## Why this is worth shipping when nothing reaches it today

The `add_2` drift is harmless **because of guards** — `migrated_can_serve` refusing without a project id, `ensure_editor` navigating directly, `character create` requiring `--project`. Guards are exactly what a port relaxes. A spike hit this message on 2026-09-07 and learned nothing from it; the next person to un-guard a path would get the same.

So the measured fact now sits beside the constant: **`add`, never `add_2`** (composer `add=1/add_2=0`, editor `add=2/add_2=0`, per-surface controls passing), including why a `mat-icon` twin would not have helped — this is a ligature *name* drift, not the carrier split #735 fixed.

## Tests

Watched red first:
```
RuntimeError: Could not find 'New project' CTA on Flow gallery. URL: https://flow.google.com/?hl=en
```

Three tests, then green:
- migrated gallery → `FlowHostMigratedError` naming the host and `--project`
- **labs gallery still reports genuine CTA absence as drift** — the migrated branch must not swallow the failure mode it was carved out of
- the cascade still anchors on `add_2` — if anyone re-anchors it on `add`, this fails and the branch gets revisited rather than silently kept

## Validation

- [x] `pytest -q --cov` — **4046 passed**, 7 skipped, 92% coverage
- [x] `pyright src` 0 errors · `ruff check` / `format --check` clean
- [x] doc links · hygiene 1031 files · website mirror in sync

**E2E:** none owed. This changes an error message on a path no production flow reaches on the migrated host, and leaves the labs path byte-identical. The behaviour is pinned by unit tests on both branches; a live run would exercise neither, since reaching it requires deliberately calling `_enter_editor` without a project id on a migrated account — which is what the spike did, and what produced the misleading message in the first place.
