### PR TITLE
fix(723): retract the wrong entity-submit diagnosis, and bank the character-voice recipe

### DIFF
--- a/scripts/dev/spike_entity_submit_rpcs.py
+++ b/scripts/dev/spike_entity_submit_rpcs.py
@@ -43,11 +43,13 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 
 from gflow_cli.api.transports.migrated_composer import (  # noqa: E402
+    MODEL_KEY,
     SUBMIT_RPCS,
     MigratedComposer,
     _ligature,
 )
 from gflow_cli.api.video import (  # noqa: E402
+    _VIDEO_MODEL_FROM_CLI,
     Aspect,
     GenerateVideoRequest,
     Mode,
@@ -77,7 +79,8 @@ def _rpcid(url: str) -> str | None:
         return None
 
 
-async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: float) -> dict:
+async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: float,
+                 ref_image: Path | None = None, model: VideoModel | None = None) -> dict:
     seen: list[dict[str, Any]] = []
     phase = {"now": "idle"}
 
@@ -86,12 +89,27 @@ async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: 
         if "batchexecute" not in url:
             return
         rid = _rpcid(url)
-        seen.append({
+        row: dict[str, Any] = {
             "dir": "request",
             "phase": phase["now"],
             "rpcid": rid,
             "watched": rid in SUBMIT_RPCS,
-        })
+        }
+        # The submit body carries the MODEL KEY Flow derived from the submode plus the
+        # picker choice (e.g. `abra_r2v_8s`, `veo_3_1_r2v_lite_low_priority`). When the
+        # backend rejects an entity-bound run with a null payload and no message, that
+        # key is the only place the chosen model is visible — and a model the character
+        # form does not support would look exactly like this.
+        if rid in SUBMIT_RPCS:
+            try:
+                body = request.post_data
+            except Exception:  # noqa: BLE001 - some requests expose no body
+                body = None
+            if body:
+                keys = sorted(set(MODEL_KEY.findall(body)))
+                row["model_keys"] = keys
+                row["body_head"] = body[:700]
+        seen.append(row)
 
     async def on_response(response: Any) -> None:
         url = str(getattr(response, "url", ""))
@@ -125,22 +143,38 @@ async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: 
     # "clicked submit and got no reply at all". A spike that omits this stage measures
     # the omission, not the port.
     phase["now"] = "apply_settings"
+    # With --ref-image this is a genuine R2V run carrying a media reference AND a
+    # character, which is the combination attach_character_entities documents as
+    # supported ("an r2v run can carry media references AND characters"). Without it,
+    # a T2V request sits in the Ingredients submode the entity forces, and the app
+    # derives its model key from that submode plus the picker choice — so a t2v key
+    # under Ingredients is a plausible cause of a backend rejection, and untested.
     request = GenerateVideoRequest(
         prompt=PROMPT,
-        mode=Mode.T2V,
+        mode=Mode.R2V if ref_image else Mode.T2V,
         aspect=Aspect.LANDSCAPE,
-        model=VideoModel.OMNI_FLASH,
+        model=model,  # None -> Flow's own UI default, untouched picker
         duration=8,
+        reference_images=(ref_image,) if ref_image else (),
         reference_entities=(entity_id,),
         reference_entity_names=(name,),
     )
     await composer.apply_video_settings(page, request)
-    _stage("video settings applied (Ingredients submode, omni-flash, 16:9, 8s)")
+    _stage(
+        f"settings applied: mode={request.mode.value}, "
+        f"model={model or 'FLOW DEFAULT'}, 16:9, 8s"
+    )
+
+    reference_ids: tuple[str, ...] = ()
+    if ref_image:
+        phase["now"] = "attach_reference_image"
+        reference_ids = await composer.attach_references(page, project_id, (ref_image,))
+        _stage(f"reference image attached: {reference_ids}")
 
     phase["now"] = "attach_entity"
     _stage(f"attaching entity {name} ({entity_id})")
     await composer.attach_character_entities(
-        page, entity_ids=(entity_id,), names=(name,), clear=True
+        page, entity_ids=(entity_id,), names=(name,), clear=not reference_ids
     )
     chips_after_attach = await composer.read_chips(page)
     _stage(f"chips after attach: {chips_after_attach}")
@@ -180,16 +214,20 @@ async def _probe(page: Any, project_id: str, entity_id: str, name: str, wait_s: 
                 else "only watched rpcids fired — the reply shape is the problem, not the id"
             )
         ),
+        "submit_model_keys": sorted(
+            {k for e in seen if e.get("model_keys") for k in e["model_keys"]}
+        ),
         "events": seen,
     }
 
 
 async def _main(profile: str, project_id: str, entity_id: str, name: str,
-                wait_s: float, out_path: str) -> int:
+                wait_s: float, out_path: str, ref_image: Path | None,
+                model: VideoModel | None) -> int:
     async with build_client(resolve_profile_dir(profile)) as client:
         page = client._page  # noqa: SLF001 — dev instrument
         assert page is not None
-        report = await _probe(page, project_id, entity_id, name, wait_s)
+        report = await _probe(page, project_id, entity_id, name, wait_s, ref_image, model)
         Path(out_path).write_text(
             json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
         )
@@ -205,10 +243,20 @@ def main() -> int:
     p.add_argument("--entity-id", required=True)
     p.add_argument("--entity-name", required=True)
     p.add_argument("--wait", type=float, default=90.0)
+    p.add_argument("--ref-image", default=None,
+                   help="local image to attach as an R2V media reference alongside the "
+                        "character; makes this a genuine r2v run rather than t2v-in-Ingredients")
+    p.add_argument("--model", default=None,
+                   help="omni-flash | veo-lite | veo-fast | veo-quality; omit to leave "
+                        "Flow's own picker untouched, which is what a human gets")
     p.add_argument("--out", default=None)
     a = p.parse_args()
     out = a.out or str(default_out_path("entity_submit_rpcs"))
-    return asyncio.run(_main(a.profile, a.project_id, a.entity_id, a.entity_name, a.wait, out))
+    ref = Path(a.ref_image) if a.ref_image else None
+    mdl = _VIDEO_MODEL_FROM_CLI[a.model] if a.model else None
+    return asyncio.run(
+        _main(a.profile, a.project_id, a.entity_id, a.entity_name, a.wait, out, ref, mdl)
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/dev/spike_project_media_status.py
+++ b/scripts/dev/spike_project_media_status.py
@@ -1,0 +1,120 @@
+"""List a migrated project's recent generations and their status — read-only, $0.
+
+Opens the project editor and reads the page's own ``jwpduf`` poll in full (the submit
+spike truncates bodies to 400 chars, which is enough to see a prompt and not enough to
+see an outcome). Nothing is attached and nothing is submitted, so this cannot spend.
+
+**Why it exists.** An entity-bound run was read as "failed" from a null ``MZZa6b`` reply,
+and Flow's own gallery then showed a card reading **Queued** for the same submission. A
+null submit payload and a failed generation are not the same thing, and guessing between
+them from the submit reply alone is what produced a wrong conclusion. This reads the
+outcome instead.
+
+Usage:
+    uv run python scripts/dev/spike_project_media_status.py <profile> <project_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from gflow_cli.api.transports.migrated_composer import MigratedComposer  # noqa: E402
+
+from _spike_common import build_client, default_out_path, resolve_profile_dir  # noqa: E402, isort: skip
+
+# A generation row carries: mediaId, projectId, workflowId, a "CAE"-ish enum, then a
+# timestamp pair and the prompt. Status lives in the enum and in a trailing int.
+ROW = re.compile(r'\\"([0-9a-f-]{36})\\",\\"([0-9a-f-]{36})\\",\\"([0-9a-f-]{36})\\",\\"(\w+)\\"')
+
+
+def _rpcid(url: str) -> str | None:
+    try:
+        return urllib.parse.parse_qs(urllib.parse.urlparse(url).query).get("rpcids", [None])[0]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def _probe(page: Any, project_id: str, wait_s: float) -> dict[str, Any]:
+    bodies: list[str] = []
+
+    async def on_response(response: Any) -> None:
+        url = str(getattr(response, "url", ""))
+        if "batchexecute" not in url or _rpcid(url) != "jwpduf":
+            return
+        try:
+            bodies.append(await response.text())
+        except Exception:  # noqa: BLE001
+            return
+
+    page.on("response", lambda r: asyncio.create_task(on_response(r)))
+    await MigratedComposer().ensure_editor(page, project_id)
+    await page.wait_for_timeout(int(wait_s * 1000))
+
+    rows: dict[str, dict[str, Any]] = {}
+    for b in bodies:
+        for m in ROW.finditer(b):
+            media_id, proj, workflow, enum = m.groups()
+            if proj != project_id:
+                continue
+            tail = b[m.end() : m.end() + 900]
+            prompt = ""
+            pm = re.search(r'\\"([^"\\]{20,200})', tail)
+            if pm:
+                prompt = pm.group(1)
+            rows[media_id] = {
+                "media_id": media_id,
+                "workflow_id": workflow,
+                "enum": enum,
+                "prompt_head": prompt[:110],
+            }
+    # Keep one raw body: the first pass at this script keyed on the 4th field and got
+    # "CAE" for every row, including one the gallery showed as Queued and one it showed
+    # as Failed. A constant is not a status. Until the real status field is located in
+    # the wire shape, the raw sample is the only honest artefact to reason from.
+    sample = max(bodies, key=len) if bodies else ""
+    return {
+        "project_id": project_id,
+        "poll_bodies": len(bodies),
+        "rows": list(rows.values()),
+        "raw_sample_len": len(sample),
+        "raw_sample": sample[:20000],
+    }
+
+
+async def _main(profile: str, project_id: str, wait_s: float, out_path: str) -> int:
+    async with build_client(resolve_profile_dir(profile)) as client:
+        page = client._page  # noqa: SLF001 — dev instrument
+        assert page is not None
+        report = await _probe(page, project_id, wait_s)
+        Path(out_path).write_text(json.dumps(report, indent=2, ensure_ascii=False), "utf-8")
+        print(
+            f"[spike] {len(report['rows'])} generation rows from "
+            f"{report['poll_bodies']} polls -> {out_path}"
+        )
+        for r in report["rows"][:25]:
+            print(f"  {r['enum']:6} {r['media_id'][:8]}  {r['prompt_head']}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("profile")
+    p.add_argument("project_id")
+    p.add_argument("--wait", type=float, default=25.0)
+    p.add_argument("--out", default=None)
+    a = p.parse_args()
+    out = a.out or str(default_out_path("project_media_status"))
+    return asyncio.run(_main(a.profile, a.project_id, a.wait, out))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/video-production/SKILL.md
+++ b/skills/video-production/SKILL.md
@@ -161,6 +161,83 @@ you meant the file, reference it by path (`--ref <path>`) rather than by name. A
 silently binds a still image where you asked for a character produces footage that looks
 right and drifts on the next cut.
 
+### 4b-bis. A cast with VOICES — the whole recipe, end to end
+
+A character entity is the only thing that carries a **voice**. A plate does not: it carries
+face and wardrobe as pixels, and the engine invents a new voice for every clip. Measured
+2026-09-07 on one character across three plate-bound takes: **88 Hz, 103 Hz, 118 Hz** — three
+different actors — against an engine noise floor of **4.3 Hz** on an identical prompt
+repeated three times. No re-shoot fixes that, because nothing in a plate was ever carrying
+the voice.
+
+So if anyone speaks more than once, you need rung 1. Here is the whole path.
+
+**1 — pick the voice before you create anyone.** `gflow character voices` lists 29 presets.
+Each has a public sample you can actually listen to, so audition rather than trust the
+descriptor — five of the 29 descriptors disagree with the measured pitch of their own sample:
+
+```bash
+gflow character voices --json
+# every voice has: https://gstatic.com/aitestkitchen/voices/samples/<Name>.wav
+```
+
+**2 — create the character with the voice bound.** Face, body and voice in one call:
+
+```bash
+gflow character create --project "$PROJECT" \
+  --name    "<UniqueName>" \
+  --face-prompt "a man, <face description with a GENDER WORD>" \
+  --body-prompt "<outfit; no print, no logo>" \
+  --voice   "<VoiceName>" \
+  --personality "<how they behave>" \
+  --json > cast_<name>.json
+```
+
+Three traps, each measured:
+
+- **The name must collide with nothing in the media library.** Flow's `@` picker searches
+  characters and media together and does not rank them (4b), so an uploaded `kael_ref.jpg`
+  wins the query `@Kael` and your character becomes unreachable by name. **Never name a
+  plate after a character**; `plate_a.png`, not `<name>_ref.jpg`.
+- **A face prompt with no gender word gets a gender chosen for it.** This fires on the
+  prose canon too, not just on `character create` — a two-hander whose unbound actor is
+  described without one renders the wrong person.
+- **Keep the `entity_id` yourself.** Read it from `--json` at creation. Do not plan on
+  recovering it from the catalog afterwards.
+
+**3 — attach the character to every shot they appear in.**
+
+```bash
+gflow video t2v "<prompt>" --project "$PROJECT" \
+  --reference-entity      "<entity_id>" \
+  --reference-entity-name "<UniqueName>" \
+  --aspect 16:9 --duration 8
+```
+
+One face-bearing reference per generation **[CONSTRAINT]** — so in a two-hander, bind the
+person who **speaks** and carry the other in prose. Getting that backwards is what produced
+the 88 Hz stranger above: the beat bound the silent actor, so the speaker fell to rung 4.
+
+**4 — expect the submit to outlive your patience, and do not read a timeout as a failure.**
+Flow allows **five concurrent generations** and throttles per-minute throughput after heavy
+daily use, so a queued job routinely outlives gflow's submit-reply budget. An
+entity-bound run can exit **9 `TransportTimeoutError`** while the video is rendering
+normally — the job is in Flow's queue and will finish. Check the project before you
+re-submit, or you will double-spend on a generation you already have. (gflow-cli #723,
+#741.)
+
+**5 — verify the voice actually landed, relatively.** Never assert an absolute band: a
+character legitimately speaks differently in an action beat than in a quiet one, and the
+pitch follows the performance. The two sound comparisons are:
+
+- **the same character across comparably-staged shots** — the medians should sit close
+- **a bound take against that voice's own public sample** — the same neighbourhood
+
+And stage every dialogue beat in **still air**. An energy gate is not a voicing gate: on
+this production's own wordless clips the detector reported a confident 145 Hz and 280 Hz
+with no speech present at all, and periodicity did not separate them either. A beat shot in
+wind cannot be checked.
+
 ### 4c. A costume is part of the identity, so a costume change is a NEW entity [CONSTRAINT]
 
 A Flow character entity bundles face **and** wardrobe — the body reference fixes the outfit.

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -251,41 +251,41 @@ def _unported_form(request: GenerateVideoRequest) -> str | None:
     # without consulting it — so that refusal is unreachable for exactly the accounts
     # that need it. This one is on the path every request takes.
     if request.reference_entities:
-        # STILL REFUSED, and deliberately so — the port is HALF done (#723).
+        # STILL REFUSED — but NOT because the backend rejects it. The port is half done
+        # in a narrower way than previously recorded here (#723).
         #
-        # What is measured and works: `MigratedComposer.attach_character_entities` drives
-        # the `@` picker, commits the chip, and verifies it carries
-        # data-reference-type="entity" with the requested id. Confirmed live 2026-09-07 —
-        # `migrated.character_entities_attached` fires and Flow loads the character's
-        # voice sample. A route-aborted capture showed the assembled MZZa6b payload
-        # carrying that id in its own reference slot.
+        # What works: `attach_character_entities` drives the `@` picker, commits the
+        # chip, and verifies it carries data-reference-type="entity" with the requested
+        # id. `migrated.character_entities_attached` fires and Flow loads the
+        # character's voice sample. And the SUBMIT IS ACCEPTED: measured 2026-09-07,
+        # entity-bound submissions appear in Flow's own gallery as **Queued** and
+        # proceed. Nothing is refused server-side.
         #
-        # What does NOT work: the BACKEND rejects the generation. This was previously
-        # recorded here as "the submit never produces a YhhmEf/eb1hJf/MZZa6b reply,
-        # cause unknown, undiagnosable without fixing #722". Both halves of that were
-        # wrong, and `scripts/dev/spike_entity_submit_rpcs.py` shows why — it logs every
-        # batchexecute rpcid through the submit instead of only the three watched ones:
+        # What breaks is the OBSERVER, and the mechanism is exact:
         #
         #   MZZa6b -> [["wrb.fr","MZZa6b",null,null,null,[5],"generic"]]
-        #   WuwhI  -> []
-        #   jwpduf -> the generation IS listed in the project, prompt prefixed with the
-        #             entity name
         #
-        # So MZZa6b DOES reply — with a null result and an error slot — and the run
-        # enqueues and then fails. Flow's own UI says so: "Failed. Sorry, this video
-        # failed to generate. You have not been charged for this generation." There is
-        # nothing missing from SUBMIT_RPCS, and reading the wire live sidesteps the
-        # empty incident bundle entirely, so #722 was never on this path.
+        # The submit reply carries a NULL payload, so it never names a media id and the
+        # `submitted` future in submit_and_observe never resolves. That wait is bounded
+        # by SUBMIT_REPLY_BUDGET_S (60 s), a value calibrated on runs where "the submit
+        # reply arrived 4.0-4.6 s after the click" — i.e. a plate-based generation
+        # against an idle queue. So the run times out (exit 9, TransportTimeoutError)
+        # while the job sits in Flow's queue and completes on its own.
         #
-        # Measured 2026-09-07 across three configurations, all identical:
-        #   - portrait-only character, settings not applied
-        #   - portrait-only character, Ingredients + omni_flash + 16:9 + 8s
-        #   - character with face AND body triptych, same settings
-        # Character completeness is not the variable; the backend refuses the form.
+        # This is also what the ORIGINAL note here described as "the submit never
+        # produces a reply, three runs, 60 s each, cause unknown". Three timeouts
+        # against a queue, read as a refusal. Two later comments (including one of
+        # mine) hardened that misreading further; both were wrong.
         #
-        # Relaxing this gate therefore trades a clear, instant exit 36 for a failed card
-        # the user has to interpret, which is strictly worse. The refusal stays until an
-        # entity-bound generation has actually completed on this host.
+        # Queue latency is not incidental: Flow documents a limit of FIVE concurrent
+        # generations, and rate-limits per-minute throughput after heavy daily use, so
+        # 60 s is routinely too short in real production.
+        #
+        # THE FIX, when someone takes it: on a null submit payload, fall through to the
+        # status poll (jwpduf/as29s) keyed on the project instead of requiring the
+        # submit reply to name the media id, and make the budget configurable. The guard
+        # stays only until that lands, because today the CLI would report a timeout on a
+        # generation that is actually running — worse than an honest refusal.
         return "character references"
     if request.mode is Mode.T2V:
         return None


### PR DESCRIPTION
## Why this is urgent

`develop` currently contains **`1958b5af`**, which records on the `_unported_form` guard that *"the BACKEND rejects the generation"* for entity-bound video. **That is wrong**, and it shipped in #736 before the evidence that disproves it existed. This PR carries the retraction.

Left as-is, the next person to look at #723 reads a confident, incorrect cause in the code and goes to fix the wrong thing — which is exactly what happened to me, because the *original* note on that same guard was the same class of error.

## What is actually true

Entity-bound generations are **accepted and queued**. Flow derives an `abra_r2v_8s` model key for them and they proceed to render. What fails is the **observer**:

```
MZZa6b -> [["wrb.fr","MZZa6b",null,null,null,[5],"generic"]]
```

The submit reply carries a null payload, so it never names a media id, `submit_and_observe`'s `submitted` future never resolves, and the wait is bounded by `SUBMIT_REPLY_BUDGET_S = 60.0` — a value whose own comment records it was calibrated where *"the submit reply arrived 4.0–4.6 s after the click"*, i.e. against an idle queue. The run exits **9 `TransportTimeoutError`** while the video is still rendering.

The account owner disproved my conclusion by opening the project and seeing **Queued**, after I had asserted a backend refusal three times.

Queue latency is not incidental: Google documents a **five concurrent generation** limit and reduced per-minute throughput after heavy daily use, so 60 s is routinely too short during real production.

## Commits

| commit | what |
|---|---|
| `276d5e02` | retracts `1958b5af`; guard **stays**, reason corrected, and the fix is named in the comment |
| `40ccf9c0` | `spike_project_media_status.py` — read a project's generation state without submitting (#741) |
| `0cb35f1e` | `video-production` skill: the end-to-end recipe for a cast with voices |

## Why the guard stays

Until the observer is fixed, relaxing it would make the CLI report a timeout on a generation that is actually running — worse for a user than an explicit refusal. The fix is written into the comment: on a null submit payload, fall through to the `jwpduf`/`as29s` status poll instead of requiring the submit reply to name the media id, and make the budget configurable.

## Skill content

`4b-bis` gives the whole path for a cast **with voices**, as a template. It exists because a plate carries face and wardrobe but not voice — measured across three plate-bound takes of one character: **88 / 103 / 118 Hz**, three different actors, against a **4.3 Hz** engine noise floor on an identical prompt. A production can otherwise reach a finished cut before anyone notices the cast has no voices.

Each trap in it was paid for: the picker name collision (an uploaded `kael_ref.jpg` wins `@Kael`), the missing gender word firing on the prose canon, binding the silent actor instead of the speaker, and reading a queue timeout as a failure.

## Test plan

- [x] `ruff check src tests` · `ruff format --check` · `pyright src` — clean
- [x] `pytest tests/api/transports/` — 912 passed, 1 skipped
- [x] `check_repo_hygiene.py` — 1030 files, no violations
- [x] `check_doc_links.py` — 29 files resolved
- [x] `generate_website_docs.py --check` — mirror in sync
- [x] `check_council_memory.py` — 49 files, all cited
- [ ] e2e — not applicable: no Flow surface behaviour changes. `276d5e02` is a comment, `40ccf9c0` is a dev script, `0cb35f1e` is skill documentation.