### PR TITLE
fix(character): an emptied prompt box is not a rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--format-prompt` could submit an EMPTY prompt and log it as success.** The
+  observed-rewrite gate compared `abs(len(current) - len(typed)) >= 16`, and `abs` accepts
+  change in either direction. Flow **clears** the composer before repopulating it, so a poll
+  landing in that window read `""`, `abs(0 - 19) = 19` passed the gate, and `_send_prompt`
+  called `_click_submit` on the very next line — submitting nothing, on a path that spends
+  image quota, while `ui_automation.prompt_formatted` logged `prompt_len_after=0`
+  (`prompt_hash=e3b0c442`, the SHA-256 of the empty string).
+
+  Silent, billed, and self-certifying: a user hitting it would see a charge, an empty
+  result, and a log line saying it worked. It is also the exact defect the same release
+  fixes — a success signal that fires on the **absence** of the thing it measures — rebuilt
+  inside its own fix.
+
+  The gate now requires **growth** (`len(current) >= len(typed) + MIN_DELTA`) rather than an
+  absolute delta, plus a settle check: two reads one poll-interval apart must agree, because
+  the single discrete swap measured live was sampled at 250 ms and a partial write between
+  samples was never ruled out. Found by an adversarial review of the fix, not by the fix's
+  own tests. ([#745](https://github.com/ffroliva/gflow-cli/issues/745))
+
 - **The "+ New project" CTA is found by structure again, not by English.** Its Tier-1 anchors
   all targeted the `add_2` ligature. The migrated `flow.google.com` gallery renders **`add`**
   under a `<mat-icon>` and renders `add_2` nowhere on that surface, so every structural entry

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -1765,20 +1765,40 @@ class UiAutomationTransport(VideoGenerationMixin):
             except Exception as e:
                 log.debug("ui_automation.format_readback_failed", error=str(e))
                 continue
-            if abs(len(current) - len(typed)) >= _FORMAT_REWRITE_MIN_DELTA and current != typed:
-                # Lengths and a stable hash only. Flow ELABORATES a terse
-                # description into a detailed physical one, so the rewrite is more
-                # PII-dense than the input, and structlog is not governed by
-                # GFLOW_CLI_HISTORY_PROMPTS — no operator control would apply to it.
-                log.info(
-                    "ui_automation.prompt_formatted",
-                    selector=selector,
-                    elapsed_ms=int((time.monotonic() - started) * 1000),
-                    prompt_len_before=len(typed),
-                    prompt_len_after=len(current),
-                    prompt_hash=_prompt_hash_stable(current),
-                )
-                return True
+            # GROWTH, not absolute delta. `abs()` accepted change in either direction, and
+            # Flow CLEARS the box before repopulating it — so a poll landing in that window
+            # read "" and `abs(0 - 19) >= 16` passed. `prompt_formatted` then logged
+            # `prompt_len_after=0` and `_click_submit` ran on the next line, submitting an
+            # EMPTY prompt on a path that spends image quota (#745). A success signal that
+            # fires on the ABSENCE of the thing it measures is the defect #727 was about,
+            # rebuilt inside its own fix.
+            if len(current) < len(typed) + _FORMAT_REWRITE_MIN_DELTA or current == typed:
+                continue
+            # And confirm it settled. One read can land mid-write; the rewrite observed live
+            # was a single discrete swap, but that was sampled at 250ms and a partial write
+            # between samples was never ruled out. Two agreeing reads cost one interval.
+            await page.wait_for_timeout(_jitter_ms(_FORMAT_REWRITE_POLL_MS))
+            try:
+                settled = (await prompt_box.inner_text()).strip()
+            except Exception as e:
+                log.debug("ui_automation.format_readback_failed", error=str(e))
+                continue
+            if settled != current:
+                log.debug("ui_automation.format_still_settling", chars=len(settled))
+                continue
+            # Lengths and a stable hash only. Flow ELABORATES a terse description into a
+            # detailed physical one, so the rewrite is more PII-dense than the input, and
+            # structlog is not governed by GFLOW_CLI_HISTORY_PROMPTS — no operator control
+            # would apply to it.
+            log.info(
+                "ui_automation.prompt_formatted",
+                selector=selector,
+                elapsed_ms=int((time.monotonic() - started) * 1000),
+                prompt_len_before=len(typed),
+                prompt_len_after=len(current),
+                prompt_hash=_prompt_hash_stable(current),
+            )
+            return True
 
         # Say what was observed, never what Flow "failed" to do: an unchanged box
         # also covers Flow declining, erroring, or judging the prompt already

--- a/tests/api/transports/test_ui_character_editor.py
+++ b/tests/api/transports/test_ui_character_editor.py
@@ -1336,6 +1336,26 @@ class _FakePromptBox:
         return self._before
 
 
+class _FakeClearingPromptBox:
+    """Models Flow's real sequence: typed -> "" (cleared) -> rewritten.
+
+    The empty window is what a fixed-cadence poll can land in, and what the original
+    `abs()` gate accepted as a rewrite.
+    """
+
+    def __init__(self, before: str, after: str) -> None:
+        self._seq = [before, before, "", "", after]
+        self.reads = 0
+        self.saw_empty = False
+
+    async def inner_text(self) -> str:
+        v = self._seq[min(self.reads, len(self._seq) - 1)]
+        self.reads += 1
+        if v == "":
+            self.saw_empty = True
+        return v
+
+
 def _make_format_page(
     *,
     matching_selector: str | None = PROMPT_FORMAT_SELECTORS[0],
@@ -1496,6 +1516,37 @@ class TestFormatCharacterPrompt:
         assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
         assert button.clicked
         assert box.reads > 1, "must poll the box, not return on the click"
+
+    @pytest.mark.asyncio
+    async def test_a_cleared_box_is_not_a_rewrite(self) -> None:
+        """#745: Flow CLEARS the box before repopulating it. An empty read is not success.
+
+        The gate was `abs(len(current) - len(typed)) >= MIN_DELTA`, and `abs` accepts
+        change in EITHER direction. A poll landing in the clear-then-repopulate window
+        reads "" -> abs(0 - 19) = 19 >= 16 -> passes. `prompt_formatted` would log
+        `prompt_len_after=0` and `_send_prompt` calls `_click_submit` on the very next
+        line, submitting an EMPTY prompt on a path that spends image quota.
+
+        A success signal that fires on the ABSENCE of the thing it measures is the exact
+        defect #727 was about, rebuilt inside its own fix.
+        """
+        page, _button = _make_format_page()
+        box = _FakePromptBox(TYPED, "", change_after_reads=1)
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is False, (
+            "an emptied box must never count as a rewrite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_rewrite_seen_after_a_clear_still_counts(self) -> None:
+        """The clear is transient — the real rewrite that follows must still be observed."""
+        page, _button = _make_format_page()
+        box = _FakeClearingPromptBox(TYPED, REWRITTEN)
+        t = _make_transport(page=page)
+
+        assert await t.format_character_prompt(page, prompt_box=box, typed_text=TYPED) is True
+        assert box.saw_empty, "fixture must actually exercise the empty window"
 
     @pytest.mark.asyncio
     async def test_returns_false_when_the_rewrite_never_lands(self) -> None:


### PR DESCRIPTION
## Summary

The observed-rewrite gate could accept an **emptied** prompt box as a rewrite, submit nothing, and log it as success.

```
prompt_formatted  prompt_len_after=0  prompt_len_before=19  prompt_hash=e3b0c442
```

`e3b0c442` is the SHA-256 of the empty string.

`abs(len(current) - len(typed)) >= 16` accepts change in **either direction**. Flow **clears** the composer before repopulating it, so a poll landing in that window reads `""` → `abs(0 - 19) = 19` → passes → and `_send_prompt` calls `_click_submit` on the very next line.

**An empty prompt, submitted on a path that spends image quota, logged as success.** Silent, billed, and self-certifying: a user hitting it sees a charge, an empty result, and a log line saying it worked — they cannot even file a good bug from that.

It is also precisely the defect this same release fixes — a success signal firing on the **absence** of the thing it measures — rebuilt inside its own fix.

Refs #745

## Fix

- **Growth, not absolute delta**: `len(current) >= len(typed) + MIN_DELTA`
- **Plus a settle check** — two reads one poll-interval apart must agree. The single discrete swap measured live was sampled at 250 ms, so a partial write between samples was never ruled out.

## Tests, watched red first

The log line above **is** the red. Two new tests:
- an emptied box must return `False`
- a rewrite arriving **after** a clear must still be observed — the fixture asserts it actually exercised the empty window, so the test cannot pass by never reaching it

## Provenance

Found by an adversarial `/code-review` of my own fix, not by that fix's own tests. The tests I wrote all passed while this was live.

On severity I am adopting the release manager's framing over my own: I called it "a race my live runs never hit". That is what you would expect **from** a race — it is not evidence of rarity. The shape is what matters.

## Validation

- [x] `pytest tests/api/transports/test_ui_character_editor.py::TestFormatCharacterPrompt` — **19 passed**
- [x] `pyright src` 0 errors · `ruff check` / `format --check` clean
- [x] `check_doc_links.py` · `check_repo_hygiene.py` (1034 files)
- [ ] **Full local offline suite was still running at PR time** — stated rather than implied. CI runs the full suite on 3.11 / 3.12 / 3.13 here, which is the stronger gate; do not merge if it goes red.

**E2E:** not re-run. The changed code is the format gate, whose live behaviour was verified earlier in this release (`1 passed in 406.20s`, observed rewrite at 4178 ms). This change makes that gate **stricter** — it can only reject reads it previously accepted — so the passing live path is unaffected. The failure it closes is a poll landing inside Flow's clear window, which is a race an e2e cannot reliably provoke; the offline fixture reproduces it deterministically instead.
