### PR TITLE
fix(migrated): make the agent-mode recovery say which of three things happened (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   label, and the chip's own component class plus `aria-pressed` carry the same identity in every
   locale. ([#749](https://github.com/ffroliva/gflow-cli/issues/749))
 
+  **Follow-up ([#752](https://github.com/ffroliva/gflow-cli/issues/752)):** the fix worked and
+  its diagnostics did not. Three states were collapsed into one message — the chip was clicked,
+  the chip was found but the click was blocked, the chip was clicked and the mode is still on —
+  and all three read as *"the chip was clicked to leave it … the mode may be pinned"*. A modal
+  eating the click sent the user to toggle a chip; genuine selector drift **after** the mode was
+  successfully left was reported as a pinned mode, so the drift bug never got filed. The chip's
+  `aria-pressed` is now read back before that claim is made, a blocked click raises at once
+  instead of waiting out the 20 s recovery window (worst case 55 s → 35 s), the click's own
+  exception is chained rather than truncated into a log line, and `_open_pane` — the same gate
+  one step later — guards on **visibility** rather than `count()`, so a mode flip mid-run maps
+  to exit 23 naming agent mode instead of escaping as a bare Playwright timeout. Searchable
+  entry added to [KNOWN_ISSUES.md](KNOWN_ISSUES.md), which the shipped message gave a user no
+  way to find.
+
 ## [0.71.0] — 2026-09-07
 
 ### Fixed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1189,6 +1189,8 @@ now names which of three things happened rather than blaming drift:
 | `the account is in Flow's agent mode … the chip could not be clicked` | something is covering the chip (a modal) | dismiss it in a browser; re-run |
 | `the chip was clicked, and it is STILL pressed` | the mode is pinned on this account | turn the **Agent** chip off in a browser; re-run |
 | `agent mode was left, but the settings trigger … still did not become visible` | the mode is off — this is real selector drift | file a bug; it is not this issue |
+| `the chip could not be read back, so whether the mode is still on is unknown` | the page went dark mid-recovery | check the **Agent** chip in a browser *before* filing this as drift |
+| `the settings trigger … is not visible — the account is in Flow's agent mode` | the mode flipped **mid-run**, after the editor was already ready | turn the **Agent** chip off in a browser; re-run |
 
 **On 0.71.0 and earlier there is no recovery.** Open the project on
 `flow.google.com`, click the **Agent** chip off, and the account works again.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1169,6 +1169,30 @@ a `WireFormatError` about video bytes — neither naming the cause). `auto` now 
 instead of a mid-run failure, and `GFLOW_CLI_PREFER_CLASSIC=1` is no longer the
 workaround anyone needs to discover.
 
+### Flow's agent-mode chip hides the settings trigger on `flow.google.com` (exit 23)
+
+- **Status:** Mitigated · **Severity:** High while it lasts (every video run on the account fails) · **Affects:** the migrated `flow.google.com` host, all versions through 0.71.0 · **Tracked:** [#749](https://github.com/ffroliva/gflow-cli/issues/749), follow-up [#752](https://github.com/ffroliva/gflow-cli/issues/752)
+
+The migrated composer has an **Agent** chip. Pressed, Flow swaps the prompt box and
+leaves `.settings-trigger-button` — the element this driver waits on — in the DOM under
+a bare `hidden` (`display: none`, 0×0). Flow **remembers the chip per account**, so a
+single click in a browser made every later `gflow video` run on that account die at 30 s
+as `UiSelectorDriftError` (exit 23), telling the user to file a frontend-drift bug about
+a frontend that was working correctly.
+
+**Mitigation** (unreleased line, post-v0.71.0): the readiness gate leaves agent mode by
+itself, so an account parked there recovers with no user action. If it cannot, the error
+now names which of three things happened rather than blaming drift:
+
+| The message says | What it means | What to do |
+|---|---|---|
+| `the account is in Flow's agent mode … the chip could not be clicked` | something is covering the chip (a modal) | dismiss it in a browser; re-run |
+| `the chip was clicked, and it is STILL pressed` | the mode is pinned on this account | turn the **Agent** chip off in a browser; re-run |
+| `agent mode was left, but the settings trigger … still did not become visible` | the mode is off — this is real selector drift | file a bug; it is not this issue |
+
+**On 0.71.0 and earlier there is no recovery.** Open the project on
+`flow.google.com`, click the **Agent** chip off, and the account works again.
+
 ### Auth verification depends on Google's NextAuth session endpoint
 
 - **Status:** Mitigated · **Severity:** Low (degrades fail-closed) · **Affects:** issue #15 fix onward · **Tracked:** issue #15

--- a/scripts/dev/spike_migrated_composer_arms.py
+++ b/scripts/dev/spike_migrated_composer_arms.py
@@ -237,9 +237,14 @@ async def main() -> int:
         # Only a toggle is clicked, and only if one is present. No text is typed: the
         # reporter's "the composer must be touched first" claim is a SEPARATE question,
         # and mixing it in here would leave neither answered.
+        # `button.agent-mode-chip`, not the bare attribute: in agent mode a SECOND
+        # `button[aria-pressed]` is present (`agent-action-button`, ligature
+        # `article_spark`), so re-running this against a profile ALREADY in agent mode
+        # would let `.first` toggle the wrong control — and a non-transition would then
+        # read as evidence about the mode.
         toggle_sel = None
         if findings["state_a"]["aria_pressed"]:
-            toggle_sel = "button[aria-pressed]"
+            toggle_sel = "button.agent-mode-chip[aria-pressed]"
         elif findings["state_a"]["tune_buttons"]:
             toggle_sel = AGENT_TUNE
         findings["toggle_selector"] = toggle_sel

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -532,8 +532,9 @@ class MigratedComposer:
                     detail=(
                         f"migrated host: the account is in Flow's agent mode, which hides "
                         f"the settings trigger, and the chip ({AGENT_MODE_CHIP}) could not "
-                        f"be clicked on {page.url} (host=migrated) — something is covering "
-                        f"it; turn the Agent chip off in a browser and re-run: {click_error}"
+                        f"be clicked on {page.url} after {timeout_s:.0f}s (host=migrated) — "
+                        f"something is covering it; turn the Agent chip off in a browser and "
+                        f"re-run. Readiness gate: {e}. Chip click: {click_error}"
                     ),
                 ) from click_error
             try:
@@ -542,12 +543,22 @@ class MigratedComposer:
                 # Which of these two it is decides who can fix it, so the chip is read
                 # BACK rather than assumed. Reporting both as "the mode may be pinned"
                 # hides genuine selector drift behind a mode the driver already left.
-                if await self._agent_chip_pressed(page):
+                pressed = await self._agent_chip_pressed(page)
+                if pressed:
                     detail = (
                         f"migrated host: the account was in Flow's agent mode, the chip was "
                         f"clicked, and it is STILL pressed {AGENT_RECOVERY_S:.0f}s later on "
                         f"{page.url} (host=migrated) — the mode is pinned on this account; "
                         f"turn the Agent chip off in a browser and re-run: {e2}"
+                    )
+                elif pressed is None:
+                    detail = (
+                        f"migrated host: the account was in Flow's agent mode, the chip was "
+                        f"clicked, and the settings trigger ({READY_ANCHOR}) did not come "
+                        f"back within {AGENT_RECOVERY_S:.0f}s on {page.url} (host=migrated) "
+                        f"— the chip could not be read back, so whether the mode is still "
+                        f"on is unknown; check the Agent chip in a browser before filing "
+                        f"this as drift: {e2}"
                     )
                 else:
                     detail = (
@@ -558,25 +569,39 @@ class MigratedComposer:
                     )
                 raise UiSelectorDriftError(detail=detail) from e2
         # One count() on the happy path, for the cohort that would render the agent prompt
-        # box while LEAVING the trigger visible: nothing downstream would notice, and
-        # `send_prompt` would type into the agent composer ([contenteditable='true'].first).
-        # Not observed on either account — this costs less than the run it would waste.
-        await self._exit_agent_mode(page)
+        # box while LEAVING the trigger visible: `send_prompt` would type into the agent
+        # composer ([contenteditable='true'].first) and nothing downstream would notice.
+        #
+        # It OBSERVES and does not act, which is the whole point. Clicking here would
+        # mutate a server-remembered account setting on a run that is otherwise healthy,
+        # and it would do it in the one window where that is wrong: right after a
+        # successful recovery, where a chip still reporting `aria-pressed='true'` for a
+        # frame would toggle the account straight back INTO agent mode. `AGENT_MODE_CHIP`
+        # being self-guarding only holds while the click is reserved for a trigger that
+        # did NOT come up. No cohort has been measured here, so a log line is the honest
+        # instrument — the next occurrence is then diagnosable from a run instead of a
+        # re-run (the same reason #719 asks for telemetry before a fix).
+        if await self._agent_chip_pressed(page):
+            log.warning("migrated.agent_mode_chip_pressed_while_ready", issue_ref="#752")
         log.info("migrated.editor_ready", url=page.url)
 
     @staticmethod
-    async def _agent_chip_pressed(page: Page) -> bool:
+    async def _agent_chip_pressed(page: Page) -> bool | None:
         """Is Flow's agent-mode chip pressed right now? One count, and never the failure.
 
-        A probe that cannot answer must read as "no". Answering "yes" would put "the
-        account was in Flow's agent mode" in front of a user on the strength of a query
-        that never returned, sending them to fix a mode they may never have been in.
+        ``None`` — the query did not answer at all — is a third answer, not a quiet
+        ``False``. Both of the claims this feeds are unsafe to make on an unanswered
+        probe: "you were in agent mode" sends a user to fix a mode they may never have
+        been in, and its negation, "the mode is off, so file a drift bug", sends a user
+        whose account really is pinned to file a bug about a healthy frontend. A caller
+        that only needs the safe direction can use the falsiness; one that reports on the
+        absence has to look at ``None``.
         """
         try:
             return bool(await page.locator(AGENT_MODE_CHIP).first.count())
-        except Exception as e:  # noqa: BLE001 - an unreadable page is ordinary drift
+        except Exception as e:  # noqa: BLE001 - an unreadable page is not an answer
             log.warning("migrated.agent_mode_probe_failed", error=str(e)[:200])
-            return False
+            return None
 
     @classmethod
     async def _exit_agent_mode(cls, page: Page) -> tuple[AgentModeExit, Exception | None]:

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -31,7 +31,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import unquote_plus, urlsplit
 
 import structlog
@@ -83,30 +83,32 @@ RADIOGROUP = "[role='radiogroup']"
 RADIO = "[role='radio']"
 MENU_ITEM = "[role='menuitem']"
 COMPOSER = "[contenteditable='true']"
-#: Flow's agent-mode chip. Pressed, the app swaps `flow-prompt-box` for
-#: `flow-creative-agent-prompt-box`: `.settings-trigger-button` stays in the DOM but gains
-#: a bare `hidden` (display:none, 0x0, not hit-testable), and a `div.agent-footer-actions`
-#: with its own `tune` button appears instead. The mode is remembered per account, so one
-#: click in a browser breaks every later run until something clicks it back — which is
-#: exactly what #749 reported.
+#: Flow's agent-mode chip. Pressed, `.settings-trigger-button` stays in the DOM but gains
+#: a bare `hidden` (display:none, 0x0, not hit-testable) — which is why every gate on it
+#: waits for VISIBILITY and never `count()` (#749).
 #:
-#: Anchored on the component class plus `aria-pressed`, never on the label: the chip's text
-#: is translated (the reporter's was "Configuración"), and in agent mode a SECOND
-#: `button[aria-pressed]` appears (`agent-action-button`, ligature `article_spark`), so the
-#: bare attribute selector is ambiguous there. `[aria-pressed='true']` also makes the
-#: locator self-guarding — it matches only when there is something to undo, so the recovery
-#: cannot click a healthy composer INTO agent mode.
+#: Three constraints put this exact selector here, none of them cosmetic: the component
+#: class, because in agent mode a SECOND `button[aria-pressed]` appears
+#: (`agent-action-button`) and the bare attribute selector is ambiguous there;
+#: `aria-pressed` rather than the label, because the label is translated; and `='true'`
+#: specifically, which makes the locator self-guarding — it matches only when there is
+#: something to undo, so the recovery cannot click a healthy composer INTO agent mode.
 #:
 #: `mode_control.py` handles this same split on labs and is deliberately not reused: it
 #: refuses this host (`raise_if_migrated`), and its `AGENT_TOGGLE_SELECTOR` requires a
-#: `span.content` this chip does not have (measured `has_span_content: false`).
-#: Measured 2026-09-08 on ffroliva + denon82, $0 —
+#: `span.content` this chip does not have.
+#:
+#: Accounts, measurements and the transition inventory:
 #: docs/superpowers/spikes/2026-09-08-migrated-composer-agent-mode-hides-settings.md
 AGENT_MODE_CHIP = "button.agent-mode-chip[aria-pressed='true']"
 #: How long the classic composer gets to come back after the chip is clicked. The swap is
 #: a local Angular re-render, not a navigation — measured well under a second on both
 #: accounts — so this is headroom, not an expectation.
 AGENT_RECOVERY_S = 20.0
+#: What :meth:`MigratedComposer._exit_agent_mode` did. `"blocked"` — the chip was there
+#: and the click did not land — is not `"clicked"`: nothing was toggled, so there is
+#: nothing to wait :data:`AGENT_RECOVERY_S` for.
+AgentModeExit = Literal["clicked", "blocked", "absent"]
 #: The submode radio that renders the Start/End frame chips (i2v).
 FRAMES_LIGATURE = "crop_free"
 DIALOG = "[role='dialog']"
@@ -512,7 +514,8 @@ class MigratedComposer:
             # recovery no-opped, and the run failed exactly as it did before the fix
             # (caught by this change's own e2e, 2026-09-08). Waiting first also costs a
             # healthy run nothing — no extra query is issued unless the gate has failed.
-            if not await self._exit_agent_mode(page):
+            state, click_error = await self._exit_agent_mode(page)
+            if state == "absent":
                 raise UiSelectorDriftError(
                     detail=(
                         f"migrated host: the settings trigger ({READY_ANCHOR}) did not "
@@ -520,52 +523,86 @@ class MigratedComposer:
                         f"(host=migrated): {e}"
                     ),
                 ) from e
+            if state == "blocked":
+                # Nothing was toggled, so the trigger cannot have changed — spending
+                # AGENT_RECOVERY_S here buys a verdict already in hand. The click's own
+                # exception IS the message: a modal eating the click is a different bug
+                # from a pinned mode, and only that exception says which one this is.
+                raise UiSelectorDriftError(
+                    detail=(
+                        f"migrated host: the account is in Flow's agent mode, which hides "
+                        f"the settings trigger, and the chip ({AGENT_MODE_CHIP}) could not "
+                        f"be clicked on {page.url} (host=migrated) — something is covering "
+                        f"it; turn the Agent chip off in a browser and re-run: {click_error}"
+                    ),
+                ) from click_error
             try:
                 await trigger.wait_for(state="visible", timeout=int(AGENT_RECOVERY_S * 1000))
             except Exception as e2:
-                # Distinct from ordinary drift, and actionable: the frontend is fine,
-                # the account is parked somewhere gflow could not get it out of.
-                raise UiSelectorDriftError(
-                    detail=(
-                        f"migrated host: the account was in Flow's agent mode and the chip "
-                        f"was clicked to leave it, but the classic composer did not come "
-                        f"back within {AGENT_RECOVERY_S:.0f}s on {page.url} (host=migrated) "
-                        f"— the mode may be pinned on this account; turn the Agent chip off "
-                        f"in a browser and re-run: {e2}"
-                    ),
-                ) from e2
+                # Which of these two it is decides who can fix it, so the chip is read
+                # BACK rather than assumed. Reporting both as "the mode may be pinned"
+                # hides genuine selector drift behind a mode the driver already left.
+                if await self._agent_chip_pressed(page):
+                    detail = (
+                        f"migrated host: the account was in Flow's agent mode, the chip was "
+                        f"clicked, and it is STILL pressed {AGENT_RECOVERY_S:.0f}s later on "
+                        f"{page.url} (host=migrated) — the mode is pinned on this account; "
+                        f"turn the Agent chip off in a browser and re-run: {e2}"
+                    )
+                else:
+                    detail = (
+                        f"migrated host: Flow's agent mode was left, but the settings "
+                        f"trigger ({READY_ANCHOR}) still did not become visible within "
+                        f"{AGENT_RECOVERY_S:.0f}s on {page.url} (host=migrated) — the mode "
+                        f"is off, so this is ordinary selector drift: {e2}"
+                    )
+                raise UiSelectorDriftError(detail=detail) from e2
+        # One count() on the happy path, for the cohort that would render the agent prompt
+        # box while LEAVING the trigger visible: nothing downstream would notice, and
+        # `send_prompt` would type into the agent composer ([contenteditable='true'].first).
+        # Not observed on either account — this costs less than the run it would waste.
+        await self._exit_agent_mode(page)
         log.info("migrated.editor_ready", url=page.url)
 
     @staticmethod
-    async def _exit_agent_mode(page: Page) -> bool:
-        """Turn Flow's agent mode off if it is on. Returns whether the chip was clicked.
+    async def _agent_chip_pressed(page: Page) -> bool:
+        """Is Flow's agent-mode chip pressed right now? One count, and never the failure.
+
+        A probe that cannot answer must read as "no". Answering "yes" would put "the
+        account was in Flow's agent mode" in front of a user on the strength of a query
+        that never returned, sending them to fix a mode they may never have been in.
+        """
+        try:
+            return bool(await page.locator(AGENT_MODE_CHIP).first.count())
+        except Exception as e:  # noqa: BLE001 - an unreadable page is ordinary drift
+            log.warning("migrated.agent_mode_probe_failed", error=str(e)[:200])
+            return False
+
+    @classmethod
+    async def _exit_agent_mode(cls, page: Page) -> tuple[AgentModeExit, Exception | None]:
+        """Turn Flow's agent mode off if it is on.
 
         Agent mode `hidden`s the settings trigger this driver waits on (#749), and Flow
         remembers the chip per account — so without this, a single click in a browser
-        leaves every later run failing as selector drift. The locator matches only
-        ``aria-pressed='true'``, so on a healthy composer this is one cheap count and
-        nothing else.
+        leaves every later run failing as selector drift. :data:`AGENT_MODE_CHIP` matches
+        only ``aria-pressed='true'``, so on a healthy composer this is one cheap count.
+
+        The three outcomes are not interchangeable, which is why this is not a bool:
+        ``"clicked"`` means the page was asked to change and may still be re-rendering,
+        ``"blocked"`` means it was never asked — there is nothing to wait for — and
+        ``"absent"`` means the mode was not the problem. ``"blocked"`` carries the click's
+        own exception, so the caller can chain it instead of truncating it into a warning
+        nobody reads.
         """
-        chip = page.locator(AGENT_MODE_CHIP).first
+        if not await cls._agent_chip_pressed(page):
+            return "absent", None
         try:
-            found = await chip.count()
-        except Exception as e:  # noqa: BLE001 - an unreadable page is ordinary drift
-            # Returning True here would put "the account was in Flow's agent mode" in
-            # front of a user on the strength of a query that never answered. Only a
-            # chip actually FOUND may claim that.
-            log.warning("migrated.agent_mode_probe_failed", error=str(e)[:200])
-            return False
-        if not found:
-            return False
-        try:
-            await chip.click(timeout=5000)
-        except Exception as e:  # noqa: BLE001 - the trigger wait is the real verdict
-            # The chip was there, so agent mode is confirmed either way — and the
-            # pinned-mode message is the accurate one to end on.
+            await page.locator(AGENT_MODE_CHIP).first.click(timeout=5000)
+        except Exception as e:  # noqa: BLE001 - the caller decides what it means
             log.warning("migrated.agent_mode_exit_failed", error=str(e)[:200])
-            return True
+            return "blocked", e
         log.info("migrated.agent_mode_exited", issue_ref="#749")
-        return True
+        return "clicked", None
 
     @staticmethod
     async def _dismiss_dialog(page: Page) -> None:
@@ -666,10 +703,25 @@ class MigratedComposer:
 
     async def _open_pane(self, page: Page) -> Any:
         trigger = page.locator(READY_ANCHOR).first
-        if not await trigger.count():
-            raise UiSelectorDriftError(
-                detail=f"migrated host: settings trigger ({READY_ANCHOR}) missing (host=migrated)"
+        try:
+            # Visibility, not `count()`. Agent mode leaves the trigger in the DOM under a
+            # bare `hidden` (#749), and the mode can flip between `ensure_editor` and
+            # here — a count-guard then walks into a click that expires as a bare
+            # Playwright TimeoutError, with no exit code and no mention of the mode.
+            await trigger.wait_for(state="visible", timeout=5000)
+        except Exception as e:
+            why = (
+                " — the account is in Flow's agent mode, which hides it; turn the Agent "
+                "chip off in a browser and re-run"
+                if await self._agent_chip_pressed(page)
+                else ""
             )
+            raise UiSelectorDriftError(
+                detail=(
+                    f"migrated host: the settings trigger ({READY_ANCHOR}) is not visible"
+                    f"{why} (host=migrated)"
+                ),
+            ) from e
         await trigger.click(timeout=5000)
         # THE overlay that holds the option groups — not `.last`: once the model
         # menu (a second overlay) has opened and closed, a detached menu pane can

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -129,10 +129,17 @@ class Dom:
     # the trigger stayed hidden" would report that as ordinary selector drift again.
     agent_chip_sticks: bool = False
     agent_chip_clicks: int = 0
-    # A page that cannot answer the probe at all (closed / detached). Distinct from
-    # "no chip": the driver must NOT tell the user they were in agent mode on the
-    # strength of a query that never answered.
-    agent_chip_probe_raises: bool = False
+    #: The unmeasured cohort: agent mode on, and the trigger left VISIBLE anyway. Every
+    #: account seen so far hides it, but nothing downstream would notice if one did not —
+    #: `send_prompt` would type into the agent composer and the run would be wasted.
+    agent_mode_hides_trigger: bool = True
+    # A page that cannot answer the probe (closed / detached). The index is which probe
+    # stops answering, because the driver reads the chip more than once and the reads are
+    # not interchangeable: 0 = never answers, so no claim of agent mode may be made at
+    # all; 1 = answers, is clicked, and then goes dark before the read-back — where the
+    # unsafe claim is the OPPOSITE one, "the mode is off, so file a drift bug".
+    agent_chip_probe_raises_from: int | None = None
+    agent_chip_probes: int = 0
     agent_chip_click_raises: bool = False
 
 
@@ -224,8 +231,15 @@ class FakeLocator:
 
     # --- reads --------------------------------------------------------------
     async def count(self) -> int:
-        if self.kind == "agent_chip" and self.page.dom.agent_chip_probe_raises:
-            raise PlaywrightTimeoutError("count: Target page, context or browser has been closed")
+        if self.kind == "agent_chip":
+            dom = self.page.dom
+            index, dom.agent_chip_probes = dom.agent_chip_probes, dom.agent_chip_probes + 1
+            if dom.agent_chip_probe_raises_from is not None and (
+                index >= dom.agent_chip_probe_raises_from
+            ):
+                raise PlaywrightTimeoutError(
+                    "count: Target page, context or browser has been closed"
+                )
         return len(self.items)
 
     async def is_visible(self) -> bool:
@@ -461,7 +475,7 @@ class FakePage:
                 self,
                 "trigger",
                 ["trigger"] if dom.trigger_present else [],
-                visible=lambda: not dom.agent_mode,
+                visible=lambda: not (dom.agent_mode and dom.agent_mode_hides_trigger),
             )
         if css == migrated_composer.AGENT_MODE_CHIP:
             pressed = dom.agent_mode and dom.agent_chip_present
@@ -1939,7 +1953,7 @@ async def test_ensure_editor_does_not_claim_agent_mode_when_the_probe_itself_fai
 
     page = FakePage()
     page.dom.agent_mode = True
-    page.dom.agent_chip_probe_raises = True
+    page.dom.agent_chip_probe_raises_from = 0
     with capture_logs() as logs, pytest.raises(UiSelectorDriftError) as exc:
         await MigratedComposer().ensure_editor(page, "p1", timeout_s=0.2)
     assert page.dom.agent_chip_clicks == 0
@@ -2014,6 +2028,49 @@ async def test_open_pane_names_agent_mode_when_the_mode_flips_after_readiness() 
     with pytest.raises(UiSelectorDriftError) as exc:
         await composer.apply_video_settings(page, _t2v())
     assert "agent mode" in str(exc.value).casefold()
+
+
+async def test_ensure_editor_will_not_call_it_drift_when_the_chip_cannot_be_read_back() -> None:
+    """The mirror of the probe-failure case, and the one that bites harder. `False` and
+    "could not answer" are the same value to a bool, but here the claim rides on the
+    NEGATIVE: an account genuinely pinned in agent mode, on a page that went dark during
+    the recovery wait, would be told the mode is off and to file a frontend-drift bug —
+    the exact mis-routing this whole issue exists to stop, one inversion further on."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.agent_mode = True
+    page.dom.agent_chip_sticks = True
+    page.dom.agent_chip_probe_raises_from = 1  # answers once, dark by the read-back
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await MigratedComposer().ensure_editor(page, "p1", timeout_s=0.2)
+    assert page.dom.agent_chip_clicks == 1
+    assert "could not be read back" in str(exc.value)
+    assert "ordinary selector drift" not in str(exc.value)
+    assert "pinned" not in str(exc.value)
+
+
+async def test_ensure_editor_reports_but_never_clicks_a_chip_pressed_beside_a_ready_trigger() -> (
+    None
+):
+    """The unmeasured cohort: agent mode on, trigger visible anyway. The readiness gate
+    passes, so nothing downstream would ever notice that `send_prompt` is about to type
+    into the agent composer. It is recorded — and NOT clicked: a click here mutates a
+    server-remembered account setting on a run that is otherwise healthy, and the same
+    line fires right after a successful recovery, where a chip still reading pressed for
+    one frame would toggle the account straight back into agent mode."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.agent_mode = True
+    page.dom.agent_mode_hides_trigger = False
+    with capture_logs() as logs:
+        await MigratedComposer().ensure_editor(page, "p1", timeout_s=1.0)
+    events = [e["event"] for e in logs]
+    assert "migrated.agent_mode_chip_pressed_while_ready" in events
+    assert "migrated.editor_ready" in events
+    assert page.dom.agent_chip_clicks == 0
+    assert page.dom.agent_mode is True
 
 
 async def test_ensure_editor_drift_message_does_not_blame_agent_mode_in_classic() -> None:

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -114,14 +115,14 @@ class Dom:
     chip_bound: bool = False
     dialog_present: bool = False  # a `[role=dialog]` (the changelog modal) on load
     dialog_closed: int = 0
-    # --- #749: Flow's agent mode, measured 2026-09-08 on ffroliva AND denon82 ---------
-    # `button.agent-mode-chip[aria-pressed]` swaps the whole prompt box. Pressed, the
-    # classic `.settings-trigger-button` stays in the DOM but gains a bare `hidden`
-    # (display:none, 0x0), and `flow-creative-agent-prompt-box` + `div.agent-footer-actions`
-    # appear instead. Flow remembers the chip per account, so one click in the browser
-    # breaks every later gflow run. Spike:
-    # docs/superpowers/spikes/2026-09-08-migrated-composer-agent-mode-hides-settings.md
+    # --- #749: Flow's agent mode ------------------------------------------------------
+    # Pressed, the chip leaves `.settings-trigger-button` in the DOM under a bare `hidden`
+    # — present to `count()`, never visible. The knobs below are the states the driver has
+    # to tell apart; `migrated_composer.AGENT_MODE_CHIP` carries the selector rationale
+    # and points at the spike that measured all of this.
     agent_mode: bool = False
+    #: The mode is on but the chip is not in the DOM — nothing to click, so the driver
+    #: must fall back to the ordinary drift message rather than promise a recovery.
     agent_chip_present: bool = True
     # A chip that will not toggle off. NOT observed on either of our accounts — kept
     # because the reporter's might pin the mode, and a fix that cannot say "I tried and
@@ -168,7 +169,7 @@ class FakeLocator:
         kind: str,
         items: list[Any],
         *,
-        visible: bool | Any = True,
+        visible: bool | Callable[[], bool] = True,
     ) -> None:
         self.page, self.kind, self.items = page, kind, items
         #: Present in the DOM but not visible — what a bare `hidden` attribute does
@@ -1947,8 +1948,12 @@ async def test_ensure_editor_does_not_claim_agent_mode_when_the_probe_itself_fai
 
 
 async def test_ensure_editor_still_names_agent_mode_when_the_chip_click_fails() -> None:
-    """The mirror of the above: the chip WAS found, so agent mode is confirmed whether
-    or not the click landed — the pinned-mode message is the accurate one to end on."""
+    """The mirror of the above: the chip WAS found, so agent mode is confirmed whether or
+    not the click landed. But a click that never landed changed nothing, so the message
+    must say THAT — "the chip was clicked to leave it" sends a user to toggle a chip when
+    a modal was covering it — and the run must not wait AGENT_RECOVERY_S for a trigger it
+    knows was never asked to change. The click's own exception is chained, not truncated
+    into a warning nobody reads."""
     from gflow_cli.api.transports.migrated_composer import MigratedComposer
 
     page = FakePage()
@@ -1958,7 +1963,57 @@ async def test_ensure_editor_still_names_agent_mode_when_the_chip_click_fails() 
         await MigratedComposer().ensure_editor(page, "p1", timeout_s=0.2)
     assert page.dom.agent_chip_clicks == 1
     assert "agent mode" in str(exc.value).casefold()
+    assert "could not be clicked" in str(exc.value)
+    assert "pinned" not in str(exc.value)
+    assert isinstance(exc.value.__cause__, PlaywrightTimeoutError)
     assert "migrated.agent_mode_exit_failed" in [e["event"] for e in logs]
+
+
+async def test_ensure_editor_falls_back_to_drift_when_agent_mode_renders_no_chip() -> None:
+    """Mode on, chip absent — a cohort that hides it, or a renamed class. There is
+    nothing to click, so nothing may be promised: the ordinary drift message is the
+    honest one, and the `agent_chip_present` knob exists for exactly this state."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.agent_mode = True
+    page.dom.agent_chip_present = False
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await MigratedComposer().ensure_editor(page, "p1", timeout_s=0.2)
+    assert page.dom.agent_chip_clicks == 0
+    assert "agent mode" not in str(exc.value).casefold()
+
+
+async def test_ensure_editor_reports_drift_once_agent_mode_is_actually_off() -> None:
+    """The chip clicked, the mode left, and the trigger STILL missing — a real
+    selector-drift bug someone should file. A pinned-mode message written without reading
+    `aria-pressed` back would bury it behind an account setting the driver just changed."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.agent_mode = True
+    page.dom.trigger_present = False  # gone for real, not merely hidden
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await MigratedComposer().ensure_editor(page, "p1", timeout_s=0.2)
+    assert page.dom.agent_chip_clicks == 1
+    assert not page.dom.agent_mode
+    assert "ordinary selector drift" in str(exc.value)
+    assert "pinned" not in str(exc.value)
+
+
+async def test_open_pane_names_agent_mode_when_the_mode_flips_after_readiness() -> None:
+    """#749 at the second gate. `ensure_editor` passed, then the mode flipped: a `count()`
+    guard sees the still-present trigger, clicks the hidden element, and the run dies as a
+    bare Playwright timeout with no exit code and no mention of the mode."""
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    composer = MigratedComposer()
+    await composer.ensure_editor(page, "p1", timeout_s=1.0)
+    page.dom.agent_mode = True
+    with pytest.raises(UiSelectorDriftError) as exc:
+        await composer.apply_video_settings(page, _t2v())
+    assert "agent mode" in str(exc.value).casefold()
 
 
 async def test_ensure_editor_drift_message_does_not_blame_agent_mode_in_classic() -> None:

--- a/tests/e2e/test_migrated_host_e2e.py
+++ b/tests/e2e/test_migrated_host_e2e.py
@@ -170,9 +170,15 @@ async def test_e2e_agent_mode_is_left_before_the_readiness_gate(
             # on restores it — including when it failed. gflow 0.71.0 and earlier have no
             # recovery at all, so a chip left pressed here breaks every run a user makes
             # on that build until someone clicks it back in a browser.
-            pressed = page.locator("button.agent-mode-chip[aria-pressed='true']").first
-            if await pressed.count():
-                await pressed.click(timeout=10_000)
+            # Best-effort by construction: if the body failed BECAUSE something is
+            # covering the chip, this click times out too, and an exception here would
+            # replace the real assertion failure with a cleanup one.
+            try:
+                pressed = page.locator("button.agent-mode-chip[aria-pressed='true']").first
+                if await pressed.count():
+                    await pressed.click(timeout=10_000)
+            except Exception as cleanup_error:  # noqa: BLE001 - never mask the verdict
+                print(f"agent-mode restore failed, chip may still be pressed: {cleanup_error}")
     finally:
         await transport.teardown()
 

--- a/tests/e2e/test_migrated_host_e2e.py
+++ b/tests/e2e/test_migrated_host_e2e.py
@@ -147,17 +147,32 @@ async def test_e2e_agent_mode_is_left_before_the_readiness_gate(
         await page.locator(migrated_composer.READY_ANCHOR).first.wait_for(
             state="hidden", timeout=15_000
         )
+        try:
+            # --- control: the recovery cannot fire -> the gate must still fail -----
+            # `monkeypatch.context()`, never `undo()`: this is the function-scoped
+            # instance the autouse `_isolate_settings` and the e2e `GFLOW_CLI_HOME`
+            # were set through, and `undo()` pops the WHOLE stack — every line after it
+            # would resolve against the developer's own catalog and profile store
+            # (#86's pollution mode, reintroduced mid-test).
+            with monkeypatch.context() as m:
+                m.setattr(migrated_composer, "AGENT_MODE_CHIP", "button.gflow-no-such-chip")
+                # Pinned to the message, not just the class: without this the control
+                # passes on ANY drift, including one raised by the recovery firing
+                # wrongly, and stops discriminating the moment it matters.
+                with pytest.raises(UiSelectorDriftError, match="did not become visible"):
+                    await composer.ensure_editor(page, project, timeout_s=10.0)
 
-        # --- control: the recovery cannot fire -> the gate must still fail ---------
-        monkeypatch.setattr(migrated_composer, "AGENT_MODE_CHIP", "button.gflow-no-such-chip")
-        with pytest.raises(UiSelectorDriftError):
-            await composer.ensure_editor(page, project, timeout_s=10.0)
-
-        # --- fix: the recovery fires -> the classic composer comes back ------------
-        monkeypatch.undo()
-        _set_flow_host(monkeypatch, None)
-        await composer.ensure_editor(page, project, timeout_s=45.0)
-        assert await page.locator(migrated_composer.READY_ANCHOR).first.is_visible()
+            # --- fix: the recovery fires -> the classic composer comes back --------
+            await composer.ensure_editor(page, project, timeout_s=45.0)
+            assert await page.locator(migrated_composer.READY_ANCHOR).first.is_visible()
+        finally:
+            # Agent mode is remembered per ACCOUNT, server-side, so a test that turns it
+            # on restores it — including when it failed. gflow 0.71.0 and earlier have no
+            # recovery at all, so a chip left pressed here breaks every run a user makes
+            # on that build until someone clicks it back in a browser.
+            pressed = page.locator("button.agent-mode-chip[aria-pressed='true']").first
+            if await pressed.count():
+                await pressed.click(timeout=10_000)
     finally:
         await transport.teardown()
 

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -1189,6 +1189,8 @@ now names which of three things happened rather than blaming drift:
 | `the account is in Flow's agent mode … the chip could not be clicked` | something is covering the chip (a modal) | dismiss it in a browser; re-run |
 | `the chip was clicked, and it is STILL pressed` | the mode is pinned on this account | turn the **Agent** chip off in a browser; re-run |
 | `agent mode was left, but the settings trigger … still did not become visible` | the mode is off — this is real selector drift | file a bug; it is not this issue |
+| `the chip could not be read back, so whether the mode is still on is unknown` | the page went dark mid-recovery | check the **Agent** chip in a browser *before* filing this as drift |
+| `the settings trigger … is not visible — the account is in Flow's agent mode` | the mode flipped **mid-run**, after the editor was already ready | turn the **Agent** chip off in a browser; re-run |
 
 **On 0.71.0 and earlier there is no recovery.** Open the project on
 `flow.google.com`, click the **Agent** chip off, and the account works again.

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -1169,6 +1169,30 @@ a `WireFormatError` about video bytes — neither naming the cause). `auto` now 
 instead of a mid-run failure, and `GFLOW_CLI_PREFER_CLASSIC=1` is no longer the
 workaround anyone needs to discover.
 
+### Flow's agent-mode chip hides the settings trigger on `flow.google.com` (exit 23)
+
+- **Status:** Mitigated · **Severity:** High while it lasts (every video run on the account fails) · **Affects:** the migrated `flow.google.com` host, all versions through 0.71.0 · **Tracked:** [#749](https://github.com/ffroliva/gflow-cli/issues/749), follow-up [#752](https://github.com/ffroliva/gflow-cli/issues/752)
+
+The migrated composer has an **Agent** chip. Pressed, Flow swaps the prompt box and
+leaves `.settings-trigger-button` — the element this driver waits on — in the DOM under
+a bare `hidden` (`display: none`, 0×0). Flow **remembers the chip per account**, so a
+single click in a browser made every later `gflow video` run on that account die at 30 s
+as `UiSelectorDriftError` (exit 23), telling the user to file a frontend-drift bug about
+a frontend that was working correctly.
+
+**Mitigation** (unreleased line, post-v0.71.0): the readiness gate leaves agent mode by
+itself, so an account parked there recovers with no user action. If it cannot, the error
+now names which of three things happened rather than blaming drift:
+
+| The message says | What it means | What to do |
+|---|---|---|
+| `the account is in Flow's agent mode … the chip could not be clicked` | something is covering the chip (a modal) | dismiss it in a browser; re-run |
+| `the chip was clicked, and it is STILL pressed` | the mode is pinned on this account | turn the **Agent** chip off in a browser; re-run |
+| `agent mode was left, but the settings trigger … still did not become visible` | the mode is off — this is real selector drift | file a bug; it is not this issue |
+
+**On 0.71.0 and earlier there is no recovery.** Open the project on
+`flow.google.com`, click the **Agent** chip off, and the account works again.
+
 ### Auth verification depends on Google's NextAuth session endpoint
 
 - **Status:** Mitigated · **Severity:** Low (degrades fail-closed) · **Affects:** issue #15 fix onward · **Tracked:** issue #15


### PR DESCRIPTION
## Summary

Closes #752 — the 13 review findings on #751, worked in the order the issue ranks them, plus the ones a **second** review found in my own fix.

The shipped #751 recovery works (re-verified live here). Its diagnostics collapsed three distinct states into one message: *the chip was clicked* · *the chip was found and the click was blocked* · *the chip was clicked and the mode is still on*. All three read as "the chip was clicked to leave it … the mode may be pinned". So a modal eating the click sent the user to toggle a chip that was never the problem, and genuine selector drift **after** the mode was successfully left was filed under an account setting the driver had already changed — which is to say, not filed.

## What changed

`_exit_agent_mode` returns `("clicked" | "blocked" | "absent", click_error)`.

- **blocked** raises at once, naming the click and chaining its exception. Nothing was toggled, so waiting out `AGENT_RECOVERY_S` buys a verdict already in hand — worst case **55 s → 35 s**.
- **clicked but timed out** re-reads `aria-pressed` before choosing between *pinned* and *ordinary drift*.
- `_agent_chip_pressed` returns `bool | None`, because both claims now ride on it and an unanswered probe is unsafe in **both** directions.
- `_open_pane` had the same defect the fix was about, one gate later: it guarded with `count()`, and agent mode leaves the trigger present-but-`hidden`. A mode flip between `ensure_editor` and `apply_video_settings` escaped as a bare Playwright `TimeoutError` with no exit code and no mention of the mode. It waits on **visibility** now.

Findings 1–3 (the two real test defects and the ambiguous spike anchor), 9–13 (KNOWN_ISSUES entry, `match=` on the A/B control, the dead `agent_chip_present` knob, `bool | Any`, the five-fold narrative) are all in. Finding 8 shipped as a **log line, not a click** — see below.

## The review of the fix caught a regression I introduced

I ran `/code-review high` on this branch **before** opening the PR — the gate that ran too late on #751 and produced #752 in the first place. It found seven things. One was mine:

The happy-path line added for finding 8 called `_exit_agent_mode`, which **clicks**. The issue asked for a probe ("one `count()`, cheap enough to just do"); a click mutates a server-remembered, per-account setting on an otherwise healthy run — and the same line fires right after a successful recovery, where a chip still reporting `aria-pressed='true'` for one frame would toggle the account straight **back into** agent mode. `AGENT_MODE_CHIP` being self-guarding only holds while the click is reserved for a trigger that did *not* come up, and I had quietly removed that condition. It observes and logs now.

The second one is subtler: `_agent_chip_pressed` returning `False` on an unanswered probe was safe for the claim it was written for and unsafe for its negation. A genuinely pinned account, on a page that goes dark during the 20 s wait, would have been told the mode is off and to file a drift bug — the same mis-routing this issue exists to stop, one inversion further on.

## ⚠️ Overlaps with #750 — needs reconciliation

**#750 independently implements its own `_exit_agent_mode`.** It was branched before #751 merged, so it will conflict with `develop` regardless of this PR. Two things there are worth a look before it lands:

1. It calls `_exit_agent_mode` **before** the readiness wait. That is the ordering #751 measured as wrong: `goto` returns on `domcontentloaded` and Angular mounts the composer seconds later, so the chip is reliably absent at that point and the recovery no-ops.
2. It reads `get_attribute("aria-pressed")` on `button.agent-mode-chip`, where develop now anchors `[aria-pressed='true']` into the selector so the locator cannot click a healthy composer *into* agent mode.

Whichever lands second reconciles. Flagging rather than touching it.

## Verification

| Layer | Result |
|---|---|
| `tests/api/transports/test_migrated_composer.py` | **86 passed** (+2 new cases) |
| `tests/api/transports` | **957 passed**, 1 skipped |
| hygiene · doc-links · PII · website mirror · council-memory · ruff check · ruff format | green |
| **`pytest -m e2e -k agent_mode`, live, $0** | **passed** — twice: once before the review fixes and again after, since the first run no longer covered the code |

Live log from the run after the fixes (profile `ffroliva`, `flow.google.com`):

```
migrated.editor_ready                       # healthy start
  → test clicks the chip INTO agent mode
  → control arm (chip selector neutered): raised "did not become visible"
migrated.agent_mode_exited  issue_ref=#749  # fix arm
migrated.editor_ready                       # classic composer back
1 passed in 104.93s
```

Two details in that run are load-bearing. The control arm producing *"did not become visible"* rather than an agent-mode message confirms the new `absent` branch is what fires when the chip cannot be found, and that the `match=` pin discriminates instead of passing on any drift. And neither `editor_ready` logged `migrated.agent_mode_chip_pressed_while_ready` — the expected negative, confirming the live account does hide the trigger in agent mode and the new probe does not false-positive.

**MCP parity:** no CLI leaf, option, queued-payload key or tool docstring claim changes here — this is internal driver diagnostics, tests and docs. Nothing to mirror.

`pyright src` reports 86 errors on this branch **and on clean `develop`** (all untyped-import noise in `mcp/tools.py` / `ui/app.py` from a stale local venv). Pre-existing, unrelated, not introduced here.
