### PR TITLE
fix(migrated): name Flow's one-time upload-terms dialog instead of blaming the file (#719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A blocked first upload no longer reads as a broken file or a broken network.** On the
+  migrated `flow.google.com` host, `video i2v --initial-frame` and `video r2v --ref` failed
+  on an account's **first** upload with `MediaUploadRejectedError` (exit 27) — *"no maseQ
+  reply within 60s of choosing the file — the upload never reached Flow or was dropped"* —
+  and advised re-encoding the image to strip metadata. Neither the file nor the network was
+  involved: Flow shows a one-time **"Rights to use this image"** confirmation *after* the
+  chooser hands the file over, and sends nothing until a human accepts it, so the driver
+  spent its whole budget waiting for a request the page had already declined to make.
+  Measured across 8 runs on 3 profiles — the two accounts that had uploaded before never saw
+  the dialog and uploaded fine, the account that never had failed 3/3, and accepting it once
+  made that account upload on the next run and every run after
+  ([spike](docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md)).
+
+  The driver now counts dialogs across the upload and, when one appeared *during* it, names
+  the one-time confirmation and tells the user to accept it once in a browser. **It is
+  counted rather than matched on purpose:** the dialog's two buttons are
+  `button.flow-button-medium` with no ligature and no data attribute, separable only by DOM
+  order, and its copy is translated — there is no anchor there that satisfies this project's
+  locale rule, whereas "a dialog appeared between the file being chosen and the wait
+  expiring" is upload-related by construction and cannot rot when Angular renames a class.
+
+  **gflow does not accept the dialog for you**, and there is no flag to make it: the dialog
+  affirms that *you* hold the rights to what you upload, it is one-off per account, and the
+  path already requires an interactive `gflow auth login` — so a setting that could never
+  safely default to on would be a flag nobody sets.
+  ([#719](https://github.com/ffroliva/gflow-cli/issues/719))
+
 - **Flow's agent mode no longer bricks the account for every later run.** On the migrated
   `flow.google.com` host the composer carries an **agent-mode chip**
   (`button.agent-mode-chip[aria-pressed]`). Pressed, Flow swaps `flow-prompt-box` for

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -687,15 +687,28 @@ This is because Chromium holds an exclusive lock on its SQLite cookie database w
 ---
 
 
-### Flow's first-upload terms-of-use dialog ("Aviso") blocks the worker (worker-only)
+### Flow's one-time upload-terms dialog blocks the FIRST upload on an account
 
-- **Status:** Open · **Severity:** Low · **Affects:** the legacy in-tree Compiled Growth worker, NOT `gflow-cli` itself
+- **Status:** Mitigated · **Severity:** High until accepted (every `i2v --initial-frame` and `r2v --ref` on that account fails) · **Affects:** the migrated `flow.google.com` host, all versions through 0.71.0 · **Tracked:** [#719](https://github.com/ffroliva/gflow-cli/issues/719)
 
-Flow shows a one-time "Aviso" / "Notice" terms-of-use confirmation on the first image upload of a new account session. The legacy Playwright worker has to explicitly click "Concordo" / "Agree". `gflow-cli`'s API-driven path bypasses this dialog entirely (the REST endpoint already implies acceptance).
+Flow shows a one-time **"Rights to use this image"** confirmation the first time an account uploads a file. It renders **after** the file chooser has handed the file over, and Flow sends **nothing** until it is accepted — so the driver waited out its full 60 s budget for an upload request the page had already decided not to make, then reported:
 
-**Workaround in gflow-cli:** none needed.
+```
+MediaUploadRejectedError (exit 27): migrated host: no maseQ reply within 60s of choosing
+the file — the upload never reached Flow or was dropped
+```
 
-**Workaround in legacy worker:** see Compiled Growth's `flow_video.py` consent-dismiss block.
+…and advised re-encoding the image to strip metadata. Neither the file nor the network was ever involved. Measured 2026-09-08 on three profiles, eight runs: the two accounts that had uploaded before never saw the dialog and uploaded fine; the account that never had failed 3/3. See [the spike](docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md).
+
+> **This entry previously said the opposite.** It read *"Affects: the legacy in-tree Compiled Growth worker, NOT `gflow-cli` itself"*, because *"gflow-cli's API-driven path bypasses this dialog entirely (the REST endpoint already implies acceptance)"*, with *"Workaround in gflow-cli: none needed."* That was true of the REST path and became false when the migrated driver started using the editor's **own** upload — so the entry a user hitting #719 would find was reassuring them about the exact thing that was breaking their run.
+
+**Mitigation** (unreleased line, post-v0.71.0): when the upload budget expires, the driver checks whether a dialog opened *during* the upload window and, if so, says so and points the user at the one-time acceptance instead of blaming the file.
+
+**Workaround / how to clear it — once per account, ever:** open the project on `flow.google.com`, upload any image by hand, and accept the dialog. Uploads then work unattended forever.
+
+**gflow does not accept it for you, by design.** The dialog affirms that *you* hold the rights to the content you upload; that is not a claim a tool may make on an account owner's behalf. It is also a 30-second step, once, on a path that already requires an interactive browser login (`gflow auth login`) — so automating it would buy nothing and assert something on your behalf. There is deliberately no config flag: a setting that can never safely default to on, on a once-per-account event, is a flag nobody sets.
+
+**Legacy worker:** Compiled Growth's `flow_video.py` clicks "Concordo" / "Agree" in its own consent-dismiss block. That is a different product decision, recorded here so the two are not confused.
 
 ---
 

--- a/docs/LIVE_VERIFICATION_v0.71.0.md
+++ b/docs/LIVE_VERIFICATION_v0.71.0.md
@@ -5,8 +5,17 @@
 > Flow for this release, and — just as importantly — what was **not**.
 
 **Date:** 2026-09-07 · **Profiles:** `ffroliva` (migrated `flow.google.com`, 501→ credits),
-`ci-probe` (labs, freemium, **no credit**) · **Host lane matters here**: several items below
-are migrated-host-specific.
+`ci-probe` (**migrated `flow.google.com`**, freemium, **no credit**) · **Host lane matters
+here**: several items below are migrated-host-specific.
+
+> **Host label corrected 2026-09-08.** This line said `ci-probe` was on **labs**, which
+> contradicted [LIVE_VERIFICATION_v0.70.0](LIVE_VERIFICATION_v0.70.0.md) one day earlier and
+> was wrong. Measured: `labs.google/fx/tools/flow` on that profile redirects to
+> `flow.google.com/` — the one-way migration redirect. In a repo where "Flow's UI shows X"
+> is not a fact until the host is named, a mislabelled host in a verification ledger
+> silently re-scopes every conclusion keyed to it — and this one helped make a credit
+> theory look plausible for #719 when the real cause was a one-time consent dialog
+> ([spike](superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md)).
 
 ---
 

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -124,6 +124,25 @@ DIALOG = "[role='dialog']"
 # docs/superpowers/spikes/2026-09-07-credit-shortfall-looks-like-selector-drift.md
 CREDITS_WARNING = "button.prompt-warning-button, [aria-label*='Insufficient credits']"
 DIALOG_CLOSE = f"{DIALOG} button:has(mat-icon:text-is('close'))"
+#: Flow shows a one-time upload-terms dialog ("rights to use this image") the first time an
+#: account uploads a file on this host. It renders AFTER the file chooser hands the file
+#: over, so `_dismiss_dialog` — which runs back in `ensure_editor` — never sees it, and Flow
+#: does not send the upload until a human accepts it. The driver's `FRAME_UPLOAD_S` wait was
+#: therefore waiting for a request the page had already decided not to make, and reported it
+#: as "the upload never reached Flow", advising the user to re-encode their image (#719).
+#:
+#: **This is detected by COUNTING dialogs across the upload, not by matching one.** Its two
+#: buttons are `button.flow-button-medium` with no ligature and no data attribute, separable
+#: only by DOM order, and its copy is translated — so there is no anchor here that satisfies
+#: this module's locale rule. A dialog that appears between "the file was chosen" and "we
+#: gave up waiting" is upload-related by construction, which needs no selector at all and
+#: cannot rot when Angular renames a class.
+#:
+#: gflow never clicks it. Accepting affirms that the ACCOUNT OWNER holds the rights to the
+#: content being uploaded, which is not a claim a script may make on someone's behalf — and
+#: since it is one-off per account on a path that already requires an interactive browser
+#: login, the manual step costs a user 30 seconds once. Measured 2026-09-08 on ci-probe:
+#: docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md
 
 #: ``YhhmEf`` is the text-to-video submit; ``eb1hJf`` the image-to-video one (a bound
 #: Start chip switches the app between them — 2026-09-05 frames spike).
@@ -1046,10 +1065,30 @@ class MigratedComposer:
                         f"{FRAME_PICKER_OPEN_S:.0f}s (host=migrated)"
                     ),
                 ) from e
+            # Counted BEFORE the file is handed over, so the check after a timeout can ask
+            # the only question that matters: did a dialog appear *during* the upload
+            # window? See UPLOAD_CONSENT_DIALOG for why this is a count and not a selector.
+            dialogs_before = await page.locator(DIALOG).count()
             await chooser.set_files(str(image_path))
             try:
                 status, text = await asyncio.wait_for(reply, timeout=FRAME_UPLOAD_S)
             except TimeoutError:
+                if await page.locator(DIALOG).count() > dialogs_before:
+                    raise MediaUploadRejectedError(
+                        detail=(
+                            f"migrated host: a dialog opened after the file was chosen and no "
+                            f"{UPLOAD_RPC} request was ever sent — Flow is holding the upload "
+                            f"behind its one-time upload-terms confirmation (host=migrated)"
+                        ),
+                        route=route,
+                        remediation_hint=(
+                            "Open the project on flow.google.com, upload any image by hand, "
+                            "and accept the one-time 'rights to use this image' dialog. gflow "
+                            "does not accept it for you: it affirms that YOU hold the rights "
+                            "to what you upload. It appears once per account — after that, "
+                            "uploads work unattended. Nothing was spent; re-run when done."
+                        ),
+                    ) from None
                 raise MediaUploadRejectedError(
                     detail=(
                         f"migrated host: no {UPLOAD_RPC} reply within {FRAME_UPLOAD_S:.0f}s "

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -1011,7 +1011,20 @@ class MigratedComposer:
             if not reply.done():
                 reply.set_result((status, text))
 
+        # The response listener alone cannot tell "the page never asked" from "Flow was
+        # slow" — and those are different bugs with opposite fixes (#719: shape A is a
+        # blocked send, shape B is a lost reply). One boolean splits them at the point of
+        # failure instead of leaving both as one 60 s timeout.
+        sent = False
+
+        def on_request(request: Any) -> None:
+            nonlocal sent
+            url = str(getattr(request, "url", ""))
+            if "batchexecute" in url and _rpcid(url) == UPLOAD_RPC:
+                sent = True
+
         page.on("response", on_response)
+        page.on("request", on_request)
         try:
             add = page.locator(TOOLBAR_ADD).first
             if not await add.count():
@@ -1069,12 +1082,20 @@ class MigratedComposer:
             try:
                 status, text = await asyncio.wait_for(reply, timeout=FRAME_UPLOAD_S)
             except TimeoutError:
-                if await page.locator(DIALOG).count() > dialogs_before:
+                try:
+                    opened = await page.locator(DIALOG).count() > dialogs_before
+                except Exception:  # noqa: BLE001 - a probe is never the failure it reports
+                    # The likeliest reason no reply came is that the page died or navigated,
+                    # in which case this count raises too. Letting that escape would replace
+                    # a mapped exit 27 and its remediation with an unmapped traceback — the
+                    # #752 lesson, one surface over.
+                    opened = False
+                if opened and not sent:
                     raise MediaUploadRejectedError(
                         detail=(
                             f"migrated host: a dialog opened after the file was chosen and no "
-                            f"{UPLOAD_RPC} request was ever sent — Flow is holding the upload "
-                            f"behind its one-time upload-terms confirmation (host=migrated)"
+                            f"{UPLOAD_RPC} request left the page — most likely Flow's one-time "
+                            f"upload-terms confirmation (host=migrated)"
                         ),
                         route=route,
                         remediation_hint=(
@@ -1082,13 +1103,22 @@ class MigratedComposer:
                             "and accept the one-time 'rights to use this image' dialog. gflow "
                             "does not accept it for you: it affirms that YOU hold the rights "
                             "to what you upload. It appears once per account — after that, "
-                            "uploads work unattended. Nothing was spent; re-run when done."
+                            "uploads work unattended. If you see a different dialog instead "
+                            "(an error, a quota notice, a re-login), that is the one blocking "
+                            "the upload. Nothing was spent; re-run when done."
                         ),
                     ) from None
+                # Say which half of #719 this is. `sent` is observed, not inferred: the
+                # request listener above saw the upload leave the page, or it did not.
+                went_out = (
+                    "the request left the page and Flow did not answer in time"
+                    if sent
+                    else "no upload request ever left the page"
+                )
                 raise MediaUploadRejectedError(
                     detail=(
                         f"migrated host: no {UPLOAD_RPC} reply within {FRAME_UPLOAD_S:.0f}s "
-                        "of choosing the file — the upload never reached Flow or was dropped"
+                        f"of choosing the file — {went_out}"
                     ),
                     route=route,
                 ) from None
@@ -1122,6 +1152,7 @@ class MigratedComposer:
             return media_id
         finally:
             page.remove_listener("response", on_response)
+            page.remove_listener("request", on_request)
 
     async def attach_references(
         self, page: Page, project_id: str, paths: tuple[Path, ...]

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -124,25 +124,6 @@ DIALOG = "[role='dialog']"
 # docs/superpowers/spikes/2026-09-07-credit-shortfall-looks-like-selector-drift.md
 CREDITS_WARNING = "button.prompt-warning-button, [aria-label*='Insufficient credits']"
 DIALOG_CLOSE = f"{DIALOG} button:has(mat-icon:text-is('close'))"
-#: Flow shows a one-time upload-terms dialog ("rights to use this image") the first time an
-#: account uploads a file on this host. It renders AFTER the file chooser hands the file
-#: over, so `_dismiss_dialog` — which runs back in `ensure_editor` — never sees it, and Flow
-#: does not send the upload until a human accepts it. The driver's `FRAME_UPLOAD_S` wait was
-#: therefore waiting for a request the page had already decided not to make, and reported it
-#: as "the upload never reached Flow", advising the user to re-encode their image (#719).
-#:
-#: **This is detected by COUNTING dialogs across the upload, not by matching one.** Its two
-#: buttons are `button.flow-button-medium` with no ligature and no data attribute, separable
-#: only by DOM order, and its copy is translated — so there is no anchor here that satisfies
-#: this module's locale rule. A dialog that appears between "the file was chosen" and "we
-#: gave up waiting" is upload-related by construction, which needs no selector at all and
-#: cannot rot when Angular renames a class.
-#:
-#: gflow never clicks it. Accepting affirms that the ACCOUNT OWNER holds the rights to the
-#: content being uploaded, which is not a claim a script may make on someone's behalf — and
-#: since it is one-off per account on a path that already requires an interactive browser
-#: login, the manual step costs a user 30 seconds once. Measured 2026-09-08 on ci-probe:
-#: docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md
 
 #: ``YhhmEf`` is the text-to-video submit; ``eb1hJf`` the image-to-video one (a bound
 #: Start chip switches the app between them — 2026-09-05 frames spike).
@@ -1065,9 +1046,24 @@ class MigratedComposer:
                         f"{FRAME_PICKER_OPEN_S:.0f}s (host=migrated)"
                     ),
                 ) from e
-            # Counted BEFORE the file is handed over, so the check after a timeout can ask
-            # the only question that matters: did a dialog appear *during* the upload
-            # window? See UPLOAD_CONSENT_DIALOG for why this is a count and not a selector.
+            # Flow holds an account's FIRST upload behind a one-time "rights to use this
+            # image" confirmation. It renders only once the chooser has handed the file
+            # over — so `_dismiss_dialog`, back in `ensure_editor`, never sees it — and
+            # Flow sends nothing until a human accepts, which is why the wait below used
+            # to expire on a request the page had already declined to make (#719).
+            #
+            # Counted, never matched. The dialog's two buttons are
+            # `button.flow-button-medium` with no ligature and no data attribute,
+            # separable only by DOM order, and its copy is translated — no anchor there
+            # satisfies this module's locale rule. "A dialog appeared between the file
+            # being chosen and the wait expiring" is upload-related by construction: it
+            # needs no selector and cannot rot when Angular renames a class. The baseline
+            # is taken BEFORE `set_files` so an already-open modal is never blamed.
+            #
+            # gflow does not click it: accepting affirms that the ACCOUNT OWNER holds the
+            # rights to the content, which is not a claim a script may make for someone.
+            # Measured 2026-09-08 across 6 runs on ci-probe —
+            # docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md
             dialogs_before = await page.locator(DIALOG).count()
             await chooser.set_files(str(image_path))
             try:

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -118,6 +118,11 @@ class Dom:
     #: handed over, and Flow sends NOTHING until a human accepts it — so this both
     #: raises a dialog and withholds the reply, which is the whole shape of the bug.
     consent_dialog_on_upload: bool = False
+    #: The page dies once the file is handed over (navigation, crash, context
+    #: teardown) — the likeliest reason a reply never comes, and the state in which
+    #: the post-timeout dialog probe would itself raise.
+    page_dies_on_upload: bool = False
+    dialog_probe_raises: bool = False
     dialog_closed: int = 0
     # --- #749: Flow's agent mode ------------------------------------------------------
     # Pressed, the chip leaves `.settings-trigger-button` in the DOM under a bare `hidden`
@@ -235,6 +240,8 @@ class FakeLocator:
 
     # --- reads --------------------------------------------------------------
     async def count(self) -> int:
+        if self.kind == "dialog" and self.page.dom.dialog_probe_raises:
+            raise PlaywrightTimeoutError("count: Target page, context or browser has been closed")
         if self.kind == "agent_chip":
             dom = self.page.dom
             index, dom.agent_chip_probes = dom.agent_chip_probes, dom.agent_chip_probes + 1
@@ -348,8 +355,15 @@ class FakeFileChooser:
         if dom.consent_dialog_on_upload:
             dom.dialog_present = True
             return  # ...and no upload request is ever made
+        if dom.page_dies_on_upload:
+            dom.dialog_probe_raises = True
+            return
         reply = dom.maseq_reply
         if reply == "none":
+            return
+        # Everything past here means the upload actually left the page.
+        self.page._fire_request(_batch_url("maseQ"))
+        if reply == "sent_no_reply":
             return
         payloads: dict[str, list[Any]] = {
             "ok": [MEDIA_UP, PROJ_UUID, "44444444-4444-4444-8444-444444444444", "CAE"],
@@ -455,6 +469,10 @@ class FakePage:
 
     def listeners(self, event: str) -> list[Any]:
         return list(self._handlers[event])
+
+    def _fire_request(self, url: str) -> None:
+        for h in list(self._handlers["request"]):
+            asyncio.get_event_loop().create_task(_maybe_await(h(FakeRequest(url, ""))))
 
     def _fire_response(self, response: FakeResponse) -> None:
         for h in list(self._handlers["response"]):
@@ -1621,7 +1639,10 @@ async def test_attach_names_the_one_time_terms_dialog_when_one_opens(
     with pytest.raises(MediaUploadRejectedError) as ei:
         await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
     assert "one-time upload-terms" in str(ei.value)
+    assert "most likely" in str(ei.value)  # a count is evidence for a guess, not a fact
     assert "rights" in ei.value.remediation_hint
+    # A different modal (an error, a quota notice) must leave the user somewhere to go.
+    assert "different dialog" in ei.value.remediation_hint
     # The wrong advice this replaces must not survive on this branch.
     assert "re-encoding" not in ei.value.remediation_hint
     assert ei.value.route == "batchexecute:maseQ"
@@ -1644,7 +1665,46 @@ async def test_attach_does_not_blame_a_dialog_that_was_already_open(
     with pytest.raises(MediaUploadRejectedError) as ei:
         await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
     assert "one-time upload-terms" not in str(ei.value)
-    assert "never reached Flow" in str(ei.value)
+    assert "no upload request ever left the page" in str(ei.value)
+
+
+async def test_attach_says_the_request_left_the_page_when_flow_just_never_answers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#719 shape B, and the half the old message could not express. Watching only
+    responses cannot tell "the page never asked" from "Flow was slow" — and they are
+    different bugs with opposite fixes: one argues for a retry, the other against.
+    `FRAME_UPLOAD_S` itself concedes a large file on a slow link can exceed the budget,
+    so claiming nothing was sent would have been false on a perfectly healthy upload."""
+    from gflow_cli.api.transports import migrated_composer
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    monkeypatch.setattr(migrated_composer, "FRAME_UPLOAD_S", 0.2)
+    page = FakePage()
+    page.dom.maseq_reply = "sent_no_reply"
+    with pytest.raises(MediaUploadRejectedError) as ei:
+        await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
+    assert "the request left the page and Flow did not answer" in str(ei.value)
+    assert "one-time upload-terms" not in str(ei.value)
+
+
+async def test_attach_keeps_exit_27_when_the_dialog_probe_itself_dies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probe must never become the failure it was added to describe. The likeliest
+    reason no reply arrived is that the page died or navigated — in which case the dialog
+    count raises too, and letting that escape would swap a mapped exit 27 and its
+    remediation for an unmapped traceback. Same lesson as #752, one surface over."""
+    from gflow_cli.api.transports import migrated_composer
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    monkeypatch.setattr(migrated_composer, "FRAME_UPLOAD_S", 0.2)
+    page = FakePage()
+    page.dom.page_dies_on_upload = True
+    with pytest.raises(MediaUploadRejectedError) as ei:
+        await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
+    assert EXIT_CODE_MAP[MediaUploadRejectedError] == 27
+    assert "no upload request ever left the page" in str(ei.value)
 
 
 async def test_attach_is_upload_rejected_on_a_non_200_maseq(tmp_path: Path) -> None:

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -114,6 +114,10 @@ class Dom:
     chip_binds: bool = True  # the option click flips the Start chip to a bound one
     chip_bound: bool = False
     dialog_present: bool = False  # a `[role=dialog]` (the changelog modal) on load
+    #: #719: the one-time upload-terms modal. It appears only once the file has been
+    #: handed over, and Flow sends NOTHING until a human accepts it — so this both
+    #: raises a dialog and withholds the reply, which is the whole shape of the bug.
+    consent_dialog_on_upload: bool = False
     dialog_closed: int = 0
     # --- #749: Flow's agent mode ------------------------------------------------------
     # Pressed, the chip leaves `.settings-trigger-button` in the DOM under a bare `hidden`
@@ -341,6 +345,9 @@ class FakeFileChooser:
     async def set_files(self, files: Any) -> None:
         dom = self.page.dom
         dom.chosen_files.append(str(files))
+        if dom.consent_dialog_on_upload:
+            dom.dialog_present = True
+            return  # ...and no upload request is ever made
         reply = dom.maseq_reply
         if reply == "none":
             return
@@ -1591,6 +1598,53 @@ async def test_attach_is_upload_rejected_when_maseq_does_not_answer(
     assert ei.value.route == "batchexecute:maseQ"
     assert EXIT_CODE_MAP[MediaUploadRejectedError] == 27
     assert page.dom.picked == [] and not page.dom.picker_open
+    # No dialog opened, so this stays the plain timeout — the terms wording must not
+    # leak onto a run where nothing was asked of the user.
+    assert "one-time upload-terms" not in str(ei.value)
+
+
+async def test_attach_names_the_one_time_terms_dialog_when_one_opens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#719 shape A. Flow holds the first upload of an account behind a one-time
+    terms dialog, rendered only AFTER the file is handed over — so `_dismiss_dialog`,
+    which runs back in `ensure_editor`, never sees it, and the driver waited out the
+    full budget for a request the page had already declined to make. The old message
+    said the upload "never reached Flow" and told the user to re-encode their image;
+    it is neither the file nor the network."""
+    from gflow_cli.api.transports import migrated_composer
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    monkeypatch.setattr(migrated_composer, "FRAME_UPLOAD_S", 0.2)
+    page = FakePage()
+    page.dom.consent_dialog_on_upload = True
+    with pytest.raises(MediaUploadRejectedError) as ei:
+        await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
+    assert "one-time upload-terms" in str(ei.value)
+    assert "rights" in ei.value.remediation_hint
+    # The wrong advice this replaces must not survive on this branch.
+    assert "re-encoding" not in ei.value.remediation_hint
+    assert ei.value.route == "batchexecute:maseQ"
+
+
+async def test_attach_does_not_blame_a_dialog_that_was_already_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control for the guard. It fires on a dialog that appeared DURING the upload,
+    never on one that was already on screen — otherwise a lingering changelog modal
+    (#26) would rewrite every unrelated upload timeout into a terms message and send
+    the user to accept something that was never asked of them."""
+    from gflow_cli.api.transports import migrated_composer
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    monkeypatch.setattr(migrated_composer, "FRAME_UPLOAD_S", 0.2)
+    page = FakePage()
+    page.dom.dialog_present = True  # already there before the file is chosen
+    page.dom.maseq_reply = "none"
+    with pytest.raises(MediaUploadRejectedError) as ei:
+        await MigratedComposer().attach_start_frame(page, PROJ, _png(tmp_path))
+    assert "one-time upload-terms" not in str(ei.value)
+    assert "never reached Flow" in str(ei.value)
 
 
 async def test_attach_is_upload_rejected_on_a_non_200_maseq(tmp_path: Path) -> None:

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -687,15 +687,28 @@ This is because Chromium holds an exclusive lock on its SQLite cookie database w
 ---
 
 
-### Flow's first-upload terms-of-use dialog ("Aviso") blocks the worker (worker-only)
+### Flow's one-time upload-terms dialog blocks the FIRST upload on an account
 
-- **Status:** Open · **Severity:** Low · **Affects:** the legacy in-tree Compiled Growth worker, NOT `gflow-cli` itself
+- **Status:** Mitigated · **Severity:** High until accepted (every `i2v --initial-frame` and `r2v --ref` on that account fails) · **Affects:** the migrated `flow.google.com` host, all versions through 0.71.0 · **Tracked:** [#719](https://github.com/ffroliva/gflow-cli/issues/719)
 
-Flow shows a one-time "Aviso" / "Notice" terms-of-use confirmation on the first image upload of a new account session. The legacy Playwright worker has to explicitly click "Concordo" / "Agree". `gflow-cli`'s API-driven path bypasses this dialog entirely (the REST endpoint already implies acceptance).
+Flow shows a one-time **"Rights to use this image"** confirmation the first time an account uploads a file. It renders **after** the file chooser has handed the file over, and Flow sends **nothing** until it is accepted — so the driver waited out its full 60 s budget for an upload request the page had already decided not to make, then reported:
 
-**Workaround in gflow-cli:** none needed.
+```
+MediaUploadRejectedError (exit 27): migrated host: no maseQ reply within 60s of choosing
+the file — the upload never reached Flow or was dropped
+```
 
-**Workaround in legacy worker:** see Compiled Growth's `flow_video.py` consent-dismiss block.
+…and advised re-encoding the image to strip metadata. Neither the file nor the network was ever involved. Measured 2026-09-08 on three profiles, eight runs: the two accounts that had uploaded before never saw the dialog and uploaded fine; the account that never had failed 3/3. See [the spike](https://github.com/ffroliva/gflow-cli/blob/main/docs/superpowers/spikes/2026-09-08-migrated-upload-fails-two-ways.md).
+
+> **This entry previously said the opposite.** It read *"Affects: the legacy in-tree Compiled Growth worker, NOT `gflow-cli` itself"*, because *"gflow-cli's API-driven path bypasses this dialog entirely (the REST endpoint already implies acceptance)"*, with *"Workaround in gflow-cli: none needed."* That was true of the REST path and became false when the migrated driver started using the editor's **own** upload — so the entry a user hitting #719 would find was reassuring them about the exact thing that was breaking their run.
+
+**Mitigation** (unreleased line, post-v0.71.0): when the upload budget expires, the driver checks whether a dialog opened *during* the upload window and, if so, says so and points the user at the one-time acceptance instead of blaming the file.
+
+**Workaround / how to clear it — once per account, ever:** open the project on `flow.google.com`, upload any image by hand, and accept the dialog. Uploads then work unattended forever.
+
+**gflow does not accept it for you, by design.** The dialog affirms that *you* hold the rights to the content you upload; that is not a claim a tool may make on an account owner's behalf. It is also a 30-second step, once, on a path that already requires an interactive browser login (`gflow auth login`) — so automating it would buy nothing and assert something on your behalf. There is deliberately no config flag: a setting that can never safely default to on, on a once-per-account event, is a flag nobody sets.
+
+**Legacy worker:** Compiled Growth's `flow_video.py` clicks "Concordo" / "Agree" in its own consent-dismiss block. That is a different product decision, recorded here so the two are not confused.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #719 shape A. Builds on the instruments and findings in #754.

Flow holds an account's **first** upload behind a one-time **"Rights to use this image"** confirmation. It renders *after* the file chooser hands the file over — so `_dismiss_dialog`, which runs back in `ensure_editor`, never sees it — and Flow sends **nothing** until a human accepts it. The driver spent its full 60 s budget waiting for a request the page had already declined to make, then reported:

```
MediaUploadRejectedError (exit 27): migrated host: no maseQ reply within 60s of choosing
the file — the upload never reached Flow or was dropped
```

…and advised re-encoding the image to strip metadata. Neither the file nor the network was ever involved. This blocked **both** `video i2v --initial-frame` and `video r2v --ref`, which is every form that binds a local file on this host.

## The guard

```python
dialogs_before = await page.locator(DIALOG).count()
await chooser.set_files(str(image_path))
try:
    status, text = await asyncio.wait_for(reply, timeout=FRAME_UPLOAD_S)
except TimeoutError:
    try:
        opened = await page.locator(DIALOG).count() > dialogs_before
    except Exception:            # a probe is never the failure it reports
        opened = False
    if opened and not sent:      # `sent` comes from a request listener
        raise MediaUploadRejectedError(detail=..., remediation_hint=...)
    raise MediaUploadRejectedError(...)   # now says whether the request left the page
```

It sits in `_upload_via_toolbar`, where `i2v --initial-frame` and `r2v --ref` already converge, so one check covers both surfaces.

**It counts dialogs rather than matching one, and that is the load-bearing decision.** The dialog's two buttons are `button.flow-button-medium` with **no ligature and no data attribute**, separable only by DOM order, and its copy is translated — there is no anchor there that satisfies this project's locale-invariance rule. "A dialog appeared between the file being chosen and the wait expiring" is upload-related by construction: it needs no selector, and it cannot rot when Angular renames a class.

The `_default_remediation` ("re-encode the image to strip metadata") is **not** changed — it is still correct for the original #287 case, a 4xx on one file's metadata. It is overridden on this branch only.

## gflow does not accept the dialog, and there is no flag to make it

The dialog affirms that *you* hold the rights to the content being uploaded. That is not a claim a script may make on an account owner's behalf. It is also **one-off per account**, on a path that already requires an interactive `gflow auth login` — so the manual step costs 30 seconds once in an account's life, and automating it would assert something on the user's behalf to save nothing.

No config flag either: a setting that can never safely default to on, for an event that happens once, is a flag nobody sets.

## Verification

Measured live on `ci-probe` (#754 carries the instrument). The order was forced — the dialog is one-off, so the guard had to be written and verified against the live dialog **before** anything was accepted, or the failing state would be gone forever.

| # | Run | Result |
|---|---|---|
| 1–3 | upload, pre-fix | `no maseQ reply within 60s` — the misleading message |
| 4 | upload, **with this guard** | `a dialog opened after the file was chosen and no maseQ request was ever sent — Flow is holding the upload behind its one-time upload-terms confirmation` *(the pre-review wording; it is now hedged to "most likely" and backed by an observed request listener — see below)* |
| 5 | accept (owner-authorised) → retry, same session | **`media_id 8914400f-…`** |
| 6 | plain upload, fresh session | **uploaded, `dialog: None`, 4 POSTs** |

The dialog blocks the send (4), accepting unlocks it (5), it never returns (6).

**Offline:** 90 tests in `test_migrated_composer.py`, full `tests/api/transports` suite, and the nine local gates.

## `/code-review high` ran before this PR, and found three things

Per the process change from #752 — the gate goes before the merge, not after. All three are fixed in this branch:

1. **The dialog probe could become the failure it describes.** The `count()` runs inside `except TimeoutError`, and the likeliest reason no reply arrived is that the page died or navigated — in which case the count raises too, escapes in place of `MediaUploadRejectedError`, and the run exits with an unmapped code 1 and a traceback instead of the mapped **27** with its remediation. Before this change the timeout path had no awaits and could not fail that way. It now degrades to the plain timeout. Same lesson as #752, one surface over.

2. **The message asserted two things the code never observed.** *"no maseQ request was ever sent"* was inferred from a **response** listener, so a request that did leave and was answered slower than `FRAME_UPLOAD_S` produced it falsely — and that constant's own comment concedes a 20 MB file on a slow link needs longer. Fixed by watching the request too, which is worth more than the wording: **`sent` now splits #719 shape A (nothing left the page) from shape B (it left, Flow didn't answer) at the point of failure**, and those argue for opposite fixes — one for a retry, one against. That is exactly what the spike doc recommended, and it costs one boolean.

   *"Flow is holding the upload behind its one-time upload-terms confirmation"* was asserted as fact from a bare dialog count, so any modal in that window inherited it — an error modal, a quota notice, a re-login prompt. It now says **"most likely"**, and the remediation tells a user who sees a different dialog that *that* is the one blocking them. A count is evidence for a guess, not a fact — which is the whole thing #719 is about.

3. A `#:` block documented an `UPLOAD_CONSENT_DIALOG` constant **that was never defined**, so it dangled between `DIALOG_CLOSE` and `SUBMIT_RPCS` and the guard's comment pointed at a name not in the file. I caught this one myself reading the diff, before the review returned it. Nothing to rename — the guard counts precisely so it needs no selector — so the rationale moved to the guard.

Four unit cases, and the last two came out of the review:

- the terms branch produces the new message and drops the wrong "re-encode" advice;
- **a control proving the guard does not fire on a dialog that was already open** — otherwise a lingering changelog modal (#26) would rewrite every unrelated upload timeout into a terms message and send the user to accept something never asked of them. The plain-timeout test also now asserts the terms wording does not leak onto it;
- the shape-B wording on a request that left the page and went unanswered;
- **exit 27 surviving a probe that dies mid-upload** — the regression the review found.

The fake now models the upload request leaving the page, and a page that dies once the file is handed over, so both states are constructible rather than argued.

### On the Iron Law — why there is no new e2e for the positive branch

The guard's **firing** branch was verified live (run 4 above, against the real dialog), and that is the strongest evidence available for it. It is also **unrepeatable**: the dialog is one-off per account, and all three accounts on this machine have now accepted it. Reproducing the un-consented state needs a Google account that has never uploaded on `flow.google.com` — a named external blocker, not a skipped step.

The **non-firing** branch is where the regression risk actually lives (a guard that fires wrongly would mislabel every unrelated upload timeout), and that is covered offline by the control test plus the existing `e2e_video` i2v/r2v tests, which exercise the healthy upload path end to end.

If a fresh account ever appears, `scripts/dev/spike_migrated_upload_wire.py` (#754) reproduces the whole six-run sequence, including `--accept-terms`.

## `KNOWN_ISSUES.md` corrected

The entry for this dialog said:

> **Affects:** the legacy in-tree Compiled Growth worker, **NOT `gflow-cli` itself** … `gflow-cli`'s API-driven path bypasses this dialog entirely (the REST endpoint already implies acceptance). **Workaround in gflow-cli:** none needed.

True of the REST path, and false since the migrated driver began using the editor's own upload — so the entry a user hitting #719 would find was reassuring them about the exact thing breaking their run. Rewritten with the measurement, the one-off workaround, and why gflow does not click it.

## Scope

**Not fixed here: #719 shape B** — 1/4 on a funded account, the `maseQ` POST goes out with 8 675 B, no reply arrives, and 2.6 s later the whole project-load rpcid inventory fires. Unrelated to consent, still open, and #719 stays open for it.

**MCP parity:** no CLI leaf, option, queued-payload key or tool docstring claim changes. The guard is in the shared transport, so the MCP twin gets the improved error for free — same code path, no adapter change.
