### PR TITLE
test: stop two suites from silently validating the wrong thing (#758, #760)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,40 @@ import structlog
 from tests.fixtures.doctor_env import healthy_doctor_env  # noqa: F401
 
 
+def _assert_source_under_test_is_this_tree() -> None:
+    """Fail loudly if ``gflow_cli`` resolves outside the tree these tests live in (#760).
+
+    A git worktree has no ``.venv`` of its own: the venv's editable install pins ``src/``
+    in the PRIMARY checkout. So ``pytest`` run inside a worktree executes the worktree's
+    TESTS against the main checkout's SOURCE — and it fails *open*. A release branch runs
+    its own gates, sees green, and has validated code it is not shipping; a regression on
+    that branch passes, because the other tree's healthy code answered for it.
+
+    Caught during the v0.71.1 release only because one new assertion happened to differ
+    between the two trees. Nothing structural would have caught it, which is why this is a
+    hard error rather than a warning.
+
+    Deliberately narrow: it fires only when a local ``src/gflow_cli`` exists beside these
+    tests AND the import came from somewhere else. Testing an installed wheel — where no
+    local source tree is present — is untouched.
+    """
+    import gflow_cli
+
+    tests_root = Path(__file__).resolve().parent.parent
+    local_src = tests_root / "src" / "gflow_cli"
+    if not local_src.is_dir():
+        return  # no source tree beside the tests: an installed-package run, leave it alone
+    imported = Path(gflow_cli.__file__).resolve().parent
+    if imported == local_src.resolve():
+        return
+    raise pytest.UsageError(
+        f"gflow_cli was imported from {imported}, but these tests live in {tests_root} "
+        f"(which ships {local_src}). The tests would validate the WRONG source tree and "
+        f"pass regardless — see #760. If you are in a git worktree, prefix the run with "
+        f'PYTHONPATH="{tests_root / "src"}".'
+    )
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Stop git from escaping pytest's basetemp into the real clone (#605).
 
@@ -48,6 +82,7 @@ def pytest_configure(config: pytest.Config) -> None:
     (``tmp_path_factory.getbasetemp()``) free to walk out. Any ceiling the
     developer already set is preserved after ours.
     """
+    _assert_source_under_test_is_this_tree()
     basetemp = config.getoption("basetemp", None)
     if basetemp:
         ceilings = [str(Path(basetemp).resolve().parent), os.environ.get("GIT_CEILING_DIRECTORIES")]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -603,8 +603,18 @@ class TestRemovedGeminiKeyNotice:
         env = {"GFLOW_CLI_GEMINI_API_KEY": "AIza-old", replacement: "set"}
         assert warn_if_removed_gemini_key_set(env) is False
 
-    def test_key_is_never_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The notice reports; it must not resurrect the value as a fallback."""
+    def test_key_is_never_forwarded(self, clean_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The notice reports; it must not resurrect the value as a fallback.
+
+        ``clean_env`` is load-bearing, not decoration (#758). ``delenv`` clears the
+        process env var, but ``Settings`` also reads the dotenv files from
+        ``config._env_files()`` — so on any machine whose repo-root ``.env`` sets
+        ``GFLOW_CLI_LLM_API_KEY`` (the documented dev setup) pydantic-settings loaded it
+        straight back and this failed, while CI stayed green because CI has no ``.env``.
+        It failed, in other words, for exactly the developers whose environment could
+        exhibit the leak it guards against. ``clean_env`` fences both dotenv entries into
+        ``tmp_path`` — see ``TestCleanEnvHermeticity``, which documents this hazard.
+        """
         monkeypatch.setenv("GFLOW_CLI_GEMINI_API_KEY", "AIza-old")
         monkeypatch.delenv("GFLOW_CLI_LLM_API_KEY", raising=False)
         assert Settings().llm_api_key is None


### PR DESCRIPTION
Closes #758. Closes #760.

Both found while running the v0.71.1 release gates. Neither is a product bug — both are **tests that pass while checking something other than what they claim**, which is worth more than either individual fix.

## #758 — a security-property test that failed only for the developers it protects

`test_key_is_never_forwarded` guards the rule that a removed key is never resurrected as a fallback. It cleared the process env var with `delenv`, but `Settings` **also** reads the dotenv files from `config._env_files()`. So on any machine whose repo-root `.env` sets `GFLOW_CLI_LLM_API_KEY` — the documented dev setup — pydantic-settings loaded it straight back and the assertion failed. CI stayed green, because CI has no `.env`.

It therefore failed for exactly the developers whose environment could exhibit the leak it exists to catch — the population most likely to learn to ignore a red they see on every run.

**The fix is one fixture, not new machinery.** `clean_env` already fences *both* dotenv entries into `tmp_path`, and `TestCleanEnvHermeticity` already documents this precise hazard ("the repo root's gitignored `.env` is the documented dev setup"). The test simply never used it.

## #760 — pytest in a worktree validates the wrong source tree, silently

A git worktree has no `.venv` of its own; the venv's editable install pins `src/` in the **primary** checkout. So `pytest` inside a worktree runs the worktree's **tests** against the main checkout's **source**.

It fails **open**. A release branch runs its own gates, sees green, and has validated code it is not shipping — and a regression on that branch *passes*, because the healthy tree answered for it. `/gflow:release` step 5 **requires** cutting in a worktree, so every release has carried this exposure.

It surfaced during v0.71.1 only because one newly added assertion happened to differ between the two trees. Nothing structural would have caught it, which is why this is a hard `UsageError` at `pytest_configure` rather than a warning.

The check is deliberately narrow: it fires only when a local `src/gflow_cli` exists beside the tests **and** the import came from elsewhere. Testing an installed wheel — no local source tree — is untouched.

### A/B verified, because a guard that never fires is worse than none

In a real second worktree, on this commit:

| Arm | Command | Result |
|---|---|---|
| **A** | `pytest tests/test_config.py` | **fires** — names both trees and the exact `PYTHONPATH` fix |
| **B** | `PYTHONPATH=<wt>/src pytest tests/test_config.py` | 66 passed |

**Before this commit, arm A reported `66 passed`** while validating a completely different source tree. That is the whole bug: the failure was indistinguishable from success.

## Verification

- Full offline suite: **4086 passed**, 24 skipped, 0 failures.
- All nine gates green.
- **No `src/` change and no Flow surface touched**, so per AGENTS.md this is explicitly out of scope for an e2e run rather than left blank. The change is test-harness only; its own correctness rests on the A/B above.

> One note on the suite: the run initially showed `test_imports_succeed` failing, because the back-merge bumped `__version__` to 0.71.1 while the local venv's editable dist-info still recorded 0.71.0. That is stale local state, not a defect — `uv sync` refreshes it and both agree. Worth knowing that a version bump leaves this red behind until the next sync.

## Follow-up worth considering separately

`/gflow:release` step 5 and CLAUDE.md § Worktrees could also carry the `PYTHONPATH` prefix as guidance — but guidance relies on being remembered, which is why this ships the assertion instead.
