### PR TITLE
chore(workflow): make the Bug Lane the documented route from symptom to fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ that did not run.
 |---|---|---|
 | Claim a Flow surface is broken, missing, or impossible | `/gflow:spike <question>` | A selector that misses is evidence about the SELECTOR; "labs-only, ever" came from one 20 s timeout and cost a day |
 | Touch a GitHub issue | `/gflow:issue-assessment <N>` | Read-only triage precedes any fix; classification changes what "fixing" means |
+| Explain a symptom, or fix a bug whose cause is not yet proven | The **Bug Lane** — [`skills/issue-resolve/SKILL.md`](skills/issue-resolve/SKILL.md) | The issue names a symptom; the cause is usually a caller above it. Skipping to the fix patches one path and leaves its siblings broken |
+| Write the test for a scenario that can only happen in a browser | [`docs/E2E_TESTING.md`](docs/E2E_TESTING.md) § BDD-bound e2e | A mocked page asserts *our* code; the bug was that Flow did something else. The Gherkin tag is what makes it an e2e test |
 | Propose a transport, auth, selector, or schema change | `/gflow:predict <proposal>` | Five adversarial personas return GO / CAUTION / STOP before code exists |
 | Start a feature | `/gflow:scenario` → `/gflow:plan` | Edge cases before tasks; tasks before code |
 | Resume work / ask "where are we?" | `/gflow:status` | The current plan's next unchecked task is the answer, not your guess |
@@ -159,7 +161,10 @@ captured, and it cannot prove the surface an agent or a user actually calls is w
 the code under test. Everything not exercised is unknown, and unknown ships as a bug.
 
 If no e2e test covers the change, **write one** — that is part of the change, not
-follow-up work.
+follow-up work. For a bug, the lane that gets you there — spike → debug → BDD → TDD
+→ e2e, and which steps a given bug may skip — is
+[`skills/issue-resolve/SKILL.md`](skills/issue-resolve/SKILL.md) § The Bug Lane. It is
+written once, there; this section states the law, that one states the route.
 
 **The only permitted exception is a named external blocker** you cannot remove: an
 exhausted API quota, hardware you do not have, an account you do not control, a cohort
@@ -235,8 +240,9 @@ All AI agents and harnesses working on `gflow-cli` follow this standard 10-phase
 |---|---|---|---|
 | 0. Spike | `/gflow:spike <question>` | Evidence from the live surface (DOM / network / HAR) whenever a claim of absence is in play | `scripts/dev/spike_*.py` + `docs/superpowers/spikes/<date>-<slug>.md` |
 | 1. Triage | `/gflow:issue-assessment <N>` | Read-only issue analysis & root cause hypothesis | `issue_assessment_<N>.md` |
+| 1b. Root cause | `superpowers:systematic-debugging` (the **Bug Lane**, [`skills/issue-resolve`](skills/issue-resolve/SKILL.md)) | Turn the triage *hypothesis* into a proven cause at `<file>:<line>`, then grep every caller so the fix lands at the root | Root cause + the callers it covers |
 | 2. Pre-Implementation | `/gflow:predict <proposal>` | Adversarial audit (D14 YAGNI, security, risks) | GO / CAUTION / STOP verdict |
-| 3. BDD Scaffolding | `/gflow:scenario <feature>` | Edge-case explorer & BDD Gherkin spec | `Scenario:` blocks & test scaffold |
+| 3. BDD Scaffolding | `/gflow:scenario <feature>` | Edge-case explorer & BDD Gherkin spec | `Scenario:` blocks + the binding its **surface** dictates: a browser-only scenario is tagged `@e2e @e2e_<tier>` and bound from `tests/e2e/`, everything else stays offline in `tests/features/` |
 | 4. Implementation Plan | `/gflow:plan <feature>` | Task-by-task atomic implementation plan | `docs/superpowers/plans/<date>-<slug>/PLAN.md` |
 | 5. Council Review | `/gflow:pr-council-review` / `llm-council` | Multi-dimensional audit across 6 core dimensions | Consensus verdict report |
 | 6. Task Execution | `/gflow:status` | Track unchecked tasks during TDD execution | Next unchecked task |
@@ -251,7 +257,8 @@ Every AI agent executing any phase of this pipeline MUST proactively state the c
 
 | Current Phase | Completed Artifact / Gate | Next Sequential Phase & Command |
 |---|---|---|
-| Phase 1: Triage | `issue_assessment_<N>.md` | ➔ Phase 2: Pre-Implementation (`/gflow:predict <proposal>`) |
+| Phase 1: Triage | `issue_assessment_<N>.md` | ➔ Phase 1b: Root cause (`superpowers:systematic-debugging`) — skip only when the cause is already proven, and say so |
+| Phase 1b: Root cause | Proven cause at `<file>:<line>` + its callers | ➔ Phase 3: BDD Scaffolding (`/gflow:scenario`), written at the **root**, not the symptom |
 | Phase 2: Pre-Implementation | Verdict `GO` or `CAUTION` | ➔ Phase 3: BDD Scaffolding (`/gflow:scenario <feature>`) |
 | Phase 3: BDD Scaffolding | `Scenario:` blocks & test scaffold | ➔ Phase 4: Implementation Plan (`/gflow:plan <feature>`) |
 | Phase 4: Implementation Plan | `PLAN.md` created & approved | ➔ Phase 6: Task Execution (`/gflow:status`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Workflow: the Bug Lane is now the documented route from symptom to fix.**
+  `skills/issue-resolve/SKILL.md` gains a canonical `spike → systematic-debugging →
+  BDD → TDD → fix → e2e` chain, gated by *surface* (steps 0–2 are skippable for a
+  one-line fix whose cause is proven — but a skip is a claim and must be stated;
+  steps 3–5 never are). AGENTS.md, `skills/spike`, `skills/scenario`,
+  `docs/E2E_TESTING.md` and `docs/INDEX.md` cite it; none restate it.
+  - Removes a real contradiction: `issue-resolve` step 3 previously permitted "the
+    closest browser-free proxy" while AGENTS.md's Iron Law said a change with no e2e
+    coverage must get one and listed "covered by unit tests" among the excuses that
+    are *not* blockers. Two disjoint files, no merge conflict, no gate that could
+    see it.
+  - "Browser-free" is no longer accepted as a verification blocker: only a **named**
+    external blocker is (an account you do not control, a Mac, an exhausted quota).
+
+### Added
+
+- **BDD scenarios can now be bound as e2e tests**, with no new machinery: pytest-bdd
+  converts Gherkin tags into pytest markers, so a Feature tagged `@e2e @e2e_auth`
+  is filtered by the existing `addopts` and selected by the existing `-m <tier>`.
+  Feature files stay in `tests/features/`; their step module lives in `tests/e2e/`
+  so it inherits that suite's profile-gating fixtures. See
+  [docs/E2E_TESTING.md § BDD-bound e2e](docs/E2E_TESTING.md#bdd-bound-e2e).
+- `tests/features/test_e2e_binding_guard.py` — offline guard (no browser, runs in
+  hosted CI) for three ways that binding breaks silently: an `@e2e` scenario nobody
+  wrote a test for, an `@e2e` Feature with no cost sub-marker (invisible to the
+  nightly canary), and the inverse hazard — a Feature bound from `tests/e2e/` but
+  left untagged, which escapes `addopts` and makes hosted CI try to drive Chrome.
+  It carries its own fire-test, so a green run means "no orphans", not "never looked".
+
 ## [0.72.0] — 2026-09-09
 
 ### Added

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -77,6 +77,55 @@ e2e ─┬─ e2e_auth     (auth/session, health check — zero credits)
 
 ---
 
+## BDD-bound e2e
+
+A live test can be written as Gherkin. This is the required form for a bug whose
+scenario can only happen in a browser — see
+[`skills/issue-resolve/SKILL.md`](../skills/issue-resolve/SKILL.md) § The Bug Lane,
+step 5. It needs **no new machinery**: pytest-bdd (already a dependency) converts every
+Gherkin tag into a pytest marker, so a tagged scenario is filtered by the same
+`addopts` and selected by the same `-m <tier>` as a hand-written e2e test.
+
+**The three moving parts:**
+
+```gherkin
+# tests/features/account_chooser_landing.feature
+@e2e @e2e_auth                                   # ← tags become pytest markers
+Feature: A known landing state is named, not reported as selector drift
+  Scenario: the OAuth callback error page
+    Given a profile whose Flow session is authenticated
+    When the UI transport lands on /fx/api/auth/signin?error=Callback
+    Then it names the sign-in state, not a missing 'New project' CTA
+```
+
+```python
+# tests/e2e/test_account_chooser_landing_bdd.py
+from pytest_bdd import given, scenarios, then, when
+
+scenarios("../features/account_chooser_landing.feature")
+# step defs here; tests/e2e/conftest.py fixtures (e2e_profile_dir, …) apply
+```
+
+| Rule | Why |
+|---|---|
+| Feature file stays in `tests/features/` | one home for Gherkin; the guard scans one directory |
+| Step module lives in `tests/e2e/` | inherits `tests/e2e/conftest.py` — profile gating, `e2e_env`, `skip_on_migrated_host` |
+| `@e2e` **plus** a cost tier | a bare `@e2e` cannot be selected by `-m e2e_auth`, so the nightly canary never runs it |
+| One feature file, one binding module | bound from two modules, every scenario runs twice |
+
+**Enforced offline** by `tests/features/test_e2e_binding_guard.py` (no browser, normal
+CI): an `@e2e` feature with no binder under `tests/e2e/` fails, so does one with no cost
+tier, and so does the dangerous inverse — a feature bound from `tests/e2e/` but left
+untagged, which carries no `e2e` marker, escapes `addopts`, and makes hosted CI try to
+drive Chrome.
+
+> **What this does and does not prove.** The guard proves the test **exists and is
+> wired**, and runs anywhere. Proving it **passes** needs a warm profile and a real
+> browser — that is the nightly canary's job (`scripts/canary/`), on a machine that has
+> one. Hosted CI cannot run the live tiers and never could.
+
+---
+
 ## Environment variables
 
 | Variable | Default | Purpose |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -137,6 +137,8 @@ Slash commands for Claude Code, stored in `.claude/commands/gflow/`. All prefixe
 **"How do we use Copilot review on PRs?"** → [GITHUB § GitHub Copilot Code Review](GITHUB.md#github-copilot-code-review)
 **"Why did SonarCloud skip or fail on a forked PR?"** → [GITHUB § Forked PRs And SonarCloud](GITHUB.md#forked-prs-and-sonarcloud)
 **"How do I run e2e tests before a release?"** → [DEVELOPMENT § E2e gate](DEVELOPMENT.md#e2e-gate-before-merging-develop--main)
+**"A bug came in — what is the route from symptom to shipped fix?"** → [skills/issue-resolve § The Bug Lane](../skills/issue-resolve/SKILL.md) (spike → debug → BDD → TDD → e2e, and which steps a given bug may skip)
+**"The scenario only reproduces in a browser — where does its test go?"** → [E2E_TESTING § BDD-bound e2e](E2E_TESTING.md#bdd-bound-e2e)
 **"What does each e2e marker cost? How do I run only the cheap tests?"** → [E2E_TESTING § Run commands](E2E_TESTING.md#run-commands)
 **"Has Flow drifted since the last release? What is the nightly canary telling me?"** → [E2E_TESTING § Nightly canary](E2E_TESTING.md#nightly-canary-502)
 **"Which Flow selector moved? What is the CI selector probe telling me (exit 0/1/2)?"** → [E2E_TESTING § Selector drift probe](E2E_TESTING.md#selector-drift-probe-563)

--- a/skills/issue-resolve/SKILL.md
+++ b/skills/issue-resolve/SKILL.md
@@ -22,12 +22,73 @@ browser, macOS-only, credits), say so in the PR and stop. (Memory:
 
 ---
 
+## The Bug Lane — canonical here, cited everywhere
+
+**This is the chain a bug travels in gflow-cli.** It is written out once, in this
+file. `AGENTS.md`, `skills/spike`, `skills/scenario` and `docs/E2E_TESTING.md` all
+point here — none of them restate it, because a duplicated checklist drifts.
+
+```
+0  SPIKE       measure the live surface            ── only when a claim about Flow is in play
+1  DEBUG       systematic-debugging → ROOT CAUSE   ── the symptom is never the finding
+2  SCENARIO    BDD Gherkin written at the ROOT     ── the reproduction, in Given/When/Then
+3  TDD         that Gherkin RED before any fix     ── red for the right reason
+4  FIX         minimal change, at the root         ── grep every caller before editing one
+5  FORMALIZE   UI/Flow surface ⇒ it is an E2E test ── a browser-free proxy does not discharge it
+```
+
+### The surface gate — steps 0–2 are conditional, 3–5 never are
+
+Run **0 SPIKE** when the bug's explanation involves what Flow does — a selector,
+a wire response, a host behaviour, any claim of absence. Skip it when the cause is
+already proven or lives entirely in our own code.
+
+Run **1 DEBUG** and **2 SCENARIO** whenever the bug touches a Flow surface, a
+transport, auth, selectors, or the cause is not yet *proven*. Skip both for a
+fix whose cause is self-evident and whose blast radius is one line — a typo, an
+exit-code string, a doc correction. **A skip is a claim; say it out loud** ("cause
+proven at `<file>:<line>`, skipping the debug step") so the skip is reviewable.
+
+Steps **3–5 have no gate.** There is no bug small enough to fix without a test
+that failed first, and no Flow-surface change that a unit test discharges.
+
+### Step 5 is the one that gets rationalised away
+
+```
+IF THE SCENARIO CAN ONLY HAPPEN IN A BROWSER,
+THE TEST THAT PROVES IT IS AN E2E TEST.
+```
+
+Not a unit test with a mocked page. Not "the CLI path is covered and it shares the
+service." Those assert that *our* code does what we think; the bug was that Flow
+did something else. Write `tests/e2e/test_<slug>_bdd.py`, binding the Gherkin from
+step 2 — see [`docs/E2E_TESTING.md`](../../docs/E2E_TESTING.md) § BDD-bound e2e for
+the tag/marker mechanics.
+
+The only exit is a **named external blocker** (AGENTS.md Iron Law): an account you
+do not control, hardware you do not have, an exhausted quota. Write it down, use
+`Refs #N` not `Closes #N`, and leave the issue open. "I could not reach it here" is
+a blocker only after you have said *what* stopped you.
+
+> **Written from the contradiction it removes.** Until 2026-09-10 step 3 of this
+> file read "the test is the closest browser-free proxy" while AGENTS.md's Iron Law
+> read "if no e2e test covers the change, write one — that is part of the change,"
+> and listed "it's covered by unit tests" among the excuses that are *not* blockers.
+> Two files, disjoint, no merge conflict, no gate that could see it — memory
+> `prose-conflicts-hide-in-disjoint-files`. An agent following this skill could
+> ship a mocked proxy and be, by the letter, compliant.
+
+---
+
 ## Preconditions (all required before any code change)
 
 1. An `issue-assessment` verdict of `CONFIRMED-BUG` or `LIKELY-BUG`.
 2. Scope is single-surface / localized (not a cross-cutting redesign).
-3. The fix is **verifiable in this environment** (browser-free), OR the
-   verification gap is explicitly carried into the PR as "needs human e2e."
+3. The fix is **verifiable in this environment**, OR the gap is a **named external
+   blocker** carried into the PR. "Browser-free" is not itself a blocker — this host
+   has a warm profile and runs the `e2e_auth` tier at zero credits nightly. Name what
+   actually stops the run (an account you do not control, a Mac, an exhausted quota)
+   or run it.
 
 If any fails → do not resolve; return to `issue-assessment` (reply-only).
 
@@ -65,16 +126,38 @@ Urgency does not make an unverified fix verified.
 Worktree off `origin/develop` on a `bugfix/<slug>` branch (use the
 `superpowers:using-git-worktrees` skill). Never work on `develop`/`main`.
 
-### 2. Gate high-stakes changes
-If the fix touches auth, a transport, selectors, or a schema → run
-`/gflow:predict` first; for edge-case coverage run `/gflow:scenario`. Otherwise
-proceed.
+### 2. Find the root cause — lane steps 0–2
+Apply **the surface gate** above, then:
 
-### 3. Fix test-first (TDD)
-Use `superpowers:test-driven-development`. Write/confirm a **failing** test that
-reproduces the bug on the affected surface, then the minimal fix, then green.
-If the bug's surface can't be reached here, the test is the closest browser-free
-proxy and the PR flags the residual gap.
+- **0 SPIKE** — `/gflow:spike` when the explanation involves what Flow does. A
+  selector that missed is evidence about the selector, never about the feature.
+- **1 DEBUG** — `superpowers:systematic-debugging`. Backtrack from the symptom to
+  the line that causes it. The issue reports a symptom; the fix goes at the root,
+  so **grep every caller** of the function you are about to touch. One guard in the
+  shared path is a smaller diff than a guard per caller, and patching only the path
+  the ticket names leaves every sibling still broken. State the root cause as
+  `<file>:<line>` plus the evidence that pins it.
+- **2 SCENARIO** — `/gflow:scenario`. Write the reproduction as Gherkin **at the
+  root cause**, not at the symptom. Two bugs with one root cause are one scenario.
+
+If the fix touches auth, a transport, selectors, or a schema, `/gflow:predict`
+runs here too.
+
+### 3. Fix test-first — lane steps 3–5
+Use `superpowers:test-driven-development`. The step-2 Gherkin goes **red first**,
+and red for the right reason — read the failure, don't just see a red dot. Then
+the minimal fix at the root, then green.
+
+**Where the test lives is decided by the surface, not by convenience:**
+
+| The scenario can only happen… | The test is | Marked |
+|---|---|---|
+| in a real browser / against real Flow | `tests/e2e/test_<slug>_bdd.py` binding the feature | `@e2e` + a cost tier |
+| in our own code (parsing, routing, exit codes) | `tests/features/test_<slug>_steps.py` | untagged (offline) |
+
+`tests/features/test_e2e_binding_guard.py` enforces the binding both ways and
+runs offline in normal CI. A browser-free proxy **does not** discharge a
+UI-surface scenario; only a named external blocker does (see step 5 above).
 
 ### 4. Orchestrate (scales with complexity)
 For non-trivial fixes: Opus plans → delegates coding to a Sonnet subagent →
@@ -102,8 +185,12 @@ findings (or record why you declined each), then **STOP** — a human promotes a
 | Step | Tool |
 |---|---|
 | Worktree | `superpowers:using-git-worktrees` |
-| High-stakes gate | `/gflow:predict`, `/gflow:scenario` |
-| TDD | `superpowers:test-driven-development` |
+| 0 Spike (live-surface claims) | `/gflow:spike` |
+| 1 Debug → root cause | `superpowers:systematic-debugging` |
+| 2 Scenario (BDD at the root) | `/gflow:scenario` |
+| High-stakes gate | `/gflow:predict` |
+| 3 TDD | `superpowers:test-driven-development` |
+| 5 Formalize (UI ⇒ e2e) | `docs/E2E_TESTING.md` § BDD-bound e2e |
 | Pre-commit | `/gflow:check` |
 | PR review | `/gflow:pr-council-review`, `/gflow:branch-review` |
 | Verify discipline | `superpowers:verification-before-completion` |
@@ -114,6 +201,13 @@ findings (or record why you declined each), then **STOP** — a human promotes a
 
 ## Common mistakes
 
+- **Fixing the symptom the issue names.** The reporter saw a symptom; lane step 1
+  exists because the cause is usually a caller or two above it. Two issues that
+  reproduce differently can share one root — fix it once, where they meet.
+- **Letting a mocked test stand in for a browser scenario.** It is the most
+  comfortable wrong answer in this repo, which is why step 5 is written as a rule
+  and enforced by `tests/features/test_e2e_binding_guard.py` rather than left to
+  judgement.
 - Working on `develop` instead of a `bugfix/` branch off it (memory: `develop-divergence-recovery`).
 - Treating step 6's council as optional, or asking permission to run it. It is neither
   (memory: `council-review-is-standing-authorized`). Ask before merging, marking a PR

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -187,14 +187,29 @@ Test category: **Unit** (no I/O) · **Integration** (mocked HTTP/Playwright) · 
 ## Deferred (Medium + Low — log as issues, not blockers)
 1. …
 
-## Suggested BDD scenarios (for `tests/features/`)
+## Suggested BDD scenarios
 ```gherkin
+@e2e @e2e_auth
 Feature: <feature name>
   Scenario: <scenario title>
     Given …
     When …
     Then …
 ```
+
+**Tag by surface — the tag is the binding, not decoration.** pytest-bdd turns each
+Gherkin tag into a pytest marker, and `addopts`' `-m 'not e2e …'` filters on exactly
+that. So the tag decides where the scenario runs and who must run it:
+
+| The scenario can only happen… | Feature-level tags | Bound from |
+|---|---|---|
+| in a real browser / against real Flow | `@e2e` + one cost tier (`@e2e_auth`, `@e2e_image`, `@e2e_video`, …) | `tests/e2e/test_<slug>_bdd.py` |
+| in our own code (parsing, routing, exit codes, redaction) | none | `tests/features/test_<slug>_steps.py` |
+
+One feature file is bound by exactly **one** module — bound twice, its scenarios run
+twice. `tests/features/test_e2e_binding_guard.py` enforces both directions offline, so
+an `@e2e` scenario nobody wrote a test for fails normal CI. Mechanics:
+[`docs/E2E_TESTING.md`](../../docs/E2E_TESTING.md) § BDD-bound e2e.
 
 ## Known-issues cross-reference
 <Any scenario that maps to an existing KNOWN_ISSUES entry — link and note whether the proposed implementation resolves, mitigates, or is blocked by it.>
@@ -207,7 +222,10 @@ Feature: <feature name>
 1. Run `/gflow:predict` first to validate the approach (GO/CAUTION/STOP).
 2. Run `/gflow:scenario` to enumerate edge cases and build the test matrix.
 3. Use the "Must-cover before merge" list as the acceptance criteria for the PLAN.md task.
-4. Add BDD scenarios to `tests/features/` **before** coding (TDD is non-negotiable per AGENTS.md).
+4. Add BDD scenarios **before** coding (TDD is non-negotiable per AGENTS.md), each
+   tagged by its surface per the table above — a browser-only scenario is bound from
+   `tests/e2e/`, and a mocked stand-in does not discharge it
+   ([`skills/issue-resolve`](../issue-resolve/SKILL.md) § The Bug Lane, step 5).
 5. **Next step:** Proactively announce: **"BDD Scenarios generated. Next step: Phase 4 Implementation Plan (`/gflow:plan <feature>`)."**
 
 ---

--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -138,4 +138,19 @@ gap named is a lead; an unmeasured gap implied is the next day lost.
 Feeds: [`issue-assessment`](../issue-assessment/SKILL.md) (triage needs evidence, not a
 hypothesis), [`predict`](../predict/SKILL.md) (persona claims about a live surface must
 cite a capture), [`live-verify`](../live-verify/SKILL.md) (proves the fix; this proves
-the diagnosis).
+the diagnosis), and — for a bug — [`scenario`](../scenario/SKILL.md), where what you
+observed becomes the `Given`/`When`/`Then` of a test.
+
+## A spike is step 0, never the deliverable
+
+A spike answers a question. It does not close an issue, and its script is not the
+regression test — nothing re-runs it, so nothing notices when Flow changes again.
+
+**The observation you just made is the body of a scenario.** What you drove is the
+`Given`, what you triggered is the `When`, what the DOM or the wire actually returned
+is the `Then`. Carry it into [`scenario`](../scenario/SKILL.md) and, if it can only
+happen in a browser, into `tests/e2e/test_<slug>_bdd.py` — the route is
+[`issue-resolve`](../issue-resolve/SKILL.md) § The Bug Lane.
+
+A spike whose finding never became a test has bought you one answer, once, at full
+price.

--- a/tests/features/test_e2e_binding_guard.py
+++ b/tests/features/test_e2e_binding_guard.py
@@ -1,0 +1,134 @@
+"""Guard: `@e2e`-tagged Gherkin and the e2e suite must agree about each other.
+
+The Bug Lane (`skills/issue-resolve/SKILL.md`) says a scenario on a Flow/UI
+surface is formalised as an **e2e** test, and the binding is carried by a
+Gherkin tag: pytest-bdd converts `@e2e @e2e_auth` into `pytest.mark.e2e` /
+`pytest.mark.e2e_auth`, which is what `addopts`' `-m 'not e2e ...'` filters on.
+
+Three ways that binding silently breaks, all caught here without a browser:
+
+1. **Orphan scenario** — Gherkin written, e2e test never was. The lane's whole
+   failure mode ("recorded, not omitted"), invisible to every other gate.
+2. **No cost sub-marker** — `-m e2e_auth` cannot select it, so it only ever runs
+   in a full `-m e2e` sweep and the nightly canary never sees it.
+3. **Untagged live binding** — a feature bound from ``tests/e2e/`` but *not*
+   tagged carries no `e2e` marker, so `addopts` does not exclude it and hosted
+   CI runs it: Chrome launch, no profile, red for a reason nobody can read.
+
+Static text checks only. Proving these tests **pass** is a different job, done
+on a machine with a warm profile (`scripts/canary/`), never in hosted CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FEATURES_DIR = _REPO_ROOT / "tests" / "features"
+_E2E_DIR = _REPO_ROOT / "tests" / "e2e"
+
+# Mirrors the cost sub-markers registered in pyproject.toml. A bare `@e2e` is
+# not selectable by tier, and the canary runs tiers.
+_COST_MARKERS = frozenset(
+    {
+        "e2e_auth",
+        "e2e_image",
+        "e2e_video",
+        "e2e_batch",
+        "e2e_data",
+        "e2e_scene",
+        "e2e_character",
+    }
+)
+
+_TAG_LINE = re.compile(r"^\s*@[\w@\s]+$")
+
+
+def _tags(feature: Path) -> set[str]:
+    """Every Gherkin tag in a feature file, Feature- and Scenario-level alike."""
+    found: set[str] = set()
+    for line in feature.read_text(encoding="utf-8").splitlines():
+        if _TAG_LINE.match(line):
+            found.update(token.lstrip("@") for token in line.split() if token.startswith("@"))
+    return found
+
+
+def _binders(feature_name: str, search_dir: Path) -> list[Path]:
+    """Modules under `search_dir` whose `scenarios(...)` call names this feature."""
+    if not search_dir.is_dir():
+        return []
+    call = re.compile(rf"scenarios?\(\s*[\"'][^\"']*{re.escape(feature_name)}[\"']")
+    return sorted(
+        path for path in search_dir.rglob("*.py") if call.search(path.read_text(encoding="utf-8"))
+    )
+
+
+def _feature_files() -> list[Path]:
+    return sorted(_FEATURES_DIR.glob("*.feature"))
+
+
+def test_every_e2e_tagged_feature_is_bound_under_tests_e2e() -> None:
+    orphans = [
+        feature.name
+        for feature in _feature_files()
+        if "e2e" in _tags(feature) and not _binders(feature.name, _E2E_DIR)
+    ]
+    assert not orphans, (
+        f"@e2e-tagged Gherkin with no binding module under tests/e2e/: {orphans}. "
+        "The scenario was written and the e2e test never was — write "
+        f"tests/e2e/test_<slug>_bdd.py calling scenarios('../features/<name>')."
+    )
+
+
+def test_every_e2e_tagged_feature_declares_a_cost_tier() -> None:
+    untiered = [
+        feature.name
+        for feature in _feature_files()
+        if "e2e" in (tags := _tags(feature)) and not (tags & _COST_MARKERS)
+    ]
+    assert not untiered, (
+        f"@e2e Gherkin with no cost sub-marker: {untiered}. "
+        f"Add one of {sorted(_COST_MARKERS)} so `-m <tier>` and the canary can select it."
+    )
+
+
+def test_every_feature_bound_from_tests_e2e_is_tagged_e2e() -> None:
+    """The dangerous direction: an untagged live binding runs in hosted CI."""
+    untagged = [
+        feature.name
+        for feature in _feature_files()
+        if _binders(feature.name, _E2E_DIR) and "e2e" not in _tags(feature)
+    ]
+    assert not untagged, (
+        f"Bound from tests/e2e/ but not tagged @e2e: {untagged}. "
+        "Without the tag these scenarios carry no e2e marker, so addopts does not "
+        "exclude them and hosted CI will try to drive a browser."
+    )
+
+
+def test_the_guard_actually_fires(tmp_path: Path) -> None:
+    """A guard that has only ever passed vacuously has not been tested.
+
+    Feeds the detectors a synthetic orphan and a synthetic bare `@e2e`, and
+    proves each one is seen — so a green suite above means "no orphans", not
+    "the check never looked".
+    """
+    orphan = tmp_path / "orphan.feature"
+    orphan.write_text("@e2e\nFeature: nobody binds me\n", encoding="utf-8")
+    assert _tags(orphan) == {"e2e"}
+    assert not _binders(orphan.name, _E2E_DIR)
+    assert not _tags(orphan) & _COST_MARKERS
+
+    tiered = tmp_path / "tiered.feature"
+    tiered.write_text("  @e2e @e2e_auth\nFeature: tagged at scenario level\n", encoding="utf-8")
+    assert _tags(tiered) & _COST_MARKERS == {"e2e_auth"}
+
+    binder_dir = tmp_path / "e2e"
+    binder_dir.mkdir()
+    (binder_dir / "test_x_bdd.py").write_text(
+        'from pytest_bdd import scenarios\n\nscenarios("../features/orphan.feature")\n',
+        encoding="utf-8",
+    )
+    assert _binders("orphan.feature", binder_dir)
+    assert not _binders("unrelated.feature", binder_dir)

--- a/website/docs/E2E_TESTING.md
+++ b/website/docs/E2E_TESTING.md
@@ -77,6 +77,55 @@ e2e ─┬─ e2e_auth     (auth/session, health check — zero credits)
 
 ---
 
+## BDD-bound e2e
+
+A live test can be written as Gherkin. This is the required form for a bug whose
+scenario can only happen in a browser — see
+[`skills/issue-resolve/SKILL.md`](../skills/issue-resolve/SKILL.md) § The Bug Lane,
+step 5. It needs **no new machinery**: pytest-bdd (already a dependency) converts every
+Gherkin tag into a pytest marker, so a tagged scenario is filtered by the same
+`addopts` and selected by the same `-m <tier>` as a hand-written e2e test.
+
+**The three moving parts:**
+
+```gherkin
+# tests/features/account_chooser_landing.feature
+@e2e @e2e_auth                                   # ← tags become pytest markers
+Feature: A known landing state is named, not reported as selector drift
+  Scenario: the OAuth callback error page
+    Given a profile whose Flow session is authenticated
+    When the UI transport lands on /fx/api/auth/signin?error=Callback
+    Then it names the sign-in state, not a missing 'New project' CTA
+```
+
+```python
+# tests/e2e/test_account_chooser_landing_bdd.py
+from pytest_bdd import given, scenarios, then, when
+
+scenarios("../features/account_chooser_landing.feature")
+# step defs here; tests/e2e/conftest.py fixtures (e2e_profile_dir, …) apply
+```
+
+| Rule | Why |
+|---|---|
+| Feature file stays in `tests/features/` | one home for Gherkin; the guard scans one directory |
+| Step module lives in `tests/e2e/` | inherits `tests/e2e/conftest.py` — profile gating, `e2e_env`, `skip_on_migrated_host` |
+| `@e2e` **plus** a cost tier | a bare `@e2e` cannot be selected by `-m e2e_auth`, so the nightly canary never runs it |
+| One feature file, one binding module | bound from two modules, every scenario runs twice |
+
+**Enforced offline** by `tests/features/test_e2e_binding_guard.py` (no browser, normal
+CI): an `@e2e` feature with no binder under `tests/e2e/` fails, so does one with no cost
+tier, and so does the dangerous inverse — a feature bound from `tests/e2e/` but left
+untagged, which carries no `e2e` marker, escapes `addopts`, and makes hosted CI try to
+drive Chrome.
+
+> **What this does and does not prove.** The guard proves the test **exists and is
+> wired**, and runs anywhere. Proving it **passes** needs a warm profile and a real
+> browser — that is the nightly canary's job (`scripts/canary/`), on a machine that has
+> one. Hosted CI cannot run the live tiers and never could.
+
+---
+
 ## Environment variables
 
 | Variable | Default | Purpose |


### PR DESCRIPTION
## Summary

Formalises the chain a bug travels in this repo — **spike → systematic-debugging → BDD → TDD → fix → e2e** — canonically in `skills/issue-resolve/SKILL.md`, cited (never restated) from `AGENTS.md`, `skills/spike`, `skills/scenario`, `docs/E2E_TESTING.md` and `docs/INDEX.md`.

Gated by **surface**, not severity: steps 0–2 are skippable when the cause is already proven and the blast radius is one line, but **a skip is a claim and has to be said out loud**. Steps 3–5 have no gate.

## Why

Two real defects, both verified before the change:

1. **A contradiction no gate could see.** `issue-resolve` step 3 read *"the test is the closest browser-free proxy"* while `AGENTS.md`'s Iron Law read *"if no e2e test covers the change, write one"* and listed "covered by unit tests" among the excuses that are **not** blockers. Disjoint files, clean merge — an agent following either was compliant with the other's opposite. (memory `prose-conflicts-hide-in-disjoint-files`)
2. **BDD and e2e were entirely disjoint.** 24 `.feature` files, all offline-mocked; zero e2e tests used pytest-bdd; `grep -i bdd docs/E2E_TESTING.md` returned nothing.

## How BDD binds to e2e — no new machinery

pytest-bdd already converts Gherkin tags into pytest markers (verified on 8.1, `plugin.py:137`), and feature-level tags propagate to every scenario (also measured, not assumed). So a Feature tagged `@e2e @e2e_auth` is filtered by the existing `addopts` and selected by the existing `-m <tier>`.

- Feature files stay in `tests/features/`; the step module lives in `tests/e2e/` so it inherits that suite's profile-gating fixtures.
- `tests/features/test_e2e_binding_guard.py` enforces it **offline, in hosted CI, without a browser**: orphan `@e2e` Gherkin, a missing cost tier, an untagged live binding (which escapes `addopts` and makes CI drive Chrome), and double binding.
- The guard carries its own fire-test, so green means "no orphans", not "never looked".

## The CI split

Hosted CI proves the e2e test **exists and is wired** (static text). Proving it **passes** stays the nightly canary's job on a machine with a warm profile — hosted CI cannot run the live tiers and never could.

## Test plan

- [x] `4172 passed`, 92% coverage (full offline suite at this commit)
- [x] `ruff check` / `ruff format --check` on `src tests`
- [x] `check_repo_hygiene`, `check_doc_links`, `generate_website_docs --check`, `check_website_docs_pii`, `check_council_memory` — all green
- [x] pytest-bdd tag→marker conversion verified empirically before designing on it
- [ ] Reviewer: confirm the lane's gating matches how you actually want bugs worked

## Notes for review

- **Merge this before #<the landing-state PR>** — that branch stacks on this one.
- A branch-council on the stacked branch found two defects in *this* commit (a lane step that was unsatisfiable when step 2 is skipped, and an orphaned Phase 2 in the continuation table). Both are fixed in the stacked PR rather than here, so this commit is the version the council reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for routing bugs through a structured process from investigation to verification.
  * Documented browser-based BDD testing, including scenario tagging, test selection, and binding rules.
  * Added documentation index links for bug resolution and browser-only testing workflows.
  * Clarified that exploratory spikes inform tests but do not replace regression coverage.

* **Tests**
  * Added offline checks to detect missing, incorrectly tagged, or improperly connected browser scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->