### PR TITLE
fix(migrated): gate image submits behind DOM checks with typed failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Migrated image submits prove the composer before any network observer arms:
+  cookie-bar dismissal, blocking-overlay refusal, and submit pointer hit-test,
+  each raising typed `UiSelectorDriftError` with bounded redacted diagnostics
+  instead of bare Playwright timeouts.
+
+### Fixed
+
+- Image requests that the migrated composer serves, with a named project,
+  from a pre-navigation page prefer the migrated host on `auto`, so the
+  page-owned recaptcha path wins the post-goto handoff race instead of a
+  doomed pre-navigation mint (#692). Labs editors, unported forms, and
+  project-less runs keep the served host (and their pre-minted token); the
+  `labs.google` kill-switch behavior is unchanged.
+
 ## [0.73.0] — 2026-09-10
 
 ### Security

--- a/src/gflow_cli/api/client.py
+++ b/src/gflow_cli/api/client.py
@@ -2663,7 +2663,19 @@ class FlowApiClient:
                 msg,
             )
         page_owned = getattr(self.transport, "uses_page_owned_image_recaptcha", None)
+        serve_migrated = False
         if callable(page_owned) and page_owned():
+            from gflow_cli.api.transports.migrated_composer import (  # noqa: PLC0415
+                migrated_images_prefer,
+            )
+
+            # The capability answers from the page URL alone and cannot see the
+            # request: re-check servability here so entity/instruction runs and
+            # project-less runs keep their pre-minted token. A redundant mint on
+            # a migrated run is harmless (the page mints its own); a missing mint
+            # on a labs run is a terminal auth failure.
+            serve_migrated = migrated_images_prefer(req, project_id=project_id)
+        if serve_migrated:
             # The migrated Angular page mints and submits its own token on ogiZ0b.
             # Minting here first is not only redundant: the pooled bootstrap page is
             # flow.google.com/ (no enterprise.js), while /project/<id> is the page that

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -31,11 +31,12 @@ matched with a Python-side ``filter(has_text=re.compile(...))`` instead.
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import unquote_plus, urlsplit
 
 import structlog
@@ -73,7 +74,7 @@ from gflow_cli.errors import (
 from gflow_cli.redaction import redact_sensitive_text
 
 if TYPE_CHECKING:
-    from playwright.async_api import Page
+    from playwright.async_api import Locator, Page
 
     from gflow_cli.api.image import GenerateImageRequest
     from gflow_cli.api.video import GenerateVideoRequest, VideoStartedCallback
@@ -94,6 +95,9 @@ RADIOGROUP = "[role='radiogroup']"
 RADIO = "[role='radio']"
 MENU_ITEM = "[role='menuitem']"
 COMPOSER = "[contenteditable='true']"
+#: Named contract for the migrated Angular settings surface. Diagnostics include this
+#: value so a future Flow DOM variant gets a new contract instead of a fuzzy fallback.
+MIGRATED_SETTINGS_CONTRACT = "migrated-angular-settings-v1"
 #: Flow's agent-mode chip. Pressed, `.settings-trigger-button` stays in the DOM but gains
 #: a bare `hidden` (display:none, 0x0, not hit-testable) — which is why every gate on it
 #: waits for VISIBILITY and never `count()` (#749).
@@ -135,6 +139,14 @@ DIALOG = "[role='dialog']"
 # docs/superpowers/spikes/2026-09-07-credit-shortfall-looks-like-selector-drift.md
 CREDITS_WARNING = "button.prompt-warning-button, [aria-label*='Insufficient credits']"
 DIALOG_CLOSE = f"{DIALOG} button:has(mat-icon:text-is('close'))"
+#: Google's glue cookie banner (``glue-cookie-notification-bar``) sits fixed at
+#: the viewport bottom on flow.google.com project loads and its subtree
+#: intercepts every pointer event over the composer's settings trigger — the
+#: click retries until Playwright's timeout and the run dies as an unhandled
+#: ``TimeoutError`` (2026-09-09 incident 8dc6c020). ``Agree`` accepts; ``No
+#: thanks`` is equally fine for automation purposes — the bar just has to go.
+COOKIE_BAR = "#glue-cookie-notification-bar-1, .glue-cookie-notification-bar"
+COOKIE_BAR_BUTTONS = "#glue-cookie-notification-bar-1 button, .glue-cookie-notification-bar button"
 
 #: ``YhhmEf`` is the text-to-video submit; ``eb1hJf`` the image-to-video one (a bound
 #: Start chip switches the app between them — 2026-09-05 frames spike).
@@ -464,6 +476,45 @@ def _unported_image_form(request: GenerateImageRequest) -> str | None:
     return None
 
 
+def migrated_images_prefer(
+    request: GenerateImageRequest, *, page_url: str | None = None, project_id: str | None = None
+) -> bool:
+    """Whether an image request should prefer the migrated composer on ``auto``.
+
+    Three independently necessary answers, so a miss in any one of them keeps
+    the labs driver instead of stranding the run on the wrong host:
+
+    - the migrated composer serves this request at all
+      (:func:`_unported_image_form` names anything it does not);
+    - a project is named or the page already sits in one — the labs driver
+      auto-creates a project, the migrated composer needs ``--project``;
+    - the page is not already inside an editor — there the served host rules,
+      and assuming migrated would skip the mint a labs editor needs
+      (the #673 mirror: a wrong skip is a terminal auth failure, a redundant
+      mint on a migrated run is free because the page mints its own).
+
+    Pure predicate over the request and the URL: no browser, no spend. Both
+    the router and the mint decision call it so the two cannot disagree.
+    """
+    if _unported_image_form(request) is not None:
+        return False
+    editor_pid: str | None = None
+    if isinstance(page_url, str):
+        editor_pid = extract_project_id(page_url)
+        if editor_pid is not None:
+            # Already inside an editor: the served host rules.
+            return False
+    elif page_url is not None:
+        # Test doubles and malformed URLs take the served host: preferring
+        # migrated on an unreadable URL would route mocked labs-driver tests
+        # (and any real page we failed to read) at the migrated composer.
+        # Same totality discipline as :func:`flow_host_kind`.
+        return False
+    if project_id is None and editor_pid is None:
+        return False
+    return True
+
+
 def _exact(label: str) -> re.Pattern[str]:
     return re.compile(r"^\s*" + re.escape(label) + r"\s*$")
 
@@ -623,8 +674,131 @@ def _image_body_problem(
     return None
 
 
+def _redacted_page_url(page: Any) -> str:
+    """Return a diagnostic URL without query parameters or fragments."""
+    try:
+        parsed = urlsplit(str(getattr(page, "url", "") or ""))
+    except (TypeError, ValueError):
+        return "<unavailable>"
+    if not parsed.scheme or not parsed.netloc:
+        return "<unavailable>"
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
 class MigratedComposer:
     """Settings → prompt → submit → observe, against the migrated editor."""
+
+    def __init__(self, *, out_dir: Path | None = None) -> None:
+        self._out_dir = out_dir
+
+    async def _capture_ui_failure(
+        self,
+        page: Page,
+        *,
+        phase: str,
+        selector: str,
+        error: BaseException | str,
+    ) -> tuple[Path, ...]:
+        """Persist a bounded screenshot + structural DOM snapshot for UI failures.
+
+        The snapshot deliberately excludes page text and prompt contents. The viewport
+        screenshot can still contain the authenticated account indicator, so it follows
+        the existing debug-screenshot PII warning policy. Capture is best-effort and can
+        never replace the typed selector error that triggered it.
+        """
+        if self._out_dir is None:
+            return ()
+        safe_phase = re.sub(r"[^A-Za-z0-9_.-]+", "_", phase).strip("_") or "ui"
+        stem = f"{time.time_ns()}-{safe_phase}"
+        diagnostics_dir = self._out_dir / "ui-failures"
+        screenshot_path = diagnostics_dir / f"{stem}.png"
+        snapshot_path = diagnostics_dir / f"{stem}.json"
+        try:
+            diagnostics_dir.mkdir(parents=True, exist_ok=True)
+            snapshot = await page.evaluate(
+                """() => {
+                    const visible = (selector) => Array.from(document.querySelectorAll(selector))
+                        .filter((el) => {
+                            const rect = el.getBoundingClientRect();
+                            const style = getComputedStyle(el);
+                            return rect.width > 0 && rect.height > 0 &&
+                                style.display !== "none" && style.visibility !== "hidden";
+                        })
+                        .slice(0, 20)
+                        .map((el) => ({
+                            tag: el.tagName,
+                            id: el.id || null,
+                            role: el.getAttribute("role"),
+                            className: String(el.className || "").slice(0, 160),
+                        }));
+                    return {
+                        title: String(document.title || "").slice(0, 120),
+                        activeElement: document.activeElement?.tagName || null,
+                        cookieBars: visible(
+                            "#glue-cookie-notification-bar-1, .glue-cookie-notification-bar"
+                        ),
+                        overlays: visible(".cdk-overlay-pane"),
+                        radiogroups: visible("[role='radiogroup']"),
+                        menuitems: visible("[role='menuitem']"),
+                        composers: visible("[contenteditable='true']"),
+                    };
+                }"""
+            )
+            snapshot_path.write_text(
+                json.dumps(
+                    {
+                        "contract": MIGRATED_SETTINGS_CONTRACT,
+                        "phase": phase,
+                        "selector": selector,
+                        "error": str(error)[:500],
+                        "url": _redacted_page_url(page),
+                        "snapshot": snapshot,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            await page.screenshot(path=str(screenshot_path), full_page=False)
+        except Exception as capture_error:  # noqa: BLE001 - diagnostics are non-authoritative
+            log.warning(
+                "migrated.ui_failure_artifacts_unavailable",
+                phase=phase,
+                error=str(capture_error)[:200],
+            )
+            for partial in (snapshot_path, screenshot_path):
+                try:
+                    partial.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            return ()
+        log.warning(
+            "migrated.ui_failure_artifacts",
+            phase=phase,
+            screenshot=str(screenshot_path),
+            snapshot=str(snapshot_path),
+        )
+        return screenshot_path, snapshot_path
+
+    async def _ui_failure_detail(
+        self,
+        page: Page,
+        *,
+        phase: str,
+        selector: str,
+        detail: str,
+        error: BaseException | str,
+    ) -> str:
+        artifacts = await self._capture_ui_failure(
+            page,
+            phase=phase,
+            selector=selector,
+            error=error,
+        )
+        suffix = f" [contract={MIGRATED_SETTINGS_CONTRACT}"
+        if artifacts:
+            suffix += "; diagnostics=" + ",".join(str(path) for path in artifacts)
+        return detail + suffix + "]"
 
     # --- readiness ------------------------------------------------------------
 
@@ -637,6 +811,9 @@ class MigratedComposer:
             log.info("migrated.navigate", url=target)
             await page.goto(target, wait_until="domcontentloaded", timeout=45_000)
         await self._dismiss_dialog(page)
+        # The glue cookie banner intercepts pointer events over the composer
+        # (2026-09-09 incident 8dc6c020); clear it before anything clicks.
+        await self._dismiss_cookie_bar(page)
         trigger = page.locator(READY_ANCHOR).first
         try:
             await trigger.wait_for(state="visible", timeout=int(timeout_s * 1000))
@@ -901,6 +1078,97 @@ class MigratedComposer:
         # Belt and braces over the JS allowlist above.
         return redact_sensitive_text(f"{head} — {'; '.join(seen)} (host=migrated)")
 
+    async def _dismiss_cookie_bar(self, page: Page) -> None:
+        """Dismiss every visible cookie bar through a button in that bar.
+
+        The bar is a real pointer-event blocker, not an optional decoration. The button
+        locator is deliberately chained from the selected bar: composing a comma
+        selector and then appending ``button`` changes the selector's scope and can
+        match the container itself. A click is accepted only after the bar becomes
+        hidden; otherwise the run stops before any settings or Generate click.
+        """
+        try:
+            for attempt in range(1, 4):
+                bars = page.locator(COOKIE_BAR)
+                visible_bar = None
+                visible_count = 0
+                for index in range(await bars.count()):
+                    candidate = bars.nth(index)
+                    if await candidate.is_visible():
+                        visible_count += 1
+                        if visible_bar is None:
+                            visible_bar = candidate
+                if visible_bar is None:
+                    return
+                buttons = visible_bar.locator("button")
+                if not await buttons.count():
+                    detail = await self._ui_failure_detail(
+                        page,
+                        phase="dismiss_cookie_bar",
+                        selector=f"{COOKIE_BAR} -> button",
+                        detail=(
+                            "migrated host: the visible cookie bar has no dismiss button "
+                            f"({COOKIE_BAR}) (host=migrated)"
+                        ),
+                        error="no dismiss button",
+                    )
+                    raise UiSelectorDriftError(detail=detail)
+                await buttons.first.click(timeout=3000)
+                deadline = time.monotonic() + 3.0
+                while time.monotonic() < deadline:
+                    remaining = 0
+                    current_bars = page.locator(COOKIE_BAR)
+                    for index in range(await current_bars.count()):
+                        if await current_bars.nth(index).is_visible():
+                            remaining += 1
+                    if remaining < visible_count:
+                        break
+                    await asyncio.sleep(0.1)
+                else:
+                    detail = await self._ui_failure_detail(
+                        page,
+                        phase="dismiss_cookie_bar",
+                        selector=f"{COOKIE_BAR} -> button",
+                        detail=(
+                            "migrated host: the cookie bar remained visible after its "
+                            f"dismiss button was clicked (attempt {attempt}/3) (host=migrated)"
+                        ),
+                        error="cookie bar postcondition failed",
+                    )
+                    raise UiSelectorDriftError(detail=detail)
+                log.info("migrated.cookie_bar_dismissed", attempt=attempt)
+            remaining = 0
+            final_bars = page.locator(COOKIE_BAR)
+            for index in range(await final_bars.count()):
+                if await final_bars.nth(index).is_visible():
+                    remaining += 1
+            if remaining:
+                detail = await self._ui_failure_detail(
+                    page,
+                    phase="dismiss_cookie_bar",
+                    selector=f"{COOKIE_BAR} -> button",
+                    detail=(
+                        f"migrated host: {remaining} visible cookie bar(s) remain after "
+                        "the bounded dismiss budget (host=migrated)"
+                    ),
+                    error=f"{remaining} visible cookie bar(s) remain",
+                )
+                raise UiSelectorDriftError(detail=detail)
+        except UiSelectorDriftError:
+            raise
+        except Exception as e:  # noqa: BLE001 - convert actionability failures to a terminal typed error
+            detail = await self._ui_failure_detail(
+                page,
+                phase="dismiss_cookie_bar",
+                selector=f"{COOKIE_BAR} -> button",
+                detail=(
+                    "migrated host: the cookie bar could not be dismissed before composer "
+                    f"interaction ({COOKIE_BAR}) (host=migrated)"
+                ),
+                error=e,
+            )
+            raise UiSelectorDriftError(detail=detail) from e
+
     # --- settings ---------------------------------------------------------------
 
     async def apply_video_settings(self, page: Page, request: GenerateVideoRequest) -> None:
@@ -1003,6 +1271,9 @@ class MigratedComposer:
         await self._close_pane(page, strict=True)
 
     async def _open_pane(self, page: Page) -> Any:
+        # The banner can be remounted by the SPA between ensure_editor and this click;
+        # one bounded re-check closes that race without installing a global click hook.
+        await self._dismiss_cookie_bar(page)
         trigger = page.locator(READY_ANCHOR).first
         try:
             # Visibility, not `count()`. Agent mode leaves the trigger in the DOM under a
@@ -1017,12 +1288,17 @@ class MigratedComposer:
                 if await self._agent_chip_pressed(page)
                 else ""
             )
-            raise UiSelectorDriftError(
+            detail = await self._ui_failure_detail(
+                page,
+                phase="wait_settings_trigger",
+                selector=READY_ANCHOR,
                 detail=(
                     f"migrated host: the settings trigger ({READY_ANCHOR}) is not visible"
                     f"{why} (host=migrated)"
                 ),
-            ) from e
+                error=e,
+            )
+            raise UiSelectorDriftError(detail=detail) from e
         # The other half of #752 finding #7: the guard above became a visibility wait,
         # this click stayed bare, and the comment above describes what it went on doing.
         await self._click(page, trigger, named=READY_ANCHOR, timeout=5000)
@@ -1034,12 +1310,17 @@ class MigratedComposer:
         try:
             await pane.locator(RADIOGROUP).first.wait_for(state="visible", timeout=8000)
         except Exception as e:
-            raise UiSelectorDriftError(
+            detail = await self._ui_failure_detail(
+                page,
+                phase="discover_settings_pane",
+                selector=f"{OVERLAY} -> {RADIOGROUP}",
                 detail=(
                     "migrated host: the settings pane opened but rendered no option "
                     "groups ([role='radiogroup']) (host=migrated)"
                 ),
-            ) from e
+                error=e,
+            )
+            raise UiSelectorDriftError(detail=detail) from e
         return pane
 
     def _blocking_overlays(self, page: Page) -> Any:
@@ -1100,13 +1381,18 @@ class MigratedComposer:
         log.warning("migrated.pane_still_open", visible_overlays=remaining, strict=strict)
         if not strict:
             return
-        raise UiSelectorDriftError(
+        detail = await self._ui_failure_detail(
+            page,
+            phase="close_settings_pane",
+            selector=VISIBLE_OVERLAY,
             detail=(
                 f"migrated host: {remaining} overlay(s) still visible after "
                 f"{PANE_CLOSE_ESCAPES} Escape presses — the settings pane would cover the "
                 f"composer and the prompt could not be typed (host=migrated)"
             ),
+            error=f"{remaining} visible overlay(s)",
         )
+        raise UiSelectorDriftError(detail=detail)
 
     async def _pin_r2v_duration(self, page: Page, pane: Any) -> None:
         """Bind the base duration for a references run, when this pane offers durations.
@@ -1918,6 +2204,115 @@ class MigratedComposer:
             if expect_media_id is not None or expect_reference_ids:
                 page.remove_listener("request", on_request)
 
+    async def _verify_submit_target(self, page: Page, submit: Locator) -> None:
+        """Prove the submit button is visible and receives pointer events."""
+        try:
+            if not await submit.is_visible():
+                raise RuntimeError("image submit button is not visible")
+            # The JS hit-test reads viewport coordinates; a below-the-fold submit
+            # would fail it even though Playwright's click auto-scrolls. Bring the
+            # button into the viewport the gate is about to measure.
+            await submit.scroll_into_view_if_needed()
+            box = await submit.bounding_box()
+            if not isinstance(box, dict) or not all(
+                isinstance(box.get(key), (int, float)) for key in ("x", "y", "width", "height")
+            ):
+                raise RuntimeError("image submit button has no usable bounding box")
+            state: Any = await page.evaluate(
+                """
+                ({x, y}) => {
+                    const describe = (element) => element ? {
+                        tag: element.tagName,
+                        id: element.id || null,
+                        role: element.getAttribute('role'),
+                        className: String(element.className || '').slice(0, 160),
+                    } : null;
+                    const submit = [...document.querySelectorAll('button')].find((button) =>
+                        [...button.querySelectorAll('mat-icon')].some((icon) =>
+                            (icon.textContent || '').trim() === 'arrow_forward'));
+                    const top = document.elementFromPoint(x, y);
+                    const topButton = top?.closest?.('button');
+                    const target = Boolean(
+                        submit &&
+                        (top === submit || submit.contains(top) || topButton === submit)
+                    );
+                    return {
+                        target,
+                        top: describe(top),
+                    };
+                }
+                """,
+                {
+                    "x": float(box["x"]) + float(box["width"]) / 2,
+                    "y": float(box["y"]) + float(box["height"]) / 2,
+                },
+            )
+        except UiSelectorDriftError:
+            raise
+        except Exception as error:
+            detail = await self._ui_failure_detail(
+                page,
+                phase="pre_submit_button_gate",
+                selector="button -> arrow_forward",
+                detail=(
+                    "migrated host: image submit button failed the visibility or pointer "
+                    "target check (host=migrated)"
+                ),
+                error=error,
+            )
+            raise UiSelectorDriftError(detail=detail) from error
+        state_dict: dict[str, Any] = cast(dict[str, Any], state) if isinstance(state, dict) else {}
+        if not state_dict.get("target"):
+            blocker = state_dict.get("top")
+            detail = await self._ui_failure_detail(
+                page,
+                phase="pre_submit_button_gate",
+                selector="button -> arrow_forward",
+                detail=(
+                    "migrated host: an unexpected element receives pointer events at the "
+                    f"image submit target (blocker={blocker!r}) (host=migrated)"
+                ),
+                error="submit target is covered",
+            )
+            raise UiSelectorDriftError(detail=detail)
+
+    async def _pre_submit_gate(self, page: Page) -> Any:
+        """Prove the composer is clear and submit is present and hit-testable.
+
+        Runs before any network observer arms. Enablement is waited on
+
+        downstream by the submit path itself (with the out-of-credits
+        interrogation); this gate refuses missing/covered targets first.
+        """
+        await self._dismiss_cookie_bar(page)
+        blockers = self._blocking_overlays(page)
+        remaining = await blockers.count()
+        if remaining:
+            detail = await self._ui_failure_detail(
+                page,
+                phase="pre_submit_overlay_gate",
+                selector=VISIBLE_OVERLAY,
+                detail=(
+                    f"migrated host: {remaining} blocking overlay(s) remain before image "
+                    "Generate (host=migrated)"
+                ),
+                error=f"{remaining} blocking overlay(s)",
+            )
+            raise UiSelectorDriftError(detail=detail)
+        submit = page.locator("button").filter(has=_ligature(page, "arrow_forward")).first
+        if not await submit.count():
+            await _raise_if_out_of_credits(page)
+            detail = await self._ui_failure_detail(
+                page,
+                phase="pre_submit_button_gate",
+                selector="button -> arrow_forward",
+                detail="migrated host: image submit button is missing (host=migrated)",
+                error="submit button missing",
+            )
+            raise UiSelectorDriftError(detail=detail)
+        await self._verify_submit_target(page, submit)
+        return submit
+
     async def submit_images_and_observe(
         self,
         page: Page,
@@ -1926,6 +2321,10 @@ class MigratedComposer:
         reference_ids: tuple[str, ...] = (),
     ) -> list[GeneratedImage]:
         """Submit Image mode and decode the completed ``ogiZ0b`` reply."""
+        # Complete all UI gates before registering network observers or clicking
+        # Generate. A deterministic DOM failure therefore cannot spend a request or
+        # enter the transport retry loop.
+        submit = await self._pre_submit_gate(page)
         loop = asyncio.get_running_loop()
         result: asyncio.Future[list[GeneratedImage]] = loop.create_future()
         route_error: asyncio.Future[WireFormatError] = loop.create_future()
@@ -1989,12 +2388,6 @@ class MigratedComposer:
         page.on("request", on_request)
         page.on("response", on_response)
         try:
-            submit = page.locator("button").filter(has=_ligature(page, "arrow_forward")).first
-            if not await submit.count():
-                await _raise_if_out_of_credits(page)
-                raise UiSelectorDriftError(
-                    detail="migrated host: image submit button is missing (host=migrated)"
-                )
             enable_deadline = time.monotonic() + SUBMIT_ENABLE_BUDGET_S
             while not await submit.is_enabled():
                 if time.monotonic() >= enable_deadline:
@@ -2244,6 +2637,7 @@ async def run_images(
     request: GenerateImageRequest,
     *,
     project_id: str | None,
+    out_dir: Path | None = None,
 ) -> list[GeneratedImage]:
     """Drive supported image requests through the migrated project composer."""
     unported = _unported_image_form(request)
@@ -2261,7 +2655,7 @@ async def run_images(
                 "image generation on flow.google.com needs an existing project; pass --project <id>"
             )
         )
-    composer = MigratedComposer()
+    composer = MigratedComposer(out_dir=out_dir)
     await composer.ensure_editor(page, pid)
     await composer.apply_image_settings(page, request)
     reference_ids: tuple[str, ...] = ()

--- a/src/gflow_cli/api/transports/ui_automation.py
+++ b/src/gflow_cli/api/transports/ui_automation.py
@@ -41,7 +41,11 @@ from gflow_cli.api.transports._common import (
     raise_if_known_landing,
     raise_if_migrated,
 )
-from gflow_cli.api.transports.migrated_composer import MENU_ITEM, ModelMenuMatcher
+from gflow_cli.api.transports.migrated_composer import (
+    MENU_ITEM,
+    ModelMenuMatcher,
+    migrated_images_prefer,
+)
 from gflow_cli.api.transports.ui_automation_video import (
     ENTITY_ATTACH_DRIFT_HINT,
     MODE_SWITCH_TRIGGER_SELECTORS,
@@ -3050,7 +3054,22 @@ class UiAutomationTransport(VideoGenerationMixin):
             return self._served_migrated_host
         from gflow_cli.config import get_settings  # noqa: PLC0415
 
-        route = migrated_route(self._page.url, get_settings().flow_host)
+        url = self._page.url
+        if (
+            url.startswith("https://labs.google/fx/")
+            and extract_project_id(url) is None
+            and get_settings().flow_host != "labs.google"
+        ):
+            # Pre-navigation bootstrap page (bare or locale-prefixed, no project
+            # segment): Flow may still redirect it client-side, so assume the
+            # migrated host and let the page-owned recaptcha path win the
+            # post-goto handoff race (#692). Deliberately WITHOUT arming the
+            # latch — an assumption is not evidence, and arming it here would
+            # stop a labs account minting the token it genuinely needs.
+            # `_drive_images_generation` re-checks servability before skipping
+            # the mint, so a wrong assumption costs a redundant mint, never a run.
+            return True
+        route = migrated_route(url, get_settings().flow_host)
         if route in {"migrated", "blocked"}:
             self._served_migrated_host = True
             return True
@@ -3075,20 +3094,22 @@ class UiAutomationTransport(VideoGenerationMixin):
         from gflow_cli.config import get_settings  # noqa: PLC0415
 
         flow_host = get_settings().flow_host
-        route = migrated_route(page.url, flow_host)
+        prefer = migrated_images_prefer(request, page_url=page.url, project_id=project_id)
+        route = migrated_route(page.url, flow_host, prefer_migrated=prefer)
         if route == "labs":
             await self._enter_editor(page, out_dir, project_id=project_id)
             # Dismiss any Flow changelog / "What's new" overlay that may be on top
             # of the editor before we click into settings / submit (#26).
             await self._dismiss_blocking_overlays(page, out_dir)
-            route = migrated_route(page.url, flow_host)
+            prefer = migrated_images_prefer(request, page_url=page.url, project_id=project_id)
+            route = migrated_route(page.url, flow_host, prefer_migrated=prefer)
         if route in {"migrated", "blocked"}:
             self._served_migrated_host = True
         if route == "blocked":
             raise_if_migrated(page, at="image_flow_host_kill_switch")
         if route == "migrated":
             try:
-                return await run_images(page, request, project_id=project_id)
+                return await run_images(page, request, project_id=project_id, out_dir=out_dir)
             finally:
                 # Park off the project so the next borrower of this page does not
                 # inherit a mounted composer. The URL is therefore NOT a reliable

--- a/tests/api/test_image_capability_and_cookie_bar.py
+++ b/tests/api/test_image_capability_and_cookie_bar.py
@@ -1,0 +1,338 @@
+"""Contract tests for the #780 image submit gates.
+
+- ``migrated_images_prefer`` decides the migrated route per request: servable
+  t2i/i2i with a named project from a pre-navigation page go migrated (the
+  #692 race); anything unported, project-less, or already inside an editor
+  keeps the served host.
+- The mint skip is ANDed with servability in ``_drive_images_generation`` so
+  a page-URL-level True can never strand a labs run without its token.
+- ``MigratedComposer.ensure_editor`` must clear the glue cookie banner
+  before waiting for the settings trigger (incident 8dc6c020).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture()
+def wip_src(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Import gflow_cli from THIS checkout, not the installed venv copy."""
+    src = Path(__file__).resolve().parents[1] / "src"
+    monkeypatch.syspath_prepend(str(src))
+    return src
+
+
+@pytest.mark.asyncio()
+async def test_ensure_editor_dismisses_cookie_bar_before_ready_wait(wip_src):
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = MagicMock()
+    page.url = "https://flow.google.com/project/p-1"
+    page.goto = AsyncMock()
+
+    composer = MigratedComposer()
+    call_order: list[str] = []
+
+    async def fake_cookie(page_: object) -> None:
+        call_order.append("cookie")
+
+    async def fake_trigger_wait(*a: object, **kw: object) -> None:
+        call_order.append("trigger")
+
+    trigger = MagicMock()
+    trigger.wait_for = AsyncMock(side_effect=fake_trigger_wait)
+
+    def factory(selector: str):
+        loc = MagicMock()
+        loc.first = trigger if selector == ".settings-trigger-button" else loc
+        loc.wait_for = trigger.wait_for
+        return loc
+
+    page.locator = MagicMock(side_effect=factory)
+    composer._dismiss_dialog = AsyncMock()  # type: ignore[method-assign]
+    composer._dismiss_cookie_bar = fake_cookie  # type: ignore[method-assign]
+
+    await composer.ensure_editor(page, "p-1", timeout_s=1)
+    assert call_order == ["cookie", "trigger"]
+
+
+@pytest.mark.asyncio()
+async def test_cookie_selector_is_button_scoped_and_dismisses_both_variants(wip_src):
+    from playwright.async_api import async_playwright
+
+    from gflow_cli.api.transports.migrated_composer import (
+        COOKIE_BAR,
+        COOKIE_BAR_BUTTONS,
+        MigratedComposer,
+    )
+
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+        except Exception as exc:  # pragma: no cover - depends on local browser install
+            pytest.skip(f"Playwright Chromium is unavailable: {exc}")
+        try:
+            page = await browser.new_page()
+            await page.set_content(
+                """
+                <div id="glue-cookie-notification-bar-1">
+                  <button onclick="this.parentElement.remove()">Agree</button>
+                </div>
+                <div class="glue-cookie-notification-bar">
+                  <button onclick="this.parentElement.remove()">No thanks</button>
+                </div>
+                """
+            )
+            buttons = page.locator(COOKIE_BAR_BUTTONS)
+            assert await buttons.count() == 2
+            assert await buttons.evaluate_all("els => els.map(el => el.tagName)") == [
+                "BUTTON",
+                "BUTTON",
+            ]
+            assert await page.locator(COOKIE_BAR).count() == 2
+
+            await MigratedComposer()._dismiss_cookie_bar(page)  # noqa: SLF001
+
+            assert await page.locator(COOKIE_BAR).count() == 0
+        finally:
+            await browser.close()
+
+
+@pytest.mark.asyncio()
+async def test_ui_failure_artifacts_redact_query_and_preserve_structural_state(
+    wip_src, tmp_path: Path
+):
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = MagicMock()
+    page.url = "https://flow.google.com/project/p-1?auth=secret"
+    page.evaluate = AsyncMock(return_value={"overlays": [], "radiogroups": []})
+
+    async def write_screenshot(path: str, *, full_page: bool) -> None:
+        assert full_page is False
+        Path(path).write_bytes(b"PNG")
+
+    page.screenshot = AsyncMock(side_effect=write_screenshot)
+    paths = await MigratedComposer(out_dir=tmp_path)._capture_ui_failure(  # noqa: SLF001
+        page,
+        phase="pre_submit_overlay_gate",
+        selector=".cdk-overlay-pane:visible",
+        error="overlay blocked",
+    )
+
+    assert len(paths) == 2
+    assert paths[0].suffix == ".png" and paths[0].read_bytes() == b"PNG"
+    payload = json.loads(paths[1].read_text(encoding="utf-8"))
+    assert payload["url"] == "https://flow.google.com/project/p-1"
+    assert "auth=secret" not in paths[1].read_text(encoding="utf-8")
+    assert payload["contract"] == "migrated-angular-settings-v1"
+    assert payload["snapshot"] == {"overlays": [], "radiogroups": []}
+
+
+class _SelectorDriftImageTransport:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def uses_page_owned_image_recaptcha(self) -> bool:
+        return True
+
+    async def generate_images(self, **_: Any) -> list[Any]:
+        self.calls += 1
+        from gflow_cli.errors import UiSelectorDriftError
+
+        raise UiSelectorDriftError(detail="migrated host: deterministic selector drift")
+
+
+async def test_client_does_not_retry_typed_selector_drift():
+    from gflow_cli.api.client import FlowApiClient
+    from gflow_cli.api.image import GenerateImageRequest
+    from gflow_cli.errors import UiSelectorDriftError
+
+    transport = _SelectorDriftImageTransport()
+    client = FlowApiClient.__new__(FlowApiClient)
+    client.transport = transport  # type: ignore[assignment]
+
+    with pytest.raises(UiSelectorDriftError):
+        await client._drive_images_generation(  # noqa: SLF001
+            project_id="p-1",
+            req=GenerateImageRequest(prompt="a blue cup"),
+            recaptcha_action="imageGeneration",
+        )
+
+    assert transport.calls == 1
+
+
+@pytest.mark.asyncio()
+async def test_pre_submit_gate_rejects_an_unexpected_pointer_blocker(wip_src):
+    from playwright.async_api import async_playwright
+
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+    from gflow_cli.errors import UiSelectorDriftError
+
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+        except Exception as exc:  # pragma: no cover - depends on local browser install
+            pytest.skip(f"Playwright Chromium is unavailable: {exc}")
+        try:
+            page = await browser.new_page()
+            await page.set_content(
+                """
+                <style>
+                  #submit { position: absolute; left: 40px; top: 40px; width: 140px; height: 48px; }
+                  #blocker { position: absolute; left: 40px; top: 40px; width: 140px; height: 48px;
+                            z-index: 10; background: rgba(0, 0, 0, 0.1); }
+                </style>
+                <button id="submit"><mat-icon>arrow_forward</mat-icon></button>
+                <div id="blocker"></div>
+                """
+            )
+
+            with pytest.raises(UiSelectorDriftError, match="pointer|blocker"):
+                await MigratedComposer()._pre_submit_gate(page)  # noqa: SLF001
+        finally:
+            await browser.close()
+
+
+def _plain_request():
+    from gflow_cli.api.image import GenerateImageRequest
+
+    return GenerateImageRequest(prompt="a blue cup")
+
+
+def test_migrated_images_prefer_servable_request_from_bootstrap(wip_src):
+    from gflow_cli.api.transports.migrated_composer import migrated_images_prefer
+
+    assert (
+        migrated_images_prefer(
+            _plain_request(),
+            page_url="https://labs.google/fx/tools/flow?hl=en",
+            project_id="p-1",
+        )
+        is True
+    )
+
+
+def test_migrated_images_prefer_refuses_unported_forms(wip_src):
+    from gflow_cli.api.image import GenerateImageRequest
+    from gflow_cli.api.transports.migrated_composer import migrated_images_prefer
+
+    base = "https://labs.google/fx/tools/flow?hl=en"
+    assert (
+        migrated_images_prefer(
+            GenerateImageRequest(prompt="x", reference_entities=("e1",)),
+            page_url=base,
+            project_id="p-1",
+        )
+        is False
+    )
+    assert (
+        migrated_images_prefer(
+            GenerateImageRequest(prompt="x", instructions=None)
+            if False
+            else GenerateImageRequest(prompt="x", reference_entities=("e2",)),
+            page_url=base,
+            project_id="p-1",
+        )
+        is False
+    )
+
+
+def test_migrated_images_prefer_keeps_project_less_runs_on_labs(wip_src):
+    from gflow_cli.api.transports.migrated_composer import migrated_images_prefer
+
+    # The labs driver auto-creates the project; the migrated composer needs
+    # --project. Preferring migrated here would trade the auto-create path
+    # for a ConfigurationError.
+    assert (
+        migrated_images_prefer(
+            _plain_request(),
+            page_url="https://labs.google/fx/tools/flow?hl=en",
+            project_id=None,
+        )
+        is False
+    )
+
+
+def test_migrated_images_prefer_follows_the_served_editor(wip_src):
+    from gflow_cli.api.transports.migrated_composer import migrated_images_prefer
+
+    # Already inside an editor the served host rules — assuming migrated here
+    # would skip the mint a labs editor genuinely needs.
+    assert (
+        migrated_images_prefer(
+            _plain_request(),
+            page_url="https://labs.google/fx/en/tools/flow/project/p-1",
+            project_id="p-1",
+        )
+        is False
+    )
+
+
+class _SelectorDriftImageTransport:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def uses_page_owned_image_recaptcha(self) -> bool:
+        return True
+
+    async def generate_images(self, **_: Any) -> list[Any]:
+        self.calls += 1
+        from gflow_cli.errors import UiSelectorDriftError
+
+        raise UiSelectorDriftError(detail="migrated host: deterministic selector drift")
+
+
+def _drive_client(transport: Any):
+    from gflow_cli.api.client import FlowApiClient
+
+    client = FlowApiClient.__new__(FlowApiClient)
+    client.transport = transport  # type: ignore[assignment]
+    return client
+
+
+async def test_drive_mints_when_request_is_not_migrated_servable():
+    from unittest.mock import AsyncMock
+
+    from gflow_cli.api.image import GenerateImageRequest
+    from gflow_cli.errors import UiSelectorDriftError
+
+    transport = _SelectorDriftImageTransport()
+    client = _drive_client(transport)
+    client._mint_recaptcha_token = AsyncMock(return_value="tok")  # type: ignore[method-assign]
+
+    with pytest.raises(UiSelectorDriftError):
+        await client._drive_images_generation(  # noqa: SLF001
+            project_id="p-1",
+            req=GenerateImageRequest(prompt="a blue cup", reference_entities=("e1",)),
+            recaptcha_action="imageGeneration",
+        )
+
+    client._mint_recaptcha_token.assert_awaited_once()  # type: ignore[attr-defined]
+    assert transport.calls == 1
+
+
+async def test_drive_skips_mint_for_servable_request():
+    from unittest.mock import AsyncMock
+
+    from gflow_cli.errors import UiSelectorDriftError
+
+    transport = _SelectorDriftImageTransport()
+    client = _drive_client(transport)
+    client._mint_recaptcha_token = AsyncMock(return_value="tok")  # type: ignore[method-assign]
+
+    with pytest.raises(UiSelectorDriftError):
+        await client._drive_images_generation(  # noqa: SLF001
+            project_id="p-1",
+            req=_plain_request(),
+            recaptcha_action="imageGeneration",
+        )
+
+    client._mint_recaptcha_token.assert_not_awaited()  # type: ignore[attr-defined]
+    assert transport.calls == 1

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -129,6 +129,7 @@ class Dom:
     page_dies_on_upload: bool = False
     dialog_probe_raises: bool = False
     dialog_closed: int = 0
+    cookie_bar_present: bool = False
     # --- #749: Flow's agent mode ------------------------------------------------------
     # Pressed, the chip leaves `.settings-trigger-button` in the DOM under a bare `hidden`
     # — present to `count()`, never visible. The knobs below are the states the driver has
@@ -246,6 +247,8 @@ class FakeLocator:
 
     # --- reads --------------------------------------------------------------
     async def count(self) -> int:
+        if self.kind == "cookie_bar":
+            return 1 if self.page.dom.cookie_bar_present else 0
         if self.kind == "dialog" and self.page.dom.dialog_probe_raises:
             raise PlaywrightTimeoutError("count: Target page, context or browser has been closed")
         if self.kind == "agent_chip":
@@ -261,6 +264,14 @@ class FakeLocator:
 
     async def is_visible(self) -> bool:
         return bool(self.items) and self._visible_now
+
+    async def scroll_into_view_if_needed(self, **_: Any) -> None:
+        await asyncio.sleep(0)
+
+    async def bounding_box(self) -> dict[str, float] | None:
+        if not self.items:
+            return None
+        return {"x": 0.0, "y": 0.0, "width": 10.0, "height": 10.0}
 
     async def is_enabled(self) -> bool:
         if self.kind == "submit":
@@ -342,6 +353,8 @@ class FakeLocator:
             dom.picker_open = False
             if dom.chip_binds:
                 dom.chip_bound = True
+        elif self.kind == "cookie_button":
+            dom.cookie_bar_present = False
         elif self.kind == "dialog_close":
             dom.dialog_present = False
             dom.dialog_closed += 1
@@ -514,8 +527,19 @@ class FakePage:
     def expect_file_chooser(self, **_: Any) -> FakeChooserContext:
         return FakeChooserContext(self)
 
+    async def evaluate(self, expression: str, argument: Any = None) -> Any:
+        if "elementFromPoint" in expression:
+            return {"target": True, "top": None}
+        return {}
+
     def locator(self, css: str, *, scope: FakeLocator | None = None) -> FakeLocator:
         dom = self.dom
+        if css == migrated_composer.COOKIE_BAR:
+            return FakeLocator(
+                self, "cookie_bar", ["cookie"], visible=lambda: dom.cookie_bar_present
+            )
+        if css == "button" and scope is not None and scope.kind == "cookie_bar":
+            return FakeLocator(self, "cookie_button", ["button"] if dom.cookie_bar_present else [])
         if css == ".settings-trigger-button":
             # In agent mode it is still THERE (count 1) — just `hidden`. The reporter
             # counted 57 locator matches on an element that never became visible.
@@ -2511,3 +2535,20 @@ async def test_an_image_submit_that_stays_disabled_is_drift_not_a_hang(
             page, GenerateImageRequest(prompt="a blue cup")
         )
     assert page.dom.submit_clicked == 0
+
+
+async def test_pre_submit_gate_refuses_blocking_overlay_before_network_observers() -> None:
+    from gflow_cli.api.image import GenerateImageRequest
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = _image_page()
+    page.dom.pane_open = True
+
+    with pytest.raises(UiSelectorDriftError, match="blocking overlay"):
+        await MigratedComposer().submit_images_and_observe(
+            page, GenerateImageRequest(prompt="a blue cup")
+        )
+
+    assert page.dom.submit_clicked == 0
+    assert page.listeners("request") == []
+    assert page.listeners("response") == []

--- a/tests/api/transports/test_migrated_images.py
+++ b/tests/api/transports/test_migrated_images.py
@@ -278,6 +278,16 @@ def test_page_owned_recaptcha_is_only_selected_for_the_migrated_route(
     page = MagicMock()
     transport._page = page  # noqa: SLF001
 
+    # Pre-navigation bootstrap page: assume migrated so the page-owned mint
+    # wins the post-goto handoff race instead of minting on a script-less
+    # gallery page (the #692 race). `_drive_images_generation` re-checks
+    # servability before skipping the mint, so the assumption cannot strand
+    # a labs run.
+    page.url = "https://labs.google/fx/tools/flow?hl=en"
+    assert transport.uses_page_owned_image_recaptcha()
+    # Already inside a labs editor: follow the served host. A labs editor
+    # needs its pre-minted token; assuming migrated here would skip the mint
+    # and strand it in a terminal auth failure (#780 review).
     page.url = f"https://labs.google/fx/en/tools/flow/project/{PROJECT}"
     assert not transport.uses_page_owned_image_recaptcha()
     page.url = f"https://flow.google.com/project/{PROJECT}"
@@ -331,6 +341,10 @@ def test_a_never_migrated_transport_does_not_latch_into_the_page_owned_path(
     page = MagicMock()
     transport._page = page  # noqa: SLF001
 
+    # Under labs.google kill-switch the capability must stay False so a labs
+    # account keeps minting the token it genuinely needs.
+    monkeypatch.setenv("GFLOW_CLI_FLOW_HOST", "labs.google")
+    reset_settings()
     for url in ("about:blank", f"https://labs.google/fx/en/tools/flow/project/{PROJECT}"):
         page.url = url
         assert not transport.uses_page_owned_image_recaptcha(), url


### PR DESCRIPTION
## Summary

Migrated image submits prove the composer **before** any network observer arms: cookie-bar dismissal, blocking-overlay refusal, and submit pointer hit-test — each raising typed `UiSelectorDriftError` with bounded redacted diagnostics instead of bare Playwright timeouts. Plus a servability-gated migrated preference so the page-owned recaptcha path wins the post-goto handoff race (#692) without stranding labs flows.

Fixes #780.

## Lifecycle

- [x] Issue filed first (#780) with $0 evidence and related issues (#692, #719, #745)
- [ ] `predict` verdict recorded — struck: external contribution, no access to council tooling; the failure classes touched (selector drift vs auth vs host) are named in the issue
- [ ] `scenario` + `plan` under `docs/superpowers/plans/` — struck: bounded single-transport change, design record is #780; no agentic-worker orchestration involved
- [x] `check` green: `check_repo_hygiene.py` clean (one branch-name advisory, renamed to `bugfix/`), `check_doc_links.py` clean
- [x] MCP twin: reasoned exemption — no CLI surface change (no new commands/flags/output shapes); transport behavior covered by `tests/api` + `tests/features` steps
- [x] **E2E evidence**: `tests/e2e/test_account_chooser_e2e.py` (real Playwright pages, route interception, $0) — 7 passed; new `test_cookie_selector_is_button_scoped_and_dismisses_both_variants` + `test_pre_submit_gate_rejects_an_unexpected_pointer_blocker` drive real Chromium, $0
- [x] Live-verified against real Flow: `gflow image t2i --model nano-pro` on profile `presentation-reels-google`, project `dcc9bde8` (2026-09-11, pure CLI without wrapper patches) — `status: ok`, 1 image (media `a284c5ec`, 768x1376, seed 1413641395, signed URL + local download, 653KB valid JPEG). Bootstrap → cookie-aware editor entry → settings → pre-submit gate → submit → `ogiZ0b` reply → download, no typed errors, 1 paid generation. Receipt: `audit-reports/live-t2i-2026-09-11/` (PR author run, not committed)
- [ ] Council review run — struck: external contribution; requesting it here

## Validation

- [x] Focused tests added/updated: `test_image_capability_and_cookie_bar.py` (new: gates, artifacts, no-retry contract, prefer matrix, mint-skip AND), `test_migrated_composer.py` (+cookie-bar fake states, overlay-gate test), `test_migrated_images.py` (capability editor/bootstrap split)
- [x] Documentation updated: `CHANGELOG.md` `[Unreleased]` (Added + Fixed)
- [x] `uv run python scripts/ci/check_doc_links.py`
- [x] `uv run ruff check src tests`
- [x] `uv run pyright src` (0 errors)
- [x] Relevant pytest command: `uv run pytest tests/api -q` (full API suite green); `uv run pytest tests/e2e/test_account_chooser_e2e.py -q -m e2e` (7 passed)

## Contribution Checklist

- [x] This PR targets `develop`
- [x] Commits use real Git identity; external commit carries `Signed-off-by:` (DCO)
- [x] No secrets, cookies, account tokens, signed URLs, or private captured data (test accounts are `example.com`; receipts assert redaction of query strings)
- [x] AI-assisted changes reviewed before submitting (adversarial + neuro-slop pass; dead helpers and tautological tests removed, duplicate overlay/enable paths merged into upstream `_click` machinery rather than forked)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation now supports all aspect ratio options, including 3:4 portrait.
  * Projects can be created automatically when generating a video without selecting a project.
  * Migrated image submissions can use the migrated Composer when eligible.

* **Bug Fixes**
  * Improved image submission validation prevents blocked or obscured controls from causing unclear failures.
  * Selector and editor errors now provide typed, redacted diagnostics instead of generic timeouts.
  * Cookie banners are dismissed during Composer setup to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->