### PR TITLE
fix(migrated): clear Google's consent bar, and name it when it will not go (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Google's cookie-consent bar no longer blocks generation on `flow.google.com`.**
+  The `glue` bar is fixed at `z-index: 1000` and Flow's composer is bottom-anchored in
+  the same band, so the bar sat on the settings trigger *and* on the image submit:
+  `elementFromPoint` over each returned the bar in 5/5 rendered samples, on the same
+  profile and project where the click had landed 3/3 the day before. Every image and
+  video run on a re-prompted profile failed, before any submit, so nothing was billed.
+  The driver now clears the bar before its first click. It **rejects** rather than
+  accepts — both remove the bar, and only one answers a consent question on your
+  behalf. Reported by @stgmt in [#780](https://github.com/ffroliva/gflow-cli/issues/780);
+  measured in [the 2026-09-11 spike](docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md).
+- **A click post-mortem now names the thing on top, not its inner node.** The occluder
+  allowlist matched `cdk|mat|mdc|flow` class prefixes on the element `elementFromPoint`
+  returned — but a consent bar puts an unnamed label span there and keeps its identity
+  in an `id` the allowlist deliberately drops, so #776's attribution reported
+  `it is covered by span`. It now adds Google's `glue` prefix and climbs to the nearest
+  ancestor that names itself, reporting `div.glue-cookie-notification-bar`. Unchanged
+  for the CDK overlays that already worked, and the `id` is still never echoed.
+
 ## [0.73.0] — 2026-09-10
 
 ### Security

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -218,11 +218,13 @@ Installs from PyPI are unaffected.
 Google's `glue` consent bar (`#glue-cookie-notification-bar-1`) is `position: fixed`
 at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The bar
 therefore lands **on** the settings trigger *and* on the image submit button.
-Measured 2026-09-11: `elementFromPoint` over each returned the bar's label span in
-5/5 rendered samples, on the same profile and project where the click had landed 3/3
-the day before — so it arrives whenever Google re-prompts for consent, not once per
-profile. The labs driver survives it by accident; `_bypass_onboarding` carries a text
-match on "Agree". The migrated driver had no equivalent.
+Measured 2026-09-11 on the `ci-probe` profile: `elementFromPoint` over each returned
+the bar's label span in 5/5 rendered samples, on the same profile and project where
+the click had landed 3/3 the day before. **How widely it fires is unmeasured** — one
+account observed blocked, one observed already-consented — so treat the recurrence
+pattern as unknown rather than as once-per-profile. The labs driver survives it by
+accident; `_bypass_onboarding` carries a text match on "Agree". The migrated driver
+had no equivalent.
 
 Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
 top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -210,6 +210,34 @@ on the first try.
 with `uv tool run --from gflow-cli python -c "import importlib.metadata as m; print(m.version('playwright'))"`.
 Installs from PyPI are unaffected.
 
+### Google's cookie-consent bar covers the composer on the migrated host — fixed in 0.73.1
+
+- **Status:** Fixed in 0.73.1 ([#780](https://github.com/ffroliva/gflow-cli/issues/780)) · **Affects:** `flow.google.com`, all versions through 0.73.0
+- **Severity:** High while it fires (every image and video run on that profile fails) · **Cost:** none — it fails before any submit, so no credits are spent
+
+Google's `glue` consent bar (`#glue-cookie-notification-bar-1`) is `position: fixed`
+at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The bar
+therefore lands **on** the settings trigger *and* on the image submit button.
+Measured 2026-09-11: `elementFromPoint` over each returned the bar's label span in
+5/5 rendered samples, on the same profile and project where the click had landed 3/3
+the day before — so it arrives whenever Google re-prompts for consent, not once per
+profile. The labs driver survives it by accident; `_bypass_onboarding` carries a text
+match on "Agree". The migrated driver had no equivalent.
+
+Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
+top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,
+so the message named nothing actionable.
+
+0.73.1 dismisses the bar before the first click, choosing **reject** over accept
+(both clear it; only one answers a consent question for you), and teaches the
+post-mortem to climb to the nearest ancestor that names itself, so any bar that
+still refuses to go is reported as `div.glue-cookie-notification-bar`.
+
+**Workaround on 0.73.0 and earlier:** open that profile once in Chrome and dismiss
+the bar by hand. Consent persists in the profile.
+
+Evidence: [`docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md`](docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md).
+
 ### One-time Flow banner/modal can cover the composer on first load
 
 - **Status:** Open ([#369](https://github.com/ffroliva/gflow-cli/issues/369))

--- a/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
+++ b/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
@@ -1,0 +1,117 @@
+# Does Google's glue cookie bar render on flow.google.com, and does it block? (#780 / PR #781)
+
+- **Date:** 2026-09-11
+- **Script:** [`scripts/dev/spike_migrated_cookie_bar.py`](../../../scripts/dev/spike_migrated_cookie_bar.py)
+- **Profile / project:** `ci-probe` · `1e4efe0d-…` (migrated host, `flow.google.com`)
+- **Cost:** $0 — navigation, DOM reads, and one consent click in the control arm. No
+  credits, no quota.
+- **Raw:** `scripts/dev/_spike_out/spike_migrated_cookie_bar_20260911_0951*.json` and
+  `…_0953*.json` (gitignored)
+
+## The question
+
+[#780](https://github.com/ffroliva/gflow-cli/issues/780) opens with a claim, and PR #781
+builds three gates on it:
+
+> Google's glue cookie banner (`glue-cookie-notification-bar`) sits fixed at the viewport
+> bottom and intercepts every pointer event over the composer's settings trigger.
+
+Nothing in this repo had ever observed that bar on `flow.google.com`. Both prior sightings
+are **labs.google**: `test_assets/debug_editor/buttons.json` (its sibling buttons carry
+styled-components classes, which is labs' React build, not the migrated host's Angular
+one) and `scripts/smoke_video_editor.py:385`. And yesterday's spike,
+[`2026-09-10-migrated-click-blocked.md`](2026-09-10-migrated-click-blocked.md), read 159
+DOM samples on this exact host and project, found **zero** overlays and **zero** dialogs,
+and watched the click land 3/3 in 65–130 ms.
+
+That spike never looked for a cookie bar. So it neither found nor excluded one.
+
+```
+A SELECTOR NOBODY LOOKED FOR IS NOT AN ABSENCE.
+A BAR THAT EXISTS IS NOT YET A BLOCKER.
+```
+
+Two questions, because #780 conflates them: does it render here, and if it does, does it
+actually win `elementFromPoint` over the controls the driver clicks.
+
+## Pre-registered readings
+
+Written into the script's docstring before the run.
+
+| Outcome | Reading |
+|---|---|
+| bar visible, wins `elementFromPoint` over a control | #780's premise holds |
+| bar visible, controls still hit-test to themselves | the bar EXISTS and does NOT block — premise falsified |
+| bar absent on migrated, present on labs | a labs surface; #781 guards the Angular composer against React-app furniture |
+| bar absent on both, glue bundle absent too | strongest available negative |
+| bar absent on both, glue bundle PRESENT | **does not reproduce here; settles nothing** — consent already stored |
+
+## What was observed
+
+6 samples across the composer-mount window, then a 4-sample control arm.
+
+| Reading | Before | After the driver's `_dismiss_cookie_bar` |
+|---|---|---|
+| bar elements visible | 6 / 6 | 0 / 4 |
+| samples where a control was covered by the bar | 5 | 0 |
+| settings trigger hit-testable | 0 / 5 rendered | 4 / 4 |
+| image submit hit-testable | 0 / 5 rendered | 4 / 4 |
+
+The bar is `div#glue-cookie-notification-bar-1.glue-cookie-notification-bar`,
+`position: fixed`, `z-index: 1000`, `pointer-events: auto`, occupying y 547→655 of a
+655 px viewport. Its consent bundle is served from
+`https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.{js,css}`
+and it installs a `glue` global.
+
+Both controls sit **inside that band**: the settings trigger at y 582 (h 32) and the image
+submit at y 582 (32×32). `elementFromPoint` over each returned
+`span#glue-cookie-notification-bar-1-label` in every rendered sample. Flow's composer is
+itself bottom-fixed (`flow-prompt-box.prompt-box-container` appears in the same
+bottom-fixed inventory), so this is a collision between two bottom-anchored layers, not an
+artifact of a short window.
+
+## Verdict: #780's premise is CONFIRMED, and it is broader than #780 says
+
+The bar renders on the migrated host, and it covers **both** the settings trigger *and*
+the image submit button. #780 names only the trigger. PR #781's `_dismiss_cookie_bar`
+cleared it in one attempt and restored hit-testability on both controls, 4/4.
+
+**This does not contradict yesterday's 0/3.** Same profile, same project, seventeen hours
+apart: the consent bar was absent then and present now. Yesterday's spike said the state
+it could not measure was one "you cannot summon on demand — a first visit after a Flow
+deployment". This is that state, arriving on its own. It is the reason that spike declined
+to call 0/3 evidence of transience, and it was right to.
+
+## Two things this did NOT measure
+
+**The labs contrast arm failed.** `ci-probe` is a moved account, so
+`labs.google/fx/tools/flow/project/<id>` redirected straight to `flow.google.com` and the
+second arm re-measured the first. Whether an **unmoved** account sees the same bar on the
+labs editor is still unknown. It matters for PR #781's other half, which routes unmoved
+accounts onto the migrated host for images.
+
+**The state is now consumed.** The control arm clicked the bar's first button to dismiss
+it, so a re-run on `ci-probe` will read 0/N until Google re-prompts. Capture before you
+dismiss.
+
+## A finding the control arm produced by accident
+
+The bar's buttons are, in DOM order, `glue-cookie-notification-bar__accept` ("Agree") then
+`glue-cookie-notification-bar__reject` ("No thanks"). PR #781 dismisses with
+`buttons.first`, so it **accepts** cookies on the user's behalf. `scripts/smoke_video_editor.py`
+already does the same. Rejecting unblocks the composer identically — the bar just has to
+go — so index 1 is the same fix without making a consent decision for the operator.
+
+## What this means for the fix
+
+The dismissal earns its place and should land. The gates built *around* it are a separate
+question: the hit-test gate refuses on a covered submit, which is the state measured here,
+but PR #781 also reports the covering element's raw `id` and `className` into a
+user-facing error, which is the data
+[#776's](https://github.com/ffroliva/gflow-cli/issues/776) closed allowlist exists to keep
+out of one.
+
+## Related
+
+- [`2026-09-10-migrated-click-blocked.md`](2026-09-10-migrated-click-blocked.md) — the 0/3 this completes
+- [`2026-09-05-migrated-frames-attach.md`](2026-09-05-migrated-frames-attach.md) — a non-blocking "high demand" banner on the same host

--- a/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
+++ b/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
@@ -118,10 +118,16 @@ dismiss.
 ## A finding the control arm produced by accident
 
 The bar's buttons are, in DOM order, `glue-cookie-notification-bar__accept` ("Agree") then
-`glue-cookie-notification-bar__reject` ("No thanks"). PR #781 dismisses with
-`buttons.first`, so it **accepts** cookies on the user's behalf. `scripts/smoke_video_editor.py`
-already does the same. Rejecting unblocks the composer identically — the bar just has to
-go — so index 1 is the same fix without making a consent decision for the operator.
+`glue-cookie-notification-bar__reject` ("No thanks"). PR #781 dismissed with
+`buttons.first`, so it **accepted** cookies on the user's behalf — and because the control
+arm ran that version, this spike accepted on `ci-probe` before anyone noticed.
+`scripts/smoke_video_editor.py` still does the same. Rejecting unblocks the composer
+identically, so index 1 is the same fix without making a consent decision for the operator.
+
+The shipped fix (PR #782) therefore anchors on `.glue-cookie-notification-bar__reject`,
+and re-running this spike's `--dismiss` arm today rejects rather than accepts: it imports
+the driver's own `_dismiss_cookie_bar` instead of clicking the bar itself, so the control
+arm always measures whatever actually ships.
 
 ## What this means for the fix
 

--- a/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
+++ b/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
@@ -82,7 +82,28 @@ it could not measure was one "you cannot summon on demand — a first visit afte
 deployment". This is that state, arriving on its own. It is the reason that spike declined
 to call 0/3 evidence of transience, and it was right to.
 
-## Two things this did NOT measure
+## How widely does it fire? Still n=1
+
+A second profile was attempted specifically to answer this, and it did not answer it.
+
+`denon82` — an independent account, never touched by this spike — was driven at both
+hosts. **Both arms landed on `https://flow.google.com/about`**, not the project, so no
+composer ever mounted: `trigger_rendered_in` and `submit_rendered_in` were 0/5 in both.
+That run measured a marketing page. It is not a second sample and must not be counted as
+one.
+
+The one thing it does say: on that origin the bar was **in the DOM but hidden** (5/5), so
+consent is already stored for `denon82`. Which is consistent with the mechanism — the bar
+is consent-state dependent, so it fires on a rolling subset of profiles rather than on
+everyone at once — but it is corroboration, not a measurement of prevalence.
+
+**So: one account confirmed blocked, one account confirmed already-consented, prevalence
+unmeasured.** What would settle it: the same probe on several profiles that reach the
+editor. The `/about` redirect that stopped this one is separately recorded in
+[`2026-09-10-about-redirect-stability.md`](2026-09-10-about-redirect-stability.md) and was
+not investigated here.
+
+## Two more things this did NOT measure
 
 **The labs contrast arm failed.** `ci-probe` is a moved account, so
 `labs.google/fx/tools/flow/project/<id>` redirected straight to `flow.google.com` and the

--- a/scripts/dev/spike_migrated_cookie_bar.py
+++ b/scripts/dev/spike_migrated_cookie_bar.py
@@ -316,7 +316,15 @@ async def main() -> int:
             "does the glue cookie bar render on flow.google.com/project/<id>, and does it "
             "win elementFromPoint over the settings trigger or the image submit? (#780/#781)"
         ),
-        "cost": "credit-free: navigation and DOM reads only; the bar is observed, never clicked",
+        "cost": (
+            "credit-free: navigation and DOM reads"
+            + (
+                "; one consent REJECT click in the control arm"
+                if args.dismiss
+                else "; the bar is observed, never clicked"
+            )
+        ),
+        "dismiss_arm": args.dismiss,
         "cookie_bar_selector": COOKIE_BAR,
         "cookie_bar_buttons_selector": COOKIE_BAR_BUTTONS,
         "visits": [],

--- a/scripts/dev/spike_migrated_cookie_bar.py
+++ b/scripts/dev/spike_migrated_cookie_bar.py
@@ -1,0 +1,362 @@
+r"""Does Google's glue cookie bar render on flow.google.com, and does it block? ($0)
+
+Settles the premise of #780 / PR #781.
+
+#780 asserts, as its first of three "measured" failure modes:
+
+    Google's glue cookie banner (`glue-cookie-notification-bar`) sits fixed at the
+    viewport bottom and intercepts every pointer event over the composer's settings
+    trigger. Click retries run into Playwright's timeout and the run dies as an
+    unhandled TimeoutError.
+
+PR #781 builds three gates on that premise. Nothing in this repo has ever observed the
+bar on `flow.google.com`. What it HAS observed:
+
+- `test_assets/debug_editor/buttons.json` -- the bar, with `__accept` ("Agree") first and
+  `__reject` ("No thanks") second. Captured on a **labs.google** editor: the sibling
+  buttons in that same file carry styled-components classes (`sc-e8425ea6-0 gLXNUV`),
+  which is labs' React build, not the migrated host's Angular one.
+- `scripts/smoke_video_editor.py:385` -- dismisses `#glue-cookie-notification-bar-1
+  button`, again on the labs editor.
+- `docs/superpowers/spikes/2026-09-10-migrated-click-blocked.md` -- 159 DOM samples on
+  `flow.google.com`, **zero** `.cdk-overlay-pane` and **zero** `[role='dialog']` before
+  the click, click landed 3/3 in 65-130 ms. That probe never looked for a cookie bar,
+  so it neither found nor excluded one.
+
+    A SELECTOR NOBODY LOOKED FOR IS NOT AN ABSENCE.
+    A BAR THAT EXISTS IS NOT YET A BLOCKER.
+
+So this probe asks two separate questions, because #780 conflates them:
+
+1. **Does the bar render on the migrated host at all?** Inventory the selectors, and --
+   because a warm profile has usually already answered consent -- also record whether the
+   *machinery* is even shipped: any script/link/global that Google's glue consent bundle
+   would bring with it. A page that never loads the bundle cannot grow the bar later.
+2. **If it renders, does it block?** `elementFromPoint` over the settings trigger and
+   over the image submit button (`arrow_forward`). Fixed furniture at the bottom of a
+   viewport is only a blocker if it is on top of the control being clicked.
+
+Contrast arm: the same inventory on `labs.google`, so "the bar is real" and "the bar is
+on THIS host" cannot be confused for each other again.
+
+## Pre-registered readings -- written before the run, so the result cannot be respun
+
+| Outcome | Reading |
+|---|---|
+| bar visible on migrated, and it wins `elementFromPoint` over a control | #780's premise holds; PR #781's cookie gate has a real target |
+| bar visible on migrated, controls still hit-test to themselves | the bar EXISTS and does NOT block -- #780's stated mechanism is falsified and the gate guards a decoration |
+| bar absent on migrated, present on labs | the bar is a labs surface; PR #781 gates the Angular composer against React-app furniture |
+| bar absent on both, glue bundle absent too | strongest available negative: the machinery is not shipped to this page |
+| bar absent on both, glue bundle PRESENT | **does not reproduce here; settles nothing** -- consent is already stored on this profile. Report as unmeasured. |
+
+What would settle that last row: a profile that has never answered consent, or an EU
+egress. Neither is summonable on demand, which is why the bundle reading is captured --
+it is the one signal a dismissed-consent profile cannot suppress.
+
+The last row is the one worth pre-writing. This account has driven Flow for weeks, so a
+stored consent cookie is the *expected* reason to see nothing, and a 0/N here is
+consistent with both "never renders" and "already dismissed". Only the bundle reading
+separates them.
+
+## The control arm (`--dismiss`)
+
+Off by default, because dismissing the bar is what destroys the evidence. Passed, the
+probe re-reads the same inventory AFTER running the driver's own `_dismiss_cookie_bar`,
+so "the bar blocks" and "dismissing it unblocks" are two separate measurements rather
+than one assumption. A result with no control is a coincidence with formatting.
+
+## Cost
+
+Zero. Navigation and DOM reads; with `--dismiss`, one click on a consent button. Nothing
+typed, nothing submitted, nothing created or deleted. No credits, no daily quota.
+
+    python scripts/dev/spike_migrated_cookie_bar.py \
+        --profile ci-probe --project <project-id> --samples 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+# Copied from migrated_composer.py so the probe and the driver cannot disagree about
+# which controls are under discussion. COOKIE_BAR/COOKIE_BAR_BUTTONS are PR #781's own
+# constants, reproduced verbatim: the probe must test the selector the PR ships, not a
+# better one, or a miss here would be evidence about my selector instead of theirs.
+READY_ANCHOR = ".settings-trigger-button"
+COOKIE_BAR = "#glue-cookie-notification-bar-1, .glue-cookie-notification-bar"
+COOKIE_BAR_BUTTONS = "#glue-cookie-notification-bar-1 button, .glue-cookie-notification-bar button"
+
+MIGRATED_URL = "https://flow.google.com/project/{project_id}"
+LABS_URL = "https://labs.google/fx/tools/flow/project/{project_id}"
+
+_INVENTORY_JS = r"""
+() => {
+  const BAR = "#glue-cookie-notification-bar-1, .glue-cookie-notification-bar";
+  const rectOf = (el) => {
+    const b = el.getBoundingClientRect();
+    return {x: Math.round(b.x), y: Math.round(b.y),
+            w: Math.round(b.width), h: Math.round(b.height)};
+  };
+  const describe = (el) => el ? {
+    tag: el.tagName.toLowerCase(),
+    id: el.id || null,
+    cls: [...el.classList].slice(0, 4),
+    role: el.getAttribute('role'),
+  } : null;
+  const visible = (el) => {
+    const cs = getComputedStyle(el), b = el.getBoundingClientRect();
+    return b.width > 0 && b.height > 0 && cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  // --- 1. the bar itself, by PR #781's own selector -------------------------
+  const bars = [...document.querySelectorAll(BAR)].map((el) => ({
+    tag: el.tagName.toLowerCase(),
+    id: el.id || null,
+    cls: [...el.classList].slice(0, 4),
+    visible: visible(el),
+    rect: rectOf(el),
+    position: getComputedStyle(el).position,
+    zIndex: getComputedStyle(el).zIndex,
+    pointerEvents: getComputedStyle(el).pointerEvents,
+    buttons: [...el.querySelectorAll('button')].map((b) => ({
+      cls: [...b.classList].slice(0, 4),
+      ariaLabel: b.getAttribute('aria-label'),
+      disabled: b.hasAttribute('disabled'),
+    })),
+  }));
+
+  // --- 2. is the glue consent MACHINERY even shipped to this page? ----------
+  // A warm profile hides a bar it already dismissed; it cannot hide the bundle.
+  const srcs = [...document.querySelectorAll('script[src], link[href]')]
+    .map((el) => el.getAttribute('src') || el.getAttribute('href') || '')
+    .filter((u) => /glue|cookie|consent|funding/i.test(u))
+    .slice(0, 20);
+  const globals = ['glue', 'gluecookie', 'googlefc', 'cookieChoices']
+    .filter((k) => k in window);
+
+  // --- 3. positive observation of WHAT IS THERE at the viewport bottom ------
+  // The claim is "sits fixed at the viewport bottom". Enumerate everything that
+  // actually does, so a negative on the selector is not a negative on the idea.
+  const bottomFixed = [...document.querySelectorAll('body *')]
+    .filter((el) => {
+      const cs = getComputedStyle(el);
+      if (cs.position !== 'fixed' && cs.position !== 'sticky') return false;
+      if (!visible(el)) return false;
+      const b = el.getBoundingClientRect();
+      return b.bottom > window.innerHeight - 160 && b.width > 200;
+    })
+    .slice(0, 15)
+    .map((el) => ({tag: el.tagName.toLowerCase(), id: el.id || null,
+                   cls: [...el.classList].slice(0, 4), rect: rectOf(el),
+                   zIndex: getComputedStyle(el).zIndex}));
+
+  // --- 4. do the controls hit-test to themselves? --------------------------
+  // Existing is not blocking. This is the half of #780 that its own evidence skips.
+  const hit = (el) => {
+    if (!el) return null;
+    const b = el.getBoundingClientRect();
+    if (!b.width || !b.height) return {rendered: false};
+    const top = document.elementFromPoint(b.x + b.width / 2, b.y + b.height / 2);
+    const own = !!top && (top === el || el.contains(top) || top.contains(el));
+    return {
+      rendered: true, rect: rectOf(el), hit_testable: own,
+      top: describe(top),
+      top_is_cookie_bar: !!top && !!top.closest(BAR),
+    };
+  };
+  const submit = [...document.querySelectorAll('button')].find((b) =>
+    [...b.querySelectorAll('mat-icon, i.google-symbols')].some((i) =>
+      (i.textContent || '').trim() === 'arrow_forward'));
+
+  return {
+    url_origin: location.origin,
+    url_path: location.pathname,
+    ready_state: document.readyState,
+    body_pointer_events: getComputedStyle(document.body).pointerEvents,
+    bars: bars,
+    bar_button_count: document.querySelectorAll(
+      "#glue-cookie-notification-bar-1 button, .glue-cookie-notification-bar button").length,
+    glue_resources: srcs,
+    glue_globals: globals,
+    bottom_fixed: bottomFixed,
+    settings_trigger: hit(document.querySelector('.settings-trigger-button')),
+    image_submit: hit(submit || null),
+  };
+}
+"""
+
+
+async def _sample(page: Any, *, samples: int, interval_s: float) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    t0 = time.monotonic()
+    for _ in range(samples):
+        try:
+            reading = await page.evaluate(_INVENTORY_JS)
+            reading["t_ms"] = round((time.monotonic() - t0) * 1000)
+        except Exception as exc:  # noqa: BLE001 - an unreadable sample is a datum
+            reading = {"t_ms": round((time.monotonic() - t0) * 1000), "error": str(exc)[:200]}
+        out.append(reading)
+        await asyncio.sleep(interval_s)
+    return out
+
+
+async def _visit(
+    client: Any, url: str, *, label: str, samples: int, dismiss: bool = False
+) -> dict[str, Any]:
+    page = client.transport._page  # noqa: SLF001 - the spike drives gflow's own page
+    step(label, f"goto {url}")
+    nav_error: str | None = None
+    try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+    except Exception as exc:  # noqa: BLE001
+        nav_error = str(exc)[:200]
+    # The composer mounts 1479-3143 ms after domcontentloaded (2026-09-10 spike), and a
+    # cookie bar is furniture that can arrive later still. Sample across the window
+    # rather than reading once, or a "0" would only mean "too early".
+    readings = await _sample(page, samples=samples, interval_s=1.5)
+    landed = str(getattr(page, "url", ""))
+    step(label, f"landed on {landed}")
+    visit: dict[str, Any] = {
+        "label": label,
+        "requested_url": url,
+        "landed_url": landed,
+        "nav_error": nav_error,
+        "readings": readings,
+    }
+    if dismiss:
+        # The driver's OWN dismissal, imported rather than reimplemented: a probe that
+        # clicked the bar itself would measure my click, not the one that ships.
+        from gflow_cli.api.transports.migrated_composer import (  # noqa: PLC0415
+            MigratedComposer,
+        )
+
+        step(label, "running the driver's _dismiss_cookie_bar")
+        try:
+            await MigratedComposer()._dismiss_cookie_bar(page)  # noqa: SLF001
+            visit["dismiss_error"] = None
+        except Exception as exc:  # noqa: BLE001 - a refusal is a datum
+            visit["dismiss_error"] = f"{type(exc).__name__}: {str(exc)[:300]}"
+        visit["readings_after_dismiss"] = await _sample(page, samples=samples, interval_s=1.0)
+    return visit
+
+
+def _summarise(visit: dict[str, Any], key: str = "readings") -> dict[str, Any]:
+    readings = [r for r in visit.get(key, []) if "error" not in r]
+    bars_seen = [b for r in readings for b in r.get("bars", [])]
+    visible_bars = [b for b in bars_seen if b.get("visible")]
+    blocked = [
+        r
+        for r in readings
+        if (r.get("settings_trigger") or {}).get("top_is_cookie_bar")
+        or (r.get("image_submit") or {}).get("top_is_cookie_bar")
+    ]
+    return {
+        "samples": len(visit.get(key, [])),
+        "readable": len(readings),
+        "bar_elements_matched": len(bars_seen),
+        "bar_elements_visible": len(visible_bars),
+        "glue_resources": sorted({u for r in readings for u in r.get("glue_resources", [])}),
+        "glue_globals": sorted({g for r in readings for g in r.get("glue_globals", [])}),
+        "samples_where_a_control_was_covered_by_the_bar": len(blocked),
+        "trigger_rendered_in": sum(
+            1 for r in readings if (r.get("settings_trigger") or {}).get("rendered")
+        ),
+        "trigger_hit_testable_in": sum(
+            1 for r in readings if (r.get("settings_trigger") or {}).get("hit_testable")
+        ),
+        "submit_rendered_in": sum(
+            1 for r in readings if (r.get("image_submit") or {}).get("rendered")
+        ),
+        "submit_hit_testable_in": sum(
+            1 for r in readings if (r.get("image_submit") or {}).get("hit_testable")
+        ),
+        "bottom_fixed_tags": sorted(
+            {
+                f"{e.get('tag')}.{'.'.join(e.get('cls') or [])}"
+                for r in readings
+                for e in r.get("bottom_fixed", [])
+            }
+        ),
+    }
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--samples", type=int, default=6)
+    ap.add_argument("--skip-labs", action="store_true", help="migrated arm only")
+    ap.add_argument(
+        "--dismiss",
+        action="store_true",
+        help="control arm: re-read after the driver's own _dismiss_cookie_bar (clicks consent)",
+    )
+    args = ap.parse_args()
+
+    profile_dir = resolve_profile_dir(args.profile)
+    result: dict[str, Any] = {
+        "profile": args.profile,
+        "project": args.project,
+        "question": (
+            "does the glue cookie bar render on flow.google.com/project/<id>, and does it "
+            "win elementFromPoint over the settings trigger or the image submit? (#780/#781)"
+        ),
+        "cost": "credit-free: navigation and DOM reads only; the bar is observed, never clicked",
+        "cookie_bar_selector": COOKIE_BAR,
+        "cookie_bar_buttons_selector": COOKIE_BAR_BUTTONS,
+        "visits": [],
+    }
+
+    async with build_client(profile_dir) as client:
+        result["visits"].append(
+            await _visit(
+                client,
+                MIGRATED_URL.format(project_id=args.project),
+                label="migrated",
+                samples=args.samples,
+                dismiss=args.dismiss,
+            )
+        )
+        if not args.skip_labs:
+            result["visits"].append(
+                await _visit(
+                    client,
+                    LABS_URL.format(project_id=args.project),
+                    label="labs",
+                    samples=args.samples,
+                )
+            )
+
+    summary: dict[str, Any] = {}
+    for visit in result["visits"]:
+        summary[visit["label"]] = _summarise(visit)
+        if "readings_after_dismiss" in visit:
+            summary[f"{visit['label']}_after_dismiss"] = _summarise(
+                visit, "readings_after_dismiss"
+            )
+            summary[f"{visit['label']}_dismiss_error"] = visit.get("dismiss_error")
+    result["summary"] = summary
+    out = default_out_path("spike_migrated_cookie_bar", ".json")
+    out.write_text(json.dumps(result, indent=1, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+    print(json.dumps(result["summary"], indent=2, ensure_ascii=False), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -136,6 +136,21 @@ DIALOG = "[role='dialog']"
 CREDITS_WARNING = "button.prompt-warning-button, [aria-label*='Insufficient credits']"
 DIALOG_CLOSE = f"{DIALOG} button:has(mat-icon:text-is('close'))"
 
+#: Google's `glue` consent bar — a Google-wide component, not one of Flow's. It is
+#: `position: fixed`, `z-index: 1000`, and Flow's composer is bottom-anchored in the
+#: same band, so the bar lands ON the settings trigger and on the submit button:
+#: `elementFromPoint` over each returned the bar's label span in 5/5 rendered samples
+#: (2026-09-11, `ci-probe`, same profile and project where the click had landed 3/3 the
+#: day before). The labs driver survives this by accident — `_bypass_onboarding`'s
+#: Tier 2 carries `button:has-text('Agree')` — and this host had no equivalent.
+#: Evidence: docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
+COOKIE_BAR = "#glue-cookie-notification-bar-1, .glue-cookie-notification-bar"
+#: REJECT, not accept. Both buttons remove the bar and unblock the composer identically,
+#: and only one of them answers a consent question on the operator's behalf. The class is
+#: structural (glue's own BEM modifier), so this stays locale-invariant where matching
+#: "No thanks" would not.
+COOKIE_BAR_REJECT = "button.glue-cookie-notification-bar__reject"
+
 #: ``YhhmEf`` is the text-to-video submit; ``eb1hJf`` the image-to-video one (a bound
 #: Start chip switches the app between them — 2026-09-05 frames spike).
 #: t2v submits on ``YhhmEf``, i2v on ``eb1hJf``, and an Ingredients (r2v) run on
@@ -214,11 +229,21 @@ _CLICK_POSTMORTEM_JS = r"""
   const cx = box.x + box.width / 2, cy = box.y + box.height / 2;
   const top = (box.width && box.height) ? document.elementFromPoint(cx, cy) : null;
   const hit = !!top && (top === el || el.contains(top) || top.contains(el));
-  // Angular/CDK, Material and Flow's own components. A layout class on a bare <div>
-  // is an accident; `cdk-overlay-backdrop` is a component boundary and says what the
-  // thing IS, in any locale.
+  // Angular/CDK, Material, Flow's own components, and Google's `glue` design system.
+  // A layout class on a bare <div> is an accident; `cdk-overlay-backdrop` is a
+  // component boundary and says what the thing IS, in any locale.
   const structural = (n) =>
-    [...n.classList].filter(c => /^(cdk|mat|mdc|flow)-/.test(c)).slice(0, 3).join('.');
+    [...n.classList].filter(c => /^(cdk|mat|mdc|flow|glue)-/.test(c)).slice(0, 3).join('.');
+  // The element on top is often an inner node that names nothing — a consent bar's
+  // label is a bare <span> whose identity lives in an `id` the allowlist deliberately
+  // drops, so the report read "it is covered by span". Climb to the nearest ancestor
+  // that DOES name itself. Bounded by <body>; when nothing on the chain qualifies the
+  // tag name is still reported, exactly as before.
+  const carrier = (n) => {
+    let cur = n;
+    while (cur && cur !== document.body && !structural(cur)) cur = cur.parentElement;
+    return (cur && structural(cur)) ? cur : n;
+  };
   return {
     visible: cs.display !== 'none' && cs.visibility !== 'hidden'
              && box.width > 0 && box.height > 0,
@@ -229,7 +254,8 @@ _CLICK_POSTMORTEM_JS = r"""
     // reading that never fires costs nothing, and a missing one costs a wrong answer.
     body_blocked: getComputedStyle(document.body).pointerEvents === 'none',
     occluder: (top && !hit)
-      ? (top.tagName.toLowerCase() + (structural(top) ? '.' + structural(top) : ''))
+      ? ((c) => c.tagName.toLowerCase() + (structural(c) ? '.' + structural(c) : ''))(
+          carrier(top))
       : null,
   };
 }
@@ -1002,7 +1028,32 @@ class MigratedComposer:
             raise
         await self._close_pane(page, strict=True)
 
+    async def _dismiss_cookie_bar(self, page: Page) -> None:
+        """Clear Google's consent bar, which sits on top of the controls we click.
+
+        Called from :meth:`_open_pane` — the one place both the image and the video path
+        take their FIRST click, and early enough that consent is stored before anything
+        else on the page is touched. The bar was already up 114 ms after
+        ``domcontentloaded`` in every measured sample, so nothing here has to wait for it.
+
+        **Best-effort on purpose.** A bar that refuses to go is not turned into a second
+        error path: the click one line later fails through :meth:`_click`, whose
+        post-mortem now names ``div.glue-cookie-notification-bar`` as the occluder. One
+        attributed failure beats two competing ones, and it costs no code.
+        """
+        bar = page.locator(COOKIE_BAR).first
+        try:
+            if not await bar.is_visible():
+                return
+            await bar.locator(COOKIE_BAR_REJECT).first.click(timeout=3000)
+            await bar.wait_for(state="hidden", timeout=3000)
+        except Exception as e:  # noqa: BLE001 - the click post-mortem reports what is left
+            log.warning("migrated.cookie_bar_not_dismissed", error=str(e)[:120])
+            return
+        log.info("migrated.cookie_bar_dismissed")
+
     async def _open_pane(self, page: Page) -> Any:
+        await self._dismiss_cookie_bar(page)
         trigger = page.locator(READY_ANCHOR).first
         try:
             # Visibility, not `count()`. Agent mode leaves the trigger in the DOM under a

--- a/tests/api/transports/test_click_attribution.py
+++ b/tests/api/transports/test_click_attribution.py
@@ -159,6 +159,66 @@ async def test_a_failed_hit_test_without_an_occluder_is_not_called_healthy(
     assert "hit-testable at the moment" not in detail
 
 
+@pytest.mark.asyncio
+async def test_a_stuck_consent_bar_does_not_become_its_own_error(
+    composer: MigratedComposer,
+) -> None:
+    """The dismissal is best-effort, and that is load-bearing rather than lazy.
+
+    A bar that refuses to go must fall through to the click post-mortem, which names it.
+    Raising here instead would produce a second, competing error for one fact — and it
+    would fire on a page where the bar is visible but harmless, which the labs surface
+    shows is the common case.
+
+    The browser proves the whole path in ``tests/e2e/test_click_attribution_bdd.py``;
+    this pins the contract that no exception escapes, which no e2e assertion states.
+    """
+
+    class _StuckBar:
+        first = property(lambda self: self)  # type: ignore[assignment]
+
+        async def is_visible(self) -> bool:
+            return True
+
+        def locator(self, _sel: str) -> Any:
+            return self
+
+        async def click(self, **_: object) -> None:
+            raise PlaywrightTimeoutError("Timeout 3000ms exceeded")
+
+        async def wait_for(self, **_: object) -> None:  # pragma: no cover - never reached
+            raise AssertionError("the click failed; the postcondition must not be waited on")
+
+    class _PageWithBar:
+        def locator(self, _sel: str) -> Any:
+            return _StuckBar()
+
+    await composer._dismiss_cookie_bar(_PageWithBar())  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_no_consent_bar_costs_one_visibility_read(composer: MigratedComposer) -> None:
+    """The common case — no bar — must not click, wait, or raise."""
+    clicked: list[str] = []
+
+    class _AbsentBar:
+        first = property(lambda self: self)  # type: ignore[assignment]
+
+        async def is_visible(self) -> bool:
+            return False
+
+        def locator(self, sel: str) -> Any:
+            clicked.append(sel)
+            return self
+
+    class _PageWithoutBar:
+        def locator(self, _sel: str) -> Any:
+            return _AbsentBar()
+
+    await composer._dismiss_cookie_bar(_PageWithoutBar())  # noqa: SLF001
+    assert clicked == [], f"reached for a dismiss button with no bar present: {clicked}"
+
+
 async def _drift(composer: MigratedComposer, *, state: dict[str, Any]) -> UiSelectorDriftError:
     with pytest.raises(UiSelectorDriftError) as caught:
         await composer._click(  # noqa: SLF001

--- a/tests/api/transports/test_migrated_composer.py
+++ b/tests/api/transports/test_migrated_composer.py
@@ -94,6 +94,10 @@ class Dom:
     # would trade a false "file a frontend bug" for a false "top up your account".
     submit_anchor_present: bool = True
     credits_warning_present: bool = False
+    # Google's `glue` consent bar. Default False because that is the ordinary page —
+    # it appears only when Google re-prompts, which is exactly why it went unnoticed
+    # until it covered the settings trigger and the submit button on 2026-09-11.
+    cookie_bar_visible: bool = False
     events: list[str] = field(default_factory=list)
     # --- i2v: the toolbar upload path and the Frames picker (2026-09-05 frames spike) ---
     add_button_present: bool = True  # the toolbar `+` outside flow-prompt-box
@@ -298,7 +302,18 @@ class FakeLocator:
         dom = self.page.dom
         target = self.items[0]
         if self.kind == "trigger":
+            if dom.cookie_bar_visible:
+                # The real bar wins elementFromPoint over this control, so a driver that
+                # clicks without clearing it first gets Playwright's actionability
+                # timeout — the 2026-09-11 failure, reproduced here rather than assumed.
+                raise PlaywrightTimeoutError(
+                    "Locator.click: Timeout 5000ms exceeded. waiting for element to "
+                    "receive pointer events (the consent bar is covering it)"
+                )
             dom.pane_open = not dom.pane_open
+        elif self.kind == "cookie_reject":
+            dom.cookie_bar_visible = False
+            dom.events.append("cookie_bar_rejected")
         elif self.kind == "agent_close":
             dom.agent_panel_expanded = False
         elif self.kind == "agent_toggle":
@@ -609,6 +624,13 @@ class FakePage:
         if css == migrated_composer.CREDITS_WARNING:
             hits = ["warning"] if dom.credits_warning_present else []
             return FakeLocator(self, "credits_warning", hits)
+        if css == migrated_composer.COOKIE_BAR:
+            # Always in the DOM, visibility read LAZILY: the driver holds this locator
+            # across the dismiss click and then waits for it to go hidden, so a bool
+            # snapshotted here would make a working dismissal look stuck.
+            return FakeLocator(self, "cookie_bar", ["bar"], visible=lambda: dom.cookie_bar_visible)
+        if css == migrated_composer.COOKIE_BAR_REJECT:
+            return FakeLocator(self, "cookie_reject", ["reject"] if dom.cookie_bar_visible else [])
         raise AssertionError(f"composer used an unmodelled selector: {css!r}")
 
 
@@ -716,6 +738,26 @@ async def test_apply_video_settings_selects_each_axis_and_reads_back() -> None:
     assert page.dom.groups["duration"][1].checked  # 6s
     assert page.dom.groups["count"][1].checked  # x2
     assert not page.dom.pane_open  # closed afterwards
+
+
+async def test_the_consent_bar_is_cleared_on_the_video_path_too() -> None:
+    """The bar covers the trigger for BOTH surfaces, so the fix belongs where they meet.
+
+    `_open_pane` is the one place the image and video paths take their first click, which
+    is why the dismissal lives there rather than in each caller. The fake refuses the
+    trigger click while the bar is up — the 2026-09-11 geometry — so this fails if the
+    dismissal is removed or moved above only the image path.
+    """
+    from gflow_cli.api.transports.migrated_composer import MigratedComposer
+
+    page = FakePage()
+    page.dom.cookie_bar_visible = True
+
+    await MigratedComposer().apply_video_settings(page, _t2v())
+
+    assert "cookie_bar_rejected" in page.dom.events, page.dom.events
+    assert not page.dom.cookie_bar_visible
+    assert not page.dom.pane_open  # opened, bound, and closed again
 
 
 async def test_apply_image_settings_selects_mode_model_aspect_and_count() -> None:

--- a/tests/e2e/test_click_attribution_bdd.py
+++ b/tests/e2e/test_click_attribution_bdd.py
@@ -81,7 +81,7 @@ def _page(
     chip_html = "<button class='agent-mode-chip' aria-pressed='true'>agent</button>" if chip else ""
     cls = "settings-trigger-button jitter" if jitter else "settings-trigger-button"
     return (
-        f"<!doctype html><html><head><style>{_STYLE}</style></head><body>"
+        f"<!doctype html><html><head><style>{_STYLE}{_CONSENT_STYLE}</style></head><body>"
         f"{chip_html}"
         f"<button class='{cls}' aria-label='Settings trigger'>settings</button>"
         f"{cover}"
@@ -103,12 +103,45 @@ _LEAKY_COVER = (
 )
 
 
+def _consent_bar(*, reject_works: bool = True) -> str:
+    """Google's glue consent bar, in the shape measured on 2026-09-11.
+
+    Two details are load-bearing and both come from the capture, not from convenience:
+    the element that actually wins `elementFromPoint` is the **label span**, which
+    carries an `id` and NO classes at all; and the accept button precedes the reject
+    button in DOM order, so anything reaching for "the first button" takes Agree.
+
+    Accepting is therefore made *visibly wrong* here — it records itself in the title
+    and leaves the bar up, so a driver that accepts fails the scenario instead of
+    passing it for the wrong reason.
+    """
+    dismiss = "this.closest('.glue-cookie-notification-bar').remove()" if reject_works else ""
+    return (
+        "<div id='glue-cookie-notification-bar-1' class='glue-cookie-notification-bar'>"
+        "<span id='glue-cookie-notification-bar-1-label'>We use cookies</span>"
+        "<button class='glue-cookie-notification-bar__accept' "
+        "onclick=\"document.title='ACCEPTED'\">Agree</button>"
+        f"<button class='glue-cookie-notification-bar__reject' "
+        f"onclick=\"document.title='REJECTED';{dismiss}\">No thanks</button>"
+        "</div>"
+    )
+
+
+#: The bar is `position: fixed; z-index: 1000` over the trigger's band — the geometry
+#: measured live, not an invented stack.
+_CONSENT_STYLE = """
+  .glue-cookie-notification-bar { position: fixed; top: 90px; left: 0;
+      width: 100vw; height: 108px; z-index: 1000; background: #eee; }
+  #glue-cookie-notification-bar-1-label { display: block; width: 100vw; height: 108px; }
+"""
+
+
 @pytest.fixture
 def world() -> dict[str, Any]:
     return {}
 
 
-async def _drive(html: str, run: Any) -> BaseException | None:
+async def _drive(html: str, run: Any, world: dict[str, Any] | None = None) -> BaseException | None:
     """Launch a real browser, serve `html` for every Flow URL, run `run(page)`."""
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(headless=True)
@@ -122,9 +155,17 @@ async def _drive(html: str, run: Any) -> BaseException | None:
             await page.goto(PROJECT_URL, wait_until="domcontentloaded")
             try:
                 await run(page)
+                return None
             except BaseException as exc:  # noqa: BLE001 - the failure IS the assertion
                 return exc
-            return None
+            finally:
+                # Read the page's own record of what was clicked BEFORE the browser
+                # goes away. The title is the carrier because it survives a failed run.
+                if world is not None:
+                    try:
+                        world["title"] = await page.title()
+                    except Exception:  # noqa: BLE001 - a readback never masks the result
+                        world["title"] = ""
         finally:
             await browser.close()
 
@@ -134,6 +175,7 @@ def _open_pane(world: dict[str, Any]) -> None:
         _drive(
             world["html"],
             lambda page: MigratedComposer()._open_pane(page),  # noqa: SLF001
+            world,
         )
     )
 
@@ -169,6 +211,20 @@ def _chip_pressed(world: dict[str, Any]) -> None:
 @given("the covering element carries an account email and a signed media URL")
 def _leaky(world: dict[str, Any]) -> None:
     world["html"] = _page(cover=_LEAKY_COVER)
+
+
+@given("a Flow project page whose settings trigger is under Google's consent bar")
+def _under_consent_bar(world: dict[str, Any]) -> None:
+    world["html"] = _page(cover=_consent_bar())
+    world["occluder"] = "glue-cookie-notification-bar"
+
+
+@given("a Flow project page whose consent bar ignores its own dismiss button")
+def _stuck_consent_bar(world: dict[str, Any]) -> None:
+    # The dismissal is best-effort, so this must NOT become a second error path — it
+    # has to fall through to the click post-mortem and be named there.
+    world["html"] = _page(cover=_consent_bar(reject_works=False))
+    world["occluder"] = "glue-cookie-notification-bar"
 
 
 @given("the page navigates away while the click is pending")
@@ -229,9 +285,23 @@ def _not_an_overlay(world: dict[str, Any]) -> None:
 
 @then("the message names the covering element by tag and structural class")
 def _names_occluder(world: dict[str, Any]) -> None:
+    # Each Given names the class it expects, because the two covers fail differently:
+    # the CDK backdrop IS the element on top, while the consent bar puts an unnamed
+    # label span there and keeps its identity one level up.
     text = _text(world)
+    expected = world.get("occluder", "cdk-overlay-backdrop")
     assert "div" in text, text
-    assert "cdk-overlay-backdrop" in text, text
+    assert expected in text, f"expected {expected!r}, got: {text}"
+
+
+@then("the consent bar was rejected, not accepted")
+def _rejected_not_accepted(world: dict[str, Any]) -> None:
+    # Both buttons clear the bar on the real surface, so "the pane opened" cannot tell
+    # them apart. The page records which one was pressed.
+    assert world.get("title") == "REJECTED", (
+        f"expected the reject button, page recorded {world.get('title')!r} — accepting "
+        "answers a consent question on the operator's behalf"
+    )
 
 
 @then("the message reports the control as visible, enabled and hit-testable")

--- a/tests/features/click_attribution.feature
+++ b/tests/features/click_attribution.feature
@@ -60,6 +60,28 @@ Feature: A click that never lands says why
     Then it fails with exit 23
     And the message contains neither the account email nor the signed URL
 
+  Scenario: Google's consent bar is cleared before the first click
+    # Measured 2026-09-11 on `ci-probe`: the glue bar is fixed at z-index 1000 and Flow's
+    # composer is bottom-anchored in the same band, so the bar lands on the settings
+    # trigger AND on the submit button — 0/5 hit-testable until it goes. The labs driver
+    # survives this by accident (`_bypass_onboarding` carries a text match on "Agree");
+    # this host had nothing.
+    Given a Flow project page whose settings trigger is under Google's consent bar
+    When the driver opens the settings pane
+    Then the pane opens and nothing is raised
+    And the consent bar was rejected, not accepted
+
+  Scenario: A consent bar that will not close is named, never swallowed
+    # The dismissal is best-effort by design: rather than a second error path, a bar that
+    # refuses to go falls through to the click post-mortem. That only works if the
+    # post-mortem can NAME it — and before this fix it could not. The element on top is
+    # the bar's label span, which carries its identity in an `id` the allowlist drops, so
+    # the message read "it is covered by span".
+    Given a Flow project page whose consent bar ignores its own dismiss button
+    When the driver opens the settings pane
+    Then it fails with exit 23
+    And the message names the covering element by tag and structural class
+
   Scenario: A page that cannot be read still reports the failed locator
     # #722's shape: by the time the failure is diagnosed, the document the click was made
     # against is gone and the post-mortem read has nothing to answer with. A diagnostic

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -210,6 +210,34 @@ on the first try.
 with `uv tool run --from gflow-cli python -c "import importlib.metadata as m; print(m.version('playwright'))"`.
 Installs from PyPI are unaffected.
 
+### Google's cookie-consent bar covers the composer on the migrated host — fixed in 0.73.1
+
+- **Status:** Fixed in 0.73.1 ([#780](https://github.com/ffroliva/gflow-cli/issues/780)) · **Affects:** `flow.google.com`, all versions through 0.73.0
+- **Severity:** High while it fires (every image and video run on that profile fails) · **Cost:** none — it fails before any submit, so no credits are spent
+
+Google's `glue` consent bar (`#glue-cookie-notification-bar-1`) is `position: fixed`
+at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The bar
+therefore lands **on** the settings trigger *and* on the image submit button.
+Measured 2026-09-11: `elementFromPoint` over each returned the bar's label span in
+5/5 rendered samples, on the same profile and project where the click had landed 3/3
+the day before — so it arrives whenever Google re-prompts for consent, not once per
+profile. The labs driver survives it by accident; `_bypass_onboarding` carries a text
+match on "Agree". The migrated driver had no equivalent.
+
+Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
+top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,
+so the message named nothing actionable.
+
+0.73.1 dismisses the bar before the first click, choosing **reject** over accept
+(both clear it; only one answers a consent question for you), and teaches the
+post-mortem to climb to the nearest ancestor that names itself, so any bar that
+still refuses to go is reported as `div.glue-cookie-notification-bar`.
+
+**Workaround on 0.73.0 and earlier:** open that profile once in Chrome and dismiss
+the bar by hand. Consent persists in the profile.
+
+Evidence: [`docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md`](https://github.com/ffroliva/gflow-cli/blob/main/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md).
+
 ### One-time Flow banner/modal can cover the composer on first load
 
 - **Status:** Open ([#369](https://github.com/ffroliva/gflow-cli/issues/369))

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -218,11 +218,13 @@ Installs from PyPI are unaffected.
 Google's `glue` consent bar (`#glue-cookie-notification-bar-1`) is `position: fixed`
 at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The bar
 therefore lands **on** the settings trigger *and* on the image submit button.
-Measured 2026-09-11: `elementFromPoint` over each returned the bar's label span in
-5/5 rendered samples, on the same profile and project where the click had landed 3/3
-the day before — so it arrives whenever Google re-prompts for consent, not once per
-profile. The labs driver survives it by accident; `_bypass_onboarding` carries a text
-match on "Agree". The migrated driver had no equivalent.
+Measured 2026-09-11 on the `ci-probe` profile: `elementFromPoint` over each returned
+the bar's label span in 5/5 rendered samples, on the same profile and project where
+the click had landed 3/3 the day before. **How widely it fires is unmeasured** — one
+account observed blocked, one observed already-consented — so treat the recurrence
+pattern as unknown rather than as once-per-profile. The labs driver survives it by
+accident; `_bypass_onboarding` carries a text match on "Agree". The migrated driver
+had no equivalent.
 
 Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
 top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,


### PR DESCRIPTION
## Summary

Google's `glue` consent bar is `position: fixed` at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The bar therefore lands **on** the settings trigger *and* on the image submit button, and every image and video run on `flow.google.com` fails until it goes. It fails before any submit, so nothing is billed.

Reported by @stgmt in #780. Their PR #781 carries a working dismissal bundled with a host-routing change and a diagnostics layer; this takes only the dismissal, because the surface is broken now. Review of the rest is on #781.

## The measurement

Spiked before reviewing, because the premise was unverified in-tree and I nearly rejected it. Both prior sightings of `glue-cookie-notification-bar` in this repo are labs.google, and the [2026-09-10 spike](https://github.com/ffroliva/gflow-cli/blob/develop/docs/superpowers/spikes/2026-09-10-migrated-click-blocked.md) read 159 DOM samples on this exact host and project and watched the click land 3/3. That spike never looked for a cookie bar.

Seventeen hours later, same profile, same project:

| Reading | Before | After the dismissal |
|---|---|---|
| bar elements visible | 6 / 6 | 0 / 4 |
| settings trigger hit-testable | 0 / 5 rendered | 4 / 4 |
| image submit hit-testable | 0 / 5 rendered | 4 / 4 |

The 2026-09-10 spike was right to record its 0/3 as *unmeasured* rather than as transience, and it named "a first visit after a Flow deployment" as the state it could not summon on demand. This is that state, arriving on its own.

Writeup: `docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md`. Script with a `--dismiss` control arm: `scripts/dev/spike_migrated_cookie_bar.py`.

## The change

**1. `_open_pane` clears the bar before its first click.** That is the one place the image and video paths meet, so neither caller carries a copy. It **rejects** rather than accepts: both buttons remove the bar and unblock the composer identically, and only one answers a consent question for the operator. `__accept` is first in DOM order, so anything reaching for "the first button" takes Agree.

**2. The click post-mortem names the thing on top, not its inner node.** #776's occluder allowlist matched `cdk|mat|mdc|flow` class prefixes on whatever `elementFromPoint` returned. A consent bar puts an unnamed label span there and keeps its identity in an `id` the allowlist deliberately drops, so a blocked user on 0.73.0 gets:

```
migrated host: .settings-trigger-button did not accept a click within 5000 ms
  — it is covered by span (host=migrated)
```

It now adds Google's `glue` prefix and climbs to the nearest ancestor that names itself, reporting `div.glue-cookie-notification-bar`. Unchanged for the CDK overlays that already worked; the `id` is still never echoed.

Because (2) makes a stuck bar self-describing, (1) is deliberately **best-effort** and does not raise. A bar that refuses to go falls through to the post-mortem. One attributed failure beats two competing ones, and it is the smaller diff.

## Verification

- **Offline:** 4234 passed, 24 skipped. The fake page's strict selector allowlist caught this change immediately and now models the bar, refusing the trigger click while it is up — the real geometry, reproduced rather than assumed.
- **E2E:** 8/8 in `tests/e2e/test_click_attribution_bdd.py`, two of them new. **Control run with the src change stashed: both new scenarios fail**, and the failure prints the exact `it is covered by span` this PR removes.
- **Live, $0:** `ensure_editor` → `apply_image_settings` → close against real Flow on `ci-probe`. Editor ready in 2 s, model and aspect bound, pane closed. This proves the new call is harmless on the ordinary bar-free page, which is the regression risk the change introduces.
- `ruff`, `ruff format`, `pyright src` (0 errors), and all six hygiene gates including the website mirror.

## What is NOT verified

**The cure against a live bar.** The spike's control arm consumed the consent on the only profile that had it, and a second profile (`denon82`) never reached the editor — both arms redirected to `/about`. So the live cure is proven in the browser against the measured DOM shape, not against a live bar, and **prevalence is unmeasured**: one account confirmed blocked, one confirmed already-consented.

This is recorded rather than claimed. What would settle it: the same probe on several profiles that reach the editor, next time Google re-prompts.

## MCP parity

No CLI surface change, no new option, no new output shape. Both doors share this transport, and the improved error detail reaches the queued path through the typed-error branch #778 established.

## Suggested release

Patch, `v0.73.1`. It is a bug fix with no API change, and 0.73.0 is what users have.

https://claude.ai/code/session_01Nr4XuvvZv3PrL3pKEzkrLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image and video generation failures on migrated Flow pages caused by Google’s cookie-consent bar blocking composer controls.
  * The consent prompt is now rejected automatically before interaction.
  * Improved click-error reporting to identify the blocking consent bar clearly.

* **Documentation**
  * Added known-issue details, affected versions, workaround guidance, and investigation findings for the consent-bar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->