### PR TITLE
docs(780): prevalence answered by mechanism, and the cure verified against a live bar

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -220,11 +220,19 @@ at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The
 therefore lands **on** the settings trigger *and* on the image submit button.
 Measured 2026-09-11 on the `ci-probe` profile: `elementFromPoint` over each returned
 the bar's label span in 5/5 rendered samples, on the same profile and project where
-the click had landed 3/3 the day before. **How widely it fires is unmeasured** — one
-account observed blocked, one observed already-consented — so treat the recurrence
-pattern as unknown rather than as once-per-profile. The labs driver survives it by
-accident; `_bypass_onboarding` carries a text match on "Agree". The migrated driver
-had no equivalent.
+the click had landed 3/3 the day before.
+
+**Who gets it:** anyone who has not yet dismissed it on that origin. The gate is a
+single key, `localStorage["glue.CookieNotificationBar"]` on `flow.google.com` — not a
+cookie, which is why no profile here carries `SOCS`. A clean browser profile reads the
+bar visible 4/4, and removing that key on a consented profile brings it straight back
+with both controls covered again. So it is the **default state**, and a stored
+dismissal is what removes it: every new gflow profile meets it on its first Flow load,
+and any profile whose stored dismissal Google resets meets it again — as `ci-probe` did
+within seventeen hours.
+
+The labs driver survives it by accident; `_bypass_onboarding` carries a text match on
+"Agree". The migrated driver had no equivalent.
 
 Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
 top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,

--- a/docs/LIVE_VERIFICATION_v0.73.1.md
+++ b/docs/LIVE_VERIFICATION_v0.73.1.md
@@ -76,7 +76,36 @@ without spending quota a second time.
 
 ---
 
-## What was NOT verified, and why
+## Addendum, same day — the two open items closed
+
+Both were recorded below as *not verified* at tag time. Both were then measured, and this
+section is the record rather than a rewrite of what shipped.
+
+**Prevalence — answered by mechanism.** A count of users is not obtainable here (no
+telemetry), but the gate is: `localStorage["glue.CookieNotificationBar"]` on the
+`flow.google.com` origin. Not a cookie, which is why no profile carried `SOCS`. A clean
+browser profile reads the bar visible **4/4**; a second untouched authenticated profile
+(`pr389fresh2`) read **5/5**. Removing that one key on `ci-probe` — touching no cookie,
+so no auth — flipped the editor from *both controls hit-testable* to **both covered by
+`span#glue-cookie-notification-bar-1-label`**. So the bar is the origin's default state
+and a stored dismissal is what removes it: every fresh profile meets it, and any profile
+whose dismissal Google resets meets it again.
+
+**The cure, against a live bar, on the released build.** With the bar restored by that
+intervention, the ordinary CLI command ran on `cli_version: 0.73.1`:
+`migrated.editor_ready` → **`migrated.cookie_bar_dismissed`** 86 ms later →
+`image_settings_applied` → `prompt_typed` → `status: ok`, media `257d8f79-…`, a
+651,576-byte `ffd8ffe0` JPEG that Pillow reads as 1024×1024 RGB.
+
+Still not measured: the *covering* geometry on a second account's editor. `denon82` and
+`pr389fresh2` both redirect to `/about`, so origin-level presence is measured on three
+profiles and the occlusion on one.
+
+---
+
+## What was NOT verified at tag time, and why
+
+*(The first two are closed by the addendum above; kept as written for the record.)*
 
 **The cure against a live bar, outside the browser.** The consent state is not summonable
 on demand, and this release's own control arm consumed it on the only profile that had it.

--- a/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
+++ b/docs/superpowers/spikes/2026-09-11-migrated-cookie-bar-blocks-the-composer.md
@@ -82,38 +82,78 @@ it could not measure was one "you cannot summon on demand — a first visit afte
 deployment". This is that state, arriving on its own. It is the reason that spike declined
 to call 0/3 evidence of transience, and it was right to.
 
-## How widely does it fire? Still n=1
+## How widely does it fire? Answered — by mechanism, not by a count
 
-A second profile was attempted specifically to answer this, and it did not answer it.
+A count of affected users is not obtainable from here: there is no telemetry. The
+mechanism is, and it is the more durable answer.
 
-`denon82` — an independent account, never touched by this spike — was driven at both
-hosts. **Both arms landed on `https://flow.google.com/about`**, not the project, so no
-composer ever mounted: `trigger_rendered_in` and `submit_rendered_in` were 0/5 in both.
-That run measured a marketing page. It is not a second sample and must not be counted as
-one.
+**A clean browser profile gets the bar.** A brand-new persistent context in a temp dir —
+no consent state by construction, not signed in — loaded `flow.google.com` and read the
+bar visible in **4/4** samples, same geometry (`position: fixed`, `z-index: 1000`, pinned
+to the bottom of the viewport), same `__accept` then `__reject` button order.
 
-The one thing it does say: on that origin the bar was **in the DOM but hidden** (5/5), so
-consent is already stored for `denon82`. Which is consistent with the mechanism — the bar
-is consent-state dependent, so it fires on a rolling subset of profiles rather than on
-everyone at once — but it is corroboration, not a measurement of prevalence.
+**A second authenticated profile had it up, untouched.** `pr389fresh2` — a different
+gflow profile that this spike had never opened — read **5/5** visible.
 
-**So: one account confirmed blocked, one account confirmed already-consented, prevalence
-unmeasured.** What would settle it: the same probe on several profiles that reach the
-editor. The `/about` redirect that stopped this one is separately recorded in
-[`2026-09-10-about-redirect-stability.md`](2026-09-10-about-redirect-stability.md) and was
-not investigated here.
+**And the gate is one localStorage key.** Diffed across a reject click on a throwaway
+profile: no cookie changes at all, and one key appears —
 
-## Two more things this did NOT measure
+```
+localStorage["glue.CookieNotificationBar"]   on the flow.google.com origin
+  → [{"category":"2A","date":"2026-09-11T…","siteId":…}]
+```
 
-**The labs contrast arm failed.** `ci-probe` is a moved account, so
+That is why no profile here carries `SOCS`, and why grepping for a consent *cookie*
+finds nothing.
+
+**Proven by intervention, not correlation.** Removing that one key on `ci-probe` — which
+touches no cookie and therefore no auth — and reloading the editor:
+
+| | key present | key removed |
+|---|---|---|
+| visible bars | 0 | 1 |
+| settings trigger | hit-testable | **covered by `span#glue-cookie-notification-bar-1-label`** |
+| image submit | hit-testable | **covered by `span#glue-cookie-notification-bar-1-label`** |
+
+So the bar is the **default state of the origin**, and stored consent is what removes it.
+`ci-probe` was not singled out. Every profile that has not yet dismissed it is exposed,
+which includes every freshly created gflow profile on its first Flow load, and any
+profile whose stored consent Google expires or resets — as happened to `ci-probe` within
+seventeen hours of a run where the click landed 3/3.
+
+## The cure, verified against a live bar
+
+With the bar restored by the intervention above, the ordinary CLI command was run on the
+**released** build:
+
+```
+gflow image t2i "a plain grey pebble on white paper, flat lighting"   --profile ci-probe --project 1e4efe0d-… --model nano-pro --aspect 1:1
+```
+
+`cli_version: 0.73.1` · `migrated.editor_ready` → **`migrated.cookie_bar_dismissed`** (86 ms
+later) → `image_settings_applied` → `prompt_typed` → `status: ok`, media
+`257d8f79-…`, a 651,576-byte `ffd8ffe0` JPEG that Pillow reads as 1024×1024 RGB.
+
+This is the item the release shipped as *not verified*. It is now measured.
+
+## Two things this did NOT measure
+
+**The labs contrast arm still failed.** `ci-probe` is a moved account, so
 `labs.google/fx/tools/flow/project/<id>` redirected straight to `flow.google.com` and the
 second arm re-measured the first. Whether an **unmoved** account sees the same bar on the
 labs editor is still unknown. It matters for PR #781's other half, which routes unmoved
 accounts onto the migrated host for images.
 
-**The state is now consumed.** The control arm clicked the bar's first button to dismiss
-it, so a re-run on `ci-probe` will read 0/N until Google re-prompts. Capture before you
-dismiss.
+**No second account reached an editor with the bar up.** `denon82` and `pr389fresh2` both
+redirect to `flow.google.com/about`, so the *covering* geometry is measured on one account
+only — the origin-level presence is measured on three. The `/about` redirect is separately
+recorded in [`2026-09-10-about-redirect-stability.md`](2026-09-10-about-redirect-stability.md)
+and was not investigated here.
+
+**The state is no longer scarce.** Deleting `localStorage["glue.CookieNotificationBar"]`
+on the flow.google.com origin restores the bar on demand, and the driver's own dismissal
+writes it back. Capture before you dismiss anyway — but a consumed reproducer is now one
+line to recreate, not a wait for Google.
 
 ## A finding the control arm produced by accident
 

--- a/website/docs/KNOWN_ISSUES.md
+++ b/website/docs/KNOWN_ISSUES.md
@@ -220,11 +220,19 @@ at `z-index: 1000`, and Flow's composer is bottom-anchored in the same band. The
 therefore lands **on** the settings trigger *and* on the image submit button.
 Measured 2026-09-11 on the `ci-probe` profile: `elementFromPoint` over each returned
 the bar's label span in 5/5 rendered samples, on the same profile and project where
-the click had landed 3/3 the day before. **How widely it fires is unmeasured** — one
-account observed blocked, one observed already-consented — so treat the recurrence
-pattern as unknown rather than as once-per-profile. The labs driver survives it by
-accident; `_bypass_onboarding` carries a text match on "Agree". The migrated driver
-had no equivalent.
+the click had landed 3/3 the day before.
+
+**Who gets it:** anyone who has not yet dismissed it on that origin. The gate is a
+single key, `localStorage["glue.CookieNotificationBar"]` on `flow.google.com` — not a
+cookie, which is why no profile here carries `SOCS`. A clean browser profile reads the
+bar visible 4/4, and removing that key on a consented profile brings it straight back
+with both controls covered again. So it is the **default state**, and a stored
+dismissal is what removes it: every new gflow profile meets it on its first Flow load,
+and any profile whose stored dismissal Google resets meets it again — as `ci-probe` did
+within seventeen hours.
+
+The labs driver survives it by accident; `_bypass_onboarding` carries a text match on
+"Agree". The migrated driver had no equivalent.
 
 Through 0.73.0 the run fails at exit 23 with `it is covered by span` — the element on
 top is the bar's label, whose identity lives in an `id` the occluder allowlist drops,


### PR DESCRIPTION
v0.73.1 shipped with two items recorded as **not verified**. Both are now measured.

## Prevalence — answered by mechanism, not a count

A count of affected users is not obtainable here (no telemetry). The gate is, and it is more durable:

```
localStorage["glue.CookieNotificationBar"]   on the flow.google.com origin
```

Not a cookie — which is why no profile carried `SOCS` and why grepping for a consent cookie found nothing. Measured by diffing cookies, localStorage and sessionStorage across a reject click on a throwaway profile: **zero** cookie changes, one new key.

Three independent observations of the bar, not one:

| Where | Bar visible |
|---|---|
| a clean browser profile, never signed in | 4 / 4 |
| `pr389fresh2`, authenticated, never opened by this spike | 5 / 5 |
| `ci-probe`, on the editor | 6 / 6, both controls covered |

And proven by **intervention** rather than correlation. Removing that one key on `ci-probe` — touching no cookie, so no auth — flipped the editor:

| | key present | key removed |
|---|---|---|
| visible bars | 0 | 1 |
| settings trigger | hit-testable | **covered** |
| image submit | hit-testable | **covered** |

So the bar is the origin's **default state** and a stored dismissal is what removes it. `ci-probe` was not singled out; every fresh gflow profile meets it on its first Flow load.

## The cure, against a live bar, on the released build

With the bar restored by that intervention, the ordinary CLI command:

`cli_version: 0.73.1` · `migrated.editor_ready` → **`migrated.cookie_bar_dismissed`** (86 ms later) → `image_settings_applied` → `prompt_typed` → `status: ok`, media `257d8f79-…`, a 651,576-byte `ffd8ffe0` JPEG that Pillow reads as 1024×1024 RGB.

## Still not measured, and it says so

The *covering* geometry on a **second** account's editor. `denon82` and `pr389fresh2` both redirect to `/about`, so origin-level presence is measured on three profiles and the occlusion on one.

## Note on the ledger

`docs/LIVE_VERIFICATION_v0.73.1.md` keeps its tag-time text and carries this as an **addendum** rather than being rewritten. What shipped unverified should stay legible.

Docs only — no source change, no version change.

https://claude.ai/code/session_01Nr4XuvvZv3PrL3pKEzkrLc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the cookie-consent bar appears by default for new or reset Flow profiles.
  - Documented that dismissing the bar stores consent locally, while reset profiles may see it again.
  - Added measured prevalence and verification results across multiple profiles, including validation on the released 0.73.1 build.
  - Updated known-issue guidance to note differing behavior between supported browsing drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->