### PR TITLE
fix(756): measure the /about retry flag, and unpin a test from terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `/about` landing's `retryable=False` is now a measurement, not a preserved
+  default.** A live occurrence was caught on a second account and the #756 stability
+  probe re-run unmodified: **5/5** attempts landed on `/about` over ~3 minutes, on the
+  account's own project, with a healthy session — so a retry is doomed and costs ~35 s
+  each. Two comments that said the measurement *could not* be made are corrected;
+  behaviour is unchanged. Still unmeasured: the cause, and whether it ever clears.
+- **An auth-status test no longer depends on how wide the terminal is.** Several steps
+  assert a substring of Rich's output, which hard-wraps — so a temp path landing near
+  the wrap column split `experiments` into `profile_e` + `xperiments` and failed on
+  formatting rather than behaviour. Pinned at the shared `CliRunner` fixture, which is
+  the one chokepoint for every invoke in that file.
+
 ## [0.73.1] — 2026-09-11
 
 ### Fixed

--- a/docs/superpowers/spikes/2026-09-10-about-redirect-stability.md
+++ b/docs/superpowers/spikes/2026-09-10-about-redirect-stability.md
@@ -60,9 +60,12 @@ existing answer instead of inventing a new one under cover of an exit-code chang
 
 - **Why the redirect happened at all**, in either direction. Out of scope by design;
   #756 warns against a fix that asserts an unmeasured cause.
-- **Whether a *second* attempt wins during a live occurrence.** This is the question
-  that actually settles the flag, and it needs someone to catch the redirect while it
-  is happening. Re-run this script with `--attempts 5` at that moment and the answer
-  falls out.
+- ~~**Whether a *second* attempt wins during a live occurrence.**~~ **ANSWERED
+  2026-09-11 — see [`2026-09-11-about-redirect-is-stable-for-an-account.md`](2026-09-11-about-redirect-is-stable-for-an-account.md).**
+  A live occurrence was caught on `denon82` while measuring something else, this script
+  was re-run unmodified at `--attempts 5`, and it came back **5/5 `/about`** over ~3
+  minutes on the account's own project with a healthy session. Per the reading
+  pre-registered above, that is *stable*: a retry is doomed, and `retryable=False` is now
+  the measured answer rather than the preserved one.
 - **Any other account.** One profile is one account; per
   `flow-capabilities-are-cohort-dependent`, an account is not a cohort.

--- a/docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md
+++ b/docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md
@@ -1,0 +1,82 @@
+# Does a retry win during a LIVE `/about` occurrence? — 5/5 no. Stable.
+
+- **Date:** 2026-09-11
+- **Script:** [`scripts/dev/spike_about_redirect_stability.py`](../../../scripts/dev/spike_about_redirect_stability.py) (unchanged — `--profile denon82`)
+- **Profile / project:** `denon82` · `4ccb3222-…` — **the account's own project**
+- **Cost:** $0 — five navigations, no generation
+- **Raw:** `scripts/dev/_spike_out/about_redirect_stability_20260911_141153.json` (gitignored)
+- **Refs:** [#756](https://github.com/ffroliva/gflow-cli/issues/756)
+
+## The question the previous run left open
+
+[`2026-09-10-about-redirect-stability.md`](2026-09-10-about-redirect-stability.md) got
+**0 of 5** — the redirect had stopped reproducing on `ci-probe` — and recorded that as
+*unmeasured* rather than as transience. It then named, precisely, what would settle it:
+
+> **Whether a *second* attempt wins during a live occurrence.** This is the question that
+> actually settles the flag, and it needs someone to catch the redirect while it is
+> happening. Re-run this script with `--attempts 5` at that moment and the answer falls
+> out.
+
+While measuring something else entirely (the #780 consent bar), `denon82` turned out to be
+redirecting. That is the moment. The script was run **unmodified**, so the reading it
+pre-registered still governs.
+
+## Pre-registered readings — inherited, not rewritten
+
+| Outcome | Reading |
+|---|---|
+| N/N `/about` | stable for this account — a retry is doomed; must not be retryable |
+| mixed | it flaps — a retry can win; retryable is defensible |
+| 0/N `/about` | does not reproduce; settles **nothing** |
+
+## What was observed
+
+| # | Result | Landed | Elapsed |
+|---|---|---|---|
+| 1 | raised, `is_about=True` | `/about` | 31.2 s |
+| 2 | raised, `is_about=True` | `/about` | 35.1 s |
+| 3 | raised, `is_about=True` | `/about` | 35.3 s |
+| 4 | raised, `is_about=True` | `/about` | 34.9 s |
+| 5 | raised, `is_about=True` | `/about` | 35.0 s |
+
+**5 of 5**, over roughly three minutes of consecutive attempts.
+
+The session was healthy throughout — `flow_session_cookie_present=True`,
+`flow_session_cookie_expired=False`, `google_sapisid_present=True`, 68 context cookies —
+and the project is **the account's own**, listed by `gflow project list` on that same
+profile. So this is neither an expired session nor a project the account cannot see.
+
+## Verdict: STABLE, and the retry flag is now measured
+
+`retryable=False` at `_common.py::raise_if_known_landing` was previously a **preserved
+default** — the code comment and `FlowAppError`'s docstring both said so in as many words,
+because the 2026-09-10 run could not measure it. It is now the measured answer: a retry is
+doomed for an account in this state, and five of them cost a user **~3 minutes** to learn
+nothing.
+
+Both comments are corrected in the same change as this document. They were accurate when
+written and became false the moment this ran, which is exactly the kind of claim this
+repo's Iron Law is about.
+
+## What is still NOT measured
+
+**Why the redirect happens**, in either direction. Unchanged and deliberately so — #756
+warns against a fix that asserts an unmeasured cause, and nothing here names one. What is
+now *excluded* is narrower but real: not an expired session, not a missing project, and
+not transience.
+
+**Whether it ever clears for this account**, and on what timescale. Five attempts over
+three minutes is stability at that scale, not forever. `ci-probe` went from reproducing
+(2026-09-08) to not (2026-09-10) without anyone watching the transition.
+
+**Any wider population.** Two accounts have now shown it — `denon82` today, `ci-probe`
+before 2026-09-10 — and one account is still not a cohort.
+
+## A consequence worth naming
+
+This is what blocked the #780 consent-bar spike from measuring the covering geometry on a
+**second** account's editor: `denon82` and `pr389fresh2` both land here, so neither can
+mount a composer at all. That gap is recorded in
+[`2026-09-11-migrated-cookie-bar-blocks-the-composer.md`](2026-09-11-migrated-cookie-bar-blocks-the-composer.md)
+and now has a named cause rather than an unexplained one.

--- a/src/gflow_cli/api/transports/_common.py
+++ b/src/gflow_cli/api/transports/_common.py
@@ -264,9 +264,12 @@ def raise_if_known_landing(page: object, *, requested: str, at: str) -> None:
             f"may not have access to that project on this host. It is not selector "
             f"drift, and no gflow-cli release changes it."
         ),
-        # NOT a claim that a retry fails — the ABSENCE of one. See FlowAppError's
-        # docstring for the measurement that could not be made and why False preserves
-        # the answer this shape already gave as exit 23.
+        # MEASURED, as of 2026-09-11: 5/5 consecutive attempts over ~3 minutes on a
+        # live occurrence all landed here, on the account's own project, with a healthy
+        # session. A retry is doomed for an account in this state and costs ~35 s each.
+        # (This was a PRESERVED default until that run — the 2026-09-10 spike got 0/5
+        # because the redirect had stopped reproducing. See
+        # docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md.)
         retryable=False,
     )
 

--- a/src/gflow_cli/errors.py
+++ b/src/gflow_cli/errors.py
@@ -715,12 +715,15 @@ class FlowAppError(GFlowError):
     1. **Its React error boundary** — the app crashed client-side. Transient;
        retry works. Detected at the mode-switch raise site via the error-page title.
     2. **A redirect to Flow's public landing page** (``/about``, #756) — the app
-       declined to open the project for this session. *Why* is not measured:
+       declined to open the project for this session. *Why* is still not measured:
        ``gflow auth status`` reports the session verified while it happens, so the
-       message names the redirect and stops rather than inventing a cause. Nor is it
-       known whether a retry helps — the redirect stopped reproducing before it could
-       be measured (spike 2026-09-10), so this raise site passes ``retryable=False``
-       to PRESERVE the answer it gave as exit 23, not to claim a retry fails.
+       message names the redirect and stops rather than inventing a cause. Whether a
+       retry helps **is** now measured, on a live occurrence caught 2026-09-11: 5/5
+       consecutive attempts landed on ``/about``, over ~3 minutes, on the account's
+       own project with a healthy session — so ``retryable=False`` at that raise site
+       is the measured answer, not the preserved one it was through 2026-09-10.
+       Excluded by that run, narrowly: not an expired session, not a missing project,
+       not transience. Still open: the cause, and whether it ever clears.
 
     Both otherwise surface as a misleading ``UiSelectorDriftError`` "file a bug" —
     which is the whole reason this class exists. See

--- a/tests/features/test_auth_steps.py
+++ b/tests/features/test_auth_steps.py
@@ -34,7 +34,16 @@ scenarios("auth.feature")
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner()
+    # Pin the console width. Rich hard-wraps its output to the terminal, and several
+    # `then` steps below assert a SUBSTRING of it — so a profile path that happens to
+    # land near the wrap column splits the word and the assertion fails on formatting,
+    # not on behaviour. Reproduced 2026-09-11: `--basetemp=…/t9` printed
+    # "profile_e\nxperiments" and failed `"experiments" in result.output`, while
+    # `--basetemp=…/t10b` passed — same code, same assertion, one character of path.
+    # Pinned at the fixture because it is the single chokepoint for every invoke here;
+    # normalising newlines at each assertion would fix the symptom ten times and let
+    # the eleventh one in.
+    return CliRunner(env={"COLUMNS": "200"})
 
 
 @pytest.fixture


### PR DESCRIPTION
Two independent findings, both from catching a live `/about` occurrence while measuring something else.

## 1. The `/about` retry flag is now measured

The [2026-09-10 spike](https://github.com/ffroliva/gflow-cli/blob/develop/docs/superpowers/spikes/2026-09-10-about-redirect-stability.md) got **0/5** — the redirect had stopped reproducing — and recorded that as *unmeasured* rather than as transience. It then named exactly what would settle it: catch a live occurrence and re-run with `--attempts 5`.

`denon82` was redirecting. The script was run **unmodified**, so its pre-registered reading still governs.

| # | Result | Elapsed |
|---|---|---|
| 1–5 | `/about`, every time | 31–35 s each |

**5 of 5**, over ~3 minutes. The session was healthy throughout (cookie present, not expired, SAPISID present, 68 cookies) and the project is the account's **own**. So this is neither an expired session nor a project the account cannot see.

Per the inherited reading, N/N means *stable*: a retry is doomed, and costs a user ~35 s to learn nothing. `retryable=False` was a **preserved default**, and both the code comment and `FlowAppError`'s docstring said so in as many words. Those two statements became false the moment this ran. **Behaviour is unchanged** — the flag was already right, it just was not known to be.

Still not measured, and it says so: *why* it happens, and whether it ever clears. Newly excluded, narrowly: not an expired session, not a missing project, not transience.

This also explains rather than merely notes why the #780 spike could not measure the covering geometry on a second account's editor — `denon82` and `pr389fresh2` both land here, so neither mounts a composer.

## 2. An auth test depended on terminal width

Found while running the suite for (1), and **proven not to be my change by a control**: same `--basetemp`, my edits stashed, still fails.

`test_auth_steps.py` asserts substrings of Rich's output, which hard-wraps to the terminal. A temp path landing near the wrap column split the word:

```
--basetemp=…/t9     ->  "profile_e\nxperiments"  ->  FAILS
--basetemp=…/t10b   ->  "profile_experiments"    ->  passes
```

Same code, same assertion, one character of path. A latent CI flake waiting for a runner whose tmp path is a different length.

Pinned `COLUMNS` at the shared `CliRunner` fixture rather than normalising newlines at each of the ten assertion sites — the fixture is the single chokepoint, and fixing the symptom ten times lets the eleventh one in.

## Verification

- The four path lengths that flipped it: all pass.
- Full offline suite **at the path that exposed the flake**: 4234 passed, 24 skipped.
- `ruff`, `ruff format`, `pyright src` 0 errors, doc links, hygiene, website mirror.

https://claude.ai/code/session_01Nr4XuvvZv3PrL3pKEzkrLc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented measured stability of the `/about` redirect across five consecutive attempts.
  * Clarified that the redirect is treated as non-retryable based on observed behavior, while its underlying cause remains unresolved.
  * Added supporting spike findings and updated the changelog.

* **Tests**
  * Stabilized authentication output checks by using a consistent terminal width, preventing formatting-dependent assertion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->