### PR TITLE
spike(756): the /about redirect is decided client-side, without asking Flow anything

### DIFF
--- a/docs/superpowers/spikes/2026-09-11-about-redirect-is-decided-client-side.md
+++ b/docs/superpowers/spikes/2026-09-11-about-redirect-is-decided-client-side.md
@@ -1,0 +1,93 @@
+# The `/about` redirect is decided client-side, in ~200 ms, without asking Flow anything
+
+- **Date:** 2026-09-11
+- **Script:** [`scripts/dev/spike_about_redirect_cause.py`](../../../scripts/dev/spike_about_redirect_cause.py)
+- **Arms:** `denon82` (redirects) vs `ci-probe` (opens) — an **A/B**, not an inspection
+- **Cost:** $0 — navigations and response *metadata* only. No bodies, no headers, no generation.
+- **Raw:** `scripts/dev/_spike_out/spike_about_redirect_cause_20260911_154808.json` (gitignored)
+- **Refs:** [#756](https://github.com/ffroliva/gflow-cli/issues/756)
+
+## Why it was askable at all
+
+#756 measured the redirect and explicitly declined to measure its cause. The
+[2026-09-10 spike](2026-09-10-about-redirect-stability.md) could not investigate one
+because the redirect had stopped reproducing. As of today it reproduces **stably** on
+`denon82` ([5/5](2026-09-11-about-redirect-is-stable-for-an-account.md)), and a stable
+reproducer is the condition under which a cause becomes measurable. That state is
+perishable — `ci-probe` went from reproducing to not in two days with nobody watching —
+so it was measured while it was there.
+
+One clue was already in hand: `gflow project list` on `denon82` returns 50 projects
+**including** the one that redirects. The backend grants access while the frontend
+declines to open it.
+
+## Pre-registered readings
+
+| Outcome | Reading |
+|---|---|
+| document 3xx with `Location: /about` | server-side; the app never boots |
+| document 200, then a client-side navigation | the app boots and decides; the differing rpcid is the lead |
+| an rpcid in both, non-2xx only on `denon82` | that call is the decision point |
+| the arms differ in no request at all | not on the wire; record as unmeasured |
+
+## What was observed
+
+| | `denon82` (fails) | `ci-probe` (control) |
+|---|---|---|
+| document response | **200**, no `Location` | **200**, no `Location` |
+| first navigation | 146 ms, `/project/<id>` | 90 ms, `/project/<id>` |
+| second navigation | **338 ms, `/about`** | 700 ms, same `/project/<id>` |
+| total responses | 7 | 43 |
+| `batchexecute` calls | **0** | 20, first at **275 ms** |
+| non-2xx from any Flow endpoint | **none** | none |
+
+The only non-2xx on the failing arm is `play.google.com/log` 401 — telemetry, on a
+different origin, and unrelated.
+
+## Verdict
+
+**Not a server-side redirect.** Both documents are served `200` with no `Location`. This
+is the app deciding, client-side, 192 ms after its own first navigation commits.
+
+**And it decides without asking Flow.** The failing arm issued **zero** `batchexecute`
+calls — not "called and was refused", *never called*. There is no 401, no 403, no 404 to
+point at, because there is no request. The sixteen rpcids the control makes
+(`Zzl0ze`, `as29s`, `tRARke`, …) are simply absent.
+
+The cross-arm timing is what makes that a finding rather than a race: the control had
+already made its **first** rpc at 275 ms, before the failing arm hopped at 338 ms. Two
+runs, so this is suggestive rather than airtight — but combined with zero calls in the
+5.5 s *after* the hop, the app plainly is not waiting on a Flow answer to decide.
+
+**It is account-wide, not project-specific.** A second `denon82` project
+(`5200b87d-…`) redirects identically, 2/2.
+
+So the signal the app acts on is already present at page load — embedded bootstrap data,
+a cookie, or client-side storage — and not fetched.
+
+## What this does NOT establish
+
+**Which signal.** Naming it means reading the document's embedded bootstrap payload,
+which on this origin is exactly where bearer tokens and account data live. Not read here.
+#756's warning stands: **do not encode a remedy that asserts a mechanism this cannot
+see.** A lead is not a cause.
+
+**Whether it ever clears, or why it started.** Five attempts over three minutes plus two
+more on another project is stability at that scale, not forever.
+
+**Any wider population.** Two accounts have shown it — `denon82` now, `ci-probe` before
+2026-09-10 — and an account is not a cohort.
+
+**What would settle it:** a HAR capture of the failing document through
+[`scripts/dev/har-spike/`](../../../scripts/dev/har-spike/README.md), diffed against a
+working one, with `extract_har_summary.py` producing the redacted summary. That harness
+exists for exactly this and is the tiebreaker rung. It was not run here because the
+finding above already changes what the next person should look at, and because a raw
+capture of this page must not leave the machine.
+
+## What changes as a result
+
+Nothing in the code. `retryable=False` was already correct and is now measured
+([the stability spike](2026-09-11-about-redirect-is-stable-for-an-account.md)); the
+message already names the redirect and stops. This narrows the search for whoever picks
+up #756: it is not a permissions call being refused, so looking for one is a dead end.

--- a/docs/superpowers/spikes/2026-09-11-about-redirect-is-decided-client-side.md
+++ b/docs/superpowers/spikes/2026-09-11-about-redirect-is-decided-client-side.md
@@ -4,7 +4,7 @@
 - **Script:** [`scripts/dev/spike_about_redirect_cause.py`](../../../scripts/dev/spike_about_redirect_cause.py)
 - **Arms:** `denon82` (redirects) vs `ci-probe` (opens) — an **A/B**, not an inspection
 - **Cost:** $0 — navigations and response *metadata* only. No bodies, no headers, no generation.
-- **Raw:** `scripts/dev/_spike_out/spike_about_redirect_cause_20260911_154808.json` (gitignored)
+- **Raw:** `scripts/dev/_spike_out/spike_about_redirect_cause_20260911_{154808,192135}.json` (gitignored)
 - **Refs:** [#756](https://github.com/ffroliva/gflow-cli/issues/756)
 
 ## Why it was askable at all
@@ -35,24 +35,39 @@ declines to open it.
 | | `denon82` (fails) | `ci-probe` (control) |
 |---|---|---|
 | document response | **200**, no `Location` | **200**, no `Location` |
+| document **resolved** URL | `/project/<id>` | `/project/<id>` |
+| any 3xx response at all | **none** | one — an avatar on `lh3.google.com` |
 | first navigation | 146 ms, `/project/<id>` | 90 ms, `/project/<id>` |
 | second navigation | **338 ms, `/about`** | 700 ms, same `/project/<id>` |
 | total responses | 7 | 43 |
-| `batchexecute` calls | **0** | 20, first at **275 ms** |
+| Flow requests: `batchexecute` | **0** | 20, first at **275 ms** |
+| Flow requests: **anything else** | **1 — the document itself** | 15 |
+| non-Flow (fonts, GTM, analytics, OneGoogle, Play) | 6 | 8 |
 | non-2xx from any Flow endpoint | **none** | none |
 
-The only non-2xx on the failing arm is `play.google.com/log` 401 — telemetry, on a
-different origin, and unrelated.
+Every response is classified, not just the `batchexecute` ones: "zero `batchexecute`
+calls" is a statement about one route shape and would leave any other Flow request
+unexamined. Classified in full, the failing arm's **only** request to `flow.google.com`
+is the document. The single non-2xx anywhere is `play.google.com/log` 401 — telemetry, a
+different origin, present regardless.
+
+Two runs, ~3.5 hours apart, identical on every row above.
 
 ## Verdict
 
-**Not a server-side redirect.** Both documents are served `200` with no `Location`. This
-is the app deciding, client-side, 192 ms after its own first navigation commits.
+**Not a server-side redirect.** `page.goto` resolves to the *final* main resource after
+following any server redirect, so a `200` with no `Location` is on its own consistent
+with both a client hop and a 302 to `/about` — the status alone settles nothing. Two
+things do: the document's **resolved URL is `/project/<id>`**, not `/about` (a server
+redirect would have resolved to the destination), and there is **no 3xx response
+anywhere** in the failing arm. So this is the app deciding, client-side, 192 ms after its
+own first navigation commits.
 
-**And it decides without asking Flow.** The failing arm issued **zero** `batchexecute`
-calls — not "called and was refused", *never called*. There is no 401, no 403, no 404 to
-point at, because there is no request. The sixteen rpcids the control makes
-(`Zzl0ze`, `as29s`, `tRARke`, …) are simply absent.
+**And it decides without asking Flow.** The failing arm's only request to
+`flow.google.com` is the document itself — zero `batchexecute`, and zero of anything
+else. Not "called and was refused", *never called*. There is no 401, no 403, no 404 to
+point at, because there is no request. The sixteen rpcids the control makes (`Zzl0ze`,
+`as29s`, `tRARke`, …) are simply absent, as are its other fifteen Flow calls.
 
 The cross-arm timing is what makes that a finding rather than a race: the control had
 already made its **first** rpc at 275 ms, before the failing arm hopped at 338 ms. Two

--- a/docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md
+++ b/docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md
@@ -61,10 +61,13 @@ repo's Iron Law is about.
 
 ## What is still NOT measured
 
-**Why the redirect happens**, in either direction. Unchanged and deliberately so — #756
-warns against a fix that asserts an unmeasured cause, and nothing here names one. What is
-now *excluded* is narrower but real: not an expired session, not a missing project, and
-not transience.
+**Why the redirect happens**, in either direction. Narrowed the same day by
+[`2026-09-11-about-redirect-is-decided-client-side.md`](2026-09-11-about-redirect-is-decided-client-side.md),
+which A/B'd the wire against a working account: the document is served **200** with no
+`Location`, the hop is client-side at 338 ms, and the failing arm makes **zero**
+`batchexecute` calls — so there is no refused permissions call to point at. Still not
+named, and #756's warning still stands. What is *excluded* is narrower but real: not an
+expired session, not a missing project, not transience, and not a server-side redirect.
 
 **Whether it ever clears for this account**, and on what timescale. Five attempts over
 three minutes is stability at that scale, not forever. `ci-probe` went from reproducing
@@ -72,6 +75,9 @@ three minutes is stability at that scale, not forever. `ci-probe` went from repr
 
 **Any wider population.** Two accounts have now shown it — `denon82` today, `ci-probe`
 before 2026-09-10 — and one account is still not a cohort.
+
+It is, however, **account-wide rather than project-specific**: a second `denon82` project
+(`5200b87d-…`) redirects identically, 2/2.
 
 ## A consequence worth naming
 

--- a/scripts/dev/spike_about_redirect_cause.py
+++ b/scripts/dev/spike_about_redirect_cause.py
@@ -174,30 +174,83 @@ def _rpcids(arm: dict[str, Any]) -> dict[str, list[int]]:
     return out
 
 
+#: Hosts that are Google furniture rather than Flow's API: fonts, tag manager, analytics,
+#: the OneGoogle account bar, Play logging. Listed so EVERY response can be classified —
+#: "zero batchexecute calls" is a statement about one route shape and would leave any
+#: other Flow request unexamined, which is not the same claim at all.
+_NON_FLOW_HOSTS = (
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+    "www.googletagmanager.com",
+    "region1.google-analytics.com",
+    "www.google-analytics.com",
+    "ogads-pa.clients6.google.com",
+    "play.google.com",
+    "lh3.google.com",
+    "www.gstatic.com",
+)
+
+
+def _classify(arm: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Every response, bucketed — so nothing is left unexamined by omission."""
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "flow_batchexecute": [],
+        "flow_other": [],
+        "non_flow": [],
+    }
+    for r in arm["responses"]:
+        host = urlsplit(r["route"]).netloc
+        if "rpcids=" in r["route"]:
+            buckets["flow_batchexecute"].append(r)
+        elif any(host == h for h in _NON_FLOW_HOSTS):
+            buckets["non_flow"].append(r)
+        else:
+            buckets["flow_other"].append(r)
+    return buckets
+
+
 def report(failing: dict[str, Any], control: dict[str, Any]) -> dict[str, Any]:
     f_rpc, c_rpc = _rpcids(failing), _rpcids(control)
-    f_bad = [r for r in failing["responses"] if r["status"] >= 400]
-    c_bad = [r for r in control["responses"] if r["status"] >= 400]
+    f_cls, c_cls = _classify(failing), _classify(control)
     return {
-        "document_status": {
-            "failing": (failing.get("document") or {}).get("status"),
-            "control": (control.get("document") or {}).get("status"),
+        "document": {
+            # `page.goto` resolves to the FINAL main resource after following any server
+            # redirect, so `status` alone cannot tell 200-then-client-hop from
+            # 302-to-/about: both end 200 with no Location. The discriminators are the
+            # resolved URL (a server redirect resolves to /about) and the 3xx list below.
+            "failing_status": (failing.get("document") or {}).get("status"),
+            "failing_resolved_url": (failing.get("document") or {}).get("url"),
             "failing_location": (failing.get("document") or {}).get("location"),
+            "failing_requested": failing["requested"],
+            "control_status": (control.get("document") or {}).get("status"),
+        },
+        "redirect_responses_3xx": {
+            "failing": [r for r in failing["responses"] if 300 <= r["status"] < 400],
+            "control": [r for r in control["responses"] if 300 <= r["status"] < 400],
         },
         "landed": {"failing": failing["landed"], "control": control["landed"]},
         "navigation_count": {
             "failing": len(failing["navigations"]),
             "control": len(control["navigations"]),
         },
+        "response_classes": {
+            arm: {k: len(v) for k, v in cls.items()}
+            for arm, cls in (("failing", f_cls), ("control", c_cls))
+        },
+        # Named in full, because "0 batchexecute" is not "no Flow request".
+        "failing_flow_requests_other_than_batchexecute": f_cls["flow_other"],
+        "failing_all_routes": [r["route"] for r in failing["responses"]],
         "rpcids_only_in_control": sorted(set(c_rpc) - set(f_rpc)),
         "rpcids_only_in_failing": sorted(set(f_rpc) - set(c_rpc)),
+        # Multiset, not set: [200] and [200, 200] are different answers, and collapsing
+        # them would hide a call the failing arm made half as often.
         "rpcids_in_both_differing_status": {
-            k: {"failing": f_rpc[k], "control": c_rpc[k]}
+            k: {"failing": sorted(f_rpc[k]), "control": sorted(c_rpc[k])}
             for k in sorted(set(f_rpc) & set(c_rpc))
-            if set(f_rpc[k]) != set(c_rpc[k])
+            if sorted(f_rpc[k]) != sorted(c_rpc[k])
         },
-        "non_2xx_failing": f_bad,
-        "non_2xx_control": c_bad,
+        "non_2xx_failing": [r for r in failing["responses"] if r["status"] >= 400],
+        "non_2xx_control": [r for r in control["responses"] if r["status"] >= 400],
     }
 
 

--- a/scripts/dev/spike_about_redirect_cause.py
+++ b/scripts/dev/spike_about_redirect_cause.py
@@ -1,0 +1,234 @@
+r"""WHY does flow.google.com redirect a project to /about? A/B on the wire. ($0)
+
+#756 measured the redirect and explicitly declined to measure its cause, and the
+2026-09-10 stability spike could not investigate one because the redirect had stopped
+reproducing. As of 2026-09-11 it reproduces **stably** on `denon82` -- 5/5, see
+`docs/superpowers/spikes/2026-09-11-about-redirect-is-stable-for-an-account.md` -- and a
+stable reproducer is the condition a cause becomes measurable in. That state is
+perishable: `ci-probe` went from reproducing to not in two days with nobody watching.
+
+One clue is already in hand and it is a sharp one: `gflow project list` on `denon82`
+returns 50 projects INCLUDING the one that redirects. So the backend grants access to it
+while the frontend declines to open it. That rules out "the account cannot see the
+project" and points at what the app asks for between `goto` and the hop.
+
+    A REDIRECT IS EVIDENCE ABOUT WHAT THE APP ASKED AND WAS TOLD.
+    IT IS NOT, BY ITSELF, EVIDENCE ABOUT ACCESS.
+
+## The design: an A/B, not an inspection
+
+Reading only the failing account would show a page that redirects and a pile of requests,
+with nothing to say which of them is abnormal. So the SAME capture runs on:
+
+- `denon82`  -- redirects (the arm under test)
+- `ci-probe` -- opens the editor (the control)
+
+and the finding is the DIFFERENCE. A request present in both proves nothing; one that
+appears, fails, or is answered differently only in the failing arm is the lead.
+
+## What is recorded
+
+- the document response itself: status, and any `Location` (server 302 vs client-side hop)
+- every `batchexecute` rpcid, with status, for both arms
+- any non-2xx on either arm, with the route stripped of its query
+- the navigation timeline, so a client-side hop is visible as a second navigation
+- how long after `goto` the hop lands
+
+Deliberately NOT recorded: request bodies, response bodies, headers, cookies. The
+question is *which call was answered how*, and bodies on this origin carry prompts and
+bearer tokens.
+
+## Pre-registered readings -- written before the run
+
+| Outcome | Reading |
+|---|---|
+| document 3xx + `Location` | server-side; the app never boots |
+| document 200, then a client hop | the app decides; the differing rpcid is the lead |
+| rpcid in both, non-2xx only here | that call is the decision point -- never guess it |
+| no request differs at all | not on the wire; record unmeasured, say what settles it |
+
+A named call is a LEAD, not a cause. #756's warning stands: do not encode a remedy that
+asserts a mechanism this cannot see.
+
+## Cost
+
+Zero. Two navigations per arm, metadata only, no generation, nothing written to Flow.
+
+    python scripts/dev/spike_about_redirect_cause.py \
+        --failing denon82 --failing-project 4ccb3222-... \
+        --control ci-probe --control-project 1e4efe0d-...
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+MIGRATED_PROJECT_URL = "https://flow.google.com/project/{project_id}"
+
+
+def _route(url: str) -> str:
+    """Query-stripped route. Flow's URLs carry rpcids in the query, so keep the ONE
+    parameter that names the call and drop everything else (auth, tokens, prompts)."""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "<unparseable>"
+    rpcids = ""
+    for chunk in (parts.query or "").split("&"):
+        if chunk.startswith("rpcids="):
+            rpcids = f"?{chunk}"
+            break
+    return f"{parts.scheme}://{parts.netloc}{parts.path}{rpcids}"
+
+
+async def capture(profile: str, project_id: str, *, label: str, settle_s: float) -> dict[str, Any]:
+    responses: list[dict[str, Any]] = []
+    navigations: list[dict[str, Any]] = []
+
+    async with build_client(resolve_profile_dir(profile)) as client:
+        page = client.transport._page  # noqa: SLF001
+        target = MIGRATED_PROJECT_URL.format(project_id=project_id)
+        t0 = time.monotonic()
+
+        def on_response(resp: Any) -> None:
+            try:
+                url = str(resp.url)
+                if "google" not in urlsplit(url).netloc:
+                    return
+                responses.append(
+                    {
+                        "t_ms": round((time.monotonic() - t0) * 1000),
+                        "status": int(resp.status),
+                        "route": _route(url),
+                    }
+                )
+            except Exception:  # noqa: BLE001 - a listener must never break the run
+                return
+
+        def on_nav(frame: Any) -> None:
+            try:
+                if frame == page.main_frame:
+                    navigations.append(
+                        {
+                            "t_ms": round((time.monotonic() - t0) * 1000),
+                            "url": _route(str(frame.url)),
+                        }
+                    )
+            except Exception:  # noqa: BLE001
+                return
+
+        page.on("response", on_response)
+        page.on("framenavigated", on_nav)
+        try:
+            step(label, f"goto {target}")
+            nav = await page.goto(target, wait_until="domcontentloaded", timeout=45_000)
+            doc = (
+                {
+                    "status": int(nav.status),
+                    "url": _route(str(nav.url)),
+                    "location": (await nav.header_value("location")) or None,
+                }
+                if nav is not None
+                else None
+            )
+            await asyncio.sleep(settle_s)
+        finally:
+            page.remove_listener("response", on_response)
+            page.remove_listener("framenavigated", on_nav)
+
+        landed = _route(str(page.url))
+        step(label, f"landed {landed}")
+        return {
+            "label": label,
+            "profile": profile,
+            "requested": _route(target),
+            "landed": landed,
+            "is_about": landed.endswith("/about"),
+            "document": doc,
+            "navigations": navigations,
+            "responses": responses,
+        }
+
+
+def _rpcids(arm: dict[str, Any]) -> dict[str, list[int]]:
+    out: dict[str, list[int]] = {}
+    for r in arm["responses"]:
+        if "rpcids=" in r["route"]:
+            out.setdefault(r["route"].split("rpcids=")[1], []).append(r["status"])
+    return out
+
+
+def report(failing: dict[str, Any], control: dict[str, Any]) -> dict[str, Any]:
+    f_rpc, c_rpc = _rpcids(failing), _rpcids(control)
+    f_bad = [r for r in failing["responses"] if r["status"] >= 400]
+    c_bad = [r for r in control["responses"] if r["status"] >= 400]
+    return {
+        "document_status": {
+            "failing": (failing.get("document") or {}).get("status"),
+            "control": (control.get("document") or {}).get("status"),
+            "failing_location": (failing.get("document") or {}).get("location"),
+        },
+        "landed": {"failing": failing["landed"], "control": control["landed"]},
+        "navigation_count": {
+            "failing": len(failing["navigations"]),
+            "control": len(control["navigations"]),
+        },
+        "rpcids_only_in_control": sorted(set(c_rpc) - set(f_rpc)),
+        "rpcids_only_in_failing": sorted(set(f_rpc) - set(c_rpc)),
+        "rpcids_in_both_differing_status": {
+            k: {"failing": f_rpc[k], "control": c_rpc[k]}
+            for k in sorted(set(f_rpc) & set(c_rpc))
+            if set(f_rpc[k]) != set(c_rpc[k])
+        },
+        "non_2xx_failing": f_bad,
+        "non_2xx_control": c_bad,
+    }
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--failing", required=True)
+    ap.add_argument("--failing-project", required=True)
+    ap.add_argument("--control", required=True)
+    ap.add_argument("--control-project", required=True)
+    ap.add_argument("--settle-s", type=float, default=12.0)
+    args = ap.parse_args()
+
+    failing = await capture(
+        args.failing, args.failing_project, label="failing", settle_s=args.settle_s
+    )
+    control = await capture(
+        args.control, args.control_project, label="control", settle_s=args.settle_s
+    )
+    result = {
+        "question": "why does flow.google.com redirect a project to /about? (#756)",
+        "cost": "credit-free: two navigations, response metadata only, no bodies",
+        "failing": failing,
+        "control": control,
+        "diff": report(failing, control),
+    }
+    out = default_out_path("spike_about_redirect_cause", ".json")
+    out.write_text(json.dumps(result, indent=1, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+    print(json.dumps(result["diff"], indent=2, ensure_ascii=False), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
#756 measured the redirect and declined to measure its cause. The [2026-09-10 spike](https://github.com/ffroliva/gflow-cli/blob/develop/docs/superpowers/spikes/2026-09-10-about-redirect-stability.md) could not investigate one because it had stopped reproducing.

It reproduces **stably on `denon82` right now**, and a stable reproducer is the condition under which a cause becomes measurable. That state is perishable — `ci-probe` went from reproducing to not in two days with nobody watching — so it was measured while it was there.

## Designed as an A/B, not an inspection

Reading only the failing account shows a page that redirects and a pile of requests, with nothing to say which is abnormal. Same capture on both arms; the finding is the difference.

| | `denon82` (fails) | `ci-probe` (control) |
|---|---|---|
| document response | **200**, no `Location` | **200**, no `Location` |
| first navigation | 146 ms, `/project/<id>` | 90 ms, `/project/<id>` |
| second navigation | **338 ms → `/about`** | 700 ms, same `/project/<id>` |
| total responses | 7 | 43 |
| `batchexecute` calls | **0** | 20, first at **275 ms** |
| non-2xx from any Flow endpoint | none | none |

## Two findings

**Not a server-side redirect.** Both documents are `200` with no `Location`, so the hop is the app deciding client-side, 192 ms after its own first navigation commits.

**It decides without asking Flow.** The failing arm issued **zero** `batchexecute` calls — not *called and was refused*, **never called**. There is no 401, 403 or 404 to point at because there is no request. The sixteen rpcids the control makes are simply absent.

The cross-arm timing is what makes that a finding rather than a race: the control had already made its **first** rpc at 275 ms, before the failing arm hopped at 338 ms. Two runs, so suggestive rather than airtight — but with zero calls in the 5.5 s *after* the hop too, the app is plainly not waiting on a Flow answer.

**Account-wide, not project-specific**: a second `denon82` project redirects identically, 2/2.

Also already in hand: `gflow project list` on `denon82` returns the redirecting project. The backend grants access while the frontend declines to open it.

## What this does NOT establish

**Which signal.** Naming it means reading the document's embedded bootstrap payload, which on this origin is exactly where bearer tokens and account data live. **Not read here.** #756's warning stands: a lead is not a cause, and no remedy should assert a mechanism this cannot see.

What would settle it: a HAR capture of the failing document through `scripts/dev/har-spike/`, diffed against a working one, with `extract_har_summary.py` producing the redacted summary. Not run here because the finding already changes what the next person should look at, and a raw capture of this page must not leave the machine.

## Scope

**No code changes.** `retryable=False` was already correct and was measured in #785. This narrows the search for whoever picks up #756: it is not a permissions call being refused, so looking for one is a dead end.

Cost: $0 — navigations and response *metadata* only. No bodies, no headers, no cookies.

https://claude.ai/code/session_01Nr4XuvvZv3PrL3pKEzkrLc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added investigation findings about `/about` navigation behavior.
  - Documented that affected projects receive a successful page response before navigating to `/about` client-side.
  - Recorded that the behavior is consistent across projects within an account and is not caused by session expiry, missing access, a temporary condition, or a server-side redirect.
  - Clarified which potential causes remain unconfirmed and documented differences between affected and control sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->