### PR TITLE
spike(787): Nano Banana 2 Lite is real and usable; its binding is unverifiable

### DIFF
--- a/docs/superpowers/spikes/2026-09-11-nano2-lite-capability.md
+++ b/docs/superpowers/spikes/2026-09-11-nano2-lite-capability.md
@@ -109,6 +109,50 @@ attribution that was never observed, on every migrated image, for every tier. A 
 reading that field — or a future recorder persisting it — believes something no surface
 confirmed. Filed separately; it is pre-existing on `develop` and not #787's doing.
 
+## Addendum — the search was widened, and the boundary moved
+
+"Unverifiable" was challenged as too strong, and fairly. A second pass
+([`spike_image_model_attribution.py`](../../../scripts/dev/spike_image_model_attribution.py))
+removed the filter: **every** `batchexecute` reply on a project load, 20-21 of them, all
+checked for model tokens and for the two media ids.
+
+| rpcid | Size | Model tokens | Media ids |
+|---|---|---|---|
+| `HTrJv` | 24,760 B | **all six** | **none** |
+| `Zzl0ze` | 41,906 B | **none** | **both** |
+| `tRARke` | 31,883 B | none | none |
+| 17 others | 139-3,964 B | none | none |
+
+**No reply carries both.** The join is absent from a whole project load, not just from the
+two surfaces first checked.
+
+The page was checked too, since a UI that displays it proves the data is reachable. Two
+tier labels exist — `span.settings-summary` and `span.model-select-trigger-content` — but
+the first appears **on load, before any interaction**, so both are composer picker state,
+not a property of an image.
+
+**One reading remains open and would flip this:** whether a tier label *tracks the media
+you open*. In one run the label read `Nano Banana 2` on load and `Nano Banana 2 Lite`
+after a thumbnail click — either the settings pane simply showing current state, or the
+opened media loading its own settings into the composer, which would be attribution. The
+two could not be separated: thumbnail `src` does not carry the media id, so a per-media
+A/B could not be targeted, and a later run matched zero tiles.
+
+**What would settle it:** find how the grid identifies a tile (`Zzl0ze` carries the ids,
+so the DOM plausibly does too), then open two media generated with *different* tiers and
+read the label after each.
+
+Two further notes. gflow drives the **same web app** a user drives, so there is no
+privileged surface being missed — the difference is between hosts: labs REST returns
+`modelNameType` per image and the migrated `batchexecute` wire does not appear to. And
+Flow **does** store a model per media for **video** on the labs shape
+(`videoModelControlInput.videoModelName`), so the concept exists in their data model.
+
+No evidence this is regional. Region and cohort gating change *which models an account is
+offered* — and this account is offered Lite — not whether a reply carries a field. The
+account is served UK-region Google cookies; the same probe from another region is
+untested, so no claim is made either way.
+
 ## Not measured
 
 - **Daily quota**, per the oracle problem above. Whether Lite carries a *different* quota

--- a/docs/superpowers/spikes/2026-09-11-nano2-lite-capability.md
+++ b/docs/superpowers/spikes/2026-09-11-nano2-lite-capability.md
@@ -1,0 +1,119 @@
+# Nano Banana 2 Lite: the tier is real, the quality is fine, and the binding is unverifiable
+
+- **Date:** 2026-09-11
+- **Script:** [`scripts/dev/spike_nano2_lite_capability.py`](../../../scripts/dev/spike_nano2_lite_capability.py)
+- **Profile / project:** `ci-probe` · `1e4efe0d-…` (migrated host)
+- **Cost:** four image generations — **0 Flow credits**, daily quota only. No video.
+- **Raw:** `scripts/dev/_spike_out/spike_nano2_lite_capability_20260911_2007*.json` (gitignored)
+- **Refs:** [#787](https://github.com/ffroliva/gflow-cli/pull/787)
+
+## Why it was run
+
+`tests/flow_selectors/test_model_governance.py` carried a waiver:
+
+> `"🍌 Nano Banana 2 Lite"` — Discovered 2026-08-26. A lower-tier image model we do not
+> expose. **Waived pending a capability spike (cost/quality) before we ship it.**
+
+PR #787 removes the waiver and ships the tier. This is the spike it was waiting for.
+
+## Rung 1 changed the question
+
+Two existing specs already list this as open, and one of them makes half the waiver
+unanswerable:
+
+- **Image generation costs 0 Flow credits** — so "cost" for an image tier means *daily
+  quota*, not credits.
+- **"Daily quota has no such oracle. It is observable *only on exhaustion*, via the
+  429."** ([`2026-08-26-model-cost-quota-catalog.md`](../specs/2026-08-26-model-cost-quota-catalog.md))
+
+So the **cost half cannot be measured without deliberately burning an account's day**, and
+this spike does not pretend otherwise.
+
+Rung 1 also exposed a sharper question. `migrated_composer.py` builds its result with
+`model_name_type=request.model.value` — it **echoes the model we asked for**. The labs path
+reads `generated["modelNameType"]` from the response; this one does not. And
+`batchexecute.image_records` decodes media id, workflow id, url, seed, prompt and
+dimensions — **no model field at all**.
+
+```
+A REPLY THAT REPEATS OUR REQUEST IS NOT AN OBSERVATION.
+```
+
+So "it generated an image with `--model nano2-lite`" proves the UI did not error. It does
+**not** prove the tier bound.
+
+## Pre-registered readings
+
+| Outcome | Reading |
+|---|---|
+| lite carries HARBOR_SEAL, control NARWHAL | the picker binds; #787's mapping is real |
+| both replies carry the SAME token | the lite selection silently falls back |
+| neither reply carries any token | the wire does not attribute images at all here |
+| a reply is unparseable, or a run fails | unmeasured for that arm; report it, never average |
+
+## What was observed
+
+**Both tiers generate.** Two arms, same prompt, same aspect, no errors:
+
+| Arm | Elapsed | Dimensions | Media |
+|---|---|---|---|
+| `HARBOR_SEAL` (nano2-lite) | 20.3 s | 1024×1024 | `6ae9628b-…` |
+| `NARWHAL` (nano2) | 25.4 s | 1024×1024 | `a5c0bf04-…` |
+
+**The submit reply attributes nothing.** Both `ogiZ0b` replies were real payloads
+(~1141 bytes) and **neither contained any model token** — not the wire name, not the menu
+label. That is the third pre-registered reading.
+
+**Nor does the project load.** Re-opening the project and searching every `batchexecute`
+reply:
+
+| rpcid | Size | Model tokens | Media ids |
+|---|---|---|---|
+| `HTrJv` | 24,762 B | **all six** — HARBOR_SEAL, NARWHAL, GEM_PIX_2, and the three menu labels | **none** |
+| `Zzl0ze` | 38,880 B | **none** | **both** |
+
+The catalogue lists models. The media listing lists media. **Neither joins them.**
+
+## Verdict
+
+**The tier is real.** `HARBOR_SEAL` and `Nano Banana 2 Lite` both appear in `HTrJv`,
+Flow's own model catalogue for this account — independent corroboration of #787's
+wire-string discovery, from a surface that is not our request echoed back.
+
+**The quality is fine, and is not ranked.** Both arms returned 1024×1024 RGB JPEGs
+(428,799 B for lite, 384,036 B for nano2) with no visible degradation on either; lite
+showed slightly more surface texture, nano2 slightly smoother. **One prompt cannot rank
+two tiers** and this does not try to. What it supports is the narrower claim the waiver
+needed: lite is a working tier that returns a usable image at full resolution.
+
+**The binding is unverifiable.** No surface gflow reads associates a generated image with
+the model that produced it. So neither #787's live check nor this one can establish that
+`--model nano2-lite` actually bound rather than silently falling back. Reported as
+**unmeasured**, which is the honest answer, not a failed run.
+
+**The cost half is unmeasurable by design** — see rung 1. Recording *why* is the answer
+here; inferring a number would be worse than the gap.
+
+## On the waiver
+
+Its stated condition was "cost/quality". Quality is answered. Cost is not answerable
+without exhausting a day, and the repo already wrote that down in 2026-08. Un-waiving on
+the quality half plus the catalogue corroboration is defensible — **provided the cost gap
+is carried forward rather than deleted with the waiver**, which is what the spec files
+already do.
+
+## What this surfaced that is not about Lite
+
+`model_name_type` on the migrated path is an **unbacked claim**: gflow reports a model
+attribution that was never observed, on every migrated image, for every tier. A caller
+reading that field — or a future recorder persisting it — believes something no surface
+confirmed. Filed separately; it is pre-existing on `develop` and not #787's doing.
+
+## Not measured
+
+- **Daily quota**, per the oracle problem above. Whether Lite carries a *different* quota
+  is therefore still open, exactly as the 2026-08-26 catalogue recorded it.
+- **Whether the picker silently falls back** when a tier is unavailable — unverifiable by
+  the routes tested, and the reason the point above matters.
+- **Quality at scale.** Two images. Any ranking would need a prompt set and a blind
+  comparison, which is a different exercise from this gate.

--- a/scripts/dev/spike_image_model_attribution.py
+++ b/scripts/dev/spike_image_model_attribution.py
@@ -1,0 +1,214 @@
+r"""Is a migrated image's model recorded ANYWHERE reachable? ($0)
+
+The 2026-09-11 Lite spike reported the binding as unverifiable after searching two
+surfaces. "Unverifiable by the routes tested" is not "unknowable", and three things say
+the search was too narrow:
+
+1. The labs trpc `initialdata` capture (in `_spike_out/`, 2026-08-31)
+   shows Flow DOES store a model per media -- `mediaMetadata.requestData
+   .videoGenerationRequestData.videoModelControlInput.videoModelName` -- for video. An
+   image equivalent plausibly exists and was simply never requested.
+2. The previous probe FILTERED: it only recorded replies already containing a media id or
+   a model token, and only during the first 12 s of a project load. A reply carrying
+   attribution under a different key, or fetched on interaction, was dropped unseen.
+3. If Flow's own UI shows which model produced an image, the data is on the page.
+
+So this probe removes the filter and adds the interaction:
+
+- **every** `batchexecute` reply on load, by rpcid, with per-token and per-media-id
+  co-occurrence -- nothing dropped
+- then the DOM: does any visible text name a model tier while a generated image is open
+
+## Pre-registered readings
+
+| Outcome | Reading |
+|---|---|
+| an rpcid carries a media id AND a model token | reachable; decode it, stop echoing |
+| the DOM names a tier next to an image | reachable via the page, if not via a reply |
+| all rpcids and the DOM are silent | genuinely absent here, not merely unread |
+| the media tile cannot be opened | interaction arm unmeasured; load arm stands |
+
+## Cost
+
+Zero. Navigation, DOM reads, and at most one click on an existing thumbnail. No
+generation, nothing created or deleted.
+
+    python scripts/dev/spike_image_model_attribution.py \
+        --profile ci-probe --project <id> --media <uuid> [--media <uuid>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+_MODEL_TOKENS = (
+    "HARBOR_SEAL",
+    "NARWHAL",
+    "GEM_PIX_2",
+    "IMAGEN_3_5",
+    "Nano Banana 2 Lite",
+    "Nano Banana Pro",
+    "Nano Banana 2",
+)
+
+#: Keys the labs shape uses for the same idea, searched for by NAME so a rename is
+#: visible as a miss rather than as an absence.
+_ATTRIBUTION_KEYS = (
+    "imageModelName",
+    "modelNameType",
+    "imageModelControlInput",
+    "imageGenerationRequestData",
+    "videoModelName",
+    "requestData",
+    "mediaMetadata",
+)
+
+#: Read visible text only, and only short runs, so a prompt or a signed URL cannot ride
+#: along. A tier label is at most a few words.
+_DOM_TIER_JS = r"""
+(tokens) => {
+  const out = [];
+  const walk = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let n;
+  while ((n = walk.nextNode())) {
+    const t = (n.textContent || '').trim();
+    if (!t || t.length > 60) continue;
+    if (tokens.some((tok) => t.includes(tok))) {
+      const el = n.parentElement;
+      out.push({
+        text: t,
+        tag: el ? el.tagName.toLowerCase() : null,
+        cls: el ? [...el.classList].slice(0, 3) : [],
+      });
+    }
+  }
+  return out.slice(0, 25);
+}
+"""
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--media", action="append", default=[])
+    args = ap.parse_args()
+
+    replies: list[dict[str, Any]] = []
+
+    async with build_client(resolve_profile_dir(args.profile)) as client:
+        page = client.transport._page  # noqa: SLF001
+
+        def on_response(resp: Any) -> None:
+            url = str(getattr(resp, "url", ""))
+            if "batchexecute" not in url:
+                return
+
+            async def _read() -> None:
+                try:
+                    text = await resp.text()
+                except Exception:  # noqa: BLE001
+                    return
+                rpcids = re.findall(r"rpcids=([A-Za-z0-9,]+)", url)
+                replies.append(
+                    {
+                        "rpcid": rpcids[0] if rpcids else "?",
+                        "len": len(text),
+                        "model_tokens": sorted({t for t in _MODEL_TOKENS if t in text}),
+                        "attribution_keys": sorted({k for k in _ATTRIBUTION_KEYS if k in text}),
+                        "media_ids": sorted({m for m in args.media if m in text}),
+                    }
+                )
+
+            asyncio.ensure_future(_read())  # noqa: RUF006
+
+        page.on("response", on_response)
+        step("load", f"opening project {args.project}")
+        await page.goto(
+            f"https://flow.google.com/project/{args.project}",
+            wait_until="domcontentloaded",
+            timeout=45_000,
+        )
+        await asyncio.sleep(14.0)
+        load_replies = len(replies)
+
+        dom_on_load = await page.evaluate(_DOM_TIER_JS, list(_MODEL_TOKENS))
+        step("load", f"{load_replies} batchexecute replies; DOM tier hits: {len(dom_on_load)}")
+
+        # Interaction arm, run PER MEDIA -- this is the control that matters. A tier
+        # label appearing once proves nothing: `model-select-trigger-content` is the
+        # composer's own picker, which would read the same whatever is open. Only a
+        # label that CHANGES with the opened media is attribution.
+        # Thumbnail `src` does not carry the media id, so target BY INDEX and ask the one
+        # question that separates the two readings: does the tier label CHANGE between
+        # two different thumbnails? Tracking the opened media means attribution; holding
+        # still means it is the composer's own picker and says nothing about the image.
+        tiles = page.locator("img[src*='flow-content'], img[src*='googleusercontent']")
+        tile_count = await tiles.count()
+        per_media: list[dict[str, Any]] = []
+        for index in range(min(tile_count, 3)):
+            entry: dict[str, Any] = {"tile_index": index}
+            try:
+                await tiles.nth(index).click(timeout=5000)
+                await asyncio.sleep(5.0)
+                entry["opened"] = True
+                entry["dom_tier_hits"] = await page.evaluate(_DOM_TIER_JS, list(_MODEL_TOKENS))
+            except Exception as exc:  # noqa: BLE001 - a failed arm is a datum
+                entry["opened"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+            step("open", f"tile {index} -> {entry.get('dom_tier_hits', entry['opened'])}")
+            per_media.append(entry)
+
+        opened = [e.get("opened") for e in per_media]
+        dom_after_open = per_media
+        page.remove_listener("response", on_response)
+
+    result = {
+        "question": "is a migrated image's model recorded anywhere reachable? (#789)",
+        "cost": "credit-free: navigation, DOM reads, one thumbnail click",
+        "media_watched": args.media,
+        "replies": replies,
+        "replies_on_load": load_replies,
+        "thumbnail_opened": opened,
+        "dom_tier_hits_on_load": dom_on_load,
+        "dom_tier_hits_after_open": dom_after_open,
+        "joins_media_and_model": [r for r in replies if r["media_ids"] and r["model_tokens"]],
+    }
+    out = default_out_path("spike_image_model_attribution", ".json")
+    out.write_text(json.dumps(result, indent=1, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+    print(
+        json.dumps(
+            {
+                "rpcids": [
+                    f"{r['rpcid']} len={r['len']} tokens={r['model_tokens']} "
+                    f"keys={r['attribution_keys']} media={len(r['media_ids'])}"
+                    for r in replies
+                ],
+                "joins": result["joins_media_and_model"],
+                "dom_after_open": dom_after_open,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/dev/spike_nano2_lite_capability.py
+++ b/scripts/dev/spike_nano2_lite_capability.py
@@ -1,0 +1,293 @@
+r"""Nano Banana 2 Lite: does selecting it BIND, and what does it produce? (0 credits)
+
+The capability spike `tests/flow_selectors/test_model_governance.py` demanded before this
+tier ships. Its waiver read:
+
+    "Nano Banana 2 Lite" -- Discovered 2026-08-26. A lower-tier image model we do not
+    expose. Waived pending a capability spike (cost/quality) before we ship it.
+
+PR #787 removes that waiver. This is the spike it was waiting for.
+
+## Rung 1 first -- what the repo already established
+
+- **Image generation costs 0 Flow credits** (the 2026-08-26 model-cost-quota catalogue).
+  So "cost" for an image tier is DAILY QUOTA, not credits.
+- **"Daily quota has no such oracle. It is observable *only on exhaustion*, via the 429."**
+  Same doc. So the cost half of "cost/quality" is NOT measurable here without burning an
+  account's day, and this spike does not pretend otherwise -- it says so and stops.
+- Both `2026-08-26-model-attribution-provenance.md` and the cost/quota catalogue already
+  list "Cost/quota of Nano Banana 2 Lite" as explicitly NOT established.
+
+## The sharper question rung 1 exposed
+
+`migrated_composer.py` builds its result with `model_name_type=request.model.value` -- it
+ECHOES the model we asked for. The labs path reads `generated["modelNameType"]` from the
+response; this one does not. And `batchexecute.image_records` decodes media id, workflow
+id, url, seed, prompt and dimensions -- **no model field at all**.
+
+So on the migrated host, "it generated an image with --model nano2-lite" proves the UI did
+not error. It does NOT prove the tier bound. A picker click that silently did not apply is
+a known bug class here -- the provenance spec names it, and cites
+`_assert_image_entities_attached` as the precedent for verifying a UI action at the wire.
+
+    A REPLY THAT REPEATS OUR REQUEST IS NOT AN OBSERVATION.
+
+So: capture the raw `ogiZ0b` reply for one generation per tier and search it, structurally,
+for the wire model tokens. Whatever is found (or is not) answers both the binding question
+and whether attribution on this host is verifiable at all.
+
+## Pre-registered readings -- written before the run
+
+| Outcome | Reading |
+|---|---|
+| lite carries HARBOR_SEAL, control NARWHAL | the picker binds; #787's mapping is real |
+| both replies carry the SAME token | the lite selection silently falls back |
+| neither reply carries any token | the wire does not attribute images at all here |
+| a reply is unparseable, or a run fails | unmeasured for that arm; report it, never average |
+
+Quality is reported as measured artifacts (dimensions, bytes, and the files themselves for
+a human look) and explicitly NOT as a verdict: two images from one prompt cannot rank two
+tiers, and saying they can is how a preference becomes a fact.
+
+## Cost
+
+Two image generations: **0 Flow credits**, some daily quota. No video. Nothing deleted.
+The prompt is benign and fixed so the two arms are comparable.
+
+    python scripts/dev/spike_nano2_lite_capability.py --profile ci-probe --project <id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _spike_common import (  # noqa: E402, isort: skip
+    build_client,
+    default_out_path,
+    resolve_profile_dir,
+    step,
+)
+
+from gflow_cli.api.image import Aspect, GenerateImageRequest  # noqa: E402
+from gflow_cli.api.image import Model as ImageModel  # noqa: E402
+
+
+#: Resolved by NAME, not by attribute: `HARBOR_SEAL` exists only on the branch that adds
+#: it (#787), and a spike that cannot be imported on `develop` is a spike nobody re-runs.
+#: A missing tier is reported as a skipped arm rather than an ImportError.
+def _model(name: str) -> ImageModel | None:
+    return getattr(ImageModel, name, None)
+
+
+#: The submit RPC whose reply carries the generated media.
+IMAGE_SUBMIT_RPC = "ogiZ0b"
+
+#: Every wire tier name this repo knows, plus the two menu labels. Searched for as
+#: TOKENS in the reply — the body itself is never recorded, only which tokens appeared
+#: and how often, because these payloads carry prompts and signed URLs.
+_MODEL_TOKENS = (
+    "HARBOR_SEAL",
+    "NARWHAL",
+    "GEM_PIX_2",
+    "IMAGEN_3_5",
+    "Nano Banana 2 Lite",
+    "Nano Banana 2",
+    "Nano Banana Pro",
+)
+
+PROMPT = "a single green pear on a plain white background, soft even studio light"
+
+
+def _token_hits(text: str) -> dict[str, int]:
+    """Which model tokens appear in the reply, and how often. Never the text itself."""
+    return {tok: len(re.findall(re.escape(tok), text)) for tok in _MODEL_TOKENS if tok in text}
+
+
+async def run_arm(profile_dir: Path, project_id: str, model: ImageModel) -> dict[str, Any]:
+    replies: list[dict[str, Any]] = []
+
+    async with build_client(profile_dir) as client:
+        page = client.transport._page  # noqa: SLF001
+
+        def on_response(resp: Any) -> None:
+            if IMAGE_SUBMIT_RPC not in str(getattr(resp, "url", "")):
+                return
+
+            async def _read() -> None:
+                try:
+                    text = await resp.text()
+                except Exception:  # noqa: BLE001 - a listener must never break the run
+                    return
+                replies.append(
+                    {
+                        "len": len(text),
+                        "model_tokens": _token_hits(text),
+                        # Structural only: the JSON keys present at the top of the frame,
+                        # so a future reader can see WHERE a model field would live.
+                        "keys_seen": sorted(set(re.findall(r'"([a-zA-Z]{3,30})":', text)))[:40],
+                    }
+                )
+
+            asyncio.ensure_future(_read())  # noqa: RUF006
+
+        page.on("response", on_response)
+        t0 = time.monotonic()
+        step(model.value, "generating")
+        try:
+            image = await client.generate_image(
+                project_id=project_id,
+                req=GenerateImageRequest(prompt=PROMPT, model=model, aspect=Aspect.SQUARE, count=1),
+            )
+            err = None
+        except Exception as exc:  # noqa: BLE001 - a failed arm is a datum
+            image, err = None, f"{type(exc).__name__}: {str(exc)[:200]}"
+        await asyncio.sleep(1.0)  # let the reply reader finish
+        page.remove_listener("response", on_response)
+
+        out: dict[str, Any] = {
+            "requested_model": model.value,
+            "elapsed_s": round(time.monotonic() - t0, 1),
+            "error": err,
+            "replies": replies,
+        }
+        if image is not None:
+            out["result"] = {
+                "media_name": image.media_name,
+                "seed": image.seed,
+                # NOTE: echoed from our request on this host -- that is the finding,
+                # not a measurement. Recorded so the two can be compared side by side.
+                "model_name_type_ECHOED": image.model_name_type,
+                "dimensions": list(image.dimensions),
+                "aspect_ratio": image.aspect_ratio,
+                "display_name": image.display_name,
+                "is_signed_url": image.is_signed_url,
+            }
+        return out
+
+
+async def verify_attribution(
+    profile_dir: Path, project_id: str, media_by_model: dict[str, str]
+) -> dict[str, Any]:
+    """Re-open the project and look for the model Flow RECORDED against each media.
+
+    The submit reply carries no attribution, so this asks the other surface: the
+    project load. Every ``batchexecute`` reply is searched for the media ids created
+    above and for the wire model tokens, and only the CO-OCCURRENCE is recorded — never
+    the body, which carries prompts and signed URLs.
+
+    A media id and a model token in the same reply is a lead, not a binding: proximity
+    in one payload does not prove the pair is associated. Whether a reply contains both
+    is still the difference between "attribution exists somewhere" and "it does not".
+    """
+    found: list[dict[str, Any]] = []
+
+    async with build_client(profile_dir) as client:
+        page = client.transport._page  # noqa: SLF001
+
+        def on_response(resp: Any) -> None:
+            url = str(getattr(resp, "url", ""))
+            if "batchexecute" not in url:
+                return
+
+            async def _read() -> None:
+                try:
+                    text = await resp.text()
+                except Exception:  # noqa: BLE001
+                    return
+                tokens = _token_hits(text)
+                ids = {name: mid for name, mid in media_by_model.items() if mid in text}
+                if tokens or ids:
+                    rpcids = re.findall(r"rpcids=([A-Za-z0-9]+)", url)
+                    found.append(
+                        {
+                            "rpcid": rpcids[0] if rpcids else "?",
+                            "len": len(text),
+                            "model_tokens": tokens,
+                            "media_ids_present": sorted(ids),
+                        }
+                    )
+
+            asyncio.ensure_future(_read())  # noqa: RUF006
+
+        page.on("response", on_response)
+        step("verify", f"re-opening project {project_id}")
+        await page.goto(
+            f"https://flow.google.com/project/{project_id}",
+            wait_until="domcontentloaded",
+            timeout=45_000,
+        )
+        await asyncio.sleep(12.0)
+        page.remove_listener("response", on_response)
+
+    return {"replies_with_a_hit": found}
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", required=True)
+    ap.add_argument("--project", required=True)
+    args = ap.parse_args()
+
+    profile_dir = resolve_profile_dir(args.profile)
+    arms: list[dict[str, Any]] = []
+    for name in ("HARBOR_SEAL", "NARWHAL"):
+        model = _model(name)
+        if model is None:
+            step(name, "SKIPPED - this build does not define the tier")
+            arms.append({"requested_model": name, "skipped": "tier not in this build"})
+            continue
+        arms.append(await run_arm(profile_dir, args.project, model))
+
+    media_by_model = {
+        a["requested_model"]: a["result"]["media_name"]
+        for a in arms
+        if a.get("result", {}).get("media_name")
+    }
+    attribution = (
+        await verify_attribution(profile_dir, args.project, media_by_model)
+        if media_by_model
+        else {"replies_with_a_hit": [], "note": "no media created; nothing to verify"}
+    )
+
+    result = {
+        "question": (
+            "does --model nano2-lite BIND on the migrated host, and what does it produce? "
+            "(the capability spike the model-governance waiver required)"
+        ),
+        "cost": "two image generations: 0 Flow credits, daily quota only",
+        "prompt": PROMPT,
+        "note_on_cost": (
+            "Daily quota is observable ONLY on exhaustion (429 naming the model) per "
+            "docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md, so the COST "
+            "half of 'cost/quality' is not measured here and is not inferred."
+        ),
+        "arms": arms,
+        "attribution_on_project_load": attribution,
+    }
+    out = default_out_path("spike_nano2_lite_capability", ".json")
+    out.write_text(json.dumps(result, indent=1, ensure_ascii=False), encoding="utf-8")
+    step("done", f"wrote {out}")
+    for arm in arms:
+        if "skipped" in arm:
+            step(arm["requested_model"], f"SKIPPED - {arm['skipped']}")
+            continue
+        step(
+            arm["requested_model"],
+            f"error={arm['error']} replies={len(arm['replies'])} "
+            f"tokens={[r['model_tokens'] for r in arm['replies']]}",
+        )
+    step("verify", json.dumps(attribution["replies_with_a_hit"])[:600])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
The capability spike `test_model_governance.py`'s waiver demanded before this tier ships. #787 removes that waiver; this is what it was waiting for.

## Rung 1 changed the question, twice

The [2026-08-26 cost/quota catalogue](https://github.com/ffroliva/gflow-cli/blob/develop/docs/superpowers/specs/2026-08-26-model-cost-quota-catalog.md) already establishes that image generation costs **0 Flow credits** — so "cost" here means daily quota — and that **"daily quota has no such oracle. It is observable *only on exhaustion*, via the 429."** The cost half of "cost/quality" is therefore unanswerable without burning an account's day. Recorded as such, not inferred.

It also exposed a sharper question: `migrated_composer` sets `model_name_type=request.model.value`. It **echoes our request**. The labs path reads `generated["modelNameType"]`; this one does not, and `image_records` decodes no model field at all.

> A reply that repeats our request is not an observation.

## What was measured — 4 generations, 0 credits

**The tier is real.** `HARBOR_SEAL` and `Nano Banana 2 Lite` both appear in `HTrJv`, Flow's own model catalogue for this account — corroboration from a surface that is not our request reflected back.

**Quality is fine, and is not ranked.** Both arms: 1024×1024 RGB, 428,799 B (lite) vs 384,036 B (nano2), no visible degradation, lite slightly more textured. One prompt cannot rank two tiers and this does not try to. It supports the narrower claim the waiver needed.

**The binding is unverifiable.**

| Surface | Size | Model tokens | Media ids |
|---|---|---|---|
| `ogiZ0b` submit reply | ~1141 B | **none** (both arms) | — |
| `HTrJv` project load | 24,762 B | **all six** | **none** |
| `Zzl0ze` project load | 38,880 B | **none** | **both** |

The catalogue lists models. The media listing lists media. **Nothing joins them.** So neither #787's live check nor this one establishes that `--model nano2-lite` bound rather than silently falling back. That is the third pre-registered reading, reported as **unmeasured** — which the spike protocol treats as a real finding, not a failed run.

## Surfaced, and not about Lite

`model_name_type` on the migrated path is an unbacked claim on **every** migrated image, for every tier. Filed as #789 against `develop`; pre-existing, not #787's doing.

## Scope

Docs and one spike script. No source change, no version change. Cost: four image generations, zero Flow credits, daily quota only.

https://claude.ai/code/session_01Nr4XuvvZv3PrL3pKEzkrLc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a capability report for the Nano Banana 2 Lite image tier.
  - Recorded successful 1024×1024 image generation for both evaluated tiers, with no observed errors or Flow credit usage.
  - Documented limitations in verifying tier binding, model attribution, quality ranking, and cost measurement.
  - Added findings from expanded checks of project responses and visible tier labels.

- **Chores**
  - Added evaluation tooling to capture generation outcomes, inspect model attribution, and handle unavailable tiers or failed runs without interrupting assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->