### PR TITLE
fix: migrated-host auth verification + i2v picker confirm + run-unique upload

### DIFF
--- a/src/gflow_cli/api/transports/migrated_composer.py
+++ b/src/gflow_cli/api/transports/migrated_composer.py
@@ -1346,10 +1346,26 @@ class MigratedComposer:
         from gflow_cli.api.client import validate_image_file  # noqa: PLC0415 - cycle
 
         await validate_image_file(image_path)
-        # No outer budget: each leg is bounded, and an outer one firing first would
-        # replace the stage-named failure with a generic "attach timed out".
-        media_id = await self._upload_via_toolbar(page, project_id, image_path)
-        await self._pick_frame_by_name(page, image_path.name, media_id)
+        # ai4u delta (2026-09-12): the picker lists assets by display name and the
+        # submit body is asserted to carry THIS upload's media id. Repeated runs with
+        # the same file name leave look-alike assets in the library, and the name
+        # search then binds a stale duplicate — the submit body carries the wrong id
+        # and the run dies WireFormatError post-click (credits spent). Upload a
+        # run-unique COPY so the name search has exactly one match.
+        import shutil  # noqa: PLC0415
+        import uuid as _uuid  # noqa: PLC0415
+
+        unique_image = image_path.with_name(
+            f"{image_path.stem}-{_uuid.uuid4().hex[:8]}{image_path.suffix}"
+        )
+        shutil.copy2(image_path, unique_image)
+        try:
+            # No outer budget: each leg is bounded, and an outer one firing first would
+            # replace the stage-named failure with a generic "attach timed out".
+            media_id = await self._upload_via_toolbar(page, project_id, unique_image)
+            await self._pick_frame_by_name(page, unique_image.name, media_id)
+        finally:
+            unique_image.unlink(missing_ok=True)
         return media_id
 
     async def _upload_via_toolbar(self, page: Page, project_id: str, image_path: Path) -> str:
@@ -1747,6 +1763,22 @@ class MigratedComposer:
                 # Outside the except above on purpose: a click that fails here is not
                 # "the picker never listed it", and must not be reported as one.
                 await options.first.click(timeout=4000)
+                # ai4u delta (2026-09-12): Flow's picker no longer auto-closes on pick —
+                # it now requires an explicit confirm button ("Add to prompt" in en).
+                # Without clicking it the overlay stays up and the wait-for-hidden below
+                # raised UiSelectorDriftError on every i2v (observed 5/5 on a migrated
+                # account; landscape t2v unaffected — no picker). Grace-wait, confirm if
+                # the picker is still up, else fall through to the auto-close wait.
+                try:
+                    await page.wait_for_timeout(1200)
+                    if await picker.is_visible():
+                        confirm = page.locator(
+                            "button:has-text('Add to prompt')"
+                        ).first
+                        await confirm.wait_for(state="visible", timeout=3000)
+                        await confirm.click(timeout=3000)
+                except Exception:
+                    pass  # auto-close variant, or confirm already gone — wait below decides
                 break
         try:
             # Re-queried, and `.last` like the open: the picker overlay is detached

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
@@ -320,6 +321,73 @@ async def verify_flow_session(
     return result
 
 
+async def _verify_migrated_host_fallback(
+    profile_dir: Path, source: str
+) -> FlowSessionStatus | None:
+    """ai4u delta (2026-09-12) — migrated-host session oracle.
+
+    For accounts Google has moved to flow.google.com, the labs.google NextAuth
+    session is never minted (the labs app hands off immediately; observed:
+    47 cookies, zero on labs.google, but OSID/__Secure-OSID present on
+    .flow.google.com and SAPISID/SID on .google.com). The labs oracle then
+    reports GOOGLE_SESSION_ONLY although the workspace is fully usable —
+    gflow's own migrated-host driver authenticates via exactly these cookies
+    (spike 2026-09-05-migrated-host-wire-protocol: ".google.com SSO cookies
+    already in the profile authenticate the host").
+
+    Fail-closed: upgrades GOOGLE_SESSION_ONLY to AUTHENTICATED only when BOTH
+    the .google.com SSO cookie (SAPISID) AND the flow.google.com app session
+    cookie (__Secure-OSID/OSID) are present, AND the account email resolves
+    from myaccount.google.com. Anything else returns None (caller keeps the
+    original outcome). Never touches other outcomes.
+    """
+    from .strategies import async_playwright
+
+    try:
+        async with async_playwright() as pw:
+            ctx = await pw.chromium.launch_persistent_context(
+                user_data_dir=str(profile_dir),
+                channel="chrome",
+                headless=True,
+                args=["--password-store=basic"],
+            )
+            try:
+                cookies = await ctx.cookies()
+                names = {(c.get("name"), c.get("domain", "")) for c in cookies}
+                has_sso = any(
+                    n == "SAPISID" and "google.com" in d for n, d in names
+                )
+                has_flow_osid = any(
+                    n in ("__Secure-OSID", "OSID") and "flow.google.com" in d
+                    for n, d in names
+                )
+                if not (has_sso and has_flow_osid):
+                    return None
+                resp = await ctx.request.get(
+                    "https://myaccount.google.com/?hl=en", timeout=15_000
+                )
+                page_body = await resp.text()
+            finally:
+                await ctx.close()
+    except Exception as exc:
+        logger.warning(
+            "auth_migrated_fallback_probe_error", source=source, error=type(exc).__name__
+        )
+        return None
+
+    match = re.search(r"[\w.+-]+@[\w-]*\.?gmail\.com", page_body)
+    if not match:
+        logger.warning(
+            "auth_migrated_fallback_no_email", source=source
+        )
+        return None
+    return FlowSessionStatus(
+        outcome=FlowSessionOutcome.AUTHENTICATED,
+        user_email=match.group(0),
+        source=source,
+    )
+
+
 async def verify_flow_profile(
     profile_dir: Path,
     *,
@@ -331,6 +399,9 @@ async def verify_flow_profile(
     (falling back to a marker-gated Playwright context on decryption failure),
     then calls the NextAuth session endpoint with up to `_MAX_ATTEMPTS` attempts.
     Fail-closed: any failure yields VERIFICATION_ERROR, never AUTHENTICATED.
+
+    ai4u delta (2026-09-12): when the labs oracle yields GOOGLE_SESSION_ONLY,
+    a migrated-host fallback probe runs (see _verify_migrated_host_fallback).
     """
     _validate_profile_in_home(profile_dir)
 
@@ -362,4 +433,15 @@ async def verify_flow_profile(
             source=source,
             status_code=status_code,
         )
+    if result.outcome is FlowSessionOutcome.GOOGLE_SESSION_ONLY:
+        # ai4u delta (2026-09-12): migrated-host fallback — see
+        # _verify_migrated_host_fallback docstring. Fail-closed.
+        fallback = await _verify_migrated_host_fallback(profile_dir, source)
+        if fallback is not None:
+            logger.warning(
+                "auth_migrated_host_fallback_authenticated",
+                source=source,
+                detail="labs NextAuth absent; flow.google.com OSID session + SSO cookies present",
+            )
+            return fallback
     return result


### PR DESCRIPTION
# fix: migrated-host auth verification + i2v frame-picker confirm + run-unique upload

Fixes three production blockers hit generating on a **server-migrated** account
(ULTRA, flow.google.com is the only frontend — the labs handoff fires instantly),
all verified end-to-end on live generations:

## 1. `auth/verification.py` — migrated-host session fallback

For migrated accounts the labs.google NextAuth session is **never minted** (the
labs app hands off to flow.google.com before/at the NextAuth callback; observed
`all_cookies: 47, flow_domain: 0` — no labs cookies at all), so the
`labs.google/fx/api/auth/session` oracle reports `GOOGLE_SESSION_ONLY` forever
and login can never succeed, even with the Flow workspace + composer fully
loaded in gflow's own Chrome window (5 attempts, agent-verified).

Fail-closed fallback: when the labs oracle yields `GOOGLE_SESSION_ONLY`,
upgrade to AUTHENTICATED **only if** the profile holds BOTH `SAPISID`
(.google.com) AND `__Secure-OSID`/`OSID` (.flow.google.com — the migrated app's
own session), with the email resolved from myaccount.google.com. Anything else
keeps the original outcome.

Related: #639, #644, #681 (this is the login-side of the migrated-host family).
Also reported as kodelyx/flow-agent#15's "the session BFF is the sole oracle"
problem, same root from the other side.

## 2. `migrated_composer.py::_pick_frame_by_name` — click the picker's confirm

Flow's Frames picker no longer auto-closes on pick: it now requires an explicit
confirm button ("Add to prompt" in en). gflow clicked the asset, waited
`FRAME_COMMIT_HIDDEN_S` for an auto-close that never came, and raised
`UiSelectorDriftError` — **5/5 failures on i2v** (landscape t2v unaffected: no
picker). Fix: grace-wait 1.2 s; if the picker is still visible, click the
confirm button; the original wait-for-hidden then decides (auto-close variant
unchanged).

## 3. `migrated_composer.py::attach_start_frame` — run-unique upload name

The picker lists assets by display name, and repeated runs with the same
keyframe file leave N look-alikes in the library. The name search then binds a
**stale duplicate** and the submit-body assertion fires post-click —
`eb1hJf does not carry the uploaded start frame <id> (ids in the body: …)` —
after the credit-spending click. Fix: upload a run-unique COPY of the frame
(`<stem>-<8hex><ext>`) so the search has exactly one match; temp copy removed
after attach.

## Verification (all on the migrated host, live)

- Login: `auth_flow_session_verified user_email=<account> probe=on_disk` via
  the fallback; profile renamed + set default; `auth status` green.
- `gflow video i2v <keyframe> --aspect 9:16 --duration 8 --project <id>`:
  submit body carries the matching upload id → `YhhmEf` submit → `jwpduf`
  polls 6→2→3 → `as29s` → auto-download → **ffprobe 720×1280, 8.0 s**. Zero
  Computer-Use, zero manual steps.
- `gflow image t2i --model nano2 --aspect 16:9`: 5/5 free keyframes.

Notes for review:
- The fallback's myaccount.google.com email scrape is locale-tolerant for
  gmail.com addresses; a structural anchor (or the app's own account endpoint)
  would be the cleaner upstream form.
- The confirm-button anchor uses en text (`Add to prompt`) — the module's
  locale-independence rule would prefer a structural/ligature anchor; left as
  text because the button has no icon in the observed DOM.
- Both deltas are intentionally conservative (fail-closed) and only activate on
  migrated accounts.

Witnessed on the way (not addressed here): exit-23 selector drift on the
labs cohort with no duration control (#681 family) and credits probing
aisandbox-pa on migrated accounts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authentication fallback for migrated environments using Google SSO session cookies.
  - Validates sessions through Google account verification and only accepts secure, valid account results.
  - Recognizes Workspace email domains and displays the most frequently detected domain when available.
  - Supports successful authentication even when no email domain can be identified.

- **Bug Fixes**
  - Prevents authentication when required session cookies are missing.
  - Rejects sign-in redirects, invalid destinations, and failed account checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->