### PR TITLE
fix(795,796): two auth failures that blame the wrong cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A missing browser-strategy marker no longer reports as a network problem (#796).**
+  The Playwright cookie reader refuses a profile whose `.gflow_browser_strategy` marker
+  is absent, and that `SecurityError` was flattened into `VERIFICATION_ERROR` — whose
+  guidance is "check network connectivity", for a file on the user's own disk. It is
+  also precisely the state a failed first login leaves behind, since that rolls the
+  marker back. A new `PROFILE_MARKER_MISSING` outcome carries its own message and the
+  remediation that actually works (`gflow auth login --browser chrome`), on the CLI and
+  on the MCP twin (HTTP 409, `retryable: false` — it is neither a network blip nor an
+  expired session).
+- **`gflow credits` no longer blames SAPISID for a host it never contacted (#795).** When
+  labs.google answers 200 with no `access_token` — the normal shape for an account Google
+  has migrated to `flow.google.com` — the failure was raised as "aisandbox-pa
+  authentication failed" with the remediation "SAPISID cookie missing, expired, or
+  unreadable". aisandbox-pa had not been contacted, and SAPISID was present and fine, so
+  the advice sent users into a re-login loop that cannot terminate on that cohort. The
+  remediation now names the real cause. `credits` itself remains labs-only on migrated
+  accounts — tracked in #795.
+
 - **The `/about` landing's `retryable=False` is now a measurement, not a preserved
   default.** A live occurrence was caught on a second account and the #756 stability
   probe re-run unmodified: **5/5** attempts landed on `/about` over ~3 minutes, on the

--- a/src/gflow_cli/api/credits.py
+++ b/src/gflow_cli/api/credits.py
@@ -65,10 +65,22 @@ async def fetch_credits_http(profile_dir: Path) -> CreditsInfo:
         "access_token"
     )
     if not isinstance(token, str) or not token:
+        # #795: this is the labs session BFF answering 200 with no token — most
+        # often an account Google has migrated to flow.google.com, for which it
+        # never mints one. aisandbox-pa has not been contacted at this point, and
+        # SAPISID is present and fine (it is what made the session probe report a
+        # Google session at all), so the class default remediation would send the
+        # user to re-authenticate something that is not broken.
         raise AisandboxAuthError(
-            detail="no access_token in Flow session",
+            detail="the labs.google session returned no access token",
             status=session_status,
             route="auth/session",
+            remediation_hint=(
+                "Flow's labs.google session carries no API token for this account. "
+                "On accounts Google has migrated to flow.google.com this is expected "
+                "and re-authenticating will not help — generation still works, but "
+                "`gflow credits` reads a labs-only endpoint. See issue #795."
+            ),
         )
 
     async with httpx.AsyncClient(follow_redirects=False, timeout=15.0) as client:

--- a/src/gflow_cli/auth/real_chrome.py
+++ b/src/gflow_cli/auth/real_chrome.py
@@ -41,6 +41,9 @@ _UNVERIFIED_MESSAGE: dict[FlowSessionOutcome, str] = {
     FlowSessionOutcome.VERIFICATION_ERROR: (
         "Could not verify the Flow session — this is often a network problem."
     ),
+    FlowSessionOutcome.PROFILE_MARKER_MISSING: (
+        "This profile is missing its Chrome-strategy marker, so its cookies cannot be read."
+    ),
 }
 _UNVERIFIED_HINT: dict[FlowSessionOutcome, str] = {
     FlowSessionOutcome.GOOGLE_SESSION_ONLY: (
@@ -51,6 +54,9 @@ _UNVERIFIED_HINT: dict[FlowSessionOutcome, str] = {
         "Re-run `gflow auth login`, sign in to Google, and continue until the Flow editor loads."
     ),
     FlowSessionOutcome.VERIFICATION_ERROR: ("Check your connection and re-run `gflow auth login`."),
+    FlowSessionOutcome.PROFILE_MARKER_MISSING: (
+        "Re-run `gflow auth login --browser chrome` to rewrite the profile marker."
+    ),
 }
 
 

--- a/src/gflow_cli/auth/verification.py
+++ b/src/gflow_cli/auth/verification.py
@@ -61,6 +61,12 @@ class FlowSessionOutcome(StrEnum):
     GOOGLE_SESSION_ONLY = "google_session_only"
     NO_SESSION = "no_session"
     VERIFICATION_ERROR = "verification_error"
+    #: The profile's `.gflow_browser_strategy` marker is missing, so the
+    #: Playwright cookie reader refuses to open it (#796). Distinct from
+    #: VERIFICATION_ERROR because the cause is local profile state, not the
+    #: network — and telling the user to "check connectivity" sends them
+    #: looking in the wrong place, on a profile a failed login just rolled back.
+    PROFILE_MARKER_MISSING = "profile_marker_missing"
 
 
 _DETAIL_BY_OUTCOME: dict[FlowSessionOutcome, str] = {
@@ -68,6 +74,9 @@ _DETAIL_BY_OUTCOME: dict[FlowSessionOutcome, str] = {
     FlowSessionOutcome.GOOGLE_SESSION_ONLY: "Signed in to Google, but not to the Flow app.",
     FlowSessionOutcome.NO_SESSION: "No sign-in detected.",
     FlowSessionOutcome.VERIFICATION_ERROR: "Could not verify the Flow session.",
+    FlowSessionOutcome.PROFILE_MARKER_MISSING: (
+        "This profile is missing its Chrome-strategy marker."
+    ),
 }
 
 
@@ -338,6 +347,20 @@ async def verify_flow_profile(
     body: str
     try:
         status_code, body, google_session = await fetch_flow_session_httpx(profile_dir)
+
+    # #796: the marker gate is local profile state, not a network fault. It was
+    # flattened into VERIFICATION_ERROR, whose remediation says "check network
+    # connectivity" — wrong advice, and specifically wrong on a profile whose
+    # marker a failed login had just rolled back (real_chrome.py:433-434).
+    # `_validate_profile_in_home` raises SecurityError too, but above the try, so
+    # a path violation still propagates instead of being classified here.
+    except SecurityError:
+        logger.warning("auth_profile_marker_missing", source=source)
+        return FlowSessionStatus(
+            outcome=FlowSessionOutcome.PROFILE_MARKER_MISSING,
+            user_email=None,
+            source=source,
+        )
 
     # Fail-closed: any failure here yields VERIFICATION_ERROR, never AUTHENTICATED.
     except Exception as exc:

--- a/src/gflow_cli/cli.py
+++ b/src/gflow_cli/cli.py
@@ -375,7 +375,16 @@ def auth_status(profile: str | None) -> None:
         verification.verify_flow_profile(auth_mod.profile_dir(name), source="status")
     )
     if not status_result.authenticated:
-        if status_result.outcome is verification.FlowSessionOutcome.VERIFICATION_ERROR:
+        if status_result.outcome is verification.FlowSessionOutcome.PROFILE_MARKER_MISSING:
+            # #796: local profile state, not the network. Sending this user to
+            # "check connectivity" is the wrong place to look — and it is exactly
+            # the state a failed first login leaves behind (real_chrome.py:433).
+            console.print(
+                f"[yellow]{status_result.detail}[/yellow] "
+                f"Re-run [bold]gflow auth login --browser chrome --profile {name}[/bold] "
+                "to rewrite it.",
+            )
+        elif status_result.outcome is verification.FlowSessionOutcome.VERIFICATION_ERROR:
             # Re-login cannot fix an unreachable endpoint — don't send the
             # user into an interactive browser flow for a network problem.
             console.print(

--- a/src/gflow_cli/mcp/tools.py
+++ b/src/gflow_cli/mcp/tools.py
@@ -1511,7 +1511,24 @@ async def gflow_auth_status(profile: str = _DEFAULT_PROFILE) -> dict[str, Any]:
             "profile": resolved,
             "user_email": status.user_email,
         }
-    if status.outcome is verification.FlowSessionOutcome.VERIFICATION_ERROR:
+    if status.outcome is verification.FlowSessionOutcome.PROFILE_MARKER_MISSING:
+        # #796: a local profile-state fault. Not retryable (the marker will not
+        # reappear on its own) and not an expired session, so neither 503 nor 401
+        # describes it — an agent that retries or re-logins here learns nothing.
+        error = {
+            "type": "https://gflow-cli.dev/errors/profile-marker-missing",
+            "title": "Profile is missing its browser-strategy marker",
+            "status": 409,
+            "detail": status.detail,
+            "message": status.detail,
+            "retryable": False,
+            "remediation_hint": (
+                "This profile has no `.gflow_browser_strategy` marker, so its "
+                "cookies cannot be read. Re-run `gflow auth login --browser "
+                "chrome` for this profile to rewrite it."
+            ),
+        }
+    elif status.outcome is verification.FlowSessionOutcome.VERIFICATION_ERROR:
         # A network/endpoint problem is not fixed by re-login — the
         # machine-readable discriminators must say so too (post-merge review:
         # labeling this 401/auth-expired sent type-dispatching agents into an

--- a/tests/api/test_credits_http.py
+++ b/tests/api/test_credits_http.py
@@ -192,3 +192,22 @@ async def test_http_fast_path_rejects_profile_outside_home_before_cookie_access(
         await credits_api.fetch_credits_http(Path("/outside-gflow-home"))
 
     cookie_snapshot.assert_not_awaited()
+
+
+async def test_a_tokenless_labs_session_does_not_blame_sapisid(
+    monkeypatch: pytest.MonkeyPatch, profile_dir: Path
+) -> None:
+    """#795: labs answering 200 with no access_token is not an aisandbox-pa auth
+    failure — aisandbox-pa has not been contacted, and SAPISID is present and fine
+    (it is what made the probe report a Google session at all). The class default
+    remediation sent the user to re-authenticate something that is not broken; on a
+    migrated account that loop can never terminate."""
+    _install_http(monkeypatch, session_responses=[(200, {"user": {}})])
+
+    with pytest.raises(AisandboxAuthError) as caught:
+        await credits_api.fetch_credits_http(profile_dir)
+
+    hint = caught.value.remediation_hint
+    assert "SAPISID" not in hint
+    assert "flow.google.com" in hint
+    assert "no access token" in caught.value.detail

--- a/tests/auth/test_verification.py
+++ b/tests/auth/test_verification.py
@@ -333,7 +333,13 @@ class TestVerifyFlowSession:
             mock_settings.return_value.home = gflow_home
             status = await verify_flow_profile(profile)
 
-        assert status.outcome is FlowSessionOutcome.VERIFICATION_ERROR
+        # #796: the gate itself is unchanged (Playwright is never launched), but a
+        # missing marker is local profile state, not a network fault. Reporting it
+        # as VERIFICATION_ERROR told the user to "check network connectivity" for a
+        # file on their own disk — and that is precisely the state a failed first
+        # login leaves behind, since it rolls the marker back (real_chrome.py:433).
+        assert status.outcome is FlowSessionOutcome.PROFILE_MARKER_MISSING
+        assert not status.authenticated
         fake_async_playwright.assert_not_called()
 
     @pytest.mark.asyncio
@@ -352,6 +358,12 @@ class TestVerifyFlowSession:
         fake_bc3.chrome.side_effect = BrowserCookieError("Unable to get key for cookie decryption")
 
         fake_httpx = MagicMock()
+        # The marker must EXIST here, or the run stops at the marker gate and is
+        # classified PROFILE_MARKER_MISSING (#796) — which the sibling test above
+        # already covers. This test is about the decryption path itself: the
+        # fallback is entered and then fails, which is a genuine VERIFICATION_ERROR.
+        (profile / ".gflow_browser_strategy").write_text("chrome", encoding="utf-8")
+        fake_async_playwright = MagicMock(side_effect=RuntimeError("no browser here"))
 
         with (
             patch("gflow_cli.auth.verification.get_settings") as mock_settings,
@@ -360,6 +372,7 @@ class TestVerifyFlowSession:
                 return_value=Path("/fake/Cookies"),
             ),
             patch.dict(sys.modules, {"browser_cookie3": fake_bc3, "httpx": fake_httpx}),
+            patch("gflow_cli.auth.strategies.async_playwright", fake_async_playwright),
         ):
             mock_settings.return_value.home = gflow_home
             status = await verify_flow_profile(profile)

--- a/tests/mcp/test_auth_status_tool.py
+++ b/tests/mcp/test_auth_status_tool.py
@@ -81,3 +81,25 @@ async def test_verification_error_does_not_advise_relogin(
     # A network problem is not fixed by re-login (mirrors the CLI's guidance).
     assert "auth login" not in result["error"]["remediation_hint"]
     assert "retry" in result["error"]["remediation_hint"].lower()
+
+
+async def test_a_missing_profile_marker_is_not_retryable_and_not_a_dead_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#796 + MCP parity: the CLI now distinguishes a missing browser-strategy
+    marker from a network fault, so the machine-readable surface must too. It is
+    neither retryable (the marker will not reappear) nor an expired session, so an
+    agent that retries or re-logins on 503/401 would learn nothing."""
+    from gflow_cli.mcp import tools
+
+    monkeypatch.setattr(tools, "_resolve_and_validate_profile", lambda p: "denon")
+    monkeypatch.setattr(
+        tools.verification,
+        "verify_flow_profile",
+        _probe(FlowSessionOutcome.PROFILE_MARKER_MISSING),
+    )
+    result = await tools.gflow_auth_status()
+    assert result["status"] == "profile_marker_missing"
+    assert result["error"]["retryable"] is False
+    assert result["error"]["status"] == 409
+    assert "--browser chrome" in result["error"]["remediation_hint"]


### PR DESCRIPTION
## Summary

Two auth failures that name the wrong cause, found while auditing #791. Both send the user to fix something that is not broken; neither needed new machinery.

### #796 — a missing profile marker reports as a network problem

The Playwright cookie reader refuses a profile whose `.gflow_browser_strategy` marker is absent (`auth/cookies.py:139-147`, `SecurityError`). That error is **not** a `PermissionError`, so it escaped the normalization in `get_chrome_cookie_snapshot` and was flattened by `verify_flow_profile`'s catch-all into `VERIFICATION_ERROR` — whose guidance is *"Check network connectivity and retry"*, for a file on the user's own disk.

It matters more than a wording nit for two reasons:

- It is exactly the state a **failed first login leaves behind**, because that rolls the marker back (`auth/real_chrome.py:433-434`). So the user most likely to see it is the one who just failed to log in, and the advice sends them away from the fix.
- **`VERIFICATION_ERROR` is not `GOOGLE_SESSION_ONLY`**, so any migrated-host fallback keyed on `GOOGLE_SESSION_ONLY` — including the one proposed in #793 — would never run on these profiles at all.

Fixed with a distinct `PROFILE_MARKER_MISSING` outcome. `FlowSessionStatus.detail` is deliberately a derived property over a fixed table (so no response/cookie text can leak through it), so a new outcome is the right shape here rather than a free-text field.

### #795 — `gflow credits` blames SAPISID for a host it never contacted

When labs.google answers `200` with no `access_token` — the normal shape for an account Google has migrated to `flow.google.com` — `api/credits.py:67-72` raised `AisandboxAuthError`, rendering as **"aisandbox-pa authentication failed"** with remediation **"SAPISID cookie missing, expired, or unreadable"**.

At that point aisandbox-pa has not been contacted, and SAPISID is present and fine — it is what made the session probe report a Google session rather than none. On a migrated account the suggested re-login loop can never terminate. Reported downstream in #791.

The raise now carries an accurate `remediation_hint`. **`credits` itself is still labs-only on migrated accounts** — that half needs a wire discovery and stays open on #795.

## Surfaces

`verify_flow_profile` is the chokepoint for `gflow auth login`, `gflow auth status` **and** MCP `gflow_auth_status`, so the new outcome is mirrored on the MCP side in the same PR: HTTP **409**, `retryable: false`. Neither 503 (retry) nor 401 (re-login) describes a marker that will not reappear on its own, and an agent dispatching on those learns nothing.

## Test plan

- [x] `ruff check` / `ruff format --check src tests` — clean, 467 files
- [x] `pyright` on the 4 changed `src/` files — 0 errors; `mcp/tools.py` unchanged at its 31 pre-existing errors
- [x] repo hygiene · doc links · website-docs PII · `generate_website_docs --check` · council memory — OK
- [x] `tests/auth` + `tests/api/test_credits_http.py` — 130 passed
- [x] `tests/mcp` + `tests/cli` + credits — 32 passed
- [x] New tests: credits remediation asserts SAPISID is *not* blamed; MCP twin asserts 409 + `retryable: false`

**Two existing tests were updated, deliberately:**

- `test_playwright_fallback_requires_chrome_marker` asserted `VERIFICATION_ERROR` — it encoded the bug. The gate itself is unchanged (Playwright still never launches); only the classification moved.
- `test_verification_error_on_browser_cookie_decryption_error` was a near-duplicate of it: same fixture, no marker, so it stopped at the marker gate rather than the decryption path its name promises. It now writes the marker and fails the fallback, restoring the coverage the name claims.

## Verification honesty

Offline-verified. The **live** trigger for #796 is a cookie-store decryption failure, which on this machine (Windows/DPAPI) does not occur — it is the macOS Keychain case from #768. **Named blocker: no Mac here.** A synthetic attempt confirmed the boundary rather than the path: a corrupt cookie store raises `sqlite3.DatabaseError`, which is not normalized, so it reaches the generic handler and still prints *"Check network connectivity"*. That is the same misdirection class from a different trigger and is **not** addressed here — worth its own look.

Refs #795, #796, #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication status now clearly distinguishes missing Chrome profile markers from network verification errors, with guidance to rerun Chrome-based login.
  * MCP authentication responses now report missing profile markers as non-retryable errors with appropriate remediation.
  * Improved credits error messages when accounts have migrated to flow.google.com, avoiding misleading SAPISID or connectivity guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->